### PR TITLE
Fix Reading list dropdown displacing other content.

### DIFF
--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -151,6 +151,7 @@ div#subjectLists {
 div.Tools {
   div.dropper {
     z-index: @z-index-level-14;
+    position: absolute;
 
     &.on {
       background-color: @lightest-grey;


### PR DESCRIPTION
Closes #1507  

Description:
In this Pull Request we have made the following changes:
Previously the Reading list-dropdown was displacing other content on the page. It's no longer the case.
