### PR TITLE
Hide label of cbox close icon for floaterShut

### DIFF
--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -107,6 +107,9 @@ div.coverFloat {
   background: @white;
   text-align: left;
   a.floaterShut {
+    // hide label
+    text-indent: 999px;
+    overflow: hidden;
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
(This minor change cleans up the CSS a little by making it more obvious how components are supposed to behave)

Rather than rely on helper class "shift" which I want us to move
away from, I want to explicitly make the shifting of the close icon
happen inside the cbox component.
