### PR TITLE
exclude fake works that actually have an edition key from works autocomplete

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -827,7 +827,8 @@ class works_autocomplete(delegate.page):
         }
 
         data = solr.select(solr_q, **params)
-        docs = data['docs']
+        # exclude fake works that actually have an edition key
+        docs = [d for d in data['docs'] if d['key'][-1] == 'W']
 
         for d in docs:
             # Required by the frontend


### PR DESCRIPTION
Closes #761 

## Description:
In this Pull Request we have made the following changes:
* the /works/_autocomplete endpoint will exclude results that have a fake work key that actually represents an edition like `/works/OL12345M`
