### PR TITLE
fixes #793, dev solr updater

### DIFF
--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -121,7 +121,7 @@ class BetterDataProvider(LegacyDataProvider):
 
     def preload_metadata(self, identifiers):
         identifiers = [id for id in identifiers if id not in self.metadata_cache]
-        if not identifiers:
+        if not (identifiers and self.ia_db):
             return
 
         logger.info("preload_metadata %s", identifiers)

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -168,7 +168,7 @@ def update_keys(keys):
     keys = (k for k in keys if k.count("/") == 2 and k.split("/")[1] in ["books", "authors", "works"])
     update_work.clear_monkeypatch_cache(max_size=10000)
     print str(args)
-    update_work.load_configs(args.ol_url,args.config,'default')
+    update_work.load_configs(args.ol_url, args.config, 'default')
 
     count = 0
     for chunk in web.group(keys, 100):


### PR DESCRIPTION
This gets the solr-updater running on the dev instance, which does not have an

`ia_db:` section in conf/openlibrary.yml   The code expects a `ia_db` to be configured in the data_provider, but elsewhere it appears entirely optional.

I don't yet understand what the `ia_db` connection is used for, but from the code I guess it must be present in production. It looks like it gives direct access to archive.org metadata, but if that were the case, shouldn't we be leveraging it more? 

Once this is merged we can begin reproducing SOLR indexing issues in dev, and add better logging to catch some of the issues that stop items getting indexed.


The updater logs are written to:
`/var/log/upstart/ol-solr-updater.log`

Check the status of ol-solr-updater:
`status ol-solr-updater`

Stop:
`sudo stop ol-solr-updater`

Start:
`sudo start ol-solr-updater`
