### PR TITLE
Omit leading zeros in css fractions

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,6 +9,7 @@
 		"function-url-quotes": "never",
 		"length-zero-no-unit": true,
 		"max-empty-lines": 1,
-		"no-eol-whitespace": true
+		"no-eol-whitespace": true,
+		"number-leading-zero": "never"
 	}
 }

--- a/static/css/components/Tools.less
+++ b/static/css/components/Tools.less
@@ -128,7 +128,7 @@
   }
 
   li {
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     padding-left: 42px;
     margin-bottom: 5px;
@@ -150,7 +150,7 @@
     }
 
     td {
-      font-size: 0.6875em;
+      font-size: .6875em;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
       &.price {
         padding: 3px 0 0 0;
@@ -219,7 +219,7 @@
       }
       &.subhead {
         padding-left: 10px;
-        font-size: 0.6875em;
+        font-size: .6875em;
         color: @light-grey;
       }
     }
@@ -286,13 +286,13 @@
   }
 
   p {
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     padding-left: 42px;
     margin-bottom: 5px;
   }
   #readBooks p {
-    font-size: 0.75em !important;
+    font-size: .75em !important;
   }
   #widget-add.old-style-lists {
     div.edition-page-lists-dropdown {

--- a/static/css/components/borrowTable-adminUser.less
+++ b/static/css/components/borrowTable-adminUser.less
@@ -17,7 +17,7 @@ body#user {
         font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
         color: @brown;
         font-weight: 600;
-        font-size: 0.6875em;
+        font-size: .6875em;
         text-transform: uppercase;
         white-space: nowrap;
         text-align: center;

--- a/static/css/components/borrowTable.less
+++ b/static/css/components/borrowTable.less
@@ -33,7 +33,7 @@
       }
       &.returns {
         background-color: @lightest-grey;
-        font-size: 0.8125em;
+        font-size: .8125em;
         color: @dark-grey;
         text-align: center;
         padding: 20px 15px;

--- a/static/css/components/buttonsAndLinks.less
+++ b/static/css/components/buttonsAndLinks.less
@@ -11,7 +11,7 @@ a {
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     text-align: center;
     padding: 5px 20px;
-    font-size: 0.8em;
+    font-size: .8em;
   }
   &.cancel {
     color: @red;
@@ -96,7 +96,7 @@ button {
   &.plainText {
     border: none;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-    font-size: 0.75em;
+    font-size: .75em;
     color: @red;
     background-color: @white;
     cursor: pointer;
@@ -107,7 +107,7 @@ button {
   &.plain {
     border: none;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-    font-size: 0.75em;
+    font-size: .75em;
     color: @black;
     background-color: transparent !important;
     cursor: pointer;

--- a/static/css/components/category-item.less
+++ b/static/css/components/category-item.less
@@ -38,7 +38,7 @@ p {
     font-style: italic;
   }
   &.category-title {
-    font-size: 0.875em;
+    font-size: .875em;
     text-align: center;
     line-height: 1;
     margin: 0;

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -14,7 +14,7 @@
     width: 100%;
     height: 100%;
     background: @brown-3a301e;
-    opacity: 0.5;
+    opacity: .5;
     filter: alpha(opacity=50);
   }
   &MiddleLeft,

--- a/static/css/components/chart.less
+++ b/static/css/components/chart.less
@@ -9,7 +9,7 @@
   height: 140px;
   padding: 0 0 20px 20px;
   margin-top: 0;
-  font-size: 0.6875em;
+  font-size: .6875em;
   font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
   background-color: transparent;
   background-image: url(/images/ajax-loader-bar.gif);

--- a/static/css/components/datatables.less
+++ b/static/css/components/datatables.less
@@ -219,7 +219,7 @@ tr.odd {
 }
 
 tfoot input {
-  margin: 0.5em 0;
+  margin: .5em 0;
   width: 100%;
   color: @darker-grey;
 }

--- a/static/css/components/diff.less
+++ b/static/css/components/diff.less
@@ -68,7 +68,7 @@ dd {
   font-family: "Lucida Console","Courier New", monospace;
   background: @lightest-grey;
   vertical-align: top;
-  font-size: 0.875em;
+  font-size: .875em;
   border-right: 1px solid @white;
   border-bottom: 1px solid @white;
 }

--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -65,7 +65,7 @@ div#subjectLists {
     }
     p.listed {
       color: @grey;
-      font-size: 0.8125em;
+      font-size: .8125em;
       padding: 0 0 0 42px;
       margin: 0 0 5px;
     }
@@ -170,7 +170,7 @@ div.Tools {
     min-height: 45px;
     p.listed {
       color: @grey;
-      font-size: 0.8125em;
+      font-size: .8125em;
       padding: 0 0 0 42px;
       margin: 0 0 5px;
     }
@@ -206,7 +206,7 @@ div#listsWork {
 
     p.listed {
       color: @grey;
-      font-size: 0.8125em;
+      font-size: .8125em;
       padding: 0 0 0 42px;
       margin: 0 0 5px;
     }

--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -84,19 +84,19 @@ img#archive-logo {
   margin-right: 10px;
   padding: 0;
   height: 27.5px;
-  opacity: 0.7;
+  opacity: .7;
 }
 
 // Legal information
 div#legal-details {
-  flex: 0.9;
+  flex: .9;
   margin-bottom: 8px;
 }
 
 // Github version shown in bottom right corner of footer
 div#version-details {
   text-align: right;
-  flex: 0.1;
+  flex: .1;
   margin-top: 8px;
 }
 

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -37,7 +37,7 @@ form.olform {
   }
 
   textarea {
-    font-size: 0.75em;
+    font-size: .75em;
   }
 
   &.books {
@@ -45,7 +45,7 @@ form.olform {
     fieldset.major input[type=email],
     fieldset.major input[type=password],
     fieldset.major textarea {
-      font-size: 0.875em;
+      font-size: .875em;
     }
 
     .input,

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -528,9 +528,9 @@ header#header-bar {
   .search-bar {
     max-width: none;
     min-width: none;
-    -webkit-transition: all 0.2s;
-    -o-transition: all 0.2s;
-    transition: all 0.2s;
+    -webkit-transition: all .2s;
+    -o-transition: all .2s;
+    transition: all .2s;
     background: @grey-fafafa;
     border-radius: .3em;
     -webkit-box-flex: 1;
@@ -555,9 +555,9 @@ header#header-bar {
       outline: none;
       background: @grey-fafafa;
       color: @light-grey;
-      -webkit-transition: all 0.5s;
-      -o-transition: all 0.5s;
-      transition: all 0.5s;
+      -webkit-transition: all .5s;
+      -o-transition: all .5s;
+      transition: all .5s;
       display: none;
     }
     input[type=submit] {

--- a/static/css/components/header.less
+++ b/static/css/components/header.less
@@ -36,7 +36,7 @@ div#header {
           height: 22px;
           padding: 10px 0 0 10px;
           font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-          font-size: 0.6875em;
+          font-size: .6875em;
           font-weight: 700;
           text-transform: uppercase;
           color: @black;
@@ -70,7 +70,7 @@ div#header {
       width: 220px;
       text-align: center;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-      font-size: 0.6875em;
+      font-size: .6875em;
       color: @dark-grey;
       margin: 0;
       padding: 0;
@@ -93,7 +93,7 @@ div#header {
   }
   &Login {
     text-align: right;
-    font-size: 0.6875em;
+    font-size: .6875em;
     padding-top: 20px;
     color: @grey;
   }

--- a/static/css/components/headings.less
+++ b/static/css/components/headings.less
@@ -4,7 +4,7 @@ h1 {
     font-size: 1.25em;
   }
   span.subtitle {
-    font-size: 0.65em;
+    font-size: .65em;
     font-weight: normal;
   }
   &.publisher {
@@ -96,7 +96,7 @@ h3 {
 }
 
 h4 {
-  font-size: 0.8125em;
+  font-size: .8125em;
   &.publisher {
     font-family: "Lucida Grande", Verdana, Helvetica, Geneva, sans-serif;
     color: @black;
@@ -106,7 +106,7 @@ h4 {
   }
   &.facetHead {
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-weight: 700;
     color: @black;
     text-transform: uppercase;
@@ -125,13 +125,13 @@ h4 {
 }
 
 h5 {
-  font-size: 0.875em;
+  font-size: .875em;
   font-family: Georgia, "Palatino Linotype", "Book Antiqua", Palatino, serif !important;
   font-weight: normal !important;
 }
 
 h6 {
-  font-size: 0.6875em;
+  font-size: .6875em;
 }
 
 div.head {

--- a/static/css/components/home.less
+++ b/static/css/components/home.less
@@ -36,7 +36,7 @@ div.chartHome a:hover {
         }
         .label {
           font-family: "Lucida Grande","Arial","Helvetica",sans-serif;
-          font-size: 0.625em;
+          font-size: .625em;
           text-transform: uppercase;
         }
       }

--- a/static/css/components/illustration.less
+++ b/static/css/components/illustration.less
@@ -66,7 +66,7 @@
     font-size: 11px;
   }
   .edition {
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
     margin: 10px auto;
   }

--- a/static/css/components/resultsCovers.less
+++ b/static/css/components/resultsCovers.less
@@ -47,7 +47,7 @@
     left: 349px;
     background: transparent url(/images/ajax-loader-bar.gif) no-repeat;
     padding-top: 19px;
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
 }
 

--- a/static/css/components/ui-tabs.less
+++ b/static/css/components/ui-tabs.less
@@ -23,7 +23,7 @@
     a {
       display: block;
       font-weight: 600;
-      font-size: 0.6875em;
+      font-size: .6875em;
       background: @white;
       border-bottom: 3px solid @lightest-grey;
       padding: 4px 8px 3px;

--- a/static/css/components/wmd.less
+++ b/static/css/components/wmd.less
@@ -193,7 +193,7 @@ form#addAuthor.olform .wmd-preview {
 
 .wmd-prompt-background {
   background-color: @black;
-  opacity: 0.9;
+  opacity: .9;
   filter: Alpha(Opacity=90);
 }
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -43,7 +43,7 @@ table {
   border-spacing: 0;
   &#toc-table {
     width: 100%;
-    font-size: 0.8125em;
+    font-size: .8125em;
     td {
       padding: 5px 15px 5px 0;
     }
@@ -93,7 +93,7 @@ table {
     margin-top: 10px;
     border-top: 1px solid @grey-e7e7e7;
     td {
-      font-size: 0.6875em;
+      font-size: .6875em;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
       color: @grey;
       border-bottom: 1px solid @grey-e7e7e7;
@@ -120,7 +120,7 @@ table {
     }
     .label {
       text-transform: uppercase;
-      font-size: 0.5625em;
+      font-size: .5625em;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     }
   }
@@ -130,7 +130,7 @@ table {
     color: @dark-grey;
     th {
       font-family: "Lucida Grande", Verdana, Helvetica, sans-serif;
-      font-size: 0.6875em;
+      font-size: .6875em;
       text-align: right;
       vertical-align: bottom;
       padding: 0 8px;
@@ -139,11 +139,11 @@ table {
       padding: 8px;
       text-align: right;
       vertical-align: bottom;
-      font-size: 0.75em;
+      font-size: .75em;
     }
     td.type {
       font-family: "Lucida Grande", Verdana, Helvetica, sans-serif;
-      font-size: 0.6875em;
+      font-size: .6875em;
     }
     tr.major {
       td.amount {
@@ -186,13 +186,13 @@ table {
       border-bottom: 1px solid @grey-e7e7e7;
       color: @brown;
       text-transform: uppercase !important;
-      font-size: 0.6875em;
+      font-size: .6875em;
       padding: 10px;
     }
     td {
       border-bottom: 1px solid @grey-e7e7e7;
       padding: 10px;
-      font-size: 0.75em;
+      font-size: .75em;
       color: @grey;
     }
   }
@@ -216,14 +216,14 @@ table {
       background-color: @lightest-grey;
       border-bottom: 1px solid @admin-table-border;
       color: @grey;
-      font-size: 0.8675em;
+      font-size: .8675em;
       font-weight: 700;
       padding: 10px;
     }
     td {
       border-bottom: 1px solid @admin-table-border;
       padding: 10px;
-      font-size: 0.75em;
+      font-size: .75em;
       &.number {
         text-align: right;
       }
@@ -233,7 +233,7 @@ table {
     margin: 20px 0;
     border-top: 1px solid @grey-e7e7e7;
     th {
-      font-size: 0.75em;
+      font-size: .75em;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
       color: @grey;
       border-bottom: 1px solid @grey-e7e7e7;
@@ -242,7 +242,7 @@ table {
       background-color: @lightest-grey;
     }
     td {
-      font-size: 0.75em;
+      font-size: .75em;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
       color: @grey;
       border-bottom: 1px solid @grey-e7e7e7;
@@ -283,7 +283,7 @@ li {
       display: block;
       margin: 10px 0;
       background-color: @lightest-grey;
-      font-size: 0.80em;
+      font-size: .80em;
       padding: 20px;
       font-style: italic;
     }
@@ -373,7 +373,7 @@ em {
       margin-top: 10px;
       margin-left: 0;
       font-family: "Lucida Grande", "Trebuchet MS", Geneva, Helvetica, Arial, sans-serif;
-      font-size: 0.8125em;
+      font-size: .8125em;
       color: @grey;
       li {
         list-style: none !important;
@@ -508,7 +508,7 @@ em {
 pre,
 code {
   font-family: "Lucida Console","Courier New",monospace;
-  font-size: 0.875em;
+  font-size: .875em;
   font-weight: normal;
   white-space: pre-wrap;
 }
@@ -535,12 +535,12 @@ q {
   border: 1px solid @lighter-grey;
   padding: 4px;
   background-color: @white;
-  font-size: 0.75em;
-  opacity: 0.80;
+  font-size: .75em;
+  opacity: .80;
 }
 
 .pagination {
-  font-size: 0.75em;
+  font-size: .75em;
   margin: 5px 0;
   .display-flex();
   flex-wrap: wrap;
@@ -600,7 +600,7 @@ div.unordered {
 }
 
 div.superNav {
-  font-size: 0.6875em;
+  font-size: .6875em;
   font-family: "Lucida Grande", Verdana, Helvetica, Geneva, sans-serif;
   color: @grey;
   margin-bottom: 5px;
@@ -671,7 +671,7 @@ span {
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     color: @grey;
     span.resultType {
-      font-size: 0.75em;
+      font-size: .75em;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
       color: @brown;
     }
@@ -686,7 +686,7 @@ span {
     }
     .bookauthor,
     .resultPublisher {
-      font-size: 0.75em;
+      font-size: .75em;
       color: @grey;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
       font-weight: normal;
@@ -710,7 +710,7 @@ span {
 }
 
 .caption {
-  font-size: 0.5625em;
+  font-size: .5625em;
   font-family: "Lucida Grande",Verdana,Helvetica,Geneva,sans-serif;
   font-weight: normal;
   color: @grey;
@@ -719,11 +719,11 @@ span {
 
 p {
   &.instruct {
-    font-size: 0.875em;
+    font-size: .875em;
     margin-bottom: 0;
   }
   &.alert {
-    font-size: 0.875em;
+    font-size: .875em;
     color: @brown;
     background-color: @light-yellow;
     background-position: 10px 50%;
@@ -759,7 +759,7 @@ select,
 textarea {
   font-family: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
   color: @darker-grey;
-  font-size: 0.875em;
+  font-size: .875em;
 }
 
 input {
@@ -779,12 +779,12 @@ input {
 }
 
 .published {
-  font-size: 0.85em;
+  font-size: .85em;
   font-weight: bold;
 }
 
 .format {
-  font-size: 0.75em;
+  font-size: .75em;
   margin-top: 5px;
 }
 
@@ -999,7 +999,7 @@ div.formElement {
   label,
   select#date1,
   select#date2 {
-    font-size: 0.75em;
+    font-size: .75em;
   }
   .input label {
     font-size: 1.0em;
@@ -1015,7 +1015,7 @@ div.formElement {
   }
   blockquote {
     font-family: Georgia,"Palatino Linotype", "Book Antiqua", Palatino, serif;
-    font-size: 0.875em;
+    font-size: .875em;
     margin: 1em 40px;
   }
 }
@@ -1085,7 +1085,7 @@ fieldset {
       .SRPCoverBlank {
         width: 90px;
         height: 150px;
-        font-size: 0.75em;
+        font-size: .75em;
         .innerBorder {
           border: 1px solid @white;
           width: 88px;
@@ -1211,7 +1211,7 @@ form {
   &.recordsAdd {
     margin-bottom: 30px;
     input[type=text] {
-      font-size: 0.875em;
+      font-size: .875em;
       font-family: Georgia, "Palatino Linotype", "Book Antiqua", Palatino, serif;
       color: @dark-grey;
       padding: 3px;
@@ -1239,11 +1239,11 @@ form {
     textarea {
       width: 623px !important;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-      font-size: 0.875em;
+      font-size: .875em;
     }
     input#comment {
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-      font-size: 0.875em;
+      font-size: .875em;
     }
   }
   &#register {
@@ -1362,11 +1362,11 @@ div.searchFilter {
   .searchOpener {
     right: 0;
     margin-top: 5px;
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
   .searchCheckboxes {
     margin-top: 5px;
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
 }
 
@@ -1441,7 +1441,7 @@ div.searchOptions {
 
 .searchPlus {
   font-family: "Lucida Grande", Verdana, Arial, sans-serif;
-  font-size: 0.75em;
+  font-size: .75em;
   color: @dark-grey;
   padding: 15px 0;
 }
@@ -1470,7 +1470,7 @@ div.searchOptions {
   width: 100%;
   height: 100%;
   background-color: @black;
-  opacity: 0.5;
+  opacity: .5;
   filter: alpha(opacity=50);
   z-index: 9999 !important;
 }
@@ -1551,7 +1551,7 @@ div.searchOptions {
 
 div.cclicense {
   font-family: "Lucida Grande", "Trebuchet MS", Geneva, Helvetica, sans-serif;
-  font-size: 0.75em;
+  font-size: .75em;
   min-height: 20px;
   padding: 3px 0 0 30px;
   color: @brown;
@@ -1590,7 +1590,7 @@ div#editionBuy {
     height: auto !important;
     padding-top: 0;
     text-align: left;
-    font-size: 0.75em;
+    font-size: .75em;
     font-weight: normal;
     color: @link-blue;
     text-decoration: underline;
@@ -1679,7 +1679,7 @@ hr.forgot-padding {
 }
 
 .forgot-email {
-  font-size: 0.8em;
+  font-size: .8em;
   &-form {
     padding: 10px 0;
     .form-row {
@@ -1719,7 +1719,7 @@ hr.forgot-padding {
 @import (less) 'components/footer.less';
 
 #archive-details {
-  flex: 0.8;
+  flex: .8;
 }
 
 /* CONTENT */
@@ -2080,7 +2080,7 @@ div#searchResults {
     text-decoration: none;
     text-align: center;
     padding: 5px 0;
-    font-size: 0.8em;
+    font-size: .8em;
     .badge {
       background-color: @orange-two;
       padding: 4px 7px;
@@ -2227,13 +2227,13 @@ div.list {
   }
   .tags {
     font-family: "Lucida Grande", Arial, Geneva, Helvetica, sans-serif;
-    font-size: 0.6875em;
+    font-size: .6875em;
     color: @grey;
     margin-bottom: 5px;
   }
   .owner {
     font-family: "Lucida Grande", Arial, Geneva, Helvetica, sans-serif;
-    font-size: 0.6875em;
+    font-size: .6875em;
     color: @grey;
     text-align: right;
   }
@@ -2393,7 +2393,7 @@ div.books {
     padding: 5px;
     text-align: center;
     float: left;
-    font-size: 0.6875em;
+    font-size: .6875em;
     cursor: pointer;
     display: none;
     background-color: @lighter-grey;
@@ -2417,7 +2417,7 @@ div.books {
     color: @grey;
     font-style: italic;
     padding: 4px 4px 0;
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
 }
 
@@ -2440,13 +2440,13 @@ ul.urlList {
     }
     span.quote {
       font-family: Georgia, "Palatino Linotype", "Book Antiqua", Palatino, serif;
-      font-size: 0.75em;
+      font-size: .75em;
       color: @grey;
     }
   }
   span.date {
     font-family: "Lucida Grande", "Trebuchet MS", Geneva, Helvetica, Arial, sans-serif;
-    font-size: 0.6875em;
+    font-size: .6875em;
     color: @grey;
   }
 }
@@ -2585,14 +2585,14 @@ div.excerpt {
   width: 100%;
   .text {
     padding: 15px;
-    font-size: 0.875em;
+    font-size: .875em;
     line-height: 1.25em;
     font-style: italic;
   }
   .attribution {
     padding-left: 15px;
     font-family: "Lucida Grande", Verdana, Helvetica, Geneva, sans-serif;
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
 }
 
@@ -2671,7 +2671,7 @@ ul {
 .section {
   margin-bottom: 20px;
   .sansserif {
-    font-size: 0.75em;
+    font-size: .75em;
   }
   p {
     margin-bottom: 1em;
@@ -2742,7 +2742,7 @@ div#history {
       border-top-left-radius: 8px;
       color: @white;
       font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-      font-size: 0.6875em;
+      font-size: .6875em;
       font-weight: 700;
       padding: 10px 37px 10px 10px;
       text-decoration: none;
@@ -2764,7 +2764,7 @@ div#history {
       color: @brown;
     }
     .revertThis {
-      font-size: 0.75em;
+      font-size: .75em;
       color: @grey;
     }
   }
@@ -2814,10 +2814,10 @@ div#history {
         font-size: 12px;
       }
       input[type=submit] {
-        font-size: 0.6875em;
+        font-size: .6875em;
       }
       a#revertSlideIn {
-        font-size: 0.6875em;
+        font-size: .6875em;
         color: @red;
         text-decoration: none;
       }
@@ -2857,7 +2857,7 @@ div#history {
       max-width: 530px;
     }
     #author {
-      font-size: 0.6875em;
+      font-size: .6875em;
       color: @grey;
     }
     #comment {
@@ -2946,7 +2946,7 @@ div#history {
       margin: 0 20px 5px 0;
       text-align: center;
       background: @lighter-grey;
-      font-size: 0.875em;
+      font-size: .875em;
       cursor: pointer;
       display: none;
       .innerBorder {
@@ -2968,7 +2968,7 @@ div#history {
   margin-top: -50px;
   vertical-align: middle;
   color: @dark-grey;
-  font-size: 0.875em;
+  font-size: .875em;
   line-height: normal;
 }
 
@@ -3102,7 +3102,7 @@ ul#siteSearch {
   }
   span.resultTitle .bookauthor,
   span.resultPublisher {
-    font-size: 0.75em;
+    font-size: .75em;
     color: @grey;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
   }
@@ -3110,7 +3110,7 @@ ul#siteSearch {
     display: block;
   }
   span.resultType {
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
 }
 
@@ -3187,12 +3187,12 @@ div#editionsCovers {
 }
 
 .Publisher {
-  font-size: 0.6875em;
+  font-size: .6875em;
   color: @black;
 }
 
 .Year {
-  font-size: 0.6875em;
+  font-size: .6875em;
   color: @brown;
 }
 
@@ -3294,7 +3294,7 @@ div.pop {
     text-align: center;
   }
   &Notify {
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-family: "Lucida Grande", Verdana, Helvetica, sans-serif;
     margin: 10px 20px;
   }
@@ -3472,7 +3472,7 @@ td.nagios {
 div#prolific {
   span {
     font-family: "Lucida Grande", Verdana, Helvetica, Geneva, sans-serif;
-    font-size: 0.6875em;
+    font-size: .6875em;
   }
 }
 
@@ -3493,7 +3493,7 @@ div.measurements {
     padding-top: 20px;
   }
   .measure {
-    font-size: 0.875em;
+    font-size: .875em;
   }
   .large {
     font-size: 1.125em !important;
@@ -3512,7 +3512,7 @@ div#admin {
   &Twitter {
     width: 300px;
     float: left;
-    font-size: 0.75em;
+    font-size: .75em;
     div.tweet_avatar {
       width: 35px;
     }
@@ -3597,7 +3597,7 @@ div.merge {
       margin-bottom: 0 !important;
       li {
         color: @grey!important;
-        font-size: 0.75em;
+        font-size: .75em;
       }
     }
     .name {
@@ -3620,19 +3620,19 @@ div.merge {
     }
     .metaDate {
       color: @brown;
-      font-size: 0.8125em;
+      font-size: .8125em;
       padding-left: 10px;
     }
     .metaSubject {
       color: @grey;
-      font-size: 0.8125em;
+      font-size: .8125em;
       display: block;
     }
   }
   div.count {
     width: 86px;
     float: left;
-    font-size: 0.8125em;
+    font-size: .8125em;
     text-align: right;
   }
 }
@@ -3805,13 +3805,13 @@ ul#listResults {
     }
 
     span.meta {
-      font-size: 0.75em;
+      font-size: .75em;
       display: block;
       color: @grey;
     }
 
     span.time {
-      font-size: 0.75em;
+      font-size: .75em;
       display: block;
       color: @light-grey;
     }
@@ -3825,35 +3825,35 @@ ul#listResults {
       background-color: @teal;
       color: @white;
       padding: 1px;
-      opacity: 0.50;
+      opacity: .50;
     }
 
     span.subject {
       background-color: @orange;
       color: @white;
       padding: 1px;
-      opacity: 0.50;
+      opacity: .50;
     }
 
     span.place {
       background-color: @red;
       color: @white;
       padding: 1px;
-      opacity: 0.50;
+      opacity: .50;
     }
 
     span.book {
       background-color: @dark-green;
       color: @white;
       padding: 1px;
-      opacity: 0.50;
+      opacity: .50;
     }
 
     span.people {
       background-color: @brown;
       color: @white;
       padding: 1px;
-      opacity: 0.50;
+      opacity: .50;
     }
 
     span.listDelete {
@@ -3956,7 +3956,7 @@ div#listsWork {
   }
 
   p {
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     padding-left: 42px;
     margin-bottom: 5px !important;
@@ -4018,7 +4018,7 @@ div#subjectLists {
     }
   }
   p {
-    font-size: 0.6875em;
+    font-size: .6875em;
     font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
     padding-left: 42px;
     margin-bottom: 5px !important;
@@ -4120,7 +4120,7 @@ div#subjectLists {
     .description {
       p,
       li {
-        font-size: 0.8125em;
+        font-size: .8125em;
         color: @dark-grey;
         margin: 0 !important;
       }
@@ -4136,7 +4136,7 @@ div#subjectLists {
 
 /* SEARCH INSIDE */
 .snipHL {
-  opacity: 0.20;
+  opacity: .20;
   filter: alpha(opacity=20);
   background-color: @blue;
   position: absolute;
@@ -4182,12 +4182,12 @@ div#subjectLists {
     content: "";
     position: absolute;
     left: 0;
-    top: 0.25em;
+    top: .25em;
     width: 1em;
-    height: 0.15em;
+    height: .15em;
     background: @black;
-    -webkit-box-shadow: 0 0.25em 0 0 @black, 0 0.5em 0 0 @black;
-    box-shadow: 0 0.25em 0 0 @black, 0 0.5em 0 0 @black;
+    -webkit-box-shadow: 0 .25em 0 0 @black, 0 .5em 0 0 @black;
+    box-shadow: 0 .25em 0 0 @black, 0 .5em 0 0 @black;
   }
 }
 

--- a/static/css/page-book-widget.less
+++ b/static/css/page-book-widget.less
@@ -67,7 +67,7 @@ img.bookcover {
   font-family: Georgia, "Palatino Linotype", "Book Antiqua", Palatino, serif;
   margin: 7px auto 0 auto;
   color: @grey-555;
-  font-size: 0.8em;
+  font-size: .8em;
   width: 130px;
 }
 
@@ -77,7 +77,7 @@ a.noshow {
 
 .author {
   font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-  font-size: 0.7em;
+  font-size: .7em;
   font-weight: normal;
   color: @grey;
   margin: 5px auto 7px auto;

--- a/static/css/page-design.less
+++ b/static/css/page-design.less
@@ -21,7 +21,7 @@ p {
 }
 
 h1, h2, h3, h4 {
-  margin: 1.414em 0 0.5em;
+  margin: 1.414em 0 .5em;
   font-weight: inherit;
   line-height: 1.2;
 }

--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -39,7 +39,7 @@ body#edit {
     position: absolute;
     top: 60px;
     right: 20px;
-    font-size: 0.75em;
+    font-size: .75em;
     font-family: "Lucida Grande",Verdana,Geneva,Helvetica,Arial,sans-serif;
   }
   .formElement {
@@ -54,13 +54,13 @@ body#edit {
       font-weight: 700;
     }
     span {
-      font-size: 0.75em;
+      font-size: .75em;
       font-family: "Lucida Grande", "Trebuchet MS", Geneva, Helvetica, Arial, sans-serif;
     }
   }
   textarea {
     font-family: "Lucida Console", "Courier New", monospace;
-    font-size: 0.875em;
+    font-size: .875em;
     padding: 5px;
   }
   .formElement input[type=text],
@@ -79,7 +79,7 @@ body#edit {
       background-color: @white;
       vertical-align: top;
       font-family: "Lucida Console", "Courier New", monospace;
-      font-size: 0.875em;
+      font-size: .875em;
       padding: 5px;
     }
   }
@@ -88,7 +88,7 @@ body#edit {
     margin: 20px 20px 0;
     background-color: @light-yellow;
     a {
-      font-size: 0.75em;
+      font-size: .75em;
     }
   }
   #editHead {

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -86,7 +86,7 @@ body#form {
     }
   }
   .portlet-content {
-    padding: 0.4em;
+    padding: .4em;
   }
   .imagePost {
     float: left;
@@ -96,7 +96,7 @@ body#form {
   .imageSaved {
     float: left;
     width: 300px;
-    font-size: 0.75em;
+    font-size: .75em;
     color: @grey;
   }
   .saved {

--- a/static/css/page-plain.less
+++ b/static/css/page-plain.less
@@ -47,7 +47,7 @@ body#plain {
       padding: 0;
     }
     p {
-      font-size: 0.75em;
+      font-size: .75em;
       padding: 0;
       margin: 0;
     }
@@ -60,13 +60,13 @@ body#plain {
   }
   #faq {
     h4 {
-      font-size: 0.75em;
+      font-size: .75em;
       color: @black;
       text-transform: uppercase;
       margin-bottom: 0;
     }
     p {
-      font-size: 0.75em;
+      font-size: .75em;
       color: @dark-grey;
     }
   }
@@ -94,7 +94,7 @@ body#plain {
   }
   div.navBorrow {
     margin: 50px 0 10px;
-    font-size: 0.75em;
+    font-size: .75em;
   }
   .panel {
     background-color: @white;
@@ -117,16 +117,16 @@ body#plain {
       font-weight: 700;
     }
     span.author {
-      font-size: 0.875em;
+      font-size: .875em;
       color: @dark-grey;
     }
     span.publisher,
     span.contributor {
       color: @dark-grey;
-      font-size: 0.875em;
+      font-size: .875em;
     }
     div.date {
-      font-size: 0.75em;
+      font-size: .75em;
       color: @grey;
     }
     span.expires {
@@ -138,7 +138,7 @@ body#plain {
   }
   div#listsWork {
     p {
-      font-size: 0.75em;
+      font-size: .75em;
       padding-left: 0;
       margin-bottom: 5px !important;
     }
@@ -148,7 +148,7 @@ body#plain {
     margin: 60px 0 25px;
 
     p {
-      font-size: 0.875em;
+      font-size: .875em;
       margin: 0;
       padding: 0;
     }
@@ -166,7 +166,7 @@ body#plain {
           font-family: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
           color: @brown;
           font-weight: 600;
-          font-size: 0.6875em;
+          font-size: .6875em;
           text-transform: uppercase;
           white-space: nowrap;
         }


### PR DESCRIPTION
Closes #1099  

## Description:
- Add removal of leading zeroes linting rule in `.stylelintrc.json`.
- Fix all offenders in `/static/css` that contained leading zeros by running `npm run lint:fix`.
