### PR TITLE
Author autocomplete supports search by key

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -16,6 +16,7 @@ from infogami.utils.view import safeint, add_flash_message
 from infogami.infobase.client import ClientException
 
 from openlibrary.plugins.openlibrary.processors import urlsafe
+from openlibrary.utils import is_author_olid
 from openlibrary.utils.solr import Solr
 from openlibrary.i18n import gettext as _
 from openlibrary import accounts
@@ -822,28 +823,40 @@ class authors_autocomplete(delegate.page):
 
         solr = get_authors_solr()
 
-        escaped_q = solr.escape(i.q)
-        name_q = escaped_q + "*"
-        key_q = escaped_q.upper() # ensure uppercase; key is case sensitive
-        q = 'name:(%s) OR alternate_names:(%s) OR key:"/authors/%s"' % (
-            name_q, name_q, key_q)
+        q = solr.escape(i.q).strip()
+        solr_q = ''
+        if is_author_olid(q.upper()):
+            # ensure uppercase; key is case sensitive in solr
+            key_q = q.upper()
+            if config.get('single_core_solr'):
+                key_q = "/authors/" + key_q
+            solr_q = 'key:"%s"' % key_q
+        else:
+            prefix_q = q + "*"
+            solr_q = 'name:(%s) OR alternate_names:(%s)' % (prefix_q, prefix_q)
+
         params = {
             'q_op': 'AND',
             'sort': 'work_count desc',
             'rows': i.limit
         }
+
         if config.get('single_core_solr'):
             params['fq'] = 'type:author'
-        data = solr.select(q, **params)
+        data = solr.select(solr_q, **params)
         docs = data['docs']
-        for d in docs:
-            if not config.get('single_core_solr'):
+
+        if not config.get('single_core_solr'):
+            for d in docs:
                 d.key = "/authors/" + d.key
+
+        for d in docs:
             if 'top_work' in d:
                 d['works'] = [d.pop('top_work')]
             else:
                 d['works'] = []
             d['subjects'] = d.pop('top_subjects', [])
+
         return to_json(docs)
 
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -822,8 +822,11 @@ class authors_autocomplete(delegate.page):
 
         solr = get_authors_solr()
 
-        name = solr.escape(i.q) + "*"
-        q = 'name:(%s) OR alternate_names:(%s)' % (name, name)
+        escaped_q = solr.escape(i.q)
+        name_q = escaped_q + "*"
+        key_q = escaped_q.upper() # ensure uppercase; key is case sensitive
+        q = 'name:(%s) OR alternate_names:(%s) OR key:"/authors/%s"' % (
+            name_q, name_q, key_q)
         params = {
             'q_op': 'AND',
             'sort': 'work_count desc',

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -61,3 +61,7 @@ def dicthash(d):
     else:
         return d
 
+author_olid_re = re.compile(r'^OL\d+A$')
+def is_author_olid(s):
+    """Case sensitive check for strings like 'OL123A'."""
+    return bool(author_olid_re.match(s))


### PR DESCRIPTION
A lot of results appear in the author autocomplete, making it hard to find the right one if you're searching for a common name ("John Smith", anyone?). This adds support for searching by an author key.