### PR TITLE
Function parameters may not be explicit tuples in Python 3

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -85,7 +85,8 @@ class upload:
         success_url = i.success_url or web.ctx.get('HTTP_REFERRER') or '/'
         failure_url = i.failure_url or web.ctx.get('HTTP_REFERRER') or '/'
 
-        def error((code, msg)):
+        def error(code__msg):
+            (code, msg) = code__msg
             print("ERROR: upload failed, ", i.olid, code, repr(msg), file=web.debug)
             _cleanup()
             url = changequery(failure_url, errcode=code, errmsg=msg)
@@ -123,7 +124,8 @@ class upload2:
         web.ctx.pop("_fieldstorage", None)
         web.ctx.pop("_data", None)
 
-        def error((code, msg)):
+        def error(code__msg):
+            (code, msg) = code__msg
             _cleanup()
             e = web.badrequest()
             e.data = simplejson.dumps({"code": code, "message": msg})

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -369,8 +369,10 @@ class Solr_client(object):
         # print >> web.debug, '* basic search: query=(%r)'% bquery
         return self.advanced_search(bquery, **params)
 
-# get second element of a tuple
-def snd((a,b)): return b
+def snd(a__b):
+    """Get second element of a tuple."""
+    (a, b) = a__b
+    return b
 
 def facet_counts(result_list, facet_fields):
     """Return list of facet counts for a search result set.


### PR DESCRIPTION
These are syntax errors in Python 3...  See __make lint__ when run on Python 3 for confirmation.

This is yet another in a long list of subsets of #1466.  It represents an edit of a partial set of the fixes that would get executed via __futurize -f lib2to3.fixes.fix_tuple_params -w .__.  This set of changes is about __functions__ while to other set is about __lambdas__ but those changes were deemed to have readability issues so they will be addressed in a separate PR.