### PR TITLE
Docker-compose dev environment

### DIFF
--- a/conf/openlibrary-docker.yml
+++ b/conf/openlibrary-docker.yml
@@ -1,4 +1,4 @@
-# Open Library fastcgi configuration
+# Open Library Docker (dev) configuration
 
 connection_type: hybrid
 
@@ -32,7 +32,6 @@ support_default_assignees:
   developer/api/covers_question/bug_report: "noufal+bugs@gmail.com"
   default: "noufal+default@gmail.com"
 
-
 smtp_server: localhost
 
 dummy_sendmail: True
@@ -58,9 +57,6 @@ coverstore_config_file: coverstore.yml
 
 loanstatus_url: http://localhost/
 ia_access_secret: foobar
-
-#dev_instance: True
-dev_instance_url: http://127.0.0.1:8080/
 
 memcache_servers:
     - localhost:11211
@@ -125,11 +121,9 @@ lists:
     editions_view: http://127.0.0.1:5984/editions/_fti/_design/seeds/by_seed
 
 admin:
-    olsystem_root: /home/noufal/projects/OL/olsystem/
     nagios_url: http://monitor.us.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=24.openlibrary&style=detail
     statsd_server: localhost:9090
     admin_db: http://127.0.0.1:5984/admin
-
 
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
@@ -176,10 +170,8 @@ stats: # This section is used to state what stats need to be gathered.
       pattern: /api/volumes/.*
       time: total
 
-
 libraries_admin_email: admin@dev-instance
 
-graphite_base_url: http://ol-admin.us.archive.org:7080
 geoip_database: var/cache/GeoLiteCity.dat
 
 # prefixes ignored for /books/ia:xxx URLs and new-solr-updater.py

