### PR TITLE
WIP: provide archive.org user id and ocaid in ia_auth response

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -899,7 +899,7 @@ def get_ia_auth_dict(user, item_id, user_specified_loan_key, access_token):
         if not user_has_current_loan:
             raise Exception('lending: no current loan for this user found but no error condition specified')
 
-    return { 'success': True, 'token': make_ia_token(item_id, bookreader_auth_seconds) }
+    return { 'success': True, 'token': make_ia_token(item_id, bookreader_auth_seconds), 'userid': user.itemname(), 'ocaid': item_id }
 
 
 def make_ia_token(item_id, expiry_seconds):


### PR DESCRIPTION
@rchrd2  Here are the changes we discussed, I'm still finding a way to test this does what we expect locally.

@mekarpeles for your review -- @rchrd2 and I were discussing the recent archive.org lending improvements and what needed to change on OL. This (hopefully!) provides the data archive.org needs to manage multiple loans and assign items to the correct user. 