### PR TITLE
Debug: In dev mode add viewport to all pages

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -72,7 +72,6 @@ features:
     stats-header: enabled
     inlibrary: enabled
     support: admin
-    dev: enabled
     superfast: enabled
     publishers: enabled
     languages: enabled

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -6,7 +6,7 @@ $def with (page)
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />
 
-    $if 'v2' in page:
+    $if 'v2' in page or "dev" in ctx.features:
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <meta name="author" content="OpenLibrary.org" />

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bundlesize": [
     {
       "path": "static/build/all.css",
-      "maxSize": "26.86KB"
+      "maxSize": "26.88KB"
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
Not having the viewport on some pages is making it hard to test
how it works in mobile. I'd like to turn it on in dev mode so that
I can focus on specific problems with pages.

Fixes: #1142

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
