### PR TITLE
Fix missing Python Standard Library imports

### DIFF
--- a/openlibrary/catalog/lc_updates/update.py
+++ b/openlibrary/catalog/lc_updates/update.py
@@ -37,7 +37,7 @@ def put_file(con, ia, filename):
         if no_bucket_error not in body and internal_error not in body:
             sys.exit(0)
         print('retry')
-        time.sleep(5)
+        sleep(5)
     print('too many failed attempts')
 
 subprocess.call(["/usr/bin/perl", "get.pl"])

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
 import re, web
+import json
+import urllib2
 from openlibrary.catalog.importer.db_read import get_mc
 from openlibrary.api import unmarshal
 from time import sleep

--- a/scripts/2009/07/delete_spam_users.py
+++ b/scripts/2009/07/delete_spam_users.py
@@ -4,6 +4,7 @@ Earlier to block all the spam users, user's key has been prefixed with SPAM. Tha
 This script removes all the SPAM/* users to restore log-replay.
 """
 
+import os
 import sys
 
 def main(database):

--- a/scripts/solr_author_merge_work_finder.py
+++ b/scripts/solr_author_merge_work_finder.py
@@ -5,6 +5,7 @@ import _init_path
 
 from openlibrary import config
 import argparse, simplejson, re
+import sys
 from urllib import urlopen
 from time import time, sleep
 from openlibrary.catalog.works.find_works import find_title_redirects, find_works, get_books, books_query, update_works
@@ -103,4 +104,3 @@ while True:
         if update_times:
             print("average update time: %.1f seconds" % (float(sum(update_times)) / float(len(update_times))))
     print(offset, file=open(state_file, 'w'))
-

--- a/scripts/solr_author_merge_work_finder.py
+++ b/scripts/solr_author_merge_work_finder.py
@@ -7,6 +7,7 @@ from openlibrary import config
 import argparse, simplejson, re
 import sys
 from urllib import urlopen
+from urllib2 import URLError
 from time import time, sleep
 from openlibrary.catalog.works.find_works import find_title_redirects, find_works, get_books, books_query, update_works
 


### PR DESCRIPTION
These fixes are modifications to Python files that use functions from Standard Library modules but do not actually import those modules.  This leads to an _undefined name_ situation which has the potential to raise __NameError__ at runtime if other Python files have not already imported the modules in question.

To defuse these _ticking timebomb_ situations, this PR advocates that all Python files explicitly import the Standard Library modules that they use.

These issues were discovered via a command that is _temporarily_ disabled in our __make lint__:

$ __python2 -m flake8 . --count --show-source --statistics --select=F821__
```
./openlibrary/catalog/utils/edit.py:56:22: F821 undefined name 'json'
    prev = unmarshal(json.load(urllib2.urlopen(url)))
                     ^
./openlibrary/catalog/utils/edit.py:56:32: F821 undefined name 'urllib2'
    prev = unmarshal(json.load(urllib2.urlopen(url)))
                               ^
./openlibrary/catalog/lc_updates/update.py:40:9: F821 undefined name 'time'
        time.sleep(5)
        ^
./scripts/solr_author_merge_work_finder.py:67:12: F821 undefined name 'URLError'
    except URLError as inst:
           ^
./scripts/solr_author_merge_work_finder.py:71:13: F821 undefined name 'sys'
            sys.exit(0)
            ^
./scripts/2009/07/delete_spam_users.py:10:57: F821 undefined name 'os'
    db = web.database(dbn='postgres', db=database, user=os.getenv('USER'), pw='')
                                                        ^
6   F821 undefined name 'out'
6
```