### PR TITLE
Issue #103, standardise subject search buttons

### DIFF
--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -29,7 +29,7 @@ $if q:
     
     <form class="siteSearch olform" action="">
         <input type="text" class="larger" name="q" size="100" style="width: 505px;" value="$q"/>
-        <button type="submit" class="larger">$_('Search')</button>
+        <input type="submit" class="large" value="$_('Search')"/>
     </form>
     
     </div>

--- a/openlibrary/templates/subjects/index.html
+++ b/openlibrary/templates/subjects/index.html
@@ -14,7 +14,7 @@ $var title: Subjects
 	    <h2 class="collapse"><label for="searchSubjects">Subject Search</label>  <span class="sansserif grey smaller">Try a keyword.</span></h2>
 	    <p>
 	        <input type="text" name="q" id="searchSubjects" size="100" class="larger" value=""/>
-	        <button type="submit" class="larger" name="search">Search</button>
+	        <input type="submit" class="large" value="Search"/>
 	    </p>
 	</form>
 	<div class="contentQuarter">


### PR DESCRIPTION
Remove the trailing `&search=` from the query mentioned in this issue https://github.com/internetarchive/openlibrary/issues/103

by bringing these template inline with those in `openlibrary/templates/search/*.html` and `openlibrary/templates/*/index.html`