### PR TITLE
/api/import Import refactor + enable orphan reimport

### DIFF
--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -40,7 +40,6 @@ def extract_item_metadata(item_json):
         metadata['_filenames'] = [f['name'] for f in files]
     return metadata
 
-
 def get_metadata(itemid):
     item_json = get_item_json(itemid)
     return extract_item_metadata(item_json)
@@ -209,6 +208,7 @@ class ItemEdition(dict):
         * no-imagecount
         * prefix-blacklisted
         * noindex-true
+        * no-ol-import
         """
         # Not a book, or scan not complete or no images uploaded
         if metadata.get("mediatype") != "texts":
@@ -244,6 +244,10 @@ class ItemEdition(dict):
             and "inlibrary" not in collections \
             and "lendinglibrary" not in collections:
             return "noindex-true"
+        # Gio - April 2016
+        # items with metadata no_ol_import=true will be not imported
+        if metadata.get("no_ol_import", '').lower() == 'true':
+            return "no-ol-import"
 
         return "ok"
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -129,11 +129,11 @@ class importapi:
 
         try:
             edition, format = parse_data(data)
-        except DataError, e:
+        except DataError as e:
             return self.error(str(e), 'Failed to parse import data')
 
         if not edition:
-            return self.error('unknown_error', 'Failed to parse Edition data')
+            return self.error('unknown_error', 'Failed to parse import data')
 
         ## Anand - July 2014
         ## This is adding source_records as [null] as queue_s3_upload is disabled.
@@ -143,7 +143,10 @@ class importapi:
         #     source_url = queue_s3_upload(data, format)
         #     edition['source_records'] = [source_url]
 
-        reply = add_book.load(edition)
+        try:
+            reply = add_book.load(edition)
+        except add_book.RequiredField as e:
+            return self.error('missing-required-field', str(e))
         #if source_url:
         #    reply['source_record'] = source_url
         return json.dumps(reply)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -77,46 +77,12 @@ def parse_data(data):
         edition_builder = import_edition_builder.import_edition_builder(init_dict=obj)
         format = 'json'
     else:
-        # Special case to load IA records, DEPRECATED: use import/ia endpoint
-        # Just passing ia:foo00bar is enough to load foo00bar from IA.
-        if data.startswith("ia:"):
-            source_records = [data]
-            itemid = data[len("ia:"):]
-
-            metadata = ia.get_metadata(itemid)
-            if not metadata:
-                raise DataError("invalid-ia-identifier")
-
-            # see ia_importapi to address `imagecount` limitations
-            status = ia.get_item_status(itemid, metadata)
-            if status != 'ok':
-                raise DataError(status)
-
-            try:
-                rec = get_marc_record_from_ia(itemid)
-
-                # skip serials
-                if rec and rec.leader()[7] == 's':
-                    raise DataError("item-is-serial")
-            except IOError:
-                raise DataError("no-marc-record")
-
-            if not rec:
-                raise DataError("no-marc-record")
-        else:
-            source_records = None
-            itemid = None
-
-            #Marc Binary
-            if len(data) < 5 or len(data) != int(data[:5]):
-                raise DataError("no-marc-record")
-
-            rec = MarcBinary(data)
+        #Marc Binary
+        if len(data) < 5 or len(data) != int(data[:5]):
+            raise DataError('no-marc-record')
+        rec = MarcBinary(data)
 
         edition = read_edition(rec)
-        if source_records:
-            edition['source_records'] = source_records
-            edition['ocaid'] = itemid
         edition_builder = import_edition_builder.import_edition_builder(init_dict=edition)
         format = 'marc'
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -217,13 +217,7 @@ class ia_importapi(importapi):
 
             # Add next_data to the response as location of next record:
             result.update(next_data)
-
             return json.dumps(result)
-
-        # Case 0 - Is the item already loaded
-        key = self.find_edition(identifier)
-        if key:
-            return self.status_matched(key)
 
         # Case 1 - Is this a valid Archive.org item?
         try:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -239,11 +239,6 @@ class ia_importapi(importapi):
         if status != 'ok':
             return self.error(status, "Prohibited Item")
 
-        # Gio - April 2016
-        # items with metadata no_ol_import=true will be not imported
-        if metadata.get("no_ol_import", '').lower() == 'true':
-            return self.error("no-ol-import")
-
         # Case 4 - Does this item have a marc record?
         marc_record = self.get_marc_record(identifier)
         if marc_record:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -27,6 +27,7 @@ from lxml import etree
 import logging
 
 IA_BASE_URL = config.get('ia_base_url')
+MARC_LENGTH_POS = 5
 logger = logging.getLogger("openlibrary.importapi")
 
 class DataError(ValueError):
@@ -78,7 +79,7 @@ def parse_data(data):
         format = 'json'
     else:
         #Marc Binary
-        if len(data) < 5 or len(data) != int(data[:5]):
+        if len(data) < MARC_LENGTH_POS or len(data) != int(data[:MARC_LENGTH_POS]):
             raise DataError('no-marc-record')
         rec = MarcBinary(data)
 
@@ -207,7 +208,7 @@ class ia_importapi(importapi):
                 logger.error("failed to read from bulk MARC record %s", details)
                 return self.error('invalid-marc-record', details, **next_data)
 
-            actual_length = int(rec.leader()[:5])
+            actual_length = int(rec.leader()[:MARC_LENGTH_POS])
             edition['source_records'] = 'marc:%s/%s:%s:%d' % (ocaid, filename, offset, actual_length)
 
             #TODO: Look up URN prefixes to support more sources

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1374,6 +1374,8 @@ def update_keys(keys, commit=True, output_file=None):
         else:
             if edition.get("works"):
                 wkeys.add(edition["works"][0]['key'])
+                # Make sure we remove any fake works created from orphaned editons
+                deletes.append(k.replace('/books/', '/works/'))
             else:
                 # index the edition as it does not belong to any work
                 wkeys.add(k)


### PR DESCRIPTION
This brings `/api/import` in line with recent improvements and error reporting added on `/api/import/ia`, removes duplicated code, and re-enables + improves the orphaned edition fixing on reimport functionality.

It also adds a method to _remove_ indexed fake-works for orphaned editions once the data is cleaned up. Previously they would remain in search results even after the data was fixed. 