### PR TITLE
updated  /etc/init/ol-solr-updater.conf with a valid location for the config file

### DIFF
--- a/conf/init/ol-solr-updater.conf
+++ b/conf/init/ol-solr-updater.conf
@@ -7,4 +7,4 @@ stop on runlevel [!2345]
 chdir /openlibrary
 respawn
 
-exec sudo -u vagrant python scripts/new-solr-updater.py -c /vagrant/conf/openlibrary.yml --state-file /vagrant/solr-update.offset --ol-url http://localhost/
+exec sudo -u vagrant python scripts/new-solr-updater.py -c /openlibrary/conf/openlibrary.yml --state-file /openlibrary/solr-update.offset --ol-url http://localhost/


### PR DESCRIPTION
the /etc/init/ol-solr-updater.conf file contains invalid conf file locations that causes the solr updater to fail immediately, as in https://github.com/internetarchive/openlibrary/pull/218#issuecomment-69619680

updated with the correct one.