### PR TITLE
Fix old style except clauses for Python 3

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -194,7 +194,7 @@ class Account(web.storage):
             return "account_blocked"
         try:
             web.ctx.site.login(self.username, password)
-        except ClientException, e:
+        except ClientException as e:
             code = e.get_data().get("code")
             return code
         else:
@@ -465,7 +465,7 @@ class OpenLibraryAccount(Account):
             return "account_blocked"
         try:
             web.ctx.site.login(ol_account.username, password)
-        except ClientException, e:
+        except ClientException as e:
             code = e.get_data().get("code")
             return code
         else:

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -62,7 +62,7 @@ def single_thing_skeleton(**kargs):
         start = kargs['start'].strftime("%Y-%m-%d")
         end   = kargs['end'].strftime("%Y-%m-%d %H:%M:%S")
         db    = kargs['thingdb']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_range__%s"%(k, typ))
     return query_single_thing(db, typ, start, end)
 
@@ -76,7 +76,7 @@ def admin_range__human_edits(**kargs):
         start = kargs['start'].strftime("%Y-%m-%d")
         end   = kargs['end'].strftime("%Y-%m-%d %H:%M:%S")
         db    = kargs['thingdb']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_range__human_edits"%k)
     q1 = "SELECT count(*) AS count FROM transaction WHERE created >= '%s' and created < '%s'"% (start, end)
     result = db.query(q1)
@@ -94,7 +94,7 @@ def admin_range__bot_edits(**kargs):
         start = kargs['start'].strftime("%Y-%m-%d")
         end   = kargs['end'].strftime("%Y-%m-%d %H:%M:%S")
         db    = kargs['thingdb']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_range__bot_edits"%k)
     q1 = "SELECT count(*) AS count FROM transaction t, version v WHERE v.transaction_id=t.id AND t.created >= '%s' and t.created < '%s' AND t.author_id IN (SELECT thing_id FROM account WHERE bot = 't')"% (start, end)
     result = db.query(q1)
@@ -108,7 +108,7 @@ def admin_range__covers(**kargs):
         start = kargs['start'].strftime("%Y-%m-%d")
         end   = kargs['end'].strftime("%Y-%m-%d %H:%M:%S")
         db    = kargs['coverdb']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_range__covers"%k)
     q1 = "SELECT count(*) as count from cover where created>= '%s' and created < '%s'"% (start, end)
     result = db.query(q1)
@@ -127,7 +127,7 @@ def admin_range__visitors(**kargs):
     "Finds number of unique IPs to visit the OL website."
     try:
         date = kargs['start']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_range__visitors"%k)
     global sqlitefile
     if not sqlitefile:
