### PR TITLE
Change OL URL to 0.0.0.0 so Solr updater can reach the local OL site

### DIFF
--- a/conf/init/ol-solr-updater.conf
+++ b/conf/init/ol-solr-updater.conf
@@ -7,4 +7,4 @@ stop on runlevel [!2345]
 chdir /vagrant
 respawn
 
-exec sudo -u vagrant python scripts/new-solr-updater.py -c /vagrant/conf/openlibrary.yml --state-file /vagrant/solr-update.offset --ol-url http://localhost/
+exec sudo -u vagrant python scripts/new-solr-updater.py -c /vagrant/conf/openlibrary.yml --state-file /vagrant/solr-update.offset --ol-url http://0.0.0.0/


### PR DESCRIPTION
When adding a book on a development instance of OL, the service ol-solr-updater tries to load updated records from the URL given on the commandline, which should have been `http://localhost:8080/` or `http://0.0.0.0/`.