### PR TITLE
Fix tests to allow Travis CI to pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ install_solr:
 
 setup_coverstore:
 	@echo "** setting up coverstore **"
-	env/bin/python scripts/setup_dev_instance.py --setup-coverstore
+	$(PYTHON) scripts/setup_dev_instance.py --setup-coverstore
 
 setup_ol: git
 	@echo "** setting up openlibrary webapp **"
-	env/bin/python scripts/setup_dev_instance.py --setup-ol
+	$(PYTHON) scripts/setup_dev_instance.py --setup-ol
 	@# When bootstrapping, PYTHON will not be env/bin/python as env dir won't be there when make is invoked.
 	@# Invoking make again to pick the right PYTHON.
 	make all
@@ -74,7 +74,7 @@ run:
 
 load_sample_data:
 	@echo "loading sample docs from openlibrary.org website"
-	env/bin/python scripts/copydocs.py --list /people/anand/lists/OL1815L
+	$(PYTHON) scripts/copydocs.py --list /people/anand/lists/OL1815L
 	curl http://localhost:8080/_dev/process_ebooks # hack to show books in returncart
 
 destroy:

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ setup_ol: git
 bootstrap: venv install_solr setup_coverstore setup_ol
 	
 run:
-	env/bin/python scripts/openlibrary-server conf/openlibrary.yml
+	$(PYTHON) scripts/openlibrary-server conf/openlibrary.yml
 
 load_sample_data:
 	@echo "loading sample docs from openlibrary.org website"

--- a/openlibrary/core/tests/test_waitinglist.py
+++ b/openlibrary/core/tests/test_waitinglist.py
@@ -3,19 +3,22 @@ from openlibrary.core import db
 import web
 import datetime
 import json
+import pytest
 
+@pytest.mark.xfail(run=False)
 class TestWaitingLoan:
     def setup_method(self, method):
         web.config.db_parameters = dict(dbn='postgres', db='oltest')
-        db.query("TRUNCATE waitingloan")
+        #db.query("TRUNCATE waitingloan")
 
     def test_new(self):
         book_key = '/books/OL1234M'
         user_key = '/people/user1'
-        WaitingLoan.new(book_key=book_key, 
-                        user_key=user_key)
+        identifier = '/books/OL1234M'
+        w = WaitingLoan.new(book_key=book_key,
+                        user_key=user_key,
+                        identifier=identifier)
         
-        w = WaitingLoan.find(book_key=book_key, user_key=user_key)
         assert w is not None
         assert w['status'] == 'waiting'
         assert w['book_key'] == book_key

--- a/openlibrary/core/tests/test_waitinglist.py
+++ b/openlibrary/core/tests/test_waitinglist.py
@@ -4,56 +4,38 @@ import web
 import datetime
 import json
 import pytest
+from .. import lending
 
-@pytest.mark.xfail(run=False)
 class TestWaitingLoan:
-    def setup_method(self, method):
-        web.config.db_parameters = dict(dbn='postgres', db='oltest')
-        #db.query("TRUNCATE waitingloan")
-
-    def test_new(self):
-        book_key = '/books/OL1234M'
+    def test_new(self, monkeypatch):
         user_key = '/people/user1'
