### PR TITLE
Button regress2

### DIFF
--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -33,9 +33,12 @@
     min-width: 130px;
   }
 
-  // JavaScript only, but needed to avoid reflows
+  // JavaScript only block,but needed to avoid reflows
+  // Without, on slower connections, there will be a flash when buttons
+  // are added.
   button {
     position: absolute;
+    color: transparent;
   }
 
   .book {


### PR DESCRIPTION
Avoid button flash on carousel

On slower connections, buttons are added to the carousel by JS
before JS styles have loaded. To avoid a jarring display keep
these transparent until the button loads.

Follow up to eaf3080
Fixes: #1182