### PR TITLE
update travis config to use new container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
   postgresql: "9.3"
 python:
     - "2.7"
-#before_install:
-#    - sudo apt-get install -qq python-lxml python-yaml python-psycopg2 libgeoip-dev
 install: pip install -r test_requirements.txt
 before_script:
   - psql -c 'create database oltest' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: python
+sudo: false
 addons:
+  apt:
+    packages:
+      - libgeoip-dev
+      - python-lxml
+      - python-psycopg2
+      - python-yaml
   postgresql: "9.3"
 python:
     - "2.7"
-before_install:
-    - sudo apt-get install -qq python-lxml python-yaml python-psycopg2 libgeoip-dev
+#before_install:
+#    - sudo apt-get install -qq python-lxml python-yaml python-psycopg2 libgeoip-dev
 install: pip install -r test_requirements.txt
 before_script:
   - psql -c 'create database oltest' -U postgres


### PR DESCRIPTION
Looks like updating to the new travis infrastructure allows the tests to pass.

The previous
```
before_install:
    - sudo apt-get install -qq python-lxml python-yaml python-psycopg2 libgeoip-dev
```
section was giving problems, and the new way does not support use of `sudo`.

The upgrading guide was relatively straightforward: https://docs.travis-ci.com/user/migrating-from-legacy/

and all the required packages appear to be on the whitelist.