### PR TITLE
Correct author_roles creation

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -457,9 +457,9 @@ class _yaml(delegate.mode):
         d = self.get_data(key)
 
         if web.input(text="false").text.lower() == "true":
-            web.header('Content-Type', 'text/plain')
+            web.header('Content-Type', 'text/plain; charset=utf-8')
         else:
-            web.header('Content-Type', 'text/x-yaml')
+            web.header('Content-Type', 'text/x-yaml; charset=utf-8')
 
         raise web.ok(self.dump(d))
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -629,7 +629,7 @@ class book_edit(delegate.page):
                 'key': '',
                 'type': {'key': '/type/work'},
                 'title': edition.title,
-                'authors': [{'type': '/type/author_role', 'author': {'key': a['key']}} for a in edition.get('authors', [])],
+                'authors': [{'type': {'key': '/type/author_role'}, 'author': {'key': a['key']}} for a in edition.get('authors', [])],
                 'subjects': edition.get('subjects', []),
                 'covers': edition.get('covers', [])
             })


### PR DESCRIPTION
There is a related PR in the ol-client https://github.com/internetarchive/openlibrary-client/pull/49

I believe the correct format of `author_role` is the type: key: variety.

This PR fixes the code that creates new works for editions without works to add the author roles in the correct format.