### PR TITLE
Requirements: six==1.11.0

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -18,6 +18,7 @@ pystatsd==0.1.6
 PyYAML==3.10
 eventer==0.1.1
 lepl==5.1.3
+six==1.11.0
 sixpack-client==1.1.0
 psycopg2==2.7.3.2
 OL-GeoIP==1.2.4


### PR DESCRIPTION
Yet another subset of #1466 as discussed at: https://github.com/internetarchive/openlibrary/pull/1466#discussion_r230570214

We are going to need six (or similar) to get to Python 3 compatibility without breaking Python 2.