### PR TITLE
Fix CSS regression relating to dropper height

### DIFF
--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -164,15 +164,15 @@ div.Tools {
         }
       }
     }
+  }
 
-    div.dropit {
-      min-height: 45px;
-      p.listed {
-        color: @grey;
-        font-size: 0.8125em;
-        padding: 0 0 0 42px;
-        margin: 0 0 5px;
-      }
+  div.dropit {
+    min-height: 45px;
+    p.listed {
+      color: @grey;
+      font-size: 0.8125em;
+      padding: 0 0 0 42px;
+      margin: 0 0 5px;
     }
   }
 


### PR DESCRIPTION
Follow up to 980151a
.dropit is not a child of div.dropper
Thus CSS rules were not being invoked.
