### PR TITLE
jquery-repeat needs to support both active versions of jQuery

### DIFF
--- a/openlibrary/plugins/openlibrary/js/jquery.repeat.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.repeat.js
@@ -3,8 +3,11 @@
  *
  * Used in addbook process.
  */
-(function($){    
+(function($){
+    // For v2 and v1 page support. Can be removed when no v1 support needed
+    var isOldJQuery = $( 'body' ).on === undefined;
     $.fn.repeat = function(options) {
+        var addSelector, removeSelector;
         options = options || {};
 
         var id = "#" + this.attr("id");
@@ -35,8 +38,8 @@
             });
             return data;
         }
-        
-        $(id + " .repeat-add").on("click", function(event) {
+        function onAdd(event) {
+            console.log('add');
             event.preventDefault();
             
             var index = elems.display.children().length;
@@ -59,12 +62,21 @@
                              
             $("input[type!=button], textarea", elems.form).filter(":not(.repeat-ignore)").val("");
             elems._this.trigger("repeat-add");
-        });
-        
-        $(id + " .repeat-remove").on("click", function(event) {
+        }
+        function onRemove(event) {
             event.preventDefault();
             $(this).parents(".repeat-item:eq(0)").remove();
             elems._this.trigger("repeat-remove");
-        });
+        }
+        addSelector = id + " .repeat-add";
+        removeSelector = id + " .repeat-remove";
+        // Click handlers should apply to newly created add/remove selectors
+        if ( isOldJQuery ) {
+            $(addSelector).live("click", onAdd);
+            $(removeSelector).live("click", onRemove);
+        } else {
+            $(document).on("click", addSelector, onAdd);
+            $(document).on("click", removeSelector, onRemove);
+        }
     }
 })(jQuery);


### PR DESCRIPTION
Follow up to a199194 - the jquery.repeat plugin breaks with old
versions of jQuery
e.g. author edit page

This is because I didn't understand when writing that patch that
elements will be added to the interface after the code has run and
the document is ready.

Restore live, and its more modern counterpart in jQuery
1.11.0
Fixes: #1396

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
