### PR TITLE
Bulk MARC import improvements required for Trent and local_id imports

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -596,7 +596,7 @@ def load(rec):
         need_edition_save = True
 
     # add values to edition lists
-    for f in 'source_records', 'ia_box_id', 'ia_loaded_id':
+    for f in 'source_records', 'local_id', 'ia_box_id', 'ia_loaded_id':
         if f not in rec:
             continue
         # ensure values is a list
@@ -623,6 +623,5 @@ def load(rec):
         reply['work']['status'] = 'created' if work_created else 'modified'
         edits.append(w)
     if edits:
-        web.ctx.site.save_many(edits, 'import new book')
-
+        web.ctx.site.save_many(edits, 'import existing book')
     return reply

--- a/openlibrary/catalog/marc/marc_base.py
+++ b/openlibrary/catalog/marc/marc_base.py
@@ -4,6 +4,16 @@ re_isbn = re.compile('([^ ()]+[\dX])(?: \((?:v\. (\d+)(?: : )?)?(.*)\))?')
 # handle ISBN like: 1402563884c$26.95
 re_isbn_and_price = re.compile('^([-\d]+X?)c\$[\d.]+$')
 
+class MarcException(Exception):
+    # Base MARC exception class
+    pass
+
+class BadMARC(MarcException):
+    pass
+
+class NoTitle(MarcException):
+    pass
+
 class MarcBase(object):
     def read_isbn(self, f):
         found = []

--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -1,16 +1,13 @@
 from openlibrary.catalog.marc import fast_parse
 #TODO: Move fast_parse get_tag_lines(), handle_wrapped_lines(), get_all_tag_lines() into this class
-from marc_base import MarcBase
+from marc_base import MarcBase, MarcException, BadMARC
 from unicodedata import normalize
 from pymarc import MARC8ToUnicode
 from openlibrary.catalog.marc import mnemonics
 
 marc8 = MARC8ToUnicode(quiet=True)
 
-class BadLength(Exception):
-    pass
-
-class BadMARC(Exception):
+class BadLength(MarcException):
     pass
 
 def norm(s):
@@ -88,9 +85,9 @@ class MarcBinary(MarcBase):
             assert len(data) and isinstance(data, basestring)
             length = int(data[:5])
         except:
-            raise BadMARC
+            raise BadMARC("No MARC data found")
         if len(data) != length:
-            raise BadLength
+            raise BadLength("Record length %s does not match reported length %s." % (len(data), length))
         self.data = data
 
     def leader(self):

--- a/openlibrary/catalog/marc/marc_xml.py
+++ b/openlibrary/catalog/marc/marc_xml.py
@@ -1,5 +1,5 @@
 from lxml import etree
-from marc_base import MarcBase
+from marc_base import MarcBase, MarcException
 from unicodedata import normalize
 
 data_tag = '{http://www.loc.gov/MARC21/slim}datafield'
@@ -9,16 +9,16 @@ leader_tag = '{http://www.loc.gov/MARC21/slim}leader'
 record_tag = '{http://www.loc.gov/MARC21/slim}record'
 collection_tag = '{http://www.loc.gov/MARC21/slim}collection'
 
+class BlankTag(MarcException):
+    pass
+
+class BadSubtag(MarcException):
+    pass
+
 def read_marc_file(f):
     for event, elem in etree.iterparse(f, tag=record_tag):
         yield MarcXml(elem)
         elem.clear()
-
-class BlankTag(Exception):
-    pass
-
-class BadSubtag(Exception):
-    pass
 
 def norm(s):
     return normalize('NFC', unicode(s.replace(u'\xa0', ' ')))

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -2,6 +2,7 @@ import re
 from openlibrary.catalog.utils import pick_first_date, tidy_isbn, flip_name, remove_trailing_dot, remove_trailing_number_dot
 from get_subjects import subjects_for_work
 from collections import defaultdict
+from marc_base import BadMARC, NoTitle, MarcException
 
 re_question = re.compile('^\?+$')
 re_lccn = re.compile('(...\d+).*')
@@ -17,10 +18,7 @@ foc = '[from old catalog]'
 def strip_foc(s):
     return s[:-len(foc)].rstrip() if s.endswith(foc) else s
 
