### PR TITLE
fix existing work detection when importing an existing edition

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -558,7 +558,7 @@ def load(rec):
     need_work_save = need_edition_save = False
     w = None
     e = web.ctx.site.get(match)
-    if hasattr(e, 'works'):
+    if e.get('works'):
         w = e.works[0].dict()
         work_created = False
     else:


### PR DESCRIPTION
This PR corrects the existing work check which was previously passing when an edition had empty works.

Now it correctly detects a work in None / not present and will create one.

@mekarpeles, I have tested this with imports on dev.openlibrary.org (testing the behaviour of orphaned editions is currentlyhard to set up locally) example: https://dev.openlibrary.org/recentchanges/2018/11/05/bulk_update/54468808