### PR TITLE
Publishing history is an inline heading

### DIFF
--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -58,12 +58,12 @@ $:render_template("lib/covers", page)
 <div id="contentMeta" style="padding-top:0;">
 
   <div class="head">
-    <h2 style="margin-bottom:0px!important;">
+    <h2 class="inline">
       $_("Publishing History")
+    </h2>
       <span class="shift">$:_('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.')</span>
       <span class="count hidden chartZoom">&nbsp;<a href="javascript:;" class="resetSelection small">$_("Reset chart")</a> $_("or continue zooming in.")</span>
       <span class="count chartUnzoom">&nbsp;$_("This graph charts editions published on this subject. Click to view a single year, or drag across a range.")</span>
-    </h2>
   </div>
 
 <script type="text/javascript">

--- a/openlibrary/templates/subjects/index.html
+++ b/openlibrary/templates/subjects/index.html
@@ -11,7 +11,10 @@ $var title: Subjects
 	<p>Browse the wonderful world of Subject Headings. It's a bit like a thesaurus, only better!
 	</p>
 	<form action="/search/subjects" class="olform">
-	    <h2 class="collapse"><label for="searchSubjects">Subject Search</label>  <span class="sansserif grey smaller">Try a keyword.</span></h2>
+	    <h2 class="collapse inline">
+			<label for="searchSubjects">Subject Search</label>
+		</h2>
+		<span class="sansserif grey smaller">Try a keyword.</span>
 	    <p>
 	        <input type="text" name="q" id="searchSubjects" size="100" class="larger" value=""/>
 	        <input type="submit" class="large" value="Search"/>


### PR DESCRIPTION
Right now the h2 element encapsulates a lot more than the heading
Be consistent with how the subject heading works
![screen shot 2018-09-28 at 1 50 20 pm](https://user-images.githubusercontent.com/148752/46232869-80fbec00-c325-11e8-8bb3-b0d214add96c.png)


(the margin is redundant as inline elements do not have margins)