### PR TITLE
HTML5 validation tidy up

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -5,8 +5,6 @@ $ isbn = opts.get('isbn')
 $ asin = opts.get('asin')
 $ scribd = opts.get('scribd')
 
-
-<ul>
 $if asin:
     $ amazon = "http://www.amazon.com/dp/%s/?tag=%s" % (asin, affiliate_id('amazon'))
     <table class="buy-options-table">

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -9,7 +9,7 @@ $ scribd = opts.get('scribd')
 <ul>
 $if asin:
     $ amazon = "http://www.amazon.com/dp/%s/?tag=%s" % (asin, affiliate_id('amazon'))
-    <table class="buy-options-table"">
+    <table class="buy-options-table">
       <tbody>
         <tr>
           <td>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -21,13 +21,13 @@ $def with (doc)
                  class="results">$doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')</a>
          </h3>
       </span>
-      <div class="bookauthor">by
+      <span class="bookauthor">by
         $if not doc.authors:
           <em>Unknown author</em>
         $else:
           $for a in doc.authors:
             <a itemprop="author" href="$(a.get('url') or a.key)" class="results">$a.name</a>$(',' if not loop.last else '')
-      </div>
+      </span>
       <span class="resultPublisher">
               $commify(doc.edition_count) edition$("s" if doc.edition_count != 1 else "")
               $if len(doc.ia):

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -57,11 +57,8 @@ $ library = None
 
 </style>
 
-
-
 <div class="Tools">
-<a name="read"></a>
-
+<div id="read">
 $ collections = set()
 $ meta_fields = page.get_ia_meta_fields()
 $if meta_fields:
@@ -72,7 +69,6 @@ $if meta_fields:
 
 
 $if page.volumes:
-    <div>
     <h3 class="header">
         <span class="icon read"></span>
         <span class="head">Browse</span>
@@ -82,9 +78,7 @@ $if page.volumes:
             <div class="panel">
                 <p><a href="$viewbook.replace('XXX', v.ia_id)">View Volume $v.volume_number</a></p>
             </div>
-    </div>
 $elif page.is_access_restricted():
-    <div>
         <h3 class="header">
             <span class="icon read"></span>
             <span class="head">Read</span>
@@ -92,9 +86,7 @@ $elif page.is_access_restricted():
         <div class="panel">
             <p><a href="$page.url('/daisy')" title="Download Protected DAISY" class="plain"><meta itemprop="bookFormat" content="EBook/DAISY3"/><span class="underline">DAISY</span> <img src="/images/icons/icon-encrypto-sm.png" width="11" height="14" alt="Download Protected DAISY"/></a></p>
         </div>
-    </div>
 $elif page.get('ocaid'):
-    <div>
         <h3 class="header">
             <span class="icon read"></span>
             <span class="head">Read</span>
@@ -112,9 +104,7 @@ $elif page.get('ocaid'):
             $if mobi:
                 <p><a href="$mobi" title="Download a MOBI file from Internet Archive">MOBI</a>
         </div>
-    </div>
 $else:
-    <div>
         <h3 class="closed">
             <span class="icon readinact"></span>
             <span class="head">Read</span>
@@ -122,7 +112,8 @@ $else:
 	<div class="panel">
             <p class="smaller">No readable version available.</p>
 	</div>
-    </div>
+
+</div>
 
 $if (isbn or oclc_numbers or 'lendinglibrary' in collections or library) and not private_collection_in(collections):
     <div>

--- a/openlibrary/templates/books/edition-show.html
+++ b/openlibrary/templates/books/edition-show.html
@@ -201,8 +201,8 @@ $ publishers = (', '.join(book.publishers))
                     Wikipedia citation
                     <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();"><span class="shift">Close</span></a>
                 </div>
