### PR TITLE
Travis CI: make lint before pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   allow_failures:
     - python: "3.6"
 install:
+  - make lint
   - pip install -r requirements_test.txt
   - npm install
-before_script: make lint
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
   allow_failures:
     - python: "3.6"
 install:
+  - pip install flake8
   - make lint
   - pip install -r requirements_test.txt
   - npm install


### PR DESCRIPTION
There are several dependencies that are currently failing the __pip install__ on Python 3 (#1454, etc.) so let's run flake8 earlier in the process so we can see if this repo's code is Python 3 before moving on to the dependencie.

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
