### PR TITLE
Author VIAF and Wikidata links

### DIFF
--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -33,7 +33,7 @@ $def with (work, prefix="")
                         </td>
                         <td valign="top">
                             <div class="input">
-                                <input type="text" name="url" id="link-url" class="addweb" value="http://"/>
+                                <input type="text" name="url" id="link-url" class="addweb" value="https://"/>
                             </div>
                         </td>
                         <td valign="top">

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -255,7 +255,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     $if page.remote_ids.wikidata:
                         <li><a href="https://tools.wmflabs.org/reasonator/?q=$page.remote_ids.wikidata">Wikidata</a></li>
                 $if page.wikipedia and page.wikipedia.startswith("http"):
-                    <li><a href="$page.wikipedia" class="sidebar">Wikipedia</a></li>
+                    <li><a href="$page.wikipedia">Wikipedia</a></li>
                 $for link in page.links:
                     <li><a href="$link.url">$link.title</a></li>
                 </ul>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -246,8 +246,14 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
         <div class="section">
             <h3>Links <span class="gray small sansserif">(outside Open Library)</span></h3>
 
-            $if page.links or (page.wikipedia and page.wikipedia.startswith("http")):
+            $if page.links or page.remote_ids or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">
+                $if page.remote_ids:
+                    $if page.remote_ids.viaf:
+                        $ viaf = page.remote_ids.viaf
+                        <li><a href="https://viaf.org/viaf/$viaf">VIAF ID: $viaf</a></li>
+                    $if page.remote_ids.wikidata:
+                        <li><a href="https://tools.wmflabs.org/reasonator/?q=$page.remote_ids.wikidata">Wikidata</a></li>
                 $if page.wikipedia and page.wikipedia.startswith("http"):
                     <li><a href="$page.wikipedia" class="sidebar">Wikipedia</a></li>
                 $for link in page.links:

--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -187,7 +187,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     <h3>$_("Links") <span class="gray small sansserif">$_("(outside Open Library)")</span></h3>
                     <ul class="booklinks sansserif">
                     $if page.wikipedia and page.wikipedia.startswith("http"):
-                        <li><a href="$page.wikipedia" class="sidebar">Wikipedia</a></li>
+                        <li><a href="$page.wikipedia">Wikipedia</a></li>
                     $for link in page.links:
                         <li><a href="$link.url">$link.title</a></li>
                     </ul>


### PR DESCRIPTION
This PR adds links to VIAF authority control IDs and Wikidata links (via the Reasonator tool) to Author view pages, if the author has `remote_ids`.

Example with the new Links:
![ol_links](https://user-images.githubusercontent.com/905545/29245925-dd0e0572-803d-11e7-9870-64115ade0725.png)

relates to, and hopefully addresses,  #527

This retains the old built in Wikipedia link field, which I believe is deprecated anyway.

1820 authors (out of 6 million) have the `wikipedia` field populated. 271 of those are invalid urls. Of the valid ones most link to English wikipedia, but quite a few are to German wikipedia.