### PR TITLE
Simple v2 subject page

### DIFF
--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -43,7 +43,9 @@ class subjects_index(delegate.page):
     path = "/subjects"
 
     def GET(self):
-        return render_template("subjects/index.html")
+        page = render_template("subjects/index.html")
+        page.v2 = True
+        return page
 
 class subjects(delegate.page):
     path = '(/subjects/[^/]+)'
@@ -53,13 +55,16 @@ class subjects(delegate.page):
         if nkey != key:
             raise web.redirect(nkey)
 
-        page = get_subject(key, details=True)
-
-        if not page or page.work_count == 0:
+        subj = get_subject(key, details=True)
+        subj.v2 = True
+        if not subj or subj.work_count == 0:
             web.ctx.status = "404 Not Found"
-            return render_template('subjects/notfound.tmpl', key)
+            page = render_template('subjects/notfound.tmpl', key)
+        else:
+            page = render_template("subjects", page=subj)
 
-        return render_template("subjects", page)
+        page.v2 = True
+        return page
 
     def normalize_key(self, key):
         key = key.lower()

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -13,33 +13,10 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
     <span class="heading">
         <span class="count" id="coversCount">
             <strong><span>$sprintf(ungettext("%s work", "%s works", page.work_count), commify(page.work_count))</span></strong>
-            $if page.ebook_count > 0:
-                / <a href="javascript:;" class="ebookcount"><span id="ebooks">$sprintf(ungettext("%s ebook", "%s ebooks", page.ebook_count), commify(page.ebook_count))</span></a>
-            $else:
-                / 0 ebooks
-            <span class="clickdata"></span>
         </span>
-
-        <span class="count hidden smaller chartZoom"><a href="javascript:;" class="resetSelection small">$_("Clear this selection")</a></span>
     </span>
     <a href="#search" class="shift">Search for books with subject ${page.name}.</a>
 
-    <p class="collapse sansserif">
-      <span class="tools brown">
-        <img src="/images/icons/icon_sort.png" alt="Sorting by" width="9" height="11" style="margin-right:10px;"/>
-        Sort by:
-        <span id="sortByNew" style="display:none">
-          <a href="javascript:;" class="sortEditionCount"># of Editions</a>
-          |
-          <strong class="lightgreen">Most Recent Publish Date</strong>
-        </span>
-        <span id="sortByEdition">
-          <strong class="lightgreen"># of Editions</strong>
-          |
-          <a href="javascript:;" class="sortFirstPublish">Most Recent Publish Date</a>
-        </span>
-      </span>
-    </p>
     <form action="/search" class="olform pagesearchbox">
       <input type="hidden" name="${page.subject_type}_facet" value="$page.name" />
       <input type="text" name="q" id="searchSubjects" size="100" class="larger" value="" />
@@ -65,7 +42,7 @@ $else:
     </h2>
       <span class="shift">$:_('This is a chart to show the publishing history of editions of works about this subject. Along the X axis is time, and on the y axis is the count of editions published. <a href="#subjectRelated">Click here to skip the chart</a>.')</span>
       <span class="count hidden chartZoom">&nbsp;<a href="javascript:;" class="resetSelection small">$_("Reset chart")</a> $_("or continue zooming in.")</span>
-      <span class="count chartUnzoom">&nbsp;$_("This graph charts editions published on this subject. Click to view a single year, or drag across a range.")</span>
+      <span class="count chartUnzoom">&nbsp;$_("This graph charts editions published on this subject.")</span>
   </div>
 
 <script type="text/javascript">
@@ -190,43 +167,6 @@ function set_hash(data) {
             \$("#chartLabel").remove();
             previousPoint = null;
         }
-    });
-    placeholder.bind("plotclick", function (event, pos, item) {
-        \$.scrollTo( \$('#scrollHere'), 800);
-        if (page.getPageCount() > 0) {\$("#coversNone").hide();};
-        \$("#coversLoading").show();
-        \$(".jcarousel-prev").hide();
-        \$(".jcarousel-next").hide();
-
-        if (item) {
-            plot.unhighlight();
-            var x = item.datapoint[0].toFixed(0),
-                y = item.datapoint[1].toFixed(0);
-            page.addFilter({"published_in": item.datapoint[0]}, reset);
-            plot.highlight(item.series,item.datapoint);
-        }
-        else {
-            page.addFilter({"published_in": page._published_in}, reset);
-            plot.unhighlight();
-        }
-    });
-
-    placeholder.bind("plotselected", function (event, ranges) {
-        plot = \$.plot(placeholder, data,
-            \$.extend(true, {}, options, {
-                xaxis: { min: ranges.xaxis.from, max: ranges.xaxis.to },
-                yaxis: { min: ranges.yaxis.from, max: ranges.yaxis.to }
-            })
-        );
-
-        var yearFrom = ranges.xaxis.from.toFixed(0);
-        var yearTo = ranges.xaxis.to.toFixed(0);
-        \$.scrollTo( \$('#scrollHere'), 800);
-        if (page.getPageCount() > 0) {\$("#coversNone").hide();};
-        \$("#coversLoading").show();
-        \$(".jcarousel-prev").hide();
-        \$(".jcarousel-next").hide();
-        page.addFilter({"published_in": yearFrom + "-" + yearTo}, reset);
     });
     var plot = \$.plot(placeholder, data, options);
     var dateFrom = plot.getAxes().xaxis.min.toFixed(0);

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -26,15 +26,13 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 
 <script type="text/javascript">
 <!--
-var page = new Subject($:json_encode(page));
+window.q.push( function () {
+    window.page = new Subject($:json_encode(page));
+} );
 //-->
 </script>
-$if 'v2' in page:
-    $:render_template("books/custom_carousel", books=page.works, key="subjects")
-$else:
-    $:render_template("lib/covers", page)
-
-<div id="contentMeta" style="padding-top:0;">
+<div class="contentBody" style="padding-top:0;">
+  $:render_template("books/custom_carousel", books=page.works, key="subjects")
 
   <div class="head">
     <h2 class="inline">
@@ -89,7 +87,7 @@ function set_hash(data) {
     document.location.hash = hash;
 }
 
-\$().ready(function() {
+window.q.push(function() {
     var _hash = parse_hash();
 
     if (_hash.ebooks === 'true') {
@@ -494,9 +492,12 @@ $ publishers_feature_enabled = "publishers" in ctx.features
 
 <script type="text/javascript">
 <!--
+window.q.push( function () {
+    var page = window.page;
     $ page_key = page.key[page.key.rindex('/')+1:]
     var page_key = "$page_key";
     var publishers_feature_enabled = $:json_encode(publishers_feature_enabled);
+} );
 //-->
 </script>
 $jsdef renderPublishers(publishers):


### PR DESCRIPTION
Descope the subjects page

The JavaScript on openlibrary has fallen into disrepair and
the subject page has various functionality that is non-trivial
(in need of a complete rewrite) to work going forward on our "v2"
mode - which modernises jQuery, replaces jCarousels with slick
carousels and mobile friendliness.

This patch descopes a lot of the functionality of the subject pages
specifically it removes the ability to load different carousels by clicking on
sort facets in the graph and in links in the header.

The descoped subject page is trivial to migrate to v2, and when in the future
when our JavaScript is in a better state, it can be restored.

Fixes: #1319

Make subject page v2

*Update the template and make the JS asynchronous

Fixes: #1207