### PR TITLE
Author autocomplete search-by-olid: ui tip + hide create author

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -4,7 +4,13 @@
     // author-autocomplete
     $.fn.author_autocomplete = function(options) {
         var local_options = {
-            addnew: true,
+            // Custom option; when returning true for the given query, this
+            // will append a special "__new__" item so the user can enter a
+            // custom value (i.e. new author in this case)
+            addnew: function(query) {
+                // Don't render "Create new author" if searching by key
+                return !/^OL\d+A/i.test(query);
+            },
 
             minChars: 2,
             max: 11,
@@ -23,7 +29,7 @@
                         '<div class="ac_author ac_addnew" title="Add a new author">' +
                             '<span class="action">' + _('Create a new record for') + '</span>' +
                             '<span class="name">' + item.name + '</span>' +
-                        '</div>'
+                        '</div>';
                 }
                 else if (item.work_count == 0) {
                     return '<div class="ac_author" title="Select this author">' +
@@ -88,14 +94,15 @@
                         result: row.name
                     });
                 }
-                if (options.addnew) {
-                    // XXX: this won't work when _this is multiple values (like $("input"))
-                    var name = $(_this).val();
+
+                // XXX: this won't work when _this is multiple values (like $("input"))
+                var query = $(_this).val();
+                if (options.addnew && options.addnew(query)) {
                     parsed = parsed.slice(0, options.max - 1);
                     parsed.push({
-                        data: {name: name, key: "__new__"},
-                        value: name,
-                        result: name
+                        data: {name: query, key: "__new__"},
+                        value: query,
+                        result: query
                     });
                 }
                 return parsed;

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -17,13 +17,6 @@
             matchSubset: false,
             autoFill: false,
             formatItem: function(item) {
-                var author_lifespan = '';
-                if (item.birth_date || item.death_date) {
-                    var birth = item.birth_date || ' ';
-                    var death = item.death_date || ' ';
-                    author_lifespan = ' (' + birth + '-' + death + ')';
-                }
-
                 if (item.key == "__new__") {
                     return '' +
                         '<div class="ac_author ac_addnew" title="Add a new author">' +
@@ -31,26 +24,39 @@
                             '<span class="name">' + item.name + '</span>' +
                         '</div>';
                 }
-                else if (item.work_count == 0) {
-                    return '<div class="ac_author" title="Select this author">' +
-                               '<span class="name">' + item.name + author_lifespan + '</span>' +
-                               '<span class="subject">No books associated with ' + item.name +'</span>' +
-                           '</div>';
-                }
-                else if (item.work_count == 1) {
-                    return '<div class="ac_author" title="Select this author">' +
-                               '<span class="name">' + item.name + author_lifespan + '</span>' +
-                               '<span class="books">1 book</span> <span class="work">titled <i>' + (item.works[0]) + '</i></span><br/>' +
-                               '<span class="subject">Subjects: ' + (item.subjects && item.subjects.join(", ") || "") + '</span>' +
-                           '</div>';
-                }
                 else {
+                    var subjects_str = item.subjects ? item.subjects.join(', ') : '';
+                    var main_work = item.works ? item.works[0] : '';
+                    var author_lifespan = '';
+                    if (item.birth_date || item.death_date) {
+                        var birth = item.birth_date || ' ';
+                        var death = item.death_date || ' ';
+                        author_lifespan = ' (' + birth + '-' + death + ')';
+                    }
+
+                    var name_html = '<span class="name">' + item.name + author_lifespan + '</span>';
+                    var olid_html = '<span class="olid">' + item.key.match(/OL\d+A/)[0] + '</span>';
+                    var books_html = '<span class="books">' + item.work_count + ' books</span>';
+                    var main_work_html =  '<span class="work">including <i>' + main_work + '</i></span><br/>';
+                    var subjects_html = '<span class="subject">Subjects: ' + subjects_str + '</span>'
+
+                    if (subjects_str == '')
+                        subjects_html = '';
+
+                    if (item.work_count == 0) {
+                        books_html = '';
+                        main_work_html = '<span class="work">No books associated with ' + item.name + '</span>';
+                    }
+                    else if (item.work_count == 1) {
+                        books_html = '<span class="books">1 book</span>';
+                        main_work_html = '<span class="work">titled <i>' + main_work + '</i></span><br/>';
+                    }
+
                     return '<div class="ac_author" title="Select this author">' +
-                               '<span class="name">' + item.name + author_lifespan + '</span>' +
-                               '<span class="books">' + (item.work_count) + ' books</span>' +
-                               ' <span class="work">including <i>' + (item.works && item.works[0] || "") + '</i></span><br/>' +
-                               '<span class="subject">Subjects: ' + (item.subjects && item.subjects.join(", ") || "") + '</span>' +
-                           '</div>';
+                                name_html +
+                                olid_html + ' &bull; ' + books_html + ' ' + main_work_html +
+                                subjects_html +
+                            '</div>';
                 }
             }
         };

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -149,6 +149,7 @@ $jsdef render_author(i, author):
             </div>
             <div class="label">
                 <label for="author-$0">Author</label>
+                <span class="tip">You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href="/authors/OL23919A" target="_blank"><em>OL23919A</em></a>).</span>
             </div>
             $ authors = work.authors and [a.author for a in work.authors]
             <div id="authors">

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -596,6 +596,7 @@ li.ac_over {
 
 .ac_results .ac_author {
     line-height: normal;
+    color: #999;
 }
 .ac_results .ac_author:hover {
     background-color: #fffdcd;
@@ -607,6 +608,9 @@ li.ac_over {
     display: block;
     color: #000;
 }
+.ac_results .olid {
+    font-family: monospace;
+}
 .ac_results .books {
     font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
     font-size: 12px;
@@ -617,7 +621,6 @@ li.ac_over {
 .ac_results .work {
     font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
     font-size: 11px;
-    color: #999;
 }
 .ac_results .work i {
     color: #615132;
@@ -625,7 +628,6 @@ li.ac_over {
 .ac_results .subject {
     font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
     font-size: 11px;
-    color: #999;
 }
 .ac_results .action {
     font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6251786/32254650-914bdabe-be78-11e7-8062-980260fb8507.png)

I realized I'd inadvertently partially resolved #174 with #606 , so decided to finish it up. Added some markup to the edit page so this can be discovered and made sure "Create Author" doesn't appear when searching by olid. This solution should work (until someone names their kid `OL1A`, anyways).