### PR TITLE
Hotfix: Fix some invalid css properties that came from the autoformatting

### DIFF
--- a/static/css/master.less
+++ b/static/css/master.less
@@ -121,7 +121,7 @@ table#editions div.links {
 
 .dataTables_paginate {
   width: 44px;
-  *: 50px;
+  *width: 50px;
   float: right;
   text-align: right;
   font-size: 12px;
@@ -164,7 +164,7 @@ table.display {
 
 table.display thead th {
   cursor: pointer;
-  *: hand;
+  *cursor: hand;
 }
 
 table.display tfoot th {


### PR DESCRIPTION
Contributes to #968, hotfixes some errors introduced by #1010 

## Description:
In this Pull Request we have made the following changes:

* Fix invalid CSS properties: Autoformat clobbered some CSS property hacks, and this stops the Less from compiling properly.