### PR TITLE
Retain list-style-none rule

### DIFF
--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -60,8 +60,11 @@ table#editions {
     background-color: none !important;
   }
 
-  .links ul {
-    list-style-type: none;
+  .links {
+    li,
+    ul {
+      list-style-type: none;
+    }
   }
 }
 


### PR DESCRIPTION
Follow up to 81252b7
When porting to the editions component this one CSS rule was missed.

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
