### PR TITLE
fix /type/language page search links

### DIFF
--- a/openlibrary/templates/type/language/view.html
+++ b/openlibrary/templates/type/language/view.html
@@ -24,7 +24,7 @@ $var title: $page.name
        <span class="tag">$page.name</span>
     </div>
 
-    <p>Try a <a href="/search?language=$page.code">search for books in $page.name</a>?</p>
+    <p>Try a <a href="/search?q=language:$page.code">search for books in $page.name</a>?</p>
 
     $:render_template("lib/history", page)
 


### PR DESCRIPTION
Currently language pages have broken search links that return no results, e.g: https://openlibrary.org/languages/eng

This PR corrects the search url.

Language pages can be navigated to from edition pages that have their written-in language set.