### PR TITLE
Solr Docker image

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,18 +1,16 @@
 FROM ubuntu:xenial
 
-# Expose Open Library and SOLR
-EXPOSE 80 7000 8983
+# Expose Open Library and Infobase
+EXPOSE 80 7000
 
 ENV LANG en_US.UTF-8
 
 # required for postgres
 ENV LC_ALL POSIX
 
-WORKDIR /openlibrary
-
 RUN apt-get -qq update && apt-get install -y \
     nginx \
-    solr-tomcat \
+    authbind \
     postgresql \
     build-essential \
     git-core \
@@ -33,5 +31,7 @@ RUN apt-get -qq update && apt-get install -y \
 RUN npm install less -g && ln -s /usr/bin/nodejs /usr/bin/node
 
 COPY . /openlibrary
+WORKDIR /openlibrary
+
 RUN pip install -r test_requirements.txt
 

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -10,6 +10,9 @@ RUN touch /etc/authbind/byport/80 && chmod 777 /etc/authbind/byport/80
 
 WORKDIR /openlibrary
 
+# Set owner to be openlibrary user
+RUN chown -R openlibrary .
+
 # Setup nginx
 RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/sites-available/ \
     && ln -s /etc/nginx/sites-available/openlibrary.conf /etc/nginx/sites-enabled/

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -1,4 +1,4 @@
-FROM olbase 
+FROM olbase
 
 # Using vim to change and test things, may want to remove?
 RUN apt-get install -y vim
@@ -17,21 +17,15 @@ RUN chown -R openlibrary .
 RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/sites-available/ \
     && ln -s /etc/nginx/sites-available/openlibrary.conf /etc/nginx/sites-enabled/
 
-# SOLR
-RUN sed -i 's/8080/8983/g' /etc/tomcat7/server.xml \
-  && cp conf/solr/conf/schema.xml /etc/solr/conf/
-
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
     && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary
 
 # TODO: remove vagrant bootstrap.sh and conf/init services
 
-# Update dev IA s3 endpoints to use container port 80
-# TODO: update openlibrary.yml directly once we have fully deprecated Vagrant
-RUN sed -i 's/127.0.0.1:8080/127.0.0.1/g' conf/openlibrary.yml
-
-# Replace Vagrant User with `openlibrary` in dev db dump
-RUN sed -i 's/vagrant/openlibrary/g' scripts/dev-instance/dev_db.pg_dump
+# TODO: Find safer way to update conf
+RUN sed -i 's/127.0.0.1:8080/127.0.0.1/g' conf/openlibrary.yml # Fix dev IA s3 endpoints
+RUN sed -i 's/localhost:8983/solr:8080/g' conf/openlibrary.yml # Fix Solr endpoint
+RUN sed -i 's/vagrant/openlibrary/g' scripts/dev-instance/dev_db.pg_dump # Replace user in dev db dump
 
 # Setup db
 USER postgres
@@ -51,7 +45,7 @@ USER root
 RUN ln -s vendor/infogami/infogami infogami
 RUN make
 
-# Expose Open Library, Infogami, and SOLR
-EXPOSE 80 7000 8983
+# Expose Open Library and Infobase
+EXPOSE 80 7000
 
 CMD docker/ol-docker-start.sh