--- a/conf/openlibrary-docker.yml
+++ b/conf/openlibrary-docker.yml
@@ -1,0 +1,208 @@
+# Open Library fastcgi configuration
+
+connection_type: hybrid
+
+site: openlibrary.org
+
+from_address: "Open Library <noreply@openlibrary.org>"
+report_spam_address: "Open Library <info@openlibrary.org>"
+
+support_case_notification_address: "Open Library <info@openlibrary.org>"
+support_case_control_address : "support@openlibrary.org"
+
+# Legal values for support_default_assignees are
+#
+# bug_report
+# borrowing_books
+# buying_books
+# contact_an_author
+# deletion_request
+# developer/api/covers_question
+# editing_problem
+# image_upload
+# login_trouble
+# spam_report
+# other
+#
+# and
+#
+# default (in case there is no special email address for the given category)
+
+support_default_assignees:
+  developer/api/covers_question/bug_report: "noufal+bugs@gmail.com"
+  default: "noufal+default@gmail.com"
+
+
+smtp_server: localhost
+
+dummy_sendmail: True
+debug: True
+
+coverstore_url: http://0.0.0.0/covers/
+
+state_dir: var/run
+
+# enable http compression
+use_gzip: True
+
+admin_password: admin123
+errorlog: /var/log/openlibrary/ol-errors
+login_cookie_name: session
+
+infobase_server: localhost:7000
+
+# contents of this file are assigned to config["infobase"]
+# Path can be relative to this file
+infobase_config_file: infobase.yml
+coverstore_config_file: coverstore.yml
+
+loanstatus_url: http://localhost/
+ia_access_secret: foobar
+
+#dev_instance: True
+dev_instance_url: http://127.0.0.1:8080/
+
+memcache_servers:
+    - localhost:11211
+
+plugin_modules:
+    - openlibrary
+    - infogami.plugins.links
+    - infogami.plugins.api
+
+plugin_worksearch:
+    solr: solr:8080
+    spellcheck_count: 3
+    ebook_count_db_parameters:
+        db: openlibrary_ebook_count
+        host: localhost
+
+ia_ol_xauth_s3:
+    s3_key: XXX
+    s3_secret: XXX
+
+ia_loan_api_url: http://127.0.0.1/internal/fake/loans
+ia_availability_api_url: http://127.0.0.1/internal/fake/availability
+ia_xauth_api_url: http://127.0.0.1/internal/fake/xauth
+http_request_timeout: 10
+
+stats_solr: solr:8080
+
+features:
+    upstream: enabled
+    cache_most_recent: enabled
+    recentchanges_v2: enabled
+    history_v2: admin
+    merge-authors:
+        filter: usergroup
+        usergroup: /usergroup/librarians
+    merge-editions: admin
+    undo: enabled
+    dev: enabled
+    lists: enabled
+    lending_v2: enabled
+    stats: enabled
+    stats-header: enabled
+    inlibrary: enabled
+    support: admin
+    dev: enabled
+    superfast: enabled
+    publishers: enabled
+    languages: enabled
+
+upstream_to_www_migration: true
+default_template_root: /upstream
+css_root: /upstream/css
+js_root: /upstream/js
+use_google_cdn: false
+logging_config_file: conf/logging.ini
+email_config_file: conf/email.ini
+
+lists:
+    seeds_db: http://127.0.0.1:5984/seeds
+    editions_db: http://127.0.0.1:5984/editions
+    works_db: http://127.0.0.1:5984/works
+    editions_view: http://127.0.0.1:5984/editions/_fti/_design/seeds/by_seed
+
+admin:
+    olsystem_root: /home/noufal/projects/OL/olsystem/
+    nagios_url: http://monitor.us.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=24.openlibrary&style=detail
+    statsd_server: localhost:9090
+    admin_db: http://127.0.0.1:5984/admin
+
+
+stats: # This section is used to state what stats need to be gathered.
+    pageload.all:
+      filter: all
+      time: total
+
+    pageload.books:
+      filter: url
+      pattern: /books/OL\d+M
+      time: total
+
+    pageload.works:
+      filter: url
+      pattern: /works/OL\d+M
+      time: total
+
+    pageload.authors:
+      filter: url
+      pattern: /authors/OL\d+M
+      time: total
+
+    pageload.author:
+      filter: url
+      pattern: /authors/OL\d+M
+      time: total
+
+    pageload.home:
+      filter: url
+      pattern: ^/$
+      time: total
+
+    pageload.recentchanges:
+      filter: url
+      pattern: /recentchanges
+      time: total
+
+    pageload.lists:
+      filter: url
+      pattern: /lists
+      time: total
+
+    ol.pageload.readapi:
+      filter: url
+      pattern: /api/volumes/.*
+      time: total
+
+
+libraries_admin_email: admin@dev-instance
+
+graphite_base_url: http://ol-admin.us.archive.org:7080
+geoip_database: var/cache/GeoLiteCity.dat
+
+# prefixes ignored for /books/ia:xxx URLs and new-solr-updater.py
+ia_ignore_prefixes:
+    - "jstor-"
+    - "imslp-"
+    - "nasa_techdoc_"
+    - "gov.uscourts."
+
+plugin_recaptcha:
+    public_key: ''
+    private_key: ''
+
+plugin_inside:
+    search_endpoint: https://be-api.us.archive.org/fts/v1/search
+
+affiliate_ids:
+    # Amazon is a book source, not just an affiliate, so we make its affiliate
+    # tag generally available
+    amazon: internetarchi-20
+
+internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
+ia_availability_api_url: https://archive.org/services/loans/beta/loan/index.php # to be deprecated in favor of _v1 below
+ia_availability_api_v1_url: https://archive.org/services/loans/beta/loan/index.php
+ia_availability_api_v2_url: https://archive.org/services/availability/
+ia_base_url: https://archive.org

--- a/conf/openlibrary-docker.yml
+++ b/conf/openlibrary-docker.yml
@@ -8,7 +8,7 @@ from_address: "Open Library <noreply@openlibrary.org>"
 report_spam_address: "Open Library <info@openlibrary.org>"
 
 support_case_notification_address: "Open Library <info@openlibrary.org>"
-support_case_control_address : "support@openlibrary.org"
+support_case_control_address: "support@openlibrary.org"
 
 smtp_server: localhost
 
