### PR TITLE
Eliminate Borrow interstitial page in favor of direct-to-BookReader links

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -245,16 +245,15 @@ class Edition(Thing):
             borrowable = ('lendinglibrary' in collections or
                          ('inlibrary' in collections and inlibrary.get_library() is not None))
 
-            archive_bookreader_url = 'https://archive.org/stream/%s' % self.ocaid
             if borrowable:
-                d['borrow_url'] = archive_bookreader_url
-                key = 'ebooks' + self.key
+                d['borrow_url'] = self.url("/borrow")
+                key = "ebooks" + self.key
                 doc = self._site.store.get(key) or {}
-                d['borrowed'] = doc.get('borrowed') == 'true'
+                d['borrowed'] = doc.get("borrowed") == "true"
             elif 'printdisabled' in collections:
                 pass # ebook is not available
             else:
-                d['read_url'] = archive_bookreader_url
+                d['read_url'] = "https://archive.org/stream/%s" % self.ocaid
         return d
 
     def get_ia_collections(self):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -245,15 +245,16 @@ class Edition(Thing):
             borrowable = ('lendinglibrary' in collections or
                          ('inlibrary' in collections and inlibrary.get_library() is not None))
 
+            archive_bookreader_url = 'https://archive.org/stream/%s' % self.ocaid
             if borrowable:
-                d['borrow_url'] = self.url("/borrow")
-                key = "ebooks" + self.key
+                d['borrow_url'] = archive_bookreader_url
+                key = 'ebooks' + self.key
                 doc = self._site.store.get(key) or {}
-                d['borrowed'] = doc.get("borrowed") == "true"
+                d['borrowed'] = doc.get('borrowed') == 'true'
             elif 'printdisabled' in collections:
                 pass # ebook is not available
             else:
-                d['read_url'] = "https://archive.org/stream/%s" % self.ocaid
+                d['read_url'] = archive_bookreader_url
         return d
 
     def get_ia_collections(self):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -28,24 +28,11 @@ $if user:
 $ borrow_link = page.url() + '/borrow'
 
 $if user_loan:
-    $if user_loan['resource_type'] == 'bookreader':
-        $# "do_return" is a fake "title" for the book that can be used for stats
-        $ return_url = user_loan['book'] + '/do_return/borrow'
-        $ loan_id = user_loan['_key'].replace('/', '_') # / not legal in HTML id
-        $ form_id = 'return_' + loan_id
-        $ read_form_id = 'read_' + loan_id
-
-        <form id='$form_id' action="$return_url" method="post" style='display:hidden'>
-        <input type="hidden" name="action" value="return" />
-        </form>
-        <form id='$read_form_id' method="POST" action="$page.key/_doread/borrow" style='display:hidden' id><input type="hidden" name="action" value="read"/><input type="text" name="ol_host" value="" class="hidden ol_host" /></form>
-        <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor">$ebook_text</a> <span class="smaller">You have this book checked out.
-        <a href="$user_loan['loan_link']" onclick="javascript:jQuery('#$read_form_id').submit(); return false">Read it</a> or <a href="$return_url" onclick="javascript:jQuery('.ol_host').attr('value', location.host); jQuery('#$form_id').submit(); return false;">return now</a>?</span></p>
-    $else:
-        <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor">$ebook_text</a> <span class="smaller">You have this book checked out.</span></p>
-
+    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor" class="borrow-link">Read/Return eBook</a><br />
+    <span class="smaller">You have this book checked out from $contributor</span></p>
 $elif available_loans:
-    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor">$ebook_text</a> <span class="smaller">PDF, ePub or in browser $:{line_break}from $contributor</span></p>
+    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor" class="borrow-link">Borrow eBook</a><br />
+    <span class="smaller">from $contributor</span></p>
 $else:
     <p style="padding-bottom:10px;">
         <span class="smaller">eBook is checked out.</span>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -28,10 +28,10 @@ $if user:
 $ borrow_link = page.url() + '/borrow'
 
 $if user_loan:
-    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor" class="borrow-link">Read/Return eBook</a><br />
+    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor" class="borrow-btn borrow-link">Read/Return eBook</a><br />
     <span class="smaller">You have this book checked out from $contributor</span></p>
 $elif available_loans:
