### PR TITLE
preventing non-admins from reverting deleted pages

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -19,6 +19,7 @@ from utils import render_template
 
 from openlibrary.core import cache
 from openlibrary.core.lending import amazon_api
+from openlibrary import accounts
 from openlibrary.plugins.openlibrary.processors import ReadableUrlProcessor
 from openlibrary.plugins.openlibrary import code as ol_code
 
@@ -271,10 +272,13 @@ class revert(delegate.mode):
     def POST(self, key):
         i = web.input("v", _comment=None)
         v = i.v and safeint(i.v, None)
+
         if v is None:
             raise web.seeother(web.changequery({}))
 
-        if not web.ctx.site.can_write(key):
+        user = accounts.get_current_user()
+        admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
+        if not (admin and web.ctx.site.can_write(key)):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -277,8 +277,8 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         user = accounts.get_current_user()
-        admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
-        if not (admin and web.ctx.site.can_write(key)):
+        is_admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
+        if not (is_admin and web.ctx.site.can_write(key)):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/templates/type/delete/view.html
+++ b/openlibrary/templates/type/delete/view.html
@@ -11,8 +11,11 @@ $var title: $page.key
 <div id="contentBody">
     <p><strong>$_("What would you like to do?")</strong></p>
 
-    <p><a href="$url(v=page.revision - 1)">$_("View the previous version")</a><br/>
-    <a href="$url(m='edit', v=page.revision - 1)">$_("Recreate it")</a><br/>
-    <a href="$url(m='history')">$_("See the page's history")</a><br/>
-    <a href="javascript:;" onclick="history.go(-1);">$_("Go back where I came from")</a></p>
+    <ul>
+      <li><a href="javascript:;" onclick="history.go(-1);">$_("Go back where I came from")</a></li>
+      $if ctx.user and ctx.user.is_admin():
+        <li><a href="$url(v=page.revision - 1)">$_("View the previous version")</a></li>
+        <li><a href="$url(m='edit', v=page.revision - 1)">$_("Recreate it")</a></li>
+        <li><a href="$url(m='history')">$_("See the page's history")</a></li>
+    </ul>
 </div>

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $ v = query_param("v", None)
 
-$if ctx.user:
+$if ctx.user and ctx.user.is_admin():
     $if v and not page.key.startswith("/books/ia:"):
         <div id="revertNotice">
             <form name="revert" method="POST" action="$changequery(m='revert')">
@@ -10,6 +10,7 @@ $if ctx.user:
             </form>
         </div>
         <div id="revertLink"><a rel="nofollow" href="$changequery(m='revert')">$_("Revert to this revision")</a>?</div>
+
         $putctx("robots", "noindex,nofollow")
     $else:
         $ ctx.setdefault("links", [])


### PR DESCRIPTION
Making it so only admins can delete + revert
cc: @JeffKaplan 