### PR TITLE
Explicit tuple in Python 3 list comprehensions

### DIFF
--- a/openlibrary/catalog/merge/amazon.py
+++ b/openlibrary/catalog/merge/amazon.py
@@ -151,7 +151,7 @@ def substr_match(a, b):
     return a.find(b) != -1 or b.find(a) != -1
 
 def keyword_match(in1, in2):
-    s1, s2 = [i.split() for i in in1, in2]
+    s1, s2 = [i.split() for i in (in1, in2)]
     s1_set = set(s1)
     s2_set = set(s2)
     match = s1_set & s2_set

--- a/openlibrary/catalog/merge/merge.py
+++ b/openlibrary/catalog/merge/merge.py
@@ -148,7 +148,7 @@ def substr_match(a, b):
     return a.find(b) != -1 or b.find(a) != -1
 
 def keyword_match(in1, in2):
-    s1, s2 = [i.split() for i in in1, in2]
+    s1, s2 = [i.split() for i in (in1, in2)]
     s1_set = set(s1)
     s2_set = set(s2)
     match = s1_set & s2_set

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -166,7 +166,7 @@ def substr_match(a, b):
     return a.find(b) != -1 or b.find(a) != -1
 
 def keyword_match(in1, in2):
-    s1, s2 = [i.split() for i in in1, in2]
+    s1, s2 = [i.split() for i in (in1, in2)]
     s1_set = set(s1)
     s2_set = set(s2)
     match = s1_set & s2_set

--- a/openlibrary/catalog/merge/names.py
+++ b/openlibrary/catalog/merge/names.py
@@ -8,7 +8,7 @@ re_amazon_space_name = re.compile('^(.+?[^ ]) +([A-Z][a-z]?)$')
 
 verbose = False
 
-titles = frozenset([normalize(x) for x in 'Mrs', 'Sir', 'pseud', 'Lady', 'Baron', 'lawyer', 'Lord', 'actress', 'Dame', 'Mr', 'Viscount', 'professeur', 'Graf', 'Dr', 'Countess', 'Ministerialrat', 'Oberamtsrat', 'Rechtsanwalt'])
+titles = frozenset([normalize(x) for x in ('Mrs', 'Sir', 'pseud', 'Lady', 'Baron', 'lawyer', 'Lord', 'actress', 'Dame', 'Mr', 'Viscount', 'professeur', 'Graf', 'Dr', 'Countess', 'Ministerialrat', 'Oberamtsrat', 'Rechtsanwalt')])
 
 # marquis de
 


### PR DESCRIPTION
Yet another subset of #1466 which deals with the fact that Python 3 requires explicit tuples in the "__in__" clause of a list comprehension.

This PR represents the output of __futurize -f lib2to3.fixes.fix_paren -w__ which adds the missing parentheses which works as expected in both Python 2 and Python 3.

424 days until Python 2 end of life.