### PR TITLE
Fixing search to rm flickering, availability check moved to backend

### DIFF
--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -1,0 +1,79 @@
+$def with(page, availability)
+
+$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
+$ user_loan = None
+$ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
+$ wlsize = availability.get('num_waitlist', 0)
+$ current_and_available_loans = []
+
+$if page.get('ocaid'):
+  $ current_and_available_loans = page.get_current_and_available_loans()
+  $ user_loan = None
+  $if ctx.user:
+    $for current_loan in current_and_available_loans[0]:
+      $if current_loan['user'] == ctx.user.key:
+        $ user_loan = current_loan
+        $ break
+
+$ current_loans = current_and_available_loans[0] if current_and_available_loans else []
+
+$if ctx.user:
+    $for current_loan in current_loans:
+        $if current_loan['user'] == ctxuser.key:
+            $ user_loan = current_loan
+            $ break
+
+$if availability['status'] in ['open', 'borrow_available', 'borrow_unavailable']:
+  $ read_link = '/borrow/ia/%s' % availability['identifier']
+
+  $if user_loan:
+    <a href="$read_link" title="Borrow"
+       data-userid="$(user_loan['userid'])" id="read_ebook"
+       class="borrow-btn borrow-link">Read eBook</a>
+
+    $ return_url = page.url.rsplit('/', 1)[0] + '/do_return/borrow'
+    <form action="$return_url" method="post" class="waitinglist-form return-book">
+      <input type="hidden" name="action" value="return" />
+      <input type="submit" value="Return eBook" class="submit unwait-btn" id="return_ebook"/>
+    </form>
+
+  $elif (availability['status'] == 'borrow_available') or my_turn_to_borrow:
+    <a href="$read_link" class="borrow_available borrow-link cta-btn" title="Borrow" id="borrow_ebook">
+      Borrow
+    </a>
+
+  $elif (availability['status'] == 'borrow_unavailable'):
+    $if waiting_loan:
+        <span class="borrow_unavailable" data-ol-link-track="borrow_unavailable">
+          <form method="POST" action="$(read_link)?action=join-waitinglist" class="leave-waitlist waitinglist-form">
+            <input type="hidden" name="action" value="leave-waitinglist"/>
+            <input type="submit" class="submit unwait-btn" id="unwaitlist_ebook" value="Leave waiting list"/>
+          </form>
+        </span>
+        <div class="waitlist-msg">
+          $ spot = ctx.user.get_waiting_loan_for(page)['position']
+          $if spot == 1:
+              You are <strong>next</strong> on the waiting list
+          $else:
+              You are <strong>#$(spot)</strong> of $(wlsize) on the waiting list.
+        </div>
+
+    $else:
+        <span class="borrow_unavailable" data-ol-link-track="borrow_unavailable">
+          <form method="POST" action="$(read_link)?action=join-waitinglist" class="join-waitlist waitinglist-form">
+            <input type="hidden" name="action" value="join-waitinglist"/>
+            <button type="submit" class="submit wait-btn" id="waitlist_ebook">
+              Join Waitlist
+              $if wlsize and int(wlsize):
+                <span class="badge">$wlsize</span>
+            </button>
+          </form>
+        </span>
+        $if not wlsize or int(wlsize) == 0:
+          <div class="waitlist-msg">
+            You will be first in line!
+          </div>
+
+  $elif (availability['status'] == 'open'):
+    <a href="$read_link" data-ol-link-track="read_unrestricted" title="Use BookReader to read online"
+       id="read_ebook" class="borrow_available borrow-link cta-btn">Read</a>

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -1,68 +1,53 @@
-$def with(page, availability)
+$def with(page, availability, user)
 
-$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
-$ user_loan = None
+$ ocaid = availability and availability.get('identifier')
+$ loan = ocaid and [loan for loan in user['loans'] if ocaid == loan.get('ocaid')]
+$ waiting_loan = ocaid and [request for request in user['waitlists'] if ocaid == request.get('identifier')]
+$if loan:
+  $ loan = loan[0]
+$if waiting_loan:
+  $ waiting_loan = waiting_loan[0]
+
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
+
+$ availability_status = availability.get('status', 'error')
 $ wlsize = availability.get('num_waitlist', 0)
 $ current_and_available_loans = []
 
-$if page.get('ocaid'):
-  $ current_and_available_loans = page.get_current_and_available_loans()
-  $ user_loan = None
-  $if ctx.user:
-    $for current_loan in current_and_available_loans[0]:
-      $if current_loan['user'] == ctx.user.key:
-        $ user_loan = current_loan
-        $ break
-
-$ current_loans = current_and_available_loans[0] if current_and_available_loans else []
-
-$if ctx.user:
-    $for current_loan in current_loans:
-        $if current_loan['user'] == ctxuser.key:
-            $ user_loan = current_loan
-            $ break
-
-$if availability['status'] in ['open', 'borrow_available', 'borrow_unavailable']:
+$if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
   $ read_link = '/borrow/ia/%s' % availability['identifier']
 
