### PR TITLE
Prioritize oclc over isbn for physical copy searches

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -7,8 +7,8 @@ $elif page.type.key in ["/type/work", "/type/edition", "/type/author"]:
 $else:
     $ edit_url = page.key + "?m=edit"
 
-$ worldcat = "http://worldcat.org/isbn/XXX"
-$ worldcatoclc = "http://worldcat.org/oclc/XXX"
+$ worldcat = "https://worldcat.org/isbn/XXX"
+$ worldcatoclc = "https://worldcat.org/oclc/XXX"
 $ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
 $ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 
@@ -178,7 +178,7 @@ $else:
             <span class="head">Borrow</span>
 	</h3>
 	<div class="panel">
-            <p class="smaller">Try a <a href="http://www.worldcat.org/" title="Search WorldCat for an available edition">WorldCat</a> search?</p>
+            <p class="smaller">Try a <a href="https://www.worldcat.org/" title="Search WorldCat for an available edition">WorldCat</a> search?</p>
 	</div>
     </div>
 

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -162,10 +162,10 @@ $if (isbn or oclc_numbers or 'lendinglibrary' in collections or library) and not
                         </p>
 
             <p>
-                $if isbn:
-                    <a href="$worldcat.replace('XXX', isbn)" title="Check WorldCat for an edition near you">
-                $elif oclc_numbers:
+                $if oclc_numbers:
                     <p><a href="$worldcatoclc.replace('XXX', oclc_numbers)" title="Check WorldCat for an edition near you">
+                $elif isbn:
+                    <a href="$worldcat.replace('XXX', isbn)" title="Check WorldCat for an edition near you">
 
 		Find a physical copy near you</a> &mdash; <span class="smaller">powered by <a href="https://worldcat.org">WorldCat</a></span>
             </p>

--- a/openlibrary/plugins/openlibrary/pages/config_edition.page
+++ b/openlibrary/plugins/openlibrary/pages/config_edition.page
@@ -189,7 +189,7 @@
             "label": "National Library of Australia"
         },
         {
-            "url": "http://www.worldcat.org/oclc/@@@?tab=details",
+            "url": "https://www.worldcat.org/oclc/@@@?tab=details",
             "name": "oclc_numbers",
             "label": "OCLC/WorldCat"
         },

--- a/openlibrary/plugins/openlibrary/pages/config_edition.page
+++ b/openlibrary/plugins/openlibrary/pages/config_edition.page
@@ -9,7 +9,7 @@
             "label": "Library of Congress"
         },
         {
-            "website": "http://rvk.uni-regensburg.de/index.php?option=com_rvko&view=show&Itemid=53",
+            "website": "https://rvk.uni-regensburg.de/index.php?option=com_rvko&view=show&Itemid=53",
             "notes": "",
             "name": "rvk",
             "label": "RVK"
@@ -106,7 +106,7 @@
     ],
     "identifiers": [
         {
-            "url": "http://www.amazon.com/gp/product/@@@",
+            "url": "https://www.amazon.com/gp/product/@@@",
             "name": "amazon",
             "label": "Amazon ASIN"
         },
@@ -124,23 +124,23 @@
         },
         {
             "url": "http://d-nb.info/@@@",
-            "website": "http://www.d-nb.de/eng/index.htm",
+            "website": "http://www.dnb.de/EN",
             "notes": "",
             "name": "dnb",
             "label": "Deutsche National Bibliothek"
         },
         {
-            "url": "http://www.goodreads.com/book/show/@@@",
+            "url": "https://www.goodreads.com/book/show/@@@",
             "name": "goodreads",
             "label": "Goodreads"
         },
         {
-            "url": "http://books.google.com/books?id=@@@",
+            "url": "https://books.google.com/books?id=@@@",
             "name": "google",
             "label": "Google"
         },
         {
-            "url": "http://www.archive.org/details/@@@",
+            "url": "https://www.archive.org/details/@@@",
             "name": "ocaid",
             "label": "Internet Archive"
         },
@@ -153,8 +153,8 @@
             "label": "ISBN 13"
         },
         {
-            "url": "http://catalog.hathitrust.org/Record/@@@",
-            "website": "http://hathitrust.org/",
+            "url": "https://catalog.hathitrust.org/Record/@@@",
+            "website": "https://hathitrust.org/",
             "name": "hathi_trust",
             "label": "Hathi Trust"
         },
