### PR TITLE
fix overdrive link errors due to overdrive site change

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -19,7 +19,7 @@ $ bookdepository = "http://www.bookdepository.com/search?searchTerm=XXX"
 
 $ worldcat = "http://worldcat.org/isbn/XXX"
 $ worldcatoclc = "http://worldcat.org/oclc/XXX"
-$ overdrive = "http://search.overdrive.com/SearchResults.aspx?ReserveID={XXX}"
+$ overdrive = "http://www.overdrive.com/search?q={XXX}"
 $ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
 $ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -193,7 +193,7 @@ def format_book_data(book):
         
     overdrive = book.get("identifiers", {}).get('overdrive')
     if overdrive:
-        d.overdrive_url = "http://search.overdrive.com/SearchResults.aspx?ReserveID={%s}" % overdrive
+        d.overdrive_url = "http://www.overdrive.com/search?q={%s}" % overdrive
 
     ia_id = book.get("ocaid")
     if ia_id:

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -11,7 +11,7 @@ $ bookdepository = "http://www.bookdepository.com/search?searchTerm=XXX"
 
 $ worldcat = "http://worldcat.org/isbn/XXX"
 $ worldcatoclc = "http://worldcat.org/oclc/XXX"
-$ overdrive = "http://search.overdrive.com/SearchResults.aspx?ReserveID={XXX}"
+$ overdrive = "http://www.overdrive.com/search?q={XXX}"
 $ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
 $ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 

--- a/openlibrary/templates/lib/covers.html
+++ b/openlibrary/templates/lib/covers.html
@@ -120,7 +120,7 @@ $jsdef render_page(page):
                  </div>
             $elif not all_borrow and w.overdrive and not w.public_scan and not borrowable:
                 <div class="coverEbook">
-                    <a href="http://search.overdrive.com/SearchResults.aspx?ReserveID={$(w.overdrive)}" title="$_('Borrow this book')"><img
+                    <a href="http://www.overdrive.com/search?q={$(w.overdrive)}" title="$_('Borrow this book')"><img
                         src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33" alt="$_('Borrow this book')"/></a>
                 </div>
         </div>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -177,7 +177,7 @@ $ library = (get_library() if 'inlibrary' in ctx.features else None)
                             </span>
                         $elif doc.overdrive:
                             <span class="actions read">
-                                <a href="http://search.overdrive.com/SearchResults.aspx?ReserveID={$(doc.overdrive[0])}" title="Link to overdrive.com">
+                                <a href="http://www.overdrive.com/search?q={$(doc.overdrive[0])}" title="Link to overdrive.com">
                                     <span class="image borrow"></span>
                                     <span class="label">Borrow</span>
                                 </a>


### PR DESCRIPTION
OverDrive urls have changed from:
search.overdrive.com/SearchResults.aspx?ReserveID=
to
www.overdrive.com/search?q=
Verified that using the second format with existing OverDrive ID's resolves to the correct title on overdrive.com.
Sample:
http://search.overdrive.com/SearchResults.aspx?ReserveID={0649E54A-657E-4342-AD7D-5BAEE9153A44}
http://www.overdrive.com/search?q={0649E54A-657E-4342-AD7D-5BAEE9153A44}
This appears to be a change throughout the entire OverDrive site.
