### PR TITLE
Allow wiki to display https links

### DIFF
--- a/openlibrary/core/olmarkdown.py
+++ b/openlibrary/core/olmarkdown.py
@@ -59,6 +59,9 @@ class OLMarkdown(markdown.Markdown):
         self._patch()
 
     def _patch(self):
+        patterns = self.inlinePatterns
+        autolink = markdown.AutolinkPattern(markdown.AUTOLINK_RE.replace('http', 'https?'))
+        patterns[patterns.index(markdown.AUTOLINK_PATTERN)] = autolink
         p = self.preprocessors
         p[p.index(markdown.LINE_BREAKS_PREPROCESSOR)] = LINE_BREAKS_PREPROCESSOR
         p.append(AUTOLINK_PREPROCESSOR)

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -10,9 +10,9 @@ def test_olmarkdown():
 
     assert md("**foo**") == p("<strong>foo</strong>")
     assert md("<b>foo</b>") == p('<b>foo</b>')
-    assert md("http://openlibrary.org") == p(
-            '<a href="http://openlibrary.org" rel="nofollow">' +
-                'http://openlibrary.org' +
+    assert md("https://openlibrary.org") == p(
+            '<a href="https://openlibrary.org" rel="nofollow">' +
+                'https://openlibrary.org' +
             '</a>'
         )
 

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -15,6 +15,11 @@ def test_olmarkdown():
                 'https://openlibrary.org' +
             '</a>'
         )
+    assert md("http://example.org") == p(
+            '<a href="http://example.org" rel="nofollow">' +
+                'http://example.org' +
+            '</a>'
+        )
 
     # why extra spaces?
     assert md("a\nb") == p("a<br/>\n   b")


### PR DESCRIPTION
This fixes the failing tests uncovered in PR #450 by @jack17529 , which happens to show the issue raised in #457 about https links not appearing on the wiki.

Strangely, this post made years ago by @anandology on a different forum helped me fix the issue: https://bugs.launchpad.net/infogami/+bug/193622  thanks! :)

Looks like a bug in infogami's markdown parser which is still current. The regex's in the olmarkdown.py that match `https` are for a link _PRE_ processor -- when the https url is passed on to the actual markdown processor, it hits the bug and is stripped.

I added in the http version of the test to ensure the markdown parser is backwards compatible and can support any urls when editing the wiki. I agree that the OL source should not publish https urls, but the http in the test is not published, merely a string used for testing the output of a valid function.

Thanks @jack17529 for highlighting this issue! It was a strange one and took me a while to get to the bottom of. Definitely more than should be expected for a simple string change! 

