### PR TITLE
Fix typo in setup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ distclean:
 venv:
 	@echo "** setting up virtualenv **"
 	mkdir -p var/cache/pip
-	virtualenv --no-site-packages env
+	virtualenv env
 	./env/bin/pip install --download-cache var/cache/pip $(OL_VENDOR)/openlibrary.pybundle
 
 install_solr: 

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 root=`dirname $0`
 
-# udpate submodules
+# update submodules
 git submodule sync
 git submodule init
 git submodule update


### PR DESCRIPTION
I fixed a typo in the documentation for setup.sh (changed 'udpate' to 'update').