### PR TITLE
Fix shareLink stylelint offender

### DIFF
--- a/static/css/components/shareLinks.less
+++ b/static/css/components/shareLinks.less
@@ -32,7 +32,6 @@
   }
   li {
     list-style-type: none;
-    display: inline;
     line-height: 24px;
     display: inline-block;
     margin: 5px 0 0;


### PR DESCRIPTION
`npm run stylelint` is failing again. Hurrah it's working!