### PR TITLE
Stop ol-solr-updater from spinning

### DIFF
--- a/conf/init/ol-solr-updater.conf
+++ b/conf/init/ol-solr-updater.conf
@@ -6,5 +6,6 @@ stop on runlevel [!2345]
 
 chdir /openlibrary
 respawn
+respawn limit 10 5
 
 exec sudo -u vagrant python scripts/new-solr-updater.py -c /openlibrary/conf/openlibrary.yml --state-file /openlibrary/solr-update.offset --ol-url http://localhost/

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1789,7 +1789,8 @@ def load_configs(c_host,c_config,c_data_provider):
     conf_file = c_config
 
     global _ia_db
-    _ia_db = get_ia_db(config.runtime_config['ia_db']) 
+    if ('ia_db' in config.runtime_config.keys()):
+        _ia_db = get_ia_db(config.runtime_config['ia_db'])
 
     global data_provider
     if data_provider == None:


### PR DESCRIPTION
Since ia_db isn't defined in the config, update_work.py throws an exception causing upstart to continually respawn ol-solr-updater resulting in CPU thrashing as the process continuously respawns.

Solve the respawning problem by checking to see if the ia_db key exists in the first place, and protect against future respawn-storms with a respawn limit. This allows ol-solr-updater to start, although I don't have any idea what it does functionally to it (ie: does it still work in the devel vagrant image or just die somewhere else?).
