### PR TITLE
make profile dropdown loans text consistent

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -112,7 +112,7 @@ $def with (page)
       </div>
       <div class="account-dropdown" id="main-account-dropdown">
         <ul class="dropdown-menu">
-          <li><a href="$homepath()/account/loans">$_("My Books")</a></li>
+          <li><a href="$homepath()/account/loans">$_("My Loans")</a></li>
           <li><a href="$ctx.user.key/lists">$_("My Lists")</a></li>
           <li><a href="$ctx.user.key">$_("My Profile")</a></li>
           <li><a href="$homepath()/account">$_("Settings")</a></li>


### PR DESCRIPTION
Proposed text change to make the new menus consistent.

The **My Books** dropdown has two sub-items, **My Loans** and **My Lists**

this change makes the first two items under the profile dropdown match.

Previously "**My Books > My Loans**" and  "**(profile dropdown) > My Books**" both linked to the loans page.