### PR TITLE
OCAID and ISBN validation

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -666,6 +666,12 @@ $if ctx.user and ctx.user.is_admin():
                 if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
                     return error("#id-errors", "id-value", "$_('ID ids cannot contain whitespace.')".replace(/ID/, label));
                 }
+                if (data.name == "isbn_10" && data.value.length != 10) {
+                    return error("#id-errors", "id-value", "$_('ID must be exactly 10 characters [0-9] or X.')".replace(/ID/, label));
+                }
+                if (data.name == "isbn_13" && data.value.length != 13) {
+                    return error("#id-errors", "id-value", "$_('ID must be exactly 13 digits [0-9].')".replace(/ID/, label));
+                }
                 \$("id-errors").hide();
                 return true;
             }

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -659,9 +659,12 @@ $if ctx.user and ctx.user.is_admin():
                 if (data.name == "" || data.name == "---") {
                     return error("#id-errors", "select-id", "$_('Please select an identifier.')")
                 }
+                var label = \$("#select-id").find("option[value=" + data.name + "]").html();
                 if (data.value == "") {
-                    var label = \$("#select-id").find("option[value=" + data.name + "]").html();
                     return error("#id-errors", "id-value", "$_('You need to give a value to ID.')".replace(/ID/, label));
+                }
+                if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
+                    return error("#id-errors", "id-value", "$_('ID ids cannot contain whitespace.')".replace(/ID/, label));
                 }
                 \$("id-errors").hide();
                 return true;


### PR DESCRIPTION
I could extend the whitespace check to catch whitespace in any other id.
ISBN check is very basic, only looks for string length. It means dashes in ISBNs will no longer be accepted.