### PR TITLE
Make most SOLR fields ignore diacritics

### DIFF
--- a/conf/solr/conf/schema.xml
+++ b/conf/solr/conf/schema.xml
@@ -219,6 +219,7 @@
         -->
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
+        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
@@ -237,6 +238,7 @@
         <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
       </analyzer>
       <analyzer type="query">
+        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory"
@@ -271,12 +273,14 @@
     <!-- A general unstemmed text field - good if one does not know the language of the field -->
     <fieldType name="textgen" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
+        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
+        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory"


### PR DESCRIPTION
Meant to address #178
![ol normalized solr](https://user-images.githubusercontent.com/6251786/31925017-a3a646ac-b853-11e7-9a2f-8d1df2faf2fe.gif)

Do note I'm not too experienced with solr, so please review carefully :)

The following fields will now map any ascii-able (see below) characters down to ascii before indexing and querying:  
```xml
<field name="title" type="text"/>
<field name="title_suggest" type="textgen"/>
<field name="subtitle" type="text"/>
<field name="alternative_title" type="text" stored="false" multiValued="true"/>
<field name="alternative_subtitle" type="text" stored="false" multiValued="true"/>
<field name="by_statement" type="text" stored="false" multiValued="true"/>
<field name="publish_date" type="text" multiValued="true"/>
<field name="lccn" type="textgen" multiValued="true"/>
<field name="oclc" type="text" multiValued="true"/>
<field name="contributor" type="textgen" multiValued="true"/>
<field name="publish_place" type="text" multiValued="true"/>
<field name="publisher" type="text" multiValued="true"/>
<field name="first_sentence" type="text" multiValued="true"/>
<field name="author_name" type="textgen" multiValued="true"/>
<field name="author_alternative_name" type="textgen" multiValued="true"/>
<field name="subject" type="text" multiValued="true"/>
<field name="place" type="textgen" multiValued="true"/>
<field name="person" type="textgen" multiValued="true"/>
<field name="time" type="text" multiValued="true"/>
<field name="text" type="text" multiValued="true"/>
<field name="name" type="textgen" indexed="true" stored="true"/>
<field name="alternate_names" type="textgen" indexed="true" stored="true" multiValued="true"/>
<dynamicField name="*_t"  type="text"    indexed="true"  stored="true"/>
<dynamicField name="attr_*" type="textgen" indexed="true" stored="true" multiValued="true"/>
```

Here are the ascii mappings that will be applied: https://www.apt-browse.org/browse/ubuntu/trusty/universe/all/solr-common/3.6.2+dfsg-2/file/etc/solr/conf/mapping-FoldToASCII.txt (this file might not be exactly the one we use depending on what version is in solr, but should be similar).

Note this will **replace** whatever file is currently at `/etc/solr/conf/schema.xml` with a symlink to the schema file in `$OL_ROOT/conf/solr/conf/schema.xml`.

Note: to fully reindex solr from the vagrant environment:
```sh
sudo /etc/init.d/tomcat6 restart # restart solr's server
sudo -u vagrant make reindex-solr
```