### PR TITLE
New private collections: prevent linking to them from Open Library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ reindex-solr:
 	psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy
 
 test:
-	py.test openlibrary/tests openlibrary/plugins/upstream/tests/test_forms.py openlibrary/plugins/upstream/tests/test_utils.py
+	py.test openlibrary/tests openlibrary/plugins/upstream/tests/test_forms.py openlibrary/plugins/upstream/tests/test_utils.py openlibrary/tests/core/test_models.py

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -36,6 +36,7 @@ __all__ = [
     "sprintf", "cond", "commify", "truncate", "datetimestr_utc",
     "urlsafe", "texsafe",
     "percentage", "affiliate_id", "bookreader_host",
+    "private_collections", "any_private_collections",
 
     # functions imported from elsewhere
     "parse_datetime", "safeint"
@@ -268,6 +269,14 @@ def affiliate_id(affiliate):
 
 def bookreader_host():
     return config.get('bookreader_host', '')
+
+def private_collections():
+    """Collections which are lendable but should not be linked from OL
+    TODO: Remove when we can handle institutional books"""
+    return ['georgetown-university-law-library-rr']
+
+def any_private_collections(collections):
+    return any(x in private_collections() for x in collections)
 
 def _get_helpers():
     _globals = globals()

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -210,7 +210,13 @@ def sync_loan(identifier, loan=NOT_INITIALIZED):
         ocaid=loan['ocaid'],
         book=loan['book'])
 
-    wl = ia_lending_api.get_waitinglist_of_book(identifier)
+    try:
+        wl = ia_lending_api.get_waitinglist_of_book(identifier)
+    except urllib2.URLError:
+        pass
+    if wl is None:
+        logger.error("failed to get waitinglist for %s", identifier, exc_info=True)
+        return
 
     # for the end user, a book is not available if it is either
     # checked out or someone is waiting.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -15,6 +15,7 @@ from openlibrary.plugins.upstream.utils import get_history
 from openlibrary.plugins.upstream.account import Account
 from openlibrary import accounts
 from openlibrary.core import loanstats
+from openlibrary.core.helpers import any_private_collections
 
 # relative imports
 from lists.model import ListMixin, Seed
@@ -265,15 +266,9 @@ class Edition(Thing):
                 or 'lendinglibrary' in collections
                 or self.get_ia_meta_fields().get("access-restricted") is True)
 
-    # Special check to prevent private collection books from
-    # appearing with Borrow links in OL
-    # TODO: Remove when we can handle institutional books
+    # Private collections are lendable books that should not be linked/revealed from OL
     def is_in_private_collection(self):
-        ia_collections = self.get_ia_collections()
-        return any(x in self.private_collections() for x in ia_collections)
-
-    def private_collections(self):
-        return ['georgetown-university-law-library-rr']
+        return any_private_collections(self.get_ia_collections())
 
     def can_borrow(self):
         collections = self.get_ia_collections()

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -265,11 +265,21 @@ class Edition(Thing):
                 or 'lendinglibrary' in collections
                 or self.get_ia_meta_fields().get("access-restricted") is True)
 
+    # Special check to prevent private collection books from
+    # appearing with Borrow links in OL
+    # TODO: Remove when we can handle institutional books
+    def is_in_private_collection(self):
+        ia_collections = self.get_ia_collections()
+        return any(x in self.private_collections() for x in ia_collections)
+
+    def private_collections(self):
+        return ['georgetown-university-law-library-rr']
+
     def can_borrow(self):
         collections = self.get_ia_collections()
-        return (
-            'lendinglibrary' in collections or
-            ('inlibrary' in collections and inlibrary.get_library() is not None))
+        return ('lendinglibrary' in collections or
+            ('inlibrary' in collections and inlibrary.get_library() is not None)
+            ) and not self.is_in_private_collection()
 
     def get_waitinglist(self):
         """Returns list of records for all users currently waiting for this book."""

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -123,7 +123,7 @@ $else:
     </div>
     </div>
 
-$if isbn or oclc_numbers or 'lendinglibrary' in collection or library:
+$if (isbn or oclc_numbers or 'lendinglibrary' in collection or library) and not any_private_collections(collection):
     <div>
     <h3 class="header">
         <span class="icon borrow"></span>

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -140,7 +140,7 @@ def loans_carousel(loans=None, css_id="CarouselLoans"):
     """Generates 'Your Loans' carousel on home page"""
     _loans = loans or []
     books = [format_book_data(web.ctx.site.get(loan['book']))
-             for loan in _loans]
+             for loan in _loans if web.ctx.site.get(loan['book'])]
     return render_template(
         "books/carousel", storify(books), id=css_id
     ) if books else ""

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -1,0 +1,4 @@
+"""py.test tests for borrow.py"""
+import web
+from .. import borrow
+

--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -90,6 +90,8 @@ $else:
         <!-- for each borrow -->
         $for loan in loans:
             $ book = get_document(loan['book'])
+            $if book is None:
+                $continue
             <tr>
                 <td class="cover">
                 $:render_template('covers/book_cover_small', book)

--- a/openlibrary/templates/books/edition-show.html
+++ b/openlibrary/templates/books/edition-show.html
@@ -175,7 +175,9 @@ $ publishers = (', '.join(book.publishers))
             <tbody>
                 $:display_identifiers("Open Library", [storage(url=None, value=book.key.split("/")[-1])])
                 $for name, values in book.get_identifiers().multi_items():
-                    $:display_identifiers(values[0].label, values)
+                    $ identifier_label = values[0].label
+                    $if not (book.is_in_private_collection() and identifier_label == 'Internet Archive'):
+                        $:display_identifiers(identifier_label, values)
             </tbody>
             </table>
             $:display_goodreads("Open Library", [storage(url=None, value=book.key.split("/")[-1])])

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -96,7 +96,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
         </div>
         </td>
 
