### PR TITLE
Allow trusted users to merge-authors

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -97,8 +97,10 @@ features:
     cache_most_recent: enabled
     recentchanges_v2: enabled
     history_v2: admin
-    merge-authors: enabled
-    merge-editions: enabled
+    merge-authors:
+        filter: usergroup
+        usergroup: /usergroup/librarians
+    merge-editions: admin
     undo: enabled
     dev: enabled
     lists: enabled

--- a/docs/design/feature-flags.rst
+++ b/docs/design/feature-flags.rst
@@ -18,7 +18,7 @@ To make some part of the template visible only if a feature-flag is enabled::
         <h3>Lists</h3>
         $for list in page.get_lists():
             ...
-            
+
 To enable a URL only if a feature flag is enabled::
 
     class home(delegate.page):
@@ -29,7 +29,7 @@ To enable a URL only if a feature flag is enabled::
         
         def GET(self):
             return render_template("home")
-            
+
 
 Setting Feature Flags
 ---------------------
@@ -41,7 +41,7 @@ In Open Library, the feature flags are specified in the ``openlibrary.yml`` file
         lists: admin
         lending_v2: 
             filter: usergroup
-            usergroup: beta-users
+            usergroup: /usergroup/beta-users
 
 The value of a feature flag is called a *filter*. A filter can be specified either as its name or as a dict containing its name and parameters. 
 For example, the following two examples mean the same. ::
@@ -70,19 +70,19 @@ Available filters are:
 **admin**
 
     Enabled for admin users.
-    
+
 **usergroup**
 
     Enabled for the users part of the specified usergroup. ::
-    
+
         lending_v2: 
             filter: usergroup
-            usergroup: beta-users
-    
+            usergroup: /usergroup/beta-users
+
 **queryparam**
 
     Enabled only if the URL has a specified query parameter. ::
-    
+
         debug:
             filter: queryparam
             name: debug

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -206,7 +206,8 @@ class merge_authors(delegate.page):
     path = '/authors/merge'
 
     def is_enabled(self):
-        return "merge-authors" in web.ctx.features
+        user = web.ctx.site.get_user()
+        return "merge-authors" in web.ctx.features or user and user.is_admin()
 
     def filter_authors(self, keys):
         docs = web.ctx.site.get_many(["/authors/" + k for k in keys])


### PR DESCRIPTION
To enable this feature toggle in production, the following lines will need to be added/modified in `config/openlibrary.yml`:

```
    merge-authors:
        filter: usergroup
        usergroup: /usergroup/librarians
```

and `/usergroup/librarians` revised to include all the users who should have access to this feature.