### PR TITLE
Builtin execfile() was removed in Python 3

### DIFF
--- a/openlibrary/plugins/openlibrary/dev_instance.py
+++ b/openlibrary/plugins/openlibrary/dev_instance.py
@@ -153,7 +153,8 @@ def load_sample_data():
     This is unused as of now.
     """
     env = {}
-    execfile("scripts/copydocs.py", env, env)
+    with open("scripts/copydocs.py") as in_file:
+        exec(in_file.read(), env, env)
     src = env['OpenLibrary']()
     dest = web.ctx.site
     comment = "Loaded sample data."


### PR DESCRIPTION
The builtin __execfile()__ was removed in Python 3 so this PR opens the file in question and then calls __exec()__ on its contents which should work as expected on both Python 2 and Python 3.