### PR TITLE
Goodbye read-btn (conflicts with btn--large)!!

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -76,7 +76,7 @@ $elif (availability_status == 'borrow_unavailable'):
 
 $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
-    <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="read-btn btn--large btn primary">Read eBook</a>
+    <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="btn--large btn primary">Read eBook</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
     <p class="smaller">No ebook available.</p>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -68,7 +68,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           $if active:
             <ul>
               $if availability.get('status') == 'open':
-                <li class="read-option"><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="read-btn">Read eBook</a></strong></li>
+                <li class="read-option"><strong><a href="$viewbook.replace('XXX', book.ocaid)" title="Read a scanned version in BookReader" class="btn primary">Read eBook</a></strong></li>
 
               $elif availability.get('status') in ['borrow_available', 'borrow_unavailable']:
                 <li class="read-option">$:macros.LoanStatus(book, ctx.user)</li>

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -2364,7 +2364,6 @@ select {
 // for backwards compatibility
 // please use btn--large instead
 .borrow-btn,
-.read-btn,
 .wait-btn,
 .unwait-btn {
   margin: 1px auto;


### PR DESCRIPTION
Read eBook button no longer needs to be a "read-btn"
This class is making the button appear smaller than it needs to be now
that it's using btn--large now (the standardised button style going forward)

The works page is the only other consumer of the read-btn and that looks
like a btn primary.

There are no references to read-btn in JS
so goodbye read-btn!

Fixes: #1499

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