@@ -166,17 +166,17 @@
             "label": "Harvard University Library"
         },
         {
-            "url": "http://lccn.loc.gov/@@@",
+            "url": "https://lccn.loc.gov/@@@",
             "name": "lccn",
             "label": "LC Control Number"
         },
         {
-            "url": "http://www.librarything.com/work/@@@",
+            "url": "https://www.librarything.com/work/@@@",
             "name": "librarything",
             "label": "Library Thing"
         },
         {
-            "url": "http://www.lulu.com/product/@@@",
+            "url": "https://www.lulu.com/product/@@@",
             "website": "http://www.lulu.com",
             "name": "lulu",
             "label": "Lulu"
@@ -199,13 +199,13 @@
             "label": "Paperback Swap"
         },
         {
-            "url": "http://www.gutenberg.org/etext/@@@",
+            "url": "https://www.gutenberg.org/etext/@@@",
             "website": "www.gutenberg.org",
             "name": "project_gutenberg",
             "label": "Project Gutenberg"
         },
         {
-            "url": "http://www.scribd.com/doc/@@@/",
+            "url": "https://www.scribd.com/doc/@@@/",
             "website": "http://www.scribd.com/",
             "name": "scribd",
             "label": "Scribd"
@@ -235,7 +235,7 @@
             "label": "ISSN"
         },
         {
-            "website": "www.alibris.com",
+            "website": "http://www.alibris.com",
             "notes": "",
             "name": "alibris",
             "label": "Alibris"

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -18,8 +18,26 @@ $ djvutxt = "//archive.org/download/XXX/XXX_djvu.txt"
 $ seeall = "//archive.org/download/XXX"
 $ google = ""
 
-$ isbn_10 = (book.isbn_10 and book.isbn_10[0]) or ""
+$ isbn = (book.isbn_10 and book.isbn_10[0]) or (book.isbn_13 and book.isbn_13[0]) or ""
+$ isbn = isbn.replace("-", "")
 $ oclc_numbers = (book.oclc_numbers and book.oclc_numbers[0]) or ""
+$ isbn_13 = (book.isbn_13 and book.isbn_13[0]) or ""
+$ isbn_10 = ""
+$if book.isbn_10:
+    $ isbn_10 = book.isbn_10[0].replace("-", "")
+$elif isbn_13:
+    $ isbn_10 = isbn_13_to_isbn_10(isbn_13)
+
+$ asin = None
+$ scribd = None
+$if book.get('identifiers'):
+    $if book.identifiers.get('scribd'):
+        $ scribd = book.identifiers.scribd[0]
+    $if book.identifiers.get('amazon'):
+        $ asin = book.identifiers.amazon[0]
+
+$if isbn_10 and not asin:
+    $ asin = isbn_10
 
 $ library = None
 $ collection = set()
@@ -29,8 +47,6 @@ $if meta_fields:
     $ contrib = meta_fields.get('contributor')
     $if 'inlibrary' in collection and 'inlibrary' in ctx.features:
         $ library = get_library()
-
-$ scribd = book.get('identifiers', {}).get('scribd', [None])[0]
 
 $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
 
@@ -96,7 +112,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
         </div>
         </td>
 
-    $if (isbn_10 or oclc_numbers or 'lendinglibrary' in collection or library) and not private_collection_in(collection):
+    $if (isbn or oclc_numbers or 'lendinglibrary' in collection or library) and not private_collection_in(collection):
         <td class="icon borrow">
             <div class="aaaa"></div>
             <div class="links">
@@ -112,8 +128,8 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
                     <li>$:macros.LoanStatus(book, 'eBook', ctx.user, current_and_available_loans, contrib, '')</li>
                 $if oclc_numbers:
                     <li><a href="$worldcatoclc.replace('XXX', oclc_numbers)" title="Look for this edition at WorldCat">Physical copy</a><br /><span class="gray smaller">via WorldCat</span></li>
-                $elif isbn_10:
-                    <li><a href="$worldcat.replace('XXX', isbn_10)" title="Look for this edition at WorldCat">Physical copy</a><br /><span class="gray smaller">via WorldCat</span></li>
+                $elif isbn:
+                    <li><a href="$worldcat.replace('XXX', isbn)" title="Look for this edition at WorldCat">Physical copy</a><br /><span class="gray smaller">via WorldCat</span></li>
                 </ul>
             </div>
         </td>
@@ -124,13 +140,11 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
             </div>
         </td>
 
-    $if isbn_10 or scribd:
-        $if isbn_10:
-            $ isbn_10 = isbn_10.replace('-', '')
+    $if isbn or scribd:
         <td class="icon buy">
         <div class="aaaa"></div>
         <div class="links">
-            $:macros.AffiliateLinks({'isbn': isbn_10, 'asin': isbn_10, 'scribd': scribd})
+            $:macros.AffiliateLinks({'isbn': isbn, 'asin': asin, 'scribd': scribd})
         </div>
         </td>
     $else:

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -110,10 +110,10 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
                                 $ user_loan = current_loan
                                 $ break
                     <li>$:macros.LoanStatus(book, 'eBook', ctx.user, current_and_available_loans, contrib, '')</li>
-                $if isbn_10:
-                    <li><a href="$worldcat.replace('XXX', isbn_10)" title="Look for this edition at WorldCat">Physical copy</a><br /><span class="gray smaller">via WorldCat</span></li>
-                $elif oclc_numbers:
+                $if oclc_numbers:
                     <li><a href="$worldcatoclc.replace('XXX', oclc_numbers)" title="Look for this edition at WorldCat">Physical copy</a><br /><span class="gray smaller">via WorldCat</span></li>
+                $elif isbn_10:
+                    <li><a href="$worldcat.replace('XXX', isbn_10)" title="Look for this edition at WorldCat">Physical copy</a><br /><span class="gray smaller">via WorldCat</span></li>
                 </ul>
             </div>
         </td>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -1,7 +1,7 @@
 $def with (book)
 
-$ worldcat = "http://worldcat.org/isbn/XXX"
-$ worldcatoclc = "http://worldcat.org/oclc/XXX"
+$ worldcat = "https://worldcat.org/isbn/XXX"
+$ worldcatoclc = "https://worldcat.org/oclc/XXX"
 $ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
 $ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -140,7 +140,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
             </div>
         </td>
 
-    $if isbn or scribd:
+    $if isbn or asin or scribd:
         <td class="icon buy">
         <div class="aaaa"></div>
         <div class="links">

--- a/openlibrary/templates/borrow/about.html
+++ b/openlibrary/templates/borrow/about.html
@@ -42,8 +42,8 @@ $var title: $title
         <p class="large collapse"><strong>$_("Open Lending")</strong></p>
         <p class="average collapse">$:_('Any Open Library account holder around the world can borrow from a smaller collection of <a href="/search?sort=new&subject_facet=Lending+library" title="Search the Lending Library"><strong>about 10,000 eBooks</strong></a>. Brought to you by the <a href="//archive.org/" title="Visit the Internet Archive">Internet Archive</a> and its partner libraries.')</p>
         <br/>
-        <p class="large collapse"><strong>$_("WorldCat")</strong> <a href="http://www.worldcat.org/" title="Visit WorldCat.org"><img src="/images/icons/icon_linkout-sm.png" alt="icon_linkout-sm" width="16" height="16" title="external link"/></a></p>
-        <p class="average collapse">$:_('If we can\'t offer an eBook to borrow, we link into the <a href="http://www.worldcat.org/" title="Visit WorldCat.org">WorldCat</a> catalog to help you find a copy to borrow from a library near you.')</p>
+        <p class="large collapse"><strong>$_("WorldCat")</strong> <a href="https://www.worldcat.org/" title="Visit WorldCat.org"><img src="/images/icons/icon_linkout-sm.png" alt="icon_linkout-sm" width="16" height="16" title="external link"/></a></p>
+        <p class="average collapse">$:_('If we can\'t offer an eBook to borrow, we link into the <a href="https://www.worldcat.org/" title="Visit WorldCat.org">WorldCat</a> catalog to help you find a copy to borrow from a library near you.')</p>
     </div>
 
     <p class="left smaller center lightgrey sansserif" style="width:100%;"><span class="attn large">*</span>$:_('If you\'re from a library that would like to join the In-Library Lending program, please <a href="/libraries/register" title="Add your library">register your interest</a>!')</p>

--- a/openlibrary/templates/type/edition-history/view.html
+++ b/openlibrary/templates/type/edition-history/view.html
@@ -8,7 +8,7 @@ $ title = page.title_prefix + ' ' + page.title
 
 $var title: $title
 
-$ lccn = page["lccn"] and page["lccn"][0] and ("http://lccn.loc.gov/" + page["lccn"][0])
+$ lccn = page["lccn"] and page["lccn"][0] and ("https://lccn.loc.gov/" + page["lccn"][0])
 $ oclc = page["oclc_numbers"] and page["oclc_numbers"][0] and ("https://www.worldcat.org/oclc/" + page["oclc_numbers"][0] + "?tab=details")
 $ key = page.key
 $ detailbook = "//archive.org/details/XXX"

--- a/openlibrary/templates/type/edition-history/view.html
+++ b/openlibrary/templates/type/edition-history/view.html
@@ -9,7 +9,7 @@ $ title = page.title_prefix + ' ' + page.title
 $var title: $title
 
 $ lccn = page["lccn"] and page["lccn"][0] and ("http://lccn.loc.gov/" + page["lccn"][0])
-$ oclc = page["oclc_numbers"] and page["oclc_numbers"][0] and ("http://www.worldcat.org/oclc/" + page["oclc_numbers"][0] + "?tab=details")
+$ oclc = page["oclc_numbers"] and page["oclc_numbers"][0] and ("https://www.worldcat.org/oclc/" + page["oclc_numbers"][0] + "?tab=details")
 $ key = page.key
 $ detailbook = "//archive.org/details/XXX"
 

--- a/static/openbook/openbook.js
+++ b/static/openbook/openbook.js
@@ -146,7 +146,7 @@ function setup_openbook(bibkey, book) {
     
     function make_worldcat() {
         var out = ''
-            + '<a target="_blank" href="http://worldcat.org/isbn/ISBN" title="Find this title in a local library using WorldCat">'
+            + '<a target="_blank" href="https://worldcat.org/isbn/ISBN" title="Find this title in a local library using WorldCat">'
             + 'Find in library'
             + '</a>';
         return "<div>" + out.replace("ISBN", book.isbn) + "</div>";


### PR DESCRIPTION
This should address issue #422, by making OCLC number the preferred search parameter to Worldcat when it exists, and falling back to ISBN only when it does not.