### PR TITLE
BUGFIX: allow import to get MarcXML

### DIFF
--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -84,8 +84,7 @@ def get_marc_record_from_ia(identifier):
         data = urlopen_keep_trying(item_base + marc_xml_filename).read()
         try:
             root = etree.fromstring(data)
-            if root.tag == "{http://www.loc.gov/MARC21/slim}record":
-                return MarcXml(root)
+            return MarcXml(root)
         except Exception as e:
             print "Unable to read MarcXML: %s" % e
             traceback.print_exc()
@@ -94,6 +93,8 @@ def get_marc_record_from_ia(identifier):
     if marc_bin_filename in filenames:
         data = urlopen_keep_trying(item_base + marc_bin_filename).read()
         if len(data) == int(data[:5]):
+            # This checks the reported data length against the actual data length
+            # BinaryMARCs with incorrectly converted unicode characters do not match.
             return MarcBinary(data)
 
 def get_ia(ia):

--- a/openlibrary/catalog/marc/test_parse.py
+++ b/openlibrary/catalog/marc/test_parse.py
@@ -9,13 +9,15 @@ from lxml import etree
 import os
 import simplejson
 
+collection_tag = '{http://www.loc.gov/MARC21/slim}collection'
 record_tag = '{http://www.loc.gov/MARC21/slim}record'
 
 xml_samples = ['39002054008678.yale.edu', 'flatlandromanceo00abbouoft',
     'nybc200247', 'secretcodeofsucc00stjo', 'warofrebellionco1473unit',
     'zweibchersatir01horauoft', 'onquietcomedyint00brid', '00schlgoog',
     '0descriptionofta1682unit', '1733mmoiresdel00vill', '13dipolarcycload00burk',
-    'bijouorannualofl1828cole', 'soilsurveyrepor00statgoog', 'diebrokeradical400poll', 'cu31924091184469',
+    'bijouorannualofl1828cole', 'soilsurveyrepor00statgoog', 'diebrokeradical400poll',
+    'cu31924091184469', # MARC XML collection record
     'engineercorpsofh00sher',
     ]
 
@@ -40,7 +42,8 @@ class TestParse(unittest.TestCase):
                 expect_filename = "%s/xml_expect/%s_marc.xml" % (test_data, i)
                 path            = "%s/xml_input/%s_marc.xml"  % (test_data, i)
                 element = etree.parse(open(path)).getroot()
-                if element.tag != record_tag and element[0].tag == record_tag:
+                # Handle MARC XML collection elements in our test_data expectations:
+                if element.tag == collection_tag and element[0].tag == record_tag:
                     element = element[0]
                 rec = MarcXml(element)
                 edition_marc_xml = read_edition(rec)

--- a/openlibrary/catalog/marc/test_parse.py
+++ b/openlibrary/catalog/marc/test_parse.py
@@ -55,7 +55,6 @@ class TestParse(unittest.TestCase):
                     continue
                 self.assertEqual(sorted(edition_marc_xml.keys()), sorted(j.keys()))
                 for k in edition_marc_xml.keys():
-                    print `i, k, edition_marc_xml[k]`
                     self.assertEqual(edition_marc_xml[k], j[k])
                 self.assertEqual(edition_marc_xml, j)
             except:
@@ -86,7 +85,6 @@ class TestParse(unittest.TestCase):
                 for k in edition_marc_bin.keys():
                     if isinstance(j[k], list):
                         for item1, item2 in zip(edition_marc_bin[k], j[k]):
-                            #print (i, k, item1)
                             self.assertEqual(item1, item2)
 
                     self.assertEqual(edition_marc_bin[k], j[k])

--- a/openlibrary/catalog/marc/test_parse.py
+++ b/openlibrary/catalog/marc/test_parse.py
@@ -48,7 +48,7 @@ class TestParse(unittest.TestCase):
                 if os.path.exists(expect_filename):
                     j = simplejson.load(open(expect_filename))
                     if not j:
-                        print expect_filename
+                        print "Unable to open test data: %s" % expect_filename
                     assert j
                 if not j:
                     simplejson.dump(edition_marc_xml, open(expect_filename, 'w'), indent=2)
@@ -77,7 +77,7 @@ class TestParse(unittest.TestCase):
                 if os.path.exists(expect_filename):
                     j = simplejson.load(open(expect_filename))
                     if not j:
-                        print expect_filename
+                        print "Unable to open test data: %s" % expect_filename
                     assert j
                 if not j:
                     simplejson.dump(edition_marc_bin, open(expect_filename, 'w'), indent=2)

--- a/openlibrary/catalog/marc/test_parse.py
+++ b/openlibrary/catalog/marc/test_parse.py
@@ -4,7 +4,6 @@ import unittest
 from parse import read_edition, SeeAlsoAsTitle, NoTitle
 from marc_binary import MarcBinary
 from marc_xml import MarcXml, BadSubtag, BlankTag
-from pprint import pprint, pformat
 from urllib import urlopen
 from lxml import etree
 import os
@@ -32,12 +31,14 @@ bin_samples = ['bpl_0486266893', 'flatlandromanceo00abbouoft_meta.mrc',
     'engineercorpsofh00sher_meta.mrc', 'henrywardbeecher00robauoft_meta.mrc',
     'thewilliamsrecord_vol29b_meta.mrc', '13dipolarcycload00burk_meta.mrc' ]
 
+test_data = "%s/test_data" % os.path.dirname(__file__)
+
 class TestParse(unittest.TestCase):
     def test_xml(self):
         for i in xml_samples:
             try:
-                expect_filename = os.path.dirname(__file__) + '/test_data/xml_expect/' + i + '_marc.xml'
-                path = os.path.dirname(__file__) + '/test_data/xml_input/' + i + '_marc.xml'
+                expect_filename = "%s/xml_expect/%s_marc.xml" % (test_data, i)
+                path            = "%s/xml_input/%s_marc.xml"  % (test_data, i)
                 element = etree.parse(open(path)).getroot()
                 if element.tag != record_tag and element[0].tag == record_tag:
                     element = element[0]
@@ -47,10 +48,9 @@ class TestParse(unittest.TestCase):
                 j = {}
                 if os.path.exists(expect_filename):
                     j = simplejson.load(open(expect_filename))
-                    if not j:
-                        print "Unable to open test data: %s" % expect_filename
-                    assert j
-                if not j:
+                    assert j, "Unable to open test data: %s" % expect_filename
+                else:
+                    print "WARNING: test data %s not found, recreating it!" % expect_filename
                     simplejson.dump(edition_marc_xml, open(expect_filename, 'w'), indent=2)
                     continue
                 self.assertEqual(sorted(edition_marc_xml.keys()), sorted(j.keys()))
@@ -58,14 +58,14 @@ class TestParse(unittest.TestCase):
                     self.assertEqual(edition_marc_xml[k], j[k])
                 self.assertEqual(edition_marc_xml, j)
             except:
-                print 'bad marc:', i
+                print 'Bad MARC:', i
                 raise
 
     def test_binary(self):
         for i in bin_samples:
             try:
-                expect_filename = os.path.dirname(__file__) + '/test_data/bin_expect/' + i
-                data = open(os.path.dirname(__file__) + '/test_data/bin_input/' + i).read()
+                expect_filename = "%s/bin_expect/%s" % (test_data, i)
+                data = open("%s/bin_input/%s" % (test_data, i)).read()
                 if len(data) != int(data[:5]):
                     data = data.decode('utf-8').encode('raw_unicode_escape')
                 assert len(data) == int(data[:5])
@@ -75,10 +75,9 @@ class TestParse(unittest.TestCase):
                 j = {}
                 if os.path.exists(expect_filename):
                     j = simplejson.load(open(expect_filename))