-    $if isbn_10 or oclc_numbers or 'lendinglibrary' in collection or library:
+    $if (isbn_10 or oclc_numbers or 'lendinglibrary' in collection or library) and not any_private_collections(collection):
         <td class="icon borrow">
             <div class="aaaa"></div>
             <div class="links">

--- a/openlibrary/templates/borrow.html
+++ b/openlibrary/templates/borrow.html
@@ -98,8 +98,8 @@ $if wlsize > 0 and (not waiting_loan or waiting_loan['status'] != 'available'):
             <h2 class="sansserif">This book isn't available to borrow.</h2>
             <p>This book is part of a special collection. Look for something else in the <a href="/borrow">lending library</a>?</p>
 
-        $# Check for in-library
         $elif 'inlibrary' in page.get_ia_collections():
+            $# Check for in-library
             $if available_loans:
                 <div class="message info">
                     $# george copy

--- a/openlibrary/templates/borrow.html
+++ b/openlibrary/templates/borrow.html
@@ -93,8 +93,13 @@ $if wlsize > 0 and (not waiting_loan or waiting_loan['status'] != 'available'):
             </p>
         </div>
     $elif not page.can_borrow():
+        $# Check for private collection
+        $if page.is_in_private_collection():
+            <h2 class="sansserif">This book isn't available to borrow.</h2>
+            <p>This book is part of a special collection. Look for something else in the <a href="/borrow">lending library</a>?</p>
+
         $# Check for in-library
-        $if 'inlibrary' in page.get_ia_collections():
+        $elif 'inlibrary' in page.get_ia_collections():
             $if available_loans:
                 <div class="message info">
                     $# george copy

--- a/openlibrary/templates/borrow.html
+++ b/openlibrary/templates/borrow.html
@@ -86,7 +86,7 @@ $if wlsize > 0 and (not waiting_loan or waiting_loan['status'] != 'available'):
     $if ctx.user and ctx.user.has_borrowed(page):
         $ active_loan = ctx.user.get_loan_for(page)
         <div class="message info">
-            <h2 class="sansserif">You have this book checked out. You can read it online or return the book.
+            <h2 class="sansserif">You have this book checked out. You can read it online or return the book.</h2>
             <p>
             $:macros.LoanReadForm(active_loan['book'])
             $:macros.ReturnForm(active_loan)

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -26,8 +26,9 @@ $:render_template("home/splash")
     $:render_template("home/returncart")
     <div class="clearfix"></div>
 
-    $:render_template("home/loans", loans)
-    <div class="clearfix"></div>
+    $if loans:
+        $:render_template("home/loans", loans)
+        <div class="clearfix"></div>
 
     $:render_template("home/stats", stats)
     <div class="clearfix"></div>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -189,7 +189,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                                     <span class="label">Read</span>
                                 </a>
                             </span>
-                        $elif doc.lending_edition and (library or 'inlibrary' not in doc.collections):
+                        $elif doc.lending_edition and (library or 'inlibrary' not in doc.collections) and not any_private_collections(doc.collections):
                             <span class="actions read">
                                 <a href="/books/$doc.lending_edition/x/borrow" class="borrow-link" title="Read book">
                                     <span class="image borrow"></span>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -393,7 +393,9 @@ $elif ebook_status == "borrow-user-checkedout":
             <tbody>
                 $:display_identifiers("Open Library", [storage(url=None, value=page.key.split("/")[-1])])
                 $for name, values in page.get_identifiers().multi_items():
-                    $:display_identifiers(values[0].label, values, itemprop=cond(name in ["isbn_10", "isbn_13"], "isbn", None))
+                    $ identifier_label = values[0].label
+                    $if not (page.is_in_private_collection() and identifier_label == 'Internet Archive'):
+                        $:display_identifiers(identifier_label, values, itemprop=cond(name in ["isbn_10", "isbn_13"], "isbn", None))
             </tbody>
             </table>
             $:display_goodreads("Open Library", [storage(url=None, value=page.key.split("/")[-1])])

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -17,18 +17,16 @@ class TestSearch:
         browser.visit(self.host + '/search/inside')
         browser.find_by_css(".searchInsideForm > input[name='q']").fill('black cat')
         browser.find_by_css(".searchInsideForm > [type='submit']").click()
-        # No Elastic Search in test rig, so expect to return error message
         assert browser.is_text_present('Search Inside')
-        assert browser.is_element_present_by_css("[class='searchResultsError']")
+        assert browser.is_element_present_by_css('.searchInsideForm')
 
     def test_search_inside_from_global_nav(self, browser):
         browser.visit(self.host)
         browser.find_by_css("#headerSearch input[name='q']").fill('black cat')
         browser.find_by_css("#headerSearch input[name='search-fulltext']").check()
         browser.find_by_css("#headerSearch [type='submit']").click()
-        # No Elastic Search in test rig, so expect to return error message
         assert browser.is_text_present('Search Inside')
-        assert browser.is_element_present_by_css("[class='searchResultsError']")
+        assert browser.is_element_present_by_css('.searchInsideForm')
 
     def test_metadata_search(self, browser):
         browser.visit(self.host + '/search')


### PR DESCRIPTION
If an Archive book item is in a private collection (as defined in `openlibrary/core/helpers.py:private_collections()`), then don't show an IA identifier on the Edition page, and block attempts to read the items via the Borrow page. As a convenience, also remove Read links from the Edition and Work pages.

Also adds a few code defenses from bad return values and fixes an unclosed HTML tag.