### PR TITLE
refactoring stats, making admin/stats public

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -1,4 +1,7 @@
+from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
+
 from . import db
+
 
 class Bookshelves(object):
 
@@ -7,6 +10,21 @@ class Bookshelves(object):
         'Currently Reading': 2,
         'Already Read': 3
     }
+
+    @classmethod
+    def summary(cls):
+        return {
+            'total_books_logged': {
+                'total': Bookshelves.total_books_logged(),
+                'month': Bookshelves.total_books_logged(since=DATE_ONE_MONTH_AGO),
+                'week': Bookshelves.total_books_logged(since=DATE_ONE_WEEK_AGO)
+            },
+            'total_users_logged': {
+                'total': Bookshelves.total_unique_users(),
+                'month': Bookshelves.total_unique_users(since=DATE_ONE_MONTH_AGO),
+                'week': Bookshelves.total_unique_users(since=DATE_ONE_WEEK_AGO)
+            }
+        }
 
     @classmethod
     def total_books_logged(cls, shelf_ids=None, since=None):
@@ -56,9 +74,10 @@ class Bookshelves(object):
         for "Want to Read").
         """
         oldb = db.get_db()
-        query = 'select work_id, count(*) as cnt from bookshelves_books where bookshelf_id=$shelf_id group by work_id order by cnt desc limit $limit'
+        query = 'select work_id, count(*) as cnt from bookshelves_books WHERE bookshelf_id=$shelf_id '
         if since:
-            query += " WHERE created >= $since"
+            query += " AND created >= $since"
+        query += ' group by work_id order by cnt desc limit $limit'
         return list(oldb.query(query, vars={'shelf_id': shelf_id, 'limit': limit, 'since': since}))
 
     @classmethod

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -14,6 +14,7 @@ from infogami import config
 from infogami.utils import stats
 
 from openlibrary.utils import olmemcache
+from openlibrary.utils.dateutil import MINUTE_SECS
 
 __all__ = [
     "cached_property",
@@ -21,11 +22,7 @@ __all__ = [
     "memoize", "memcache_memoize"
 ]
 
-DEFAULT_CACHE_LIFETIME = 120  # seconds
-HOUR = 60 * 60
-DAY = HOUR * 24
-HALF_DAY = HOUR * 12
-ONE_WEEK = DAY * 7
+DEFAULT_CACHE_LIFETIME = 2 * MINUTE_SECS
 
 
 class memcache_memoize:
@@ -43,7 +40,7 @@ class memcache_memoize:
     :param servers: list of  memcached servers, each specified as "ip:port"
     :param timeout: timeout in seconds after which the return value must be updated
     """
-    def __init__(self, f, key_prefix=None, timeout=60):
+    def __init__(self, f, key_prefix=None, timeout=MINUTE_SECS):
         """Creates a new memoized function for ``f``.
         """
         self.f = f

--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -53,8 +53,3 @@ def increment(key, n=1):
 
 
 client = create_stats_client()
-
-
-
-
-

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -13,6 +13,7 @@ from infogami import config
 from openlibrary import accounts
 from openlibrary.core import admin, cache, ia, inlibrary, lending, \
     helpers as h
+from openlibrary.utils import dateutil
 from openlibrary.plugins.upstream import borrow
 from openlibrary.plugins.upstream.utils import get_blog_feeds
 from openlibrary.plugins.worksearch import search, subjects