@@ -51,13 +51,6 @@ plugin_worksearch:
         db: openlibrary_ebook_count
         host: localhost
 
-ia_ol_xauth_s3:
-    s3_key: XXX
-    s3_secret: XXX
-
-ia_loan_api_url: http://127.0.0.1/internal/fake/loans
-ia_availability_api_url: http://127.0.0.1/internal/fake/availability
-ia_xauth_api_url: http://127.0.0.1/internal/fake/xauth
 http_request_timeout: 10
 
 stats_solr: solr:8080
@@ -148,10 +141,6 @@ stats: # This section is used to state what stats need to be gathered.
       pattern: /api/volumes/.*
       time: total
 
-libraries_admin_email: admin@dev-instance
-
-geoip_database: var/cache/GeoLiteCity.dat
-
 # prefixes ignored for /books/ia:xxx URLs and new-solr-updater.py
 ia_ignore_prefixes:
     - "jstor-"
@@ -170,6 +159,14 @@ affiliate_ids:
     # Amazon is a book source, not just an affiliate, so we make its affiliate
     # tag generally available
     amazon: internetarchi-20
+
+ia_ol_xauth_s3:
+    s3_key: XXX
+    s3_secret: XXX
+
+ia_loan_api_url: http://127.0.0.1/internal/fake/loans
+ia_availability_api_url: http://127.0.0.1/internal/fake/availability
+ia_xauth_api_url: http://127.0.0.1/internal/fake/xauth
 
 internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_url: https://archive.org/services/loans/beta/loan/index.php # to be deprecated in favor of _v1 below

--- a/conf/openlibrary-docker.yml
+++ b/conf/openlibrary-docker.yml
@@ -10,28 +10,6 @@ report_spam_address: "Open Library <info@openlibrary.org>"
 support_case_notification_address: "Open Library <info@openlibrary.org>"
 support_case_control_address : "support@openlibrary.org"
 
-# Legal values for support_default_assignees are
-#
-# bug_report
-# borrowing_books
-# buying_books
-# contact_an_author
-# deletion_request
-# developer/api/covers_question
-# editing_problem
-# image_upload
-# login_trouble
-# spam_report
-# other
-#
-# and
-#
-# default (in case there is no special email address for the given category)
-
-support_default_assignees:
-  developer/api/covers_question/bug_report: "noufal+bugs@gmail.com"
-  default: "noufal+default@gmail.com"
-
 smtp_server: localhost
 
 dummy_sendmail: True

--- a/conf/openlibrary-docker.yml
+++ b/conf/openlibrary-docker.yml
@@ -165,11 +165,9 @@ ia_ol_xauth_s3:
     s3_secret: XXX
 
 ia_loan_api_url: http://127.0.0.1/internal/fake/loans
-ia_availability_api_url: http://127.0.0.1/internal/fake/availability
 ia_xauth_api_url: http://127.0.0.1/internal/fake/xauth
 
 internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
-ia_availability_api_url: https://archive.org/services/loans/beta/loan/index.php # to be deprecated in favor of _v1 below
 ia_availability_api_v1_url: https://archive.org/services/loans/beta/loan/index.php
 ia_availability_api_v2_url: https://archive.org/services/availability/
 ia_base_url: https://archive.org

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -1,55 +1,32 @@
-# Open Library fastcgi configuration
+# Open Library Docker (dev) configuration
 
-connection_type: "hybrid"
+connection_type: hybrid
 
-site: "openlibrary.org"
+site: openlibrary.org
 
 from_address: "Open Library <noreply@openlibrary.org>"
 report_spam_address: "Open Library <info@openlibrary.org>"
 
 support_case_notification_address: "Open Library <info@openlibrary.org>"
-support_case_control_address : "support@openlibrary.org"
+support_case_control_address: "support@openlibrary.org"
 