@@ -160,7 +160,7 @@ def admin_range__loans(**kargs):
         db = kargs['thingdb']
         start = kargs['start']
         end = kargs['end']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_total__ebooks"%k)
     result = db.query(
         "SELECT count(*) as count FROM stats" +
@@ -183,7 +183,7 @@ def admin_total__subjects(**kargs):
 def admin_total__lists(**kargs):
     try:
         db    = kargs['thingdb']
-    except KeyError, k:
+    except KeyError as k:
         raise TypeError("%s is a required argument for admin_total__lists"%k)
     # Computing total number of lists
     q1 = "SELECT id as id from thing where key='/type/list'"

--- a/openlibrary/admin/stats.py
+++ b/openlibrary/admin/stats.py
@@ -82,7 +82,7 @@ def run_gathering_functions(infobase_db, coverstore_db,
             d[key] = ret
         except numbers.NoStats:
             logger.warning("  %s - No statistics available", i)
-        except Exception, k:
+        except Exception as k:
             logger.warning("  Failed with %s", k)
     return d
 
@@ -115,7 +115,7 @@ def main(infobase_config, openlibrary_config, coverstore_config, ndays = 1):
         infobase_db = connect_to_pg(infobase_config)
         coverstore_db = connect_to_pg(coverstore_config)
         logroot = get_config_info(infobase_config)
-    except KeyError,k:
+    except KeyError as k:
         logger.critical("Config file section '%s' missing", k.args[0])
         return -1
 

--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -51,7 +51,7 @@ class OpenLibrary:
             req = urllib2.Request(url, data, headers)
             req.get_method = lambda: method
             return urllib2.urlopen(req)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             raise OLError(e)
 
     def autologin(self, section=None):
@@ -95,7 +95,7 @@ class OpenLibrary:
         try:
             data = simplejson.dumps(dict(username=username, password=password))
             response = self._request('/account/login', method='POST', data=data, headers=headers)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             response = e
 
         if 'Set-Cookie' in response.headers:

--- a/openlibrary/catalog/amazon/get_other_editions.py
+++ b/openlibrary/catalog/amazon/get_other_editions.py
@@ -22,7 +22,7 @@ for i, row in enumerate(isbn_iter):
     url = 'http://www.amazon.com/dp/other-editions/' + isbn
     try:
         page = urllib2.urlopen(url).read()
-    except urllib2.HTTPError, error:
+    except urllib2.HTTPError as error:
         if error.code != 404:
             raise
         page = ''

--- a/openlibrary/catalog/amazon/other_editions.py
+++ b/openlibrary/catalog/amazon/other_editions.py
@@ -44,7 +44,7 @@ def get_from_amazon(isbn):
     url = 'http://www.amazon.com/dp/other-editions/' + isbn
     try:
         return urllib2.urlopen(url).read()
-    except urllib2.HTTPError, error:
+    except urllib2.HTTPError as error:
         if error.code != 404:
             raise
         return ''

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -23,7 +23,7 @@ def urlopen_keep_trying(url):
         try:
             f = urllib2.urlopen(url)
             return f
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             if error.code in (403, 404, 416):
                 raise
         except urllib2.URLError:

--- a/openlibrary/catalog/importer/import_marc.py
+++ b/openlibrary/catalog/importer/import_marc.py
@@ -47,7 +47,7 @@ def get_with_retry(key):
     for i in range(3):
         try:
             return ol.get(key)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             if error.code != 500:
                 raise
         print('retry save')
@@ -58,7 +58,7 @@ def save_with_retry(key, data, comment):
     for i in range(3):
         try:
             return ol.save(key, data, comment)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             if error.code != 500:
                 raise
         print('retry save')

--- a/openlibrary/catalog/importer/merge.py
+++ b/openlibrary/catalog/importer/merge.py
@@ -188,7 +188,7 @@ def try_merge(e1, edition_key, thing):
         except NoMARCXML:
             print('no MARCXML')
             pass
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             print(error.code)
             assert error.code in (404, 403)
         if not rec2:

--- a/openlibrary/catalog/marc/show-marc.py
+++ b/openlibrary/catalog/marc/show-marc.py
@@ -36,7 +36,7 @@ class show_marc:
         rec = None
         try:
             rec = MARC21Record(result)
-        except (ValueError,MARC21Exn), e:
+        except (ValueError,MARC21Exn) as e:
             print('Invalid MARC data %s<p/>'% str(e))
 
         if rec:

--- a/openlibrary/catalog/merge/amazon.py
+++ b/openlibrary/catalog/merge/amazon.py
@@ -92,7 +92,7 @@ def compare_date(e1, e2):
             return ('publish_date', '+/-2 years', -25)
         else:
             return ('publish_date', 'mismatch', -250)
-    except ValueError, TypeError:
+    except ValueError as TypeError:
         return ('publish_date', 'mismatch', -250)
 
 def compare_isbn10(e1, e2):

--- a/openlibrary/catalog/merge/merge.py
+++ b/openlibrary/catalog/merge/merge.py
@@ -89,7 +89,7 @@ def compare_date(e1, e2):
             return ('date', '+/-2 years', -25)
         else:
             return ('date', 'mismatch', -250)
-    except ValueError, TypeError:
+    except ValueError as TypeError:
         return ('date', 'mismatch', -250)
 
 def compare_isbn10(e1, e2):

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -86,7 +86,7 @@ def compare_date(e1, e2):
             return ('date', '+/-2 years', -25)
         else:
             return ('date', 'mismatch', -250)
-    except ValueError, TypeError:
+    except ValueError as TypeError:
         return ('date', 'mismatch', -250)
 
 def compare_isbn10(e1, e2):

--- a/openlibrary/catalog/oca/parse.py
+++ b/openlibrary/catalog/oca/parse.py
@@ -13,7 +13,7 @@ def input_items (input):
 		try:
 			et = ElementTree.parse (buf)
 			elt = et.getroot ()
-		except xml_error, e:
+		except xml_error as e:
 			elt = None
 			warn ("ignoring XML error: %s" % e)
 		buf.close ()

--- a/openlibrary/catalog/onix/urlcache.py
+++ b/openlibrary/catalog/onix/urlcache.py
@@ -66,9 +66,9 @@ class URLCache:
 					tmp_data = open (tmp_data_file)
 					flock (tmp_data, LOCK_SH)
 					tmp_data.close ()
-				except OSError, e:
+				except OSError as e:
 					pass
 				return open (data_file, "r")
-			except Exception, exn:
+			except Exception as exn:
 				# in case this happens, just blow away your cache
 				raise Exception ("URLCache: sorry, corrupted state for url '%s': %s" % (url, str (exn)))

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -131,7 +131,7 @@ def get_work_title(e, mc):
             print('bad record source:', src)
             print('http://openlibrary.org' + e['key'])
             continue
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             print('HTTP error:', error.code, error.msg)
             print(e['key'])
         if not data:

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -149,7 +149,7 @@ def get_work_title(e):
             print('bad record source:', src)
             print('http://openlibrary.org' + e['key'])
             continue
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             print('HTTP error:', error.code, error.msg)
             print(e['key'])
         if not data:

--- a/openlibrary/code.py
+++ b/openlibrary/code.py
@@ -42,7 +42,7 @@ def setup_logging():
         logconfig = infogami.config.get("logging_config_file")
         if logconfig and os.path.exists(logconfig):
             logging.config.fileConfig(logconfig, disable_existing_loggers=False)
-    except Exception, e:
+    except Exception as e:
         print("Unable to set logging configuration:", str(e), file=sys.stderr)
         raise
 

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -87,7 +87,7 @@ def _old_get_meta_xml(itemid):
     try:
         defaults = {"collection": [], "external-identifier": []}
         return web.storage(xml2dict(metaxml, **defaults))
-    except Exception, e:
+    except Exception as e:
         logger.error("Failed to parse metaxml for %s", itemid, exc_info=True)
         return web.storage()
 

--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -32,7 +32,7 @@ def create_stats_client(cfg = config):
         else:
             logger.critical("Couldn't find statsd_server section in config")
             return False
-    except Exception, e:
+    except Exception as e:
         logger.critical("Couldn't create stats client - %s", e, exc_info = True)
         return False
 

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -73,7 +73,7 @@ def write_image(data, prefix):
             path = "%s-%s.jpg" % (path_prefix, name)
             resize_image(img, size).save(path, quality=90)
         return img
-    except IOError, e:
+    except IOError as e:
         print('ERROR:', str(e))
 
         # cleanup

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -33,7 +33,7 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
         code = web.template.Template.generate_code(fileobj.read().replace('\$', ''), fileobj.name)
         f = StringIO(code)
         f.name = fileobj.name
-    except Exception, e:
+    except Exception as e:
         print(fileobj.name + ':', str(e), file=web.debug)
         return []
     return extract_python(f, keywords, comment_tags, options)

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -243,13 +243,13 @@ class MockSite:
                 email=email,
                 password=password,
                 data={"displayname": displayname})
-        except common.InfobaseException, e:
+        except common.InfobaseException as e:
             raise client.ClientException("bad_data", str(e))
 
     def activate_account(self, username):
         try:
             self.account_manager.activate(username=username)
-        except common.InfobaseException, e:
+        except common.InfobaseException as e:
             raise client.ClientException(str(e))
 
     def update_account(self, username, **kw):

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -538,7 +538,7 @@ class service_status(object):
             f = open("%s/olsystem.yml"%config.admin.olsystem_root)
             nodes = services.load_all(yaml.load(f), config.admin.nagios_url)
             f.close()
-        except IOError, i:
+        except IOError as i:
             f = None
             nodes = []
         return render_template("admin/services", nodes)

--- a/openlibrary/plugins/admin/services.py
+++ b/openlibrary/plugins/admin/services.py
@@ -14,7 +14,7 @@ class Nagios(object):
     def __init__(self, url):
         try:
             self.data = BeautifulSoup.BeautifulSoup(urllib.urlopen(url).read())
-        except Exception, m:
+        except Exception as m:
             print(m)
             self.data = None
 

--- a/openlibrary/plugins/akismet/akismet.py
+++ b/openlibrary/plugins/akismet/akismet.py
@@ -98,7 +98,7 @@ class Akismet(object):
             req = urllib2.Request(url, data, headers)
             h = urllib2.urlopen(req)
             resp = h.read()
-        except (urllib2.HTTPError, urllib2.URLError, IOError), e:
+        except (urllib2.HTTPError, urllib2.URLError, IOError) as e:
             raise AkismetError(str(e))
         return resp
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -401,7 +401,7 @@ class ils_search:
     def POST(self):
         try:
             rawdata = json.loads(web.data())
-        except ValueError,e:
+        except ValueError as e:
             raise self.error("Unparseable JSON input \n %s"%web.data())
 
         # step 1: prepare the data

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -74,7 +74,7 @@ def setup_logging():
             logging.config.fileConfig(logconfig, disable_existing_loggers=False)
         logger.info("logging initialized")
         logger.debug("debug")
-    except Exception, e:
+    except Exception as e:
         print("Unable to set logging configuration:", str(e), file=sys.stderr)
         raise
 
@@ -95,7 +95,7 @@ class _inspect:
         try:
             import _inspect
             return _inspect.inspect()
-        except Exception, e:
+        except Exception as e:
             return traceback.format_exc()
 
 def get_db():

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -491,7 +491,7 @@ class _yaml(delegate.mode):
         data = dict(key=key, revision=v)
         try:
             d = api.request('/get', data=data)
-        except client.ClientException, e:
+        except client.ClientException as e:
             if e.json:
                 msg = self.dump(simplejson.loads(e.json))
             else:
@@ -523,7 +523,7 @@ class _yaml_edit(_yaml):
 
         try:
             d = self.get_data(key)
-        except web.HTTPError, e:
+        except web.HTTPError as e:
             if web.ctx.status.lower() == "404 not found":
                 d = {"key": key}
             else:
@@ -542,7 +542,7 @@ class _yaml_edit(_yaml):
             p = web.ctx.site.new(key, d)
             try:
                 p._save(i._comment)
-            except (client.ClientException, ValidationException), e:
+            except (client.ClientException, ValidationException) as e:
                 add_flash_message('error', str(e))
                 return render.edit_yaml(key, i.body)
             raise web.seeother(key + '.yml')
@@ -628,7 +628,7 @@ class new:
             h = api.get_custom_headers()
             comment = h.get('comment')
             action = h.get('action')
-        except Exception, e:
+        except Exception as e:
             raise BadRequest(str(e))
 
         self.verify_types(query)
@@ -638,7 +638,7 @@ class new:
             if not isinstance(query, list):
                 query = [query]
             web.ctx.site.save_many(query, comment=comment, action=action)
-        except client.ClientException, e:
+        except client.ClientException as e:
             raise BadRequest(str(e))
 
         #graphite/statsd tracking of bot edits

--- a/openlibrary/plugins/openlibrary/connection.py
+++ b/openlibrary/plugins/openlibrary/connection.py
@@ -181,7 +181,7 @@ class IAMiddleware(ConnectionMiddleware):
         try:
             jsontext = self.store_get(sitename, store_key)
             self.store_delete(sitename, store_key, {"_rev": None})
-        except client.ClientException, e:
+        except client.ClientException as e:
             # nothing to do if that doesn't exist
             pass
 
@@ -192,7 +192,7 @@ class IAMiddleware(ConnectionMiddleware):
         try:
             jsontext = self.store_get(sitename, store_key)
             return simplejson.loads(jsontext)
-        except client.ClientException, e:
+        except client.ClientException as e:
             logger.error("error", exc_info=True)
             if e.status.startswith("404"):
                 doc = {
@@ -441,7 +441,7 @@ class MigrationMiddleware(ConnectionMiddleware):
         try:
             d = ConnectionMiddleware.get(self, "openlibrary.org", {"key": key})
             return True
-        except client.ClientException, e:
+        except client.ClientException as e:
             return False
 
     def _process(self, data):

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -63,7 +63,7 @@ class lists_delete(delegate.page):
         }
         try:
             result = web.ctx.site.save(doc, action="lists", comment="Deleted list.")
-        except client.ClientException, e:
+        except client.ClientException as e:
             web.ctx.status = e.status
             web.header("Content-Type", "application/json")
             return delegate.RawText(e.json)
@@ -160,7 +160,7 @@ class lists_json(delegate.page):
                     "seeds": seeds
                 }
             )