@@ -88,8 +89,7 @@ def get_featured_subjects():
 @public
 def get_cached_featured_subjects():
     return cache.memcache_memoize(
-        get_featured_subjects, "home.featured_subjects", timeout=cache.HOUR)()
-
+        get_featured_subjects, "home.featured_subjects", timeout=dateutil.HOUR_SECS)()
 
 @public
 def generic_carousel(query=None, subject=None, work_id=None, _type=None,

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -21,6 +21,7 @@ from utils import render_template
 from openlibrary.core import cache
 from openlibrary.core.lending import amazon_api
 from openlibrary import accounts
+from openlibrary.utils import dateutil
 from openlibrary.plugins.openlibrary.processors import ReadableUrlProcessor
 from openlibrary.plugins.openlibrary import code as ol_code
 
@@ -141,7 +142,7 @@ def cached_get_amazon_metadata(*args, **kwargs):
     # "upstream.code._get_amazon_metadata"
     memoized_get_amazon_metadata = cache.memcache_memoize(
         _get_amazon_metadata, "upstream.code._get_amazon_metadata",
-        timeout=cache.ONE_WEEK)
+        timeout=dateutil.WEEK_SECS)
     # fetch cached value from this controller
     result = memoized_get_amazon_metadata(*args, **kwargs)
     if result is None:
