### PR TITLE
Rebased PR 136: RDF changes: consistent URIs without trailing "/", more FOAF, rdf:about=""

### DIFF
--- a/openlibrary/templates/type/author/rdf.html
+++ b/openlibrary/templates/type/author/rdf.html
@@ -27,7 +27,7 @@ $def with (author)
             <$tag>$value</$tag>
             
 
-    <foaf:Person rdf:about="http://openlibrary.org$author.key">
+    <foaf:Person rdf:about="$auri">
         $:display("foaf:name", name)
         $:display("rdg2:variantNameForThePerson", author.alternate_names)
         $:display("rdg2:biographicalInformation", author.bio)
@@ -70,7 +70,7 @@ $def with (author)
     </foaf:Person>
 
     <!-- administrative -->
-    <rdf:Description rdf:about="$auAbout">
+    <rdf:Description rdf:about="">
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$author.last_modified</dcterms:modified>
         <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$author.created</dcterms:created>
         <ov:versionnumber>$author.revision</ov:versionnumber>

--- a/openlibrary/templates/type/author/rdf.html
+++ b/openlibrary/templates/type/author/rdf.html
@@ -15,7 +15,7 @@ $def with (author)
     $else:
         $ name = author.name
 
-    $ auri = "http://openlibrary.org" + author.key + "/"
+    $ auri = "http://openlibrary.org" + author.key
     $ auAbout = "http://openlibrary.org" + author.key + "/about/"
 
 

--- a/openlibrary/templates/type/author/rdf.html
+++ b/openlibrary/templates/type/author/rdf.html
@@ -27,7 +27,7 @@ $def with (author)
             <$tag>$value</$tag>
             
 
-    <foaf:Person rdf:about="$auri">
+    <foaf:Agent rdf:about="$auri">
         $:display("foaf:name", name)
         $:display("rdg2:variantNameForThePerson", author.alternate_names)
         $:display("rdg2:biographicalInformation", author.bio)
@@ -67,7 +67,7 @@ $def with (author)
             <foaf:depiction>
             <foaf:Image rdf:about="$auphoto" /></foaf:depiction>
 
-    </foaf:Person>
+    </foaf:Agent>
 
     <!-- administrative -->
     <rdf:Description rdf:about="">

--- a/openlibrary/templates/type/author/rdf.html
+++ b/openlibrary/templates/type/author/rdf.html
@@ -16,7 +16,6 @@ $def with (author)
         $ name = author.name
 
     $ auri = "http://openlibrary.org" + author.key
-    $ auAbout = "http://openlibrary.org" + author.key + "/about/"
 
 
     $def display(tag, value):
@@ -27,7 +26,7 @@ $def with (author)
             <$tag>$value</$tag>
             
 
-    <foaf:Agent rdf:about="$auri">
+    <foaf:Person rdf:about="$auri">
         $:display("foaf:name", name)
         $:display("rdg2:variantNameForThePerson", author.alternate_names)
         $:display("rdg2:biographicalInformation", author.bio)
@@ -39,40 +38,40 @@ $def with (author)
                  <dcterms:date>$author.birth_date</dcterms:date>
             </bio:Birth>
         </bio:event>
-
+      
       $if author.death_date:
         <bio:event>
             <bio:Death>
                 <dcterms:date>$author.death_date</dcterms:date>
             </bio:Death>
-        </bio:event> 
+        </bio:event>
 
+      $if author.wikipedia:
+        <foaf:isPrimaryTopicOf>
+            <foaf:Document rdf:about="$author.wikipedia">
+                <rdfs:label>Wikipedia</rdfs:label>
+            </foaf:Document>
+        </foaf:isPrimaryTopicOf>
 
-        $if author.wikipedia:
-            <foaf:isPrimaryTopicOf>
-                <foaf:Document rdf:about="$author.wikipedia">
-                    <rdfs:label>Wikipedia</rdfs:label>
-                </foaf:Document>
-            </foaf:isPrimaryTopicOf>
+      $for link in author.links:
+        <foaf:page>
+            <foaf:Document rdf:about="$link.url">
+                <rdfs:label>$link.title</rdfs:label>
+            </foaf:Document>
+        </foaf:page>
+      
+      $for photo in author.photos:    
+        $ auphoto = "http://covers.openlibrary.org/b/id/" + str(photo) + "-M.jpg"
+        <foaf:depiction>
+            <foaf:Image rdf:about="$auphoto" />
+        </foaf:depiction>
 