-  $if user_loan:
+  $if loan:
     <a href="$read_link" title="Borrow"
-       data-userid="$(user_loan['userid'])" id="read_ebook"
-       class="borrow-btn borrow-link">Read eBook</a>
+       data-userid="$(loan['userid'])" id="read_ebook"
+       class="borrow_available borrow-link cta-btn">Read</a>
 
-    $ return_url = page.url.rsplit('/', 1)[0] + '/do_return/borrow'
-    <form action="$return_url" method="post" class="waitinglist-form return-book">
-      <input type="hidden" name="action" value="return" />
-      <input type="submit" value="Return eBook" class="submit unwait-btn" id="return_ebook"/>
-    </form>
-
-  $elif (availability['status'] == 'borrow_available') or my_turn_to_borrow:
+  $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
     <a href="$read_link" class="borrow_available borrow-link cta-btn" title="Borrow" id="borrow_ebook">
       Borrow
     </a>
 
-  $elif (availability['status'] == 'borrow_unavailable'):
+  $elif (availability_status == 'borrow_unavailable'):
     $if waiting_loan:
-        <span class="borrow_unavailable" data-ol-link-track="borrow_unavailable">
+        <span data-ol-link-track="leave_waitlist">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="leave-waitlist waitinglist-form">
             <input type="hidden" name="action" value="leave-waitinglist"/>
-            <input type="submit" class="submit unwait-btn" id="unwaitlist_ebook" value="Leave waiting list"/>
+            <input type="submit" class="unwait-btn" id="unwaitlist_ebook" value="Leave Waitlist"/>
           </form>
         </span>
         <div class="waitlist-msg">
-          $ spot = ctx.user.get_waiting_loan_for(page)['position']
+          $ spot = waiting_loan['position']
           $if spot == 1:
-              You are <strong>next</strong> on the waiting list
+              You're <strong>next</strong> in line
           $else:
-              You are <strong>#$(spot)</strong> of $(wlsize) on the waiting list.
+              There are <strong>#$(spot-1)</strong> readers ahead of you
         </div>
 
     $else:
         <span class="borrow_unavailable" data-ol-link-track="borrow_unavailable">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="join-waitlist waitinglist-form">
             <input type="hidden" name="action" value="join-waitinglist"/>
-            <button type="submit" class="submit wait-btn" id="waitlist_ebook">
+            <button type="submit" class="wait-btn" id="waitlist_ebook">
               Join Waitlist
               $if wlsize and int(wlsize):
                 <span class="badge">$wlsize</span>
@@ -71,9 +56,9 @@ $if availability['status'] in ['open', 'borrow_available', 'borrow_unavailable']
         </span>
         $if not wlsize or int(wlsize) == 0:
           <div class="waitlist-msg">
-            You will be first in line!
+            Be first in line!
           </div>
 
-  $elif (availability['status'] == 'open'):
+  $elif (availability_status == 'open'):
     <a href="$read_link" data-ol-link-track="read_unrestricted" title="Use BookReader to read online"
        id="read_ebook" class="borrow_available borrow-link cta-btn">Read</a>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True)
+$def with (doc, decorations=None, cta=True, availability=None)
 
 $ is_work = doc.get('type', {}).get('key') == '/type/work'
 $ book_url = doc.url() if is_work else doc.key
@@ -57,6 +57,9 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
           $:decorations
         </div>
       $if cta:
-        <div class="searchResultItemCTA-lending"></div>
+        <div class="searchResultItemCTA-lending">
+          $if availability:
+            $:macros.AvailabilityButton(doc, availability)
+        </div>
   </div>
 </li>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None)
+$def with (doc, decorations=None, cta=True, availability=None, user=None)
 
 $ is_work = doc.get('type', {}).get('key') == '/type/work'
 $ book_url = doc.url() if is_work else doc.key
@@ -59,7 +59,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
       $if cta:
         <div class="searchResultItemCTA-lending">
           $if availability:
