### PR TITLE
better works created from edition records

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -629,7 +629,9 @@ class book_edit(delegate.page):
                 'key': '',
                 'type': {'key': '/type/work'},
                 'title': edition.title,
-                'authors': [{'type': '/type/author_role', 'author': {'key': a['key']}} for a in edition.get('authors', [])]
+                'authors': [{'type': '/type/author_role', 'author': {'key': a['key']}} for a in edition.get('authors', [])],
+                'subjects': edition.get('subjects', []),
+                'covers': edition.get('covers', [])
             })
 
         return render_template('books/edit', work, edition, recaptcha=get_recaptcha())


### PR DESCRIPTION
This is a quick change to take covers and subjects from an orphaned edition when creating a new work via the UI.

Most orphaned editions have a cover, and many have subjects that are more useful at the work level.