### PR TITLE
Adding merge works endpoint

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -55,6 +55,14 @@ class change_photo(change_cover):
 
 del delegate.modes['change_cover']     # delete change_cover mode added by openlibrary plugin
 
+class merge_work(delegate.page):
+    path = "(/works/OL\d+W)/merge"
+    def GET(self, key):
+        return "This looks like a good place for a merge UI!"
+
+    def POST(self, key):
+        pass
+
 @web.memoize
 @public
 def vendor_js():


### PR DESCRIPTION
Closes #805

## Description:
In this Pull Request we have made the following changes:
- adds `/works/OL...W/{title}/merge?olids=` endpoint (which can be used to merge works and editions into this work) to `plugins/upstream/code.py` as `merge_work`