### PR TITLE
fixes #1014

### DIFF
--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -401,7 +401,7 @@ def format_result(result, options):
         >>> format_result({'x': 1}, {})
         'var _OLBookInfo = {"x": 1};'
         >>> format_result({'x': 1}, {'callback': 'f'})
-        'f({"x": 1});'
+        '{"x": 1}'
     """
     format = options.get('format', '').lower()
     if format == 'json':
@@ -410,7 +410,8 @@ def format_result(result, options):
         json = simplejson.dumps(result)
         callback = options.get("callback")
         if callback:
-            return "%s(%s);" % (callback, json)
+            # the API handles returning the data as a callback
+            return "%s" % json
         else:
             return "var _OLBookInfo = %s;" % json
 

--- a/openlibrary/plugins/books/tests/test_dynlinks.py
+++ b/openlibrary/plugins/books/tests/test_dynlinks.py
@@ -340,7 +340,7 @@ def test_dynlinks(monkeypatch):
     assert simplejson.loads(match.group(1)) == expected_result
 
     js = dynlinks.dynlinks(["isbn:1234567890"], {"callback": "func"})
-    match = re.match('^func\(({.*})\);$', js)
+    match = re.match('^({.*})$', js)
     assert match is not None
     assert simplejson.loads(match.group(1)) == expected_result
 
@@ -414,5 +414,4 @@ class TestDataProcessor:
         p = dynlinks.DataProcessor()
         p.authors = data9
         p.works = data9
-        print p.process_doc(data9['/books/OL9M'])
         assert p.process_doc(data9['/books/OL9M']) == data9['result']['data']


### PR DESCRIPTION
Closes #1014 

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:

API endpoint https://openlibrary.org/api/books?callback=func
was duplicating the callback -- `format_result()` was wrapping the result in the callback while the API was also handling the callback fn, so the results were doubled: e.g.

`func(func({}););`

This PR fixes it so now it returns:

`func({});`

or an example with results:
http://0.0.0.0:8080/api/books?bibkeys=OCLC%3A221499958&callback=func

```func({"OCLC:221499958": {"bib_key": "OCLC:221499958", "preview": "full", "preview_url": "https://archive.org/details/odysseybookiv00home", "info_url": "http://0.0.0.0:8080/books/OL24755423M/Odyssey_book_iv"}});```

