### PR TITLE
First round of fixing cache, no bots, re-cache

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -25,7 +25,7 @@ DEFAULT_CACHE_LIFETIME = 120  # seconds
 HOUR = 60 * 60
 DAY = HOUR * 24
 HALF_DAY = HOUR * 12
-ONE_WEEK = HALF_DAY * 2 * 7
+ONE_WEEK = DAY * 7
 
 
 class memcache_memoize:

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -25,6 +25,7 @@ DEFAULT_CACHE_LIFETIME = 120  # seconds
 HOUR = 60 * 60
 DAY = HOUR * 24
 HALF_DAY = HOUR * 12
+ONE_WEEK = HALF_DAY * 2 * 7
 
 
 class memcache_memoize:

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -94,7 +94,9 @@ def setup(config):
     config_amz_api = config.get('amazon_api')
 
     try:
-        amazon_api = AmazonAPI(config_amz_api.key, config_amz_api.secret, config_amz_api.id)
+        amazon_api = AmazonAPI(
+            config_amz_api.key, config_amz_api.secret,
+            config_amz_api.id, MaxQPS=0.9)
     except AttributeError:
         amazon_api = None
 

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -15,7 +15,7 @@ $if scribd or isbn or asin:
             <a href="$amazon" title="Look for this edition for sale at Amazon" target="_blank">Amazon</a>
           </td>
           <td class="price">
-            $if prices:
+            $if prices and not is_bot():
                 $ amazon_metadata = get_amazon_metadata(isbn)
                 $if amazon_metadata and 'price' in amazon_metadata and amazon_metadata['price']:
                     <span name="price">$(amazon_metadata['price'])</span>

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -771,6 +771,16 @@ class backdoor(delegate.page):
             result = delegate.RawText(result)
         return result
 
+def is_bot():
+    user_agent_bots = [
+        'ahrefsbot', 'bingbot', 'bot', 'coccocbot', 'dotbot',
+        'femtosearchbot', '`googlebot', 'mojeekbot', 'musobot',
+        'pinterestbot', 'semrushbot', 'uptimerobot', 'yandexbot',
+        'yandexmobilebot', 'yoozbot'
+    ]
+    user_agent = web.ctx.env['HTTP_USER_AGENT'].lower()
+    return any([bot in user_agent for bot in user_agent_bots])
+
 def setup_template_globals():
     web.template.Template.globals.update({
         "sorted": sorted,
@@ -781,6 +791,7 @@ def setup_template_globals():
         "random": random.Random(),
 
         # bad use of globals
+        "is_bot": is_bot,
         "time": time,
         "input": web.input,
         "dumps": simplejson.dumps,

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -772,6 +772,13 @@ class backdoor(delegate.page):
         return result
 
 def is_bot():
+    """Generated on ol-www1 within /var/log/nginx with:
+
+    cat access.log | grep -oh "; \w*[bB]ot" | sort --unique | awk '{print tolower($2)}'
+    cat access.log | grep -oh "; \w*[sS]pider" | sort --unique | awk '{print tolower($2)}'
+
+    Manually removed singleton `bot` (to avoid overly complex grep regex)
+    """
     user_agent_bots = [
         'sputnikbot', 'dotbot', 'semrushbot',
         'googlebot', 'yandexbot', 'monsidobot', 'kazbtbot',

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -773,10 +773,17 @@ class backdoor(delegate.page):
 
 def is_bot():
     user_agent_bots = [
-        'ahrefsbot', 'bingbot', 'bot', 'coccocbot', 'dotbot',
-        'femtosearchbot', '`googlebot', 'mojeekbot', 'musobot',
-        'pinterestbot', 'semrushbot', 'uptimerobot', 'yandexbot',
-        'yandexmobilebot', 'yoozbot'
+        'sputnikbot', 'dotbot', 'semrushbot',
+        'googlebot', 'yandexbot', 'monsidobot', 'kazbtbot',
+        'seznambot', 'dubbotbot', '360spider', 'redditbot',
+        'yandexmobilebot', 'linkdexbot', 'musobot', 'mojeekbot',
+        'focuseekbot', 'behloolbot', 'startmebot',
+        'yandexaccessibilitybot', 'uptimerobot', 'femtosearchbot',
+        'pinterestbot', 'toutiaospider', 'yoozbot', 'parsijoobot',
+        'equellaurlbot', 'donkeybot', 'paperlibot', 'nsrbot',
+        'discordbot', 'ahrefsbot', '`googlebot', 'coccocbot',
+        'buzzbot', 'laserlikebot', 'baiduspider', 'bingbot',
+        'mj12bot', 'yoozbotadsbot'
     ]
     user_agent = web.ctx.env['HTTP_USER_AGENT'].lower()
     return any([bot in user_agent for bot in user_agent_bots])

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -132,16 +132,21 @@ def cached_get_amazon_metadata(*args, **kwargs):
     """If the cached data is `None`, likely a 503 throttling occurred on
     Amazon's side. Try again to fetch the value instead of using the
     cached value. It may 503 again, in which case the next access of
-    this page will trigger another re-cache. If the book has no price
-    data, then {"price": None} will be cached will will not trigger a
-    re-cache (only the value `None` will)
-
+    this page will trigger another re-cache. If the amazon API call
+    succeeds but the book has no price data, then {"price": None} will
+    be cached as to not trigger a re-cache (only the value `None`
+    will cause re-cache)
     """
+    # fetch/compose a cache controller obj for
+    # "upstream.code._get_amazon_metadata"
     memoized_get_amazon_metadata = cache.memcache_memoize(
         _get_amazon_metadata, "upstream.code._get_amazon_metadata",
         timeout=cache.ONE_WEEK)
+    # fetch cached value from this controller
     result = memoized_get_amazon_metadata(*args, **kwargs)
     if result is None:
+        # recache / update this controller's cached value
+        # (corresponding to these input args)
         result = memoized_get_amazon_metadata.update(*args, **kwargs)[0]
     return result
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -96,7 +96,7 @@ def get_amazon_metadata(isbn):
         if isbn:
             return cached_get_amazon_metadata(isbn)
     except Exception:
-        return {}
+        return None
 
 def _get_amazon_metadata(isbn):
     try:


### PR DESCRIPTION
Amazon API is 503'ing, only allows 1 req / sec (baseline)

This PR:

- increases cache TTL from half day to one week
- re-caches if cached value is `None`
- doesn't generate price info for bot user_agents