### PR TITLE
1028/refactor/ipstats

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -125,7 +125,6 @@ lists:
     editions_view: http://127.0.0.1:5984/editions/_fti/_design/seeds/by_seed
 
 admin:
-    #counts_db: http://127.0.0.1:5984/admin
     olsystem_root: /home/noufal/projects/OL/olsystem/
     nagios_url: http://monitor.us.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=24.openlibrary&style=detail
     statsd_server: localhost:9090

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -36,10 +36,7 @@ class home(delegate.page):
 
     def GET(self):
         try:
-            if 'counts_db' in config.admin:
-                stats = admin.get_stats()
-            else:
-                stats = None
+            stats = admin.get_stats()
         except Exception:
             logger.error("Error in getting stats", exc_info=True)
             stats = None

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -7,44 +7,16 @@ import _init_path
 import os
 import datetime
 import subprocess
-from openlibrary.config import load_config
 import web
 import infogami
 
-import couchdb
-import yaml
-
-def connect_to_couch(config_file):
-    "Connects to the couch databases"
-    load_config(config_file)
-    infogami._setup()
-
-    f = open(config_file)
-    config = yaml.load(f)
-    f.close()
-    admin_db = config["admin"]["counts_db"]
-    return couchdb.Database(admin_db)
-
-def store_data(db, data, date):
+def store_data(data, date):
     uid = date.strftime("counts-%Y-%m-%d")
 
-    # start storing data in store as well, so that we can phase out couch
     doc = web.ctx.site.store.get(uid) or {}
     doc.update(data)
     doc['type'] = 'admin-stats'
     web.ctx.site.store[uid] = doc
-
-    try:
-        try:
-            vals = db[uid]
-            vals.update(data)
-        except couchdb.http.ResourceNotFound:
-            vals = data
-            db[uid] = vals
-        print "saving %s"%vals
-        db.save(vals)
-    except IOError, e:
-        print >> sys.stderr, "unable to save to couchdb:", str(e)
 
 
 def run_for_day(d):
@@ -70,15 +42,15 @@ def run_for_day(d):
     return dict (visitors = int(val))
 
 
-def main(config):
-    admin_db = connect_to_couch(config)
+def main():
+    infogami._setup()
     current = datetime.datetime.now()
     for i in range(2):
         print current
         d = run_for_day(current)
-        store_data(admin_db, d, current)
+        store_data(d, current)
         current = current - datetime.timedelta(days = 1)
 
 if __name__ == "__main__":
     import sys
-    sys.exit(main(sys.argv[1]))
+    sys.exit(main())


### PR DESCRIPTION
Closes #1028 

## Description:
Refactors ipstats.py script to not reference couchdb and to be better documented.
~Note this doesn't remove `counts_db` yet; separate PR for that because it looks a little more intricate than this.~ Nevermind, this was easy; also removes `counts_db`

**Note**: the cron file of production needs to be updated; this script no longer takes the config file as input.