### PR TITLE
Make 'json' real JSON in single changeset (fixes internetarchive#206)

### DIFF
--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -156,7 +156,7 @@ class recentchanges_view(delegate.page):
                 return render_template("recentchanges/default/view", change)
                 
     def render_json(self, change):
-        return delegate.RawText(change.dict(), content_type="application/json")
+        return delegate.RawText(simplejson.dumps(change.dict()), content_type="application/json")
                 
     def POST(self, id):
         if not features.is_enabled("undo"):


### PR DESCRIPTION
JSON parsers complain that what looks like JSON in a single changeset is not JSON. That was because the text that `dict()` produces is not JSON :)
