### PR TITLE
Subjects with unicode fails to load any results, Fix #317

### DIFF
--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -93,7 +93,8 @@ class Solr:
             data = urllib2.urlopen(url, timeout=3).read()
         else:
             logger.info("solr request: %s ...", url)
-            data = urllib2.urlopen(url, payload, timeout=3).read()
+            request = urllib2.Request(url, payload, {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"})
+            data = urllib2.urlopen(request, timeout=3).read()
         return self._parse_solr_result(
             simplejson.loads(data),
             doc_wrapper=doc_wrapper,


### PR DESCRIPTION
The POST body was not correctly recognising the encoding.
Setting charset=UTF-8 fixes the problem so now subjects containing unicode characters will produces results from posted solr queries