### PR TITLE
Remove jCarousel from vendor v2 bundle

### DIFF
--- a/static/js/vendor.jsh
+++ b/static/js/vendor.jsh
@@ -26,9 +26,9 @@ else
     xcat $VENDORJS/jquery/jquery-1.3.2.min.js
     xcat $VENDORJS/jquery-ui/jquery-ui-1.7.2.min.js
     xcat $VENDORJS/colorbox/colorbox/jquery.colorbox-min.js
+    xcat $VENDORJS/jcarousel/lib/jquery.jcarousel.js | $JSMIN
 fi
 
-xcat $VENDORJS/jcarousel/lib/jquery.jcarousel.js | $JSMIN
 xcat $VENDORJS/jquery-sparkline/jquery.sparkline.min.js
 xcat $VENDORJS/jquery-showpassword/jquery.showpassword.min.js
 xcat $VENDORJS/jquery-form/jquery.form.js | $JSMIN


### PR DESCRIPTION
In v2 pages (currently only home page) we will exclusively use the slick carousel. Use of
jCarousel on these pages will be forbidden. We only need one carousel to rule them all.
