### PR TITLE
1284

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousels.js
+++ b/openlibrary/plugins/openlibrary/js/carousels.js
@@ -1,5 +1,11 @@
 var Carousel = {
     add: function(selector, a, b, c, d, e, f) {
+        a = a || 6;
+        b = b || 5;
+        c = c || 4;
+        d = d || 3;
+        e = e || 2;
+        f = f || 1;
         var responsive_settings = [
             {
                 breakpoint: 1200,

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -10,7 +10,7 @@ $elif doc.type.key == "/type/edition":
     $ intro = _("There are two ways to get a cover image on Open Library")
     $ action = doc.url('/add-cover')
 $elif doc.get_edition_covers:
-    $ intro = _("There are two ways to get a cover image on Open Library")
+    $ intro = _("There are three ways to get a cover image on Open Library")
     $ action = doc.url('/add-cover')
 $else:
     $ intro = _("There are two ways to get a cover image on Open Library")
@@ -27,7 +27,10 @@ $if status:
 <script type="text/javascript">
 <!--
 window.q.push(function(){
-    parent.closeThrobber();
+    // page may not be loaded via iframe
+    if ( parent && parent.closeThrobber ) {
+        parent.closeThrobber();
+    }
     \$("#form.addcover-form").submit(function(event) {
 
        function val(selector) {
@@ -73,22 +76,33 @@ window.q.push(function(){
                         <div class="label">
                             <label>$:_("<strong>Pick one</strong> from the existing covers,")</label>
                         </div>
-                        <div id="covers">
-                            <ul id="popcovers">
-                            $for cover in doc.get_edition_covers():
-                                <li class="edition-cover" id="cover-$cover.id"><img src="$cover.url(size='M')"/></li>
-                            </ul>
+                        <div class="carousel-section">
+                            <div id="covers" class="carousel-container carousel-container-decorated">
+                                <div id="popcovers" class="carousel">
+                                $for cover in doc.get_edition_covers():
+                                    <div class="book carousel__item" data-id="$cover.id">
+                                        <div class="book-cover">
+                                            <img src="$cover.url(size='M')"
+                                                width="100" class="bookcover"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <input type="hidden" id="coverid" name="coverid" value=""/>
                         <script type="text/javascript">
-                        \$("#popcovers > li").click(function() {
-                            \$(this).toggleClass("selected").siblings().removeClass("selected");
-                            var coverid = "";
-                            if (\$(this).hasClass("selected")) {
-                                coverid = \$(this).attr("id").split("-")[1];
-                            }
-                            \$("#coverid").val(coverid);
-                        });
+                        window.q.push( function () {
+                            Carousel.add('#popcovers');
+                            // Clicking a cover should set the form value to the data-id of that cover
+                            \$("#popcovers .book").click(function() {
+                                \$(this).toggleClass("selected").siblings().removeClass("selected");
+                                var coverid = "";
+                                if (\$(this).hasClass("selected")) {
+                                    coverid = \$(this).data("id");
+                                }
+                                \$("#coverid").val(coverid);
+                            } );
+                        } );
                         </script>
                     </div>
 

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -77,7 +77,7 @@ window.q.push(function(){
                             <label>$:_("<strong>Pick one</strong> from the existing covers,")</label>
                         </div>
                         <div class="carousel-section">
-                            <div id="covers" class="carousel-container carousel-container-decorated">
+                            <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
                                 <div id="popcovers" class="carousel">
                                 $for cover in doc.get_edition_covers():
                                     <div class="book carousel__item" data-id="$cover.id">

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "32.3KB"
+      "maxSize": "32.4KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/static/css/components/carousel--js.less
+++ b/static/css/components/carousel--js.less
@@ -6,9 +6,8 @@
 
 .carousel-container {
   .slick-slider {
-    // disable the horizontal scroll bar and compensate for the lost pixels..
+    // allow overflow now the carousel has been initialised.
     overflow: visible;
-    margin-bottom: 15px;
   }
 }
 .carousel {

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -18,6 +18,7 @@
 }
 .carousel {
   .display-flex();
+  margin-bottom: 15px;
   overflow-x: scroll;
   padding: 10px 20px;
 
@@ -85,4 +86,12 @@
   }
 }
 
+// Hide horizontal scroll bar if JS is going to be loaded
+.client-js {
+  .carousel {
+    margin-bottom: 0;
+    // hide the overlay until carousel--js has loaded
+    overflow: hidden;
+  }
+}
 @import (less) "category-item.less";

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -16,6 +16,7 @@
   margin: 0 -20px;
   padding: 3px 15px;
 }
+
 .carousel {
   .display-flex();
   margin-bottom: 15px;
@@ -27,6 +28,15 @@
     height: 100%;
     margin: 0 10px;
     min-height: 1px;
+  }
+
+  // Modifiers
+  // A smaller carousel.
+  &--minimal {
+    img {
+      max-height: 100px;
+      width: auto;
+    }
   }
 
   > div {


### PR DESCRIPTION
 There are THREE ways to choose a cover in add-cover.
    
    This adds back the third one, and upgrades the existing cover chooser
    to use slick
    
    Closes: #1337 

    Remove carousel additional margin
    
    The margin compensates for the horizontal scroll bar that makes
    carousels accessible to non-JavaScript users.
    
    We can remove this as soon as the client-js class is added, on the
    assumption that JavaScript will be loaded.
    
    This will remove the additional 15px for JS users.
    
    Closes: #1284
