### PR TITLE
Fixed issue #1347: Search bar dropdown now has correct size

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -35,7 +35,7 @@ $def with (page)
         <div class="search-facet">
           <label class="search-facet-selector">
             <span aria-hidden="true" class="search-facet-value"></span>
-            <select aria-label="Search by">
+            <select aria-label="Search by" style="max-width: 100%;">
               <option value='all'>$_("All")</option>
               <option value='title'>$_("Title")</option>
               <option value='author'>$_("Author")</option>


### PR DESCRIPTION
Closes #1347 

<Optional Picture>

Previously:
![image](https://user-images.githubusercontent.com/8374054/47097669-2ffb5b80-d232-11e8-8d3d-13b1513c7a90.png)


Now:

![image](https://user-images.githubusercontent.com/8374054/47097645-22de6c80-d232-11e8-924e-482a28ea7c95.png)



## Description:
In this Pull Request we have made the following changes:

Add the style rule "max-width: 100%;" to the "Search by..." label to make it confine its size to its content.
