### PR TITLE
resolving issue where fts results failed

### DIFF
--- a/openlibrary/macros/FulltextResults.html
+++ b/openlibrary/macros/FulltextResults.html
@@ -1,6 +1,6 @@
 $def with(query, results, page=1)
 
-$if results.get('hits'):
+$if results and results.get('hits'):
   $ loans = ctx.user.get_loans() if ctx.user else []
   $ waiting_loans = ctx.user.get_waitinglist() if ctx.user else []
   $ user = {'loans': loans, 'waitlists': waiting_loans}


### PR DESCRIPTION
On failure `results` is [] rather than a dict containing `hits`. This probably represents a larger issue further up the call-stack (where results should return `{hits: []}` instead. For now, this fixes a failure case on production.