### PR TITLE
Fixed "checkouts caught in loop" issue.

### DIFF
--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -186,10 +186,7 @@ def get_waitinglist_for_book(book_key):
 def get_waitinglist_size(book_key):
     """Returns size of the waiting list for given book.
     """
-    key = "ebooks" + book_key
-    ebook = web.ctx.site.store.get(key) or {}
-    size = ebook.get("wl_size", 0)
-    return int(size)
+    return len(get_waitinglist_for_book(book_key))
 
 def get_waitinglist_for_user(user_key):
     """Returns the list of records for all the books that a user is waiting for.


### PR DESCRIPTION
The get_waitinglist_size() function was always returnsing 0 as it was looking
for size of waitinglists stored in OL instead of querying archive.org. Updated
that function to return correct size.