### PR TITLE
Limit the maximum size of all.css to 152.4kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,20 @@
   "repository": "github:internetarchive:openlibrary",
   "license": "AGPL-3.0",
   "scripts": {
+    "build-all-css": "lessc -x static/css/all.less static/build/all.css",
+    "check-css-size": "npm run build-all-css && bundlesize",
     "lint:fix": "stylelint --syntax less --fix static/css/",
-    "test": "stylelint  --syntax less static/css/"
+    "test": "npm run check-css-size && stylelint  --syntax less static/css/"
   },
+  "bundlesize": [
+    {
+      "path": "static/build/all.css",
+      "maxSize": "26.86KB"
+    }
+  ],
   "devDependencies": {
+    "bundlesize": "^0.17.0",
+    "less": "^3.8.1",
     "stylelint": "^9.5.0"
   }
 }


### PR DESCRIPTION
Adding a little script to run on `npm test` that
will make sure our CSS file doesn't grow in size.

If a commit is added that makes the CSS asset 'all.css' grow
in size, that commit will be rejected.

Fixes: #1124

