### PR TITLE
WIP: Limit history to 100 entries

### DIFF
--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -171,12 +171,12 @@ class subject_history(delegate.page):
     def GET(self):
         i = web.input()
 	try:
-		limit = int(i.get("limit",self.API_ROWS_LIMIT))
+		limit = int(i.get("limit", self.API_ROWS_LIMIT))
 	except (ValueError, TypeError):
-		return {'error':'limit must be an integer'}
-        if limit>self.API_ROWS_LIMIT:
-            return {'error':'limit must be less than or equal to {}'.format(self.API_ROWS_LIMIT)}
-        return history().get()
+		return {'error': 'limit must be an integer'}
+        if limit > self.API_ROWS_LIMIT:
+            return {'error': 'limit must be less than or equal to {}'.format(self.API_ROWS_LIMIT)}
+        return history().GET()
 
 def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filters):
     """Returns data related to a subject.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -176,7 +176,9 @@ class subject_history(delegate.page):
         except (ValueError, TypeError):
             return {'error': 'limit must be an integer'}
         if limit > self.API_ROWS_LIMIT:
-            return {'error': 'limit must be less than or equal to {}'.format(self.API_ROWS_LIMIT)}
+            return {'error':
+                    'limit must be less than or equal to {}'
+                    .format(self.API_ROWS_LIMIT)}
         return history().GET()
 
 def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filters):

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -10,7 +10,7 @@ import urllib
 import datetime
 
 from infogami import config
-from infogami.plugins.api.code import jsonapi
+from infogami.plugins.api.code import jsonapi, history
 from infogami.utils import delegate, stats
 from infogami.utils.view import render, render_template, safeint
 
@@ -162,6 +162,16 @@ class subject_works_json(delegate.page):
     def process_key(self, key):
         return key
 
+class subject_history(delegate.page):
+    path = '/subjects/history'
+    encoding = 'json'
+    
+    @jsonapi
+    def GET(self,key):
+        i = web.input()
+        if i.get("limit")>100:
+            return "I'm sorry Dave, I'm afraid I can't do that."
+        return history().get()
 
 def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filters):
     """Returns data related to a subject.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -165,15 +165,16 @@ class subject_works_json(delegate.page):
 class subject_history(delegate.page):
     path = '/subjects/history'
     encoding = 'json'
-    
+
     API_ROWS_LIMIT = 100
+
     @jsonapi
     def GET(self):
         i = web.input()
-	try:
-		limit = int(i.get("limit", self.API_ROWS_LIMIT))
-	except (ValueError, TypeError):
-		return {'error': 'limit must be an integer'}
+        try:
+            limit = int(i.get("limit", self.API_ROWS_LIMIT))
+        except (ValueError, TypeError):
+            return {'error': 'limit must be an integer'}
         if limit > self.API_ROWS_LIMIT:
             return {'error': 'limit must be less than or equal to {}'.format(self.API_ROWS_LIMIT)}
         return history().GET()

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -166,11 +166,16 @@ class subject_history(delegate.page):
     path = '/subjects/history'
     encoding = 'json'
     
+    API_ROWS_LIMIT = 100
     @jsonapi
-    def GET(self,key):
+    def GET(self):
         i = web.input()
-        if i.get("limit")>100:
-            return "I'm sorry Dave, I'm afraid I can't do that."
+	try:
+		limit = int(i.get("limit",self.API_ROWS_LIMIT))
+	except (ValueError, TypeError):
+		return {'error':'limit must be an integer'}
+        if limit>self.API_ROWS_LIMIT:
+            return {'error':'limit must be less than or equal to {}'.format(self.API_ROWS_LIMIT)}
         return history().get()
 
 def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filters):


### PR DESCRIPTION
Adds a 100 entry limit to /subjects/history.json requests.

Closes #314 

## Description:
In this Pull Request we have made the following changes:

 - Manually add history to subjects.

Note: If anything else needs to happen for this to work, please let me know and I will fix it ASAP.