### PR TITLE
Pick up GeoLocation database location from openlibrary.yml

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -151,3 +151,4 @@ stats: # This section is used to state what stats need to be gathered.
 libraries_admin_email: admin@dev-instance
 
 graphite_base_url: "http://ol-admin.us.archive.org:7080"
+geoip_database: var/cache/GeoLiteCity.dat

--- a/openlibrary/core/geoip.py
+++ b/openlibrary/core/geoip.py
@@ -1,3 +1,4 @@
+from infogami import config
 import GeoIP
 
 def get_region(ip):
@@ -12,4 +13,5 @@ def get_region(ip):
 
     return region
 
-gi = GeoIP.open('/usr/local/maxmind-geoip/GeoLiteCity.dat', GeoIP.GEOIP_MEMORY_CACHE)
+geoip_db = config.get("geoip_database", '/usr/local/maxmind-geoip/GeoLiteCity.dat')
+gi = GeoIP.open(geoip_db, GeoIP.GEOIP_MEMORY_CACHE)


### PR DESCRIPTION
The location of the database file is hardcoded into the app. This breaks the dev. instance. I've made the location configurable from the `openlibrary.yml` file. I've dropped a file into `var/cache/GeoLiteCity.dat` as well but this directory is excluded from version control so I haven't checked it in. 