-        identifier = '/books/OL1234M'
-        w = WaitingLoan.new(book_key=book_key,
-                        user_key=user_key,
+        identifier = 'foobar'
+        monkeypatch.setattr(lending.ia_lending_api, "query", lambda **kw: [({'status': 'waiting'})])
+        # POSTs to api to add to waiting list, then queries ia_lending_api for the result
+        w = WaitingLoan.new(user_key=user_key,
                         identifier=identifier)
-        
         assert w is not None
         assert w['status'] == 'waiting'
-        assert w['book_key'] == book_key
-        assert w['user_key'] == user_key
-        assert isinstance(w['since'], datetime.datetime)
-        assert isinstance(w['last_update'], datetime.datetime)
-        assert w['expiry'] is None
-        assert w['available_email_sent'] is False
 
+    @pytest.mark.xfail(run=False)
     def test_update(self):
-        w = WaitingLoan.new(user_key="U1", book_key="B1")
+        w = WaitingLoan.new(user_key="U1", identifier="B1")
         assert w['status'] == 'waiting'
         w.update(status='avaialble')
         assert w['status'] == 'avaialble'
 
-        w2 = WaitingLoan.find(user_key="U1", book_key="B1")
+        w2 = WaitingLoan.find(user_key="U1", identifier="B1")
         assert w2['status'] == 'avaialble'
 
+    @pytest.mark.xfail(run=False)
     def test_dict(self):
         user_key = '/people/user1'
         book_key = '/books/OL1234M'
-        w = WaitingLoan.new(user_key=user_key, book_key=book_key)
+        w = WaitingLoan.new(user_key=user_key, identifier=book_key)
         # ensure that w.dict() is JSON-able
         json.dumps(w.dict())
 
     def test_prune_expired(self):
-        now = datetime.datetime.utcnow()
-        day = datetime.timedelta(days=1)
+        # prune_expired does nothing now but 'return'
+        assert WaitingLoan.prune_expired() == None
 
-        # no expiry specified, should not be deleted.
-        w1 = WaitingLoan.new(user_key="U1", book_key="B1")
-        # going to expire in one more day
-        w2 = WaitingLoan.new(user_key="U2", book_key="B2", expiry=now+day)
-        # already expired one day ago
-        w3 = WaitingLoan.new(user_key="U3", book_key="B3", expiry=now-day)
-
-        assert WaitingLoan.prune_expired() == [w3]
-        assert WaitingLoan.query() == [w1, w2]

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -216,7 +216,7 @@ def get_waitinglist_position(user_key, book_key):
 def join_waitinglist(user_key, book_key):
     """Adds a user to the waiting list of given book.
 
-    It is done by createing a new record in the store.
+    It is done by creating a new record in the store.
     """
     book = web.ctx.site.get(book_key)
     if book and book.ocaid:

--- a/openlibrary/plugins/upstream/tests/test_forms.py
+++ b/openlibrary/plugins/upstream/tests/test_forms.py
@@ -2,7 +2,7 @@ from .. import forms
 from .. import spamcheck
 
 class TestRegister:
-    def test_leaks(slef):
+    def test_leaks(self):
         f = forms.Register()
         assert f.displayname.value is None 
         f.displayname.value = 'Foo'

--- a/openlibrary/plugins/upstream/tests/test_forms.py
+++ b/openlibrary/plugins/upstream/tests/test_forms.py
@@ -1,5 +1,5 @@
 from .. import forms
-
+from .. import spamcheck
 
 class TestRegister:
     def test_leaks(slef):
@@ -12,6 +12,7 @@ class TestRegister:
 
     def test_validate(self, monkeypatch):
         monkeypatch.setattr(forms, 'find_account', lambda **kw: None)
+        monkeypatch.setattr(spamcheck, "get_spam_domains", lambda: {})
 
         f = forms.Register()
         d = {

--- a/openlibrary/plugins/upstream/tests/test_forms.py
+++ b/openlibrary/plugins/upstream/tests/test_forms.py
@@ -12,7 +12,7 @@ class TestRegister:
 
     def test_validate(self, monkeypatch):
         monkeypatch.setattr(forms, 'find_account', lambda **kw: None)
-        monkeypatch.setattr(spamcheck, "get_spam_domains", lambda: {})
+        monkeypatch.setattr(spamcheck, "get_spam_domains", lambda: [])
 
         f = forms.Register()
         d = {


### PR DESCRIPTION
I have just started playing with the Open Library codebase, and this is my attempt to get the tests passing on Travis after successfully setting up a vagrant dev instance.

This is started as an effort to solve issue https://github.com/internetarchive/openlibrary/issues/236

I found 2 causes of failing tests:

1. It looks like the waitinglists were moved from the local db to an external api here: https://github.com/internetarchive/openlibrary/commit/b2703037996d7947653caecd1337858aaf0823f7
but the tests were not updated to reflect this.
These waitinglist tests should either be removed or updated if this PR passes.

2. The forms validate test was erroring with `AttributeError: 'site'` from 
```
    def get_spam_domains():
>       doc = web.ctx.site.store.get("spamwords") or {}

openlibrary/plugins/upstream/spamcheck.py:8: 
```
I patched the test to avoid making the request.

~~I'm not sure if there is a further travis configuration problem with the tests, the history of failed PRs shows some that failed with the `fatal: Couldn't find remote ref refs/pull/249/merge` style errors, and others that failed on the test results. I'm hoping this PR might clear that up.~~
**UPDATE** These changes allow the CI tests to pass, so the Travis config is fine.


