### PR TITLE
Refactor autocomplete code

### DIFF
--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -21,10 +21,6 @@ jQuery(function($) {
         options.fx = {"opacity": "toggle"};
     }
 
-    // autocompletes
-    $("input.author-autocomplete").author_autocomplete();
-    $("input.language-autocomplete").language_autocomplete();
-
     // validate forms
     $("form.validate").ol_validate();
 

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -90,46 +90,55 @@ function limitChars(textid, limit, infodiv) {
 </div>
 
 <script type="text/javascript">
-<!--
 \$(function() {
-    function update_visible() {
-        if (\$("#authors div.input").length > 1) {
-            \$("#authors a.remove").show();
-        }
-        else {
-            \$("#authors a.remove").hide();
-        }
-
-        \$("#authors a.add:not(:last)").hide();
-        \$("#authors a.add:last").show();
-    }
-
-    update_visible();
-
-    \$("#authors a.remove").live("click", function() {
-        if (\$("#authors div.input").length > 1) {
-            \$(this).closest("div.input").remove();
-            update_visible();
-        }
-    });
-
-    \$("#authors a.add").live("click", function(event) {
-        event.preventDefault();
-
-        var n = \$("#authors div.input:last").attr("id").substr("author-input-".length);
-        n = parseInt(n);
-
-        \$("#authors").append(render_author(n+1, {key:"", name: ""}));
-        \$("#authors input.author-autocomplete:last").author_autocomplete();
-        update_visible();
-    });
-
+    \$("#authors").setup_multi_input_autocomplete(
+        "input.author-autocomplete",
+        render_author,
+        {
+            endpoint: "/authors/_autocomplete",
+            // Don't render "Create new author" if searching by key
+            addnew: function(query) { return !/^OL\d+A/i.test(query); },
+        },
+        {
+            minChars: 2,
+            max: 11,
+            matchSubset: false,
+            autoFill: false,
+            formatItem: render_author_autocomplete_item
+        });
 });
-//-->
 </script>
 
+$jsdef render_author_autocomplete_item(item):
+    $if item.key == "__new__":
+        <div class="ac_author ac_addnew" title="Add a new author">
+            <span class="action">$_('Create a new record for') </span>
+            <span class="name">$item.name</span>
+        </div>
+    $else:
+        <div class="ac_author" title="Select this author">
+            <span class="name">
+                $item.name
+                $if item.birth_date or item.death_date:
+                    (${item.birth_date or ' '}&ndash;${item.birth_date or ' '})
+            </span>
+            <span class="olid">$item.key.split('/')[2]</span>
+            &bull;
+            $if item.work_count == 0:
+                <span class="work">No books associated with $item.name</span>
+            $elif item.work_count == 1:
+                <span class="books">1 book</span>
+                <span class="work">titled <i>$item.works[0]</i></span>
+            $else:
+                <span class="books">$item.work_count books</span>
+                <span class="work">including <i>$item.works[0]</i></span>
+
+            $if item.subjects:
+                <span class="subject">Subjects: ${', '.join(item.subjects)}</span>
+        </div>
+
 $jsdef render_author(i, author):
-    <div class="input" id="author-input-$i">
+    <div class="input">
         <input name="authors--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name"/>
         <input name="work--authors--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
         <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this author')">[x]</a>&nbsp;

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -10,54 +10,31 @@ $def radiobuttons(name, options, value):
         <label for="$id">$v</label>
         &nbsp;&nbsp;
 
+$jsdef render_language_autocomplete_item(item):
+    <div class="ac_author" title="$_('Select this language')">
+        <span class="name">$item.name</span>
+    </div>
+
+$# Render the ith language input field
 $jsdef render_language(i, language):
-    <div class="input" id="languages-input-$i">
+    <div class="input">
       <input name="languages--$i" class="language language-autocomplete" type="text" id="language-$i" value="$language.name" style="width:300px!important;"/>
       <input name="edition--languages--$i--key" type="hidden" id="language-$i-key" value="$language.key" />
       <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this language')">[x]</a>
-      <br/><a href="javascript:;" class="add small librarian hidden">Add another language?</a>
+      <br/><a href="javascript:;" class="add small">Add another language?</a>
     </div>
 
 <script type="text/javascript">
-  <!--
-  \$(function() {
-      function update_visible() {
-          if (\$("#languages div.input").length > 1) {
-              \$("#languages a.remove").show();
-          }
-          else {
-              \$("#languages a.remove").hide();
-          }
-
-          $# The add link should be made visible only if both librarian-on and it is the last element.
-          \$("#languages a.add:not(:last)").attr("style", "display: none");
-          \$("#languages a.add:last").attr("style", "");
-
-          if (\$("#translated-from").hasClass("librarian-on")) {
-              \$("#languages a.add:last").addClass("librarian-on");
-          }
-      }
-      update_visible();
-
-     \$("#languages a.remove").live("click", function() {
-         if (\$("#languages div.input").length > 1) {
-             \$(this).closest("div.input").remove();
-             update_visible();
-         }
-     });
-
-     \$("#languages a.add").live("click", function(event) {
-         event.preventDefault();
-
-         var n = \$("#languages div.input:last").attr("id").substr("languages-input-".length);
-         n = parseInt(n);
-
-         \$("#languages").append(render_language(n+1, {key:"", name: ""}));
-         \$("#languages input.language-autocomplete:last").language_autocomplete();
-         update_visible();
-     });
-  });
-  -->
+\$(function() {
+    \$("#languages").setup_multi_input_autocomplete(
+        "input.language-autocomplete",
+        render_language,
+        { endpoint: "/languages/_autocomplete" },
+        {
+            max: 6,
+            formatItem: render_language_autocomplete_item
+        });
+});
 </script>
 
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -11,7 +11,7 @@ $def radiobuttons(name, options, value):
         &nbsp;&nbsp;
 
 $jsdef render_language_autocomplete_item(item):
-    <div class="ac_author" title="$_('Select this language')">
+    <div class="ac_language" title="$_('Select this language')">
         <span class="name">$item.name</span>
     </div>
 

--- a/static/css/jquery.autocomplete.css
+++ b/static/css/jquery.autocomplete.css
@@ -61,48 +61,15 @@
     text-align: left;
 }
 
-li.ac_over { 
-    background-color: #fffdcd;
-    cursor: pointer; 
-}
-
-.ac_results .ac_author {
+.ac_results ul li {
+    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
+    cursor: pointer;
+    color: #999;
     line-height: normal;
 }
-.ac_results .ac_author:hover {
+
+.ac_results li.ac_over {
     background-color: #fffdcd;
-    cursor: pointer;
-}
-.ac_results .name {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
-    font-size: 16px;
-    display: block;
-    color: #000;
-}
-.ac_results .books {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
-    font-size: 12px;
-    color: #35672e;
-    font-weight: 700;
-    padding: 0;
-}
-.ac_results .work {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
-    font-size: 11px;
-    color: #999;
-}
-.ac_results .work i {
-    color: #615132;
-}
-.ac_results .subject {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
-    font-size: 11px;
-    color: #999;
-}
-.ac_results .action {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
-    font-size: 9px;
-    color: #748d36;
 }
 
 .ac_even, .ac_odd {

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -638,129 +638,44 @@ div.box {
 td.l {padding-left: 12px; width: 50%;}
 td.r {padding-left: 12px; width: 50%;}
 ins { background: #adc07f; text-decoration: none; }
-del { color: #e44028; text-decoration: line-through; }.ac_results {
-        padding: 0px;
-        border: 1px solid black;
-        background-color: white;
-        overflow: hidden;
-        z-index: 99999;
-}
+del { color: #e44028; text-decoration: line-through; }
 
-.ac_results ul {
-        width: 100%;
-        list-style-position: outside;
-        list-style: none;
-        padding: 0;
-        margin: 0;
-}
+/* AUTHOR AUTOCOMPLETE */
 
-.ac_results li {
-        margin: 0px;
-        padding: 5px;
-        cursor: default;
-        display: block;
-        /*
-        if width will be 100% horizontal scrollbar will apear
-        when scroll mode will be used
-        */
-        /*width: 100%;*/
-        font: menu;
-        font-size: 12px;
-        /*
-        it is very important, if line-height not set or set
-        in relative units scroll will be broken in firefox
-        */
-        line-height: 16px;
-        overflow: hidden;
-}
-
-.ac_loading {
-        background: white url('/images/indicator.gif') right center no-repeat;
-}
-
-.ac_odd {
-        background-color: #eee;
-}
-
-.ac_over {
-        background-color: #0A246A;
-        color: white;
-}
-
-/* Customizations */
-
-.ac_results {
-    position: absolute;
-    display: none;
-    top: -5px;
-    width: 493px;
-    max-height: 290px;
-    background-color: #fff;
-    border: 1px solid #999;
-    opacity: .95;
-    text-align: left;
-}
-
-li.ac_over {
-    background-color: #fffdcd;
-    cursor: pointer;
-}
-
-.ac_results .ac_author {
-    line-height: normal;
-    color: #999;
-}
-.ac_results .ac_author:hover {
-    background-color: #fffdcd;
-    cursor: pointer;
-}
-.ac_results .name {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
+.ac_results .ac_author .name {
     font-size: 16px;
     display: block;
     color: #000;
 }
-.ac_results .olid {
+.ac_results .ac_author .olid {
     font-family: monospace;
 }
-.ac_results .books {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
+.ac_results .ac_author .books {
     font-size: 12px;
     color: #35672e;
     font-weight: 700;
     padding: 0;
 }
-.ac_results .work {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
+.ac_results .ac_author .work {
     font-size: 11px;
 }
-.ac_results .work i {
+.ac_results .ac_author .work i {
     color: #615132;
 }
-.ac_results .subject {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
+.ac_results .ac_author .subject {
     font-size: 11px;
 }
-.ac_results .action {
-    font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
+.ac_results .ac_author .action {
     font-size: 9px;
     color: #748d36;
 }
 
-.ac_even, .ac_odd {
-    background-color: inherit;
+/* LANGUAGE AUTOCOMPLETE */
+.ac_results .ac_language {
+    font-size: 16px;
+    color: #000;
 }
 
-input.accept {
-}
-input.reject {
-}
-
-.ac_addnew {
-    border-top: 1px solid #ccc;
-    padding: 5px 0 0!important;
-    margin-top: -5px;
-}
 /* RESET EVERYTHING */
 
 body,div,dl,dt,dd,ul,ol,li,pre,code,form,fieldset,legend,input,textarea,th,td{margin:0;padding:0;}


### PR DESCRIPTION
Decided to do this as a separate PR first to make it easier to review.

Things to note:
- There could be a styling issue if something includes `master.css` without `jquery.autocomplete.css`, but I couldn't find anywhere where that would matter. I've left more general styling in `jquery.autocomplete.css`, and moved author/language specific styling to `master.css`
- `openlibrary/templates/type/edition/edit.html` uses the old `setup_autocomplete` method, but I can't find anywhere this template is being used