### PR TITLE
Remove inline style so that choices in search page are on the same line

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -125,7 +125,7 @@ $ )
 
     <form method="get" action="/search" class="siteSearch olform">
       <label for="q" class="hidden">Keywords</label>
-      <input type="text" name="q" id="q" value="$q_param" size="100" style="width:505px;"/>
+      <input type="text" name="q" id="q" value="$q_param" size="100"/>
       <button type="submit" class="larger" id="searchsubmit">$_("Search")</button>
       <span class="mode-options">
         <input type="radio" name="mode" value="everything" id="mode-search-everything" class="search-mode">


### PR DESCRIPTION
Closes #1224 

## Description:
In this Pull Request we have made the following changes:

* Changed search bar width so that all adjacent choices are on a single line