-# Legal values for support_default_assignees are
-#
-# bug_report
-# borrowing_books
-# buying_books
-# contact_an_author
-# deletion_request
-# developer/api/covers_question
-# editing_problem
-# image_upload
-# login_trouble
-# spam_report
-# other
-#
-# and
-#
-# default (in case there is no special email address for the given category)
-
-support_default_assignees:
-  developer/api/covers_question/bug_report: "noufal+bugs@gmail.com"
-  default: "noufal+default@gmail.com"
-
-
-smtp_server: "localhost"
+smtp_server: localhost
 
 dummy_sendmail: True
 debug: True
 
-coverstore_url: "http://0.0.0.0:8080/covers/"
+coverstore_url: http://0.0.0.0:8080/covers/
 
 state_dir: var/run
 
 # enable http compression
 use_gzip: True
 
-admin_password: "admin123"
-errorlog: "/var/log/openlibrary/ol-errors"
+admin_password: admin123
+errorlog: /var/log/openlibrary/ol-errors
 login_cookie_name: session
 
-infobase_server: "localhost:7000"
+infobase_server: localhost:7000
 
 # contents of this file are assigned to config["infobase"]
 # Path can be relative to this file
@@ -59,11 +36,8 @@ coverstore_config_file: coverstore.yml
 loanstatus_url: http://localhost/
 ia_access_secret: foobar
 
-#dev_instance: True
-dev_instance_url: http://127.0.0.1:8080/
-
 memcache_servers:
-    - "localhost:11211"
+    - localhost:11211
 
 plugin_modules:
     - openlibrary
@@ -71,22 +45,15 @@ plugin_modules:
     - infogami.plugins.api
 
 plugin_worksearch:
-    solr: "localhost:8983"
+    solr: localhost:8983
     spellcheck_count: 3
     ebook_count_db_parameters:
-        db: 'openlibrary_ebook_count'
-        host: 'localhost'
+        db: openlibrary_ebook_count
+        host: localhost
 
-ia_ol_xauth_s3:
-    s3_key: XXX
-    s3_secret: XXX
-
-ia_loan_api_url: http://127.0.0.1:8080/internal/fake/loans
-ia_availability_api_url: http://127.0.0.1:8080/internal/fake/availability
-ia_xauth_api_url: http://127.0.0.1:8080/internal/fake/xauth
 http_request_timeout: 10
 
-stats_solr: "localhost:8983"
+stats_solr: localhost:8983
 
 features:
     upstream: enabled
@@ -125,11 +92,9 @@ lists:
     editions_view: http://127.0.0.1:5984/editions/_fti/_design/seeds/by_seed
 
 admin:
-    olsystem_root: /home/noufal/projects/OL/olsystem/
     nagios_url: http://monitor.us.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=24.openlibrary&style=detail
     statsd_server: localhost:9090
     admin_db: http://127.0.0.1:5984/admin
-
 
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
@@ -176,12 +141,6 @@ stats: # This section is used to state what stats need to be gathered.
       pattern: /api/volumes/.*
       time: total
 
-
-libraries_admin_email: admin@dev-instance
-
-graphite_base_url: "http://ol-admin.us.archive.org:7080"
-geoip_database: var/cache/GeoLiteCity.dat
-
 # prefixes ignored for /books/ia:xxx URLs and new-solr-updater.py
 ia_ignore_prefixes:
     - "jstor-"
@@ -190,19 +149,25 @@ ia_ignore_prefixes:
     - "gov.uscourts."
 
 plugin_recaptcha:
-    public_key: ""
-    private_key: ""
+    public_key: ''
+    private_key: ''
 
 plugin_inside:
-    search_endpoint: "https://be-api.us.archive.org/fts/v1/search"
+    search_endpoint: https://be-api.us.archive.org/fts/v1/search
 
 affiliate_ids:
     # Amazon is a book source, not just an affiliate, so we make its affiliate
     # tag generally available
     amazon: internetarchi-20
 