-        $for link in author.links:
-            <foaf:page>
-                <foaf:Document rdf:about="$link.url">
-                    <rdfs:label>$link.title</rdfs:label>
-                </foaf:Document>
-            </foaf:page>
-        
-        $for photo in author.photos:    
-            $ auphoto = "http://covers.openlibrary.org/b/id/" + str(photo) + "-M.jpg"
-            <foaf:depiction>
-            <foaf:Image rdf:about="$auphoto" /></foaf:depiction>
-
-    </foaf:Agent>
+    </foaf:Person>
 
     <!-- administrative -->
     <rdf:Description rdf:about="">
-        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$author.last_modified</dcterms:modified>
-        <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$author.created</dcterms:created>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$author.last_modified.isoformat()</dcterms:modified>
+        <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$author.created.isoformat()</dcterms:created>
         <ov:versionnumber>$author.revision</ov:versionnumber>
     </rdf:Description>
 </rdf:RDF>

--- a/openlibrary/templates/type/author/rdf.html
+++ b/openlibrary/templates/type/author/rdf.html
@@ -38,7 +38,7 @@ $def with (author)
                  <dcterms:date>$author.birth_date</dcterms:date>
             </bio:Birth>
         </bio:event>
-      
+
       $if author.death_date:
         <bio:event>
             <bio:Death>

--- a/openlibrary/templates/type/edition/rdf.html
+++ b/openlibrary/templates/type/edition/rdf.html
@@ -18,7 +18,6 @@ $def with (book)
     $else:
         $ title = book.title
 
-    $ bookID = book.key
     $if book.pagination:
         $ pages = book.pagination
     $else:
@@ -27,7 +26,6 @@ $def with (book)
     $ work = book.works and book.works[0]
     $if work:
         $ authors = work.get_authors()
-        $ workID = work.key
     $else:
         $ authors = book.get_authors()
 
@@ -40,15 +38,14 @@ $def with (book)
         $elif value:
             <$tag>$value</$tag>
 
-    <rdf:Description rdf:about="http://openlibrary.org$bookID">
+    <rdf:Description rdf:about="http://openlibrary.org$book.key">
         $if work:
-            <rdrel:workManifested rdf:resource="http://openlibrary.org$workID"/>
+            <rdrel:workManifested rdf:resource="http://openlibrary.org$work.key"/>
 
         <!-- authors -->
         <bibo:authorList rdf:parseType="Collection">
           $for a in authors:
-              $ aID = a.key
-              <rdf:Description rdf:about="http://openlibrary.org$aID">
+              <rdf:Description rdf:about="http://openlibrary.org$a.key">
                  <foaf:name>$a.name</foaf:name>
               </rdf:Description>
         </bibo:authorList>

--- a/openlibrary/templates/type/edition/rdf.html
+++ b/openlibrary/templates/type/edition/rdf.html
@@ -18,7 +18,7 @@ $def with (book)
     $else:
         $ title = book.title
 
-    $ bookID = book.key
+    $ bookID = book.key + "/"
     $if book.pagination:
         $ pages = book.pagination
     $else:
@@ -27,6 +27,7 @@ $def with (book)
     $ work = book.works and book.works[0]
     $if work:
         $ authors = work.get_authors()
+        $ workID = work.key + "/"
     $else:
         $ authors = book.get_authors()
 
@@ -41,11 +42,13 @@ $def with (book)
 
     <rdf:Description rdf:about="http://openlibrary.org$bookID">
         $if work:
-        <rdrel:workManifested rdf:resource="http://openlibrary.org$work.key"/>
+            <rdrel:workManifested rdf:resource="http://openlibrary.org/works/$workID"/>
+
         <!-- authors -->
         <bibo:authorList rdf:parseType="Collection">
           $for a in authors:
