### PR TITLE
Fix JS on subject page (1349)

### DIFF
--- a/openlibrary/templates/lib/covers.html
+++ b/openlibrary/templates/lib/covers.html
@@ -30,6 +30,22 @@ function loadCoverCarousels(carousel, state) {
         updateBookAvailability('#coversCarousel li ');
     });
 }
+
+window.q.push(function() {
+    // setup the carousel for subjects page
+    page.renderCovers = render_page;
+    if ( page.displayCovers ) {
+        page.displayCovers(0);
+    }
+    if ( carousels ) {
+        carousels();
+    }
+    if ( carouselSetup ) {
+        carouselSetup(loadCoverCarousels);
+        \$('.jcarousel-next').attr('title','View the next editions').append('<h4 class="shift"><a href="#" onclick="return false;">View the next editions</a></h4>');
+        \$('.jcarousel-prev').attr('title','View the previous editions').append('<h4 class="shift"><a href="#" onclick="return false;">View the previous editions</a></h4>');
+    }
+});
 //-->
 </script>
 


### PR DESCRIPTION
Fix subject page
    
Restore initialisation of the carousel on the subject page which
was removed in 9be3e32

This is shared between the cover manager and carousel but only needed
for the latter. At the time of removal it was throwing errors in the
former and thus removed. The actual right way to do this is to check
whether the functions are present in the page.

Closes: #1349
