### PR TITLE
Run all plugins/upstream tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ reindex-solr:
 	psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy
 
 test:
-	py.test openlibrary/tests openlibrary/plugins/upstream/tests/test_forms.py openlibrary/plugins/upstream/tests/test_utils.py openlibrary/tests/core/test_models.py
+	py.test openlibrary/tests openlibrary/plugins/upstream/tests/test_forms.py openlibrary/plugins/upstream/tests/test_utils.py

--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ reindex-solr:
 	psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy
 
 test:
-	py.test openlibrary/tests openlibrary/plugins/upstream/tests/test_forms.py openlibrary/plugins/upstream/tests/test_utils.py
+	py.test openlibrary/tests openlibrary/plugins/upstream

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -22,12 +22,6 @@ def test_create_list_doc(wildcard):
     }
 
 @pytest.mark.xfail
-def test_verify_hash():
-    secret_key = "aqXwLJVOcV"
-    hash = account.generate_hash(secret_key, "foo")
-    assert account.verify_hash(secret_key, "foo", hash) == True
-
-@pytest.mark.xfail
 class TestAccount:
     def signup(self, b, displayname, username, password, email):
         b.open("/account/create")

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -1,6 +1,7 @@
 from .. import account
 import web
 import re
+import pytest
 
 def test_create_list_doc(wildcard):
     key = "account/foo/verify"
@@ -20,12 +21,13 @@ def test_create_list_doc(wildcard):
         "expires_on": wildcard
     }
 
+@pytest.mark.xfail
 def test_verify_hash():
     secret_key = "aqXwLJVOcV"
     hash = account.generate_hash(secret_key, "foo")
     assert account.verify_hash(secret_key, "foo", hash) == True
 
-
+@pytest.mark.xfail
 class TestAccount:
     def signup(self, b, displayname, username, password, email):
         b.open("/account/create")

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -7,7 +7,7 @@ def strip_nones(d):
     return dict((k, v) for k, v in d.items() if v is not None)
 
 class TestSaveBookHelper:
-    def get_test_authors(self, monkeypatch):
+    def test_authors(self, monkeypatch):
         def mock_user():
             return type('MockUser', (object,), {'is_admin': lambda self: False})()
 

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -1,12 +1,18 @@
 """py.test tests for addbook"""
 import web
 from .. import addbook
+from openlibrary import accounts
 
 def strip_nones(d):
     return dict((k, v) for k, v in d.items() if v is not None)
 
 class TestSaveBookHelper:
-    def test_authors(self):
+    def get_test_authors(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda self: False})()
+
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
         s = addbook.SaveBookHelper(None, None)
         def f(data):
             return strip_nones(s.process_work(web.storage(data)))

--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -16,7 +16,14 @@ def setup_module(mod):
     models.setup()
 
 class MockSite(client.Site):
+
+    class Seq(object):
+        def next_value(self, name):
+            return 1
+
     def __init__(self):
+        self.seq = self.Seq()
+        self.store = {}
         self.docs = {}
         self.query_results = {}
 
@@ -44,6 +51,7 @@ class MockSite(client.Site):
 
     def save_many(self, docs, comment=None, data={}, action=None):
         self.add(docs)
+        return [{'key': d['key'], 'revision': 1} for d in docs]
 
     def add(self, docs):
         self.docs.update((doc['key'], doc) for doc in docs)

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -1,0 +1,7 @@
+from openlibrary.accounts import model
+
+def test_verify_hash():
+      secret_key = "aqXwLJVOcV"
+      hash = model.generate_hash(secret_key, "foo")
+      assert model.verify_hash(secret_key, "foo", hash) == True
+


### PR DESCRIPTION
@mekarpeles, I'm submitting this for review. I started this PR as a way to get the existing merge authors tests running again in preparation for doing more work on merges, but it soon spread to the other tests in the directory.

See https://github.com/internetarchive/openlibrary/issues/316 for past discussions about test locations.

Outstanding issues to be addressed for plugins/upstream tests:

* test_account.py (now) has the majority of tests `xfail` marked because the accounts features have changed a lot recently. Needs review and the tests should be updated and added to to represent the new functionality.
* test_borrow.py is empty, looks like a placeholder?
* The merge authors code has comments around the code that broke the tests regarding https://github.com/internetarchive/openlibrary/issues/89 , seems like there is some tidy up to be done around that. The code and the subsequent patching to the tests seems a bit messy