-                <p>Copy and paste this code into your Wikipedia page. <a href="http://en.wikipedia.org/wiki/Template:Cite#Citing_books" target="_new" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
-                <form method="get" action="">
+                <p>Copy and paste this code into your Wikipedia page. <a href="http://en.wikipedia.org/wiki/Template:Cite#Citing_books" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
+                <form method="get">
         <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{Citation
         $for k, v in book.wp_citation_fields.iteritems():
             |$k = $v

--- a/openlibrary/templates/covers/author_photo.html
+++ b/openlibrary/templates/covers/author_photo.html
@@ -9,19 +9,18 @@ $if author_thumbnail_url:
             <a href="#seeImage" class="coverLook" title="Pull up a larger author photo"><img src="$author_thumbnail_url" class="cover" alt="Photo of $author.name"/></a>
         </div>
     </div>
+    <div class="hidden">
+        <div class="coverFloat" id="seeImage">
+            <div class="coverFloatHead">
+                $truncate(author.name or "", 60)
+                <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();"><span class="shift">$_("Close")</span></a>
+            </div>
+            <a href="javascript:;" onclick="\$.fn.colorbox.close();" title="Click to close"><img src="$author_photo_url" class="cover" alt="Photo of $author.name"/></a>
+        </div>
+    </div>
 $else:
     <div class="author coverMagic">
         <div class="SRPCover bookCover">
             <img src="/images/icons/avatar_author-lg.png" class="cover" alt="We need a photo of $author.name"/>
         </div>
     </div>
-
-<div class="hidden">
-    <div class="coverFloat" id="seeImage">
-        <div class="coverFloatHead">
-            $truncate(author.name or "", 60)
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();"><span class="shift">$_("Close")</span></a>
-        </div>
-        <a href="javascript:;" onclick="\$.fn.colorbox.close();" title="Click to close"><img src="$author_photo_url" class="cover" alt="Photo of $author.name"/></a>
-    </div>
-</div>

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -33,7 +33,7 @@ $ cur_v = query_param("v", None)
             $ rdf = page.key + ".rdf" + hist_addition
             $ json = page.key + ".json" + hist_addition
             $ opds = page.key + ".opds" + hist_addition
-            <div id="historyTools" class="smaller brown sansserif" style="float:right;padding-top:8px;">
+            <span id="historyTools" class="smaller brown sansserif" style="float:right;padding-top:8px;">
                 Download catalog record:
                 <a rel="nofollow" href="$rdf">RDF</a>
                 /
@@ -41,7 +41,7 @@ $ cur_v = query_param("v", None)
                 $if page.key.startswith("/books"):
                     /
                     <a rel="nofollow" href="$opds">OPDS</a>
-            </div>
+            </span>
 
     </h2>
 

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -118,8 +118,9 @@ $def with (page)
           <li><a href="$homepath()/account">$_("Settings")</a></li>
           <li>
             <form name="logout" action="/account/logout" method="post">
-              <a href="#" onclick="document.forms['logout'].submit()">Log out</a></li>
-          </form>
+              <a href="#" onclick="document.forms['logout'].submit()">Log out</a>
+            </form>
+          </li>
         </ul>
       </div>
     </div>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -20,7 +20,7 @@ $def with (page)
   </div>
 
   <div class="logo-component">
-    <a alt="The Internet Archive's Open Library: One page for every book" href="/">
+    <a href="/">
       <div class="logo-txt">
         <img class="logo-icon" src="/static/images/openlibrary-logo.png" alt="Open Library logo"/>
       </div>
@@ -46,7 +46,7 @@ $def with (page)
         <form class="search-bar-input" action="/search" method="get">
           <input type="text" name="q" placeholder="Search" autocomplete="off">
           <input name="mode" type="checkbox" aria-hidden="true" checked="checked" value="" id="ftokenstop" class="hidden instantsearch-mode">
-          <input type="submit" value="" class="search-bar-submit" type="submit" aria-label="Search submit">
+          <input type="submit" value="" class="search-bar-submit" aria-label="Search submit">
         </form>
       </div>
       <div class="search-dropdown">
@@ -99,8 +99,8 @@ $def with (page)
   $if not ctx.user:
     <ul class="auth-component">
       <li class="hide-me">
-        <a class="generic-button generic-button-secondary"
-           href="/account/login" class="white">$_("Log In")</a></li>
+        <a class="generic-button generic-button-secondary white"
+           href="/account/login">$_("Log In")</a></li>
       <li><a class="generic-button generic-button-primary" href="/account/create">$_("Sign Up")</a></li>
     </ul>
 

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -107,7 +107,7 @@ $def with (page)
   $if ctx.user:
     <div class="account-component">
       <div class="dropdown-avatar">
-        <button class="avatar" href="javascript:;" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
+        <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
         <img class="down-arrow" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/>
       </div>
       <div class="account-dropdown" id="main-account-dropdown">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -20,7 +20,7 @@ $def with (page)
   </div>
 
   <div class="logo-component">
-    <a href="/">
+    <a href="/" title="The Internet Archive's Open Library: One page for every book">
       <div class="logo-txt">
         <img class="logo-icon" src="/static/images/openlibrary-logo.png" alt="Open Library logo"/>
       </div>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -150,7 +150,7 @@ $if ctx.user:
                 <h2>Create a new list</h2>
                 <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();"><span class="shift">$_("Close")</span></a>
             </div>
-            <form method="post" action="" class="floatform" name="new-list" id="new-list">
+            <form method="post" class="floatform" name="new-list" id="new-list">
             <div class="formElement">
                 <div class="label">
                     <label for="list_label">Name:</label>

--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -4,7 +4,7 @@ $:get_donation_include('true')
   <div class="page-banner page-banner-black page-banner-center">
     <div class="iaBar">
       <div class="iaBarLogo">
-	<img src="/static/images/ia-logo.png">
+	<img alt="Internet Archive logo" src="/static/images/ia-logo.png">
       </div>
       <div class="iaBarMessage">
 	New to the Open Library? — <a data-ol-link-track="header-learn-more" href="/help/faq/about">Learn how it works</a>

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -1,6 +1,5 @@
 $def with (page)
 <div id="content">
-
     <div class="flash-messages">
     $for flash in get_flash_messages():
         <div class="$flash.type"><span>$flash.message</span></div>
@@ -9,7 +8,6 @@ $def with (page)
     <div id="contentMsg">
         <div class="alert attn"><span></span></div>
     </div>
-    <a name="content"></a>
 
     $:page
 

--- a/openlibrary/templates/site/neck.html
+++ b/openlibrary/templates/site/neck.html
@@ -26,7 +26,7 @@ $ bodyid = ctx.get('bodyid', 'user')
 
 <body id="$bodyid">
 <div id="background">
-<a name="top"></a>
+<span id="top"></span>
 
 $if bodyid != "form":
     <p class="shift">

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -140,7 +140,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             </div>
 
         <div class="clearfix"></div>
-        <div id="editions" class="section">
+        <div id="works" class="section">
                 <h2 class="collapse">
                     $commify(books.num_found) work$("s" if books.num_found != 1 else "")
                     <span class="count smaller"><a href="/books/add?author=$page.key">Add another</a>?</span>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -140,14 +140,12 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             </div>
 
         <div class="clearfix"></div>
-        <div class="section">
-            <a name="editions"></a>
+        <div id="editions" class="section">
                 <h2 class="collapse">
                     $commify(books.num_found) work$("s" if books.num_found != 1 else "")
                     <span class="count smaller"><a href="/books/add?author=$page.key">Add another</a>?</span>
                 </h2>
-                <a name="books"></a>
-                <p><span class="tools">
+                <p id="books"><span class="tools">
                 $if books.num_found > 1:
                     <img src="/images/icons/icon_sort.png" alt="Sorting by" width="9" height="11" style="margin-right:5px;"/>
                     $if books.sort == 'editions':

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -159,9 +159,12 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 </span>
 
                 <span class="mode-options">
-                  <input type="radio" name="mode" value="everything" id="mode-search-everything" class="search-mode">Everything</input>
-                  <input type="radio" name="mode" value="ebooks" id="mode-search-ebooks" class="search-mode">Ebooks</input>
-                  <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">Print Disabled</input>
+                  <input type="radio" name="mode" value="everything" id="mode-search-everything" class="search-mode">
+                  <label for="mode-search-everything">Everything</label>
+                  <input type="radio" name="mode" value="ebooks" id="mode-search-ebooks" class="search-mode">
+                  <label for="mode-search-ebooks">Ebooks</label>
+                  <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
+                  <label for="mode-search-printdisabled">Print Disabled</label>
                 </span>
 </p>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -409,8 +409,8 @@ $elif ebook_status == "borrow-user-checkedout":
                 Wikipedia citation
                 <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();"><span class="shift">Close</span></a>
             </div>
-            <p>Copy and paste this code into your Wikipedia page. <a href="http://en.wikipedia.org/wiki/Template:Cite#Citing_books" target="_new" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
-            <form method="get" action="">
+            <p>Copy and paste this code into your Wikipedia page. <a href="http://en.wikipedia.org/wiki/Template:Cite#Citing_books" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
+            <form method="get">
                 <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{Citation
     $for k, v in page.wp_citation_fields.iteritems():
        |$k = $v

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -113,7 +113,7 @@ $# in a work's edition listing
 
 $if ctx.user and ctx.user.is_admin():
     <div class="clearfix"></div>
-    <div align="right" class="small sansserif"><span class="adminOnly"><a href="/books/merge?$'&'.join('key=' + k for k in book_keys)">Merge editions</a></span></div>
+    <div class="small sansserif right"><span class="adminOnly"><a href="/books/merge?$'&'.join('key=' + k for k in book_keys)">Merge editions</a></span></div>
 
 $if ctx.user and ctx.user.is_admin():
     <div class="clearfix"></div>

--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -232,12 +232,13 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     $:render_template("lists/widget", page)
                 </div>
 
-        <a name="editions"></a>
+        <div id="editions" class="section">
         $if page.edition_count == 1:
             $:render_template("books/edition-show", page.get_one_edition())
         $elif page.edition_count > 1:
             <div class="clearfix"></div>
             $:render_template("type/work/editions_datatable", page)
+        </div>
 
         $:render_template("lib/history", page)
     </div>

--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -232,13 +232,11 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     $:render_template("lists/widget", page)
                 </div>
 
-        <div id="editions" class="section">
         $if page.edition_count == 1:
             $:render_template("books/edition-show", page.get_one_edition())
         $elif page.edition_count > 1:
             <div class="clearfix"></div>
             $:render_template("type/work/editions_datatable", page)
-        </div>
 
         $:render_template("lib/history", page)
     </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -155,9 +155,12 @@ function less(header) {
       <input type="text" name="q" id="q" value="$q_param" size="100" style="width:505px;"/>
       <button type="submit" class="larger" id="searchsubmit">$_("Search")</button>
       <span class="mode-options">
-        <input type="radio" name="mode" value="everything" id="mode-search-everything" class="search-mode">Everything</input>
-        <input type="radio" name="mode" value="ebooks" id="mode-search-ebooks" class="search-mode" $('checked="checked"' if 'has_fulltext' in param else '')>Ebooks</input>
-        <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">Print Disabled</input>
+        <input type="radio" name="mode" value="everything" id="mode-search-everything" class="search-mode">
+        <label for="mode-search-everything">Everything</label>
+        <input type="radio" name="mode" value="ebooks" id="mode-search-ebooks" class="search-mode" $('checked="checked"' if 'has_fulltext' in param else '')>
+        <label for="mode-search-ebooks">Ebooks</label>
+        <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
+        <label for="mode-search-printdisabled">Print Disabled</label>
       </span>
         $for k, values in param.items():
             $if k not in sticky:


### PR DESCRIPTION
I ran various pages through the [W3C HTML validator](https://validator.w3.org/) and fixed some of the easier issues, typos, un-matched tags, and removing deprecated tags / attributes.

There are still many issues on some pages, many due to `div`s and `p`s inside `a` and `span` tags on results lists, but I figure they can be changed as part of the page redesigns.

@mekarpeles , for your review, I made some changes on the search mode options, adding clickable labels to the  **Everything   Ebooks   Print Disabled** radio buttons, which validates as HTML5, and hopefully makes the controls more usable. 