### PR TITLE
prevent deleted users from editing

### DIFF
--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -23,6 +23,11 @@ def _update_spam_doc(**kwargs):
     
 def is_spam(i=None):
     user = web.ctx.site.get_user()
+
+    # Prevent deleted users from making edits.
+    if user and user.type.key == '/type/delete':
+        return True
+
     email = user and user.get_email() or ""
     if is_spam_email(email):
         return True


### PR DESCRIPTION
If a spammer has been blocked _and_ reverted, it no longer registers as an account.
Deleted users return nothing for `user.get_account()`, and this was allowing the spamcheck to pass.

Active and Blocked users are `<Thing: u'/type/user'>`
but deleted users are `<Thing: u'/type/delete'>`

There is probably a way to pull all the logic together to catch all of the scenarios in a neater fashion. I'll look into it later.

