### PR TITLE
Set the v2 and wrapped in window.q handler for issue #1248

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -228,15 +228,16 @@ class account_create(delegate.page):
         i = web.input('email', 'password', 'username', agreement="no")
         i.displayname = i.get('displayname') or i.username
         f = self.get_form()
-        page = None
         
         if not f.validates(i):
             page = render['account/create'](f)
+            page.v2 = True
             return page
 
         if i.agreement != "yes":
             f.note = utils.get_error("account_create_tos_not_selected")
             page = render['account/create'](f)
+            page.v2 = True
             return page
 
         ia_account = InternetArchiveAccount.get(email=i.email)
@@ -244,6 +245,7 @@ class account_create(delegate.page):
         if ia_account:
             f.note = LOGIN_ERRORS['email_registered']
             page = render['account/create'](f)
+            page.v2 = True
             return page
 
         try:
@@ -256,9 +258,9 @@ class account_create(delegate.page):
         except ValueError as e:
             f.note = LOGIN_ERRORS['max_retries_exceeded']
             page = render['account/create'](f)
+            page.v2 = True
             return page
 
-        page.v2 = True
         return render['account/verify'](username=i.username, email=i.email)
 
 del delegate.pages['/account/register']

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -228,16 +228,15 @@ class account_create(delegate.page):
         i = web.input('email', 'password', 'username', agreement="no")
         i.displayname = i.get('displayname') or i.username
         f = self.get_form()
-        
+        page = None
+
         if not f.validates(i):
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
         if i.agreement != "yes":
             f.note = utils.get_error("account_create_tos_not_selected")
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
         ia_account = InternetArchiveAccount.get(email=i.email)
@@ -245,7 +244,6 @@ class account_create(delegate.page):
         if ia_account:
             f.note = LOGIN_ERRORS['email_registered']
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
         try:
@@ -258,9 +256,9 @@ class account_create(delegate.page):
         except ValueError as e:
             f.note = LOGIN_ERRORS['max_retries_exceeded']
             page = render['account/create'](f)
-            page.v2 = True
             return page
-
+            
+        page.v2 = True
         return render['account/verify'](username=i.username, email=i.email)
 
 del delegate.pages['/account/register']

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -203,7 +203,9 @@ class account_create(delegate.page):
 
     def GET(self):
         f = self.get_form()
-        return render['account/create'](f)
+        page = render['account/create'](f)
+        page.v2 = True
+        return page
 
     def get_form(self):
         f = forms.Register()
@@ -225,20 +227,27 @@ class account_create(delegate.page):
     def POST(self):
         i = web.input('email', 'password', 'username', agreement="no")
         i.displayname = i.get('displayname') or i.username
-
+        
         f = self.get_form()
+        
         if not f.validates(i):
-            return render['account/create'](f)
+            page = render['account/create'](f)
+            page.v2 = True
+            return page
 
         if i.agreement != "yes":
             f.note = utils.get_error("account_create_tos_not_selected")
-            return render['account/create'](f)
+            page = render['account/create'](f)
+            page.v2 = True
+            return page
 
         ia_account = InternetArchiveAccount.get(email=i.email)
         # Require email to not already be used in IA or OL
         if ia_account:
             f.note = LOGIN_ERRORS['email_registered']
-            return render['account/create'](f)
+            page = render['account/create'](f)
+            page.v2 = True
+            return page
 
         try:
             # Create ia_account: require they activate via IA email
@@ -249,7 +258,9 @@ class account_create(delegate.page):
                 verified=False, retries=USERNAME_RETRIES)
         except ValueError as e:
             f.note = LOGIN_ERRORS['max_retries_exceeded']
-            return render['account/create'](f)
+            page = render['account/create'](f)
+            page.v2 = True
+            return page
 
         return render['account/verify'](username=i.username, email=i.email)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -227,18 +227,16 @@ class account_create(delegate.page):
     def POST(self):
         i = web.input('email', 'password', 'username', agreement="no")
         i.displayname = i.get('displayname') or i.username
-        
         f = self.get_form()
+        page = None
         
         if not f.validates(i):
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
         if i.agreement != "yes":
             f.note = utils.get_error("account_create_tos_not_selected")
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
         ia_account = InternetArchiveAccount.get(email=i.email)
@@ -246,7 +244,6 @@ class account_create(delegate.page):
         if ia_account:
             f.note = LOGIN_ERRORS['email_registered']
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
         try:
@@ -259,9 +256,9 @@ class account_create(delegate.page):
         except ValueError as e:
             f.note = LOGIN_ERRORS['max_retries_exceeded']
             page = render['account/create'](f)
-            page.v2 = True
             return page
 
+        page.v2 = True
         return render['account/verify'](username=i.username, email=i.email)
 
 del delegate.pages['/account/register']

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -227,6 +227,7 @@ class account_create(delegate.page):
     def POST(self):
         i = web.input('email', 'password', 'username', agreement="no")
         i.displayname = i.get('displayname') or i.username
+
         f = self.get_form()
         page = None
 
@@ -257,7 +258,7 @@ class account_create(delegate.page):
             f.note = LOGIN_ERRORS['max_retries_exceeded']
             page = render['account/create'](f)
             return page
-            
+
         page.v2 = True
         return render['account/verify'](username=i.username, email=i.email)
 

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -12,10 +12,8 @@ $var title: $_("Sign Up to Open Library")
 <div id="contentBody">
 
 <script type="text/javascript">
-window.q.push( function() {
-    validateForms();
-});
 window.q.push( function(){
+    validateForms();
     \$('#username').keyup(function(){
         var value = \$(this).val();
         \$('#userUrl').addClass('darkgreen').text(value).css('font-weight','700');

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -12,8 +12,10 @@ $var title: $_("Sign Up to Open Library")
 <div id="contentBody">
 
 <script type="text/javascript">
-\$().ready(validateForms);
-\$().ready(function(){
+window.q.push( function() {
+    validateForms();
+});
+window.q.push( function(){
     \$('#username').keyup(function(){
         var value = \$(this).val();
         \$('#userUrl').addClass('darkgreen').text(value).css('font-weight','700');


### PR DESCRIPTION
For #1248 

## Description:
- [x] Set v2 on the page object passed to any templates (e.g. 8d79b57)
- [x] Confirmed #test-body-mobile is present in the HTML
- [x] Loaded the page and view source. Identify all script tags in the page
- [x] Ensured the inline scripts in the page are wrapped in a window.q handler
- [x] Tested the page - is everything working as before?
- [x] Opened the page in a mobile browser 

I'm pretty new, so please let me know if there were other tests I should be performed before submitting this pull request. It looks like everything works as before.

![openlib mobile view create acct](https://user-images.githubusercontent.com/7061807/46898836-9ef73f80-ce41-11e8-8854-3999ea40c202.png)