@@ -199,7 +200,7 @@ def _get_betterworldbooks_metadata(isbn):
 
 
 cached_get_betterworldbooks_metadata = cache.memcache_memoize(
-    _get_betterworldbooks_metadata, "upstream.code._get_betterworldbooks_metadata", timeout=cache.HALF_DAY)
+    _get_betterworldbooks_metadata, "upstream.code._get_betterworldbooks_metadata", timeout=dateutil.HALF_DAY_SECS)
 
 class DynamicDocument:
     """Dynamic document is created by concatinating various rawtext documents in the DB.

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -15,203 +15,198 @@ $ stats = get_admin_stats()
 </script>
 
 <div id="contentHead">
-    $:render_template("admin/menu")
-    <h1>$_("Admin Center")</h1>
+    $if ctx.user and ctx.user.is_admin():
+      $:render_template("admin/menu")
+      <div class="clearfix"></div>
+
+    <h1>$_("Stats")</h1>
 </div>
+
 <div id="contentBody">
 
-    <div class="contentLeft">
-        <div class="head rel"> <span class="caption"><a href="/recentchanges/">Edits Per Day</a></span>
-            <h2>Edits</h2>
-        </div>
-        <div class="chartHolder">
-            <div class="chartDisplay">
-	      <div id="editgraph" style="width:430px;height:50px;">
-		<!-- Edit graphs go here -->
-	      </div>
-            </div>
-        </div>
-        <table class="measurements stripeEven" id="edits">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>Today</th>
-                    <th>Yesterday</th>
-                    <th>Last 7 days</th>
-                    <th>Last 28 days</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr class="major">
-                    <td class="type">Human</td>
-                    <td class="amount"><strong>$commify(counts.human_edits.latest)</strong></td>
-                    <td class="amount">$commify(counts.human_edits.previous)</td>
-                    <td class="amount">$commify(counts.human_edits.get_summary(7))</td>
-                    <td class="amount">$commify(counts.human_edits.get_summary(28))</td>
-                </tr>
-                <tr class="even">
-                    <td class="type">Bot</td>
-                    <td class="amount"><strong>$commify(counts.bot_edits.latest)</strong></td>
-                    <td class="amount">$commify(counts.bot_edits.previous)</td>
-                    <td class="amount">$commify(counts.bot_edits.get_summary(7))</td>
-                    <td class="amount">$commify(counts.bot_edits.get_summary(28))</td>
-                </tr>
-                <tr class="totals">
-                    <td class="type">Total</td>
-                    <td class="amount">$commify(counts.bot_edits.latest + counts.human_edits.latest)</td>
-                    <td class="amount">$commify(counts.bot_edits.previous + counts.human_edits.previous)</td>
-                    <td class="amount">$commify(counts.bot_edits.get_summary(7) + counts.human_edits.get_summary(7))</td>
-                    <td class="amount">$commify(counts.bot_edits.get_summary(28) + counts.human_edits.get_summary(28))</td>
-                </tr>
-            </tbody>
-        </table>
-
+  <div class="contentLeft">
+    <div class="head rel"> <span class="caption"><a href="/recentchanges/">Edits Per Day</a></span>
+      <h2>Edits</h2>
     </div>
-
-    <div class="contentRight">
-        <div class="head rel"> <span class="caption"><a href="/admin/people">New Accounts Per Day</a></span>
-            <h2>Members</h2>
-        </div>
-        <div class="chartHolder">
-	  <div class="chartDisplay">
-	    <div id="membergraph" style="width:430px;height:50px;">
-	      <!-- Member graphs go here -->
-	    </div>
-	  </div>
-        </div>
-        <table class="measurements stripeEven" id="members">
-            <thead>
-                <tr>
-                    <th>Today</th>
-                    <th>Yesterday</th>
-                    <th>Last 7 days</th>
-                    <th>Last 28 days</th>
-                    <th class="shift">All Time</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr class="major">
-                    <td class="amount"><strong>$commify(counts.members.latest)</strong></td>
-                    <td class="amount">$commify(counts.members.previous)</td>
-                    <td class="amount">$commify(counts.members.get_summary(7))</td>
-                    <td class="amount">$commify(counts.members.get_summary(28))</td>
-                    <td class="amount shift"><strong>$commify(counts.members.total)</strong></td>
-                </tr>
-                <tr class="even">
-                    <td class="diff"></td>
-                    <td class="diff"><span class="pos">+x.x%</span></td>
-                    <td class="diff"><span class="neg">-x.x%</span></td>
-                    <td class="diff"><span class="pos">+x.x%</span></td>
-                    <td class="diff"></td>
-                </tr>
-                <tr class="totals">
-                    <td class="type">Edit ratio</td>
-                    <td class="amount">(Member)</td>
-                    <td class="amount">x :</td>
-                    <td class="amount">x (Anon)</td>
-                </tr>
-            </tbody>
-        </table>
+    <div class="chartHolder">
+      <div class="chartDisplay">
+	<div id="editgraph" style="width:430px;height:50px;">
+	  <!-- Edit graphs go here -->
+	</div>
+      </div>
     </div>
-
-    <h2>Record Counts</h2>
-    <script type="text/javascript">
-      \$(function () {
-	  plot_tooltip_graph (\$("#works_minigraph"), $:json_encode(counts.works.get_counts(150, True)), " works on ");
-	  plot_tooltip_graph (\$("#editions_minigraph"), $:json_encode(counts.editions.get_counts(150, True)), " editions on ");
-	  plot_tooltip_graph (\$("#ebooks_minigraph"), $:json_encode(counts.ebooks.get_counts(150, True)), " ebooks on ");
-	  plot_tooltip_graph (\$("#covers_minigraph"), $:json_encode(counts.covers.get_counts(150, True)), " covers on ");
-	  plot_tooltip_graph (\$("#authors_minigraph"), $:json_encode(counts.authors.get_counts(150, True)), " authors on ");
-	  plot_tooltip_graph (\$("#subjects_minigraph"), $:json_encode(counts.subjects.get_counts(150, True)), " subjects on ");
-	  plot_tooltip_graph (\$("#lists_minigraph"), $:json_encode(counts.lists.get_counts(150, True)), " lists on ");
-	  plot_tooltip_graph (\$("#members_minigraph"), $:json_encode(counts.members.get_counts(150, True)), " members on ");
-      });
-</script>
-
-    <table class="measurements stripeEven">
+    <table class="measurements stripeEven" id="edits">
+      <thead>
         <tr>
-            <th></th>
-            <th>Last 7 days</th>
-            <th>Last 28 days</th>
-            <th>Trend</th>
-            <th>Total</th>
+          <th></th>
+          <th>Today</th>
+          <th>Yesterday</th>
+          <th>Last 7 days</th>
+          <th>Last 28 days</th>
         </tr>
+      </thead>
+      <tbody>
         <tr class="major">
-            <td>Works</td>
-            <td class="amount">$commify(counts.works.get_summary(7))</td>
-            <td class="amount">$commify(counts.works.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="works_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.works.total)</td>
+          <td class="type">Human</td>
+          <td class="amount"><strong>$commify(counts.human_edits.latest)</strong></td>
+          <td class="amount">$commify(counts.human_edits.previous)</td>
+          <td class="amount">$commify(counts.human_edits.get_summary(7))</td>
+          <td class="amount">$commify(counts.human_edits.get_summary(28))</td>
         </tr>
-        <tr class="major even">
-            <td>Editions</td>
-            <td class="amount">$commify(counts.editions.get_summary(7))</td>
-            <td class="amount">$commify(counts.editions.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="editions_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.editions.total)</td>
+        <tr class="even">
+          <td class="type">Bot</td>
+          <td class="amount"><strong>$commify(counts.bot_edits.latest)</strong></td>
+          <td class="amount">$commify(counts.bot_edits.previous)</td>
+          <td class="amount">$commify(counts.bot_edits.get_summary(7))</td>
+          <td class="amount">$commify(counts.bot_edits.get_summary(28))</td>
         </tr>
-        <tr class="major">
-            <td>eBooks</td>
-            <td class="amount">$commify(counts.ebooks.get_summary(7))</td>
-            <td class="amount">$commify(counts.ebooks.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="ebooks_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.ebooks.total)</td>
+        <tr class="totals">
+          <td class="type">Total</td>
+          <td class="amount">$commify(counts.bot_edits.latest + counts.human_edits.latest)</td>
+          <td class="amount">$commify(counts.bot_edits.previous + counts.human_edits.previous)</td>
+          <td class="amount">$commify(counts.bot_edits.get_summary(7) + counts.human_edits.get_summary(7))</td>
+          <td class="amount">$commify(counts.bot_edits.get_summary(28) + counts.human_edits.get_summary(28))</td>
         </tr>
-        <tr class="major even">
-            <td>Covers</td>
-            <td class="amount">$commify(counts.covers.get_summary(7))</td>
-            <td class="amount">$commify(counts.covers.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="covers_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.covers.total)</td>
-        </tr>
-        <tr class="major">
-            <td>Authors</td>
-            <td class="amount">$commify(counts.authors.get_summary(7))</td>
-            <td class="amount">$commify(counts.authors.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="authors_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.authors.total)</td>
-        </tr>
-        <tr class="major even">
-            <td>Subjects</td>
-            <td class="amount">$commify(counts.subjects.get_summary(7))</td>
-            <td class="amount">$commify(counts.subjects.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="subjects_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.subjects.total)</td>
-        </tr>
-        <tr class="major">
-            <td>Lists</td>
-            <td class="amount">$commify(counts.lists.get_summary(7))</td>
-            <td class="amount">$commify(counts.lists.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="lists_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.lists.total)</td>
-        </tr>
-        <tr class="major even">
-            <td>Members</td>
-            <td class="amount">$commify(counts.members.get_summary(7))</td>
-            <td class="amount">$commify(counts.members.get_summary(28))</td>
-            <td><div class="sparkDisplay"><div id="members_minigraph" style="width:250px;height:35px;margin-left: 50px;"></div></div></td>
-            <td class="amount">$commify(counts.members.total)</td>
-        </tr>
+      </tbody>
     </table>
+  </div>
 
-    <div class="clearfix"></div>
-
-    <div class="tweets" id="adminTwitter">$:macros.twitter()</div>
-
-    <div class="contentSpacer"></div>
-
-    <div class="contentQuarter">
-        <!-- Start of Flickr Badge -->
-            <table id="flickr_badge_uber_wrapper">
-                <tr>
-                    <td>
-                        <table id="flickr_badge_wrapper">
-                            <script type="text/javascript" src="http://www.flickr.com/badge_code_v2.gne?count=2&display=random&size=m&layout=v&source=user&user=41108298%40N06"></script>
-                        </table>
-                    </td>
-                </tr>
-            </table>
-        <!-- End of Flickr Badge -->
+  <div class="contentRight">
+    <div class="head rel">
+      $ acts_link = '/admin/people' if (ctx.user and ctx.user.is_admin()) else '/recentchanges/new-account'
+      <span class="caption"><a href="$acts_link">New Accounts Per Day</a></span>
+      <h2>Members</h2>
     </div>
+    <div class="chartHolder">
+      <div class="chartDisplay">
+	<div id="membergraph" style="width:430px;height:50px;">
+	  <!-- Member graphs go here -->
+	</div>
+      </div>
+    </div>
+    <table class="measurements stripeEven" id="members">
+      <thead>
+        <tr>
+          <th>Today</th>
+          <th>Yesterday</th>
+          <th>Last 7 days</th>
+          <th>Last 28 days</th>
+          <th class="shift">All Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="major">
+          <td class="amount"><strong>$commify(counts.members.latest)</strong></td>
+          <td class="amount">$commify(counts.members.previous)</td>
+          <td class="amount">$commify(counts.members.get_summary(7))</td>
+          <td class="amount">$commify(counts.members.get_summary(28))</td>
+          <td class="amount shift"><strong>$commify(counts.members.total)</strong></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
+
+  <script type="text/javascript">
+    \$(function () {
+    plot_tooltip_graph (\$("#works_minigraph"), $:json_encode(counts.works.get_counts(150, True)), " works on ");
+    plot_tooltip_graph (\$("#editions_minigraph"), $:json_encode(counts.editions.get_counts(150, True)), " editions on ");
+    plot_tooltip_graph (\$("#covers_minigraph"), $:json_encode(counts.covers.get_counts(150, True)), " covers on ");
+    plot_tooltip_graph (\$("#authors_minigraph"), $:json_encode(counts.authors.get_counts(150, True)), " authors on ");
+    plot_tooltip_graph (\$("#lists_minigraph"), $:json_encode(counts.lists.get_counts(150, True)), " lists on ");
+    plot_tooltip_graph (\$("#members_minigraph"), $:json_encode(counts.members.get_counts(150, True)), " members on ");
+    });
+  </script>
+
+  <table class="measurements stripeEven">
+    <tr>
+      <th></th>
+      <th>Last 7 days</th>
+      <th>Last 28 days</th>
+      <th>Trend</th>
+      <th>Total</th>
+    </tr>
+    <tr class="major">
+      <td>Works</td>
+      <td class="amount">$commify(counts.works.get_summary(7))</td>
+      <td class="amount">$commify(counts.works.get_summary(28))</td>
+      <td><div class="sparkDisplay"><div id="works_minigraph" class="stats-spacer"></div></div></td>
+      <td class="amount">$commify(counts.works.total)</td>
+    </tr>
+    <tr class="major">
+      <td>Editions</td>
+      <td class="amount">$commify(counts.editions.get_summary(7))</td>
+      <td class="amount">$commify(counts.editions.get_summary(28))</td>
+      <td><div class="sparkDisplay"><div id="editions_minigraph" class="stats-spacer"></div></div></td>
+      <td class="amount">$commify(counts.editions.total)</td>
+    </tr>
+    <tr class="major even">
+      <td>Authors</td>
+      <td class="amount">$commify(counts.authors.get_summary(7))</td>
+      <td class="amount">$commify(counts.authors.get_summary(28))</td>
+      <td><div class="sparkDisplay"><div id="authors_minigraph" class="stats-spacer"></div></div></td>
+      <td class="amount">$commify(counts.authors.total)</td>
+    </tr>
+    <tr class="major even">
+      <td>Covers</td>
+      <td class="amount">$commify(counts.covers.get_summary(7))</td>
+      <td class="amount">$commify(counts.covers.get_summary(28))</td>
+      <td><div class="sparkDisplay"><div id="covers_minigraph" class="stats-spacer"></div></div></td>
+      <td class="amount">$commify(counts.covers.total)</td>
+    </tr>
+    <tr class="major">
+      <td>Members</td>
+      <td class="amount">$commify(counts.members.get_summary(7))</td>
+      <td class="amount">$commify(counts.members.get_summary(28))</td>
+      <td><div class="sparkDisplay"><div id="members_minigraph" class="stats-spacer"></div></div></td>
+      <td class="amount">$commify(counts.members.total)</td>
+    </tr>
+    <tr class="major">
+      <td>Lists</td>
+      <td class="amount">$commify(counts.lists.get_summary(7))</td>
+      <td class="amount">$commify(counts.lists.get_summary(28))</td>
+      <td><div class="sparkDisplay"><div id="lists_minigraph" class="stats-spacer"></div></div></td>
+      <td class="amount">$commify(counts.lists.total)</td>
+    </tr>
+    <tr class="major">
+      <td><a href="/stats/readinglog">Books Logged</a></td>
+      <td class="amount">$commify(counts.reading_log['total_books_logged']['week']['count'])</td>
+      <td class="amount">$commify(counts.reading_log['total_books_logged']['month']['count'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_books_logged']['total']['count'])</td>
+    </tr>
+    <tr class="major even">
+      <td>Users Logging</td>
+      <td class="amount">$commify(counts.reading_log['total_users_logged']['week']['count'])</td>
+      <td class="amount">$commify(counts.reading_log['total_users_logged']['month']['count'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_users_logged']['total']['count'])</td>
+    </tr>
+  </table>
+
+  <div class="clearfix"></div>
+
+  <h2>Unique Visitors</h2>
+  <img src="http://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-60days"/>
+
+  <h2>Borrows</h2>
+  <img src="http://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-3months&tz=UTC&width=900"/>
+  <img src="http://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-24months&tz=UTC&width=900"/>
+  <div class="tweets" id="adminTwitter">$:macros.twitter()</div>
+
+  <div class="contentSpacer"></div>
+
+  <div class="contentQuarter">
+    <!-- Start of Flickr Badge -->
+    <table id="flickr_badge_uber_wrapper">
+      <tr>
+        <td>
+          <table id="flickr_badge_wrapper">
+            <script type="text/javascript" src="http://www.flickr.com/badge_code_v2.gne?count=2&display=random&size=m&layout=v&source=user&user=41108298%40N06"></script>
+          </table>
+        </td>
+      </tr>
+    </table>
+    <!-- End of Flickr Badge -->
+  </div>
 </div>

--- a/openlibrary/templates/stats/readinglog.html
+++ b/openlibrary/templates/stats/readinglog.html
@@ -62,7 +62,15 @@ $def with (stats)
     <h3>Most Wanted Books (All Time)</h3>
     <div class="mybooks-list">
       <ul class="list-books" id="siteSearch">
-        $for book in stats['leaderboard']['most_wanted']: 
+        $for book in stats['leaderboard']['most_wanted_all']:
+            $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
+      </ul>
+    </div>
+
+    <h3>Most Wanted Books (This Month)</h3>
+    <div class="mybooks-list">
+      <ul class="list-books" id="siteSearch">
+        $for book in stats['leaderboard']['most_wanted_month']:
             $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
       </ul>
     </div>
@@ -72,6 +80,15 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books" id="siteSearch">
         $for book in stats['leaderboard']['most_read']:
+            $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
+      </ul>
+    </div>
+
+    <h2>Most Rated Books</h2>
+    <h3>Most Rated Books (All Time)</h3>
+    <div class="mybooks-list">
+      <ul class="list-books" id="siteSearch">
+        $for book in stats['leaderboard']['most_rated_all']:
             $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
       </ul>
     </div>

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -1,6 +1,36 @@
 """Generic date utilities.
 """
+
 import datetime
+import calendar
+
+
+MINUTE_SECS = 60
+HOUR_SECS = MINUTE_SECS * 60
+HALF_DAY_SECS = HOUR_SECS * 12
+DAY_SECS = HOUR_SECS * 24
+WEEK_SECS = DAY_SECS * 7
+
+
+def days_in_current_month():
+    now = datetime.datetime.now()
+    return calendar.monthrange(now.year, now.month)[1]
+
+
+def date_n_days_ago(n=None, start=None):
+    """
+    Args:
+        n (int) - number of days since start
+        start (date) - date to start counting from (default: today)
+    Returns:
+        A (datetime.date) of `n` days ago if n is provided, else None
+    """
+    _start = start or datetime.date.today()
+    return (_start - datetime.timedelta(days=n)) if n else None
+
+
+DATE_ONE_MONTH_AGO = date_n_days_ago(n=days_in_current_month())
+DATE_ONE_WEEK_AGO = date_n_days_ago(n=7)
 
 def parse_date(datestr):
     """Parses date string.
