### PR TITLE
Hotfix/s3 auth support

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -549,7 +549,8 @@ class InternetArchiveAccount(web.storage):
     @classmethod
     def s3auth(cls, access_key, secret_key):
         """Authenticates an Archive.org user based on s3 keys"""
-        url = "http://s3.us.archive.org?check_auth=1"
+        from openlibrary.core import lending
+        url = lending.config_ia_s3_auth_url
         try:
             req = urllib2.Request(url, headers={
                 'Content-Type': 'application/json',

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -547,6 +547,27 @@ class InternetArchiveAccount(web.storage):
         return simplejson.loads(response)
 
     @classmethod
+    def s3auth(cls, access_key, secret_key):
+        """Authenticates an Archive.org user based on s3 keys"""
+        url = "http://s3.us.archive.org?check_auth=1"
+        try:
+            req = urllib2.Request(url, headers={
+                'Content-Type': 'application/json',
+                'authorization': 'LOW %s:%s' % (access_key, secret_key)
+            })
+            f = urllib2.urlopen(req)
+            response = f.read()
+            f.close()
+        except urllib2.HTTPError as e:
+            try:
+                response = e.read()
+            except simplejson.decoder.JSONDecodeError:
+                return {'error': e.read(), 'code': e.code}
+        return simplejson.loads(response)
+
+
+
+    @classmethod
     def get(cls, email, test=False, _json=False, s3_key=None, s3_secret=None, xauth_url=None):
         email = email.strip().lower()
         response = cls.xauth(email=email, test=test, service="info",
@@ -569,7 +590,8 @@ class InternetArchiveAccount(web.storage):
             return reason
         return "ok"
 
-def audit_accounts(email, password, require_link=False, test=False):
+def audit_accounts(email, password, require_link=False,
+                   s3_access_key=None, s3_secret_key=None, test=False):
     """Performs an audit of the IA or OL account having this email.
 
     The audit:
@@ -589,10 +611,16 @@ def audit_accounts(email, password, require_link=False, test=False):
     """
     from openlibrary.core import lending
 
-    if not valid_email(email):
-        return {'error': 'invalid_email'}
-
-    ia_login = InternetArchiveAccount.authenticate(email, password)
+    if s3_access_key and s3_secret_key:
+        r = InternetArchiveAccount.s3auth(s3_access_key, s3_secret_key)
+        ia_login = 'invalid_s3keys'
+        if r.get('authorized', False):
+            ia_login = "ok"
+            email = r['username']
+    else:
+        if not valid_email(email):
+            return {'error': 'invalid_email'}
+        ia_login = InternetArchiveAccount.authenticate(email, password)
 
     if any(ia_login == err for err
             in ['account_blocked', 'account_locked']):
@@ -640,6 +668,8 @@ def audit_accounts(email, password, require_link=False, test=False):
         # lending.config_ia_auth_only is enabled, we need to create
         # and link it.
         if not ol_account:
+            if not password:
+                raise {'error': 'link_attempt_requires_password'}
             try:
                 ol_account = OpenLibraryAccount.create(
                     ia_account.itemname, email, password,

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -613,10 +613,10 @@ def audit_accounts(email, password, require_link=False,
 
     if s3_access_key and s3_secret_key:
         r = InternetArchiveAccount.s3auth(s3_access_key, s3_secret_key)
-        ia_login = 'invalid_s3keys'
-        if r.get('authorized', False):
-            ia_login = "ok"
-            email = r['username']
+        if not r.get('authorized', False):
+            return {'error': 'invalid_s3keys'}
+        ia_login = "ok"
+        email = r['username']
     else:
         if not valid_email(email):
             return {'error': 'invalid_email'}

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -48,6 +48,7 @@ config_ia_availability_api_v2_url = None
 config_ia_access_secret = None
 config_ia_ol_shared_key = None
 config_ia_ol_xauth_s3 = None
+config_ia_s3_auth_url = None
 config_ia_ol_metadata_write_s3 = None
 config_http_request_timeout = None
 config_content_server = None
@@ -68,7 +69,7 @@ def setup(config):
         config_http_request_timeout, config_amz_api, amazon_api, \
         config_ia_availability_api_v1_url, config_ia_availability_api_v2_url, \
         config_ia_ol_metadata_write_s3, config_ia_xauth_api_url, \
-        config_http_request_timeout
+        config_http_request_timeout, config_ia_s3_auth_url
 
     if config.get("content_server"):
         try:
@@ -88,6 +89,7 @@ def setup(config):
     config_ia_ol_shared_key = config.get('ia_ol_shared_key')
     config_ia_ol_auth_key = config.get('ia_ol_auth_key')
     config_ia_ol_xauth_s3 = config.get('ia_ol_xauth_s3')
+    config_ia_s3_auth_url = config.get('ia_s3_auth_url')
     config_ia_ol_metadata_write_s3 = config.get('ia_ol_metadata_write_s3')
     config_internal_tests_api_key = config.get('internal_tests_api_key')
     config_http_request_timeout = config.get('http_request_timeout')

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -152,9 +152,10 @@ class add_work_to_staff_picks:
         return render_template("admin/sync")
 
     def POST(self):
-        i = web.input(action="add", work_id='')
+        i = web.input(action="add", work_id='', subjects='openlibrary_staff_picks')
         results = {}
         work_ids = i.work_id.split(',')
+        subjects = i.subjects.split(',')
         for work_id in work_ids:
             work = web.ctx.site.get('/works/%s' % work_id)
             editions = work.editions
@@ -162,7 +163,7 @@ class add_work_to_staff_picks:
             results[work_id] = {}
             for ocaid in ocaids:
                 results[work_id][ocaid] = create_ol_subjects_for_ocaid(
-                    ocaid, subjects=['openlibrary_staff_picks'])
+                    ocaid, subjects=subjects)
         
         return delegate.RawText(simplejson.dumps(results), content_type="application/json")
                                 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -256,6 +256,30 @@ class account_create(delegate.page):
 
 del delegate.pages['/account/register']
 
+class account_login_json(delegate.page):
+
+    encoding = "json"
+    path = "/account/login"
+
+    def POST(self):
+        """Overrides `account_login` and infogami.login to prevent users from
+        logging in with Open Library username and password if the
+        payload is json. Instead, if login attempted w/ json
+        credentials, requires Archive.org s3 keys.
+        """
+        d = simplejson.loads(web.data())
+        access = d.get('access', None)
+        secret = d.get('secret', None)
+        test = d.get('test', False)
+        audit = audit_accounts(None, None, require_link=True,
+                               s3_access_key=access,
+                               s3_secret_key=secret, test=test)
+        error = audit.get('error')
+        if error:
+            raise BadRequest(error)
+        web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
+
+
 class account_login(delegate.page):
     """Account login.
 
@@ -282,24 +306,22 @@ class account_login(delegate.page):
 
     def POST(self):
         i = web.input(username="", connect=None, password="", remember=False,
-                      redirect='/', test=False, s3_access_key=None, s3_secret_key=None)
+                      redirect='/', test=False, access=None, secret=None)
         email = i.username  # XXX username is now email
         audit = audit_accounts(email, i.password, require_link=True,
-                               s3_access_key=i.s3_access_key,
-                               s3_secret_key=i.s3_secret_key, test=i.test)
+                               s3_access_key=i.access,
+                               s3_secret_key=i.secret, test=i.test)
         error = audit.get('error')
-
         if error:
             return self.render_error(error, i)
 
+        expires = (i.remember and 3600 * 24 * 7) or ""
+        web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token(),
+                      expires=expires)
         blacklist = ["/account/login", "/account/password", "/account/email",
                      "/account/create"]
         if i.redirect == "" or any([path in i.redirect for path in blacklist]):
             i.redirect = "/"
-        expires = (i.remember and 3600 * 24 * 7) or ""
-
-        web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token(),
-                      expires=expires)
         raise web.seeother(i.redirect)
 
     def POST_resend_verification_email(self, i):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -55,7 +55,7 @@ LOGIN_ERRORS = {
         "username_registered": "This username is already registered",
         "ia_login_only": "Sorry, you must use your Internet Archive email and password to log in",
         "max_retries_exceeded": "A problem occurred and we were unable to log you in.",
-        "invalid_s3keys": "Login attempted with invalid IA s3 credentials.",
+        "invalid_s3keys": "Login attempted with invalid Internet Archive s3 credentials.",
         "wrong_ia_account": "An Open Library account with this email is already linked to a different Internet Archive account. Please contact info@openlibrary.org."
     }
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -281,9 +281,11 @@ class account_login(delegate.page):
 
     def POST(self):
         i = web.input(username="", connect=None, password="", remember=False,
-                      redirect='/', test=False)
+                      redirect='/', test=False, s3_access_key=None, s3_secret_key=None)
         email = i.username  # XXX username is now email
-        audit = audit_accounts(email, i.password, require_link=True, test=i.test)
+        audit = audit_accounts(email, i.password, require_link=True,
+                               s3_access_key=i.s3_access_key,
+                               s3_secret_key=i.s3_secret_key, test=i.test)
         error = audit.get('error')
 
         if error:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -55,6 +55,7 @@ LOGIN_ERRORS = {
         "username_registered": "This username is already registered",
         "ia_login_only": "Sorry, you must use your Internet Archive email and password to log in",
         "max_retries_exceeded": "A problem occurred and we were unable to log you in.",
+        "invalid_s3keys": "Login attempted with invalid IA s3 credentials.",
         "wrong_ia_account": "An Open Library account with this email is already linked to a different Internet Archive account. Please contact info@openlibrary.org."
     }
 


### PR DESCRIPTION
Allows users to login + use openlibrary-client using s3 credentials (instead of username/password)