### PR TITLE
Tools margins are set in tablet

### DIFF
--- a/static/css/components/Tools--tablet.less
+++ b/static/css/components/Tools--tablet.less
@@ -6,6 +6,11 @@
  */
 .Tools {
   width: 250px;
+  margin: 0 0 25px 20px;
+
+  .btn-notice {
+    margin-left: 35px;
+  }
 }
 div.tools-override {
   width: 180px;

--- a/static/css/components/Tools.less
+++ b/static/css/components/Tools.less
@@ -6,13 +6,11 @@
  */
 
 .Tools {
-  margin: 0 0 25px 20px;
   position: relative;
 
   .btn-notice {
     line-height: 1.5em;
     font-size: 1em;
-    margin-left: 35px;
     padding: 10px;
     margin-bottom: 10px;
     background-color: @white;


### PR DESCRIPTION
On mobile the margins are unnecessary and take away valuable
screen real estate.

Due to vertical stacking contentBody's padding is all that's needed
here.

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
