### PR TITLE
Restore JS on book editor

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -7,17 +7,17 @@ $putctx("robots", "noindex,nofollow")
 
 <script type="text/javascript">
 <!--
-loadStyle("$static_url('build/js-books-edit.css')");
-\$().ready(Tabs);
-\$().ready(function(){
+window.q.push( function () {
+    loadStyle("$static_url('build/js-books-edit.css')");
+    Tabs();
     if(jQuery.support.opacity){
         \$("#tabsAddbook").tabs({fx:{opacity:'toggle'}});
     } else {
         \$("#tabsAddbook").tabs();
     };
-});
-\$().ready(boxPop);
-\$().ready(function(){\$("#coverPop").colorbox({inline:true, opacity:"0.5", href:"#addCover"});});
+    boxPop();
+    \$("#coverPop").colorbox({inline:true, opacity:"0.5", href:"#addCover"});
+} );
 
 function limitChars(textid, limit, infodiv) {
     var text = \$('#'+textid).val();
@@ -31,9 +31,8 @@ function limitChars(textid, limit, infodiv) {
         return true;
     }
 };
-\$().ready(function(){\$('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});});
-
-\$().ready(function() {
+window.q.push( function(){
+    \$('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});
     var hash = document.location.hash || "#edition";
     var tab = hash.split("/")[0]
     var link = "#" + "link_" + tab.substr(1);
@@ -53,7 +52,7 @@ function limitChars(textid, limit, infodiv) {
         }
         \$(window).scrollTop(\$("#contentHead").offset().top);
     }, 1000);
-});
+} );
 //-->
 </script>
 
@@ -91,7 +90,7 @@ function limitChars(textid, limit, infodiv) {
 </div>
 
 <script type="text/javascript">
-\$(function() {
+window.q.push( function () {
     \$("#authors").setup_multi_input_autocomplete(
         "input.author-autocomplete",
         render_author,
@@ -107,7 +106,7 @@ function limitChars(textid, limit, infodiv) {
             autoFill: false,
             formatItem: render_author_autocomplete_item
         });
-});
+} );
 </script>
 
 $jsdef render_author_autocomplete_item(item):

--- a/openlibrary/templates/books/edit/addfield.html
+++ b/openlibrary/templates/books/edit/addfield.html
@@ -2,7 +2,7 @@ $def with (book)
 
 <script type="text/javascript">
 <!--
-\$(function() {
+window.q.push(function() {
     function error(error_div, input, message) {
         \$(error_div).show().html(message);
         \$.fn.colorbox.resize();

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -65,7 +65,7 @@ $jsdef render_work_autocomplete_item(item):
     </div>
 
 <script type="text/javascript">
-\$(function() {
+window.q.push(function() {
     \$("#languages").setup_multi_input_autocomplete(
         "input.language-autocomplete",
         render_language_field,
@@ -675,7 +675,9 @@ $if ctx.user and ctx.user.is_admin():
 
 <script type="text/javascript">
 <!--
-    \$().ready(function() {
+    window.q.push(function() {
+        // FIXME: Error code duplicated in various templates.
+        // Should be pushed into a macro.
         function error(errordiv, input, message) {
             \$(errordiv).show().html(message);
             \$(input).focus();

--- a/openlibrary/templates/books/edit/excerpts.html
+++ b/openlibrary/templates/books/edit/excerpts.html
@@ -97,7 +97,7 @@ $def with (work)
 
     <script type="text/javascript">
     <!--
-        \$().ready(function() {
+        window.q.push(function() {
             function error(errordiv, input, message) {
                 \$(errordiv).show().html(message);
                 \$(input).focus();

--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -75,7 +75,7 @@ $def with (work, prefix="")
 
 <script type="text/javascript">
 <!--
-    \$().ready(function() {
+    window.q.push(function() {
         \$("#links").repeat({
             vars: {
                 prefix: "$prefix"


### PR DESCRIPTION


When we ported the books page to v2 we also ported all the other
books subpages, the code for which is tightly coupled.

Previously the covers feature was broken and now this was
identified.

Lesson learned... and we'll have to be more careful with that
in future.

Luckily making these edit pages v2 compatible is much more
straightforward.

Fixes: #1328
Fixes: #1346
