### PR TITLE
Mobile friendly chart component

### DIFF
--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -495,11 +495,11 @@ function set_hash(data) {
 //-->
 </script>
 
-    <div class="chart" style="width:898px;height:140px;">
-        <div id="chartPubHistory" class="thisChart" style="width:898px;height:140px;">
+    <div class="chart">
+        <div id="chartPubHistory" class="thisChart">
             <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
         </div>
-        <div class="chartYaxis" style="width:140px;">$_("Editions Published")</div>
+        <div class="chartYaxis">$_("Editions Published")</div>
         <div class="chartXaxis">$_("Year of Publication")</div>
     </div>
 

--- a/static/css/components/chart.less
+++ b/static/css/components/chart.less
@@ -4,12 +4,15 @@
 */
 @import (less) "less/font-families.less";
 
+@chart-height: 140px;
+@chart-width: 898px;
+@chart-bottom-padding: 20px;
+
 .chart {
-  float: left;
   position: relative;
-  width: 898px;
-  height: 140px;
-  padding: 0 0 20px 20px;
+  height: @chart-height + @chart-bottom-padding;
+  width: 100%;
+  padding: 0 8px @chart-bottom-padding 20px;
   margin-top: 0;
   font-size: .6875em;
   font-family: @lucida_sans_serif-1;
@@ -17,6 +20,8 @@
   background-image: url(/images/ajax-loader-bar.gif);
   background-repeat: no-repeat;
   background-position: 340px 60px;
+  box-sizing: border-box;
+
   &Yaxis {
     position: absolute;
     text-align: center;
@@ -38,5 +43,25 @@
     font-size: 10px;
     color: @olive;
     text-transform: uppercase;
+  }
+  &Zoom {
+    white-space: nowrap;
+  }
+  .thisChart {
+    height: @chart-height;
+    width: 100%;
+  }
+}
+
+@media all and ( min-width: @width-breakpoint-desktop ) {
+  .chart {
+    float: left;
+    width: @chart-width;
+    &Yaxis {
+      width: @chart-height;
+    }
+    .thisChart {
+      width: @chart-width;
+    }
   }
 }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -632,7 +632,6 @@ span {
     font-weight: normal !important;
     font-family: @lucida_sans_serif-1;
     color: @brown;
-    white-space: nowrap;
     padding: 5px 5px 0;
   }
   &.caption {
@@ -4106,6 +4105,11 @@ ul#myreads-paginator {
 }
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
+  span {
+    &.count {
+      white-space: nowrap;
+    }
+  }
   div.edition {
     &Cover {
       float: left;


### PR DESCRIPTION
The chart component as featured on the subject page, doesn't work
well at mobile resolutions.

We limit the problematic styles to the desktop breakpoint

Additional changes:
* The count style is also problematic on mobile, so we moves its
whitespace property in the legacy file. The styles stay in legacy
as I'm hoping to see these removed in the revised page stylesheet.

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
