### PR TITLE
Component: Read-statuses component

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "32.4KB"
+      "maxSize": "32.5KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/static/css/components/cover.less
+++ b/static/css/components/cover.less
@@ -1,0 +1,5 @@
+/**
+ * Cover
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#cover
+ */
+@import (less) "illustration.less";

--- a/static/css/components/read-statuses.less
+++ b/static/css/components/read-statuses.less
@@ -1,0 +1,28 @@
+/**
+ * ReadStatuses
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#readstatuses
+ */
+.read-statuses {
+  border-bottom: 1px solid @lightest-grey;
+  button {
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: @dark-grey;
+    font-weight: bold;
+    width: 100%;
+    text-align: left;
+    font-size: .8em;
+    padding: 10px;
+    border-bottom: 1px solid @lightest-grey;
+    &:hover {
+      color: @black;
+      background-color: @white;
+    }
+  }
+  form:last-child {
+    button.nostyle-btn {
+      border: none;
+    }
+  }
+}

--- a/static/css/js-all.less
+++ b/static/css/js-all.less
@@ -12,6 +12,8 @@
 @import (less) "components/cbox.less";
 @import (less) 'components/jquery.autocomplete.less';
 
+@import (less) "components/read-statuses.less";
+
 // Not clear if these are needed. please review.
 .tools a {
   // The on class is added inside openlibrary/plugins/openlibrary/js/ol.js

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -3949,32 +3949,6 @@ div#subjectLists {
   }
 }
 
-.nostyle-btn {
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: @dark-grey;
-  font-weight: bold;
-  width: 100%;
-  text-align: left;
-  font-size: .8em;
-  padding: 10px;
-  border-bottom: 1px solid @lightest-grey;
-  &:hover {
-    color: @black;
-    background-color: @white;
-  }
-}
-
-.read-statuses {
-  border-bottom: 1px solid @lightest-grey;
-  form:last-child {
-    button.nostyle-btn {
-      border: none;
-    }
-  }
-}
-
 ul#myreads-paginator {
   margin-top: 10px;
 


### PR DESCRIPTION
This component is only needed for JS so is loaded in the js-all
entry point.

Rather than use the nostyle-btn (not used anywhere else), we
style the generic button class

See: #1092

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
