### PR TITLE
BUGFIX: some lists were causing errors: local variable 'ebook' refere…

### DIFF
--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -184,6 +184,7 @@ function get_seed_count() {
                 <span class="seed-key hidden">$seed.key</span>
                 <span class="details">
                     <span class="resultTitle">
+                        $ ebook = {}
                         $if seed.type in ['edition', 'work']:
                             $ ebook = seed.document.get_ebook_info()
                             $ doc = seed.document
@@ -191,7 +192,7 @@ function get_seed_count() {
                         <h3 class="booktitle">
                             <a href="$seed.url" class="results">$seed.title</a>
                         </h3>
-                        $if seed.type == "work" or seed.type == "edition":
+                        $if seed.type in ['edition', 'work']:
                             $if seed.type == "work":
                                 $ authors = seed.document.get_authors()
                             $else:


### PR DESCRIPTION
…nced before assignment

Example list: https://openlibrary.org/people/lindaisling/lists/OL62634L/My_Authors_List

```
/opt/openlibrary/deploys/openlibrary/3920297/openlibrary/templates/type/list/view.html: error in processing template: UnboundLocalError: local variable 'ebook' referenced before assignment (falling back to default template)
```
The error was on line 242 (243 is this changed version) variable `ebooks` was only set if a list item was an edition or work. Authors and subjects (and other things) can be added to lists. This fixes the problem by assigning `ebooks` a default empty value regardless of type.