### PR TITLE
dockerignore .pyc files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ errors
 infogami
 config
 build
+**.pyc
+**__pycache__


### PR DESCRIPTION
Small improvement to help when volume mounting local dev dir into a running container, to ignore the resulting .pyc and pycache dirs.