-    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor" class="borrow-link">Borrow eBook</a><br />
+    <p style="padding-bottom:10px;"><a href="$borrow_link" title="Borrow from $contributor" class="borrow-btn borrow-link">Borrow eBook</a><br />
     <span class="smaller">from $contributor</span></p>
 $else:
     <p style="padding-bottom:10px;">

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -99,7 +99,7 @@ $elif page.get('ocaid'):
             <span class="head">Read</span>
         </h3>
         <div class="panel" id="readBooks">
-            <p><a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online"><strong>Read online</strong></a><br/><br/></p>
+            <p><a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="read-link" target="_blank"><strong>Read online</strong></a></p>
             $if downloadbook:
                 <p><a href="$downloadbook" title="Download a PDF from Internet Archive">PDF</a></p>
             $if djvutxt:

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -12,7 +12,7 @@ $ worldcatoclc = "http://worldcat.org/oclc/XXX"
 $ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
 $ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 
-$ viewbook = "//%s/stream/XXX" % bookreader_host()
+$ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
 $ downloadbook = page.get_ia_download_link(".pdf")
 $ pdfbw = page.get_ia_download_link("_bw.pdf")
 $ daisy = page.get_ia_download_link("_daisy.zip")

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -99,7 +99,7 @@ $elif page.get('ocaid'):
             <span class="head">Read</span>
         </h3>
         <div class="panel" id="readBooks">
-            <p><a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="read-link" target="_blank"><strong>Read online</strong></a></p>
+            <p><a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="read-btn" target="_blank"><strong>Read online</strong></a></p>
             $if downloadbook:
                 <p><a href="$downloadbook" title="Download a PDF from Internet Archive">PDF</a></p>
             $if djvutxt:

--- a/openlibrary/plugins/openlibrary/js/bookreader_direct.js
+++ b/openlibrary/plugins/openlibrary/js/bookreader_direct.js
@@ -1,0 +1,20 @@
+// Make Borrow links act as if POSTing to Borrow page
+
+jQuery(function() {
+  var borrowLinks = $('.image.borrow, .image.checked-out').closest('a');
+  borrowLinks.click(function(event) {
+    event.preventDefault();
+    var $this = $(this);
+    var borrowUrl = $this.attr('href');
+    var borrowFormString = "<form action='" + borrowUrl + "' method='POST'>\n" +
+      "<input type='hidden' name='action' value='borrow' />\n" +
+      "<input type='hidden' name='format' value='bookreader' />\n" +
+      "<input type='hidden' name='ol_host' value='" + location.host + "' />\n" +
+      "</form>";
+    $this.after($(borrowFormString));
+    $this.next().submit();
+    if (window.archive_analytics) {
+        window.archive_analytics.ol_send_event_ping({'category': 'BorrowLink', 'action': 'bookreader'});
+    }
+  });
+});

