### PR TITLE
adding libffi-dev as apt dependency vagrant docker

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -18,6 +18,7 @@ RUN apt-get -qq update && apt-get install -y \
     libpq-dev \
     libxml2-dev \
     libxslt-dev \
+    libffi-dev \
     curl \
     screen \
     npm \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -25,6 +25,7 @@ memcached
 libpq-dev
 libxml2-dev
 libxslt-dev
+libffi-dev
 curl
 screen
 npm


### PR DESCRIPTION
re-closes #1311

adds libffi-dev as docker + vagrant dep