### PR TITLE
Fixing a spacing issue which was breaking isni for authors

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -217,7 +217,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 <ul class="booklinks sansserif">
                 $if page.remote_ids:
                     $if page.remote_ids.isni:
-                        $ isni = page.remote_ids.isni
+                       $ isni = page.remote_ids.isni
                        <li>ISNI: <a href="http://www.isni.org/$isni">$' '.join([isni[i:i+4] for i in range(0, 16, 4)])</a></li>
                     $if page.remote_ids.viaf:
                         $ viaf = page.remote_ids.viaf


### PR DESCRIPTION
## Description:
In this Pull Request we have made the following changes:

Fixes author isni issue. At some point, a single space was introduced before the definition of `$ isni` within the template, causing it to be out of scope for the next line (which was not indented to the same depth)