### PR TITLE
Search bar dropdown now has correct size

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -390,6 +390,7 @@ header#header-bar {
         background: none;
         border: none;
         cursor: pointer;
+        max-width: 100%;
         -moz-appearance: none;
         appearance: none;
         -webkit-appearance: none;


### PR DESCRIPTION
Add a max-width per @glatteis to the search dropdown
Tested on non-JavaScript browsers and this continues to
work as before on v2 pages.

v1 pages although functional, appear a little broken before
this patch and will continue to do so, but do not regress

Closes: #1347 


Previously:
![image](https://user-images.githubusercontent.com/8374054/47097669-2ffb5b80-d232-11e8-8d3d-13b1513c7a90.png)


Now:

![image](https://user-images.githubusercontent.com/8374054/47097645-22de6c80-d232-11e8-924e-482a28ea7c95.png)