--- a/openlibrary/plugins/openlibrary/js/bookreader_direct.js
+++ b/openlibrary/plugins/openlibrary/js/bookreader_direct.js
@@ -1,7 +1,7 @@
 // Make Borrow links act as if POSTing to Borrow page
 
 jQuery(function() {
-  var borrowLinks = $('.image.borrow, .image.checked-out').closest('a');
+  var borrowLinks = $('.image.borrow, .image.checked-out, .borrow-link').closest('a');
   borrowLinks.click(function(event) {
     event.preventDefault();
     var $this = $(this);

--- a/openlibrary/plugins/openlibrary/js/bookreader_direct.js
+++ b/openlibrary/plugins/openlibrary/js/bookreader_direct.js
@@ -1,7 +1,8 @@
 // Make Borrow links act as if POSTing to Borrow page
 
 jQuery(function() {
-  $('.borrow-link').click(function(event) {
+  // TODO: After update jQuery, will need to get rid of deprecated .live()
+  $('.borrow-link').live('click', function(event) {
     event.preventDefault();
     var $this = $(this);
     var borrowUrl = $this.attr('href');

--- a/openlibrary/plugins/openlibrary/js/bookreader_direct.js
+++ b/openlibrary/plugins/openlibrary/js/bookreader_direct.js
@@ -5,7 +5,7 @@ jQuery(function() {
   $('.borrow-link').live('click', function(event) {
     event.preventDefault();
     var $this = $(this);
-    var borrowUrl = $this.attr('href');
+    var borrowUrl = $this.attr('href').replace(/'/g, '%27');
     var borrowFormString = "<form action='" + borrowUrl + "' method='POST' target='_blank'>\n" +
       "<input type='hidden' name='action' value='borrow' />\n" +
       "<input type='hidden' name='format' value='bookreader' />\n" +

--- a/openlibrary/plugins/openlibrary/js/bookreader_direct.js
+++ b/openlibrary/plugins/openlibrary/js/bookreader_direct.js
@@ -1,12 +1,11 @@
 // Make Borrow links act as if POSTing to Borrow page
 
 jQuery(function() {
-  var borrowLinks = $('.image.borrow, .image.checked-out, .borrow-link').closest('a');
-  borrowLinks.click(function(event) {
+  $('.borrow-link').click(function(event) {
     event.preventDefault();
     var $this = $(this);
     var borrowUrl = $this.attr('href');
-    var borrowFormString = "<form action='" + borrowUrl + "' method='POST'>\n" +
+    var borrowFormString = "<form action='" + borrowUrl + "' method='POST' target='_blank'>\n" +
       "<input type='hidden' name='action' value='borrow' />\n" +
       "<input type='hidden' name='format' value='bookreader' />\n" +
       "<input type='hidden' name='ol_host' value='" + location.host + "' />\n" +

--- a/openlibrary/templates/books/carousel_item.html
+++ b/openlibrary/templates/books/carousel_item.html
@@ -26,7 +26,7 @@ $else:
 
     $if book.get("read_url"):
         <div class="coverEbook">
-            <a href="$book.read_url" title="$_('Read online')"><img src="/images/icons/icon_ebook-avail.png" border="0" width="32" height="33" alt="$_('Read online')"/></a>
+            <a href="$book.read_url?ref=ol" target="_blank" title="$_('Read online')"><img src="/images/icons/icon_ebook-avail.png" border="0" width="32" height="33" alt="$_('Read online')"/></a>
         </div>
     $elif book.get("borrow_url"):
         <div class="coverEbook">
@@ -35,7 +35,7 @@ $else:
                     src="/images/icons/icon_borrow-not-avail.png" border="0" width="32" height="33"
                     alt="$_('This book is checked out')"/></a>
             $else:
-                <a href="$book.borrow_url" title="$_('Borrow this book')"><img
+                <a href="$book.borrow_url" target="_blank" title="$_('Borrow this book')" class="borrow-link"><img
                     src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33"
                     alt="$_('Borrow this book')"/></a>
         </div>
@@ -44,7 +44,7 @@ $else:
             $if book.get("checked_out"):
                 <a href="$book.url" title="$_('This book is checked out')"><img src="/images/icons/icon_borrow-not-avail.png" border="0" width="32" height="33" alt="$_('This book is checked out')"/></a>
             $else:
-                <a href="$book.inlibrary_borrow_url" title="$_('Borrow this book')"><img src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33" alt="$_('Borrow this book')"/></a>
+                <a href="$book.inlibrary_borrow_url" target="_blank" title="$_('Borrow this book')" class="borrow-link"><img src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33" alt="$_('Borrow this book')"/></a>
         </div>
     $elif book.get("daisy_url"):
         <div class="coverEbook">

--- a/openlibrary/templates/books/carousel_item.html
+++ b/openlibrary/templates/books/carousel_item.html
@@ -35,7 +35,7 @@ $else:
                     src="/images/icons/icon_borrow-not-avail.png" border="0" width="32" height="33"
                     alt="$_('This book is checked out')"/></a>
             $else:
-                <a href="$book.borrow_url" target="_blank" title="$_('Borrow this book')" class="borrow-link"><img
+                <a href="$book.borrow_url" title="$_('Borrow this book')" class="borrow-link"><img
                     src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33"
                     alt="$_('Borrow this book')"/></a>
         </div>
@@ -44,7 +44,7 @@ $else:
             $if book.get("checked_out"):
                 <a href="$book.url" title="$_('This book is checked out')"><img src="/images/icons/icon_borrow-not-avail.png" border="0" width="32" height="33" alt="$_('This book is checked out')"/></a>
             $else:
-                <a href="$book.inlibrary_borrow_url" target="_blank" title="$_('Borrow this book')" class="borrow-link"><img src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33" alt="$_('Borrow this book')"/></a>
+                <a href="$book.inlibrary_borrow_url" title="$_('Borrow this book')" class="borrow-link"><img src="/images/icons/icon_borrow-avail.png" border="0" width="32" height="33" alt="$_('Borrow this book')"/></a>
         </div>
     $elif book.get("daisy_url"):
         <div class="coverEbook">

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -5,7 +5,7 @@ $ worldcatoclc = "http://worldcat.org/oclc/XXX"
 $ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
 $ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 
-$ viewbook = "//%s/stream/XXX" % bookreader_host()
+$ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
 $ detailbook = "//archive.org/details/XXX"
 $ downloadbook = "//archive.org/download/XXX/XXX.pdf"
 $ pdfbw = "//archive.org/download/XXX/XXX_bw.pdf"
@@ -79,7 +79,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
         <div class="aaaa"></div>
         <div class="links">
             <ul>
-            <li><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="read-link">Read online</a></strong><br/></li>
+            <li><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="read-link" target="_blank">Read online</a></strong><br/></li>
             <li><a href="$downloadbook.replace('XXX', book.ocaid)" title="Download a PDF">PDF</a></li>
             <li><a href="$djvutxt.replace('XXX', book.ocaid)" title="Download a plain text version">Plain text</a></li>
             <li><a href="$book.url('/daisy')" title="Download a zipped DAISY file">DAISY</a></li>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -79,7 +79,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
         <div class="aaaa"></div>
         <div class="links">
             <ul>
-            <li><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader">Read online</a></strong><br/><br/></li>
+            <li><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="read-link">Read online</a></strong><br/></li>
             <li><a href="$downloadbook.replace('XXX', book.ocaid)" title="Download a PDF">PDF</a></li>
             <li><a href="$djvutxt.replace('XXX', book.ocaid)" title="Download a plain text version">Plain text</a></li>
             <li><a href="$book.url('/daisy')" title="Download a zipped DAISY file">DAISY</a></li>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -79,7 +79,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
         <div class="aaaa"></div>
         <div class="links">
             <ul>
-            <li><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="read-link" target="_blank">Read online</a></strong><br/></li>
+            <li><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="read-btn" target="_blank">Read online</a></strong><br/></li>
             <li><a href="$downloadbook.replace('XXX', book.ocaid)" title="Download a PDF">PDF</a></li>
             <li><a href="$djvutxt.replace('XXX', book.ocaid)" title="Download a plain text version">Plain text</a></li>
             <li><a href="$book.url('/daisy')" title="Download a zipped DAISY file">DAISY</a></li>

--- a/openlibrary/templates/lib/covers.html
+++ b/openlibrary/templates/lib/covers.html
@@ -99,7 +99,7 @@ $jsdef render_page(page):
 
             $ borrowable = all_borrow or contains(w.subject, 'Lending library') or (inlibrary and contains(w.subject, 'In library'))
             $if not all_borrow and w.ia and w.public_scan:
-                <div class="coverEbook"><a href="//archive.org/stream/$w.ia" title="$_('Read online')"><img src="/images/icons/icon_ebook-avail.png" border="0" width="32" height="33" alt="$_('Read online')"/></a></div>
+                <div class="coverEbook"><a href="//archive.org/stream/$w.ia?ref=ol" target="_blank" title="$_('Read online')"><img src="/images/icons/icon_ebook-avail.png" border="0" width="32" height="33" alt="$_('Read online')"/></a></div>
             $elif w.ia and w.lending_edition and borrowable:
                 $if w.checked_out:
                     $ img_src = "/images/icons/icon_borrow-not-avail.png"
@@ -108,7 +108,7 @@ $jsdef render_page(page):
                     $ img_src = "/images/icons/icon_borrow-avail.png"
                     $ img_title = _("Borrow this book")
                 <div class="coverEbook">
-                    <a href="/books/$w.lending_edition/x/borrow" title="$img_title"><img
+                    <a href="/books/$w.lending_edition/x/borrow" class="borrow-link" title="$img_title"><img
                         src="$img_src"
                         border="0" width="32" height="33" alt="$img_title"/></a>
                 </div>

--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -75,7 +75,7 @@ $if q:
                             </span>
                             <span class="actions">
                                     $if not (no_snippet & collection):
-                                            <a href="//archive.org/stream/$ia#search/$q" target="_blank" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
+                                            <a href="//archive.org/stream/$ia?ref=ol#search/$q" target="_blank" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
                                                     <span class="image read"></span>
                                                     <span class="label">$_("Read")</span>
                                             </a>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -192,12 +192,12 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                         $elif doc.lending_edition and (library or 'inlibrary' not in doc.collections):
                             <span class="actions read">
                                 $if doc.checked_out:
-                                    <a href="/books/$doc.lending_edition/x/borrow" title="This book is checked out">
+                                    <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="This book is checked out">
                                         <span class="image checked-out"></span>
                                         <span class="label">Checked out</span>
                                     </a>
                                 $else:
-                                    <a href="/books/$doc.lending_edition/x/borrow" title="Borrow book now">
+                                    <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Borrow book now">
                                         <span class="image borrow"></span>
                                         <span class="label">Borrow</span>
                                     </a>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -184,7 +184,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                         </span>
                         $if doc.public_scan:
                             <span class="actions read">
-                                <a href="//archive.org/stream/$doc.ia[0]" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
+                                <a href="//archive.org/stream/$doc.ia[0]?ref=ol" target="_blank" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
                                     <span class="image read"></span>
                                     <span class="label">Read</span>
                                 </a>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -168,13 +168,13 @@ $ ebook_status = page.get_ebook_status()
 $if ebook_status == "read-online":
     <div class="page-banner sansserief">
         This title is part of the <a href="https://openlibrary.org/read">classic eBook collection</a>.
-        $ read_url = "https://%s/stream/%s" % (bookreader_host(), page.ocaid)
-        <a class="button" href="$read_url">Read online now!</a>
+        $ read_url = "https://%s/stream/%s?ref=ol" % (bookreader_host(), page.ocaid)
+        <a class="button" target="_blank" href="$read_url">Read online now!</a>
     </div>
 $elif ebook_status == "borrow-available":
     <div class="page-banner sansserief">
         This title is part of the <a href="https://openlibrary.org/borrow">Lending Library collection</a>.
-        <a class="button" href="$page.url('/borrow')">Borrow eBook</a>
+        <a class="button borrow-link" href="$page.url('/borrow')">Borrow eBook</a>
     </div>
 $elif ebook_status == "borrow-checkedout":
     <div class="page-banner sansserief">

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -196,12 +196,12 @@ function get_seed_count() {
                                     </a>
                                 $elif 'borrow_url' in ebook:
                                     $if ebook.get('borrowed'):
-                                        <a href="$ebook['borrow_url']" title="This book is checked out">
+                                        <a href="$ebook['borrow_url']" class="borrow-link" title="This book is checked out">
                                             <span class="image checked-out"></span>
                                             <span class="label">Checked out</span>
                                         </a>
                                     $else:
-                                        <a href="$ebook['borrow_url']" title="Borrow book">
+                                        <a href="$ebook['borrow_url']" class="borrow-link" title="Borrow book">
                                             <span class="image borrow"></span>
                                             <span class="label">Borrow</span>
                                         </a>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -190,7 +190,7 @@ function get_seed_count() {
                             <!-- $:json_encode(ebook) -->
                             <span class="actions" style="float: right;">
                                 $if 'read_url' in ebook:
-                                    <a href="$ebook['read_url']" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
+                                    <a href="$ebook['read_url']?ref=ol" target="_blank" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
                                         <span class="image read"></span>
                                         <span class="label">$_("Read")</span>
                                     </a>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -271,7 +271,7 @@ function less(header) {
             </span>
             $if doc.public_scan and doc.get('has_fulltext'):
                 <span class="actions">
-                    <a href="//archive.org/stream/$doc.ia[0]" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
+                    <a href="//archive.org/stream/$doc.ia[0]?ref=ol" target="_blank" title="$_('Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT formats from main book page')">
                         <span class="image read"></span>
                         <span class="label">$_("Read")</span>
                     </a>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -279,12 +279,12 @@ function less(header) {
             $elif doc.lending_edition and (library or 'inlibrary' not in doc.collections):
                 <span class="actions">
                     $if doc.checked_out:
-                        <a href="/books/$doc.lending_edition/x/borrow" title="This book is checked out">
+                        <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="This book is checked out">
                             <span class="image checked-out"></span>
                             <span class="label">Checked out - Join waiting list</span>
                         </a>
                     $else:
-                        <a href="/books/$doc.lending_edition/x/borrow" title="Borrow book">
+                        <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Borrow book">
                             <span class="image borrow"></span>
                             <span class="label">Borrow</span>
                         </a>

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -1705,6 +1705,22 @@ table.navEdition td {
 select#select-id {
     max-width: 300px;
 }
+.borrow-link, .read-link {
+    color: white;
+    background: #036DAA;
+    border-radius: 5px;
+    padding: 5px 8px;
+    cursor: pointer;
+    display: inline-block;
+}
+.borrow-link:link, .borrow-link:visited, .read-link:link, .read-link:visited {
+    color: white;
+    text-decoration: none;
+}
+.borrow-link:hover, .read-link:hover {
+    color: white;
+    text-decoration: underline;
+}
 
 /* POPUP CAROUSEL SKIN */
 body#form .jcarousel-list-horizontal {
@@ -1791,6 +1807,9 @@ table.meta td.title {white-space:nowrap;width:120px;}
 table.meta td.object {white-space:nowrap;}
 table.meta td.tag {white-space:nowrap;}
 table.meta td.descrip {white-space:nowrap;width:65px;}
+
+#editions .links ul {list-style-type: none}
+#editions .links li {list-style-type: none}
 
 /* HISTORY */
 
@@ -3359,6 +3378,7 @@ p#borrowList {position:absolute;top:0;left:100%;width:300px;font-size:.75em;}
 p#postBorrowList {font-size:.75em;padding-left:55px;}
 .indent table.borrow {width:100%;}
 .indent table.borrow th,.indent table.borrow td {text-align: center;vertical-align: top;font-size: .875em;font-weight: 700;padding-bottom: 20px;}
+
 /* LISTS */
 #listTools ul {font-size:.75em;color:#666;font-family:"Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;margin:0 0 20px 0!important;}
 #contentHead #listTools ul {margin:15px 0 0 0!important;}

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -1705,7 +1705,7 @@ table.navEdition td {
 select#select-id {
     max-width: 300px;
 }
-.borrow-link, .read-link {
+.borrow-btn, .read-btn {
     color: white;
     background: #036DAA;
     border-radius: 5px;
@@ -1713,11 +1713,11 @@ select#select-id {
     cursor: pointer;
     display: inline-block;
 }
-.borrow-link:link, .borrow-link:visited, .read-link:link, .read-link:visited {
+.borrow-btn:link, .borrow-btn:visited, .read-btn:link, .read-btn:visited {
     color: white;
     text-decoration: none;
 }
-.borrow-link:hover, .read-link:hover {
+.borrow-btn:hover, .read-btn:hover {
     color: white;
     text-decoration: underline;
 }


### PR DESCRIPTION
Generally, all links where the user should be able to *read the book* now go directly to BookReader. OTOH, if a user tries to go to a book which has been checked out, they'll reach the old Borrow page, which has waitlist options; in that case, can't send them to BookReader directly because the special backdoor which allows OL users to interact with BookReader without needing an Archive account doesn't come into play.

In addition, the Read/Borrow links were made to look more like buttons. These links now open in `target="_blank"` since they go "offsite" to Archive.org. And public-domain BookReader links now add a `ref=ol` parameter so BookReader in the future can configure its Back button to point back to OL instead of Archive.