### PR TITLE
add user reading stats and rating stats to work page

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -177,3 +177,16 @@ class Bookshelves(object):
             return result if lazy else list(result)
         except:
             return None
+
+    @classmethod
+    def get_num_users_by_bookshelf_by_work_id(cls, work_id):
+        """Returns a dict mapping a work_id to the
+        number of number of users who have placed that work_id in each shelf, i.e. {bookshelf_id:
+        count}.
+        """
+        oldb = db.get_db()
+        query = ("SELECT bookshelf_id, count(DISTINCT username) as user_count from bookshelves_books where"
+                 " work_id=$work_id"
+                 " GROUP BY bookshelf_id")
+        result = oldb.query(query, vars={'work_id': int(work_id)})
+        return dict([(i['bookshelf_id'], i['user_count']) for i in result]) if result else {}

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -428,6 +428,15 @@ class Work(Thing):
         status_id = Bookshelves.get_users_read_status_of_work(username, work_id)
         return status_id
 
+    def get_num_users_by_bookshelf(self):
+        work_id = extract_numeric_id_from_olid(self.key)
+        num_users_by_bookshelf = Bookshelves.get_num_users_by_bookshelf_by_work_id(work_id)
+        return {
+            'want-to-read': num_users_by_bokshelf.get(Bookshelves.PRESET_BOOKSHELVES['Want to Read'], 0),
+            'currently-reading': num_users_by_bokshelf.get(Bookshelves.PRESET_BOOKSHELVES['Currently Reading'], 0),
+            'already-read': num_users_by_bokshelf.get(Bookshelves.PRESET_BOOKSHELVES['Already Read'], 0)
+        }
+
     def _get_d(self):
         """Returns the data that goes into memcache as d/$self.key.
         Used to measure the memcache usage.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -440,7 +440,7 @@ class Work(Thing):
     def get_rating_stats(self):
         work_id = extract_numeric_id_from_olid(self.key)
         rating_stats = Ratings.get_rating_stats(work_id)
-        return {'avg_rating': rating_stats['avg_rating'], 'num_ratings': rating_stats['num_ratings']}
+        return {'avg_rating': round(rating_stats['avg_rating'],2), 'num_ratings': rating_stats['num_ratings']}
 
     def _get_d(self):
         """Returns the data that goes into memcache as d/$self.key.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -437,6 +437,11 @@ class Work(Thing):
             'already-read': num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES['Already Read'], 0)
         }
 
+    def get_rating_stats(self):
+        work_id = extract_numeric_id_from_olid(self.key)
+        rating_stats = Ratings.get_rating_stats(work_id)
+        return rating_stats
+
     def _get_d(self):
         """Returns the data that goes into memcache as d/$self.key.
         Used to measure the memcache usage.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -440,7 +440,11 @@ class Work(Thing):
     def get_rating_stats(self):
         work_id = extract_numeric_id_from_olid(self.key)
         rating_stats = Ratings.get_rating_stats(work_id)
-        return {'avg_rating': round(rating_stats['avg_rating'],2), 'num_ratings': rating_stats['num_ratings']} if rating_stats else {}
+        if rating_stats and rating_stats['num_ratings'] > 0:
+            return {
+            'avg_rating': round(rating_stats['avg_rating'],2),
+            'num_ratings': rating_stats['num_ratings']
+            }
 
     def _get_d(self):
         """Returns the data that goes into memcache as d/$self.key.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -440,7 +440,7 @@ class Work(Thing):
     def get_rating_stats(self):
         work_id = extract_numeric_id_from_olid(self.key)
         rating_stats = Ratings.get_rating_stats(work_id)
-        return rating_stats
+        return {'avg_rating': rating_stats['avg_rating'], 'num_ratings': rating_stats['num_ratings']}
 
     def _get_d(self):
         """Returns the data that goes into memcache as d/$self.key.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -440,7 +440,7 @@ class Work(Thing):
     def get_rating_stats(self):
         work_id = extract_numeric_id_from_olid(self.key)
         rating_stats = Ratings.get_rating_stats(work_id)
-        return {'avg_rating': round(rating_stats['avg_rating'],2), 'num_ratings': rating_stats['num_ratings']}
+        return {'avg_rating': round(rating_stats['avg_rating'],2), 'num_ratings': rating_stats['num_ratings']} if rating_stats else {}
 
     def _get_d(self):
         """Returns the data that goes into memcache as d/$self.key.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -432,9 +432,9 @@ class Work(Thing):
         work_id = extract_numeric_id_from_olid(self.key)
         num_users_by_bookshelf = Bookshelves.get_num_users_by_bookshelf_by_work_id(work_id)
         return {
-            'want-to-read': num_users_by_bokshelf.get(Bookshelves.PRESET_BOOKSHELVES['Want to Read'], 0),
-            'currently-reading': num_users_by_bokshelf.get(Bookshelves.PRESET_BOOKSHELVES['Currently Reading'], 0),
-            'already-read': num_users_by_bokshelf.get(Bookshelves.PRESET_BOOKSHELVES['Already Read'], 0)
+            'want-to-read': num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES['Want to Read'], 0),
+            'currently-reading': num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES['Currently Reading'], 0),
+            'already-read': num_users_by_bookshelf.get(Bookshelves.PRESET_BOOKSHELVES['Already Read'], 0)
         }
 
     def _get_d(self):

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -45,7 +45,7 @@ class Ratings(object):
                  " FROM ratings"
                  " WHERE work_id = $work_id")
         result = oldb.query(query, vars={'work_id': int(work_id)})
