### PR TITLE
Paginate Admin People Edits view

### DIFF
--- a/openlibrary/templates/admin/people/edits.html
+++ b/openlibrary/templates/admin/people/edits.html
@@ -1,6 +1,11 @@
-$def with (account)
+$def with (account, limit=100, paginate=True)
 
 $var title: [Admin Center] Edits of $account.displayname
+
+$if paginate:
+    $ page = safeint(query_param('page', '1'))
+$else:
+    $ page = 1
 
 <div id="contentHead">
     $:render_template("admin/menu")
@@ -19,7 +24,7 @@ a.blocked-ip {
 }
 </style>
 
-$ changes = recentchanges(dict(author=account.get_user().key, limit=100, offset=0))
+$ changes = recentchanges(dict(author=account.get_user().key, limit=limit, offset=(page-1) * limit))
 
 $def call_template(name, change):
     $ t = get_template("recentchanges/" + change.kind + "/" + name) or get_template("recentchanges/default/" + name)
@@ -96,3 +101,11 @@ $def call_template(name, change):
 
 </form>
 </div>
+$if paginate:
+    <div class="historyPager small sansserif gray">
+        $if len(changes) == limit:
+            <a href="$:changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a>
+        $if page > 1:
+             &nbsp;|&nbsp;
+            <a href="$:changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
+    </div>

--- a/openlibrary/templates/admin/people/edits.html
+++ b/openlibrary/templates/admin/people/edits.html
@@ -1,4 +1,4 @@
-$def with (account, limit=100, paginate=True)
+$def with (account, paginate=True)
 
 $var title: [Admin Center] Edits of $account.displayname
 
@@ -6,6 +6,8 @@ $if paginate:
     $ page = safeint(query_param('page', '1'))
 $else:
     $ page = 1
+
+$ limit = safeint(query_param('limit', '100'))
 
 <div id="contentHead">
     $:render_template("admin/menu")

--- a/openlibrary/templates/admin/people/edits.html
+++ b/openlibrary/templates/admin/people/edits.html
@@ -102,7 +102,6 @@ $def call_template(name, change):
 </div>
 
 </form>
-</div>
 $if paginate:
     <div class="historyPager small sansserif gray">
         $if len(changes) == limit:
@@ -111,3 +110,4 @@ $if paginate:
              &nbsp;|&nbsp;
             <a href="$:changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
     </div>
+</div>


### PR DESCRIPTION
Hi @gdamdam, could you please review this change to an admin template?

This adds the ability to paginate the list of user edits in the admin interface. The new feature is the "Older | Newer" links at the bottom of this screenshot.
<img width="734" alt="screen shot 2015-11-23 at 22 24 51" src="https://cloud.githubusercontent.com/assets/905545/11333457/a17181a6-9232-11e5-9df8-f0aad1db8a7a.png">


Previously it was not possible to navigate to changes beyond the most recent 100, which meant for account blocks that error on automatic reverts, there was no way to check which edits were un-reverted beyond that.

I have also added the ability to manually specify a limit other than the default of 100 to assist with reverting larger sets of spam if needed.

example url:
`admin/people/<username>/edits?limit=10&page=2`

I have tested this locally with limited test data.