### PR TITLE
Update about.html - small typo fix

### DIFF
--- a/openlibrary/templates/borrow/about.html
+++ b/openlibrary/templates/borrow/about.html
@@ -11,7 +11,7 @@ $var title: $title
 
 <div class="contentBody indent">
     <h2 class="serif black" style="font-size:1.5em;font-weight:normal;">$_('Up to 5 titles for 2 weeks each, either in-browser or as a PDF or ePub.')</h2>
-    <p class="larger">$:_('Open Library account holders can borrow an eBook from the growing collection of mainly 20th Century titles available now. Each title can be borrowed by one patron at once, and you can read it in a web browser. or in <a href="http://www.adobe.com/products/digitaleditions/" title="Download Adobe Digital Editions">Adobe Digital Editions</a> as a PDF or ePub.')</p>
+    <p class="larger">$:_('Open Library account holders can borrow an eBook from the growing collection of mainly 20th Century titles available now. Each title can be borrowed by one patron at once, and you can read it in a web browser or in <a href="http://www.adobe.com/products/digitaleditions/" title="Download Adobe Digital Editions">Adobe Digital Editions</a> as a PDF or ePub.')</p>
 </div>
 
 <div class="contentBody gradient indent">


### PR DESCRIPTION
typo fix for About page. Removed a period in the middle of a sentence.
