### PR TITLE
use xauthn service param, have archive.org activation redir to OL

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -534,8 +534,17 @@ class InternetArchiveAccount(web.storage):
             'access': s3_key or lending.config_ia_ol_xauth_s3.get('s3_key'),
             'secret': s3_secret or lending.config_ia_ol_xauth_s3.get('s3_secret')
         })
+
+        # Currently, optional parameters, like `service` are passed as
+        # **kwargs (i.e. **data). The xauthn service uses the named
+        # parameter `activation-type` which contains a dash and thus
+        # is unsuitable as a kwarg name. Therefore, if we're
+        # performing an account `create` xauthn operation and the
+        # `service` parameter is present, we need to rename `service`
+        # as `activation-type` so it is forwarded correctly to xauth:
         if op == 'create' and 'service' in data:
             data['activation-type'] = data.pop('service')
+
         payload = simplejson.dumps(data)
         if test:
             url += "&developer=%s" % test

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -10,6 +10,7 @@ import simplejson
 import uuid
 import urllib
 import urllib2
+import logging
 
 import lepl.apps.rfc3696
 import web
@@ -20,6 +21,7 @@ from infogami.infobase.client import ClientException
 
 from openlibrary.core import stats, helpers
 
+logger = logging.getLogger("openlibrary.account.model")
 
 def append_random_suffix(text, limit=9999):
     return '%s%s' % (text, random.randint(0, limit))
@@ -501,8 +503,9 @@ class InternetArchiveAccount(web.storage):
         attempt = 0
         while True:
             response = cls.xauth(
-                'create', test=test, email=email, password=password,
-                screenname=_screenname, verified=verified)
+                'create', test=test, email=email,
+                password=password, screenname=_screenname,
+                verified=verified, service='openlibrary', notifications=[])
 
             if response.get('success'):
                 ia_account = cls.get(email=email)
@@ -523,13 +526,16 @@ class InternetArchiveAccount(web.storage):
             attempt += 1
 
     @classmethod
-    def xauth(cls, service, test=None, s3_key=None, s3_secret=None, xauth_url=None, **data):
+    def xauth(cls, op, test=None, s3_key=None, s3_secret=None,
+              xauth_url=None, **data):
         from openlibrary.core import lending
-        url = "%s?op=%s" % (xauth_url or lending.config_ia_xauth_api_url, service)
+        url = "%s?op=%s" % (xauth_url or lending.config_ia_xauth_api_url, op)
         data.update({
             'access': s3_key or lending.config_ia_ol_xauth_s3.get('s3_key'),
             'secret': s3_secret or lending.config_ia_ol_xauth_s3.get('s3_secret')
         })
+        if op == 'create' and 'service' in data:
+            data['activation-type'] = data.pop('service')
         payload = simplejson.dumps(data)
         if test:
             url += "&developer=%s" % test
@@ -566,12 +572,10 @@ class InternetArchiveAccount(web.storage):
                 return {'error': e.read(), 'code': e.code}
         return simplejson.loads(response)
 
-
-
     @classmethod
     def get(cls, email, test=False, _json=False, s3_key=None, s3_secret=None, xauth_url=None):
         email = email.strip().lower()
-        response = cls.xauth(email=email, test=test, service="info",
+        response = cls.xauth(email=email, test=test, op="info",
                              s3_key=s3_key, s3_secret=s3_secret, xauth_url=xauth_url)
         if 'success' in response:
             values = response.get('values', {})


### PR DESCRIPTION
Closes #834 

## Description:
In this Pull Request we have made the following changes:

Integrates `service` param into `xauthn` API so archive.org activation success page can link back to the correct service for login (e.g. `service=openlibrary` should show an archive.org activation page which redirects to openlibrary.org)