### PR TITLE
Remove octal dates for Python 3

### DIFF
--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -35,7 +35,7 @@ class TestHomeTemplates:
         posts = [web.storage({
             "title": "Blog-post-0",
             "link": "http://blog.openlibrary.org/2011/01/01/blog-post-0",
-            "pubdate": datetime.datetime(2011, 01, 01)
+            "pubdate": datetime.datetime(2011, 1, 1)
         })]
         html = unicode(render_template("home/about", blog_posts=posts))
         assert "About the Project" in html

--- a/openlibrary/tests/core/test_processors_invalidation.py
+++ b/openlibrary/tests/core/test_processors_invalidation.py
@@ -33,7 +33,7 @@ class TestInvalidationProcessor:
             "key": "/templates/site.tmpl",
             "type": "/type/template"
         }
-        web.ctx.site.save(doc, timestamp=datetime.datetime(2010, 01, 01))
+        web.ctx.site.save(doc, timestamp=datetime.datetime(2010, 1, 1))
 
         hook = invalidation._InvalidationHook("/templates/site.tmpl", cookie_name="invalidation-cookie", expire_time=120)
         hook.on_new_version(web.ctx.site.get(doc['key']))


### PR DESCRIPTION
Yet another subset of #1466 that removes Python 3 syntax errors from two different files.  This is caused because __01__ meant octal 1 in Python 2 but this was not intuitive and resulted in difficult to debug errors as discussed [here](https://github.com/internetarchive/openlibrary/pull/1466#discussion_r229902687).

To remedy this situation, Python 3 treats __01__ as a syntax error and so __0o1__ the correct way to write octal 1 in both Python 2 and Python 3.