### PR TITLE
Builtin xrange() was removed in Python 3

### DIFF
--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -3,6 +3,9 @@ import re, web
 from unicodedata import normalize
 import openlibrary.catalog.merge.normalize as merge
 
+from six.moves import range
+
+
 re_date = map (re.compile, [
     '(?P<birth_date>\d+\??)-(?P<death_date>\d+\??)',
     '(?P<birth_date>\d+\??)-',
@@ -132,7 +135,7 @@ def combinations(items, n):
     if n==0:
         yield []
     else:
-        for i in xrange(len(items)):
+        for i in range(len(items)):
             for cc in combinations(items[i+1:], n-1):
                 yield [items[i]]+cc
 

--- a/openlibrary/plugins/search/facet_hash.py
+++ b/openlibrary/plugins/search/facet_hash.py
@@ -1,6 +1,9 @@
 import string
 from hashlib import sha1 as mkhash
 
+from six.moves import range
+
+
 # choose token length to make collisions unlikely (if there is a
 # rare collision once in a while, we tolerate it, it just means
 # that users may occasionally see some extra search results.
@@ -31,7 +34,7 @@ def facet_token(field, v):
     field = coerce_str(field)
 
     q = int(mkhash('FT,%s,%s'%(field,v)).hexdigest(), 16)
-    for i in xrange(facet_token_length):
+    for i in range(facet_token_length):
         q,r = divmod(q, 26)
         token.append(string.lowercase[r])
     return ''.join(token)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -31,6 +31,9 @@ import utils
 import borrow
 
 
+from six.moves import range
+
+
 logger = logging.getLogger("openlibrary.account")
 
 USERNAME_RETRIES = 3
@@ -715,7 +718,7 @@ class ReadingLog(object):
         ocaids = [i['identifier'] for i in waitlists]
         edition_keys = web.ctx.site.things({"type": "/type/edition", "ocaid": ocaids})
         editions = web.ctx.site.get_many(edition_keys)
-        for i in xrange(len(editions)):
+        for i in range(len(editions)):
             # insert the waitlist_entry corresponding to this edition
             editions[i].waitlist_record = keyed_waitlists[editions[i].ocaid]
         return editions

--- a/openlibrary/solr/facet_hash.py
+++ b/openlibrary/solr/facet_hash.py
@@ -1,6 +1,9 @@
 import string
 from hashlib import sha1 as mkhash
 
+from six.moves import range
+
+
 # choose token length to make collisions unlikely (if there is a
 # rare collision once in a while, we tolerate it, it just means
 # that users may occasionally see some extra search results.
@@ -31,7 +34,7 @@ def facet_token(field, v):
     field = coerce_str(field)
 
     q = int(mkhash('FT,%s,%s'%(field,v)).hexdigest(), 16)
-    for i in xrange(facet_token_length):
+    for i in range(facet_token_length):
         q,r = divmod(q, 26)
         token.append(string.lowercase[r])
     return ''.join(token)

--- a/scripts/ol-solr-indexer.py
+++ b/scripts/ol-solr-indexer.py
@@ -30,6 +30,9 @@ from openlibrary import config
 from openlibrary.core import helpers as h
 from openlibrary.solr import update_work
 
+from six.moves import range
+
+
 logger = logging.getLogger("openlibrary.search-indexer")
 logger.setLevel(logging.DEBUG)
 handler = logging.StreamHandler()
@@ -185,7 +188,7 @@ def submit_update_to_solr(target):
     '''Executes the update queries for every element in the taget list.'''
     global sub_count
     seq = int(math.ceil(len(target)/float(CHUNK_SIZE)))
-    chunks = [ target[i::seq] for i in xrange(seq) ]
+    chunks = [ target[i::seq] for i in range(seq) ]
     for chunk in chunks:
         update_work.load_configs(options.server,options.config,'default')
         logger.info("Request %s/%s to update works: %s",str(sub_count),str(CHUNKS_NUM),str(chunk))


### PR DESCRIPTION
The builtin __xrange()__ was removed in Python 3 in favor of __range()__ so this PR uses [__six.moves.range()__](https://six.readthedocs.io/#module-six.moves) as a replacement that works as expected in both Python 2 and Python 3.