-              <rdf:Description rdf:about="http://openlibrary.org$a.key">
+              $ aID = a.key + "/"
+              <rdf:Description rdf:about="http://openlibrary.org$aID">
                  <foaf:name>$a.name</foaf:name>
               </rdf:Description>
         </bibo:authorList>

--- a/openlibrary/templates/type/edition/rdf.html
+++ b/openlibrary/templates/type/edition/rdf.html
@@ -18,7 +18,7 @@ $def with (book)
     $else:
         $ title = book.title
 
-    $ bookID = book.key + "/"
+    $ bookID = book.key
     $if book.pagination:
         $ pages = book.pagination
     $else:
@@ -27,7 +27,7 @@ $def with (book)
     $ work = book.works and book.works[0]
     $if work:
         $ authors = work.get_authors()
-        $ workID = work.key + "/"
+        $ workID = work.key
     $else:
         $ authors = book.get_authors()
 
@@ -47,7 +47,7 @@ $def with (book)
         <!-- authors -->
         <bibo:authorList rdf:parseType="Collection">
           $for a in authors:
-              $ aID = a.key + "/"
+              $ aID = a.key
               <rdf:Description rdf:about="http://openlibrary.org$aID">
                  <foaf:name>$a.name</foaf:name>
               </rdf:Description>

--- a/openlibrary/templates/type/edition/rdf.html
+++ b/openlibrary/templates/type/edition/rdf.html
@@ -46,7 +46,7 @@ $def with (book)
         <bibo:authorList rdf:parseType="Collection">
           $for a in authors:
               <rdf:Description rdf:about="http://openlibrary.org$a.key">
-                 <rdf:value>$a.name</rdf:value>
+                 <foaf:name>$a.name</foaf:name>
               </rdf:Description>
         </bibo:authorList>
         $if contributors:
@@ -90,7 +90,9 @@ $def with (book)
         $:display("bibo:lccn", book.lccn)
         $:display("bibo:isbn10", book.isbn_10)
         $:display("bibo:isbn13", book.isbn_13)
+    </rdf:Description>
         <!-- administrative -->
+    <rdf:Description rdf:about="">
         $:display("dcterms:modified", book.last_modified)
     </rdf:Description>
 </rdf:RDF>

--- a/openlibrary/templates/type/edition/rdf.html
+++ b/openlibrary/templates/type/edition/rdf.html
@@ -42,7 +42,7 @@ $def with (book)
 
     <rdf:Description rdf:about="http://openlibrary.org$bookID">
         $if work:
-            <rdrel:workManifested rdf:resource="http://openlibrary.org/works/$workID"/>
+            <rdrel:workManifested rdf:resource="http://openlibrary.org$workID"/>
 
         <!-- authors -->
         <bibo:authorList rdf:parseType="Collection">

--- a/openlibrary/templates/type/edition/rdf.html
+++ b/openlibrary/templates/type/edition/rdf.html
@@ -14,7 +14,7 @@ $def with (book)
   xmlns:foaf='http://xmlns.com/foaf/0.1/'
 >
     $if book.subtitle:
-        $ title = book.title + " " + book.subtitle
+        $ title = book.title + ": " + book.subtitle
     $else:
         $ title = book.title
 
@@ -44,15 +44,15 @@ $def with (book)
 
         <!-- authors -->
         <bibo:authorList rdf:parseType="Collection">
-          $for a in authors:
-              <rdf:Description rdf:about="http://openlibrary.org$a.key">
-                 <foaf:name>$a.name</foaf:name>
-              </rdf:Description>
+        $for a in authors:
+            <rdf:Description rdf:about="http://openlibrary.org$a.key">
+                <foaf:name>$a.name</foaf:name>
+            </rdf:Description>
         </bibo:authorList>
         $if contributors:
             <bibo:contributorList rdf:parseType="Collection">
             $for c in contributors:
-                 <foaf:Person><foaf:name>$c.name</foaf:name></foaf:Person>
+                <foaf:Agent><foaf:name>$c.name</foaf:name></foaf:Agent>
             </bibo:contributorList>
         $:display("dcterms:contributor", book.contributions)
         <!-- bibliographic description -->
