### PR TITLE
Fix: enable admin to author-merge on all pages

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -207,7 +207,7 @@ class merge_authors(delegate.page):
 
     def is_enabled(self):
         user = web.ctx.site.get_user()
-        return "merge-authors" in web.ctx.features or user and user.is_admin()
+        return "merge-authors" in web.ctx.features or (user and user.is_admin())
 
     def filter_authors(self, keys):
         docs = web.ctx.site.get_many(["/authors/" + k for k in keys])
@@ -255,7 +255,8 @@ class merge_authors_json(delegate.page):
     encoding = "json"
 
     def is_enabled(self):
-        return "merge-authors" in web.ctx.features
+        user = web.ctx.site.get_user()
+        return "merge-authors" in web.ctx.features or (user and user.is_admin())
 
     def POST(self):
         json = web.data()

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -179,6 +179,8 @@ $ has_profile = person.get_user() is not None
             </form>
         </td>
     </tr>
+    $if person.get_user().is_admin():
+        <tr><td>$_("Admin")</td><td>Yes</td></tr>
     <tr>
         <td>$_("Bot")</td>
         <td>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -17,7 +17,7 @@ $var title: Search Open Library for "$q"
         $if 'error' not in results:
             $ response = results['response']
             $ num_found = int(response['numFound'])
-            $if num_found >= 2 and "merge-authors" in ctx.features and ctx.user:
+            $if num_found >= 2 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
                 $ keys = '&'.join('key=%s' % doc['key'] for doc in response['docs'])
                 <div class="mergeThis">
                     <p class="smaller brown sansserif collapse">Is the same author listed twice?</p>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -1,6 +1,6 @@
 $def with (page)
 
-$if "merge-authors" in ctx.features and query_param('merge', 'false') == 'true':
+$if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
     <script type="text/javascript">
     // <!--
     \$().ready(function() {
@@ -95,7 +95,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
 <div id="contentBody">
 
-    $if "merge-authors" in ctx.features and query_param('merge', 'false') == 'true':
+    $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
        <div class="message hidden">
             <div id="preMerge" class="hidden">
                 <p class="larger collapse"><strong>Merging Authors...</strong></p>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -263,7 +263,7 @@ $if param and not error:
             $if not counts:
                 $continue
             <div class="facet $header">
-            $if header == 'author_key' and len(counts) > 1 and ctx.user and "merge-authors" in ctx.features:
+            $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
                 $ keys = '&'.join('key=%s' % k for k, display, count in counts)
                 <h4 class="facetHead">$label <span class="merge"><a href="/authors/merge?$keys" title="Merge duplicate authors from this search">Merge duplicates</a></span></h4>
             $else:


### PR DESCRIPTION
@mekarpeles  here is the fix to enable merge for admins. It would have been working as expected for librarian group members.

I'd like to have a go at centralising the check that is made in multiple places later, but this will get the functionality back.