### PR TITLE
Issue 227 List widget can create duplicate requests

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -162,7 +162,7 @@ class OpenLibrary:
         Open Library always limits the result to 1000 items due to
         performance issues. Pass limit=False to fetch all matching
         results by making multiple requests to the server. Please note
-        the an iterator is returned insted of list when limit=False is
+        that an iterator is returned instead of list when limit=False is
         passed.::
 
             >>> ol.query({'type': '/type/type', 'limit': 2}) #doctest: +SKIP

--- a/openlibrary/templates/admin/solr.html
+++ b/openlibrary/templates/admin/solr.html
@@ -8,7 +8,7 @@ $var title: Solr Admin
 </div>
 
 <div id="contentBody">
-	<div>Enter the keys of pages to be updates in OL search engine.<br/>
+	<div>Enter the keys of pages to be updated in OL search engine.<br/>
 
 	Example:
 	<pre>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -290,7 +290,7 @@ $if ctx.user:
     }
     
     function setup_submit_event() {
-        // This form in creted only at the begining. 
+        // This form in created only at the beginning. 
         // Unlike other elements, event for this form should be setup only once.
         \$("#new-list").ol_validate({
             submitHandler: function(form) {

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -185,29 +185,32 @@ $if ctx.user:
     // Lists API
 
     Lists = {
-        create: function(user, data, success) {
+        create: function(user, data, success, complete) {
             this.ajax({
                 url: user + "/lists.json",
                 data: data,
-                success: success
+                success: success,
+                complete: complete
             });
         },
-        add: function(list_key, seed, success) {
+        add: function(list_key, seed, success, complete) {
             this.ajax({
                 url: list_key + "/seeds.json",
                 data: {
                     'add': [seed]
                 },
-                success: success
+                success: success,
+                complete: complete
             });
         },
-        remove: function(list_key, seed, success) {
+        remove: function(list_key, seed, success, complete) {
             this.ajax({
                 url: list_key + "/seeds.json",
                 data: {
                     'remove': [seed]
                 },
-                success: success
+                success: success,
+                complete: complete
             });
         },
     
@@ -223,7 +226,8 @@ $if ctx.user:
                     xhr.setRequestHeader("Content-Type", "application/json");
                     xhr.setRequestHeader("Accept", "application/json");
                 },
-                success: d.success
+                success: d.success,
+                complete: d.complete
             });
         }
     }
@@ -290,6 +294,9 @@ $if ctx.user:
         // Unlike other elements, event for this form should be setup only once.
         \$("#new-list").ol_validate({
             submitHandler: function(form) {
+                // disable form while waiting for response
+                \$("#new-list button").attr("disabled", true);
+      
                 var data = {
                     name: \$("#list_label").val(),
                     description: \$("#list_desc").val(),
@@ -312,6 +319,9 @@ $if ctx.user:
                     add_page_list(list);
 
                     reload_widget();
+                }, function(){
+                    // re-enable form now that the request is finished
+                    \$("#new-list button").attr("disabled", false);
                 });
                 return false;
             }
@@ -330,13 +340,16 @@ $if ctx.user:
             event.preventDefault();
             close_popup();
         
+            \$(this).unbind("click");   // ignore clicks while waiting for response
+
             var id = \$(this).attr("id");
             var list = get_list(id);
         
             Lists.add(list.key, seed, function() {
                 list.active = true;
                 add_page_list(list);
-                reload_widget();
+            }, function(){
+                reload_widget();    // reload widget regardless of success or failure
             });
             return false;
         });


### PR DESCRIPTION
Addresses #227 by disabling the list widget's list creation form after a request is submitted. The form is reenabled by adding a 'complete' callback to the ajax request. Also prevents adding an item to a list multiple times by disabling the add-list click event handler for that list while the request is pending.

Also included are some minor typo fixes