### PR TITLE
allow unicode/asian publish date display, fixes #427

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,6 +1,6 @@
 $def with (page)
 
-$ title_suffix = cond(page.publish_date, "({0} edition)".format(page.publish_date), "(edition)")
+$ title_suffix = cond(page.publish_date, u"({0} edition)".format(page.publish_date), "(edition)")
 $ title = page.title + " " + title_suffix
 $ title_with_site = title + " | Open Library"
 $ meta_cover_url = item_image(page.get_cover_url("M"), default="https://openlibrary.org/images/icons/avatar_book-sm.png")


### PR DESCRIPTION
There is probably not many records affected by this particular issue, but there may be other uses of `.format()` in the code which could break if unicode is passed in.

#427 has an example with Asian publish dates, and as there is no validation on the date formats used, anything goes :)