-internal_tests_api_key: '8oPd1tx747YH374ohs48ZO5s2Nt1r9yD'
-ia_availability_api_url: 'https://archive.org/services/loans/beta/loan/index.php' # to be deprecated in favor of _v1 below
-ia_availability_api_v1_url: 'https://archive.org/services/loans/beta/loan/index.php'
-ia_availability_api_v2_url: 'https://archive.org/services/availability/'
-ia_base_url: 'https://archive.org'
+ia_ol_xauth_s3:
+    s3_key: XXX
+    s3_secret: XXX
+
+ia_loan_api_url: http://127.0.0.1:8080/internal/fake/loans
+ia_xauth_api_url: http://127.0.0.1:8080/internal/fake/xauth
+
+internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
+ia_availability_api_v1_url: https://archive.org/services/loans/beta/loan/index.php
+ia_availability_api_v2_url: https://archive.org/services/availability/
+ia_base_url: https://archive.org

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -52,4 +52,5 @@ RUN make
 
 # Expose Open Library and Infobase
 EXPOSE 80 7000
-CMD authbind --deep scripts/openlibrary-server conf/openlibrary-docker.yml --gunicorn -w4 -t180 -b:80
+CMD authbind --deep scripts/openlibrary-server conf/openlibrary-docker.yml \
+    --gunicorn --workers 4 --timeout 180 --bind :80

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,12 +1,12 @@
 FROM ubuntu:xenial
 
-# Expose Open Library and Infobase
-EXPOSE 80 7000
-
 ENV LANG en_US.UTF-8
 
 # required for postgres
 ENV LC_ALL POSIX
+
+# add openlibrary user
+RUN groupadd -r openlibrary && useradd --no-log-init -r -g openlibrary openlibrary
 
 RUN apt-get -qq update && apt-get install -y \
     nginx \
@@ -30,8 +30,26 @@ RUN apt-get -qq update && apt-get install -y \
 
 RUN npm install less -g && ln -s /usr/bin/nodejs /usr/bin/node
 
-COPY . /openlibrary
+# enable users to bind to port 80
+RUN touch /etc/authbind/byport/80 && chmod 777 /etc/authbind/byport/80
+
+# Setup nginx
+RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/sites-available/ \
+    && ln -s /etc/nginx/sites-available/openlibrary.conf /etc/nginx/sites-enabled/
+
+RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
+    && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary
+
+COPY --chown=openlibrary:openlibrary . /openlibrary
 WORKDIR /openlibrary
 
-RUN pip install -r test_requirements.txt
+RUN pip install -r requirements_common.txt
 
+USER openlibrary
+RUN ln -s vendor/infogami/infogami infogami
+# run make to initialize git submodules, build css and js files
+RUN make
+
+# Expose Open Library and Infobase
+EXPOSE 80 7000
+CMD authbind --deep scripts/openlibrary-server conf/openlibrary.yml --gunicorn -w4 -t180 -b:80

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -52,4 +52,4 @@ RUN make
 
 # Expose Open Library and Infobase
 EXPOSE 80 7000
-CMD authbind --deep scripts/openlibrary-server conf/openlibrary.yml --gunicorn -w4 -t180 -b:80
+CMD authbind --deep scripts/openlibrary-server conf/openlibrary-docker.yml --gunicorn -w4 -t180 -b:80

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -1,28 +1,9 @@
 FROM olbase
 
-# Using vim to change and test things, may want to remove?
-RUN apt-get install -y vim
-
-RUN groupadd -r openlibrary && useradd --no-log-init -r -g openlibrary openlibrary
-
-# enable users to bind to port 80
-RUN touch /etc/authbind/byport/80 && chmod 777 /etc/authbind/byport/80
-
 WORKDIR /openlibrary
 
-# Set owner to be openlibrary user
-RUN chown -R openlibrary .
-
-# Setup nginx
-RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/sites-available/ \
-    && ln -s /etc/nginx/sites-available/openlibrary.conf /etc/nginx/sites-enabled/
-
-RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
-    && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary
-
-# TODO: remove vagrant bootstrap.sh and conf/init services
-
 # TODO: Find safer way to update conf
+USER openlibrary
 RUN sed -i 's/127.0.0.1:8080/127.0.0.1/g' conf/openlibrary.yml # Fix dev IA s3 endpoints
 RUN sed -i 's/localhost:8983/solr:8080/g' conf/openlibrary.yml # Fix Solr endpoint
 RUN sed -i 's/vagrant/openlibrary/g' scripts/dev-instance/dev_db.pg_dump # Replace user in dev db dump
