### PR TITLE
Start a French translation file

### DIFF
--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -1,0 +1,2251 @@
+# Translations template for Open Library.
+# Copyright (C) 2018 Internet Archive
+# This file is distributed under the same license as the Open Library
+# project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Open Library VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2018-03-15 22:37+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.5.3\n"
+
+#: account.py:347 account.py:382 account.py:422 password/reset_success.html:6
+#: verify.html:5 verify/activated.html:6 verify/success.html:6
+#, python-format
+msgid "Hi, %(user)s"
+msgstr "Bienvenu %(user)s"
+
+#: account.py:348 account.py:383
+#, python-format
+msgid ""
+"We've sent the verification email to %(email)s. You'll need to read that "
+"and click on the verification link to verify your email."
+msgstr ""
+
+#: account.py:423
+#, python-format
+msgid ""
+"We've sent an email to %(email)s. You'll need to read that and click on "
+"the verification link to update your email."
+msgstr ""
+
+#: account.py:441
+msgid "Email address is already used."
+msgstr ""
+
+#: account.py:442
+msgid ""
+"Your email address couldn't be updated. The specified email address is "
+"already used."
+msgstr ""
+
+#: account.py:446
+msgid "Email verification successful."
+msgstr ""
+
+#: account.py:447
+msgid ""
+"Your email address has been successfully verified and updated in your "
+"account."
+msgstr ""
+
+#: account.py:451
+msgid "Email address couldn't be verified."
+msgstr ""
+
+#: account.py:452
+msgid ""
+"Your email address couldn't be verified. The verification link seems "
+"invalid."
+msgstr ""
+
+#: account.py:485
+msgid "Your password has been updated successfully."
+msgstr ""
+
+#: account.py:579 account.py:589
+msgid "Password reset failed."
+msgstr ""
+
+#: account.py:635 account.py:651
+msgid "Notification preferences have been updated successfully."
+msgstr ""
+
+#: forms.py:19
+msgid "Username"
+msgstr ""
+
+#: forms.py:20 openlibrary/templates/login.html:43
+msgid "Password"
+msgstr ""
+
+#: forms.py:25
+msgid "No user registered with this email address"
+msgstr ""
+
+#: forms.py:26
+msgid "Email already registered"
+msgstr ""
+
+#: forms.py:27
+msgid "Disposable email not permitted"
+msgstr ""
+
+#: forms.py:28
+msgid "Your email provider is not recognized."
+msgstr ""
+
+#: forms.py:29
+msgid "Username already used"
+msgstr ""
+
+#: forms.py:31
+msgid "Must be between 3 and 20 letters and numbers"
+msgstr ""
+
+#: forms.py:32
+msgid "Must be between 3 and 20 characters"
+msgstr ""
+
+#: forms.py:33
+msgid "Must be a valid email address"
+msgstr ""
+
+#: forms.py:47 forms.py:100
+msgid "Your email address"
+msgstr ""
+
+#: create.html:44 forms.py:50
+msgid "Choose a screen name"
+msgstr ""
+
+#: forms.py:52
+msgid "Only letters and numbers, please, and at least 3 characters."
+msgstr ""
+
+#: forms.py:54 forms.py:104
+msgid "Choose a password"
+msgstr ""
+
+#: forms.py:57
+msgid "Confirm password"
+msgstr ""
+
+#: forms.py:59
+msgid "Passwords didn't match."
+msgstr ""
+
+#: forms.py:88
+msgid "Invalid password"
+msgstr ""
+
+#: forms.py:91
+msgid "Current password"
+msgstr ""
+
+#: forms.py:92
+msgid "Choose a new password"
+msgstr ""
+
+#: email.html:24 forms.py:96
+msgid "Your new email address"
+msgstr ""
+
+#: edit.html:20
+msgid "Edit Author"
+msgstr ""
+
+#: edit.html:33
+msgid "Name"
+msgstr ""
+
+#: edit.html:35
+msgid ""
+"Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
+"<strong>Tolstoy, Leo</strong>."
+msgstr ""
+
+#: edit.html:36 edit.html:153 edit/addfield.html:96 edit/addfield.html:141
+msgid "Required field"
+msgstr ""
+
+#: edit.html:50
+msgid "About"
+msgstr ""
+
+#: edit.html:51 edit.html:177
+msgid "Links"
+msgstr ""
+
+#: edit.html:60
+msgid "A short bio?"
+msgstr ""
+
+#: edit.html:61
+msgid ""
+"If you \"borrow\" information from somewhere, please make sure to cite "
+"the source."
+msgstr ""
+
+#: edit.html:70
+msgid "Date of birth"
+msgstr ""
+
+#: edit.html:79
+msgid "Date of death"
+msgstr ""
+
+#: edit.html:88
+msgid ""
+"We're not storing structured dates (yet) so a date like \"21 May 2000\" "
+"is recommended."
+msgstr ""
+
+#: edit.html:96
+msgid "Does this author go by any other names?"
+msgstr ""
+
+#: edit.html:97 edit/about.html:17 edit/about.html:31 edit/about.html:45
+#: edit/about.html:59 edit/addfield.html:73 edit/addfield.html:100
+#: edit/addfield.html:109 edit/addfield.html:145 edit/edition.html:114
+#: edit/edition.html:135 edit/edition.html:184 edit/edition.html:216
+#: edit/edition.html:227 edit/edition.html:247 edit/edition.html:322
+#: edit/edition.html:573 edit/excerpts.html:15 edit/web.html:31
+msgid "For example:"
+msgstr ""
+
+#: edit.html:108
+msgid "Websites"
+msgstr ""
+
+#: edit.html:109
+msgid "Deprecated"
+msgstr ""
+
+#: edit.html:138 edit.html:216 openlibrary/macros/EditButtons.html:21
+msgid "Delete Record"
+msgstr ""
+
+#: view.html:132
+msgid "Website"
+msgstr ""
+
+#: view.html:138
+msgid "Location"
+msgstr ""
+
+#: view.html:237
+msgid "Alternative names"
+msgstr ""
+
+#: books.html:14
+msgid "Reading Log"
+msgstr ""
+
+#: borrow.html:3 borrow.html:66
+msgid "Books You've Checked Out"
+msgstr ""
+
+#: borrow.html:81
+msgid "1 Current Loan"
+msgstr ""
+
+#: borrow.html:83
+msgid "Current Loans"
+msgstr ""
+
+#: borrow.html:85
+msgid "Loan Expires"
+msgstr ""
+
+#: borrow.html:86
+msgid "Loan actions"
+msgstr ""
+
+#: borrow.html:114
+#, python-format
+msgid "There is one person waiting for this book."
+msgid_plural "There are %(n)s people waiting for this book."
+msgstr[0] ""
+msgstr[1] ""
+
+#: borrow.html:151
+msgid "Books You're Waiting For"
+msgstr ""
+
+#: borrow.html:190
+#, python-format
+msgid "%d book"
+msgid_plural "%d books"
+msgstr[0] ""
+msgstr[1] ""
+
+#: borrow.html:213
+#, python-format
+msgid "Waiting for %d day"
+msgid_plural "Waiting for %d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: borrow.html:222
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)s people ahead of you in the waiting list."
+msgstr[0] ""
+msgstr[1] ""
+
+#: borrow.html:260
+msgid "There are 2 different sources for borrowing books through Open Library:"
+msgstr ""
+
+#: borrow.html:264
+msgid "Internet Archive"
+msgstr "Archive Internet"
+
+#: borrow.html:266
+msgid "eBooks everywhere"
+msgstr ""
+
+#: borrow.html:268
+msgid ""
+"The <a href=\"//archive.org/\">Internet Archive</a> and several partner "
+"libraries are offering thousands of eBooks for loan to anyone with an "
+"Open Library account, anywhere in the world."
+msgstr ""
+
+#: borrow.html:274
+msgid "physical books from your local library"
+msgstr ""
+
+#: borrow.html:276
+msgid ""
+"We connect our records to WorldCat wherever possible. You can tell "
+"WorldCat your postcode/zip code, and it will tell you the closest library"
+" with a copy of the book."
+msgstr ""
+
+#: borrow.html:281
+msgid "Getting Started"
+msgstr ""
+
+#: borrow.html:282
+msgid ""
+"All you need to borrow a book scanned at the Internet Archive is an Open "
+"Library account and Adobe Digital Editions."
+msgstr ""
+
+#: borrow.html:283
+msgid ""
+"Loans through WorldCat are managed through your local libraries, not "
+"through Open Library."
+msgstr ""
+
+#: borrow.html:284
+msgid ""
+"Check out the <a href=\"/help/faq#section-borrowing\"><strong>Lending "
+"FAQ</strong></a> for more information."
+msgstr ""
+
+#: borrow.html:288
+#, python-format
+msgid ""
+"Browse all the available books through the <a "
+"href=\"/subjects/lending_library\">\"Lending Library\"</a> subject, or "
+"try a <a href=\"/search?subject_facet=Lending%20library\">search</a>."
+msgstr ""
+
+#: borrow.html:299
+msgid ""
+"If you work at a library and are interested to find out more about "
+"lending ebooks through Open Library, please <a href=\"/contact\">get in "
+"touch with us</a>!"
+msgstr ""
+
+#: create.html:3
+msgid "Sign Up to Open Library"
+msgstr ""
+
+#: create.html:6 create.html:92 nav_head.html:106 search_head.html:74
+msgid "Sign Up"
+msgstr ""
+
+#: create.html:8
+msgid "Complete the form below to create a new Internet Archive account."
+msgstr ""
+
+#: create.html:9
+msgid "Each field is required"
+msgstr ""
+
+#: create.html:25 openlibrary/templates/login.html:20
+#, python-format
+msgid "You are already logged into Open Library as %(user)s."
+msgstr ""
+
+#: create.html:26 openlibrary/templates/login.html:21
+msgid ""
+"If you'd like to create a new, different Open Library account, you'll "
+"need to <a href=\"javascript:;\" "
+"onclick=\"document.forms['logout'].submit()\">log out</a> and start the "
+"signup process afresh."
+msgstr ""
+
+#: create.html:45 create.html:56 create.html:65
+msgid "Letters and numbers only please, and at least 3 characters."
+msgstr ""
+
+#: create.html:74
+msgid "Please type in the text or number(s) below."
+msgstr ""
+
+#: create.html:74
+msgid ""
+"If you have security settings or privacy blockers installed, please "
+"disable them to see the reCAPTCHA."
+msgstr ""
+
+#: create.html:84
+msgid ""
+"I acknowledge that my use of Open Library is subject to the Internet "
+"Archive's <a href='//archive.org/about/terms.php' target='_new' "
+"title='Read the Terms of Use in a new browser.'>Terms of Use</a>."
+msgstr ""
+
+#: add.html:82 add.html:120 create.html:94 edit/addcover.html:32
+#: edit/addfield.html:83 edit/addfield.html:129 edit/addfield.html:173
+#: email.html:37 manage.html:65 notifications.html:52
+#: openlibrary/macros/EditButtons.html:19 password.html:43
+#: password/reset.html:20 privacy.html:49
+msgid "Cancel"
+msgstr ""
+
+#: delete.html:2 delete.html:6
+msgid "Delete Account"
+msgstr ""
+
+#: delete.html:11
+msgid "Sorry, this functionality is not yet implemented."
+msgstr ""
+
+#: email.html:6 nav_head.html:120 notifications.html:9
+#: openlibrary/templates/account.html:3 openlibrary/templates/account.html:8
+#: password.html:6 privacy.html:9 search_head.html:67
+msgid "Settings"
+msgstr ""
+
+#: email.html:8
+msgid "Change Your Email Address"
+msgstr ""
+
+#: email.html:18
+msgid "Your current email address is"
+msgstr ""
+
+#: email.html:35
+msgid "Change It"
+msgstr ""
+
+#: not_verified.html:3 not_verified.html:14 verify/failed.html:6
+msgid "Oops!"
+msgstr ""
+
+#: not_verified.html:32 verify/failed.html:25
+msgid "Resend the verification email"
+msgstr ""
+
+#: notifications.html:3 notifications.html:12
+msgid "Notifications from Open Library"
+msgstr ""
+
+#: notifications.html:10
+msgid "Notifications"
+msgstr ""
+
+#: notifications.html:24
+msgid ""
+"Notifications are connected to Lists at the moment. If one of the books "
+"on your list gets edited, or a new book comes into the catalog, we'll let"
+" you know, if you want."
+msgstr ""
+
+#: notifications.html:28
+msgid "Would you like to receive very occasional emails from Open Library?"
+msgstr ""
+
+#: notifications.html:35
+msgid "No, thank you"
+msgstr "Non, merci"
+
+#: notifications.html:42
+msgid "Yes! Please!"
+msgstr "Oui"
+
+#: manage.html:64 notifications.html:50 openlibrary/macros/EditButtons.html:17
+#: privacy.html:47
+msgid "Save"
+msgstr ""
+
+#: openlibrary/templates/account.html:12 password.html:8
+msgid "Change Password"
+msgstr ""
+
+#: password.html:9
+msgid ""
+"Provide your existing password (to verify that it's you) and select a new"
+" password to replace it."
+msgstr ""
+
+#: password.html:41
+msgid "Change"
+msgstr ""
+
+#: privacy.html:3
+msgid "Your Privacy on Open Library"
+msgstr ""
+
+#: privacy.html:12
+msgid "Privacy Settings"
+msgstr ""
+
+#: privacy.html:32
+msgid "Yes"
+msgstr ""
+
+#: edit/edition.html:365 privacy.html:39
+msgid "No"
+msgstr ""
+
+#: verify.html:3
+msgid "Verification email sent"
+msgstr ""
+
+#: email/forgot-ia.html:6 email/forgot.html:6
+msgid "Forgot Your Internet Archive Email?"
+msgstr ""
+
+#: email/forgot-ia.html:39 password/forgot.html:6
+msgid "Forgot your Archive.org Password?"
+msgstr ""
+
+#: email/forgot.html:11
+msgid "Forgot Your Open Library Email?"
+msgstr ""
+
+#: email/forgot.html:44 openlibrary/templates/login.html:68
+msgid "Forgot your Password?"
+msgstr ""
+
+#: password/forgot.html:3 password/sent.html:3
+msgid "Username/Password Reminder"
+msgstr ""
+
+#: password/forgot.html:7
+msgid "Forgot your Archive.org password?"
+msgstr ""
+
+#: password/forgot.html:19
+msgid "Send It"
+msgstr ""
+
+#: password/reset.html:3 password/reset.html:6
+msgid "Reset Password"
+msgstr ""
+
+#: password/reset.html:11
+msgid "Please enter a new password for your Open Library account."
+msgstr ""
+
+#: password/reset.html:19
+msgid "Reset"
+msgstr ""
+
+#: password/reset_success.html:3
+msgid "Password Reset Successful"
+msgstr ""
+
+#: password/reset_success.html:10
+msgid ""
+"Your password has been updated. Please <a "
+"href='/account/login?redirect=/'>log in to continue</a>."
+msgstr ""
+
+#: password/sent.html:6
+msgid "Done."
+msgstr ""
+
+#: password/sent.html:10
+#, python-format
+msgid ""
+"We've sent an email to %(email)s with a reminder of your username and "
+"instructions to help you reset your Open Library password. Please check "
+"your inbox for a note from us."
+msgstr ""
+
+#: verify/activated.html:3
+msgid "Account already activated"
+msgstr ""
+
+#: verify/activated.html:11
+#, python-format
+msgid ""
+"Your account has been activated already. Please <a href=\"%s\">log in to "
+"continue</a>."
+msgstr ""
+
+#: verify/failed.html:3
+msgid "Email Verification Failed"
+msgstr ""
+
+#: verify/failed.html:10
+msgid ""
+"Your email address couldn't be verified. Your verification link seems "
+"invalid or expired."
+msgstr ""
+
+#: verify/failed.html:18
+msgid "Enter your email address here"
+msgstr ""
+
+#: verify/failed.html:21
+msgid "No user registered with this email address."
+msgstr ""
+
+#: verify/success.html:3
+msgid "Email Verification Successful"
+msgstr ""
+
+#: verify/success.html:11
+#, python-format
+msgid ""
+"Yay! Your email address has been verified. Please <a href='%s'>log in to "
+"continue</a>."
+msgstr ""
+
+#: add.html:3 check.html:3
+msgid "Add a book"
+msgstr ""
+
+#: add.html:7
+msgid "Add a book to Open Library"
+msgstr ""
+
+#: add.html:9
+msgid ""
+"We require a minimum set of fields to create a new record. These are "
+"those fields."
+msgstr ""
+
+#: add.html:20 edit.html:153 nav_head.html:39 search_foot.html:4
+#: search_head.html:4
+msgid "Title"
+msgstr ""
+
+#: add.html:30 edit.html:159 nav_head.html:40 search_foot.html:5
+#: search_head.html:5
+msgid "Author"
+msgstr ""
+
+#: add.html:30
+msgid ""
+"Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
+"check to see if we already know the author."
+msgstr ""
+
+#: add.html:42 edit/edition.html:93
+msgid "Who is the publisher?"
+msgstr ""
+
+#: add.html:49 edit/edition.html:103
+msgid "When was it published?"
+msgstr ""
+
+#: add.html:49
+msgid "The year it was published is plenty."
+msgstr ""
+
+#: add.html:56
+msgid ""
+"And optionally, an ID number &#151; like an ISBN &#151; would be "
+"helpful..."
+msgstr ""
+
+#: add.html:57
+msgid "ID Type"
+msgstr ""
+
+#: add.html:60
+msgid "Select"
+msgstr ""
+
+#: add.html:73
+msgid "Since you are not logged in, please type in the text or number(s) below."
+msgstr ""
+
+#: add.html:80
+msgid "Add this book now"
+msgstr ""
+
+#: add.html:80 edit/addfield.html:81 edit/addfield.html:127
+#: edit/addfield.html:171 edit/edition.html:283 edit/edition.html:448
+#: edit/edition.html:514 edit/excerpts.html:46
+msgid "Add"
+msgstr ""
+
+#: carousel_item.html:32 covers.html:104
+msgid "Read online"
+msgstr ""
+
+#: carousel_item.html:38
+msgid "Borrow this book"
+msgstr ""
+
+#: check.html:6 nav_foot.html:9 nav_head.html:12 nav_head.html:89
+msgid "Add a Book"
+msgstr ""
+
+#: check.html:8
+#, python-format
+msgid ""
+"One moment... It looks like we already have <em>some potential "
+"matches</em> for <b>%s</b> by <b>%s</b>."
+msgstr ""
+
+#: check.html:10
+msgid ""
+"Rather than creating a duplicate record, please click through the result "
+"you think best matches your book."
+msgstr ""
+
+#: edit.html:74 edit.html:77 edit.html:80
+msgid "Add a little more?"
+msgstr ""
+
+#: edit.html:75
+msgid ""
+"<p class=\"alert thanks\">Thank you for adding that book! Any more "
+"information you could provide would be wonderful!</p>"
+msgstr ""
+
+#: edit.html:78
+#, python-format
+msgid ""
+"<p class=\"alert thanks\">We already know about <b>%s</b>, but not the "
+"<b>%s %s edition</b>. Thanks! Do you know any more about this "
+"edition?</p>"
+msgstr ""
+
+#: edit.html:81
+#, python-format
+msgid ""
+"<p class=\"alert info\">We already know about the <b>%s %s edition</b> of"
+" <b>%s</b>, but please, tell us more!</p>"
+msgstr ""
+
+#: edit.html:83
+msgid "Editing..."
+msgstr ""
+
+#: edit.html:114
+msgid "Create a new record for"
+msgstr ""
+
+#: edit.html:143
+msgid "Remove this author"
+msgstr ""
+
+#: edit.html:144
+msgid "Add another author?"
+msgstr ""
+
+#: edit.html:153
+msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
+msgstr ""
+
+#: edit.html:175
+msgid "What's It About?"
+msgstr ""
+
+#: edit.html:176
+msgid "Add Excerpts"
+msgstr ""
+
+#: edit.html:216
+msgid "Delete this book?"
+msgstr ""
+
+#: edition-show.html:57
+msgid "There is only 1 edition record, so we'll show it here..."
+msgstr ""
+
+#: edition-show.html:59
+msgid "Add another edition of"
+msgstr ""
+
+#: edition-show.html:59
+msgid "Add edition"
+msgstr ""
+
+#: edition-show.html:80
+#, python-format
+msgid "Show for other books from %s"
+msgstr ""
+
+#: edition-show.html:82
+msgid "Search for other books from"
+msgstr ""
+
+#: edition-show.html:86
+msgid "Search for subjects about"
+msgstr ""
+
+#: edition-show.html:94
+msgid "About the Book"
+msgstr ""
+
+#: edition-show.html:98
+msgid "First Sentence"
+msgstr ""
+
+#: edition-show.html:104
+msgid "Table of Contents"
+msgstr ""
+
+#: edition-show.html:119
+msgid "Edition Notes"
+msgstr ""
+
+#: edition-show.html:124
+msgid "Series"
+msgstr ""
+
+#: edition-show.html:125
+msgid "Volume"
+msgstr ""
+
+#: edition-show.html:126
+msgid "Genre"
+msgstr ""
+
+#: edition-show.html:127
+msgid "Other Titles"
+msgstr ""
+
+#: edition-show.html:128
+msgid "Copyright Date"
+msgstr ""
+
+#: edition-show.html:129
+msgid "Translation Of"
+msgstr ""
+
+#: edition-show.html:130
+msgid "Translated From"
+msgstr ""
+
+#: edit/edition.html:487 edition-show.html:138
+msgid "Classifications"
+msgstr ""
+
+#: edit/edition.html:544 edition-show.html:149
+msgid "The Physical Object"
+msgstr ""
+
+#: edition-show.html:152
+msgid "Format"
+msgstr ""
+
+#: edition-show.html:153
+msgid "Pagination"
+msgstr ""
+
+#: edition-show.html:154
+msgid "Number of pages"
+msgstr ""
+
+#: edit/edition.html:595 edition-show.html:155
+msgid "Dimensions"
+msgstr ""
+
+#: edition-show.html:156
+msgid "Weight"
+msgstr ""
+
+#: edit/edition.html:257 edition-show.html:164
+msgid "Contributors"
+msgstr ""
+
+#: edit/edition.html:413 edition-show.html:172
+msgid "ID Numbers"
+msgstr ""
+
+#: book_cover.html:36 book_cover_single_edition.html:13
+#: book_cover_single_edition.html:31 book_cover_small.html:14
+#: book_cover_work.html:13 book_cover_work.html:27
+#: openlibrary/templates/diff.html:36 show.html:12
+msgid "by"
+msgstr ""
+
+#: inside.html:80 show.html:30
+msgid "Read"
+msgstr ""
+
+#: edit/about.html:6
+msgid "How would you describe this book?"
+msgstr ""
+
+#: edit/about.html:7
+msgid "There's no wrong answer here."
+msgstr ""
+
+#: edit/about.html:16
+msgid "Some tags perhaps?"
+msgstr ""
+
+#: edit/about.html:17
+msgid "Please separate with commas."
+msgstr ""
+
+#: edit/about.html:30
+msgid "A person? Or, people?"
+msgstr ""
+
+#: edit/about.html:44
+msgid "Note any places mentioned?"
+msgstr ""
+
+#: edit/about.html:58
+msgid "When is it set or about?"
+msgstr ""
+
+#: edit/addcover.html:11
+msgid "There are two ways to get a cover image on Open Library:"
+msgstr ""
+
+#: edit/addcover.html:14
+msgid "Either choose a JPG, GIF or PNG on your computer,"
+msgstr ""
+
+#: edit/addcover.html:22
+msgid "<u>Or</u></span>, paste in a URL to an image if it's on the web."
+msgstr ""
+
+#: edit/addcover.html:31
+msgid "Upload"
+msgstr "Télécharger"
+
+#: edit/addfield.html:66
+msgid "Add a New Contributor Role"
+msgstr ""
+
+#: edit/addfield.html:73 edit/addfield.html:100 edit/addfield.html:145
+msgid "What should we show in the menu?"
+msgstr ""
+
+#: edit/addfield.html:92
+msgid "Add a New Type of Identifier"
+msgstr ""
+
+#: edit/addfield.html:109
+msgid "If the system has a website, what's the homepage?"
+msgstr ""
+
+#: edit/addfield.html:118
+msgid "Please leave a note: Why is this ID useful?"
+msgstr ""
+
+#: edit/addfield.html:137
+msgid "Add a New Classification System"
+msgstr ""
+
+#: edit/addfield.html:154
+msgid "Please leave a note: Why is this classification useful?"
+msgstr ""
+
+#: edit/addfield.html:163
+msgid ""
+"Can you direct us to more information about this classification system "
+"online?"
+msgstr ""
+
+#: edit/edition.html:14
+msgid "Select this language"
+msgstr ""
+
+#: edit/edition.html:23
+msgid "Remove this language"
+msgstr ""
+
+#: edit/edition.html:32
+msgid "Remove this work"
+msgstr ""
+
+#: edit/edition.html:83
+msgid "Expose another 20 fields about the edition"
+msgstr ""
+
+#: edit/edition.html:83
+msgid "Librarian Mode"
+msgstr ""
+
+#: edit/edition.html:87
+msgid "Publishing Info"
+msgstr ""
+
+#: edit/edition.html:94
+msgid "For example"
+msgstr ""
+
+#: edit/edition.html:104
+msgid "You should be able to find this in the first few pages of the book."
+msgstr ""
+
+#: edit/edition.html:113
+msgid "Where was the book published?"
+msgstr ""
+
+#: edit/edition.html:114
+msgid "City, Country please."
+msgstr ""
+
+#: edit/edition.html:124
+msgid "Is there a copyright date?"
+msgstr ""
+
+#: edit/edition.html:125
+msgid "The year following the copyright statement."
+msgstr ""
+
+#: edit/edition.html:134
+msgid "Is the book part of a series?"
+msgstr ""
+
+#: edit/edition.html:135
+msgid "The name of the publisher's series."
+msgstr ""
+
+#: edit/edition.html:145
+msgid "This Edition"
+msgstr ""
+
+#: edit/edition.html:151
+msgid "What work is this an edition of?"
+msgstr ""
+
+#: edit/edition.html:153
+msgid ""
+"Sometimes editions can be associated with the wrong work. You can correct"
+" that here."
+msgstr ""
+
+#: edit/edition.html:154
+msgid "You can search by title or by Open Library ID"
+msgstr ""
+
+#: edit/edition.html:158
+msgid ""
+"WARNING: Any edits made to the work from this page will be applied to the"
+" <b>old work</b>."
+msgstr ""
+
+#: edit/edition.html:174
+msgid "There are occasionally title variants amongst editions."
+msgstr ""
+
+#: edit/edition.html:183
+msgid "Subtitle"
+msgstr ""
+
+#: edit/edition.html:184
+msgid "Usually distinguished by different or smaller type."
+msgstr ""
+
+#: edit/edition.html:194
+msgid ""
+"Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
+"new lines. Like this:"
+msgstr ""
+
+#: edit/edition.html:211
+msgid "Is it known by any other titles?"
+msgstr ""
+
+#: edit/edition.html:212
+msgid "Perhaps in another language?"
+msgstr ""
+
+#: edit/edition.html:216
+msgid "is an alternate title for"
+msgstr ""
+
+#: edit/edition.html:226
+msgid "Does this edition have a specific name?"
+msgstr ""
+
+#: edit/edition.html:246
+msgid "Any notes about this specific edition?"
+msgstr ""
+
+#: edit/edition.html:247
+msgid "Anything about the book that may be of interest."
+msgstr ""
+
+#: edit/edition.html:261
+msgid "List the people involved"
+msgstr ""
+
+#: edit/edition.html:271
+msgid "Select role"
+msgstr ""
+
+#: edit/edition.html:276
+msgid "Add a new role"
+msgstr ""
+
+#: edit/edition.html:296 edit/edition.html:312
+msgid "Remove this contributor"
+msgstr ""
+
+#: edit/edition.html:321
+msgid "Is there a By Statement?"
+msgstr ""
+
+#: edit/edition.html:339
+msgid "What language is this edition written in?"
+msgstr ""
+
+#: edit/edition.html:351
+msgid "Is it a translation of another book?"
+msgstr ""
+
+#: edit/edition.html:369
+msgid "Yes, it's a translation"
+msgstr ""
+
+#: edit/edition.html:374
+msgid "What's the original book?"
+msgstr ""
+
+#: edit/edition.html:383
+msgid "What language was the original written in?"
+msgstr ""
+
+#: edit/edition.html:400
+msgid "Description of this edition"
+msgstr ""
+
+#: edit/edition.html:401
+msgid "Only if it's different from the work's description"
+msgstr ""
+
+#: edit/edition.html:419
+msgid "Do you know any identifiers for this edition?"
+msgstr ""
+
+#: edit/edition.html:420
+msgid "Like, ISBN?"
+msgstr ""
+
+#: edit/edition.html:493
+msgid "Do you know any classifications of this edition?"
+msgstr ""
+
+#: edit/edition.html:494
+msgid "Like, Dewey Decimal?"
+msgstr ""
+
+#: edit/edition.html:502
+msgid "Select one of many..."
+msgstr ""
+
+#: edit/edition.html:507
+msgid "Add a new classification type"
+msgstr ""
+
+#: edit/edition.html:524 edit/edition.html:533
+msgid "Remove this classification"
+msgstr ""
+
+#: edit/edition.html:550
+msgid "What sort of book is it?"
+msgstr ""
+
+#: edit/edition.html:551
+msgid "Paperback; Hardcover, etc."
+msgstr ""
+
+#: edit/edition.html:559
+msgid "How many pages?"
+msgstr ""
+
+#: edit/edition.html:568
+msgid "Pagination?"
+msgstr ""
+
+#: edit/edition.html:569
+msgid "Note the highest number in each pagination pattern."
+msgstr ""
+
+#: edit/edition.html:579
+msgid "How much does the book weigh?"
+msgstr ""
+
+#: edit/edition.html:603
+msgid "Height:"
+msgstr ""
+
+#: edit/edition.html:607
+msgid "Width:"
+msgstr ""
+
+#: edit/edition.html:615
+msgid "Depth:"
+msgstr ""
+
+#: edit/edition.html:629 edit/edition.html:643
+msgid "Admin Only"
+msgstr ""
+
+#: edit/edition.html:632
+msgid "Additional Metadata"
+msgstr ""
+
+#: edit/edition.html:646
+msgid "First sentence"
+msgstr ""
+
+#: edit/edition.html:670
+msgid "Please select a role."
+msgstr ""
+
+#: edit/edition.html:674
+msgid "You need to give this ROLE a name."
+msgstr ""
+
+#: edit/edition.html:687
+msgid "Please select an identifier."
+msgstr ""
+
+#: edit/edition.html:691
+msgid "You need to give a value to ID."
+msgstr ""
+
+#: edit/edition.html:694
+msgid "ID ids cannot contain whitespace."
+msgstr ""
+
+#: edit/edition.html:697
+msgid "ID must be exactly 10 characters [0-9] or X."
+msgstr ""
+
+#: edit/edition.html:700
+msgid "ID must be exactly 13 digits [0-9]."
+msgstr ""
+
+#: edit/edition.html:712
+msgid "Please select a classification."
+msgstr ""
+
+#: edit/edition.html:717
+msgid "You need to give a value to CLASS."
+msgstr ""
+
+#: edit/excerpts.html:9
+msgid ""
+"If there are particular (short) passages you feel represent the book "
+"well, please feel free to transcribe them here."
+msgstr ""
+
+#: edit/excerpts.html:14
+msgid "Page number?"
+msgstr ""
+
+#: edit/excerpts.html:26
+msgid "Transcribe the excerpt"
+msgstr ""
+
+#: edit/excerpts.html:27
+msgid "Maximum length is 2000 characters. No HTML allowed."
+msgstr ""
+
+#: edit/excerpts.html:37
+msgid "Why did you choose this excerpt?"
+msgstr ""
+
+#: edit/excerpts.html:38
+msgid "Add an optional note."
+msgstr ""
+
+#: edit/excerpts.html:52
+msgid "Excerpts so far..."
+msgstr ""
+
+#: edit/excerpts.html:66 edit/excerpts.html:88
+msgid "noted:"
+msgstr ""
+
+#: edit/excerpts.html:68 edit/excerpts.html:90
+msgid "An anonymous note:"
+msgstr ""
+
+#: edit/excerpts.html:86
+msgid "From page"
+msgstr ""
+
+#: edit/excerpts.html:114
+msgid "Please provide an excerpt."
+msgstr ""
+
+#: edit/excerpts.html:117
+msgid "That excerpt is too long."
+msgstr ""
+
+#: edit/web.html:9
+msgid ""
+"Please connect Open Library records to <u>good</u><span "
+"class=\"orange\">*</span> online resources."
+msgstr ""
+
+#: edit/web.html:18
+msgid "Give your link a label"
+msgstr ""
+
+#: edit/web.html:56 edit/web.html:65
+msgid "Remove this link"
+msgstr ""
+
+#: edit/web.html:85
+msgid "Please provide a URL."
+msgstr ""
+
+#: edit/web.html:90
+msgid "Please provide a label."
+msgstr ""
+
+#: edit/web.html:103
+msgid ""
+"\"Good\" means no spammy links, please. Keep them relevant to the book. "
+"Irrelevant sites may be removed. Blatant spam will be deleted without "
+"remorse."
+msgstr ""
+
+#: add.html:7
+msgid "There are two ways to place an author's image on Open Library"
+msgstr ""
+
+#: add.html:10 add.html:16
+msgid "There are two ways to get a cover image on Open Library"
+msgstr ""
+
+#: add.html:13
+msgid "There are three ways to get a cover image on Open Library"
+msgstr ""
+
+#: add.html:23 add.html:27
+msgid "Please provide a valid image."
+msgstr ""
+
+#: add.html:25
+msgid "Please provide an image URL."
+msgstr ""
+
+#: add.html:79
+msgid "<strong>Pick one</strong> from the existing covers,"
+msgstr ""
+
+#: add.html:102
+msgid "Choose a JPG, GIF or PNG on your computer,"
+msgstr ""
+
+#: add.html:111
+msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
+msgstr ""
+
+#: add.html:119
+msgid "Submit"
+msgstr "Soumettre"
+
+#: author_photo.html:16 book_cover.html:34 book_cover_single_edition.html:29
+#: book_cover_work.html:25 change.html:111
+msgid "Close"
+msgstr ""
+
+#: change.html:81
+msgid "One sec, we're searching for covers..."
+msgstr ""
+
+#: manage.html:25
+msgid ""
+"You can drag and drop thumbnails to reorder, or into the trash to delete "
+"them."
+msgstr ""
+
+#: saved.html:21
+msgid "Saved!"
+msgstr ""
+
+#: saved.html:24
+msgid "Notes:"
+msgstr ""
+
+#: saved.html:34
+msgid "Add another image"
+msgstr ""
+
+#: saved.html:41
+msgid "Finished"
+msgstr ""
+
+#: comment.html:28
+msgid "Edited without comment."
+msgstr ""
+
+#: about.html:11
+msgid ""
+"Open Library is an open, editable library catalog, building towards a web"
+" page for every book ever published."
+msgstr ""
+
+#: about.html:12 nav_head.html:86
+msgid "More"
+msgstr ""
+
+#: index.html:3
+msgid "Welcome to Open Library"
+msgstr ""
+
+#: edit_head.html:9
+msgid "You're in edit mode."
+msgstr ""
+
+#: edit_head.html:10
+msgid "Cancel, and go back."
+msgstr ""
+
+#: edit_head.html:14 view_head.html:10
+msgid "This doc was last edited by"
+msgstr ""
+
+#: edit_head.html:16 view_head.html:12
+msgid "This doc was last edited anonymously"
+msgstr ""
+
+#: history.html:15
+msgid "History"
+msgstr "Afficher lhistorique"
+
+#: history.html:18
+#, python-format
+msgid "Created %s"
+msgstr ""
+
+#: history.html:25
+msgid "revision"
+msgstr ""
+
+#: history.html:51 openlibrary/templates/history.html:36
+#, python-format
+msgid "View revision %s"
+msgstr ""
+
+#: history.html:56 history.html:58
+msgid "an anonymous user"
+msgstr ""
+
+#: history.html:60
+#, python-format
+msgid "Created by %s"
+msgstr ""
+
+#: history.html:62
+#, python-format
+msgid "Edited by %s"
+msgstr ""
+
+#: markdown.html:14
+msgid ""
+"We use a system called Markdown to format the text in your edits on Open "
+"Library. Some HTML formatting is also accepted. Paragraphs are "
+"automatically generated from any hard-break returns (blank lines) within "
+"your text. You can preview your work in real time below the editing "
+"field."
+msgstr ""
+
+#: markdown.html:15
+msgid "Formatting marks should envelope the effected text, for example:"
+msgstr ""
+
+#: markdown.html:74
+msgid ""
+"To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk "
+"rather than emphasizing text) place a backslash \\ prior to the "
+"character."
+msgstr ""
+
+#: nav_foot.html:7
+msgid "Go to the top of this page"
+msgstr ""
+
+#: nav_foot.html:7
+msgid "Top"
+msgstr ""
+
+#: nav_foot.html:8
+msgid "Go home"
+msgstr ""
+
+#: nav_foot.html:8
+msgid "Home"
+msgstr ""
+
+#: nav_foot.html:9
+msgid "Add a new book to Open Library"
+msgstr ""
+
+#: nav_foot.html:10
+msgid "Explore subjects"
+msgstr ""
+
+#: nav_foot.html:10
+msgid "Subjects"
+msgstr ""
+
+#: nav_foot.html:11
+msgid "Explore authors"
+msgstr ""
+
+#: nav_foot.html:11 view.html:531
+msgid "Authors"
+msgstr ""
+
+#: nav_foot.html:12
+msgid "About the Open Library staff"
+msgstr ""
+
+#: nav_foot.html:12
+msgid "About Us"
+msgstr "A Propos"
+
+#: nav_foot.html:13
+msgid "Get help"
+msgstr ""
+
+#: nav_foot.html:13
+msgid "Help"
+msgstr ""
+
+#: nav_foot.html:14
+msgid "Visit the Developers Center"
+msgstr ""
+
+#: nav_foot.html:14
+msgid "Developers"
+msgstr ""
+
+#: nav_foot.html:20
+msgid "Report a problem."
+msgstr ""
+
+#: nav_foot.html:21
+msgid "Problems?"
+msgstr ""
+
+#: nav_head.html:9 search_head.html:72
+msgid "Log in"
+msgstr ""
+
+#: nav_head.html:10
+msgid "Sign up"
+msgstr ""
+
+#: nav_head.html:13 nav_head.html:90
+msgid "Full-Text Search on Archive.org"
+msgstr ""
+
+#: nav_head.html:14 nav_head.html:91
+msgid "Random Book"
+msgstr ""
+
+#: nav_head.html:15 nav_head.html:93
+msgid "Recent Community Edits"
+msgstr ""
+
+#: nav_head.html:16 nav_head.html:92
+msgid "Advanced Search"
+msgstr ""
+
+#: nav_head.html:17 nav_head.html:94
+msgid "Developer Center"
+msgstr ""
+
+#: nav_head.html:18 nav_head.html:95
+msgid "Help & Support"
+msgstr ""
+
+#: nav_head.html:38
+msgid "All"
+msgstr ""
+
+#: nav_head.html:41 search_foot.html:7 search_head.html:7
+msgid "Subject"
+msgstr ""
+
+#: nav_head.html:42 search_foot.html:59 search_head.html:25
+msgid "Advanced"
+msgstr ""
+
+#: authors.html:43 editions.html:34 inside.html:39 nav_head.html:47
+#: notfound.html:17 openlibrary/templates/subjects.html:46
+#: openlibrary/templates/work_search.html:122
+#: openlibrary/templates/work_search.html:156 publishers.html:15
+#: search_head.html:20 subjects.html:32 view.html:584
+msgid "Search"
+msgstr ""
+
+#: nav_head.html:61
+msgid "Browse"
+msgstr ""
+
+#: nav_head.html:64
+msgid "Science"
+msgstr ""
+
+#: nav_head.html:65
+msgid "Biographies"
+msgstr ""
+
+#: nav_head.html:66
+msgid "Textbooks"
+msgstr ""
+
+#: nav_head.html:67
+msgid "Sci-Fi"
+msgstr ""
+
+#: nav_head.html:68
+msgid "Romance"
+msgstr ""
+
+#: nav_head.html:69
+msgid "Fantasy"
+msgstr ""
+
+#: nav_head.html:70
+msgid "More Subjects"
+msgstr ""
+
+#: nav_head.html:71
+msgid "Reading Lists"
+msgstr ""
+
+#: nav_head.html:76
+msgid "My Books"
+msgstr ""
+
+#: nav_head.html:79 nav_head.html:117
+msgid "My Loans"
+msgstr ""
+
+#: nav_head.html:80
+msgid "My Reading Log"
+msgstr ""
+
+#: nav_head.html:81 nav_head.html:118
+msgid "My Lists"
+msgstr ""
+
+#: nav_head.html:105 openlibrary/templates/login.html:6
+#: openlibrary/templates/login.html:64
+msgid "Log In"
+msgstr "Se Connecter"
+
+#: nav_head.html:113
+msgid "My Account"
+msgstr ""
+
+#: nav_head.html:119
+msgid "My Profile"
+msgstr ""
+
+#: nav_head.html:123
+msgid "Log out"
+msgstr "Se Déconnecter"
+
+#: pagination.html:18
+msgid "Previous"
+msgstr "Précédent"
+
+#: openlibrary/templates/history.html:80 pagination.html:33
+msgid "Next"
+msgstr "Prochain"
+
+#: search_foot.html:8 search_head.html:8
+msgid "Place"
+msgstr ""
+
+#: search_foot.html:9 search_head.html:9
+msgid "Person"
+msgstr ""
+
+#: search_foot.html:10 search_head.html:10
+msgid "Publisher"
+msgstr ""
+
+#: search_foot.html:25
+msgid "Language"
+msgstr ""
+
+#: search_foot.html:27
+msgid "any"
+msgstr ""
+
+#: search_foot.html:28
+msgid "English"
+msgstr ""
+
+#: search_foot.html:29
+msgid "German"
+msgstr ""
+
+#: search_foot.html:30
+msgid "French"
+msgstr ""
+
+#: search_foot.html:31
+msgid "Spanish"
+msgstr ""
+
+#: search_foot.html:32
+msgid "Russian"
+msgstr ""
+
+#: search_foot.html:33
+msgid "Italian"
+msgstr ""
+
+#: search_foot.html:34
+msgid "Chinese"
+msgstr ""
+
+#: search_foot.html:35
+msgid "Arabic"
+msgstr ""
+
+#: search_foot.html:36
+msgid "Japanese"
+msgstr ""
+
+#: search_foot.html:37
+msgid "Portuguese"
+msgstr ""
+
+#: search_foot.html:38
+msgid "Polish"
+msgstr ""
+
+#: search_foot.html:64 search_head.html:30
+msgid "Only eBooks"
+msgstr ""
+
+#: search_foot.html:66 search_head.html:32
+msgid "Search eBook text"
+msgstr ""
+
+#: search_head.html:64
+msgid "Your Profile"
+msgstr ""
+
+#: search_head.html:65
+msgid "Loans"
+msgstr ""
+
+#: search_head.html:66
+msgid "Lists"
+msgstr ""
+
+#: site_legal.html:5
+msgid ""
+"Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
+"Archive</a>, a 501(c)(3) non-profit, building a digital library of "
+"Internet sites and other cultural artifacts in digital form.<br/>Other <a"
+" href=\"//archive.org/projects/\">projects</a> include the <a "
+"href=\"//archive.org/web/\">Wayback Machine</a>, <a "
+"href=\"//archive.org/\">archive.org</a> and <a href=\"//archive-it.org"
+"\">archive-it.org</a>"
+msgstr ""
+
+#: site_legal.html:7
+msgid ""
+"Your use of the Open Library is subject to the Internet Archive's <a "
+"href=\"//archive.org/about/terms.php\">Terms of Use</a>."
+msgstr ""
+
+#: site_legal.html:21
+msgid ""
+"The Open Library website has not been optimized for Internet Explorer 6, "
+"so some features and graphic elements may not appear correctly. Many "
+"sites, including <a href=\"http://googleenterprise.blogspot.com/2010/01"
+"/modern-browsers-for-modern-applications.html\">Google</a> and Facebook, "
+"have phased out support for IE6 due to security and support issues. "
+"Please consider upgrading to <a "
+"href=\"http://www.microsoft.com/IE9\">Internet Explorer 9</a>, <a "
+"href=\"http://www.mozilla.com/firefox/\">Firefox</a>, <a "
+"href=\"http://www.google.com/chrome/\">Chrome</a>, <a "
+"href=\"http://www.apple.com/safari/\">Safari</a>, or <a "
+"href=\"http://www.opera.com/\">Opera</a> to use this and other web sites "
+"to your fullest advantage."
+msgstr ""
+
+#: notfound.html:6
+msgid "Publishers"
+msgstr ""
+
+#: notfound.html:11
+#, python-format
+msgid "We couldn't find any books published by %s."
+msgstr ""
+
+#: notfound.html:13 openlibrary/templates/work_search.html:129
+msgid "Try something else?"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:15 view.html:13
+#, python-format
+msgid "%s work"
+msgid_plural "%s works"
+msgstr[0] ""
+msgstr[1] ""
+
+#: openlibrary/templates/subjects.html:17 view.html:15
+#, python-format
+msgid "%s ebook"
+msgid_plural "%s ebooks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: openlibrary/templates/subjects.html:23 view.html:21
+msgid "Clear this selection"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:62 view.html:54
+msgid "Publishing History"
+msgstr ""
+
+#: view.html:55
+msgid ""
+"This is a chart to show the when this publisher published books. Along "
+"the X axis is time, and on the y axis is the count of editions published."
+" <a href=\"#subjectRelated\">Click here to skip the chart</a>."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:64 view.html:56
+msgid "Reset chart"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:64 view.html:56
+msgid "or continue zooming in."
+msgstr ""
+
+#: view.html:57
+msgid ""
+"This graph charts editions from this publisher over time. Click to view a"
+" single year, or drag across a range."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:180 view.html:124
+msgid "edition in"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:183 view.html:127
+msgid "editions in"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:381 view.html:327
+msgid "published in"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:383 view.html:329
+msgid "published between"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:498 view.html:487
+msgid "You need to have JavaScript turned on to see the nifty chart!"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:500 view.html:489
+msgid "Editions Published"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:501 view.html:490
+msgid "Year of Publication"
+msgstr ""
+
+#: view.html:496
+msgid "Common Subjects"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:521 view.html:508
+msgid "None found."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:538 view.html:525
+msgid "See more books by, and learn about, this author"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:540 publishers.html:25 view.html:527
+#, python-format
+msgid "%s book"
+msgid_plural "%s books"
+msgstr[0] ""
+msgstr[1] ""
+
+#: view.html:532
+msgid "published most by this publisher"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:568 view.html:555
+msgid "Get more information about this publisher"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:570 view.html:557
+#, python-format
+msgid "%s edition"
+msgid_plural "%s editions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: header.html:25 index.html:3 index.html:7
+msgid "Recent Changes"
+msgstr ""
+
+#: openlibrary/templates/history.html:26 render.html:28 updated_records.html:21
+msgid "When"
+msgstr ""
+
+#: render.html:29 updated_records.html:22
+msgid "What"
+msgstr ""
+
+#: openlibrary/templates/history.html:27 render.html:30
+msgid "Who"
+msgstr ""
+
+#: render.html:59
+msgid "Older"
+msgstr ""
+
+#: render.html:62
+msgid "Newer"
+msgstr ""
+
+#: default/message.html:25 edit-book/message.html:25
+msgid "opened a new Open Library account!"
+msgstr ""
+
+#: merge-authors/message.html:9
+#, python-format
+msgid "%(who)s merged one duplicate of %(master)s"
+msgid_plural "%(who)s merged %(count)d duplicates of %(master)s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: merge-authors/message.html:16
+#, python-format
+msgid "one duplicate of %(master)s was merged anonymously"
+msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
+msgstr[0] ""
+msgstr[1] ""
+
+#: authors.html:27
+msgid "Author Search"
+msgstr ""
+
+#: editions.html:14
+msgid "Edition Search"
+msgstr ""
+
+#: inside.html:27
+msgid "Search Inside"
+msgstr ""
+
+#: inside.html:78
+msgid ""
+"Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
+"formats from main book page"
+msgstr ""
+
+#: publishers.html:5
+msgid "Publishers Search"
+msgstr ""
+
+#: subjects.html:15
+msgid "Subject Search"
+msgstr ""
+
+#: openlibrary/templates/account.html:13
+msgid "Update Email Address"
+msgstr ""
+
+#: openlibrary/templates/account.html:14
+msgid "Your Notifications"
+msgstr ""
+
+#: openlibrary/templates/account.html:15
+msgid "Your Privacy Settings"
+msgstr ""
+
+#: openlibrary/templates/account.html:16
+msgid "View"
+msgstr ""
+
+#: openlibrary/templates/account.html:16
+msgid "or"
+msgstr ""
+
+#: openlibrary/templates/account.html:16
+msgid "Edit"
+msgstr ""
+
+#: openlibrary/templates/account.html:16
+msgid "Your Profile Page"
+msgstr ""
+
+#: openlibrary/templates/account.html:17
+msgid "View or Edit your Reading Log"
+msgstr ""
+
+#: openlibrary/templates/account.html:18
+msgid "View or Edit your Lists"
+msgstr ""
+
+#: openlibrary/templates/account.html:20
+msgid "Please contact us if you need help with anything else."
+msgstr ""
+
+#: openlibrary/templates/diff.html:3
+#, python-format
+msgid "Diff on %s"
+msgstr ""
+
+#: openlibrary/templates/diff.html:22
+msgid "Added"
+msgstr ""
+
+#: openlibrary/templates/diff.html:23
+msgid "Modified"
+msgstr ""
+
+#: openlibrary/templates/diff.html:24
+msgid "Removed"
+msgstr ""
+
+#: openlibrary/templates/diff.html:25
+msgid "Not changed"
+msgstr ""
+
+#: openlibrary/templates/diff.html:33
+#, python-format
+msgid "Revision %d"
+msgstr ""
+
+#: openlibrary/templates/diff.html:38
+msgid "by Anonymous"
+msgstr ""
+
+#: openlibrary/templates/diff.html:94
+msgid "Differences"
+msgstr ""
+
+#: openlibrary/templates/diff.html:151
+msgid "Both the revisions are identical."
+msgstr ""
+
+#: openlibrary/templates/history.html:17
+msgid "History of edits to"
+msgstr ""
+
+#: openlibrary/templates/history.html:25
+msgid "Revision"
+msgstr ""
+
+#: openlibrary/templates/history.html:28
+msgid "¿Qué?"
+msgstr ""
+
+#: openlibrary/templates/history.html:29
+msgid "Diff"
+msgstr ""
+
+#: openlibrary/templates/history.html:53
+msgid "Compare"
+msgstr ""
+
+#: openlibrary/templates/history.html:53
+msgid "See Diff"
+msgstr ""
+
+#: openlibrary/templates/history.html:78
+msgid "Back"
+msgstr "Retour"
+
+#: openlibrary/templates/internalerror.html:10
+msgid "Sorry. There seems to be a problem with what you were just looking at."
+msgstr ""
+
+#: openlibrary/templates/internalerror.html:11
+#, python-format
+msgid ""
+"We've noted the error %s and will look into it as soon as possible. Head "
+"for <a href=\"/\">home</a>?"
+msgstr ""
+
+#: openlibrary/templates/login.html:31
+msgid "Email"
+msgstr ""
+
+#: openlibrary/templates/login.html:70
+msgid "Not a member of Open Library? <a href=\"/account/create\">Sign up now</a>."
+msgstr ""
+
+#: openlibrary/templates/notfound.html:3
+#, python-format
+msgid "%s is not found"
+msgstr ""
+
+#: openlibrary/templates/notfound.html:10
+msgid "404 - Page Not Found"
+msgstr "404 - Pas trouvé"
+
+#: openlibrary/templates/notfound.html:14
+#, python-format
+msgid "%s does not exist."
+msgstr "%s n'existe pas"
+
+#: openlibrary/templates/notfound.html:18
+msgid "Create it?"
+msgstr "Crée le?"
+
+#: openlibrary/templates/permission_denied.html:6
+msgid "Permission denied."
+msgstr ""
+
+#: openlibrary/templates/permission_denied.html:26
+#, python-format
+msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:63
+msgid ""
+"This is a chart to show the publishing history of editions of works about"
+" this subject. Along the X axis is time, and on the y axis is the count "
+"of editions published. <a href=\"#subjectRelated\">Click here to skip the"
+" chart</a>."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:65
+msgid ""
+"This graph charts editions published on this subject. Click to view a "
+"single year, or drag across a range."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:507
+msgid "Related..."
+msgstr ""
+
+#: openlibrary/templates/subjects.html:544
+msgid "Prolific Authors"
+msgstr ""
+
+#: openlibrary/templates/subjects.html:545
+msgid "who have written the most books on this subject"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:117
+msgid "Search Results"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:128
+msgid "No hits"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:134
+msgid "Sorting by"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:136
+#: openlibrary/templates/work_search.html:138
+#: openlibrary/templates/work_search.html:140
+#: openlibrary/templates/work_search.html:142
+msgid "Relevance"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:136
+#: openlibrary/templates/work_search.html:138
+#: openlibrary/templates/work_search.html:140
+#: openlibrary/templates/work_search.html:142
+msgid "Most Editions"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:136
+#: openlibrary/templates/work_search.html:138
+#: openlibrary/templates/work_search.html:140
+#: openlibrary/templates/work_search.html:142
+msgid "First Published"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:136
+#: openlibrary/templates/work_search.html:138
+#: openlibrary/templates/work_search.html:140
+#: openlibrary/templates/work_search.html:142
+msgid "Most Recent"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:218
+msgid "Click to remove this facet"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:255
+msgid "Zoom In"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:256
+msgid "Focus your results using these"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:256
+msgid "filters"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:284
+msgid "more"
+msgstr ""
+
+#: openlibrary/templates/work_search.html:284
+msgid "less"
+msgstr ""
+
+#: openlibrary/macros/EditButtons.html:5
+msgid "Please, leave a short note about what you changed:"
+msgstr ""
+
+#: openlibrary/macros/EditButtons.html:5
+msgid "(Optional, but very useful!)"
+msgstr ""
+
+#: openlibrary/macros/EditButtons.html:13
+msgid ""
+"By saving a change to this wiki, you agree that your contribution is "
+"given freely to the world under <a "
+"href=\"https://creativecommons.org/publicdomain/zero/1.0/\" "
+"target=\"_blank\" title=\"This link to Creative Commons will open in a "
+"new window\">CC0</a>. Yippee!"
+msgstr ""
+

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -1440,7 +1440,7 @@ msgstr ""
 
 #: history.html:15
 msgid "History"
-msgstr "Afficher lhistorique"
+msgstr "Afficher l'historique"
 
 #: history.html:18
 #, python-format


### PR DESCRIPTION
On PR #801 @LeadSongDog attached a [strings.fr ](https://github.com/internetarchive/openlibrary/files/1732458/strings.fr.txt) , this is my attempt to move those strings to fr/messages.po  (as per #871) 

Tagging @roptat who expressed interest in helping with a French translation?

Please be aware that the source template has been recently updated, I've tried to tidy it as much as possible, but there will still unfortunately be some near duplicate messaging, probably unused strings, and missing messages. I'd love help to surface these sorts of issues and make the messaging better for _all_ languages (including English!) 

I'd suggest starting small, incremental addtions are prefectly OK at this stage, and focusing on the most important parts of UX.
