### PR TITLE
 fixes #760

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -411,7 +411,7 @@ class SaveBookHelper:
         if work_data:
             if self.work is None:
                 self.work = self.new_work(self.edition)
-                self.edition.works = [{'key': self.work.key}]
+                edition_data.works = [{'key': self.work.key}]
             self.work.update(work_data)
             saveutil.save(self.work)
 
@@ -613,7 +613,7 @@ class book_edit(delegate.page):
         work = edition.works and edition.works[0]
 
         if not work:
-            # HACK: create dummy work when work is not available to make edit form work
+            # HACK: create dummy work when work is not available
             work = web.ctx.site.new('', {
                 'key': '',
                 'type': {'key': '/type/work'},

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -436,10 +436,11 @@ class SaveBookHelper:
         saveutil.commit(comment=comment, action="edit-book")
 
     def new_work(self, edition):
-        work_key = web.ctx.site.new_key("/type/work")
+        work_key = web.ctx.site.new_key('/type/work')
         work = web.ctx.site.new(work_key, {
-            "key": work_key,
-            "type": {'key': '/type/work'},
+            'key': work_key,
+            'type': {'key': '/type/work'},
+            'covers': edition.get('covers', []),
         })
         return work
 
@@ -620,7 +621,6 @@ class book_edit(delegate.page):
                 'title': edition.title,
                 'authors': [{'type': {'key': '/type/author_role'}, 'author': {'key': a['key']}} for a in edition.get('authors', [])],
                 'subjects': edition.get('subjects', []),
-                'covers': edition.get('covers', [])
             })
 
         return render_template('books/edit', work, edition, recaptcha=get_recaptcha())


### PR DESCRIPTION
@cdrini , @mekarpeles This is a minimal change to fix #760 

The new feature added `works = None` to `edition_data` when previously there was no `works` key.

in https://github.com/internetarchive/openlibrary/blob/352b6cb833386875acd95141e221f8bbd84a3a64/openlibrary/plugins/upstream/addbook.py#L433

`self.edition.update(edition_data)`

`self.edition.works` was set correctly to the new work ID, but then it was being overwritten by the new `edition_data.works = None` in the `update()`.

This PR sets `edition_data.works` to the new ID, so the `update()` works as intended. Hopefully I have not broken any other use cases!