### PR TITLE
Display ISNI for Author records

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -216,11 +216,14 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             $if page.links or page.remote_ids or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">
                 $if page.remote_ids:
+                    $if page.remote_ids.isni:
+                        $ isni = page.remote_ids.isni
+                       <li>ISNI: <a href="http://www.isni.org/$isni">$' '.join([isni[i:i+4] for i in range(0, 16, 4)])</a></li>
                     $if page.remote_ids.viaf:
                         $ viaf = page.remote_ids.viaf
-                        <li><a href="https://viaf.org/viaf/$viaf">VIAF ID: $viaf</a></li>
+                        <li>VIAF: <a href="https://viaf.org/viaf/$viaf">$viaf</a></li>
                     $if page.remote_ids.wikidata:
-                        <li><a href="https://tools.wmflabs.org/reasonator/?q=$page.remote_ids.wikidata">Wikidata</a></li>
+                        <li>Wikidata: <a href="https://tools.wmflabs.org/reasonator/?q=$page.remote_ids.wikidata">$page.remote_ids.wikidata</a></li>
                 $if page.wikipedia and page.wikipedia.startswith("http"):
                     <li><a href="$page.wikipedia">Wikipedia</a></li>
                 $for link in page.links:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -211,7 +211,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             </div>
 
         <div class="section">
-            <h3>Links <span class="gray small sansserif">(outside Open Library)</span></h3>
+            <h3>$_('Links') <span class="gray small sansserif">($_('outside Open Library'))</span></h3>
 
             $if page.links or page.remote_ids or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">
@@ -230,7 +230,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     <li><a href="$link.url">$link.title</a></li>
                 </ul>
             $else:
-                <p class="sansserif small">No links yet. <a href="$page.url('/edit')#web">Add one</a>?</p>
+                <p class="sansserif small">$_('No links yet.') <a href="$page.url('/edit')#web">$_('Add one')</a>?</p>
 
         </div>
 


### PR DESCRIPTION
relates to #853 

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
* Displays ISNI if stored against an author under `remote_ids`

* The format expects ISNI to be stored _without_ spaces. Spaces are added for display.
* I have changed the existing VIAF and Wikidata link display so that only the id is clickable, which will hopefully make selecting and copy the id easier if a user just wants to get the id.
* enables a few more strings to be translated, e.g. 'Links'

![screenshot from 2018-04-04 17 52 10](https://user-images.githubusercontent.com/905545/38291156-84b70402-3832-11e8-975f-f27cbd537f81.png)



