### PR TITLE
Change /stream/ to /details/ for new Archive.org book pages.

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -36,7 +36,7 @@ LOAN_FULFILLMENT_TIMEOUT_SECONDS = dateutil.MINUTE_SECS * 5
 # How long bookreader loans should last
 BOOKREADER_LOAN_DAYS = 14
 
-BOOKREADER_STREAM_URL_PATTERN = "https://{0}/stream/{1}"
+BOOKREADER_STREAM_URL_PATTERN = "https://{0}/details/{1}"
 DEFAULT_IA_RESULTS = 42
 MAX_IA_RESULTS = 1000
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -229,7 +229,7 @@ class Edition(Thing):
         Sample return values:
 
             {
-                "read_url": "http://www.archive.org/stream/foo00bar",
+                "read_url": "http://www.archive.org/details/foo00bar",
                 "daisy_url": "/books/OL1M/foo/daisy"
             }
 
@@ -257,7 +257,7 @@ class Edition(Thing):
                 d['borrowed'] = doc.get("borrowed") == "true"
                 d['daisy_only'] = False
             elif 'printdisabled' not in collections:
-                d['read_url'] = "https://archive.org/stream/%s" % self.ocaid
+                d['read_url'] = "https://archive.org/details/%s" % self.ocaid
                 d['daisy_only'] = False
         return d
 
@@ -489,7 +489,7 @@ class Work(Thing):
         Sample return values:
 
             {
-                "read_url": "http://www.archive.org/stream/foo00bar",
+                "read_url": "http://www.archive.org/details/foo00bar",
                 "daisy_url": "/books/OL1M/foo/daisy"
             }
 
@@ -502,7 +502,7 @@ class Work(Thing):
         solrdata = web.storage(self._solr_data or {})
         d = {}
         if solrdata.get('has_fulltext') and solrdata.get('public_scan_b'):
-            d['read_url'] = "https://archive.org/stream/{0}".format(solrdata.ia[0])
+            d['read_url'] = "https://archive.org/details/{0}".format(solrdata.ia[0])
             d['has_ebook'] = True
         elif solrdata.get('lending_edition_s'):
             d['borrow_url'] = "/books/{0}/x/borrow".format(solrdata.lending_edition_s)

--- a/openlibrary/macros/FulltextSnippet.html
+++ b/openlibrary/macros/FulltextSnippet.html
@@ -10,7 +10,7 @@ $if snippets:
   <section class="fulltext-excerpts" aria-label="search results from: $doc['edition']['title']">
     <ul>
       $for snippet in snippets:
-        $if snippet: 
+        $if snippet:
           <li class="fulltext-excerpt">
             &hellip;$:(snippet.replace("<", "&laquo;").replace(">", "&raquo;").replace("{{{", "<mark class='highlight'><strong>").replace("}}}", "</strong></mark>"))&hellip;
           </li>
@@ -18,7 +18,7 @@ $if snippets:
   </section>
 
 $if availability.get('status') == 'open':
-  <p class="center"><a href="https://archive.org/stream/$(ia)?ref=ol&access=1#search/$(q)">See All Results</a></p>
+  <p class="center"><a href="https://archive.org/details/$(ia)?ref=ol&access=1&q=$(q)">See All Results</a></p>
 
 $if availability.get('status') == 'borrow_available':
-  <p class="center">Borrow &amp; <a href="https://archive.org/stream/$(ia)?ref=ol&access=1#search/$(q)">See All Results</a></p>
+  <p class="center">Borrow &amp; <a href="https://archive.org/details/$(ia)?ref=ol&access=1&q=$(q)">See All Results</a></p>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -65,7 +65,7 @@ $elif (availability_status == 'borrow_unavailable'):
           <input type="submit" class="submit unwait-btn" id="unwaitlist_ebook" value="Leave waiting list"/>
         </form>
 
-    $else:  
+    $else:
         <p>
           $("Readers waiting for this title: %s" % wlsize if wlsize else "You'll be next in line.")
         </p>
@@ -75,7 +75,7 @@ $elif (availability_status == 'borrow_unavailable'):
         </form>
 
 $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
-    $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
+    $ viewbook = "//%s/details/XXX?ref=ol" % bookreader_host()
     <p class="primary-cta"><a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="read-btn">Read eBook</a></p>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:

--- a/openlibrary/macros/SearchResults.html
+++ b/openlibrary/macros/SearchResults.html
@@ -40,13 +40,13 @@ $for b in results:
                 $if len(pages)==0: <i>Unknown</i>
                 $ a = []
                 $for pn, pg in pages:
-                    $ a.append('<a href="//archive.org/stream/%s#page/n%s/mode/1up">%s</a>'% (book.ocaid, pn-1, pg))
+                    $ a.append('<a href="//archive.org/details/%s/page/n%s/mode/1up">%s</a>'% (book.ocaid, pn-1, pg))
                 $:(',&nbsp;&nbsp;'.join(a))
                 </span>
         </span>
         $if book.ocaid:
             <span class="actions">
