### PR TITLE
Regression of large input boxes fixed

### DIFF
--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -32,7 +32,7 @@ form.olform {
 
   input[type=email],
   input[type=password],
-  .required  {
+  .required {
     height: 40px;
   }
 


### PR DESCRIPTION
Closes #1389 
## Description:
In this Pull Request we have made the following changes:
changed olform.less input box height parameter to apply only to input of type email and password.