### PR TITLE
[WIP] reverting user_can_borrow login on OL to pre v2

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -288,10 +288,7 @@ class Edition(Thing):
     def get_waitinglist_size(self):
         """Returns the number of people on waiting list to borrow this book.
         """
-        ocaid = self.ocaid
-        response = lending.get_availability_of_ocaid(ocaid)
-        availability = response[ocaid] if response else {}
-        return int(availability.get('num_waitlist', 0) or 0)
+        return waitinglist.get_waitinglist_size(self.key)
 
     def get_waitinglist_position(self, user):
         """Returns the position of this user in the waiting list."""

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -146,7 +146,6 @@ class borrow(delegate.page):
             action = 'read'
 
         if action == 'borrow':
-
             resource_type = i.format or 'bookreader'
 
             if resource_type not in ['epub', 'pdf', 'bookreader']:
@@ -154,7 +153,8 @@ class borrow(delegate.page):
 
             if user_can_borrow_edition(user, edition, resource_type):
 
-                if availability['status'] != 'borrow_available':
+                wl = edition.get_waitinglist()
+                if wl and (wl[0].get_user_key() != user.key or wl[0]['status'] != 'available'):
                     raise web.seeother(error_redirect)
 
                 loan = lending.create_loan(
@@ -784,15 +784,31 @@ def resource_uses_bss(resource_id):
                 return True
     return False
 
-def user_can_borrow_edition(user, edition, type):
+def user_can_borrow_edition(user, edition, _type):
     """Returns true if the user can borrow this edition given their current loans.  Returns False if the
        user holds a current loan for the edition."""
 
     global user_max_loans
 
+    if not can_borrow(edition):
+        return False
+
     if user.get_loan_count() >= user_max_loans:
         return False
-    return True
+
+    if edition.get_waitinglist_size() > 0:
+        # There some people are already waiting for the book,
+        # it can't be borrowed unless the user is the first in the waiting list.
+        waiting_loan = user.get_waiting_loan_for(edition)
+
+        if not waiting_loan or waiting_loan['status'] != 'available':
+            return False
+
+
+    if _type in [loan['resource_type'] for loan in edition.get_available_loans()]:
+        return True
+
+    return False
 
 
 def is_admin():


### PR DESCRIPTION
This is in attempt to address a problem @JeffKaplan is having where waitlisted users whose turn it is to borrow click the link in their email but aren't able to get their book. It reverts code changes which were made to simplify the /borrow logic and also to have editions page display more accurate borrow status