### PR TITLE
Catch HTTP exceptions from key external dependencies

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -52,8 +52,11 @@ def setup(config):
     if config.get("content_server"):
         try:
             config_content_server = ContentServer(config.get("content_server"))
-        except:
-            pass
+        except Exception:
+            logger.error('Failed to assign config_content_server')
+    else:
+        logger.warn('content_server unassigned')
+
     config_loanstatus_url = config.get('loanstatus_url')
     config_ia_access_secret = config.get('ia_access_secret')
     config_bookreader_host = config.get('bookreader_host', 'archive.org')
@@ -569,13 +572,12 @@ class IA_Lending_API:
         logger.info("POST %s %s", IA_API_URL, params)
         params['token'] = config_ia_ol_shared_key
         payload = urllib.urlencode(params)
-        jsontext = urllib2.urlopen(IA_API_URL, payload).read()
-        logger.info("POST response: %s", jsontext)
         try:
+            jsontext = urllib2.urlopen(IA_API_URL, payload, timeout=3).read()
+            logger.info("POST response: %s", jsontext)
             return simplejson.loads(jsontext)
         except Exception:
             logger.error("POST failed", exc_info=True)
-            logger.info("jsontext=%s", jsontext)
             raise
 
 ia_lending_api = IA_Lending_API()

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -52,10 +52,10 @@ def setup(config):
     if config.get("content_server"):
         try:
             config_content_server = ContentServer(config.get("content_server"))
-        except Exception:
-            logger.error('Failed to assign config_content_server')
+        except Exception as e:
+            logger.exception('Failed to assign config_content_server')
     else:
-        logger.warn('content_server unassigned')
+        logger.error('content_server unassigned')
 
     config_loanstatus_url = config.get('loanstatus_url')
     config_ia_access_secret = config.get('ia_access_secret')
@@ -576,8 +576,8 @@ class IA_Lending_API:
             jsontext = urllib2.urlopen(IA_API_URL, payload, timeout=3).read()
             logger.info("POST response: %s", jsontext)
             return simplejson.loads(jsontext)
-        except Exception:
-            logger.error("POST failed", exc_info=True)
+        except Exception as e:
+            logger.exception("POST failed")
             raise
 
 ia_lending_api = IA_Lending_API()

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -50,7 +50,10 @@ def setup(config):
     global config_content_server, config_loanstatus_url, config_ia_access_secret, config_bookreader_host, config_ia_ol_shared_key
 
     if config.get("content_server"):
-        config_content_server = ContentServer(config.get("content_server"))
+        try:
+            config_content_server = ContentServer(config.get("content_server"))
+        except:
+            pass
     config_loanstatus_url = config.get('loanstatus_url')
     config_ia_access_secret = config.get('ia_access_secret')
     config_bookreader_host = config.get('bookreader_host', 'archive.org')

--- a/openlibrary/core/tests/test_waitinglist.py
+++ b/openlibrary/core/tests/test_waitinglist.py
@@ -10,7 +10,8 @@ class TestWaitingLoan:
     def test_new(self, monkeypatch):
         user_key = '/people/user1'
         identifier = 'foobar'
-        monkeypatch.setattr(lending.ia_lending_api, "query", lambda **kw: [({'status': 'waiting'})])
+        monkeypatch.setattr(lending.ia_lending_api, 'join_waitinglist', lambda identifier, userid: True)
+        monkeypatch.setattr(lending.ia_lending_api, 'query', lambda **kw: [({'status': 'waiting'})])
         # POSTs to api to add to waiting list, then queries ia_lending_api for the result
         w = WaitingLoan.new(user_key=user_key,
                         identifier=identifier)

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -52,10 +52,10 @@ class Recaptcha(web.form.Input):
             response=i.recaptcha_response_field,
             remoteip=web.ctx.ip)
 
-        # If HTTP call fails, let the user through
         try:
-            response = urllib2.urlopen('http://www.google.com/recaptcha/api/verify', urllib.urlencode(data), timeout=2).read()
+            response = urllib2.urlopen('http://www.google.com/recaptcha/api/verify', urllib.urlencode(data), timeout=3).read()
         except urllib2.URLError:
+            logger.error('Recaptcha call failed: letting user through')
             return True
 
         if '\n' in response:

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -3,6 +3,7 @@
 import web
 import urllib
 import urllib2
+import logging
 
 _recaptcha_html = """
 <script type="text/javascript">
@@ -55,7 +56,7 @@ class Recaptcha(web.form.Input):
         try:
             response = urllib2.urlopen('http://www.google.com/recaptcha/api/verify', urllib.urlencode(data), timeout=3).read()
         except urllib2.URLError:
-            logger.error('Recaptcha call failed: letting user through')
+            logging.getLogger("openlibrary").exception('Recaptcha call failed: letting user through')
             return True
 
         if '\n' in response:

--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -2,6 +2,7 @@
 
 import web
 import urllib
+import urllib2
 
 _recaptcha_html = """
 <script type="text/javascript">
@@ -51,7 +52,12 @@ class Recaptcha(web.form.Input):
             response=i.recaptcha_response_field,
             remoteip=web.ctx.ip)
 
-        response = urllib.urlopen('http://www.google.com/recaptcha/api/verify', urllib.urlencode(data)).read()
+        # If HTTP call fails, let the user through
+        try:
+            response = urllib2.urlopen('http://www.google.com/recaptcha/api/verify', urllib.urlencode(data), timeout=2).read()
+        except urllib2.URLError:
+            return True
+
         if '\n' in response:
             success, error = response.split('\n', 1)
             if success.lower() != 'true':

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -22,12 +22,12 @@ from utils import get_coverstore_url, MultiDict, parse_toc, get_edition_config
 import account
 import borrow
 
-def follow_redirect(doc):    
+def follow_redirect(doc):
     if isinstance(doc, basestring) and doc.startswith("/a/"):
         #Some edition records have authors as ["/a/OL1A""] insead of [{"key": "/a/OL1A"}].
         # Hack to fix it temporarily.
         doc = web.ctx.site.get(doc.replace("/a/", "/authors/"))
-    
+
     if doc and doc.type.key == "/type/redirect":
         key = doc.location
         return web.ctx.site.get(key)
@@ -41,20 +41,20 @@ class Edition(models.Edition):
             return self['title_prefix'] + ' ' + self['title']
         else:
             return self['title']
-            
+
     def get_title_prefix(self):
         return ''
 
     # let title be title_prefix + title
     title = property(get_title)
     title_prefix = property(get_title_prefix)
-    
+
     def get_authors(self):
         """Added to provide same interface for work and edition"""
         authors = [follow_redirect(a) for a in self.authors]
         authors = [a for a in authors if a and a.type.key == "/type/author"]
         return authors
-        
+
     def get_next(self):
         """Next edition of work"""
         if len(self.get('works', [])) != 1:
@@ -86,14 +86,14 @@ class Edition(models.Edition):
         if i == 0:
             return
         return editions[i - 1]
- 
+
     def get_covers(self):
         return [Image(self._site, 'b', c) for c in self.covers if c > 0]
-        
+
     def get_cover(self):
         covers = self.get_covers()
         return covers and covers[0] or None
-        
+
     def get_cover_url(self, size):
         cover = self.get_cover()
         if cover:
@@ -117,14 +117,14 @@ class Edition(models.Edition):
         #     some magic that lets us check this way (and breaks using hasattr to check if defined)
         if self._ia_meta_fields:
             return self._ia_meta_fields
-            
+
         if not self.get('ocaid', None):
             meta = {}
         else:
             meta = ia.get_meta_xml(self.ocaid)
             meta.setdefault("external-identifier", [])
             meta.setdefault("collection", [])
-        
+
         self._ia_meta_fields = meta
         return self._ia_meta_fields
 
@@ -138,25 +138,25 @@ class Edition(models.Edition):
 #      def is_lending_library(self):
 #         collections = self.get_ia_collections()
 #         return 'lendinglibrary' in collections
