### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,10 @@ addons:
     packages:
       - libgeoip-dev
       - python-lxml
-      - python-psycopg2
       - python-yaml
-  postgresql: "9.3"
 python:
     - "2.7"
 install:
   - pip install -r test_requirements.txt
   - npm install
-before_script:
-  - psql -c 'create database oltest' -U postgres
-  - PYTHONPATH=. python openlibrary/core/schema.py | psql -U postgres oltest
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ addons:
   postgresql: "9.3"
 python:
     - "2.7"
-install: pip install -r test_requirements.txt
+install:
+  - pip install -r test_requirements.txt
+  - npm install
 before_script:
   - psql -c 'create database oltest' -U postgres
   - PYTHONPATH=. python openlibrary/core/schema.py | psql -U postgres oltest

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,1 @@
-All source code published here is available under the terms of the GNU Affero General Public License, version 3. Please see http://gplv3.fsf.org/ for more information.
+All source code published here is available under the terms of the GNU Affero General Public License, version 3. Please see https://www.gnu.org/licenses/agpl-3.0.html for more information.

--- a/Makefile
+++ b/Makefile
@@ -90,5 +90,5 @@ reindex-solr:
 	psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy
 
 test:
-	npm install && npm test
+	npm test
 	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "openlibrary",
   "version": "1.0.0",
+  "repository": "github:internetarchive:openlibrary",
+  "license": "AGPL-3.0",
   "scripts": {
     "lint:fix": "stylelint --syntax less --fix static/css/",
     "test": "stylelint  --syntax less static/css/"


### PR DESCRIPTION
Addresses my comment on https://github.com/internetarchive/openlibrary/pull/1127 about moving the install step to `travis.yml`, happy to keep the test run in the Makefile. I wanted to check it'd work, and this PR is the result :) @jdlrobson 

While testing that this approach, I noticed the travis postgres setup which is no longer required now that the python tests have been streamlined, so I have removed the extra setup.

Includes:
* `npm install` moved to `travis.yml` so Makefile `test` just runs tests
* Remove unused travis postgres setup
* add repo and license fields to `packages.json` to prevent warnings
* update AGPL3.0 license url to latest official https url

I can't get `stylelint` to run inside a docker container yet, but that's a separate problem, it may be because Travis provides a newer version of `node` (v4.8.6 or later?) than our Xenial base docker image (node v4.2.6)