-            $:macros.AvailabilityButton(doc, availability)
+            $:macros.AvailabilityButton(doc, availability, user)
         </div>
   </div>
 </li>

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -26,7 +26,8 @@ $(function(){
         return (window.location.pathname.match('\/people\/[^/]+') ||
                 window.location.pathname.match('\/account\/books\/[^/]+') ||
                 window.location.pathname.match('\/works\/[^/]+') ||
-                window.location.pathname.match('\/stats/[^/]+'));
+                window.location.pathname.match('\/stats/[^/]+') ||
+                window.location.pathname.match('\/search'));
     }
 
     getAvailabilityV2 = function(_type, _ids, callback) {

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -4,6 +4,7 @@ from infogami.utils import delegate, stats
 from infogami import config
 from infogami.utils.view import render, render_template, safeint
 import simplejson as json
+from openlibrary.core.lending import get_availability_of_ocaids
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.utils import url_quote, read_isbn, escape_bracket
 from unicodedata import normalize
@@ -261,9 +262,10 @@ def run_solr_query(param = {}, rows=100, page=1, sort=None, spellcheck_count=Non
 re_pre = re.compile(r'<pre>(.*)</pre>', re.S)
 
 def do_search(param, sort, page=1, rows=100, spellcheck_count=None):
-    (reply, solr_select, q_list) = run_solr_query(param, rows, page, sort, spellcheck_count)
+    (reply, solr_select, q_list) = run_solr_query(
+        param, rows, page, sort, spellcheck_count)
     is_bad = False
-    if reply.startswith('<html'):
+    if not reply or reply.startswith('<html'):
         is_bad = True
     if not is_bad:
         try:
@@ -489,7 +491,7 @@ class search(delegate.page):
                 v = re_to_esc.sub(lambda m:'\\' + m.group(), i[k].strip())
                 q_list.append(k + ':' + v)
 
-        return render.work_search(i, ' '.join(q_list), do_search, get_doc)
+        return render.work_search(i, ' '.join(q_list), do_search, get_doc, get_availability_of_ocaids)
 
 
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,4 +1,4 @@
-$def with (input, q_param, do_search, get_doc)
+$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids)
 
 $ facet_map = (
 $    ('has_fulltext', 'eBook?'),
@@ -234,11 +234,22 @@ function less(header) {
         <div id="searchResults">
           <ul id="siteSearch">
             $ work_keys = []
+            $ works = []
             $for result_doc in docs:
                 $ doc = get_doc(result_doc)
                 $ key = doc.key
                 $ work_keys.append(key)
-                $:macros.SearchResultsWork(doc)
+                $ works.append(doc)
+
+            $# filter by availability check
+            $ ocaids = [work.ia[0] for work in works if work.ia]
+            $ availability = get_availability_of_ocaids(ocaids)
+
+            $for work in works:
+                $ ocaid = work.ia[0] if work.ia else None
+                $ work_availability = availability.get(ocaid)
+                $if 'has_fulltext' not in param or work_availability['status'] not in ['error', 'private']:
+                    $:macros.SearchResultsWork(work, availability=work_availability)
           </ul>
         </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -245,11 +245,14 @@ function less(header) {
             $ ocaids = [work.ia[0] for work in works if work.ia]
             $ availability = get_availability_of_ocaids(ocaids)
 
+            $ user = {'loans': ctx.user.get_loans(), 'waitlists': ctx.user.get_waitinglist()}
+
             $for work in works:
                 $ ocaid = work.ia[0] if work.ia else None
                 $ work_availability = availability.get(ocaid)
+
                 $if 'has_fulltext' not in param or work_availability['status'] not in ['error', 'private']:
-                    $:macros.SearchResultsWork(work, availability=work_availability)
+                    $:macros.SearchResultsWork(work, availability=work_availability, user=user)
           </ul>
         </div>
 

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -3116,7 +3116,7 @@ a.cta-btn  {
     text-decoration: none;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     text-align: center;
-    padding: 5px 20px;
+    padding: 5px 0px;
     font-size: 0.8em;
 }
 
@@ -3125,6 +3125,10 @@ a.cta-btn  {
     padding: 4px 7px;
     border-radius: 5px;
     font-size: .7em;
+}
+
+.searchResultItemCTA-lending .borrow_unavailable button {
+    padding: 0px;
 }
 
 .borrow_available {

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -3095,6 +3095,9 @@ a.cta-btn  {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
+    width: 100%;
+    color: #fff;
+    cursor: pointer;
     text-align: center;
     -webkit-box-align: stretch;
     -ms-flex-align: stretch;
@@ -3102,19 +3105,21 @@ a.cta-btn  {
     -ms-flex-pack: stretch;
     align-items: stretch;
     justify-content: center;
+    font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
+}
+
+.searchResultItemCTA-lending input[type=submit]#return_ebook, 
+.searchResultItemCTA-lending input[type=submit]#unwaitlist_ebook, {
+    width: 100%;
+    font-size: .8em;
 }
 
 .searchResultItemCTA-lending .borrow_unavailable {
     border: none;
-    color: #fff;
-    width: 100%;
     border: 0;
     border-radius: 5px;
     box-sizing: border-box;
-    color: #fff;
-    cursor: pointer;
     text-decoration: none;
-    font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     text-align: center;
     padding: 5px 0px;
     font-size: 0.8em;


### PR DESCRIPTION
Closes #733 

## Description:

TL;DR: Fixing search to rm flickering, availability check moved to backend

When `ebooks` mode was selected, we used to rely on availability.js to filter out all books which didn't have ebooks. This is because our openlibrary solr things anything with an ocaid (i.e. archive.org ID) is an ebook, whereas many of these are printdisabled and can't be ready by the user. This availability check process was incorporated into the backend over our search results to prevent the interface from visually pruning records.

Also, fixes search results so they correctly show the user's waitlist + loan status on relevant titles.