### PR TITLE
Remove some JS commented out code blocks

### DIFF
--- a/openlibrary/plugins/openlibrary/js/account.js
+++ b/openlibrary/plugins/openlibrary/js/account.js
@@ -1,33 +1,3 @@
-/*
-  function finishAjaxUsername(id, response) {
-    $('#usernameLoading').hide();
-    $('#'+id).html(unescape(response));
-    $('#'+id).customFadeIn();
-  }
-  //finishAjax
-
-  // CHECK EMAIL ASSOCIATION
-  function validateCheckEmail() {
-    $('#emailLoading').hide();
-    $('#email').blur(function(){
-      $('#emailLoading').show();
-      $.post("checkemail.php", {
-        email: $('#email').val()
-      }, function(response){
-        $('#emailResult').customFadeOut();
-        setTimeout("finishAjaxEmail('emailResult', '"+escape(response)+"')", 400);
-      });
-        return false;
-    });
-  });
-
-  function finishAjaxEmail(id, response) {
-    $('#emailLoading').hide();
-    $('#'+id).html(unescape(response));
-    $('#'+id).customFadeIn();
-  }
-  //finishAjax
-  */
 /* eslint-disable no-unused-vars */
 // used in templates/account/email.html
 function validateEmail() {

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -253,28 +253,6 @@ Place.prototype.getCovers = function(pagenum, callback) {
         });
     }
 };
-/*
-function deleteVerify() {
-    $('#dialog').dialog({
-        autoOpen: false,
-        width: 400,
-        modal: true,
-        resizable: false,
-        buttons: {
-            "Yes, I'm sure": function() {
-                $("#_delete").click();
-            },
-            "No, cancel": function() {
-                $(this).dialog("close");
-            }
-        }
-    });
-    $('#delete').click(function(){
-        $('#dialog').dialog('open');
-        return false;
-    });
-};
-*/
 
 $().ready(function(){
     var cover_url = function(id) {


### PR DESCRIPTION
Commented out code is never a good idea in a working codebase
- it causes confusion an bit rots as it is not testable or runnable.

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
