### PR TITLE
corrects worldcat link on works page, closes #774

### DIFF
--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -1,15 +1,11 @@
 $def with(isbn=None, oclc_numbers=None)
 
-$ worldcat = "https://worldcat.org/isbn/XXX"
-$ worldcatoclc = "https://worldcat.org/oclc/XXX"
-
 $if oclc_numbers or isbn:
   <hr>
   <div class="cta-section">
     <p>
       <span class="cta-section-title">Prefer the physical book?</span>
-      $ worldcat_href = worldcatoclc.replace('XXX', oclc_numbers) if oclc_numbers else worldcat.replace('XXX', isbn)
-      <a class="worldcat-link" data-ol-link-track="worldcat-search" href="$worldcat_href" title="Check WorldCat for an edition near you">Check nearby libraries</a>
+      <a class="worldcat-link" data-ol-link-track="worldcat-search" href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)" title="Check WorldCat for an edition near you">Check nearby libraries</a>
       <span class="worldcat-attribution">
         powered by <a href="https://worldcat.org">WorldCat</a>
       </span>

--- a/openlibrary/macros/WorldcatUrl.html
+++ b/openlibrary/macros/WorldcatUrl.html
@@ -1,0 +1,6 @@
+$def with(text="Check nearby libraries", isbn=None, oclc_numbers=None)
+
+$ worldcat = "https://worldcat.org/isbn/XXX"
+$ worldcatoclc = "https://worldcat.org/oclc/XXX"
+
+$(worldcatoclc.replace('XXX', oclc_numbers) if oclc_numbers else worldcat.replace('XXX', isbn))

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -117,7 +117,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
                 <ul>
                     <li>$:macros.LoanStatus(book, ctx.user)</li>
                 $if oclc_numbers or isbn:
-                    <li><a href="$(worldcatoclc if oclc_numbers else worldcat).replace('XXX', oclc_numbers if oclc_numberse else isbn)"
+                    <li><a href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)"
                            title="Look for this edition at WorldCat">Find a Physical Copy</a><br /><span class="gray smaller">via WorldCat</span></li>
                 </ul>
             </div>
@@ -138,7 +138,6 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
         </td>
     $else:
         <td class="icon buy inact">
-        <div class="zzzz"></div>
-        <div class="links">
-        </div>
+          <div class="zzzz"></div>
+          <div class="links"></div>
         </td>


### PR DESCRIPTION
Closes #774

## Description:

Fixes case where the literal string oclcl/XXX was showing in the url on the `works` page.