### PR TITLE
fix account header errors on dev

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -741,4 +741,4 @@ def audit_accounts(email, password, require_link=False,
 @public
 def get_internet_archive_id(key):
     username = key.split('/')[-1]
-    return OpenLibraryAccount.get(username=username).internetarchive_itemname
+    return OpenLibraryAccount.get(username=username).itemname


### PR DESCRIPTION
This is a small fix for an issue I was seeing in dev environments caused by stale cookies where the site thought a user was logged in but couldn't find an internetarchive itemname. All the account header info and login/logout buttons would fail to load.

Opening the site in an incognito window was a workaround.

This PR uses the pre-existing `itemname()` method to get the itemname or return `None` without errors.

I was actually testing #1133 and needed a small issue to debug and fix to see how editing and reloading code would work. This was an obvious error in dev.