### PR TITLE
HOTFIX: re-fix typo lost in rebase

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -77,7 +77,7 @@ $def with (page)
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu my-books-menu-options">
           <li><a href="/account/loans">$_("My Loans")</a></li>
-          <li><a href="/account/my-books/want-to-read">$_("My Reading Log")</a></li>
+          <li><a href="/account/books/want-to-read">$_("My Reading Log")</a></li>
           <li><a href="/account/lists">$_("My Lists")</a></li>
         </ul>
       </div>


### PR DESCRIPTION
'My Books' > 'My Reading Log' was 404ing because the URL was incorrect

`/account/my-books/want-to-read` instead of the correct `/account/books/want-to-read` this had been corrected in an earlier commit https://github.com/internetarchive/openlibrary/commit/d11221d630994d13c2bdb512ca099d50360479ae#diff-cbdfe92acdfb66552507962941e4a715L80, but got lost when I rebased my recent i18n changes

@mekarpeles , sorry!