### PR TITLE
Fix list counts, fixes #449

### DIFF
--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -238,16 +238,13 @@ function get_seed_count() {
                             $if seed.ebook_count:
                                 - eBook available
                         $elif seed.type == "work":
-                            - $commify(seed.document.edition_count) edition$("s" if seed.document.edition_count != 1 else "")$cond(seed.ebook_count, ",")
-                            $if seed.ebook_count:
-                                $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
-                        $elif seed.type == "author":
-                            $ work_count = seed.document.get_books().num_found
-                            - $commify(work_count) work$("s" if work_count != 1 else "")$cond(seed.ebook_count, ",")
-                            $if seed.ebook_count:
-                                $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
+                            - $commify(seed.document.edition_count) edition$("s" if seed.document.edition_count != 1 else "")
                         $else:
-                            - $commify(seed.document.work_count) work$("s" if seed.document.work_count != 1 else "")$cond(seed.ebook_count, ",")
+                            $if seed.type == "author":
+                                $ work_count = seed.document.get_books().num_found
+                            $else:
+                                $ work_count = seed.document.work_count
+                            - $commify(work_count) work$("s" if work_count != 1 else "")$cond(seed.ebook_count, ",")
                             $if seed.ebook_count:
                                 $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
                         </span>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -241,6 +241,11 @@ function get_seed_count() {
                             - $commify(seed.document.edition_count) edition$("s" if seed.document.edition_count != 1 else "")$cond(seed.ebook_count, ",")
                             $if seed.ebook_count:
                                 $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
+                        $elif seed.type == "author":
+                            $ work_count = seed.document.get_books().num_found
+                            - $commify(work_count) work$("s" if work_count != 1 else "")$cond(seed.ebook_count, ",")
+                            $if seed.ebook_count:
+                                $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
                         $else:
                             - $commify(seed.work_count) work$("s" if seed.work_count != 1 else "")$cond(seed.ebook_count, ",")
                             $if seed.ebook_count:

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -247,7 +247,7 @@ function get_seed_count() {
                             $if seed.ebook_count:
                                 $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
                         $else:
-                            - $commify(seed.work_count) work$("s" if seed.work_count != 1 else "")$cond(seed.ebook_count, ",")
+                            - $commify(seed.document.work_count) work$("s" if seed.document.work_count != 1 else "")$cond(seed.ebook_count, ",")
                             $if seed.ebook_count:
                                 $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
                         </span>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -238,7 +238,7 @@ function get_seed_count() {
                             $if seed.ebook_count:
                                 - eBook available
                         $elif seed.type == "work":
-                            - $commify(seed.edition_count) edition$("s" if seed.edition_count != 1 else "")$cond(seed.ebook_count, ",")
+                            - $commify(seed.document.edition_count) edition$("s" if seed.document.edition_count != 1 else "")$cond(seed.ebook_count, ",")
                             $if seed.ebook_count:
                                 $commify(seed.ebook_count) ebook$("s" if seed.ebook_count != 1 else "")
                         $else:


### PR DESCRIPTION
This list template may need some more work to resolve some inconsistencies with links to ebooks and read / borrow link logic.

Works now has accurate edition counts.
Subjects and Authors now have accurate ebook counts.

This PR removes the ebook count count code from works (which never seemed to work), but there is still a separate "Read" icon to read a version. I'm not yet sure the best way to get a count of ebooks for a work. The View page doesn't use this count. I was using the view pages of the other list items to see how the work and edition counts were accessed.


