### PR TITLE
Don't show deleted authors or deleted items in Around The Library

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -587,9 +587,9 @@ def _get_recent_changes2():
 
     def is_ignored(c):
         return (
-            # Gio: c.kind=='update' allow us to ignore update recent changes on people
+            # c.kind=='update' allow us to ignore update recent changes on people
             c.kind == 'update' or
-            # Charles: ignore change if author has been deleted (e.g. spammer)
+            # ignore change if author has been deleted (e.g. spammer)
             (c.author and c.author.type.key == '/type/delete'))
 
     def render(c):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -589,7 +589,7 @@ def _get_recent_changes2():
         return (
             # Gio: c.kind=='update' allow us to ignore update recent changes on people
             c.kind == 'update' or
-            #Charles: ignore change if author has been deleted (spam)
+            # Charles: ignore change if author has been deleted (e.g. spammer)
             (c.author and c.author.type.key == '/type/delete'))
 
     def render(c):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -584,13 +584,19 @@ def _get_recent_changes2():
     
     q = {"bot": False, "limit": 100}
     changes = web.ctx.site.recentchanges(q)
-    
+
+    def is_ignored(c):
+        return (
+            # Gio: c.kind=='update' allow us to ignore update recent changes on people
+            c.kind == 'update' or
+            #Charles: ignore change if author has been deleted (spam)
+            (c.author and c.author.type.key == '/type/delete'))
+
     def render(c):
         t = get_template("recentchanges/" + c.kind + "/message") or get_template("recentchanges/default/message")
         return t(c)
 
-    # Gio: c.kind!='update' allow us to ignore update recent changes on people 
-    messages = [render(c) for c in changes if c.kind != 'update']
+    messages = [render(c) for c in changes if not is_ignored(c)]
     messages = [m for m in messages if str(m.get("ignore", "false")).lower() != "true"]
     return messages
     

--- a/openlibrary/templates/recentchanges/default/message.html
+++ b/openlibrary/templates/recentchanges/default/message.html
@@ -4,7 +4,6 @@ $if change.author:
     $ who = '<a href="%s" rel="nofollow">%s</a>' % (change.author.key, change.author.displayname or change.author.key)
 $else:
     $ who = None
-
 $if len(change.changes) == 1:
     $ doc = change.get_changes()[0]
     
@@ -29,5 +28,7 @@ $if len(change.changes) == 1:
     $else:
         $:what was $action anonymously
     <span class="timestamp">$when</span>
+    $if doc.type.key == '/type/delete':
+        $var ignore = True
 $else:
     $var ignore = True

--- a/openlibrary/templates/recentchanges/edit-book/message.html
+++ b/openlibrary/templates/recentchanges/edit-book/message.html
@@ -28,3 +28,6 @@ $elif who:
 $else:
     $:what was $action anonymously
 <span class="timestamp">$when</span>
+
+$if doc.type.key == '/type/delete':
+    $var ignore = True


### PR DESCRIPTION
This only affects the `recentchanges_v2` feature enabled recent changes.

I've added code in two places to make sure deleted / unwanted edits aren't advertised in the Around The Library footer. (generated via the message.html templates)

This won't affect the full Recent Changes page list though, I find it useful to see deleted records or spam if I go looking for it, we just shouldn't be advertising the spam / housekeeping edits on the front page!