@@ -58,13 +88,3 @@ def _resize_list(x, size):
     if len(x) < size:
         x += [None] * (size - len(x))
 
-def date_n_days_ago(n=None, start=None):
-    """
-    Args:
-        n (int) - number of days since start
-        start (date) - date to start counting from (defaut: today)
-    Returns:
-        A (datetime.date) of `n` days ago if n is provided, else None
-    """
-    _start = start or datetime.date.today()
-    return (_start - datetime.timedelta(days=n)) if n else None

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -1,72 +1,107 @@
 """Loan Stats"""
 
 import re
-import datetime
 import web
 from infogami.utils import delegate
 
+from ..utils import dateutil
 from .. import app
 from ..core import cache
 from ..core.bookshelves import Bookshelves
 from ..core.ratings import Ratings
+from ..plugins.admin.code import get_counts
+
+
+LENDING_TYPES = '(libraries|regions|countries|collections|subjects|format)'
+
+
+def reading_log_summary():
+    # enable to work w/ cached
+    if 'env' not in web.ctx:
+        delegate.fakeload()
+
+    stats = Bookshelves.summary()
+    stats.update(Ratings.summary())
+    return stats
+
+
+cached_reading_log_summary = cache.memcache_memoize(
+    reading_log_summary, 'stats.readling_log_summary',
+    timeout=dateutil.HOUR_SECS)
+
+
+def reading_log_leaderboard(limit=None):
+    # enable to work w/ cached
+    if 'env' not in web.ctx:
+        delegate.fakeload()
+
+    most_read = Bookshelves.most_logged_books(
+        Bookshelves.PRESET_BOOKSHELVES['Already Read'], limit=limit)
+    most_wanted_all = Bookshelves.most_logged_books(
+        Bookshelves.PRESET_BOOKSHELVES['Want to Read'], limit=limit)
+    most_wanted_month = Bookshelves.most_logged_books(
+        Bookshelves.PRESET_BOOKSHELVES['Want to Read'], limit=limit,
+        since=dateutil.DATE_ONE_MONTH_AGO)
+    return {
+        'leaderboard': {
+            'most_read': most_read,
+            'most_wanted_all': most_wanted_all,
+            'most_wanted_month': most_wanted_month,
+            'most_rated_all': Ratings.most_rated_books()
+        }
+    }
+
+
+def cached_reading_log_leaderboard(limit=None):
+    return cache.memcache_memoize(
+        reading_log_leaderboard, 'stats.readling_log_leaderboard',
+        timeout=dateutil.HOUR_SECS )(limit)
+
+
+def get_cached_reading_log_stats(limit):
+    stats = cached_reading_log_summary()
+    stats.update(cached_reading_log_leaderboard(limit))
+    return stats
+
 
 class stats(app.view):
     path = "/stats"
 
     def GET(self):