@@ -39,13 +20,10 @@ RUN /etc/init.d/postgresql start \
   && pg_ctlcluster 9.5 main stop
 
 USER root
-
-# run make to initialize git submodules, build css and js files
-# only root has access to .git
-RUN ln -s vendor/infogami/infogami infogami
-RUN make
+RUN pip install -r test_requirements.txt
 
 # Expose Open Library and Infobase
 EXPOSE 80 7000
 
+# runs as root in order to access su to run as openlibrary and postgres users
 CMD docker/ol-docker-start.sh

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -2,13 +2,11 @@ FROM olbase
 
 WORKDIR /openlibrary
 
-# TODO: Find safer way to update conf
 USER openlibrary
-RUN sed -i 's/127.0.0.1:8080/127.0.0.1/g' conf/openlibrary.yml # Fix dev IA s3 endpoints
-RUN sed -i 's/localhost:8983/solr:8080/g' conf/openlibrary.yml # Fix Solr endpoint
-RUN sed -i 's/vagrant/openlibrary/g' scripts/dev-instance/dev_db.pg_dump # Replace user in dev db dump
 
 # Setup db
+# Replace user in dev db dump
+RUN sed -i 's/vagrant/openlibrary/g' scripts/dev-instance/dev_db.pg_dump
 USER postgres
 RUN /etc/init.d/postgresql start \
   && createuser -s openlibrary \

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,7 +33,7 @@ docker-compose stop
 docker-compose rm -v
 ```
 
-Note: You must build `olbase` first before `oldev`. `olbase` is intended to be the core Open Library image, acting as a base for production and development. `oldev` adds a test databse and any other tools that are helpful for local development. Currently (Sep 2018) these docker images are only intented for development environments.
+Note: You must build `olbase` first before `oldev`. `olbase` is intended to be the core Open Library image, acting as a base for production and development. `oldev` adds a pre-populated development database and any other tools that are helpful for local development. Currently (Sep 2018) these docker images are only intented for development environments.
 
 This exposes the following ports:
 
@@ -50,6 +50,14 @@ If you are using Docker Toolbox on Windows, use the Docker Machine IP instead of
 
 You can customise the host ports by modifying the `-p` publish mapping in the `docker run` command to suit your development environment.
 
+## Code Updates
+
+While running the `oldev` container, gunicorn is configured to auto-reload modified files. To see the effects of your changes in the running container, the following apply:
+
+* Editing python files or web templates => simply save the file, gunicorn will auto-reload it.
+* Working on frontend css or js => you must run `docker-compose exec web make css js`. This will re-generate the assets in the persistent `ol-build` volume mount, so the latest changes will be available between stopping / starting and removing `web` containers. Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
+* Adding or changing core dependencies => you will most likely need to rebuild both `olbase` and `oldev` images. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;)
+
 ## Useful Runtime Commands
 
 See the docs for more: https://docs.docker.com/compose/reference/overview
@@ -61,10 +69,17 @@ docker-compose logs -f --tail=10 web # Show last 10 lines and follow
 
 # Analyze a container
 docker-compose exec web bash # Launch terminal in `web` service
+
+# Run tests while container is running
+docker-compose exec web make test
+```
+
+## Other Commands
+```bash
+# Run tests in a temporary container
+docker-compose run --rm web make test
 ```
 
 ## TODO
 * Fix symlinks that are causing a problem in Windows, see issue https://github.com/internetarchive/openlibrary/issues/1051 
 
-## Run tests in a temporary container
-`docker-compose run --rm web make test`

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,8 +33,7 @@ docker-compose stop
 docker-compose rm -v
 ```
 
-Note: You must build `olbase` first before `oldev`. Currently (August 2018) the division is a bit arbitrary. More should be moved into `olbase` once we clarify
-the production deployment requirements. Currently these docker images are only intented for development environments.
+Note: You must build `olbase` first before `oldev`. `olbase` is intended to be the core Open Library image, acting as a base for production and development. `oldev` adds a test databse and any other tools that are helpful for local development. Currently (Sep 2018) these docker images are only intented for development environments.
 
 This exposes the following ports:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -64,7 +64,6 @@ docker-compose exec web bash # Launch terminal in `web` service
 ```
 
 ## TODO