-        
+
     def get_lending_resources(self):
         """Returns the loan resource identifiers (in meta.xml format for ACS4 resources) for books hosted on archive.org
-        
+
         Returns e.g. ['bookreader:lettertoannewarr00west',
                       'acs:epub:urn:uuid:0df6f344-7ce9-4038-885e-e02db34f2891',
                       'acs:pdf:urn:uuid:7f192e62-13f5-4a62-af48-be4bea67e109']
         """
-        
+
         # The entries in meta.xml look like this:
         # <external-identifier>
         #     acs:epub:urn:uuid:0df6f344-7ce9-4038-885e-e02db34f2891
         # </external-identifier>
-        
+
         itemid = self.ocaid
         if not itemid:
             # Could be e.g. OverDrive
             return []
-        
+
         lending_resources = []
         # Check if available for in-browser lending - marked with 'browserlending' collection
         browserLendingCollections = ['browserlending']
@@ -166,41 +166,41 @@ class Edition(models.Edition):
                 break
 
         lending_resources.extend(self.get_ia_meta_fields()['external-identifier'])
-        
+
         return lending_resources
-        
+
     def get_lending_resource_id(self, type):
         if type == 'bookreader':
             desired = 'bookreader:'
         else:
             desired = 'acs:%s:' % type
-            
+
         for urn in self.get_lending_resources():
-            if urn.startswith(desired):            
-                # Got a match                
+            if urn.startswith(desired):
+                # Got a match
                 # $$$ a little icky - prune the acs:type if present
                 if urn.startswith('acs:'):
                     urn = urn[len(desired):]
-                    
+
                 return urn
 
         return None
-        
+
     def get_current_and_available_loans(self):
         current_loans = borrow.get_edition_loans(self)
         return (current_loans, self._get_available_loans(current_loans))
 
     def get_current_loans(self):
         return borrow.get_edition_loans(self)
-        
+
     def get_available_loans(self):
         """
         Get the resource types currently available to be loaned out for this edition.  Does NOT
         take into account the user's status (e.g. number of books out, in-library status, etc).
         This is like checking if this book is on the shelf.
-        
+
         Returns [{'resource_id': uuid, 'resource_type': type, 'size': bytes}]
-        
+
         size may be None"""
         # no ebook
         if not self.ocaid:
@@ -209,21 +209,21 @@ class Edition(models.Edition):
         # already checked out
         if lending.is_loaned_out(self.ocaid):
             return []
-        
+
         # find available loans. there are no current loans
         return self._get_available_loans([])
-        
+
     def _get_available_loans(self, current_loans):
-        
+
         default_type = 'bookreader'
-        
+
         loans = []
-        
+
         # Check if we have a possible loan - may not yet be fulfilled in ACS4
         if current_loans:
             # There is a current loan or offer
             return []
-        
+
         # Create list of possible loan formats
         resource_pattern = r'acs:(\w+):(.*)'
         for resource_urn in self.get_lending_resources():
@@ -232,15 +232,15 @@ class Edition(models.Edition):
                 loans.append( { 'resource_id': resource_id, 'resource_type': type, 'size': None } )
             elif resource_urn.startswith('bookreader'):
                 loans.append( { 'resource_id': resource_urn, 'resource_type': 'bookreader', 'size': None } )
-                    
+
         # Put default type at start of list, then sort by type name
         def loan_key(loan):
             if loan['resource_type'] == default_type:
                 return '1-%s' % loan['resource_type']
             else:
-                return '2-%s' % loan['resource_type']        
+                return '2-%s' % loan['resource_type']
         loans = sorted(loans, key=loan_key)
-                    
+
         # For each possible loan, check if it is available
         # We shouldn't be out of sync (we already checked get_edition_loans for current loans) but we fail safe, for example
         # the book may have been borrowed in a dev instance against the live ACS4 server
@@ -249,9 +249,9 @@ class Edition(models.Edition):
                 # Only a single loan of an item is allowed
                 # $$$ log out of sync state
                 return []
-                    
+
         return loans
-    
+
     def update_loan_status(self):
         """Update the loan status"""
         if self.ocaid:
@@ -263,35 +263,35 @@ class Edition(models.Edition):
             id_map[id.name] = id
             id.setdefault("label", id.name)
             id.setdefault("url_format", None)
-        
+
         d = MultiDict()
-        
+
         def process(name, value):
             if value:
                 if not isinstance(value, list):
                     value = [value]
-                    
+
                 id = id_map.get(name) or web.storage(name=name, label=name, url_format=None)
                 for v in value:
                     d[id.name] = web.storage(
-                        name=id.name, 
-                        label=id.label, 
-                        value=v, 
+                        name=id.name,
+                        label=id.label,
+                        value=v,
                         url=id.get('url') and id.url.replace('@@@', v))
-                
+
         for name in names:
             process(name, self[name])
-            
+
         for name in values:
             process(name, values[name])
-        
+
         return d
-    
+
     def set_identifiers(self, identifiers):
         """Updates the edition from identifiers specified as (name, value) pairs."""
