### PR TITLE
WIP:Removed star ratings from the publishers page

### DIFF
--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -560,7 +560,7 @@ $jsdef renderPublishers(publishers):
 $if "lists" in ctx.features:
     <div class="spacer"></div>
     <div id="subjectLists" class="widget-box">
-        $:render_template("lists/widget", page)
+        $:render_template("lists/widget", page, include_rating=False)
     </div>
 
 <div class="section clearfix"></div>


### PR DESCRIPTION
Closes #1390 

## Description:
In this Pull Request we have made the following changes:
removed the star ratings widget from publishers page