@@ -65,20 +65,20 @@ $def with (book)
         $:display("bibo:edition", book.edition_name)
         <!-- subjects -->
         $:display("dc:subject", book.subjects)
-        $for DDC in book.dewey_decimal_class:
-            <dcterms:subject>
-                <rdf:Description>
-                    <dcam:memberOf rdf:resource="http://purl.org/dc/terms/DDC"/>
-                    <rdf:value>$DDC</rdf:value>
-                </rdf:Description>
-            </dcterms:subject>
-        $for LCC in book.lc_classifications:
-             <dcterms:subject>
-                <rdf:Description>
-                    <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCC"/>
-                    <rdf:value>$LCC</rdf:value>
-                </rdf:Description>
-            </dcterms:subject>
+      $for DDC in book.dewey_decimal_class:
+        <dcterms:subject>
+            <rdf:Description>
+                <dcam:memberOf rdf:resource="http://purl.org/dc/terms/DDC"/>
+                <rdf:value>$DDC</rdf:value>
+            </rdf:Description>
+        </dcterms:subject>
+      $for LCC in book.lc_classifications:
+        <dcterms:subject>
+            <rdf:Description>
+                <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCC"/>
+                <rdf:value>$LCC</rdf:value>
+            </rdf:Description>
+        </dcterms:subject>
         <!-- description -->
         $:display("dcterms:description", book.description)
         $:display("rdvocab:note", book.notes)
@@ -91,8 +91,10 @@ $def with (book)
         $:display("bibo:isbn10", book.isbn_10)
         $:display("bibo:isbn13", book.isbn_13)
     </rdf:Description>
-        <!-- administrative -->
+    <!-- administrative -->
     <rdf:Description rdf:about="">
-        $:display("dcterms:modified", book.last_modified)
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$book.last_modified.isoformat()</dcterms:modified>
+        <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$book.created.isoformat()</dcterms:created>
+        <ov:versionnumber>$book.revision</ov:versionnumber>
     </rdf:Description>
 </rdf:RDF>

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -8,6 +8,7 @@ $def with (work)
   xmlns:dcam='http://purl.org/dc/dcam/'
   xmlns:ov='http://open.vocab.org/terms/'
   xmlns:frbr='http://purl.org/vocab/frbr/core#'
+  xmlns:foaf='http://xmlns.com/foaf/0.1/'
 >
 
     $ wuri = "http://openlibrary.org" + work.key
@@ -31,7 +32,7 @@ $def with (work)
         $for a in work.authors:
             <dcterms:creator>
               <rdf:Description rdf:about="http://openlibrary.org$a.author.key">
-              <rdf:value>$a.author.name</rdf:value> 
+              <foaf:name>$a.author.name</foaf:name> 
               </rdf:Description>
             </dcterms:creator> 
        
@@ -83,7 +84,7 @@ $def with (work)
 
     
     <!-- administrative -->
-    <rdf:Description rdf:about="$wAbout">
+    <rdf:Description rdf:about="">
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$work.last_modified</dcterms:modified>
         <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$work.created</dcterms:created>
         <ov:versionnumber>$work.revision</ov:versionnumber>

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -11,7 +11,7 @@ $def with (work)
   xmlns:foaf='http://xmlns.com/foaf/0.1/'
 >
 
-    $ wuri = "http://openlibrary.org" + work.key
+    $ wuri = "http://openlibrary.org" + work.key + "/"
     $ wAbout = "http://openlibrary.org" + work.key + "/about/"
 
     $if work.subtitle:
@@ -30,8 +30,9 @@ $def with (work)
         $:display("dcterms:title", title)
 
         $for a in work.authors:
+            $ aID = a.author.key + "/"
             <dcterms:creator>
-              <rdf:Description rdf:about="http://openlibrary.org$a.author.key">
+              <rdf:Description rdf:about="http://openlibrary.org$aID">
               <foaf:name>$a.author.name</foaf:name> 
               </rdf:Description>
             </dcterms:creator> 