-        names = ('isbn_10', 'isbn_13', 'lccn', 'oclc_numbers', 'ocaid', 
+        names = ('isbn_10', 'isbn_13', 'lccn', 'oclc_numbers', 'ocaid',
                  'dewey_decimal_class', 'lc_classifications')
-        
+
         d = {}
         for id in identifiers:
             # ignore bad values
@@ -299,13 +299,13 @@ class Edition(models.Edition):
                 continue
             name, value = id['name'], id['value']
             d.setdefault(name, []).append(value)
-        
-        # clear existing value first        
+
+        # clear existing value first
         for name in names:
            self._getdata().pop(name, None)
-           
+
         self.identifiers = {}
-            
+
         for name, value in d.items():
             # ocaid is not a list
             if name == 'ocaid':
@@ -317,10 +317,10 @@ class Edition(models.Edition):
 
     def get_classifications(self):
         names = ["dewey_decimal_class", "lc_classifications"]
-        return self._process_identifiers(get_edition_config().classifications, 
-                                         names, 
+        return self._process_identifiers(get_edition_config().classifications,
+                                         names,
                                          self.classifications)
-        
+
     def set_classifications(self, classifications):
         names = ["dewey_decimal_class", "lc_classifications"]
         d = defaultdict(list)
@@ -328,41 +328,41 @@ class Edition(models.Edition):
             if 'name' not in c or 'value' not in c or not web.re_compile("[a-z0-9_]*").match(c['name']):
                 continue
             d[c['name']].append(c['value'])
-            
+
         for name in names:
             self._getdata().pop(name, None)
         self.classifications = {}
-        
+
         for name, value in d.items():
             if name in names:
                 self[name] = value
             else:
                 self.classifications[name] = value
-            
+
     def get_weight(self):
         """returns weight as a storage object with value and units fields."""
         w = self.weight
         return w and UnitParser(["value"]).parse(w)
-        
+
     def set_weight(self, w):
         self.weight = w and UnitParser(["value"]).format(w)
-        
+
     def get_physical_dimensions(self):
         d = self.physical_dimensions
         return d and UnitParser(["height", "width", "depth"]).parse(d)
-    
+
     def set_physical_dimensions(self, d):
         # don't overwrite physical dimensions if nothing was passed in - there
         # may be dimensions in the database that don't conform to the d x d x d format
         if d:
             self.physical_dimensions = UnitParser(["height", "width", "depth"]).format(d)
-        
+
     def get_toc_text(self):
         def format_row(r):
             return "*" * r.level + " " + " | ".join([r.label, r.title, r.pagenum])
-            
+
         return "\n".join(format_row(r) for r in self.get_table_of_contents())
-        
+
     def get_table_of_contents(self):
         def row(r):
             if isinstance(r, basestring):
@@ -375,25 +375,25 @@ class Edition(models.Edition):
                 label = r.get('label', '')
                 title = r.get('title', '')
                 pagenum = r.get('pagenum', '')
-                
+
             r = web.storage(level=level, label=label, title=title, pagenum=pagenum)
             return r
-            
+
         d = [row(r) for r in self.table_of_contents]
         return [row for row in d if any(row.values())]
 
     def set_toc_text(self, text):
         self.table_of_contents = parse_toc(text)
-        
+
     def get_links(self):
-        links1 = [web.storage(url=url, title=title) 
-                  for url, title in zip(self.uris, self.uri_descriptions)] 
+        links1 = [web.storage(url=url, title=title)
+                  for url, title in zip(self.uris, self.uri_descriptions)]
         links2 = list(self.links)
         return links1 + links2
-        
+
     def get_olid(self):
         return self.key.split('/')[-1]
-    
+
     @property
     def wp_citation_fields(self):
         """
@@ -429,14 +429,14 @@ class Edition(models.Edition):
             result['author'] = authors[0].name
         else:
             for i, a in enumerate(authors):
-                result['author%s' % (i + 1)] = a.name 
+                result['author%s' % (i + 1)] = a.name
         return result
 
     def is_fake_record(self):
-        """Returns True if this is a record is not a real record from database, 
+        """Returns True if this is a record is not a real record from database,
         but created on the fly.
 
-        The /books/ia:foo00bar records are not stored in the database, but 
+        The /books/ia:foo00bar records are not stored in the database, but
         created at runtime using the data from archive.org metadata API.
         """
         return "/ia:" in self.key
@@ -444,15 +444,15 @@ class Edition(models.Edition):
 class Author(models.Author):
     def get_photos(self):
         return [Image(self._site, "a", id) for id in self.photos if id > 0]
-        
+
     def get_photo(self):
         photos = self.get_photos()
         return photos and photos[0] or None
-        
+
     def get_photo_url(self, size):
         photo = self.get_photo()
         return photo and photo.url(size)
-    
+
     def get_olid(self):
         return self.key.split('/')[-1]
 
@@ -464,7 +464,7 @@ class Author(models.Author):
         except ValueError:
             page = 1
         return works_by_author(self.get_olid(), sort=i.sort, page=page, rows=100)
-        
+
     def get_work_count(self):
         """Returns the number of works by this author.
         """
@@ -480,7 +480,7 @@ def get_works_solr():
     else:
         base_url = "http://%s/solr/works" % config.plugin_worksearch.get('solr')
     return Solr(base_url)
-        
+
 class Work(models.Work):
     def get_olid(self):
         return self.key.split('/')[-1]
@@ -492,10 +492,10 @@ class Work(models.Work):
             return self.get_covers_from_solr()
         else:
             return []
-            
+
     def get_covers_from_solr(self):
         try:
-        w = self._solr_data
+            w = self._solr_data
             logger.error('Unable to retrieve covers from solr')
         except Exception:
             return []
@@ -508,7 +508,7 @@ class Work(models.Work):
                 if cover:
                     return [cover]
         return []
-        
+
     def _get_solr_data(self):
         if config.get("single_core_solr"):
             key = self.key
@@ -518,53 +518,53 @@ class Work(models.Work):
         fields = [
             "cover_edition_key", "cover_id", "edition_key", "first_publish_year",
             "has_fulltext", "lending_edition", "checked_out", "public_scan_b", "ia"]
-        
+
         solr = get_works_solr()
         stats.begin("solr", query={"key": key}, fields=fields)
         try:
             d = solr.select({"key": key}, fields=fields)
         finally:
             stats.end()
-            
+
         if d.num_found > 0:
             w = d.docs[0]
         else:
             w = None
-                
+
         # Replace _solr_data property with the attribute
         self.__dict__['_solr_data'] = w
         return w
-        
+
     _solr_data = property(_get_solr_data)
-    
+
     def get_cover(self, use_solr=True):
         covers = self.get_covers(use_solr=use_solr)
         return covers and covers[0] or None
-    
+
     def get_cover_url(self, size, use_solr=True):
         cover = self.get_cover(use_solr=use_solr)
         return cover and cover.url(size)
-        
+
     def get_authors(self):
         authors =  [a.author for a in self.authors]
         authors = [follow_redirect(a) for a in authors]
         authors = [a for a in authors if a and a.type.key == "/type/author"]
         return authors
-    
+
     def get_subjects(self):
         """Return subject strings."""
         subjects = self.subjects
-        
+
         def flip(name):
             if name.count(",") == 1:
                 a, b = name.split(",")
                 return b.strip() + " " + a.strip()
             return name
-                
+
         if subjects and not isinstance(subjects[0], basestring):
             subjects = [flip(s.name) for s in subjects]
         return subjects
-        
+
     def get_sorted_editions(self):
         """Return a list of works sorted by publish date"""
         w = self._solr_data
@@ -574,7 +574,7 @@ class Work(models.Work):
         if len(editions) < self.edition_count:
             q = {"type": "/type/edition", "works": self.key, "limit": 10000}
             editions = [k[len("/books/"):] for k in web.ctx.site.things(q)]
-        
+
         if editions:
             return web.ctx.site.get_many(["/books/" + olid for olid in editions])
         else:
@@ -585,7 +585,7 @@ class Work(models.Work):
         return w.get("has_fulltext", False)
 
     first_publish_year = property(lambda self: self._solr_data.get("first_publish_year"))
-        
+
     def get_edition_covers(self):
         editions = web.ctx.site.get_many(web.ctx.site.things({"type": "/type/edition", "works": self.key, "limit": 1000}))
         exisiting = set(int(c.id) for c in self.get_covers())
@@ -599,41 +599,41 @@ class Subject(client.Thing):
             q = {'subjects': name, "facets": True}
             self._solr_result = SearchProcessor().search(q)
         return self._solr_result
-        
+
     def get_related_subjects(self):
         # dummy subjects
         return [web.storage(name='France', key='/subjects/places/France'), web.storage(name='Travel', key='/subjects/Travel')]
-        
+
     def get_covers(self, offset=0, limit=20):
         editions = self.get_editions(offset, limit)
         olids = [e['key'].split('/')[-1] for e in editions]
-        
+
         try:
             url = '%s/b/query?cmd=ids&olid=%s' % (get_coverstore_url(), ",".join(olids))
             data = urllib2.urlopen(url).read()
             cover_ids = simplejson.loads(data)
         except IOError, e:
-            print >> web.debug, 'ERROR in getting cover_ids', str(e) 
+            print >> web.debug, 'ERROR in getting cover_ids', str(e)
             cover_ids = {}
-            
+
         def make_cover(edition):
             edition = dict(edition)
             edition.pop('type', None)
             edition.pop('subjects', None)
             edition.pop('languages', None)
-            
+
             olid = edition['key'].split('/')[-1]
             if olid in cover_ids:
                 edition['cover_id'] = cover_ids[olid]
-            
+
             return edition
-            
+
         return [make_cover(e) for e in editions]
-    
+
     def get_edition_count(self):
         d = self._get_solr_result()
         return d['matches']
-        
+
     def get_editions(self, offset, limit=20):
         if self._solr_result and offset+limit < len(self._solr_result):
             result = self._solr_result[offset:offset+limit]
@@ -641,15 +641,15 @@ class Subject(client.Thing):
             name = self.name or ""
             result = SearchProcessor().search({"subjects": name, 'offset': offset, 'limit': limit})
         return result['docs']
-        
+
     def get_author_count(self):
         d = self._get_solr_result()
         return len(d['facets']['authors'])
-        
+
     def get_authors(self):
         d = self._get_solr_result()
         return [web.storage(name=a, key='/authors/OL1A', count=count) for a, count in d['facets']['authors']]
-    
+
     def get_publishers(self):
         d = self._get_solr_result()
         return [web.storage(name=p, count=count) for p, count in d['facets']['publishers']]
@@ -657,45 +657,45 @@ class Subject(client.Thing):
 
 class SubjectPlace(Subject):
     pass
-    
+
 
 class SubjectPerson(Subject):
     pass
 
 
 class User(models.User):
-    
+
     def get_name(self):
         return self.displayname or self.key.split('/')[-1]
     name = property(get_name)
-    
+
     def get_edit_history(self, limit=10, offset=0):
         return web.ctx.site.versions({"author": self.key, "limit": limit, "offset": offset})
-                
+
     def get_creation_info(self):
         if web.ctx.path.startswith("/admin"):
             d = web.ctx.site.versions({'key': self.key, "sort": "-created", "limit": 1})[0]
             return web.storage({"ip": d.ip, "member_since": d.created})
-            
+
     def get_edit_count(self):
         if web.ctx.path.startswith("/admin"):
             return web.ctx.site._request('/count_edits_by_user', data={"key": self.key})
         else:
             return 0
-            
+
     def get_loan_count(self):
         return len(borrow.get_loans(self))
-        
+
     def get_loans(self):
         self.update_loan_status()
         return lending.get_loans_of_user(self.key)
-        
+
     def update_loan_status(self):
         """Update the status of this user's loans."""
         loans = lending.get_loans_of_user(self.key)
         for loan in loans:
             lending.sync_loan(loan['ocaid'])
-            
+
 class UnitParser:
     """Parsers values like dimentions and weight.
 
@@ -743,7 +743,7 @@ class Changeset(client.Changeset):
         The subclasses may overwrite this as required.
         """
         return docs
-        
+
     def _undo(self):
         """Undo this transaction."""
         docs = [self._get_doc(c['key'], c['revision']-1) for c in self.changes]
@@ -754,7 +754,7 @@ class Changeset(client.Changeset):
         }
         comment = 'undo ' + self.comment
         return web.ctx.site.save_many(docs, action="undo", data=data, comment=comment)
-            
+
     def get_undo_changeset(self):
         """Returns the changeset that undone this transaction if one exists, None otherwise.
         """
@@ -762,9 +762,9 @@ class Changeset(client.Changeset):
             return self._undo_changeset
         except AttributeError:
             pass
-        
+
         changesets = web.ctx.site.recentchanges({
-            "kind": "undo", 
+            "kind": "undo",
             "data": {
                 "parent_changeset": self.id
             }
@@ -772,7 +772,7 @@ class Changeset(client.Changeset):
         # return the first undo changeset
         self._undo_changeset = changesets and changesets[-1] or None
         return self._undo_changeset
-        
+
 class NewAccountChangeset(Changeset):
     def get_user(self):
         keys = [c.key for c in self.get_changes()]
@@ -788,44 +788,44 @@ class MergeAuthors(Changeset):
         for w in works:
             if w.get("authors"):
                 authors = [follow_redirect(web.ctx.site.get(a['author']['key']))
-                            for a in w.get('authors') 
-                            if 'author' in a 
+                            for a in w.get('authors')
+                            if 'author' in a
                             and 'key' in a['author']]
                 w['authors'] = [{"author": {"key": a.key}} for a in authors]
-        return docs        
-        
+        return docs
+
     def get_master(self):
         master = self.data.get("master")
         return master and web.ctx.site.get(master, lazy=True)
-        
+
     def get_duplicates(self):
         duplicates = self.data.get("duplicates")
         changes = dict((c['key'], c['revision']) for c in self.changes)
-        
+
         return duplicates and [web.ctx.site.get(key, revision=changes[key]-1, lazy=True) for key in duplicates if key in changes]
-        
+
 class Undo(Changeset):
     def can_undo(self):
         return False
-    
+
     def get_undo_of(self):
         undo_of = self.data['undo_of']
         return web.ctx.site.get_change(undo_of)
-        
+
     def get_parent_changeset(self):
         parent = self.data['parent_changeset']
         return web.ctx.site.get_change(parent)
-        
+
 class AddBookChangeset(Changeset):
     def get_work(self):
         book = self.get_edition()
         return (book and book.works and book.works[0]) or None
-    
+
     def get_edition(self):
         for doc in self.get_changes():
             if doc.key.startswith("/books/"):
                 return doc
-        
+
     def get_author(self):
         for doc in self.get_changes():
             if doc.key.startswith("/authors/"):
@@ -836,15 +836,15 @@ class ListChangeset(Changeset):
         added = self.data.get("add")
         if added and len(added) == 1:
             return self.get_seed(added[0])
-            
+
     def get_removed_seed(self):
         removed = self.data.get("remove")
         if removed and len(removed) == 1:
             return self.get_seed(removed[0])
-            
+
     def get_list(self):
         return self.get_changes()[0]
-        
+
     def get_seed(self, seed):
         """Returns the seed object."""
         if isinstance(seed, dict):
@@ -853,7 +853,7 @@ class ListChangeset(Changeset):
 
 def setup():
     models.register_models()
-    
+
     client.register_thing_class('/type/edition', Edition)
     client.register_thing_class('/type/author', Author)
     client.register_thing_class('/type/work', Work)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -21,6 +21,7 @@ from openlibrary.utils.solr import Solr
 from utils import get_coverstore_url, MultiDict, parse_toc, get_edition_config
 import account
 import borrow
+import logging
 
 def follow_redirect(doc):
     if isinstance(doc, basestring) and doc.startswith("/a/"):
@@ -496,8 +497,8 @@ class Work(models.Work):
     def get_covers_from_solr(self):
         try:
             w = self._solr_data
-            logger.error('Unable to retrieve covers from solr')
-        except Exception:
+        except Exception as e:
+            logging.getLogger("openlibrary").exception('Unable to retrieve covers from solr')
             return []
         if w:
             if 'cover_id' in w:
@@ -523,6 +524,9 @@ class Work(models.Work):
         stats.begin("solr", query={"key": key}, fields=fields)
         try:
             d = solr.select({"key": key}, fields=fields)
+        except Exception as e:
+            logging.getLogger("openlibrary").exception("Failed to get solr data")
+            return None
         finally:
             stats.end()
 

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -494,7 +494,11 @@ class Work(models.Work):
             return []
             
     def get_covers_from_solr(self):
+        try:
         w = self._solr_data
+            logger.error('Unable to retrieve covers from solr')
+        except Exception:
+            return []
         if w:
             if 'cover_id' in w:
                 return [Image(self._site, "w", int(w['cover_id']))]

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -638,20 +638,20 @@ def _get_blog_feeds():
 
 _get_blog_feeds = cache.memcache_memoize(_get_blog_feeds, key_prefix="upstream.get_blog_feeds", timeout=5*60)
 
-def get_donation_include(type):
-    input = web.input()
+def get_donation_include(include):
+    web_input = web.input()
     url_banner_source = "https://archive.org/includes/donate.php"
     html = ''
     param = '?platform=ol'
     dd = ''
-    if 'will' in input:
+    if 'will' in web_input:
         url_banner_source = "https://www-will.archive.org/includes/donate.php"
-    if 'don' in input:
-        dd = input['don']
-        param = param+"&ymd="+dd
-    if (type=='true'):
+    if 'don' in web_input:
+        dd = web_input.get('don', '')
+        param = param + "&ymd=" + dd
+    if include == 'true':
         try:
-            html = urllib2.urlopen(url_banner_source+param, timeout=3).read()
+            html = urllib2.urlopen(url_banner_source + param, timeout=3).read()
         except urllib2.URLError:
             logging.getLogger("openlibrary").error('Could not load donation banner')
             return ''

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -651,8 +651,9 @@ def get_donation_include(type):
         param = param+"&ymd="+dd
     if (type=='true'):
         try:
-            html = urllib2.urlopen(url_banner_source+param, timeout=2).read()
+            html = urllib2.urlopen(url_banner_source+param, timeout=3).read()
         except urllib2.URLError:
+            logging.getLogger("openlibrary").error('Could not load donation banner')
             return ''
     return html
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -650,7 +650,10 @@ def get_donation_include(type):
         dd = input['don']
         param = param+"&ymd="+dd
     if (type=='true'):
-        html = urllib2.urlopen(url_banner_source+param).read()
+        try:
+            html = urllib2.urlopen(url_banner_source+param, timeout=2).read()
+        except urllib2.URLError:
+            return ''
     return html
 
 #get_donation_include = cache.memcache_memoize(get_donation_include, key_prefix="upstream.get_donation_include", timeout=60)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -22,10 +22,10 @@ from infogami.infobase.client import Thing, Changeset, storify
 from openlibrary.core.helpers import commify, parse_datetime
 from openlibrary.core.middleware import GZipMiddleware
 from openlibrary.core import cache, ab
-    
+
 class MultiDict(DictMixin):
     """Ordered Dictionary that can store multiple values.
-    
+
         >>> d = MultiDict()
         >>> d['x'] = 1
         >>> d['x'] = 2
@@ -47,84 +47,84 @@ class MultiDict(DictMixin):
     """
     def __init__(self, items=(), **kw):
         self._items = []
-        
+
         for k, v in items:
             self[k] = v
         self.update(kw)
-    
+
     def __getitem__(self, key):
         values = self.getall(key)
         if values:
             return values[-1]
         else:
             raise KeyError, key
-    
+
     def __setitem__(self, key, value):
         self._items.append((key, value))
-        
+
     def __delitem__(self, key):
         self._items = [(k, v) for k, v in self._items if k != key]
-        
+
     def getall(self, key):
         return [v for k, v in self._items if k == key]
-        
+
     def keys(self):
         return [k for k, v in self._items]
-        
+
     def values(self):
         return [v for k, v in self._items]
-        
+
     def items(self):
         return self._items[:]
-        
+
     def multi_items(self):
         """Returns items as tuple of key and a list of values."""
         items = []
         d = {}
-        
+
         for k, v in self._items:
             if k not in d:
                 d[k] = []
                 items.append((k, d[k]))
             d[k].append(v)
         return items
-        
+
 @macro
 @public
 def render_template(name, *a, **kw):
     if "." in name:
         name = name.rsplit(".", 1)[0]
     return render[name](*a, **kw)
-    
+
 @public
 def get_error(name, *args):
     """Return error with the given name from errors.tmpl template."""
     return get_message_from_template("errors", name, args)
-        
-@public        
+
+@public
 def get_message(name, *args):
     """Return message with given name from messages.tmpl template"""
     return get_message_from_template("messages", name, args)
-    
+
 def get_message_from_template(template_name, name, args):
     d = render_template(template_name).get("messages", {})
     msg = d.get(name) or name.lower().replace("_", " ")
-    
+
     if msg and args:
         return msg % args
     else:
         return msg
-    
+
 @public
 def list_recent_pages(path, limit=100, offset=0):
     """Lists all pages with name path/* in the order of last_modified."""
     q = {}
-        
+
     q['key~' ] = path + '/*'
     # don't show /type/delete and /type/redirect
     q['a:type!='] = '/type/delete'
     q['b:type!='] = '/type/redirect'
-    
+
     q['sort'] = 'key'
     q['limit'] = limit
     q['offset'] = offset
@@ -132,19 +132,19 @@ def list_recent_pages(path, limit=100, offset=0):
     # queries are very slow with != conditions
     # q['type'] != '/type/delete'
     return web.ctx.site.get_many(web.ctx.site.things(q))
-        
+
 @public
 def json_encode(d):
     return simplejson.dumps(d)
 
 def unflatten(d, seperator="--"):
     """Convert flattened data into nested form.
-    
+
         >>> unflatten({"a": 1, "b--x": 2, "b--y": 3, "c--0": 4, "c--1": 5})
         {'a': 1, 'c': [4, 5], 'b': {'y': 3, 'x': 2}}
         >>> unflatten({"a--0--x": 1, "a--0--y": 2, "a--1--x": 3, "a--1--y": 4})
         {'a': [{'x': 1, 'y': 2}, {'x': 3, 'y': 4}]}
-        
+
     """
     def isint(k):
         try:
@@ -152,14 +152,14 @@ def unflatten(d, seperator="--"):
             return True
         except ValueError:
             return False
-        
+
     def setvalue(data, k, v):
         if '--' in k:
             k, k2 = k.split(seperator, 1)
             setvalue(data.setdefault(k, {}), k2, v)
         else:
             data[k] = v
-            
+
     def makelist(d):
         """Convert d into a list if all the keys of d are integers."""
         if isinstance(d, dict):
@@ -169,7 +169,7 @@ def unflatten(d, seperator="--"):
                 return web.storage((k, makelist(v)) for k, v in d.items())
         else:
             return d
-            
+
     d2 = {}
     for k, v in d.items():
         setvalue(d2, k, v)
@@ -177,21 +177,21 @@ def unflatten(d, seperator="--"):
 
 def fuzzy_find(value, options, stopwords=[]):
     """Try find the option nearest to the value.
-    
+
         >>> fuzzy_find("O'Reilly", ["O'Reilly Inc", "Addison-Wesley"])
         "O'Reilly Inc"
     """
     if not options:
         return value
-        
+
     rx = web.re_compile("[-_\.&, ]+")
-    
+
     # build word frequency
     d = defaultdict(list)
     for option in options:
         for t in rx.split(option):
             d[t].append(option)
-    
+
     # find score for each option
     score = defaultdict(lambda: 0)
     for t in rx.split(value):
@@ -199,17 +199,17 @@ def fuzzy_find(value, options, stopwords=[]):
             continue
         for option in d[t]:
             score[option] += 1
-            
+
     # take the option with maximum score
     return max(options, key=score.__getitem__)
-    
+
 @public
 def radio_input(checked=False, **params):
     params['type'] = 'radio'
     if checked:
         params['checked'] = "checked"
     return "<input %s />" % " ".join(['%s="%s"' % (k, web.websafe(v)) for k, v in params.items()])
-    
+
 @public
 def radio_list(name, args, value):
     html = []
@@ -219,29 +219,29 @@ def radio_list(name, args, value):
         else:
             label = arg
         html.append(radio_input())
-        
+
 @public
 def get_coverstore_url():
     return config.get('coverstore_url', 'http://covers.openlibrary.org').rstrip('/')
-    
+
 def _get_changes_v1_raw(query, revision=None):
-    """Returns the raw versions response. 
-    
+    """Returns the raw versions response.
+
     Revision is taken as argument to make sure a new cache entry is used when a new revision of the page is created.
     """
     if 'env' not in web.ctx:
         delegate.fakeload()
-    
+
     versions = web.ctx.site.versions(query)
-    
+
     for v in versions:
         v.created = v.created.isoformat()
         v.author = v.author and v.author.key
-        
+
         # XXX-Anand: hack to avoid too big data to be stored in memcache.
         # v.changes is not used and it contrinutes to memcache bloat in a big way.
         v.changes = '[]'
-            
+
     return versions
 
 def get_changes_v1(query, revision=None):
@@ -252,17 +252,17 @@ def get_changes_v1(query, revision=None):
         v.created = parse_datetime(v.created)
         v.author = v.author and web.ctx.site.get(v.author, lazy=True)
         return v
-    
+
     return [process(v) for v in _get_changes_v1_raw(query, revision)]
-    
+
 def _get_changes_v2_raw(query, revision=None):
-    """Returns the raw recentchanges response. 
-    
+    """Returns the raw recentchanges response.
+
     Revision is taken as argument to make sure a new cache entry is used when a new revision of the page is created.
     """
     if 'env' not in web.ctx:
         delegate.fakeload()
-    
+
     changes = web.ctx.site.recentchanges(query)
     return [c.dict() for c in changes]
 
@@ -271,13 +271,13 @@ def _get_changes_v2_raw(query, revision=None):
 
 def get_changes_v2(query, revision=None):
     page = web.ctx.site.get(query['key'])
-    
+
     def first(seq, default=None):
         try:
             return seq.next()
         except StopIteration:
             return default
-    
+
     def process_change(change):
         change = Changeset.create(web.ctx.site, storify(change))
         change.thing = page
@@ -286,11 +286,11 @@ def get_changes_v2(query, revision=None):
         change.created = change.timestamp
 
         change.get = change.__dict__.get
-        change.get_comment = lambda: get_comment(change)        
+        change.get_comment = lambda: get_comment(change)
         change.machine_comment = change.data.get("machine_comment")
-    
+
         return change
-        
+
     def get_comment(change):
         t = get_template("recentchanges/" + change.kind + "/comment") or get_template("recentchanges/default/comment")
         return t(change, page)
@@ -298,13 +298,13 @@ def get_changes_v2(query, revision=None):
     query['key'] = page.key
     changes = _get_changes_v2_raw(query, revision=page.revision)
     return [process_change(c) for c in changes]
-    
+
 def get_changes(query, revision=None):
     if 'history_v2' in web.ctx.features:
         return get_changes_v2(query, revision=revision)
     else:
         return get_changes_v1(query, revision=revision)
-        
+
 @public
 def get_history(page):
     h = web.storage(revision=page.revision, lastest_revision=page.revision, created=page.created)
@@ -315,14 +315,14 @@ def get_history(page):
     else:
         h.initial = get_changes({"key": page.key, "limit": 1, "offset": h.revision-1}, revision=page.revision)
         h.recent = get_changes({"key": page.key, "limit": 4}, revision=page.revision)
-    
+
     return h
-    
+
     if 'history_v2' in web.ctx.features:
         return get_history_v2(page)
     else:
-        return get_history_v1(page)    
-    
+        return get_history_v1(page)
+
 @public
 def get_version(key, revision):
     try:
@@ -346,7 +346,7 @@ def get_locale():
         return babel.Locale(web.ctx.get("lang") or "en")
     except babel.core.UnknownLocaleError:
         return babel.Locale("en")
-    
+
 @public
 def process_version(v):
     """Looks at the version and adds machine_comment required for showing "View MARC" link."""
@@ -368,7 +368,7 @@ def process_version(v):
 @public
 def is_thing(t):
     return isinstance(t, Thing)
-    
+
 @public
 def putctx(key, value):
     """Save a value in the context."""
@@ -391,7 +391,7 @@ class Metatag:
 def add_metatag(tag="meta", **attrs):
     context.setdefault('metatags', [])
     context.metatags.append(Metatag(tag, **attrs))
-    
+
 def pad(seq, size, e=None):
     """
         >>> pad([1, 2], 4, 0)
@@ -439,7 +439,7 @@ def parse_toc(text):
     return [parse_toc_row(line) for line in text.splitlines() if line.strip(" |")]
 
 _languages = None
-    
+
 @public
 def get_languages():
     global _languages
@@ -447,17 +447,17 @@ def get_languages():
         keys = web.ctx.site.things({"type": "/type/language", "key~": "/languages/*", "limit": 1000})
         _languages = sorted([web.storage(name=d.name, code=d.code, key=d.key) for d in web.ctx.site.get_many(keys)], key=lambda d: d.name.lower())
     return _languages
-    
+
 @public
 def get_edition_config():
     return _get_edition_config()
-    
+
 @web.memoize
 def _get_edition_config():
     """Returns the edition config.
-    
+
     The results are cached on the first invocation. Any changes to /config/edition page require restarting the app.
-    
+
     This is is cached because fetching and creating the Thing object was taking about 20ms of time for each book request.
     """
     thing = web.ctx.site.get('/config/edition')
@@ -477,7 +477,7 @@ def get_markdown(text, safe_mode=False):
 class HTML(unicode):
     def __init__(self, html):
         unicode.__init__(self, web.safeunicode(html))
-        
+
     def __repr__(self):
         return "<html: %s>" % unicode.__repr__(self)
 
@@ -489,7 +489,7 @@ def websafe(text):
         return web.safestr(text)
     else:
         return _websafe(text)
-        
+
 
 from openlibrary.utils.olcompress import OLCompressor
 from openlibrary.utils import olmemcache
@@ -513,7 +513,7 @@ class UpstreamMemcacheClient:
         key = adapter.convert_key(key)
         if key is None:
             return None
-        
+
         try:
             value = self._client.get(web.safestr(key))
         except memcache.Client.MemcachedKeyError:
@@ -524,7 +524,7 @@ class UpstreamMemcacheClient:
     def get_multi(self, keys):
         keys = [adapter.convert_key(k) for k in keys]
         keys = [web.safestr(k) for k in keys]
-        
+
         d = self._client.get_multi(keys)
         return dict((web.safeunicode(adapter.unconvert_key(k)), self.decompress(v)) for k, v in d.items())
 
@@ -532,12 +532,12 @@ if config.get('upstream_memcache_servers'):
     olmemcache.Client = UpstreamMemcacheClient
     # set config.memcache_servers only after olmemcache.Client is updated
     config.memcache_servers = config.upstream_memcache_servers
-    
+
 def _get_recent_changes():
     site = web.ctx.get('site') or delegate.create_site()
     web.ctx.setdefault("ip", "127.0.0.1")
-    
-    # The recentchanges can have multiple revisions for a document if it has been modified more than once. 
+
+    # The recentchanges can have multiple revisions for a document if it has been modified more than once.
     # Take only the most recent revision in that case.
     visited = set()
     def is_visited(key):
@@ -546,7 +546,7 @@ def _get_recent_changes():
         else:
             visited.add(key)
             return False
-       
+
     # ignore reverts
     re_revert = web.re_compile("reverted to revision \d+")
     def is_revert(r):
@@ -564,24 +564,24 @@ def _get_recent_changes():
             t[k] = thing[k]
         t['type'] = web.storage(key=thing.type.key)
         return t
-    
+
     for r in result:
         r.author = r.author and process_thing(r.author)
         r.thing = process_thing(site.get(r.key, r.revision))
-        
+
     return result
-    
+
 def _get_recent_changes2():
     """New recent changes for around the library.
-    
+
     This function returns the message to display for each change.
     The message is get by calling `recentchanges/$kind/message.html` template.
-    
+
     If `$var ignore=True` is set by the message template, the change is ignored.
     """
     if 'env' not in web.ctx:
         delegate.fakeload()
-    
+
     q = {"bot": False, "limit": 100}
     changes = web.ctx.site.recentchanges(q)
 
@@ -599,7 +599,7 @@ def _get_recent_changes2():
     messages = [render(c) for c in changes if not is_ignored(c)]
     messages = [m for m in messages if str(m.get("ignore", "false")).lower() != "true"]
     return messages
-    
+
 _get_recent_changes = web.memoize(_get_recent_changes, expires=5*60, background=True)
 _get_recent_changes2 = web.memoize(_get_recent_changes2, expires=5*60, background=True)
 
@@ -609,12 +609,12 @@ def get_random_recent_changes(n):
         changes = _get_recent_changes2()
     else:
         changes = _get_recent_changes()
-    
+
     if len(changes) > n:
-        return random.sample(changes, n)  
+        return random.sample(changes, n)
     else:
         return changes
-        
+
 def _get_blog_feeds():
     url = "http://blog.openlibrary.org/feed/"
     try:
@@ -626,7 +626,7 @@ def _get_blog_feeds():
         return []
     finally:
         stats.end()
-    
+
     def parse_item(item):
         pubdate = datetime.datetime.strptime(item.find("pubDate").text, '%a, %d %b %Y %H:%M:%S +0000').isoformat()
         return dict(
@@ -635,7 +635,7 @@ def _get_blog_feeds():
             pubdate=pubdate
         )
     return [parse_item(item) for item in tree.findall("//item")]
-    
+
 _get_blog_feeds = cache.memcache_memoize(_get_blog_feeds, key_prefix="upstream.get_blog_feeds", timeout=5*60)
 
 def get_donation_include(type):
@@ -693,7 +693,7 @@ def setup():
     web.template.Template.FILTERS['.xml'] = websafe
 
     web.commify = commify
-    
+
     web.template.Template.globals.update({
         'HTML': HTML,
         'request': Request(),
@@ -701,7 +701,7 @@ def setup():
         'sum': sum,
         'get_donation_include': get_donation_include
     })
-    
+
     from openlibrary.core import helpers as h
     web.template.Template.globals.update(h.helpers)
 

--- a/openlibrary/plugins/worksearch/search.py
+++ b/openlibrary/plugins/worksearch/search.py
@@ -58,6 +58,8 @@ def work_search(query, limit=20, offset=0, **kw):
     stats.begin("solr", query=query, start=offset, rows=limit, kw=kw)
     try:
         result = solr.select(query, start=offset, rows=limit, **kw)
+    except Exception:
+        return None
     finally:
         stats.end()
     

--- a/openlibrary/plugins/worksearch/search.py
+++ b/openlibrary/plugins/worksearch/search.py
@@ -4,6 +4,7 @@ from openlibrary.utils.solr import Solr
 from infogami import config
 from infogami.utils import stats
 import web
+import logging
 
 def get_works_solr():
     if config.get('single_core_solr'):
@@ -58,7 +59,8 @@ def work_search(query, limit=20, offset=0, **kw):
     stats.begin("solr", query=query, start=offset, rows=limit, kw=kw)
     try:
         result = solr.select(query, start=offset, rows=limit, **kw)
-    except Exception:
+    except Exception as e:
+        logging.getLogger("openlibrary").exception("Failed solr query")
         return None
     finally:
         stats.end()

--- a/openlibrary/plugins/worksearch/search.py
+++ b/openlibrary/plugins/worksearch/search.py
@@ -32,9 +32,9 @@ def work_search(query, limit=20, offset=0, **kw):
 
     kw.setdefault("doc_wrapper", work_wrapper)
     fields = [
-        "key", 
-        "author_name", 
-        "author_key", 
+        "key",
+        "author_name",
+        "author_key",
         "title",
         "edition_count",
         "ia",
@@ -54,7 +54,7 @@ def work_search(query, limit=20, offset=0, **kw):
 
     query = process_work_query(query)
     solr = get_works_solr()
-    
+
     stats.begin("solr", query=query, start=offset, rows=limit, kw=kw)
     try:
         result = solr.select(query, start=offset, rows=limit, **kw)
@@ -62,7 +62,7 @@ def work_search(query, limit=20, offset=0, **kw):
         return None
     finally:
         stats.end()
-    
+
     return result
 
 def process_work_query(query):
@@ -108,7 +108,7 @@ def work_wrapper(w):
     # special care to handle missing author_key/author_name in the solr record
     w.setdefault('author_key', [])
     w.setdefault('author_name', [])
-    
+
     d.authors = [web.storage(key='/authors/' + k, name=n)
                  for k, n in zip(w['author_key'], w['author_name'])]
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -41,7 +41,7 @@ SUBJECTS = [
 
 class subjects_index(delegate.page):
     path = "/subjects"
-    
+
     def GET(self):
         return render_template("subjects/index.html")
 
@@ -52,7 +52,7 @@ class subjects(delegate.page):
         nkey = self.normalize_key(key)
         if nkey != key:
             raise web.redirect(nkey)
-            
+
         page = get_subject(key, details=True)
 
         if not page or page.work_count == 0:
@@ -60,7 +60,7 @@ class subjects(delegate.page):
             return render_template('subjects/notfound.tmpl', key)
 
         return render_template("subjects", page)
-        
+
     def normalize_key(self, key):
         key = key.lower()
 
@@ -81,7 +81,7 @@ class subjects_json(delegate.page):
         nkey = self.normalize_key(key)
         if nkey != key:
             raise web.redirect(nkey)
-            
+
         # Does the key requires any processing before passing using it to query solr?
         key = self.process_key(key)
 
@@ -107,10 +107,10 @@ class subjects_json(delegate.page):
 
         subject = get_subject(key, offset=i.offset, limit=i.limit, sort=i.sort, details=i.details.lower() == 'true', **filters)
         return json.dumps(subject)
-        
+
     def normalize_key(self, key):
-        return key.lower() 
-        
+        return key.lower()
+
     def process_key(self, key):
         return key
 
@@ -124,7 +124,7 @@ class subject_works_json(delegate.page):
         nkey = self.normalize_key(key)
         if nkey != key:
             raise web.redirect(nkey)
-            
+
         # Does the key requires any processing before passing using it to query solr?
         key = self.process_key(key)
 
@@ -152,7 +152,7 @@ class subject_works_json(delegate.page):
         return json.dumps(subject)
 
     def normalize_key(self, key):
-        return key.lower() 
+        return key.lower()
 
     def process_key(self, key):
         return key
@@ -166,9 +166,9 @@ def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filte
 
         >>> get_subject("/subjects/Love") #doctest: +SKIP
         {
-            "key": "/subjects/Love", 
+            "key": "/subjects/Love",
             "name": "Love",
-            "work_count": 5129, 
+            "work_count": 5129,
             "works": [...]
         }
 
@@ -176,25 +176,25 @@ def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filte
 
     >>> get_subject("/subjects/Love", details=True) #doctest: +SKIP
     {
-        "key": "/subjects/Love", 
+        "key": "/subjects/Love",
         "name": "Love",
-        "work_count": 5129, 
+        "work_count": 5129,
         "works": [...],
-        "ebook_count": 94, 
+        "ebook_count": 94,
         "authors": [
             {
-                "count": 11, 
-                "name": "Plato.", 
+                "count": 11,
+                "name": "Plato.",
                 "key": "/authors/OL12823A"
-            }, 
+            },
             ...
         ],
         "subjects": [
             {
                 "count": 1168,
-                "name": "Religious aspects", 
+                "name": "Religious aspects",
                 "key": "/subjects/religious aspects"
-            }, 
+            },
             ...
         ],
         "times": [...],
@@ -203,8 +203,8 @@ def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filte
         "publishing_history": [[1492, 1], [1516, 1], ...],
         "publishers": [
             {
-                "count": 57, 
-                "name": "Sine nomine"        
+                "count": 57,
+                "name": "Sine nomine"
             },
             ...
         ]
@@ -220,13 +220,13 @@ def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filte
                 Engine = d.get("engine") or SubjectEngine
                 return Engine()
         return SubjectEngine()
-        
+
     sort_options = {
         'editions': 'edition_count desc',
         'new': 'first_publish_year desc',
     }
     sort_order = sort_options.get(sort) or sort_options['editions']
-    
+
     engine = create_engine()
     return engine.get_subject(key, details=details, offset=offset, sort=sort_order, limit=limit, **filters)
 
@@ -259,7 +259,7 @@ class SubjectEngine:
             # Quick fix it solve that issue.
             if w.key.endswith("/works/"):
                 w.key = "/works/" + w.key.replace("/works/", "")
-                
+
         subject = Subject(
             key=key,
             name=name,
@@ -313,22 +313,22 @@ class SubjectEngine:
 
     def make_query(self, key, filters):
         meta = self.get_meta(key)
-        
+
         q = {meta.facet_key: self.normalize_key(meta.path)}
-        
+
         if filters:
             if filters.get("has_fulltext") == "true":
                 q['has_fulltext'] = "true"
             if filters.get("publish_year"):
                 q['publish_year'] = filters['publish_year']
         return q
-        
+
     def normalize_key(self, key):
         return str_to_key(key).lower()
 
     def get_ebook_count(self, name, value, publish_year):
         return get_ebook_count(name, value, publish_year)
-    
+
     def facet_wrapper(self, facet, value, count):
         if facet == "publish_year":
             return [int(value), count]
@@ -343,7 +343,7 @@ class SubjectEngine:
             return [value, count]
         else:
             return web.storage(name=value, count=count)
-            
+
     def query_optons_for_details(self):
         """Additional query options to be added when details=True.
         """
@@ -363,11 +363,11 @@ class SubjectEngine:
 
 def get_ebook_count(field, key, publish_year=None):
     ebook_count_db = get_ebook_count_db()
-    
+
     # Handle the case of ebook_count_db_parametres not specified in the config.
     if ebook_count_db is None:
         return 0
-    
+
     def db_lookup(field, key, publish_year=None):
         sql = 'select sum(ebook_count) as num from subjects where field=$field and key=$key'
         if publish_year:
@@ -395,8 +395,8 @@ def get_ebook_count(field, key, publish_year=None):
 
 @web.memoize
 def get_ebook_count_db():
-    """Returns the ebook_count database. 
-    
+    """Returns the ebook_count database.
+
     The database object is created on the first call to this function and
     cached by memoize. Subsequent calls return the same object.
     """
@@ -411,7 +411,7 @@ def get_ebook_count_db():
 def find_ebook_count(field, key):
     q = '%s_key:%s+AND+(overdrive_s:*+OR+ia:*)' % (field, re_chars.sub(r'\\\1', key).encode('utf-8'))
     return execute_ebook_count_query(q)
-    
+
 def execute_ebook_count_query(q):
     root_url = solr_select_url + '?wt=json&indent=on&rows=%d&start=%d&q.op=AND&q=%s&fl=edition_key'
     rows = 1000
@@ -419,7 +419,7 @@ def execute_ebook_count_query(q):
     ebook_count = 0
     start = 0
     solr_url = root_url % (rows, start, q)
-    
+
     stats.begin("solr", url=solr_url)
     response = json.load(urllib.urlopen(solr_url))['response']
     stats.end()
@@ -455,7 +455,7 @@ def execute_ebook_count_query(q):
 
 def setup():
     """Placeholder for doing any setup required.
-    
+
     This function is called from code.py.
     """
     pass

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -55,7 +55,7 @@ class subjects(delegate.page):
             
         page = get_subject(key, details=True)
 
-        if page.work_count == 0:
+        if not page or page.work_count == 0:
             web.ctx.status = "404 Not Found"
             return render_template('subjects/notfound.tmpl', key)
 
@@ -245,6 +245,8 @@ class SubjectEngine:
 
         from search import work_search
         result = work_search(q, offset=offset, limit=limit, sort=sort, **kw)
+        if not result:
+            return None
         for w in result.docs:
             w.ia = w.ia and w.ia[0] or None
             w['checked_out'] = False

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -7,7 +7,7 @@ $if "merge-authors" in ctx.features and query_param('merge', 'false') == 'true':
         if ("$query_param('merge', 'false')" == "true") {
             \$("#preMerge").parent().andSelf().show();
 
-            $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]            
+            $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]
             var data = {
                 "master": "$page.key",
                 "duplicates": $:json_encode(duplicates)
@@ -16,22 +16,22 @@ $if "merge-authors" in ctx.features and query_param('merge', 'false') == 'true':
             \$.post("/authors/merge.json", JSON.stringify(data),
                 function(result, status, req) {
                     \$("#preMerge").fadeOut(); \$("#postMerge").fadeIn();
-                }, 
+                },
                 "json"
             );
             */
-            
+
             \$.ajax({
                 url: "/authors/merge.json",
                 type: "POST",
                 data: JSON.stringify(data),
                 success: function(data, textStatus, XMLHttpRequest) {
-                    \$("#preMerge").fadeOut(); 
-                    \$("#postMerge").fadeIn();                    
+                    \$("#preMerge").fadeOut();
+                    \$("#postMerge").fadeIn();
                 },
                 error: function(XMLHttpRequest, textStatus, errorThrown) {
-                    \$("#preMerge").fadeOut(); 
-                    \$("#errorMerge").fadeIn();                                        
+                    \$("#preMerge").fadeOut();
+                    \$("#errorMerge").fadeIn();
                 }
             });
         }
@@ -110,7 +110,7 @@ $ library = (get_library() if 'inlibrary' in ctx.features else None)
 
         $if page.website:
             <div class="section">
-                <h6 class="collapse black uppercase">$_("Website")</h6> 
+                <h6 class="collapse black uppercase">$_("Website")</h6>
                 <a href="$page.website" class="datalink">$page.website</a>
             </div>
 
@@ -130,13 +130,13 @@ $ library = (get_library() if 'inlibrary' in ctx.features else None)
                 <a name="books"></a>
                 <p><span class="tools">
                 $if books.num_found > 1:
-                    <img src="/images/icons/icon_sort.png" alt="Sorting by" width="9" height="11" style="margin-right:5px;"/> 
+                    <img src="/images/icons/icon_sort.png" alt="Sorting by" width="9" height="11" style="margin-right:5px;"/>
                     $if books.sort == 'editions':
-                        <strong class="lightgreen">Most Editions</strong> | <a href="$changequery(sort='old')#editions">First Published</a> | <a href="$changequery(sort='new')#editions">Most Recent</a> 
+                        <strong class="lightgreen">Most Editions</strong> | <a href="$changequery(sort='old')#editions">First Published</a> | <a href="$changequery(sort='new')#editions">Most Recent</a>
                     $elif books.sort == 'old':
-                        <a href="$changequery(sort=None)#editions">Most Editions</a> | <strong class="lightgreen">First Published</strong> | <a href="$changequery(sort='new')#editions">Most Recent</a> 
+                        <a href="$changequery(sort=None)#editions">Most Editions</a> | <strong class="lightgreen">First Published</strong> | <a href="$changequery(sort='new')#editions">Most Recent</a>
                     $elif books.sort == 'new':
-                        <a href="$changequery(sort=None)#editions">Most Editions</a> |  <a href="$changequery(sort='old')#editions">First Published</a> | <strong class="lightgreen">Most Recent</strong> 
+                        <a href="$changequery(sort=None)#editions">Most Editions</a> |  <a href="$changequery(sort='old')#editions">First Published</a> | <strong class="lightgreen">Most Recent</strong>
                     $elif books.sort == 'title':
                         <a href="$changequery(sort=None)#editions">Most Editions</a> |  <a href="$changequery(sort='old')#editions">First Published</a> | <a href="$changequery(sort='new')#editions">Most Recent</a> | <strong class="lightgreen">Title</strong>
                 </span></p>
@@ -207,7 +207,7 @@ $ library = (get_library() if 'inlibrary' in ctx.features else None)
     <div class="contentOnethird">
 
         <div class="illustration">
-            $:render_template("covers/author_photo", page) 
+            $:render_template("covers/author_photo", page)
             $:render_template("covers/change", page, ".bookCover img")
         </div>
 
@@ -222,10 +222,11 @@ $ library = (get_library() if 'inlibrary' in ctx.features else None)
                 </div>
 
         <!-- SUBJECTS DISPLAY -->
-        $:render_subjects("Subjects", books.get_facet('subject_facet'), '')
-        $:render_subjects("Places", books.get_facet('place_facet'), 'place:')
-        $:render_subjects("People", books.get_facet('person_facet'), 'person:')
-        $:render_subjects("Time", books.get_facet('time_facet'), 'time:')
+        $if books.num_found > 0:
+            $:render_subjects("Subjects", books.get_facet('subject_facet'), '')
+            $:render_subjects("Places", books.get_facet('place_facet'), 'place:')
+            $:render_subjects("People", books.get_facet('person_facet'), 'person:')
+            $:render_subjects("Time", books.get_facet('time_facet'), 'time:')
         <!-- /SUBJECTS -->
 
         $if "lists" in ctx.features:

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -90,10 +90,10 @@ class Solr:
         if len(payload) < 500:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
-            data = urllib2.urlopen(url).read()
+            data = urllib2.urlopen(url, timeout=3).read()
         else:
             logger.info("solr request: %s ...", url)
-            data = urllib2.urlopen(url, payload).read()
+            data = urllib2.urlopen(url, payload, timeout=3).read()
         return self._parse_solr_result(
             simplejson.loads(data), 
             doc_wrapper=doc_wrapper, 

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -86,7 +86,7 @@ class Solr:
         # switch to POST request when the payload is too big.
         # XXX: would it be a good idea to swithc to POST always?
         payload = urlencode(params, doseq=True)
-        url = self.base_url + "/select"        
+        url = self.base_url + "/select"
         if len(payload) < 500:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
@@ -95,8 +95,8 @@ class Solr:
             logger.info("solr request: %s ...", url)
             data = urllib2.urlopen(url, payload, timeout=3).read()
         return self._parse_solr_result(
-            simplejson.loads(data), 
-            doc_wrapper=doc_wrapper, 
+            simplejson.loads(data),
+            doc_wrapper=doc_wrapper,
             facet_wrapper=facet_wrapper)
 
     def _parse_solr_result(self, result, doc_wrapper, facet_wrapper):
@@ -130,7 +130,7 @@ class Solr:
         def escape_value(v):
             if isinstance(v, tuple): # hack for supporting range
                 return "[%s TO %s]" % (escape(v[0]), escape(v[1]))
-            elif isinstance(v, list): # one of 
+            elif isinstance(v, list): # one of
                 return "(%s)" % " OR ".join(escape_value(x) for x in v)
             else:
                 return '"%s"' % escape(v)


### PR DESCRIPTION
Add some quick exception handling for the most egregious offenders which cause OL to fall on its face when Archive.org or SOLR are unavailable.

These changes could really use tests, but without a good mocking framework in place, this is not trivial. Let's get this basic protection up first.