-        raise web.seeother("/")
+        counts = get_counts()
+        counts.reading_log = cached_reading_log_summary()
+        return app.render_template("admin/index", counts)
+
 
 class lending_stats(app.view):
-    path = "/stats/lending(?:/(libraries|regions|countries|collections|subjects|format)/(.+))?"
+    path = "/stats/lending(?:/%s/(.+))?" % LENDING_TYPES
 
     def GET(self, key, value):
         raise web.seeother("/")
+
 
 class readinglog_stats(app.view):
     path = "/stats/readinglog"
 
     def GET(self):
-        ONE_MONTH_DATE = datetime.date.today() - datetime.timedelta(days=28)
         MAX_LEADERBOARD_SIZE = 50
         i = web.input(limit="10")
         limit = int(i.limit) if int(i.limit) < 51 else 50
 
-        def readinglog_stats(limit=limit):
-            if 'env' not in web.ctx:
-                delegate.fakeload()
-            most_read = Bookshelves.most_logged_books(
-                Bookshelves.PRESET_BOOKSHELVES['Already Read'], limit=limit)
-            most_wanted = Bookshelves.most_logged_books(
-                Bookshelves.PRESET_BOOKSHELVES['Want to Read'], limit=limit)
-
-            return {
-                'total_books_logged': {
-                    'total': Bookshelves.total_books_logged(),
-                    'month': Bookshelves.total_books_logged(since=ONE_MONTH_DATE)
-                },
-                'total_users_logged': {
-                    'total': Bookshelves.total_unique_users(),
-                    'month': Bookshelves.total_unique_users(since=ONE_MONTH_DATE)
-                },
-                'total_books_starred': {
-                    'total': Ratings.total_num_books_rated(),
-                    'unique': Ratings.total_num_unique_raters(),
-                    'month': Ratings.total_num_books_rated(since=ONE_MONTH_DATE)
-                },
-                'leaderboard': {
-                    'most_read': most_read,
-                    'most_wanted': most_wanted
-                }
-            }
-        stats =  cache.memcache_memoize(
-            readinglog_stats, 'stats.readlinglog_stats', timeout=cache.HOUR)(limit)
+        stats = get_cached_reading_log_stats(limit=limit)
 
         # Fetch works from solr and inject into leaderboard
         for i in range(len(stats['leaderboard']['most_read'])):
             stats['leaderboard']['most_read'][i]['work'] = web.ctx.site.get(
                 '/works/OL%sW' % stats['leaderboard']['most_read'][i]['work_id'])
