### PR TITLE
Fix recaptcha failing when js disabled

### DIFF
--- a/openlibrary/plugins/recaptcha/recaptcha.py
+++ b/openlibrary/plugins/recaptcha/recaptcha.py
@@ -18,8 +18,7 @@ var RecaptchaOptions = {
 <noscript>
    <iframe src="//www.google.com/recaptcha/api/noscript?k=KEY"
        height="300" width="500" frameborder="0"></iframe><br>
-   <textarea name="recaptcha_challenge_field" rows="3" cols="40">
-   </textarea>
+   <textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
    <input type="hidden" name="recaptcha_response_field"
        value="manual_challenge">
 </noscript>


### PR DESCRIPTION
(Sorry for the dupe PR, had a typo in my branch name -_-)

Did some digging related to #595 , and it looks like recaptcha already has a fallback for when javascript is disabled. ~I think the fallback just had a bug in it (a bug present on the official documentation page! https://developers.google.com/recaptcha/old/docs/tips ). The names of the inputs look wrong (needed to be swapped).~

~@mek Could you put this on dev before merging? It's a little hard to test this locally.~

I think the 'bug' is that the textarea for the no-js recaptcha starts with 4 spaces in it. When the user pastes the code from the recaptcha into the text area, they don't remove the spaces, so the captcha is considered wrong.