-        except client.ClientException, e:
+        except client.ClientException as e:
             headers = {"Content-Type": self.get_content_type()}
             data = {
                 "message": e.message

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -38,7 +38,7 @@ def evaluate_and_store_stat(name, stat, summary):
                 pass
             else:
                 l.warning("No storage item specified for stat %s", name)
-    except Exception, k:
+    except Exception as k:
         l.warning("Error while storing stats (%s). Complete traceback follows"%k)
         l.warning(traceback.format_exc())
 
@@ -61,7 +61,7 @@ def stats_hook():
     try:
         if "stats-header" in web.ctx.features:
             web.header("X-OL-Stats", format_stats(stats_summary))
-    except Exception, e:
+    except Exception as e:
         # don't let errors in stats collection break the app.
         print(str(e), file=web.debug)
 

--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -117,11 +117,11 @@ class fullsearch(delegate.page):
                         out.append((oln_thing, ocaid,
                                     collapse_groups(solr_pagetext.pagetext_search
                                                     (ocaid, q))))
-                except IndexError, e:
+                except IndexError as e:
                     print(('fullsearch index error', e, e.args), file=web.debug)
                     pass
             timings.update('pagetext done (oca lookups: %.4f sec)'% t_ocaid)
-        except IOError, e:
+        except IOError as e:
             errortext = 'fulltext search is temporarily unavailable (%s)' % \
                         str(e)
 
@@ -287,7 +287,7 @@ class search(delegate.page):
             #                    (len(results),results),
             #                    (len(works_groups),works_groups))
 
-        except (solr_client.SolrError, Exception), e:
+        except (solr_client.SolrError, Exception) as e:
             import traceback
             errortext = 'Sorry, there was an error in your search.'
             if i.get('safe')=='false':

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -101,7 +101,7 @@ class Solr_result(object):
             w = result_xml.encode('utf-8')
             def tx(a): return (type(a), len(a))
             et.parse(StringIO(w))
-        except SyntaxError, e:
+        except SyntaxError as e:
             ptb = traceback.extract_stack()
             raise SolrError, (e, result_xml, traceback.format_list(ptb))
         range_info = et.find('info').find('range_info')
@@ -129,7 +129,7 @@ class SR2(Solr_result):
             self.contained_in_this_set = len(r['docs'])
             self.result_list = list(d['identifier'] for d in r['docs'])
             self.raw_results = r['docs']
-        except Exception, e:
+        except Exception as e:
             ptb = traceback.extract_stack()
             raise SolrError, (e, result_json, traceback.format_list(ptb))
 
@@ -237,7 +237,7 @@ class Solr_client(object):
         e = ElementTree()
         try:
             e.parse(StringIO(result_list))
-        except SyntaxError, e:
+        except SyntaxError as e:
             raise SolrError, e
 
         total_nbr_text = e.find('info/range_info/total_nbr').text
@@ -289,7 +289,7 @@ class Solr_client(object):
         XML = ElementTree()
         try:
             XML.parse(StringIO(page_hits))
-        except SyntaxError, e:
+        except SyntaxError as e:
             raise SolrError, e
         page_ids = list(e.text for e in XML.getiterator('identifier'))
         return [extract(x)[1] for x in page_ids]
@@ -333,7 +333,7 @@ class Solr_client(object):
         try:
             # print >> web.debug, '*** parsing result_set=', result_set
             h1 = simplejson.loads(result_set)
-        except SyntaxError, e:   # we got a solr stack dump
+        except SyntaxError as e:   # we got a solr stack dump
             # print >> web.debug, '*** syntax error result_set=(%r)'% result_set
             raise SolrError, (e, result_set)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -346,7 +346,7 @@ class account_login(delegate.page):
     def POST_resend_verification_email(self, i):
         try:
             ol_login = OpenLibraryAccount.authenticate(i.email, i.password)
-        except ClientException, e:
+        except ClientException as e:
             code = e.get_data().get("code")
             if code != "account_not_verified":
                 return self.error("account_incorrect_password", i)

--- a/openlibrary/plugins/upstream/adapter.py
+++ b/openlibrary/plugins/upstream/adapter.py
@@ -64,7 +64,7 @@ class proxy:
             req = urllib2.Request(server + self.path + '?' + urllib.urlencode(self.input), self.data, headers=headers)
             req.get_method = lambda: web.ctx.method
             response = urllib2.urlopen(req)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             response = e
         self.status_code = response.code
         self.status_msg = response.msg

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -662,7 +662,7 @@ class book_edit(delegate.page):
                 add_flash_message("info", utils.get_message("flash_book_updated"))
 
             raise web.seeother(edition.url())
-        except (ClientException, ValidationException), e:
+        except (ClientException, ValidationException) as e:
             add_flash_message('error', str(e))
             return self.GET(key)
 
@@ -709,7 +709,7 @@ class work_edit(delegate.page):
             helper.save(web.input())
             add_flash_message("info", utils.get_message("flash_work_updated"))
             raise web.seeother(work.url())
-        except (ClientException, ValidationException), e:
+        except (ClientException, ValidationException) as e:
             add_flash_message('error', str(e))
             return self.GET(key)
 
@@ -744,7 +744,7 @@ class author_edit(delegate.page):
                 author = web.ctx.site.new(key, {"key": key, "type": {"key": "/type/delete"}})
                 author._save(comment=i._comment)
                 raise web.seeother(key)
-        except (ClientException, ValidationException), e:
+        except (ClientException, ValidationException) as e:
             add_flash_message('error', str(e))
             author.update(formdata)
             author['comment_'] = i._comment

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -476,7 +476,7 @@ class borrow_receive_notification(delegate.page):
             notify_obj = acs4.el_to_o(notify_xml)
 
             output = simplejson.dumps({'success':True})
-        except Exception, e:
+        except Exception as e:
             output = simplejson.dumps({'success':False, 'error': str(e)})
         return delegate.RawText(output, content_type='application/json')
 

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -64,7 +64,7 @@ class add_cover(delegate.page):
         try:
             response = urllib2.urlopen(upload_url, urllib.urlencode(params))
             out = response.read()
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             out = e.read()
 
         return web.storage(simplejson.loads(out))

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -667,7 +667,7 @@ class Subject(client.Thing):
             url = '%s/b/query?cmd=ids&olid=%s' % (get_coverstore_url(), ",".join(olids))
             data = urllib2.urlopen(url).read()
             cover_ids = simplejson.loads(data)
-        except IOError, e:
+        except IOError as e:
             print('ERROR in getting cover_ids', str(e), file=web.debug)
             cover_ids = {}
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -752,7 +752,7 @@ class search_json(delegate.page):
                                                 fields="*")
 
             response = json.loads(reply)['response'] or ''
