### PR TITLE
Change work from edition page fixes

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -823,7 +823,7 @@ class works_autocomplete(delegate.page):
             'rows': i.limit,
             'fq': 'type:work',
             # limit the fields returned for better performance
-            'fl': 'key,title,first_publish_year,author_name,edition_count'
+            'fl': 'key,title,subtitle,first_publish_year,author_name,edition_count'
         }
 
         data = solr.select(solr_q, **params)
@@ -832,6 +832,8 @@ class works_autocomplete(delegate.page):
         for d in docs:
             # Required by the frontend
             d['name'] = d['title']
+            if 'subtitle' in d:
+                d['name'] += ": " + d['subtitle']
         return to_json(docs)
 
 class authors_autocomplete(delegate.page):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -609,10 +609,10 @@ class Work(models.Work):
     def get_sorted_editions(self):
         """Return a list of works sorted by publish date"""
         w = self._solr_data
-        editions = w and w.get('edition_key') or []
+        editions = w.get('edition_key') if w else []
 
         # solr is stale
-        if len(editions) < self.edition_count:
+        if len(editions) != self.edition_count:
             q = {"type": "/type/edition", "works": self.key, "limit": 10000}
             editions = [k[len("/books/"):] for k in web.ctx.site.things(q)]
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -37,7 +37,7 @@ $jsdef render_work_field(i, work):
 $jsdef render_work_autocomplete_item(item):
     <div class="ac_work" title="Select this work">
         <span class="name">
-            <span class="title">$item.title</span>
+            <span class="title">$item.name</span>
             $if item.first_publish_year:
             <span class="first_publish_year">($item.first_publish_year)</span>
         </span>
@@ -165,6 +165,9 @@ $jsdef render_work_autocomplete_item(item):
                 <label for="edition--works--$0">$_("What work is this an edition of?")</label>
                 <span class="tip">
                     $_("Sometimes editions can be associated with the wrong work. You can correct that here.")
+                    $_("You can search by title or by Open Library ID")
+                    ($("like")
+                    <a href="/works/OL262757W" target="_blank"><em>OL262757W</em></a>).
                     <br/>
                     $:_("WARNING: Any edits made to the work from this page will be applied to the <b>old work</b>.")
                 </span>


### PR DESCRIPTION
- Markup now includes an example of an OpenLibrary ID
- Autocomplete results include subtitle; no longer just title
- Work page now queries database for editions if solr is outdated (which it will be after changing an edition's work)

![image](https://user-images.githubusercontent.com/6251786/34448851-c0f4d3a4-ecbf-11e7-911b-9d13ebcbc4cf.png)
