### PR TITLE
rm'ing duplicate page_url in js, moving carousels to own js file

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousels.js
+++ b/openlibrary/plugins/openlibrary/js/carousels.js
@@ -1,0 +1,57 @@
+var Carousel = {
+    add: function(selector, a, b, c, d, e, f) {
+        var responsive_settings = [
+            {
+                breakpoint: 1200,
+                settings: {
+                    slidesToShow: b,
+                    slidesToScroll: b,
+                    infinite: false,
+                }
+            },
+            {
+                breakpoint: 1024,
+                settings: {
+                    slidesToShow: c,
+                    slidesToScroll: c,
+                    infinite: false,
+                }
+            },
+            {
+                breakpoint: 600,
+                settings: {
+                    slidesToShow: d,
+                    slidesToScroll: d
+                }
+            },
+            {
+                breakpoint: 480,
+                settings: {
+                    slidesToShow: e,
+                    slidesToScroll: e
+                }
+            }
+            // You can unslick at a given breakpoint now by adding:
+            // settings: "unslick"
+            // instead of a settings object
+        ];
+        if (f) {
+            responsive_settings.push({
+                breakpoint: 360,
+                settings: {
+                    slidesToShow: f,
+                    slidesToScroll: f
+                }
+            });
+        }
+
+        $(selector).slick({
+            infinite: false,
+            speed: 300,
+            slidesToShow: a,
+            slidesToScroll: a,
+            responsive: responsive_settings
+        });
+    }
+};
+

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -377,7 +377,6 @@ $if ctx.user:
     var work_key = '$(work_key)';
     var edition_key = '$(edition_key)';
     var username = '$(username or "")';
-    var pageurl = '$(page.url())';
 
     function reload_widget() {
         \$("#widget-head").html(render_head());


### PR DESCRIPTION
Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
