### PR TITLE
adds /developers/routes endpoint

### DIFF
--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -1,19 +1,17 @@
 """Open Library Books API
 """
 
-from infogami.plugins.api.code import add_hook
 import dynlinks
 import readlinks
-
-import web
-from infogami.infobase import _json as simplejson
-
-from infogami.utils import delegate
-from infogami.plugins.api.code import jsonapi
 
 import urlparse
 import re
 import urllib2
+import web
+
+from infogami.infobase import _json as simplejson
+from infogami.utils import delegate
+from infogami.plugins.api.code import jsonapi
 
 class books_json(delegate.page):
     path = "/api/books"

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -18,6 +18,7 @@ import infogami
 if not hasattr(infogami.config, 'features'):
     infogami.config.features = []
 
+from infogami.utils.app import metapage
 from infogami.utils import delegate
 from infogami.utils.view import render, render_template, public, safeint, add_flash_message
 from infogami.infobase import client
@@ -166,6 +167,22 @@ def sampleload(filename="sampledump.txt.gz"):
 
     queries = [simplejson.loads(line) for  line in f]
     print web.ctx.site.save_many(queries)
+
+
+class routes(delegate.page):
+    path = "/developers/routes"
+
+    def GET(self):
+        class ModulesToStr(simplejson.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, metapage):
+                    return obj.__module__ + "." + obj.__name__
+                return super(ModulesToStr, self).default(obj)
+
+        from openlibrary import code
+        return '<pre>%s</pre>' % simplejson.dumps(
+            code.delegate.pages, sort_keys=True, cls=ModulesToStr,
+            indent=4, separators=(',', ': '))
 
 class addbook(delegate.page):
     path = "/addbook"


### PR DESCRIPTION
For a while we've been relying on https://github.com/internetarchive/openlibrary/wiki/Endpoints#list-of-all-routes for an idea of what routes are active on OpenLibrary.org
closes #1211
There's also #1160 which was created in attempt to make it easier to centralize where routes live.

Unfortunately, this solution doesn't leave an artifact in the repository (e.g. no central routes file, as #1160 kind-of did). But you can go to `https://dev.openlibrary.org/developers/routes` and see a list of active routes and their handling classes.

cc: @jdlrobson, @cdrini, and @bfalling, @tabshaikh, @salman-bhai who may find this useful