### PR TITLE
Refactor works and books pages to use linkbox component

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -243,12 +243,12 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
           $if work:
             $def render_subjects(label, subjects, prefix=""):
                 $if subjects:
-                    <div class="section">
-                        <h6 class="collapse black uppercase">$label</h6>
-                        <div class="sansserif">
+                    <div class="section link-box">
+                        <h6>$label</h6>
+                        <div><span>
                         $for subject in subjects:
                             <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',',''))">$subject</a>$cond(not loop.last,",","")
-                        </div>
+                        </span></div>
                     </div>
             $:render_subjects("Subjects", work.get_subjects())
             $:render_subjects("People", work.subject_people, prefix="person:")

--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -163,12 +163,12 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
             $def render_subjects(label, subjects, prefix=""):
                 $if subjects:
-                    <div class="section" style="margin-bottom:15px;">
-                        <h6 class="collapse black uppercase">$label</h6>
-                        <div class="sansserif">
+                    <div class="section link-box" style="margin-bottom:15px;">
+                        <h6>$label</h6>
+                        <div><span>
                         $for subject in subjects:
                             <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',',''))">$subject</a>$cond(not loop.last,",","")
-                        </div>
+                        </span></div>
                     </div>
 
             $:render_subjects("Subjects", page.get_subjects())

--- a/static/css/components/link-box.less
+++ b/static/css/components/link-box.less
@@ -4,25 +4,25 @@
  */
 
 // contentQuarter rule can likely be removed in future when legacy.css has been removed
-.contentQuarter,
-.link-box {
+.contentQuarter {
   float: left;
   max-width: 215px;
   min-height: 100px;
   margin-bottom: 20px;
+  > div {
+    padding-right: 19px;
+  }
 }
 
 .link-box {
   h6 {
     color: @black;
-    margin: 0;
+    margin: 0 !important;
+    padding: 0 !important;
     text-transform: uppercase !important;
   }
   > div span {
     font-size: .75em;
-  }
-  > div {
-    padding-right: 19px;
   }
 }
 

--- a/static/css/components/link-box.less
+++ b/static/css/components/link-box.less
@@ -9,9 +9,10 @@
   max-width: 215px;
   min-height: 100px;
   margin-bottom: 20px;
-  > div {
-    padding-right: 19px;
-  }
+}
+
+.contentQuarter div, .link-box div {
+  padding-right: 19px;
 }
 
 .link-box {


### PR DESCRIPTION
Closes #1323 

## Description:

In this Pull Request we have made the following changes:

 - The works and books pages have been updated to use the linkbox component styling
 - HTML markup has been updated to reflect existing usage, in order to take advantage of the styling rules
 - Redundant CSS classes have been removed
 - `.contentQuarter` and `.linkBox` classes have been separated in order to make the linkBox component more versatile