--- a/docker/Dockerfile.olsolr
+++ b/docker/Dockerfile.olsolr
@@ -1,0 +1,12 @@
+FROM ubuntu:xenial
+
+RUN apt-get -qq update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y solr-tomcat && \
+    ln -s /var/log/tomcat7/ /usr/share/tomcat7/logs && \
+    ln -s /etc/tomcat7/ /usr/share/tomcat7/conf
+
+COPY conf/solr/conf/schema.xml /etc/solr/conf/
+
+EXPOSE 8080
+
+CMD ["/usr/share/tomcat7/bin/catalina.sh", "run"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,36 +4,41 @@ These current Dockerfiles are designed to be an alternative to the previous Vagr
 The setup process and scripts are designed to *NOT* conflict with exisiting Vagrant provisioning, so you should be able to
 chose to develop using the exisiting Vagrant method, or try the new Docker approach if you prefer, using the same code branch.
 
-## Build images
+## Setup/Teardown Commands
 
-From the root directory run:
-```
-docker build -t olbase:latest -f docker/Dockerfile.olbase .
+All commands are from the docker directory:
 
-docker build -t oldev:latest -f docker/Dockerfile.oldev .
+```bash
+# build images
+docker build -t olbase:latest -f Dockerfile.olbase ..
+docker build -t oldev:latest -f Dockerfile.oldev ..
+docker build -t olsolr:latest -f Dockerfile.olsolr ..
+
+# start the app
+docker-compose up # Ctrl-C to stop
+docker-compose up -d # detached (silent) mode
+
+# stop the app
+docker-compose down
+
+# start specific service
+docker-compose up --no-deps -d solr
+
+# remove all volumes (i.e. reset all databases); perform WHILE RUNNING
+docker-compose stop
+docker-compose rm -v
 ```
-You must build `olbase` first before `oldev`. Currently (August 2018) the division is a bit arbitrary. More should be moved into `olbase` once we clarify
+
+Note: You must build `olbase` first before `oldev`. Currently (August 2018) the division is a bit arbitrary. More should be moved into `olbase` once we clarify
 the production deployment requirements. Currently these docker images are only intented for development environments.
 
-## Run container
+This exposes the following ports:
 
-Interactive, all services:
-
-`docker run -it --rm -p8080:80 -p7000:7000 -p8983:8983 oldev`
-
-Interactive bash (for checking the container):
-
-`docker run -it --rm -p8080:80 -p7000:7000 -p8983:8983 oldev bash`
-
-Background, detached, mode:
-
-`docker run -d -p8080:80 -p7000:7000 -p8983:8983 oldev`
-
-
-The commands above expose the main site on host port 8080:
-http://localhost:8080
-
-Infobase on port 7000, and solr on port 8983.
+Port | Service
+---- | -------
+8080 | Open Library main site
+7000 | Infobase
+8983 | Solr
 
 To access Solr admin:
 http://localhost:8983/solr/admin/
@@ -42,9 +47,22 @@ If you are using Docker Toolbox on Windows, use the Docker Machine IP instead of
 
 You can customise the host ports by modifying the `-p` publish mapping in the `docker run` command to suit your development environment.
 
-**TODO:** 
+## Useful Runtime Commands
+
+See the docs for more: https://docs.docker.com/compose/reference/overview
+
+```bash
+# Read a service's logs (replace `web` with service name)
+docker-compose logs web # Show all logs (onetime)
+docker-compose logs -f --tail=10 web # Show last 10 lines and follow
+
+# Analyze a container
+docker-compose exec web bash # Launch terminal in `web` service
+```
+
+## TODO
 * Add dev volume mount to `run` command, and provide instructions for refreshing the application.
 * Fix symlinks that are causing a problem in Windows, see issue https://github.com/internetarchive/openlibrary/issues/1051 
-## Run tests in a temporary container
 
-`docker run -it --rm oldev make test`
+## Run tests in a temporary container
+`docker-compose run --rm web make test`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  web:
+    image: oldev
+    ports:
+      - "8080:80"
+      - "7000:7000"
+    networks:
+      - webnet
+  solr:
+    image: olsolr
+    ports:
+      - "8983:8080"
+    volumes:
+      - "solr-data:/var/lib/solr/data"
+    networks:
+      - webnet
+networks:
+  webnet:
+volumes:
+  solr-data:

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -12,9 +12,6 @@ echo "Starting ol services."
 # postgres
 su postgres -c "/etc/init.d/postgresql start"
 
-# solr Reports FAIL (port already in use) even though it starts solr
-service tomcat7 start
-
 # memcached
 service memcached start
 
@@ -28,7 +25,7 @@ su openlibrary -c "until pg_isready; do sleep 5; done && make reindex-solr" &
 su openlibrary -c "python scripts/new-solr-updater.py \
   -c conf/openlibrary.yml \
   --state-file solr-update.offset \
-  --ol-url http://localhost/" &
+  --ol-url http://web/" &
 
 # ol server, running in the foreground to avoid exiting container
 su openlibrary -c "authbind --deep scripts/openlibrary-server conf/openlibrary.yml --gunicorn -w4 -t180 -b:80"


### PR DESCRIPTION
Added a solr image for docker. I had to update the openlibrary.yml file to make it point to the correct endpoint though, so this can't be merged yet without breaking vagrant. Any ideas on what the best way to handle those differences might be? I'm thinking creating a copy might be easiest, since that file is used in a lot of places.