### PR TITLE
Remove support categories where we can't offer any useful help

### DIFF
--- a/openlibrary/plugins/openlibrary/templates/support.html
+++ b/openlibrary/plugins/openlibrary/templates/support.html
@@ -12,6 +12,10 @@ $var title: What's the problem?
    <em>Your question has been submitted. We'll get back to you shortly.</em>
     
 
+Please review the <a href="/help/faq">Frequently Asked Questions</a> (FAQ) 
+to see if your question is answered there before using this form.
+We are unable to help with contacting authors or purchasing books.
+
  <form action="" method="post" name="spamForm" class="olform validate">
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
@@ -24,8 +28,6 @@ $var title: What's the problem?
      <select class = "required" name="topic" id="topic">
        <option value="">Select...</option>
        <option value="Borrowing Books">Borrowing Books</option>
-       <option value="Buying Books">Buying Books</option>
-       <option value="Contact an Author">Contact an Author</option>
        <option value="Deletion Request">Deletion Request</option>
        <option value="Developer/API/Covers Question/Bug report">Developer/API/Covers/Bug report Question</option>
        <option value="Editing Problem">Editing Problem</option>


### PR DESCRIPTION
As requested by Jessamyn on oil-discuss.  Also include link to FAQ and encouragement to check it first.