-        return {'avg_rating': result['average_rating'], 'num_ratings': result['num_ratings']} if result else {}
+        return {'avg_rating': result['avg_rating'], 'num_ratings': result['num_ratings']} if result else {}
 
     @classmethod
     def get_all_works_ratings(cls, work_id):

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -39,6 +39,15 @@ class Ratings(object):
         return list(oldb.query(query, vars={'username': username}))
 
     @classmethod
+    def get_rating_stats(cls, work_id):
+        oldb = db.get_db()
+        query = ("SELECT AVERAGE(rating) as avg_rating, COUNT(DISTINCT username) as num_ratings"
+                 " FROM ratings"
+                 " WHERE work_id = $work_id")
+        result = oldb.query(query, vars={'work_id': int(work_id)})
+        return {'avg_rating': result['average_rating'], 'num_ratings': result['num_ratings']} if result else {}
+
+    @classmethod
     def get_all_works_ratings(cls, work_id):
         oldb = db.get_db()
         query = 'select * from ratings where work_id=$work_id'

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -45,7 +45,7 @@ class Ratings(object):
                  " FROM ratings"
                  " WHERE work_id = $work_id")
         result = oldb.query(query, vars={'work_id': int(work_id)})
-        return {'avg_rating': result[0]['avg_rating'], 'num_ratings': result[0]['num_ratings']} if result else {}
+        return result[0] if result else {}
 
     @classmethod
     def get_all_works_ratings(cls, work_id):

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -45,7 +45,7 @@ class Ratings(object):
                  " FROM ratings"
                  " WHERE work_id = $work_id")
         result = oldb.query(query, vars={'work_id': int(work_id)})
-        return {'avg_rating': result['avg_rating'], 'num_ratings': result['num_ratings']} if result else {}
+        return {'avg_rating': result[0]['avg_rating'], 'num_ratings': result[0]['num_ratings']} if result else {}
 
     @classmethod
     def get_all_works_ratings(cls, work_id):

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -41,7 +41,7 @@ class Ratings(object):
     @classmethod
     def get_rating_stats(cls, work_id):
         oldb = db.get_db()
-        query = ("SELECT AVERAGE(rating) as avg_rating, COUNT(DISTINCT username) as num_ratings"
+        query = ("SELECT AVG(rating) as avg_rating, COUNT(DISTINCT username) as num_ratings"
                  " FROM ratings"
                  " WHERE work_id = $work_id")
         result = oldb.query(query, vars={'work_id': int(work_id)})

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -220,15 +220,21 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     $if page.languages:
                     <br/>Written in <span itemprop="In language">$:thingrepr(page.languages)</span>.
                 </h4>
-
                 <h4 class="publisher">
+                    <span class="sansserif">
+                    $ rating_stats = work.get_rating_stats() if work else {}
                     $ stats_by_bookshelf = work.get_num_users_by_bookshelf() if work else {}
-                    $if stats_by_bookshelf['want-to-read']:
-                        $stats_by_bookshelf['want-to-read'] want to read this book
-                    $if stats_by_bookshelf['currently-reading']:
-                        $stats_by_bookshelf['currently-reading'] are currently reading this book
-                    $if stats_by_bookshelf['already-read']:
-                        $stats_by_bookshelf['already-read'] already read this book
+                    $if rating_stats['avg_rating'] > 0 and rating_stats['num_ratings'] > 1:
+                        </br> <strong> Average rating: </strong> $rating_stats['avg_rating'] stars
+                        - rated by $rating_stats['num_ratings'] readers
+
+                    $if stats_by_bookshelf['want-to-read'] > 1:
+                        </br> <strong> $stats_by_bookshelf['want-to-read'] readers </strong> want to read
+                    $if stats_by_bookshelf['currently-reading'] > 1:
+                        - <strong> $stats_by_bookshelf['currently-reading'] readers </strong> are currently reading
+                    $if stats_by_bookshelf['already-read'] > 1:
+                        - <strong> $stats_by_bookshelf['already-read'] readers </strong> have read
+                    </span>
                   </h4>
             </div>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -224,7 +224,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     <span class="sansserif">
                     $ rating_stats = work.get_rating_stats() if work else {}
                     $ stats_by_bookshelf = work.get_num_users_by_bookshelf() if work else {}
-                    $if rating_stats['avg_rating'] > 0 and rating_stats['num_ratings'] > 1:
+                    $if rating_stats and rating_stats['avg_rating'] > 0 and rating_stats['num_ratings'] > 1:
                         </br> <strong> Average rating: </strong> $rating_stats['avg_rating'] stars
                         - rated by $rating_stats['num_ratings'] readers
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -220,6 +220,16 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     $if page.languages:
                     <br/>Written in <span itemprop="In language">$:thingrepr(page.languages)</span>.
                 </h4>
+
+                <h4 class="publisher">
+                    $ stats_by_bookshelf = work.get_num_users_by_bookshelf() if work else {}
+                    $if stats_by_bookshelf['want-to-read']:
+                        $stats_by_bookshelf['want-to-read'] want to read this book
+                    $if stats_by_bookshelf['currently-reading']:
+                        $stats_by_bookshelf['currently-reading'] are currently reading this book
+                    $if stats_by_bookshelf['already-read']:
+                        $stats_by_bookshelf['already-read'] already read this book
+                  </h4>
             </div>
 
         $if page.description:


### PR DESCRIPTION
Attempts to address #966


## Description:
Adds new methods for fetching the number of users who have added a work to the 3 given bookshelves, and shows that in the work page.

Adds new method for fetching average rating and number of ratings from `ratings`, and shows that in the work page.

Doesn't show any data if less than 2 readers have added a work, since don't feel like handing non-plural nouns 😂 .

![image](https://user-images.githubusercontent.com/2905160/42415835-4a793826-8212-11e8-9336-5059e0c042ca.png)
