### PR TITLE
Fix deleted Authors persisting in Solr index

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1206,7 +1206,7 @@ def update_author(akey, a=None, handle_redirects=True):
         author_id = solr_escape(author_id)
         delete_query = Element('delete')
         query = SubElement(delete_query, 'query')
-        query.text = 'key:%s' % author_id
+        query.text = 'key:/authors/%s' % author_id
         return [tostring(delete_query)]
     try:
         assert a['type']['key'] == '/type/author'

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1202,12 +1202,7 @@ def update_author(akey, a=None, handle_redirects=True):
     if not a:
         a = data_provider.get_document(akey)
     if a['type']['key'] in ('/type/redirect', '/type/delete') or not a.get('name', None):
-        # FIXME: should return a DeleteRequest
-        author_id = solr_escape(author_id)
-        delete_query = Element('delete')
-        query = SubElement(delete_query, 'query')
-        query.text = 'key:/authors/%s' % author_id
-        return [tostring(delete_query)]
+        return [DeleteRequest([akey])]
     try:
         assert a['type']['key'] == '/type/author'
     except AssertionError:

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -804,6 +804,12 @@ def build_data2(w, editions, authors, ia, duplicates):
     return doc
 
 def solr_update(requests, debug=False, commitWithin=60000):
+    """POSTs a collection of update requests to Solr.
+    TODO: Deprecate and remove string requests. Is anything else still generating them?
+    :param list[string or UpdateRequest or DeleteRequest] requests: Requests to send to Solr
+    :param bool debug:
+    :param int commitWithin: Solr commitWithin, in ms
+    """
     h1 = httplib.HTTPConnection(get_solr())
     url = 'http://%s/solr/update' % get_solr()
 
@@ -1013,7 +1019,7 @@ def process_work_data(work_data):
 def update_edition(e):
     """
     Get the Solr requests necessary to insert/update this edition into Solr.
-    Currently editions are not indexed by SOLR
+    Currently editions are not indexed by Solr
     (unless they are orphaned editions passed into update_work() as fake works.
     This always returns an empty list.
     :param dict e: Edition to update
@@ -1189,8 +1195,8 @@ def update_author(akey, a=None, handle_redirects=True):
     Get the Solr requests necessary to insert/update/delete an Author in Solr.
     :param string akey: The author key, e.g. /authors/OL23A
     :param dict a: Optional Author
-    :param bool handle_redirects: If true, remove from SOLR all authors that redirect to this one
-    :rtype: list[string or UpdateRequest or DeleteRequest]
+    :param bool handle_redirects: If true, remove from Solr all authors that redirect to this one
+    :rtype: list[UpdateRequest or DeleteRequest]
     """
     if akey == '/authors/':
         return

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -350,7 +350,7 @@ class Test_update_items():
         requests = update_work.update_author('/authors/OL23A')
         assert isinstance(requests, list)
         assert isinstance(requests[0], basestring)
-        assert requests[0] == '<delete><query>key:OL23A</query></delete>'
+        assert requests[0] == '<delete><query>key:/authors/OL23A</query></delete>'
 
     def test_redirect_author(self):
         update_work.data_provider = FakeDataProvider([
@@ -359,7 +359,7 @@ class Test_update_items():
         requests = update_work.update_author('/authors/OL24A')
         assert isinstance(requests, list)
         assert isinstance(requests[0], basestring)
-        assert requests[0] == '<delete><query>key:OL24A</query></delete>'
+        assert requests[0] == '<delete><query>key:/authors/OL24A</query></delete>'
 
     def test_update_author(self, monkeypatch):
         #TODO: Investigate inconsistent update_author return values:
@@ -382,6 +382,7 @@ class Test_update_items():
         assert isinstance(requests, list)
         assert isinstance(requests[0], update_work.UpdateRequest)
         assert requests[0].toxml().startswith('<add>')
+        assert '<field name="key">/authors/OL25A</field>' in requests[0].toxml()
 
     def test_delete_edition(self):
         editions = update_work.update_edition({'key': '/books/OL23M', 'type': {'key': '/type/delete'}})

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -349,8 +349,8 @@ class Test_update_items():
         ])
         requests = update_work.update_author('/authors/OL23A')
         assert isinstance(requests, list)