-                    if not j:
-                        print "Unable to open test data: %s" % expect_filename
-                    assert j
-                if not j:
+                    assert j, "Unable to open test data: %s" % expect_filename
+                else:
+                    print "WARNING: test data %s not found, recreating it!" % expect_filename
                     simplejson.dump(edition_marc_bin, open(expect_filename, 'w'), indent=2)
                     continue
                 self.assertEqual(sorted(edition_marc_bin.keys()), sorted(j.keys()))
@@ -90,15 +89,18 @@ class TestParse(unittest.TestCase):
                     self.assertEqual(edition_marc_bin[k], j[k])
                 self.assertEqual(edition_marc_bin, j)
             except:
-                print 'bad marc:', i
+                print 'Bad MARC:', i
                 raise
 
-        i = 'talis_see_also.mrc'
-        f = open(os.path.dirname(__file__) + '/test_data/bin_input/' + i)
-        rec = MarcBinary(f.read())
+    def test_raises_see_also(self):
+        filename = "%s/bin_input/talis_see_also.mrc" % test_data
+        with open(filename, 'r') as f:
+            rec = MarcBinary(f.read())
         self.assertRaises(SeeAlsoAsTitle, read_edition, rec)
 
-        i = 'talis_no_title2.mrc'
-        f = open(os.path.dirname(__file__) + '/test_data/bin_input/' + i)
-        rec = MarcBinary(f.read())
+    def test_raises_no_title(self):
+        filename = "%s/bin_input/talis_no_title2.mrc" % test_data
+        with open(filename, 'r') as f:
+            rec = MarcBinary(f.read())
         self.assertRaises(NoTitle, read_edition, rec)
+

--- a/openlibrary/catalog/marc/test_work_subject.py
+++ b/openlibrary/catalog/marc/test_work_subject.py
@@ -100,7 +100,6 @@ record_tag = '{http://www.loc.gov/MARC21/slim}record'
 
 class TestSubjects:
     def _test_subjects(self, rec, expect):
-        print read_subjects(rec)
         assert read_subjects(rec) == expect
 
     def test_subjects_xml(self):

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -25,4 +25,4 @@ class TestGetIA(unittest.TestCase):
         for item in xml_items:
             result = get_ia.get_marc_record_from_ia(item)
             self.assertIsInstance(result, MarcXml)
-
+        m.undo()

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+from _pytest.monkeypatch import monkeypatch
+from openlibrary.catalog import get_ia
+from openlibrary.catalog.marc.marc_xml import MarcXml
+from openlibrary.catalog.marc.marc_binary import MarcBinary
+
+def return_test_marc_data(url):
+    filename = url.split("/")[-1] 
+    test_data_dir = "/../../catalog/marc/test_data/xml_input/"
+    path = os.path.dirname(__file__) + test_data_dir + filename
+    return open(path)
+
+class TestGetIA(unittest.TestCase):
+    def test_get_marc_record_from_ia(self):
+        """Tests the method returning MARC records form IA
+        used by the import API. It should return an XML MARC if one exists."""
+        item = "1733mmoiresdel00vill"
+        m = monkeypatch()
+        m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_data)
+
+        result = get_ia.get_marc_record_from_ia(item)
+        self.assertIsInstance(result, MarcXml)
+

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from _pytest.monkeypatch import monkeypatch
 from openlibrary.catalog import get_ia
+from openlibrary.core import ia
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.marc_binary import MarcBinary
 
@@ -15,10 +16,13 @@ class TestGetIA(unittest.TestCase):
     def test_get_marc_record_from_ia(self):
         """Tests the method returning MARC records form IA
         used by the import API. It should return an XML MARC if one exists."""
-        item = "1733mmoiresdel00vill"
+        xml_items = ["1733mmoiresdel00vill",     # no <?xml
+                     "0descriptionofta1682unit"] # has <?xml
         m = monkeypatch()
         m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_data)
