### PR TITLE
Avoid confusion with js linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "globals": {
   },
   "rules": {
-    "no-extra-semi": "warn",
+    "no-extra-semi": "error",
     "eol-last": ["error", "always"],
     "no-mixed-spaces-and-tabs": "error",
     "no-unused-vars": "error"

--- a/openlibrary/plugins/openlibrary/js/add_new_field.js
+++ b/openlibrary/plugins/openlibrary/js/add_new_field.js
@@ -14,6 +14,9 @@
  *     - On cancel/close:
  *         - value of the select is set to "" to select "select xxx"
  */
+// We are blindly concatenating JS. The ; protects us in case the concatenation
+// goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
+// eslint-disable-next-line no-extra-semi
 ;(function($){
     $.fn.add_new_field = function(_options) {
         $(this).each(function() {

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -1,5 +1,8 @@
 // jquery plugins to provide author and language autocompletes.
 
+// We are blindly concatenating JS. The ; protects us in case the concatenation
+// goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
+// eslint-disable-next-line no-extra-semi
 ;(function($) {
     /**
      * Some extra options for when creating an autocomplete input field

--- a/openlibrary/plugins/openlibrary/js/lazy.js
+++ b/openlibrary/plugins/openlibrary/js/lazy.js
@@ -1,6 +1,9 @@
-/* eslint-disable no-unused-vars */
-// third party library
-// Add your third-party javascripts here
+/* eslint-disable */
+// third party library (legacy)
+// This file exists for historic reasons. It should be ported to the vendor bundle in
+// static/js/vendor.jsh @ the earliest opportunity.
+// Do not add any thing to this file, only remove things.
+// We are no longer "lazy" in open library :)
 
 /**
  * jQuery.ScrollTo - Easy element scrolling using jQuery.

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -12,6 +12,9 @@
 //          });
 //
 
+// We are blindly concatenating JS. The ; protects us in case the concatenation
+// goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
+// eslint-disable-next-line no-extra-semi
 ;(function() {
 
 function Subject(data, options) {

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -1,3 +1,6 @@
+// We are blindly concatenating JS. The ; protects us in case the concatenation
+// goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
+// eslint-disable-next-line no-extra-semi
 ;(function($) {
 
 // source: http://snipplr.com/view/8916/jquery-toggletext/


### PR DESCRIPTION
A few people have attempted to fix these warnings. Instead of continuing
to warn, let's document why these issues exist, and switch from a warning
to an error for future usages.

Also take the time to disable linting altogether on  lazy.js which should
be moved to vendor

Short term solution for #1489

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