-        assert isinstance(requests[0], basestring)
-        assert requests[0] == '<delete><query>key:/authors/OL23A</query></delete>'
+        assert isinstance(requests[0], update_work.DeleteRequest)
+        assert requests[0].toxml() == '<delete><query>key:/authors/OL23A</query></delete>'
 
     def test_redirect_author(self):
         update_work.data_provider = FakeDataProvider([
@@ -358,12 +358,10 @@ class Test_update_items():
         ])
         requests = update_work.update_author('/authors/OL24A')
         assert isinstance(requests, list)
-        assert isinstance(requests[0], basestring)
-        assert requests[0] == '<delete><query>key:/authors/OL24A</query></delete>'
+        assert isinstance(requests[0], update_work.DeleteRequest)
+        assert requests[0].toxml() == '<delete><query>key:/authors/OL24A</query></delete>'
 
     def test_update_author(self, monkeypatch):
-        #TODO: Investigate inconsistent update_author return values:
-        # a list of strings in 2 out of 3 cases, but a list of UpdateRequests in this case:
         update_work.data_provider = FakeDataProvider([
             make_author(key='/authors/OL25A', name='Somebody')
         ])

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -365,7 +365,7 @@ class Test_update_items():
         update_work.data_provider = FakeDataProvider([
             make_author(key='/authors/OL25A', name='Somebody')
         ])
-        # Minimal SOLR response, author not found in SOLR
+        # Minimal Solr response, author not found in Solr
         solr_response = """{
             "facet_counts": {
                 "facet_fields": {
@@ -384,11 +384,11 @@ class Test_update_items():
 
     def test_delete_edition(self):
         editions = update_work.update_edition({'key': '/books/OL23M', 'type': {'key': '/type/delete'}})
-        assert editions == [], "Editions are not indexed by SOLR, expecting empty set regardless of input. Got: %s" % editions
+        assert editions == [], "Editions are not indexed by Solr, expecting empty set regardless of input. Got: %s" % editions
 
     def test_update_edition(self):
         editions = update_work.update_edition({'key': '/books/OL23M', 'type': {'key': '/type/edition'}})
-        assert editions == [], "Editions are not indexed by SOLR, expecting empty set regardless of input. Got: %s" % editions
+        assert editions == [], "Editions are not indexed by Solr, expecting empty set regardless of input. Got: %s" % editions
 
     def test_delete_requests(self):
         olids = ['/works/OL1W', '/works/OL2W', '/works/OL3W']

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -170,7 +170,6 @@ def update_keys(keys):
         chunk = list(chunk)
         count += len(chunk)
         update_work.do_updates(chunk)
-    #    update_work.update_keys(chunk, commit=False)
 
     if count:
         logger.info("updated %d documents", count)
@@ -258,7 +257,6 @@ def main():
             f.write(offset)
 
         if COMMIT:
-            logger.info("solr commit")
             solr.commit(ndocs=count)
         else:
             logger.info("not doing solr commit as commit is off")


### PR DESCRIPTION
Closes #628 
And may help with other Author search issues...

## Description:
Turns out there was a bug where `update_author()` created its own string format delete messages for author deletes in Solr (for redirects, deletes, and blank author names). It was sending an incorrect key:  `OL...A` instead of the key indexed in Solr: `/authors/OL...A`

This means that redirected or deleted authors were not being removed from search, and explains why the deletes appeared to be failing silently but not showing up in logs.   There seems to be a way for the authors to be removed correctly _if they were reindexed as a result of an edition or work change_ , which explains why it looked like some updates would work, but it was hard to pin down why. More investigation is needed, We should add some logging to alert if a Solr update does not affect any documents in Solr. 

This was a whole lot easier to debug after #804  I was able to reproduce the issue in dev, and use tests to ensure the correct behaviour. Thanks @cdrini for the refactoring and docstrings, and @mekarpeles for the production logs! I have been chasing this issue for ages, its great to have it finally pinned down!