### PR TITLE
fixing works page to load availability of all editions in one go

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -8,9 +8,8 @@ $ contributor = meta_fields.get('contributor')
 $ user_loan = None
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
-$ realtime_availability = page.get_realtime_availability()
-$ availability = realtime_availability.get('status', 'error')
-$ wlsize = realtime_availability.get('num_waitlist', 0)
+$ availability = page.availability or page.get_realtime_availability()
+$ availability_status = availability.get('status', 'error')
 $ current_and_available_loans = []
 
 $if page.get('ocaid'):
@@ -44,14 +43,15 @@ $if user_loan:
       <input type="submit" value="Return eBook" class="submit unwait-btn" id="return_ebook"/>
     </form>
 
-$elif (availability == 'borrow_available') or my_turn_to_borrow:
+$elif (availability_status == 'borrow_available') or my_turn_to_borrow:
     <p>
       <a href="$borrow_link" title="Borrow from $contributor" id="borrow_ebook" class="borrow-btn borrow-link">
         Borrow eBook
       </a>
     </p>
 
-$elif (availability == 'borrow_unavailable'):
+$elif (availability_status == 'borrow_unavailable'):
+    $ wlsize = availability.get('num_waitlist', 0)
     $if waiting_loan:
         <p>
           $ spot = ctx.user.get_waiting_loan_for(page)['position']
@@ -86,7 +86,7 @@ $if editions_page and page.get('ocaid'):
   $:macros.daisy(page)
 
   $# If waitlisted, show other possible editions after daisy download link
-  $if (availability == 'borrow_unavailble'):
+  $if (availability_status == 'borrow_unavailable'):
       $ checkedout = current_and_available_loans[0] if current_and_available_loans else []
       $if checkedout and not user_loan:
         $if work and work.edition_count > 1:

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -622,7 +622,15 @@ class Work(models.Work):
             editions = [k[len("/books/"):] for k in web.ctx.site.things(q)]
 
         if editions:
-            return web.ctx.site.get_many(["/books/" + olid for olid in editions])
+            books = web.ctx.site.get_many(["/books/" + olid for olid in editions])
+
+            availability = lending.get_availability_of_ocaids([
+                book.ocaid for book in books if book.ocaid
+            ])
+
+            for book in books:
+                book.availability = availability.get(book.ocaid) or {"status": "error"}
+            return books
         else:
             return []
 

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -2,8 +2,6 @@ $def with (book)
 
 $ worldcat = "https://worldcat.org/isbn/XXX"
 $ worldcatoclc = "https://worldcat.org/oclc/XXX"
-$ bookmooch = "http://www.bookmooch.com/m/mooch_choice?asin=XXX"
-$ titletrader = "http://www.titletrader.com/invinfo/XXX.html"
 
 $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
 $ detailbook = "//archive.org/details/XXX"
@@ -16,7 +14,6 @@ $ kindle = "https://www.amazon.com/gp/digital/fiona/web-to-kindle?clientid=IA&it
 
 $ djvutxt = "//archive.org/download/XXX/XXX_djvu.txt"
 $ seeall = "//archive.org/download/XXX"
-$ google = ""
 
 $ isbn = (book.isbn_10 and book.isbn_10[0]) or (book.isbn_13 and book.isbn_13[0]) or ""
 $ isbn = isbn.replace("-", "")
@@ -27,17 +24,6 @@ $if book.isbn_10:
     $ isbn_10 = book.isbn_10[0].replace("-", "")
 $elif isbn_13:
     $ isbn_10 = isbn_13_to_isbn_10(isbn_13)
-
-$ asin = None
-$ scribd = None
-$if book.get('identifiers'):
-    $if book.identifiers.get('scribd'):
-        $ scribd = book.identifiers.scribd[0]
-    $if book.identifiers.get('amazon'):
-        $ asin = book.identifiers.amazon[0]
-
-$if isbn_10 and not asin:
-    $ asin = isbn_10
 
 $ library = None
 $ collection = set()
@@ -129,15 +115,8 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
             </div>
         </td>
 
-    $if isbn or asin or scribd:
-        <td class="icon buy">
-        <div class="aaaa"></div>
-        <div class="links">
-            $:macros.AffiliateLinks({'isbn': isbn, 'asin': asin, 'scribd': scribd})
-        </div>
-        </td>
-    $else:
-        <td class="icon buy inact">
-          <div class="zzzz"></div>
-          <div class="links"></div>
-        </td>
+
+    <td class="icon buy inact">
+      <div class="zzzz"></div>
+      <div class="links"></div>
+    </td>


### PR DESCRIPTION
Closes #844 

## Description:

Previously, in order to render an openlibrary `work` page, we fetched all the work's editions and then individually checked their availability, one at a time. Now, we fetch all the work's editions, filter them to those which have archive.org IDs, and then send these ids in bulk, as a single request, to the availability v2 API. This drastically improves the load time of books pages