+        m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + "_marc.xml", itemid + "_meta.mrc"]})
 
-        result = get_ia.get_marc_record_from_ia(item)
-        self.assertIsInstance(result, MarcXml)
+        for item in xml_items:
+            result = get_ia.get_marc_record_from_ia(item)
+            self.assertIsInstance(result, MarcXml)
 

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -6,23 +6,92 @@ from openlibrary.core import ia
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.marc_binary import MarcBinary
 
-def return_test_marc_data(url):
+def return_test_marc_bin(url):
+    return return_test_marc_data(url, "bin_input")
+
+def return_test_marc_xml(url):
+    return return_test_marc_data(url, "xml_input")
+
+def return_test_marc_data(url, test_data_subdir="xml_input"):
     filename = url.split("/")[-1] 
-    test_data_dir = "/../../catalog/marc/test_data/xml_input/"
+    test_data_dir = "/../../catalog/marc/test_data/%s/" % test_data_subdir
     path = os.path.dirname(__file__) + test_data_dir + filename
     return open(path)
 
 class TestGetIA(unittest.TestCase):
-    def test_get_marc_record_from_ia(self):
-        """Tests the method returning MARC records form IA
-        used by the import API. It should return an XML MARC if one exists."""
-        xml_items = ["1733mmoiresdel00vill",     # no <?xml
-                     "0descriptionofta1682unit"] # has <?xml
-        m = monkeypatch()
-        m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_data)
-        m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + "_marc.xml", itemid + "_meta.mrc"]})
+    def setUp(self):
+        self.m = monkeypatch()
 
+    def tearDown(self):
+        self.m.undo()
+
+    def test_get_marc_record_from_ia(self):
+        """Tests the method returning MARC records from IA
+        used by the import API. It should return an XML MARC if one exists."""
+        self.m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_xml)
+        self.m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + "_marc.xml", itemid + "_meta.mrc"]})
+
+        xml_items = ["1733mmoiresdel00vill",     # no <?xml
+                     "0descriptionofta1682unit", # has <?xml
+                     "cu31924091184469",         # is <collection>
+                    ]
         for item in xml_items:
             result = get_ia.get_marc_record_from_ia(item)
