### PR TITLE
Replace 'assert' statements with 'if/else' and other 'try/except' statements (fixes internetarchive#191)

### DIFF
--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -1,6 +1,10 @@
+import logging
+
+logger = logging.getLogger("openlibrary")
+
 def check_digit_10(isbn):
     if len(isbn) != 9:
-        raise ValueError
+        raise ValueError("%s is not a valid ISBN 10" % isbn)
     sum = 0
     for i in range(len(isbn)):
         c = int(isbn[i])
@@ -33,8 +37,9 @@ def isbn_13_to_isbn_10(isbn_13):
         if len(isbn_13) != 13 or not isbn_13.isdigit()\
         or not isbn_13.startswith('978')\
         or check_digit_13(isbn_13[:-1]) != isbn_13[-1]:
-            raise ValueError
-    except ValueError:
+            raise ValueError("%s is not a valid ISBN 13" % isbn_13)
+    except ValueError as e:
+        logger.info("Exception caught in ISBN transformation: %s" % e)
         return
     return isbn_13[3:-1] + check_digit_10(isbn_13[3:-1])
 
@@ -43,8 +48,9 @@ def isbn_10_to_isbn_13(isbn_10):
     try:
         if len(isbn_10) != 10 or not isbn_10[:-1].isdigit()\
         or check_digit_10(isbn_10[:-1]) != isbn_10[-1]:
-            raise ValueError
-    except ValueError:
+            raise ValueError("%s is not a valid ISBN 10" % isbn_10)
+    except ValueError as e:
+        logger.info("Exception caught in ISBN transformation: %s" % e)
         return
     isbn_13 = '978' + isbn_10[:-1]
     return isbn_13 + check_digit_13(isbn_13)


### PR DESCRIPTION
As described in internetarchive#191, exceptions raised when `assert` fails may be bypassed when Python is run with specific flags. This code raises `ValueError`s, caught in the same places as before, but they are logged in the `openlibrary` log instead of silently ignored.
