### PR TITLE
HOTFIX: I18n broke search bar

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -421,8 +421,9 @@ $().ready(function(){
         }
 
         localStorage.setItem("facet", facet_key);
-        $('header#header-bar .search-facet-selector select').val(capitalize(facet_key))
-        $('header#header-bar .search-facet-value').html(capitalize(facet_key));
+        $('header#header-bar .search-facet-selector select').val(facet_key)
+        text = $('header#header-bar .search-facet-selector select').find('option:selected').text()
+        $('header#header-bar .search-facet-value').html(text);
         $('header#header-bar .search-component ul.search-results').empty()
         q = $('header#header-bar .search-component .search-bar-input input').val();
         var url = composeSearchUrl(q)

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -35,12 +35,11 @@ $def with (page)
           <label class="search-facet-selector">
             <span aria-hidden="true" class="search-facet-value"></span>
             <select aria-label="Search by">
-              <option>$_("All")</option>
-              <option>$_("Title")</option>
-              <option>$_("Author")</option>
-              <option>$_("Subject")</option>
-              <option>$_("Advanced")</option>
-              <!-- <option>$_("Lists")</option> -->
+              <option value='all'>$_("All")</option>
+              <option value='title'>$_("Title")</option>
+              <option value='author'>$_("Author")</option>
+              <option value='subject'>$_("Subject")</option>
+              <option value='advanced'>$_("Advanced")</option>
             </select>
           </label>
         </div>


### PR DESCRIPTION
@mekarpeles The options for search were being translated and that was breaking the facet search, this is a quick fix to prevent that. 

The js changes below allow the 'Search by' label to show up in the target language. I have tested locally and search now looks good in Czech. There is a strangeness where `title: keyword` appears  in the search bar for title search that doesn't occur on any other facet, but I'm guessing there is a reason for that?

Would be good to test search further in dev. Please review, thanks!