-        except (ValueError, IOError), e:
+        except (ValueError, IOError) as e:
             logger.error("Error in processing search API.")
             response = dict(start=0, numFound=0, docs=[], error=str(e))
 

--- a/openlibrary/solr/inside/index_gevent.py
+++ b/openlibrary/solr/inside/index_gevent.py
@@ -67,7 +67,7 @@ def urlread_keep_trying(url):
     for i in range(3):
         try:
             return urllib2.urlopen(url).read()
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             if error.code in (403, 404):
                 #print "404 for '%s'" % url
                 raise
@@ -112,7 +112,7 @@ def read_text_from_node(host):
         url = 'http://%s/%s' % (host, path)
         try:
             dir_html = urlread_keep_trying('http://%s/%s' % (host, path))
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             if error.code == 403:
                 print('403 on directory listing for:', ia)
                 dir_html = None
@@ -130,7 +130,7 @@ def read_text_from_node(host):
         url = 'http://%s/~edward/abbyy_to_text.php?ia=%s&path=%s&file=%s' % (host, ia, path, filename)
         try:
             reply = urlread_keep_trying(url)
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             if error.code != 403:
                 raise
             url = 'http://%s/~edward/abbyy_to_text_p.php?ia=%s&path=%s&file=%s' % (host, ia, path, filename)
