### PR TITLE
Added margin between the footer text and github version

### DIFF
--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -90,6 +90,7 @@ img#archive-logo {
 // Legal information
 div#legal-details {
   flex: 0.9;
+  margin-bottom: 8px;
 }
 
 // Github version shown in bottom right corner of footer


### PR DESCRIPTION
Closes #1196

![footer](https://user-images.githubusercontent.com/31198893/46144595-0b3b4600-c27b-11e8-9de4-e2cc5d6d4a58.png)

## Description:
In this Pull Request we have made the following changes:
changed footer.less to add the space between the footer text and github version