### PR TITLE
Bundlesizes for plain and user pages increased

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     },
     {
       "path": "static/build/page-plain.css",
-      "maxSize": "25.2KB"
+      "maxSize": "25.3KB"
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "25KB"
+      "maxSize": "25.1KB"
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
A few changes to the edit toolbar styles in 06e64d7
and history component (04e229760) bumped up the bundle sizes
by a few bytes

This is blocking all changes in master.