@@ -264,7 +264,7 @@ def run_find_item():
         if body:
             try:
                 meta_xml = urlread_keep_trying('http://%s%s/%s_meta.xml' % (host, path, ia))
-            except urllib2.HTTPError, error:
+            except urllib2.HTTPError as error:
                 if error.code != 403:
                     raise
                 print('403 on meta XML for:', ia)

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1282,7 +1282,7 @@ def get_document(key):
             logger.info("urlopen %s", url)
             contents = urlopen(url).read()
             return json.loads(contents)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             contents = e.read()
             # genuine 404, not a server error
             if e.getcode() == 404 and '"error": "notfound"' in contents:
@@ -1562,7 +1562,7 @@ class MonkeyPatch:
     def get_document(self, key):
         try:
             return self.withKey(key)
-        except ClientException, e:
+        except ClientException as e:
             if e.status.startswith('404'):
                 logger.warn("%s is not found, considering it as deleted.", key)
                 return {"key": key, "type": {"key": "/type/delete"}}

--- a/openlibrary/solr/work_subject.py
+++ b/openlibrary/solr/work_subject.py
@@ -37,7 +37,7 @@ def get_marc_subjects(w):
             print('bad record source:', src)
             print('http://openlibrary.org' + w['key'])
             continue
-        except urllib2.HTTPError, error:
+        except urllib2.HTTPError as error:
             print('HTTP error:', error.code, error.msg)
             print('http://openlibrary.org' + w['key'])
         if not data:

