### PR TITLE
Fix has_key() for Python 3

### DIFF
--- a/openlibrary/catalog/onix/xmltramp.py
+++ b/openlibrary/catalog/onix/xmltramp.py
@@ -5,7 +5,6 @@ __author__ = "Aaron Swartz"
 __credits__ = "Many thanks to pjz, bitsko, and DanC."
 __copyright__ = "(C) 2003-2006 Aaron Swartz. GNU GPL 2."
 
-if not hasattr(__builtins__, 'True'): True, False = 1, 0
 def isstr(f): return isinstance(f, type('')) or isinstance(f, type(u''))
 def islst(f): return isinstance(f, type(())) or isinstance(f, type([]))
 

--- a/openlibrary/catalog/onix/xmltramp.py
+++ b/openlibrary/catalog/onix/xmltramp.py
@@ -228,7 +228,7 @@ class Seeder(EntityResolver, DTDHandler, ContentHandler, ErrorHandler):
         ContentHandler.__init__(self)
 
     def startPrefixMapping(self, prefix, uri):
-        if not self.prefixes.has_key(prefix): self.prefixes[prefix] = []
+        if prefix not in self.prefixes: self.prefixes[prefix] = []
         self.prefixes[prefix].append(uri)
     def endPrefixMapping(self, prefix):
         self.prefixes[prefix].pop()

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -30,9 +30,9 @@ def evaluate_and_store_stat(name, stat, summary):
         return
     try:
         if f(**stat):
-            if stat.has_key("time"):
+            if "time" in stat:
                 graphite_stats.put(name, summary[stat.time]["time"] * 100)
-            elif stat.has_key("count"):
+            elif "count" in stat:
                 #print "Storing count for key %s"%stat.count
                 # XXX-Anand: where is the code to update counts?
                 pass

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -554,7 +554,7 @@ def get_bookreader_host():
 def get_all_store_values(**query):
     """Get all values by paging through all results. Note: adds store_key with the row id."""
     query = copy.deepcopy(query)
-    if not query.has_key('limit'):
+    if 'limit' not in query:
         query['limit'] = 500
     query['offset'] = 0
     values = []


### PR DESCRIPTION
Yet another subset of #1466 which deals with the fact that __dict.has_key(key)__ was removed from Python 3 in favor of __key in dict__.

This PR represents the output of __futurize -f lib2to3.fixes.fix_has_key -w o*.__ which adopts  the __"in"__ syntax which works as expected in both Python 2 and Python 3.

424 days until Python 2 end of life.