### PR TITLE
Address a few loan status presentation bugs

### DIFF
--- a/openlibrary/macros/LoanForm.html
+++ b/openlibrary/macros/LoanForm.html
@@ -1,23 +1,10 @@
 $def with (page, available_loans)
 
-$ default_type = 'bookreader'
-$ type_info = { 'epub': ('Download ePub for Digital Editions', 'smaller file that may contain text conversion errors'),'pdf': ('Download Scanned Book for Digital Editions', 'high quality scanned images'),'bookreader': ('Read Online', 'in the BookReader'), }
-
 $if not available_loans:
     $# Caller should check before calling
     No loans available
 
 $else:
-    $# sort loans
-    $code:
-        def loan_key(loan):
-            if loan['resource_type'] == default_type:
-                return '1-%s' % loan['resource_type']
-            else:
-                return '2-%s' % loan['resource_type']
-
-        available_loans.sort(key=loan_key)
-
     <script type="text/javascript">
     \$().ready(function(){
         \$('#borrowbook label').click(function(){
@@ -38,73 +25,26 @@ $else:
     </script>
     <div class="preSubmit" style="width:690px;">
     <form method="post" id="borrowbook" name="borrowBook" class="olform">
-    $ loan_types = [loan['resource_type'] for loan in available_loans]
-    $if ['epub'] == loan_types:
-        <fieldset class="download">
-            <legend>Download &amp; Open in Adobe Digital Editions</legend>
+        <fieldset class="online">
             <label>
-                <input type="radio" name="format" class="download" value="epub"/>
-                <strong>Download ePub</strong>
-                Reflowable text version
+                <input type="radio" name="format" class="online" value="bookreader"/>
+                <strong>Read in Browser</strong>
+                Open in our BookReader
             </label>
             <div>
                 <table cellpadding="0" cellspacing="0" border="0"><tbody>
                     <tr>
-                        <td class="icon"><img src="/images/icons/icon_wrench-borrow.png" width="30" height="30"/></td>
-                        <td>You <strong>must <a href="http://www.adobe.com/products/digitaleditions/" title="Visit adobe.com in a new browser window to install the software" target="newwindow">install Adobe Digital Editions</a> to view</strong><br/>this book in ePub format. (It's free.)</td>
+                        <td class="icon"><img src="/images/icons/icon_thumbsup-borrow.png" width="25" height="25"/></td>
+                        <td>
+                            <div class="ab-control ab-alt-one-row">Read online now.<br/>No extra software!</div>
+                            <div class="ab-experiment ab-alt-two-rows ab-alt-one-row-recommended">No extra software required.<br/>The Internet Archive will administer this loan.</div>
+                    </td>
                     </tr>
                 </tbody></table>
             </div>
         </fieldset>
-    $else:
-        $if 'bookreader' in loan_types:
-            <fieldset class="online">
-                <legend>Read in Browser</legend>
-                <label>
-                    <input type="radio" name="format" class="online" value="bookreader"/>
-                    <strong>Read in Browser</strong>
-                    Open in our BookReader
-                </label>
-                <div>
-                    <table cellpadding="0" cellspacing="0" border="0"><tbody>
-                        <tr>
-                            <td class="icon"><img src="/images/icons/icon_thumbsup-borrow.png" width="25" height="25"/></td>
-                            <td>
-                                <div class="ab-control ab-alt-one-row">Read online now.<br/>No extra software!</div>
-                                <div class="ab-experiment ab-alt-two-rows ab-alt-one-row-recommended"><strong>Recommended!</strong><br/>No extra software required.<br/>The Internet Archive will administer this loan.</div>
-                        </td>
-                        </tr>
-                    </tbody></table>
-                </div>
-            </fieldset>
-
-        $if 'pdf' in loan_types or 'epub' in loan_types:
-            <fieldset class="download">
-                <legend>Download &amp; Open in Adobe Digital Editions</legend>
-                $if 'pdf' in loan_types:
-                    <label style="margin-right:15px;">
-                        <input type="radio" name="format" class="download" value="pdf"/>
-                        <strong>Download PDF</strong>
-                        High quality page images
-                    </label>
-                $if 'epub' in loan_types:
-                    <label>
-                        <input type="radio" name="format" class="download" value="epub"/>
-                        <strong>Download ePub</strong>
-                        Smaller file, may contain errors
-                    </label>
-                <div>
-                    <table cellpadding="0" cellspacing="0" border="0"><tbody>
-                        <tr>
-                            <td class="icon"><img src="/images/icons/icon_wrench-borrow.png" width="30" height="30"/></td>
-                            <td>You <strong>must <a href="http://www.adobe.com/products/digitaleditions/" title="Visit adobe.com in a new browser window to install the software" target="newwindow">install Adobe Digital Editions</a> to view</strong><br/>either of these format options. (It's free.)<br/><br/>
-                            The Internet Archive will administer this loan, but Adobe may also collect some information.</td>
-                        </tr>
-                    </tbody></table>
-                </div>
-            </fieldset>
-    <input type="text" value="" id="ol_host" name="ol_host" class="hidden"/>
-    <input type="submit" value="Borrow This Book" id="borrowBtn" name="borrowBtn" class="hidden"/>
+        <input type="text" value="" id="ol_host" name="ol_host" class="hidden"/>
+        <input type="submit" value="Borrow This Book" id="borrowBtn" name="borrowBtn" class="hidden"/>
     </form>
     </div>
 

--- a/openlibrary/templates/borrow.html
+++ b/openlibrary/templates/borrow.html
@@ -85,29 +85,13 @@ $if wlsize > 0 and (not waiting_loan or waiting_loan['status'] != 'available'):
 
     $if ctx.user and ctx.user.has_borrowed(page):
         $ active_loan = ctx.user.get_loan_for(page)
-        $if can_return_resource_type(active_loan['resource_type']):
-            <div class="message info">
-                <h2 class="sansserif">You have this book checked out. You can read it online or return the book.
-                <p>
-                $:macros.LoanReadForm(active_loan['book'])
-                $:macros.ReturnForm(active_loan)
-                </p>
-            </div>
-        $else:
-            $# Currently this means ACS4
-            $if active_loan['expiry'] is not None:
-                $# Has been fulfilled
-                <div class="message info">
-                    <h2 class="sansserif">We show that you've borrowed this title.</h2>
-                    <p>Open Adobe Digital Editions to read it or return to Open Library.</p>
-                </div>
-            $else:
-                $# $$$ wording
-                <div class="message info">
-                    <h2 class="sansserif">We show that you've borrowed this but haven't loaded it in Digital Editions yet.</h2>
-                    <p>This loan is on hold for about 5 minutes. If you don't open it up within that time, someone else may borrow it. <a href="$active_loan['loan_link']"><strong>Download again</strong></a>?</p>
-                   <p>Do you need to try <a href="http://www.adobe.com/products/digitaleditions/">downloading Adobe Digital Editions again</a>? The PDF or ePub loans will only open in that program.</p>
-                </div>
+        <div class="message info">
+            <h2 class="sansserif">You have this book checked out. You can read it online or return the book.
+            <p>
+            $:macros.LoanReadForm(active_loan['book'])
+            $:macros.ReturnForm(active_loan)
+            </p>
+        </div>
     $elif not page.can_borrow():
         $# Check for in-library
         $if 'inlibrary' in page.get_ia_collections():

--- a/openlibrary/templates/lib/covers.html
+++ b/openlibrary/templates/lib/covers.html
@@ -101,12 +101,8 @@ $jsdef render_page(page):
             $if not all_borrow and w.ia and w.public_scan:
                 <div class="coverEbook"><a href="//archive.org/stream/$w.ia?ref=ol" target="_blank" title="$_('Read online')"><img src="/images/icons/icon_ebook-avail.png" border="0" width="32" height="33" alt="$_('Read online')"/></a></div>
             $elif w.ia and w.lending_edition and borrowable:
-                $if w.checked_out:
-                    $ img_src = "/images/icons/icon_borrow-not-avail.png"
-                    $ img_title = _("This book is checked out")
-                $else:
-                    $ img_src = "/images/icons/icon_borrow-avail.png"
-                    $ img_title = _("Borrow this book")
+                $ img_src = "/images/icons/icon_borrow-avail.png"
+                $ img_title = _("Borrow this book")
                 <div class="coverEbook">
                     <a href="/books/$w.lending_edition/x/borrow" class="borrow-link" title="$img_title"><img
                         src="$img_src"

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -191,16 +191,10 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                             </span>
                         $elif doc.lending_edition and (library or 'inlibrary' not in doc.collections):
                             <span class="actions read">
-                                $if doc.checked_out:
-                                    <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="This book is checked out">
-                                        <span class="image checked-out"></span>
-                                        <span class="label">Checked out</span>
-                                    </a>
-                                $else:
-                                    <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Borrow book now">
-                                        <span class="image borrow"></span>
-                                        <span class="label">Borrow</span>
-                                    </a>
+                                <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Read book">
+                                    <span class="image borrow"></span>
+                                    <span class="label">Read</span>
+                                </a>
                             </span>
                         $elif 'printdisabled' in doc.collections:
                             <span class="actions read">

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -195,16 +195,10 @@ function get_seed_count() {
                                         <span class="label">$_("Read")</span>
                                     </a>
                                 $elif 'borrow_url' in ebook:
-                                    $if ebook.get('borrowed'):
-                                        <a href="$ebook['borrow_url']" class="borrow-link" title="This book is checked out">
-                                            <span class="image checked-out"></span>
-                                            <span class="label">Checked out</span>
-                                        </a>
-                                    $else:
-                                        <a href="$ebook['borrow_url']" class="borrow-link" title="Borrow book">
-                                            <span class="image borrow"></span>
-                                            <span class="label">Borrow</span>
-                                        </a>
+                                    <a href="$ebook['borrow_url']" class="borrow-link" title="Read book">
+                                        <span class="image borrow"></span>
+                                        <span class="label">Read</span>
+                                    </a>
                                 $elif 'daisy_url' in ebook:
                                     <a href="$ebook['daisy_url']" title="Protected DAISY">
                                         <span class="image daisy"></span>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -278,16 +278,10 @@ function less(header) {
                 </span>
             $elif doc.lending_edition and (library or 'inlibrary' not in doc.collections):
                 <span class="actions">
-                    $if doc.checked_out:
-                        <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="This book is checked out">
-                            <span class="image checked-out"></span>
-                            <span class="label">Checked out - Join waiting list</span>
-                        </a>
-                    $else:
-                        <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Borrow book">
-                            <span class="image borrow"></span>
-                            <span class="label">Borrow</span>
-                        </a>
+                    <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Read book">
+                        <span class="image borrow"></span>
+                        <span class="label">Read</span>
+                    </a>
                 </span>
             $elif not doc.public_scan and 'printdisabled' in doc.collections:
                 <span class="actions">


### PR DESCRIPTION
- Papering over erroneous borrow status icons in search results, list details, author pages, etc. Now they all say “Read” and attempt to hit BookReader! :slightly_smiling_face:
- Removing the PDF/ePub options from the OL Borrow page, since these downloadables should be done from BookReader
- Changing the Borrow page logic so that even if you have borrowed via PDF/ePub options, you won’t be blocked on that page from opening BookReader