### PR TITLE
resolves 1301 readinglog dropper btn regression

### DIFF
--- a/static/css/components/dropper--tablet.less
+++ b/static/css/components/dropper--tablet.less
@@ -5,14 +5,7 @@
  * Used in templates:
  * - openlibrary/templates/lists/widget.html
  */
-div.Tools {
-  div.dropper {
-    position: absolute;
-    top: 0;
-    left: 32px;
-    width: 198px;
-  }
-}
+
 div.tools-override {
   div.dropper {
     margin: inherit;


### PR DESCRIPTION
Closes #1301 

![screen shot 2018-10-09 at 18 49 04pmpdt](https://user-images.githubusercontent.com/978325/46708548-0b7cff00-cbf4-11e8-8fcd-03e29b59e435.png)

## Description:
In this Pull Request we have made the following changes:
- removes dropper styling which was causing css regression for reading log btn