-            self.assertIsInstance(result, MarcXml)
-        m.undo()
+            self.assertIsInstance(result, MarcXml,
+                                  "%s: expected instanceof MarcXml, got %s" % (item, type(result)))
+
+    def test_no_marc_xml(self):
+        """When no XML MARC is listed in _filenames, the Binary MARC should be fetched."""
+        self.m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_bin)
+        self.m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + "_meta.mrc"]})
+
+        bin_items = ['0descriptionofta1682unit',
+                     '13dipolarcycload00burk',
+                     'bijouorannualofl1828cole',
+                     'cu31924091184469',
+                     'diebrokeradical400poll',
+                     'engineercorpsofh00sher',
+                     'flatlandromanceo00abbouoft',
+                     'henrywardbeecher00robauoft',
+                     'lincolncentenary00horn',
+                     'livrodostermosh00bragoog',
+                     'mytwocountries1954asto',
+                     'onquietcomedyint00brid',
+                     'secretcodeofsucc00stjo',
+                     'thewilliamsrecord_vol29b',
+                     'warofrebellionco1473unit',
+                    ]
+
+        for item in bin_items:
+            result = get_ia.get_marc_record_from_ia(item)
+            self.assertIsInstance(result, MarcBinary,
+                                  "%s: expected instanceof MarcBinary, got %s" % (item, type(result)))
+            #print "%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item,
+            #                                             result.leader()[9],
+            #                                             unicode.encode(result.read_fields(['245']).next()[1].get_all_subfields().next()[1], 'utf8'))
+
+    def test_incorrect_length_marcs(self):
+        """If a Binary MARC has a different length than stated in the MARC leader, it is probably due to bad character conversions."""
+        self.m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_bin)
+        self.m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + "_meta.mrc"]})
+
+        bad_marcs = ['1733mmoiresdel00vill', # Binary MARC reports len=734, but actually=742. Has badly converted unicode
+                                             # original unicode converted as if it were MARC8
+                     'dasrmischepriv00rein', # same as zweibchersatir01horauoft, binary representation of unicode interpreted as unicode codepoints
+                     'histoirereligieu05cr', # C3A2 in this file should be single byte MARC8 combining acute 0xE2
+                                             # Original MARC8 0xE2 interpreted as u00E2 => \xC3\xA2, leader still MARC8
+                     'lesabndioeinas00sche', # Original MARC8 0xE2 interpreted as u00E2 => \xC3\xA2, leader still MARC8
+                     'poganucpeoplethe00stowuoft', # junk / unexpected character at end of publishers in field 260
+                     'scrapbooksofmoun03tupp', # possible extra chars at end of field 505?
+                     'zweibchersatir01horauoft', # leader is unicode, chars '\xc3\x83\xc2\xbc' in mrc should be '\xc3\xbc'
+                                                 # original '\xc3\xb3' was converted to '\u00c3\u00b3'
+                   ]
+
+        for bad_marc in bad_marcs:
+            result = get_ia.get_marc_record_from_ia(bad_marc)
+            #TODO: get_marc_record_from_ia() currently returns None in this case,
+            #  It should be handled by MarcBinary and raise a BadMarc exception, or similar.
+            self.assertIsNone(result)
+            #print "%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (bad_marc,
+            #                                             result.leader()[9],
+            #                                             unicode.encode(result.read_fields(['245']).next()[1].get_all_subfields().next()[1], 'utf8'))

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -29,11 +29,32 @@ class TestGetIA(unittest.TestCase):
         """Tests the method returning MARC records from IA
         used by the import API. It should return an XML MARC if one exists."""
         self.m.setattr(get_ia, 'urlopen_keep_trying', return_test_marc_xml)
-        self.m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + "_marc.xml", itemid + "_meta.mrc"]})
+        self.m.setattr(ia, 'get_metadata', lambda itemid: {'_filenames': [itemid + '_marc.xml', itemid + '_meta.mrc']})
 
-        xml_items = ["1733mmoiresdel00vill",     # no <?xml
-                     "0descriptionofta1682unit", # has <?xml
-                     "cu31924091184469",         # is <collection>
+        xml_items = ['1733mmoiresdel00vill',     # no <?xml
+                     '0descriptionofta1682unit', # has <?xml
+                     'cu31924091184469',         # is <collection>
+                     #'1893manualofharm00jadauoft', # 0 byte xml file
+                     '00schlgoog',
+                     '13dipolarcycload00burk',
+                     '39002054008678.yale.edu',
+                     'abhandlungender01ggoog',
+                     'bijouorannualofl1828cole',
+                     'dasrmischepriv00rein',
+                     'diebrokeradical400poll',
+                     'engineercorpsofh00sher',
+                     'flatlandromanceo00abbouoft',
+                     'lesabndioeinas00sche',
+                     'lincolncentenary00horn',
+                     'livrodostermosh00bragoog',
+                     'mytwocountries1954asto',
+                     'nybc200247',
+                     'onquietcomedyint00brid',
+                     'scrapbooksofmoun03tupp',
+                     'secretcodeofsucc00stjo',
+                     'soilsurveyrepor00statgoog',
+                     'warofrebellionco1473unit',
+                     'zweibchersatir01horauoft',
                     ]
         for item in xml_items:
             result = get_ia.get_marc_record_from_ia(item)


### PR DESCRIPTION
Following on from the recent discoveries about the import path, this PR allows imports to use the IA MARC XML files which have better handling of unicode characters.

Previously attempts to retrieve the MARC XML were failing because many did not have
 the `<?xml` substring that the code was looking for...