-* Add dev volume mount to `run` command, and provide instructions for refreshing the application.
 * Fix symlinks that are causing a problem in Windows, see issue https://github.com/internetarchive/openlibrary/issues/1051 
 
 ## Run tests in a temporary container

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,19 +3,25 @@ services:
   web:
     image: oldev
     ports:
-      - "8080:80"
-      - "7000:7000"
+      - 8080:80
+      - 7000:7000
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - ol-build:/openlibrary/static/build
+      - ..:/openlibrary
     networks:
       - webnet
   solr:
     image: olsolr
     ports:
-      - "8983:8080"
+      - 8983:8080
     volumes:
-      - "solr-data:/var/lib/solr/data"
+      - solr-data:/var/lib/solr/data
     networks:
       - webnet
 networks:
   webnet:
 volumes:
   solr-data:
+  ol-vendor:
+  ol-build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,12 @@ services:
       - 8080:80
       - 7000:7000
     volumes:
+      # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
+      # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
+      # The above volume mounts are required so that the local dev bind mount below
+      # does not clobber the data generated inside the image / container
       - ..:/openlibrary
     networks:
       - webnet

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -40,5 +40,6 @@ su openlibrary -c "python scripts/new-solr-updater.py \
   --ol-url http://web/" &
 
 # ol server, running in the foreground to avoid exiting container
-su openlibrary -c "authbind --deep scripts/openlibrary-server $CONFIG --gunicorn --reload -w4 -t180 -b:80"
+su openlibrary -c "authbind --deep scripts/openlibrary-server $CONFIG \
+                     --gunicorn --reload --workers 4 --timeout 180 --bind :80"
 

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -28,5 +28,5 @@ su openlibrary -c "python scripts/new-solr-updater.py \
   --ol-url http://web/" &
 
 # ol server, running in the foreground to avoid exiting container
-su openlibrary -c "authbind --deep scripts/openlibrary-server conf/openlibrary.yml --gunicorn -w4 -t180 -b:80"
+su openlibrary -c "authbind --deep scripts/openlibrary-server conf/openlibrary-docker.yml --gunicorn -w4 -t180 -b:80"
 

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -40,5 +40,5 @@ su openlibrary -c "python scripts/new-solr-updater.py \
   --ol-url http://web/" &
 
 # ol server, running in the foreground to avoid exiting container
-su openlibrary -c "authbind --deep scripts/openlibrary-server $CONFIG --gunicorn -w4 -t180 -b:80"
+su openlibrary -c "authbind --deep scripts/openlibrary-server $CONFIG --gunicorn --reload -w4 -t180 -b:80"
 


### PR DESCRIPTION
Closes #1063 
makes some changes related to ;) #1064 

and hopefully #1065

## Description:
* Clarifies the split between `olbase` and `oldev` 
    * `olbase` is a single application standard image that will run OL as the `openlibrary` user, needs to be deployed sensibly to be useful
    * `oldev` has whatever else we need to operate our dev environment, i.e. pre-populated dev db, other services and tools. `oldev` may, and _should_, be reduced over time as we split out services.

* Volume mounts local dev directory and creates docker compose volumes to retain the js + css that was created at build time, and the `vendor` dir that is used to fetch git submodules, which is also populated on build.

* Uses a new `openlibray-docker.yml` config file to not interfere with vagrant, and avoids using `sed` to fix things. I'd suggested we rename this back to `openlibrary.yml` when we fully remove all traces of vagrant.

* Adds the gunicorn `--reload` option in dev so code changes are automatically detected and reloaded :tada: 

## Usage
With the volume mount in place and the gunicorn  `--reload` option a developer can edit code locally and the webserver will automatically reload the code on save.

The instructions in docker/README.md are :ok_hand: 





