### PR TITLE
author autocomplete was not honouring limits

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -826,7 +826,8 @@ class authors_autocomplete(delegate.page):
         q = 'name:(%s) OR alternate_names:(%s)' % (name, name)
         params = {
             'q_op': 'AND',
-            'sort': 'work_count desc'
+            'sort': 'work_count desc',
+            'rows': i.limit
         }
         if config.get('single_core_solr'):
             params['fq'] = 'type:author'


### PR DESCRIPTION
Previously the results were always returning up to solr's default of 10 rows, and this could not be increased or decreased as the `limit` parameter was not used, even though it was set to a default of 5.

Hopefully this will improve performance since a default of 5 rather than 10 results will be returned?

I discovered this while working on the openlibrary-client which asks for `limit=1`, but was getting 10.