### PR TITLE
Fix add-cover and manage-covers

### DIFF
--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -10,7 +10,7 @@ $elif doc.type.key == "/type/edition":
     $ intro = _("There are two ways to get a cover image on Open Library")
     $ action = doc.url('/add-cover')
 $elif doc.get_edition_covers:
-    $ intro = _("There are three ways to get a cover image on Open Library")
+    $ intro = _("There are two ways to get a cover image on Open Library")
     $ action = doc.url('/add-cover')
 $else:
     $ intro = _("There are two ways to get a cover image on Open Library")
@@ -26,9 +26,7 @@ $if status:
 
 <script type="text/javascript">
 <!--
-\$().ready(carousels);
-\$().ready(function(){\$('#popcovers').jcarousel();});
-\$(function() {
+window.q.push(function(){
     parent.closeThrobber();
     \$("#form.addcover-form").submit(function(event) {
 

--- a/openlibrary/templates/covers/manage.html
+++ b/openlibrary/templates/covers/manage.html
@@ -4,7 +4,7 @@ $putctx("bodyid", "form")
 $putctx('robots', 'noindex,nofollow')
 
 <script type="text/javascript">
-\$(function() {
+window.q.push(function () {
     \$(".column").sortable({
         connectWith: '.trash'
     });
@@ -13,10 +13,6 @@ $putctx('robots', 'noindex,nofollow')
     });
     \$(".column").disableSelection();
     \$(".trash").disableSelection();
-});
-</script>
-<script type="text/javascript">
-\$().ready(function(){
     \$("#topNotice").hide();
 });
 </script>

--- a/openlibrary/templates/lib/covers.html
+++ b/openlibrary/templates/lib/covers.html
@@ -30,18 +30,6 @@ function loadCoverCarousels(carousel, state) {
         updateBookAvailability('#coversCarousel li ');
     });
 }
-
-\$().ready(function() {
-    page.renderCovers = render_page;
-    page.displayCovers(0);
-});
-
-\$().ready(carousels);
-\$().ready(function() {
-    carouselSetup(loadCoverCarousels);
-    \$('.jcarousel-next').attr('title','View the next editions').append('<h4 class="shift"><a href="#" onclick="return false;">View the next editions</a></h4>');
-    \$('.jcarousel-prev').attr('title','View the previous editions').append('<h4 class="shift"><a href="#" onclick="return false;">View the previous editions</a></h4>');
-});
 //-->
 </script>
 

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -3,7 +3,7 @@ $def with (page)
 $ announcement = '<strong>New Feature:</strong> You can now embed Open Library books on your website! &nbsp; <a href="https://blog.openlibrary.org/2018/05/06/turn-your-website-into-a-library/" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>'
 
 $ bodyid = ctx.get('bodyid', 'user')
-
+$ show_banners = bodyid != 'form'
 $if 'v2' in page:
   <body id="$bodyid">
     <script>
@@ -11,12 +11,16 @@ $if 'v2' in page:
         document.body.className += ' client-js';
     </script>
     <span id="top"></span>
-    $:render_template("site/alert")
-    $:render_template("lib/nav_head", None)
+    $# on form pages e.g. manage-covers, add-cover we do not display the header
+    $# this is consistent with version 1.
+    $if show_banners:
+      $:render_template("site/alert")
+      $:render_template("lib/nav_head", None)
     <div id="test-body-mobile">
-      <div class="page-banner page-banner-body">
-        $:announcement
-      </div>
+      $if show_banners:
+        <div class="page-banner page-banner-body">
+          $:announcement
+        </div>
       $:page
     </div>
 

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -37,7 +37,6 @@ body#form {
   }
   .column {
     min-height: 90px;
-    float: left;
     margin: 10px;
     background-image: url(/images/back_sortable.png);
     background-repeat: no-repeat;

--- a/static/css/v2.less
+++ b/static/css/v2.less
@@ -4,8 +4,13 @@
   max-width: 960px;
   width: 100%;
   margin: 0 auto;
-  margin-top: 20px;
   background-color: @white;
   border-radius: 5px;
   border: 1px solid @dark-beige;
+}
+// For pages without a header we don't want a margin.
+// This might be better placed in the header component in future
+// but is kept here for backwards compatibility with v1 pages
+header + #test-body-mobile {
+  margin-top: 20px;
 }


### PR DESCRIPTION
Changes:
* Pages with id "form" no longer have a header in v2
or any banners
* No margin at the top of pages without a header
* Upgrade some $.ready calls to us the window.q
* Remove some jCarousel code which wasnt functioning before
the migration to v2 and continues not to function
* "three ways" => "two ways". presumably, we used to allow
selection of covers from a carousel, but it doesnt look like
that was working (at least for me locally) prior to making the
page v2
* Remove the float on the manage covers element - it was breaking
compatability with jquery ui. This forces it onto a new line.

Fixes: #1329
Fixes: #1199

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