@@ -70,7 +71,7 @@ $def with (work)
         </frbr:Work> 
 
         $for edition in work.editions:
-            $ eduri = "http://openlibrary.org" + edition.key
+            $ eduri = "http://openlibrary.org" + edition.key + "/"
             $if edition.subtitle:
                $ etitle = edition.title + ": " + edition.subtitle
             $else:

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -12,7 +12,6 @@ $def with (work)
 >
 
     $ wuri = "http://openlibrary.org" + work.key
-    $ wAbout = "http://openlibrary.org" + work.key + "/about/"
 
     $if work.subtitle:
            $ title = work.title + ": " + work.subtitle
@@ -29,64 +28,62 @@ $def with (work)
     <frbr:Work rdf:about="$wuri">
         $:display("dcterms:title", title)
 
-        $for a in work.authors:
-            <dcterms:creator>
-              <rdf:Description rdf:about="http://openlibrary.org$a.author.key">
-              <foaf:name>$a.author.name</foaf:name> 
-              </rdf:Description>
-            </dcterms:creator> 
-       
+      $for a in work.authors:
+        <dcterms:creator>
+            <rdf:Description rdf:about="http://openlibrary.org$a.author.key">
+                <foaf:name>$a.author.name</foaf:name>
+            </rdf:Description>
+        </dcterms:creator>
        
         $:display("dcterms:subject", work.subjects)
         $:display("dcterms:coverage", work.subject_places)
         $:display("dcterms:coverage", work.subject_times)
         $:display("dcterms:description", work.description)
 
-        $for DDC in work.dewey_number:   
-            <dcterms:subject>
-                <rdf:Description>
+      $for DDC in work.dewey_number:   
+        <dcterms:subject>
+            <rdf:Description>
                 <dcam:memberOf rdf:resource="http://purl.org/dc/terms/DDC"/>
                 <rdf:value>$DDC</rdf:value>
             </rdf:Description>
-            </dcterms:subject>
-        $for LCC in work.lc_classifications:
-            <dcterms:subject>
-                <rdf:Description>
-                    <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCC"/>
-                    <rdf:value>$LCC</rdf:value>
-                </rdf:Description>
-            </dcterms:subject>
+        </dcterms:subject>
+      $for LCC in work.lc_classifications:
+        <dcterms:subject>
+            <rdf:Description>
+                <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCC"/>
+                <rdf:value>$LCC</rdf:value>
+            </rdf:Description>
+        </dcterms:subject>
 
         $:display("dcterms:date", work.first_publish_date)
 
         $:display("dcterms:alternative", work.other_titles) 
 
-        $for link in work.links:
-            <foaf:page>
-                <foaf:Document rdf:about="$link.url">
-                    <rdfs:label>$link.title</rdfs:label>
-                </foaf:Document>
-            </foaf:page>
-        </frbr:Work> 
+      $for link in work.links:
+        <foaf:page>
+            <foaf:Document rdf:about="$link.url">
+                <rdfs:label>$link.title</rdfs:label>
+            </foaf:Document>
+        </foaf:page>
+    </frbr:Work> 
 
-        $for edition in work.editions:
-            $ eduri = "http://openlibrary.org" + edition.key
-            $if edition.subtitle:
-               $ etitle = edition.title + ": " + edition.subtitle
-            $else:
-              $ etitle = edition.title
+    $for edition in work.editions:
+        $ eduri = "http://openlibrary.org" + edition.key
+        $if edition.subtitle:
+            $ etitle = edition.title + ": " + edition.subtitle
+        $else:
+            $ etitle = edition.title
 
-            <rdf:Description rdf:about="$eduri">
-               <rdrel:workManifested rdf:resource="$wuri" />
-                <dcterms:title>$etitle</dcterms:title>
-                <dcterms:date>$edition.publish_date</dcterms:date>
-            </rdf:Description>    
+        <rdf:Description rdf:about="$eduri">
+            <rdrel:workManifested rdf:resource="$wuri" />
+            <dcterms:title>$etitle</dcterms:title>
+            <dcterms:date>$edition.publish_date</dcterms:date>
+        </rdf:Description>    
 
