### PR TITLE
Remove argparse from requirements_common.txt

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -1,7 +1,6 @@
 Babel==2.5.3
 BeautifulSoup==3.2.0
 DBUtils==1.3
-argparse==1.2.1
 flake8==3.5.0
 Genshi==0.6
 gunicorn==19.9.0


### PR DESCRIPTION
See https://pypi.org/project/argparse for a discussion about how __argparse__ has moved into the Python Standard Library for all currently supported versions of Python.