### PR TITLE
Builtin raw_input() was removed in Python 3

### DIFF
--- a/openlibrary/plugins/bookrev/dev.py
+++ b/openlibrary/plugins/bookrev/dev.py
@@ -4,6 +4,9 @@ from infogami import tdb
 
 import db, reviewsources, utils
 
+from six.moves import input
+
+
 def list_latest_reviews():
     for review in tdb.Things(type=db.get_type('type/bookreview'), limit=40):
         print('[%s] %s (%s)' % (review.author, review.book, review.source))
@@ -36,14 +39,14 @@ def simple_shell():
             self.rs = reviewsources.data.get('dev')
 
         def safety_lock(self, query):
-            confirm = raw_input('\n%s [n] ' % query)
+            confirm = input('\n%s [n] ' % query)
             if ('y' in confirm) or ('Y' in confirm):
                 return
             else:
                 raise quit()
 
         def input_edition_name(self, default=''):
-            name = raw_input('\nbook edition? [%s] ' % default) or default
+            name = input('\nbook edition? [%s] ' % default) or default
             self.edition = db.get_thing(name, db.get_type('type/edition'))
             if not self.edition:
                 print('\nbook edition not found.')
@@ -53,7 +56,7 @@ def simple_shell():
         def input_user_name(self, default=''):
             if not self.edition:
                 raise quit()
-            name = raw_input('\nreview author? [%s] ' % default) or default
+            name = input('\nreview author? [%s] ' % default) or default
             self.user = db.get_thing(utils.lpad(name, 'user/'),
                                      db.get_type('type/user'))
             if not self.user:
@@ -85,4 +88,3 @@ def simple_shell():
 
     except quit:
         print('exiting.')
-

--- a/openlibrary/plugins/bookrev/utils.py
+++ b/openlibrary/plugins/bookrev/utils.py
@@ -1,6 +1,8 @@
 import web
 from infogami.core import auth
 
+from six.moves import input
+
 def require_user(f):
     def g(*a, **kw):
         self, site, params = a[0], a[1], a[2:]
@@ -22,8 +24,8 @@ def lpad(s, lpad):
 
 def read_text():
     lines = []
-    line = raw_input()
+    line = input()
     while line:
         lines.append(line)
-        line = raw_input()
+        line = input()
     return "\n\n".join(lines)


### PR DESCRIPTION
The builtin __raw_input()__ was removed in Python 3 in favor of __input()__ so this PR uses [__six.moves.input()__](https://six.readthedocs.io/#module-six.moves) as a replacement that works as expected in both Python 2 and Python 3.