-    
     <!-- administrative -->
     <rdf:Description rdf:about="">
-        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$work.last_modified</dcterms:modified>
-        <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$work.created</dcterms:created>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$work.last_modified.isoformat()</dcterms:modified>
+        <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">$work.created.isoformat()</dcterms:created>
         <ov:versionnumber>$work.revision</ov:versionnumber>
     </rdf:Description>
 

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -30,9 +30,8 @@ $def with (work)
         $:display("dcterms:title", title)
 
         $for a in work.authors:
-            $ aID = a.author.key
             <dcterms:creator>
-              <rdf:Description rdf:about="http://openlibrary.org$aID">
+              <rdf:Description rdf:about="http://openlibrary.org$a.author.key">
               <foaf:name>$a.author.name</foaf:name> 
               </rdf:Description>
             </dcterms:creator> 

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -11,7 +11,7 @@ $def with (work)
   xmlns:foaf='http://xmlns.com/foaf/0.1/'
 >
 
-    $ wuri = "http://openlibrary.org" + work.key + "/"
+    $ wuri = "http://openlibrary.org" + work.key
     $ wAbout = "http://openlibrary.org" + work.key + "/about/"
 
     $if work.subtitle:
@@ -30,7 +30,7 @@ $def with (work)
         $:display("dcterms:title", title)
 
         $for a in work.authors:
-            $ aID = a.author.key + "/"
+            $ aID = a.author.key
             <dcterms:creator>
               <rdf:Description rdf:about="http://openlibrary.org$aID">
               <foaf:name>$a.author.name</foaf:name> 
@@ -71,7 +71,7 @@ $def with (work)
         </frbr:Work> 
 
         $for edition in work.editions:
-            $ eduri = "http://openlibrary.org" + edition.key + "/"
+            $ eduri = "http://openlibrary.org" + edition.key
             $if edition.subtitle:
                $ etitle = edition.title + ": " + edition.subtitle
             $else:

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -10,7 +10,7 @@ $def with (work)
   xmlns:frbr='http://purl.org/vocab/frbr/core#'
 >
 
-    $ wuri = "http://openlibrary.org" + work.key + "/"
+    $ wuri = "http://openlibrary.org" + work.key
     $ wAbout = "http://openlibrary.org" + work.key + "/about/"
 
     $if work.subtitle:
@@ -69,7 +69,7 @@ $def with (work)
         </frbr:Work> 
 
         $for edition in work.editions:
-            $ eduri = "http://openlibrary.org" + edition.key + "/"
+            $ eduri = "http://openlibrary.org" + edition.key
             $if edition.subtitle:
                $ etitle = edition.title + ": " + edition.subtitle
             $else:

--- a/openlibrary/templates/type/work/rdf.html
+++ b/openlibrary/templates/type/work/rdf.html
@@ -76,9 +76,7 @@ $def with (work)
               $ etitle = edition.title
 
             <rdf:Description rdf:about="$eduri">
-               <rdrel:workManifested>
-                  "$wuri"
-                 </rdrel:workManifested>
+               <rdrel:workManifested rdf:resource="$wuri" />
                 <dcterms:title>$etitle</dcterms:title>
                 <dcterms:date>$edition.publish_date</dcterms:date>
             </rdf:Description>    


### PR DESCRIPTION
@bencomp ,This is your PR https://github.com/internetarchive/openlibrary/pull/136 rebased against my recent test fix. I have not looked closely at the content of your changes, I have simply replayed your changes to the templates over the latest code and passing tests, I believe this is what you wanted to do for issue https://github.com/internetarchive/openlibrary/issues/223 ?

I did this quickly, and surprisingly smoothly. Someone who knows about the RDF issues should probably review to be sure I have not missed anything. The tests pass locally, and I manually checked that the `foaf:name` changes you made to the work rdf export were present in my dev instance, I have not tested the changes any further than that.

I realise the original PR was raised a long time ago, but I am re-raising this so at least your work is in a mergeable state, and you can continue from this point if you need to. I don't know RDF, but I do know git, I hope this helps!