--- a/openlibrary/utils/httpserver.py
+++ b/openlibrary/utils/httpserver.py
@@ -34,7 +34,7 @@ class HTTPServer:
     def _start(self):
         try:
             self.server.start()
-        except Exception, e:
+        except Exception as e:
             print('ERROR: failed to start server', str(e))
 
     def stop(self):

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -22,7 +22,7 @@ class show_ia(app.view):
         url = 'http://www.archive.org/download/%s/%s_meta.mrc' % (ia, ia)
         try:
             data = urllib2.urlopen(url).read()
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             if e.code == 404:
                 error_404 = True
             else:
@@ -32,7 +32,7 @@ class show_ia(app.view):
             url = 'http://www.archive.org/download/%s/%s_meta.xml' % (ia, ia)
             try:
                 data = urllib2.urlopen(url).read()
-            except urllib2.HTTPError, e:
+            except urllib2.HTTPError as e:
                 return "ERROR:" + str(e)
             raise web.seeother('http://www.archive.org/details/' + ia)
 
@@ -108,7 +108,7 @@ class show_marc(app.view):
 
         try:
             result = urllib2.urlopen(ureq).read(100000)
-        except urllib2.HTTPError, e:
+        except urllib2.HTTPError as e:
             return "ERROR:" + str(e)
 
         len_in_rec = int(result[:5])

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -32,7 +32,7 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
         try:
             ol = get_ol(servername=servername)
             return ol.import_ocaid(item.ia_id, require_marc=require_marc)
-        except (IOError, OLError), e:
+        except (IOError, OLError) as e:
             logger.warn("Failed to contact OL server. error=%s", e)
 
 

--- a/scripts/ol-solr-indexer.py
+++ b/scripts/ol-solr-indexer.py
@@ -175,7 +175,7 @@ def check_updates(rows,timestamp):
                     else:
                         write_stout('?')
                         logger.warning('You are tring to process other item than /type/works %s',k)
-                except Exception,e:
+                except Exception as e:
                     write_stout('E')
                     logger.error('Cannot read %s : %s',str(k),e)
     write_stout('\n')


### PR DESCRIPTION
This is a subset of #1466 which only one kind of change so it should be easier to review.  @tfmorris 

It drops our number of Python 3 syntax errors on __make lint__ from 62 down to 19.