### PR TITLE
JS bundlesize increases in size

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "32.4KB"
+      "maxSize": "32.5KB"
     },
     {
       "path": "static/build/page-admin.css",


### PR DESCRIPTION
c8dccf4 got past the censors.
We should be more careful when merging as all patches are now
failing validation which is confusing to new users.. :(
