### PR TITLE
original fix should have targeted submit, not click

### DIFF
--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -38,7 +38,7 @@ jQuery(function($) {
     $(".no-img img").hide();
 
     // disable save button after click
-    $("button[name='_save']").click(function() {
+    $("button[name='_save']").submit(function() {
         $(this).attr("disabled", true);
     });
 });


### PR DESCRIPTION
Closes #934 
re: #954 

Cc: @Num170R 

## Description:
Hotfix to previous commit; should have targeted action `submit` instead of `click` (which seems to have been catching the click and preventing the submit