### PR TITLE
Remove CSS which disables accessible focus rects on all links

### DIFF
--- a/static/css/master.less
+++ b/static/css/master.less
@@ -508,10 +508,10 @@ blockquote, q {quotes: "" "";}
 
 /* SITE DEFAULTS */
 body {font-size:100%;line-height:normal;color:@dark-grey;}
-a:link{color:@link-blue;text-decoration:underline;outline:none;}
-a.on,a:hover.on,a:visited.on {color:@dark-grey;cursor:default;text-decoration:none;outline:none;}
-a:hover {color: @dark-green;text-decoration:underline;outline:none;}
-a:visited {color: @dark-blue;text-decoration:underline;outline:none;}
+a:link{color:@link-blue;text-decoration:underline;}
+a.on,a:hover.on,a:visited.on {color:@dark-grey;cursor:default;text-decoration:none;}
+a:hover {color: @dark-green;text-decoration:underline;}
+a:visited {color: @dark-blue;text-decoration:underline;}
 .collapse{margin:0!important;padding:0!important;}
 .small{font-size:12px!important;font-weight:normal!important;}
 .smaller{font-size:11px;font-weight:normal;}


### PR DESCRIPTION
Closes #1006 

## Description:
In this Pull Request we have made the following changes:

 * Remove the CSS attributes which are disabling the browser default focus rect behaviours that support keyboard navigation.