-                <a href="//archive.org/stream/$book.ocaid">
+                <a href="//archive.org/details/$book.ocaid">
                     <span class="image read"></span>
                     <span class="label">Read</span>
                 </a>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -7,7 +7,7 @@ $elif page.type.key in ["/type/work", "/type/edition", "/type/author"]:
 $else:
     $ edit_url = page.key + "?m=edit"
 
-$ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
+$ viewbook = "//%s/details/XXX?ref=ol" % bookreader_host()
 $ prices = page.key.startswith('/books/')
 
 $ isbn = (page.isbn_10 and page.isbn_10[0]) or (page.isbn_13 and page.isbn_13[0]) or ""

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -290,7 +290,7 @@ class DataProcessor:
 
             prefix = "https://archive.org/download/%s/%s" % (itemid, itemid)
             if availability == 'full':
-                d["read_url"] = "https://archive.org/stream/%s" % (itemid)
+                d["read_url"] = "https://archive.org/details/%s" % (itemid)
                 d['formats'] = {
                     "pdf": {
                         "url": prefix + ".pdf"

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -157,7 +157,7 @@ class ReadProcessor:
         ekey = edition.get('key', '')
 
         if status == 'full access':
-            itemURL = 'http://www.archive.org/stream/%s' % (iaid)
+            itemURL = 'http://www.archive.org/details/%s' % (iaid)
         else:
             # this could be rewrit in terms of iaid...
             itemURL = u'http://openlibrary.org%s/%s/borrow' % (ekey,

--- a/openlibrary/plugins/books/tests/test_dynlinks.py
+++ b/openlibrary/plugins/books/tests/test_dynlinks.py
@@ -187,7 +187,7 @@ def data9(request):
                 }],
                 "ebooks": [{
                     "preview_url": "https://archive.org/details/foo12bar",
-                    "read_url": "https://archive.org/stream/foo12bar",
+                    "read_url": "https://archive.org/details/foo12bar",
                     "availability": "full",
                     "formats": {
                         "pdf": {

--- a/openlibrary/plugins/mobile/templates/mobile/author.html
+++ b/openlibrary/plugins/mobile/templates/mobile/author.html
@@ -25,6 +25,6 @@ $for edition, work in books:
                  $(edition.publishers[0] if edition.publishers else "")
                </span>
         </td>
-        <td><a href="//archive.org/stream/$edition.ocaid">Read</a></td>
+        <td><a href="//archive.org/details/$edition.ocaid">Read</a></td>
     </tr>
 </table>

--- a/openlibrary/plugins/mobile/templates/mobile/book.html
+++ b/openlibrary/plugins/mobile/templates/mobile/book.html
@@ -1,7 +1,7 @@
 $def with(book)
 
 <h1>
-    <a href="//archive.orgstream/$book.ocaid">
+    <a href="//archive.org/details/$book.ocaid">
         <img src="$(book.get_cover_url('M') or '/images/icons/avatar_book-sm.png')"
              alt="cover image" width="180" height="275" hspace="10" align="right"/>
     </a>
@@ -15,4 +15,4 @@ $def with(book)
         <p><em>$:sanitize(format(book.description))</em></p>
     $if not book.description and book.works and book.works[0].description:
         <p><em>$:sanitize(format(book.works[0].description))</em></p>
-    <p><a href="//archive.orgstream/$book.ocaid">Read</a></p>
+    <p><a href="//archive.org/details/$book.ocaid">Read</a></p>

--- a/openlibrary/plugins/mobile/templates/mobile/edition.html
+++ b/openlibrary/plugins/mobile/templates/mobile/edition.html
@@ -12,4 +12,4 @@ $#<p><em>Six busy days it took in all<br />
 $#    To make a World and plan its jail,<br />
 $#    The seventh, SOMEONE said 'twas good<br />
 $#And rested, so you think he could? </em><a href="show full description">More</a></p>
-    <p><a href="//archive.org/stream/$edition.ocaid">Read</a></p>
+    <p><a href="//archive.org/details/$edition.ocaid">Read</a></p>

--- a/openlibrary/plugins/mobile/templates/mobile/index.html
+++ b/openlibrary/plugins/mobile/templates/mobile/index.html
@@ -29,6 +29,6 @@ $for edition in new_books:
             $(edition.publishers[0] if edition.publishers else "")
         </span>
         </td>
-        <td><a href="//archive.org/stream/$edition.ocaid">Read</a></td>
+        <td><a href="//archive.org/details/$edition.ocaid">Read</a></td>
     </tr>
 </table>

--- a/openlibrary/plugins/mobile/templates/mobile/search.html
+++ b/openlibrary/plugins/mobile/templates/mobile/search.html
@@ -31,7 +31,7 @@ $if results["books"]:
                      $(edition.publishers[0] if edition.publishers else "")
                    </span>
             </td>
-            <td><a href="//archive.org/stream/$edition.ocaid">Read</a></td>
+            <td><a href="//archive.org/details/$edition.ocaid">Read</a></td>
         </tr>
     </table>
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -210,7 +210,7 @@ def format_work_data(work):
     if 'cover_edition_key' in work:
         d['cover_url'] = h.get_coverstore_url() + "/b/olid/%s-M.jpg" % work['cover_edition_key']
 
-    d['read_url'] = "//archive.org/stream/" + work['ia'][0]
+    d['read_url'] = "//archive.org/details/" + work['ia'][0]
     return d
 
 def format_book_data(book):

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -108,7 +108,7 @@ $.extend(Subject.prototype, {
         var bookcover_url = '//covers.openlibrary.org/b/id/' + work.cover_id + '-M.jpg';
         var format = work.public_scan ? 'public' : (work.printdisabled && !work.ia_collection.includes('inlibrary')) ? 'daisy' : 'borrow';
         var bookread_url = work.public_scan ?
-            ('//archive.org/stream/' + work.ia + '?ref=ol') :
+            ('//archive.org/details/' + work.ia + '?ref=ol') :
             '/borrow/ia/' + work.ia;
         var html = renderTag('div', {'class': 'coverMagic'},
           renderTag('span', {

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -88,7 +88,7 @@ class TestHomeTemplates:
                 "url": "/books/OL1M",
                 "title": "The Great Book",
                 "authors": [web.storage({"key": "/authors/OL1A", "name": "Some Author"})],
-                "read_url": "http://archive.org/stream/foo",
+                "read_url": "http://archive.org/details/foo",
                 "borrow_url": "/books/OL1M/foo/borrow",
                 "inlibrary_borrow_url": "/books/OL1M/foo/borrow",
                 "cover_url": ""
@@ -122,7 +122,7 @@ class TestCarouselItem:
             "url": "/books/OL1M",
             "title": "The Great Book",
             "authors": [{"key": "/authors/OL1A", "name": "Some Author"}],
-            "read_url": "http://archive.org/stream/foo",
+            "read_url": "http://archive.org/details/foo",
             "borrow_url": "/books/OL1M/foo/borrow",
             "inlibrary_borrow_url": "/books/OL1M/foo/borrow",
             "cover_url": ""
@@ -141,7 +141,7 @@ class Test_carousel:
             "url": "/books/OL1M",
             "title": "The Great Book",
             "authors": [web.storage({"key": "/authors/OL1A", "name": "Some Author"})],
-            "read_url": "http://archive.org/stream/foo",
+            "read_url": "http://archive.org/details/foo",
             "borrow_url": "/books/OL1M/foo/borrow",
             "inlibrary_borrow_url": "/books/OL1M/foo/borrow",
             "cover_url": ""

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -123,9 +123,9 @@ class borrow(delegate.page):
         response = lending.get_availability_of_ocaid(edition.ocaid)
         availability = response[edition.ocaid] if response else {}
         if availability and availability['status'] == 'open':
-            raise web.seeother('https://archive.org/stream/' + edition.ocaid + '?ref=ol')
+            raise web.seeother('https://archive.org/details/' + edition.ocaid + '?ref=ol')
 
-        error_redirect = ('https://archive.org/stream/' + edition.ocaid + '?ref=ol')
+        error_redirect = ('https://archive.org/details/' + edition.ocaid + '?ref=ol')
         user = accounts.get_current_user()
 
         if user:
@@ -185,7 +185,7 @@ class borrow(delegate.page):
 
                         raise web.seeother(make_bookreader_auth_link(
                             loan.get_key(), edition.ocaid,
-                            '/stream/' + edition.ocaid, ol_host,
+                            '/details/' + edition.ocaid, ol_host,
                             ia_userid=ia_itemname))
                     elif resource_type == 'pdf':
                         stats.increment('ol.loans.pdf')
@@ -232,7 +232,7 @@ class borrow(delegate.page):
             for loan in loans:
                 if loan['book'] == edition.key:
                     raise web.seeother(make_bookreader_auth_link(
-                        loan['_key'], edition.ocaid, '/stream/' + edition.ocaid,
+                        loan['_key'], edition.ocaid, '/details/' + edition.ocaid,
                         ol_host, ia_userid=ia_itemname
                     ))
         elif action == 'join-waitinglist':

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -71,7 +71,7 @@ try:
 except AttributeError:
     bookreader_host = 'archive.org'
 
-bookreader_stream_base = 'https://' + bookreader_host + '/stream'
+bookreader_stream_base = 'https://' + bookreader_host + '/details'
 
 ########## Page Handlers
 

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -23,7 +23,7 @@ $def render_carousel_cover(book, lazy):
     $ cta_url = '/borrow/ia/%s' % book.ocaid
     $ cta = 'Borrow'
   $elif book.get('ia') and book.get('public_scan'):
-    $ cta_url = "//archive.org/stream/%s?ref=ol"%book.get('ia')
+    $ cta_url = "//archive.org/details/%s?ref=ol"%book.get('ia')
     $ cta = 'Read eBook'
   $elif book.get('lending_edition'):
     $ cta_url = "/books/%s/x/borrow"%book.get('lending_edition')

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -5,7 +5,7 @@ $ availability = book.get('availability', {})
 $ worldcat = "https://worldcat.org/isbn/XXX"
 $ worldcatoclc = "https://worldcat.org/oclc/XXX"
 
-$ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
+$ viewbook = "//%s/details/XXX?ref=ol" % bookreader_host()
 $ detailbook = "//archive.org/details/XXX"
 $ downloadbook = "//archive.org/download/XXX/XXX.pdf"
 $ pdfbw = "//archive.org/download/XXX/XXX_bw.pdf"
@@ -98,7 +98,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           $if oclc_numbers or isbn:
             <ul>
               <li>
-                <a class="plain" 
+                <a class="plain"
                    href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)"
                    title="Look for this edition at WorldCat">Find a Physical Copy</a>
                 <br /><span class="gray smaller">via WorldCat</span>

--- a/openlibrary/templates/books/show.html
+++ b/openlibrary/templates/books/show.html
@@ -25,7 +25,7 @@ $def with (book)
     </span>
     $if book.ocaid:
         <span class="actions">
-            <a href="//archive.org/stream/$book.ocaid">
+            <a href="//archive.org/details/$book.ocaid">
                 <span class="image read"></span>
                 <span class="label">$_("Read")</span>
             </a>

--- a/openlibrary/templates/books/works-show.html
+++ b/openlibrary/templates/books/works-show.html
@@ -31,7 +31,7 @@ $def with (book)
 
 $if book.ocaid:
     <span class="actions">
-        <a href="//archive.org/stream/$book.ocaid">
+        <a href="//archive.org/details/$book.ocaid">
             <span class="image read"></span>
             <span class="label">Read</span>
         </a>

--- a/openlibrary/templates/lib/covers.html
+++ b/openlibrary/templates/lib/covers.html
@@ -107,7 +107,7 @@ $jsdef render_page(page):
             $ borrowable = all_borrow or contains(w.subject, 'Lending library') or (inlibrary and contains(w.subject, 'In library'))
             $if not all_borrow and w.ia and w.public_scan:
                 <div class="coverEbook">
-                  <a href="//archive.org/stream/$w.ia?ref=ol" title="$_('Read online')" class="borrow_available cta-btn">
+                  <a href="//archive.org/details/$w.ia?ref=ol" title="$_('Read online')" class="borrow_available cta-btn">
                     Read
                   </a>
                 </div>

--- a/openlibrary/templates/search/snippets.html
+++ b/openlibrary/templates/search/snippets.html
@@ -39,7 +39,7 @@ $for match in matches:
         $ halfWidth = par['page_width'] * .5
         <div class="clipOut" id="clipout$par_num" style="position:relative;width:$(width)px;height:$(height)px;max-width:918px;overflow:hidden;padding-bottom:10px;">
             <div class="clipIn" id="clipin$par_num" style="position:absolute;clip:rect($(t)px $(r)px $(b)px $(l)px);top:-$(t)px;left:-$(l)px;">
-                <a href="//archive.org/stream/$ia#page/n$(page-1)/search/$q">
+                <a href="//archive.org/details/$ia/page/n$(page-1)?q=$q">
                 $if ia.endswith('goog'):
                     <img src="//archive.org/download/$ia/page/leaf$(page)_s$(scale).jpg" class="clipImg" width="$halfWidth"/></a>
                 $else:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -281,7 +281,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     <tr class="toc-level-$toc.level">
                         <td class="toc-label">$toc.label</td>
                         $if item_id and toc.pagenum.isdigit():
-                            <td class="toc-title"><a href="//archive.org/stream/$item_id#page/$toc.pagenum">$toc.title</a></td>
+                            <td class="toc-title"><a href="//archive.org/details/$item_id/page/$toc.pagenum">$toc.title</a></td>
                         $else:
                             <td class="toc-title">$toc.title</td>
                         <td class="toc-pagenum">$toc.pagenum</td>


### PR DESCRIPTION
- Change `/stream/` to `/details/` for new Archive.org book pages.
- Also change the `#` to `/`.
- Change `/search/<query>` to `?q=<query>`

## Description:

/details/ is the canonical book page on archive.org that we want to encourage sharing on the web. Open Library needs to adopt this page.