-        for i in range(len(stats['leaderboard']['most_wanted'])):
-            stats['leaderboard']['most_wanted'][i]['work'] = web.ctx.site.get(
-                '/works/OL%sW' % stats['leaderboard']['most_wanted'][i]['work_id'])
+        for i in range(len(stats['leaderboard']['most_wanted_all'])):
+            stats['leaderboard']['most_wanted_all'][i]['work'] = web.ctx.site.get(
+                '/works/OL%sW' % stats['leaderboard']['most_wanted_all'][i]['work_id'])
+        for i in range(len(stats['leaderboard']['most_wanted_month'])):
+            stats['leaderboard']['most_wanted_month'][i]['work'] = web.ctx.site.get(
+                '/works/OL%sW' % stats['leaderboard']['most_wanted_month'][i]['work_id'])
+        for i in range(len(stats['leaderboard']['most_rated_all'])):
+            stats['leaderboard']['most_rated_all'][i]['work'] = web.ctx.site.get(
+                '/works/OL%sW' % stats['leaderboard']['most_rated_all'][i]['work_id'])
 
         return app.render_template("stats/readinglog", stats=stats)

--- a/static/css/master.less
+++ b/static/css/master.less
@@ -3287,6 +3287,12 @@ div.chartHome a:hover {
   padding: 0 10px;
 }
 
+.stats-spacer {
+  width:250px;
+  height:35px;
+  margin-left: 50px;
+}
+
 /* RESULTS CAROUSEL SKIN */
 
 ul.homeCarousel {
@@ -3878,9 +3884,6 @@ div.workPadding p {
 }
 
 div.workHelp {
-  float: left;
-  width: 553px;
-  background-color: @light-yellow;
   padding: 20px;
   font-size: 14px;
   margin-bottom: 15px;
@@ -5679,7 +5682,6 @@ a.coverLook {
 
 /* ADMIN */
 body#admin div#contentHead {
-  float: left;
   padding-bottom: 30px;
 }
 


### PR DESCRIPTION
Closes #742 

## Description:
In this Pull Request we have made the following changes:

- makes a public version of /admin available as /stats
- updates the offerings of the /stats page and /stats/readinglog
- consolidates time CONSTs into utils/dateutil.py 