### PR TITLE
use https and avoid redirects on site footer links

### DIFF
--- a/openlibrary/templates/lib/site_legal.html
+++ b/openlibrary/templates/lib/site_legal.html
@@ -2,7 +2,7 @@ $def with (page)
 
     <div id="bottom">
         <div id="legal">
-        <p>$:_('Open Library is an initiative of the <a href="//archive.org/">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in digital form.<br/>Other <a href="//archive.org/projects/">projects</a> include the <a href="http://waybackmachine.org">Wayback Machine</a>, <a href="//archive.org/">archive.org</a> and <a href="http://www.archive-it.org">archive-it.org</a>')</p>
+        <p>$:_('Open Library is an initiative of the <a href="//archive.org/">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in digital form.<br/>Other <a href="//archive.org/projects/">projects</a> include the <a href="//archive.org/web/">Wayback Machine</a>, <a href="//archive.org/">archive.org</a> and <a href="//archive-it.org">archive-it.org</a>')</p>
 
         <p>$:_('Your use of the Open Library is subject to the Internet Archive\'s <a href="//archive.org/about/terms.php">Terms of Use</a>.')
         <!--


### PR DESCRIPTION
A small change to use https for all links in the footer. Issue #324 

https://archive.org/web/ appears to be the canonical URL for the wayback machine, this change avoids unnecessary redirects between sites controlled by the IA.  