### PR TITLE
Attempt to fix undo author merges

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -822,17 +822,6 @@ class MergeAuthors(Changeset):
     def can_undo(self):
         return self.get_undo_changeset() is None
 
-    def process_docs_before_undo(self, docs):
-        works = [doc for doc in docs if doc['key'].startswith("/works/")]
-        for w in works:
-            if w.get("authors"):
-                authors = [follow_redirect(web.ctx.site.get(a['author']['key']))
-                            for a in w.get('authors')
-                            if 'author' in a
-                            and 'key' in a['author']]
-                w['authors'] = [{"author": {"key": a.key}} for a in authors]
-        return docs
-
     def get_master(self):
         master = self.data.get("master")
         return master and web.ctx.site.get(master, lazy=True)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -771,8 +771,6 @@ class Changeset(client.Changeset):
             }
         else:
             d = web.ctx.site.get(key, revision).dict()
-            if d['type']['key'] == '/type/edition':
-                d.pop('authors', None)
             return d
 
     def process_docs_before_undo(self, docs):


### PR DESCRIPTION
In the process of undoing an author merge @tfmorris and I noticed that authors on edition records were being stripped, which left orphaned editions (i.e. editions with no works) without an author too. This is bad as it makes it harder to group them correctly.

While ideally authors should only be stored at the work level, reverting undo is _not_ the place to make this happen. Also, currently it is very helpful to have author data on orphaned editions to help group them under existing works.

Undo should simply revert the record to the previous version, with no other modifications.