### PR TITLE
refactoring waitlist logic to answer my_turn_to_borrow correctly

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -4,21 +4,15 @@ $# TODO construct list of available formats from available_loans
 
 $if current_and_available_loans:
   $ current_loans = current_and_available_loans[0]
-  $ available_loans = current_and_available_loans[1]
 $else:
   $ current_loans = []
-  $ available_loans = []
 
 $ realtime_availability = page.get_realtime_availability()
 $ availability = realtime_availability.get('status', 'error')
 $ wlsize = realtime_availability.get('num_waitlist', 0)
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
+$ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 
-$if available_loans:
-    $# When the book is available and there are people waiting for the book,
-    $# don't allow anyone other than the first person in the waiting list to borrow the book.
-    $if wlsize > 0 and (not waiting_loan or waiting_loan['status'] != 'available'):
-        $ available_loans = []
 
 $ user_loan = None
 $if user:
@@ -47,7 +41,7 @@ $if user_loan:
       </form>
     </div>
 
-$elif (availability == 'borrow_available') or available_loans:
+$elif (availability == 'borrow_available') or my_turn_to_borrow:
     <div class="btn-notice">
       <p>
         <span class="smaller">Read in-browser or download the ePub / PDF from $contributor</span>

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -152,6 +152,8 @@ class borrow(delegate.page):
                 raise web.seeother(error_redirect)
 
             user_meets_borrow_criteria = user_can_borrow_edition(user, edition, resource_type)
+            print('#' * 100)
+            print(user_meets_borrow_criteria)
 
             if user_meets_borrow_criteria:
                 loan = lending.create_loan(
@@ -796,21 +798,16 @@ def user_can_borrow_edition(user, edition, resource_type):
     availability_status = realtime_availability['status']
     waitlist_size = realtime_availability['num_waitlist']
 
-    if waitlist_size > 0:
+    if waitlist_size:
         # There some people are already waiting for the book,
         # it can't be borrowed unless the user is the first in the waiting list.
         waiting_loan = user.get_waiting_loan_for(edition)
-        if not waiting_loan or waiting_loan['status'] != 'available':
-            return False
+        my_turn_to_borrow = (waiting_loan and waiting_loan['status'] == 'available'
+                             and waiting_loan['position'] == 1)
+        return my_turn_to_borrow
 
-    if availability_status.lower() in 'borrow_available':
-        return True
-
-    elif resource_type in [loan['resource_type'] for loan in edition.get_available_loans()]:
-        return True
-
-    return False
-
+    #resource_type in [loan['resource_type'] for loan in edition.get_available_loans()]:
+    return availability_status == 'borrow_available'
 
 def is_admin():
     """"Returns True if the current user is in admin usergroup."""


### PR DESCRIPTION
This should be the final patch (for now) which fixes lending + waitlists across the board for OL
- uses realtime archive.org/metadata endpoint w/ dontcache=1 (for instant results w/o lag)
- replaced outdated db code w/ more accurate checks