-class NoTitle(Exception):
-    pass
-
-class SeeAlsoAsTitle(Exception):
+class SeeAlsoAsTitle(MarcException):
     pass
 
 want = [
@@ -45,12 +43,6 @@ want = [
     '246', '730', '740', # other titles
     '852', # location
     '856'] # URL
-
-class BadMARC(Exception):
-    pass
-
-class SeaAlsoAsTitle(Exception):
-    pass
 
 def read_lccn(rec):
     fields = rec.get_fields('010')

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -176,7 +176,7 @@ def read_title(rec):
     if not fields:
         fields = rec.get_fields('740')
     if not fields:
-        raise NoTitle
+        raise NoTitle("No Title found in either 245 or 740 fields.")
 
 #   example MARC record with multiple titles:
 #   http://openlibrary.org/show-marc/marc_western_washington_univ/wwu_bibs.mrc_revrev.mrc:299505697:862
@@ -195,14 +195,14 @@ def read_title(rec):
         title = b_and_p.pop(0).strip(' /,;:')
 # talis_openlibrary_contribution/talis-openlibrary-contribution.mrc:183427199:255
     if title in ('See.', 'See also.'):
-        raise SeeAlsoAsTitle
+        raise SeeAlsoAsTitle("Title is: %s" % title)
 # talis_openlibrary_contribution/talis-openlibrary-contribution.mrc:5654086:483
 # scrapbooksofmoun03tupp
     if title is None:
         subfields = list(fields[0].get_all_subfields())
         title = ' '.join(v for k, v in subfields)
         if not title: # ia:scrapbooksofmoun03tupp
-            raise NoTitle
+            raise NoTitle("No title found from joining subfields.")
     ret['title'] = remove_trailing_dot(title)
     if b_and_p:
         ret["subtitle"] = ' : '.join(remove_trailing_dot(x.strip(' /,;:')) for x in b_and_p)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -4,7 +4,7 @@
 from infogami.plugins.api.code import add_hook
 from infogami import config
 from openlibrary.plugins.openlibrary.code import can_write
-from openlibrary.catalog.marc.marc_binary import MarcBinary
+from openlibrary.catalog.marc.marc_binary import MarcBinary, MarcException
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.parse import read_edition
 from openlibrary.catalog import add_book
@@ -217,8 +217,7 @@ class ia_importapi:
                 data, next_offset, next_length = get_from_archive_bulk(identifier)
                 rec = MarcBinary(data)
                 edition = read_edition(rec)
-            #TODO: subclass MARC exceptions and only return those details to user
-            except Exception as e:
+            except MarcException as e:
                 details = "%s: %s" % (identifier, str(e))
                 logger.error("failed to read from bulk MARC record %s", details)
                 return self.error('invalid-marc-record', details)
@@ -290,7 +289,7 @@ class ia_importapi:
 
             try:
                 edition_data = read_edition(marc_record)
-            except Exception as e:
+            except MarcException as e:
                 logger.error("failed to read from MARC record %s: %s", identifier, str(e))
                 return self.error("invalid-marc-record")
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -146,38 +146,31 @@ class importapi:
     """
     def POST(self):
         web.header('Content-Type', 'application/json')
-
         if not can_write():
             raise web.HTTPError('403 Forbidden')
 
         data = web.data()
-        error_code = "unknown_error"
 
         try:
             edition, format = parse_data(data)
         except DataError, e:
-            edition = None
-            error_code = str(e)
+            return self.error(str(e), 'Failed to parse Edition data')
 
-        #call Edward's code here with the edition dict
-        if edition:
-            #source_url = None
+        if not edition:
+            return self.error('unknown_error', 'Failed to parse Edition data')
 
-            ## Anand - July 2014
-            ## This is adding source_records as [null] as queue_s3_upload is disabled.
-            ## Disabling this as well to fix the issue.
+        ## Anand - July 2014
+        ## This is adding source_records as [null] as queue_s3_upload is disabled.
+        ## Disabling this as well to fix the issue.
+        #source_url = None
+        # if 'source_records' not in edition:
+        #     source_url = queue_s3_upload(data, format)
+        #     edition['source_records'] = [source_url]
 
-            # if 'source_records' not in edition:
-            #     source_url = queue_s3_upload(data, format)
-            #     edition['source_records'] = [source_url]
-
-            reply = add_book.load(edition)
-            #if source_url:
-            #    reply['source_record'] = source_url
-            return json.dumps(reply)
-        else:
-            content = json.dumps({'success':False, 'error_code': error_code, 'error':'Failed to parse Edition data'})
-            raise web.HTTPError('400 Bad Request', {}, content)
+        reply = add_book.load(edition)
+        #if source_url:
+        #    reply['source_record'] = source_url
+        return json.dumps(reply)
 
 class ia_importapi:
     """/api/import/ia import endpoint for Archive.org items, requiring an ocaid identifier rather than direct data upload.

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -227,7 +227,8 @@ class ia_importapi:
             edition['source_records'] = 'marc:%s/%s:%s:%d' % (ocaid, filename, offset, actual_length)
 
             #TODO: Look up URN prefixes to support more sources
-            edition['local_id'] = ['urn:trent:%s' % rec.get_fields('001')[0]]
+            prefix = 'trent'
+            edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in rec.get_fields('001')]
             result = add_book.load(edition)
 
             # Add next_data to the response as location of next record:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -217,9 +217,11 @@ class ia_importapi:
                 data, next_offset, next_length = get_from_archive_bulk(identifier)
                 rec = MarcBinary(data)
                 edition = read_edition(rec)
+            #TODO: subclass MARC exceptions and only return those details to user
             except Exception as e:
-                logger.error("failed to read info from bulk marc_record: %s", str(e))
-                return self.error('no-marc-record')
+                details = "%s: %s" % (identifier, str(e))
+                logger.error("failed to read from bulk MARC record %s", details)
+                return self.error('invalid-marc-record', details)
 
             actual_length = int(rec.leader()[:5])
             edition['source_records'] = 'marc:%s/%s:%s:%d' % (ocaid, filename, offset, actual_length)
@@ -288,8 +290,8 @@ class ia_importapi:
 
             try:
                 edition_data = read_edition(marc_record)
-            except Exception, e:
-                logger.error("failed to read info from marc_record: %s", str(e))
+            except Exception as e:
+                logger.error("failed to read from MARC record %s: %s", identifier, str(e))
                 return self.error("invalid-marc-record")
 
         elif require_marc:


### PR DESCRIPTION

## Description:
In this Pull Request we have made the following changes:

**Trent import specific:**
* Ensures `local_id` is added to existing records if a match is found
* Enable storing multiple `local_ids` from MARC records having multiple 001 fields (many, but not all Trent records do have multiple `local_id`s)
* Still return next record length and offset on recoverable errors to allow bulk imports to proceed even if a single MARC record has issues

**Related improvements:**
* Consolidates MARC exceptions in the MARC classes
* Documentation and refactor to aid comprehension of existing code

