### PR TITLE
Stop your searching: The latest component on the block is a stunner!

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -222,7 +222,7 @@ $ )
             \$().ready(bookCovers);
         //-->
         </script>
-        <div class="resultsContainer">
+        <div class="resultsContainer search-results-container">
         <div id="searchResults">
           <ul id="siteSearch">
             $ works = add_availability([get_doc(d) for d in docs])

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -1,0 +1,74 @@
+/**
+ * Search Result Item
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#searchresultitem
+ */
+@import 'buttonBtn.less';
+@import 'buttonCta.less';
+
+// Also used on openlibrary/templates/search/editions.html
+// Can be folded into searchResultItem  when that page is using this component
+.bookauthor {
+  font-family: @lucida_sans_serif-6;
+}
+
+.searchResultItem {
+  .display-flex();
+  list-style-type: none;
+  line-height: 1.5em;
+  background-color: @grey-fafafa;
+  border-radius: 5px;
+  padding: 10px;
+  margin-bottom: 3px;
+  border-bottom: 1px solid @light-beige;
+  flex-wrap: wrap;
+
+  > div {
+    margin-top: 10px;
+    padding: 0 5px 0 15px;
+  }
+  h3.booktitle {
+    display: inline;
+    margin: 0;
+    padding: 0;
+    color: @dark-grey;
+    font-size: 1.0em;
+    font-weight: 700;
+    font-family: @lucida_sans_serif-6;
+  }
+  .details {
+    width: 100%;
+    padding: 5px;
+  }
+  span.resultTitle {
+    display: block;
+    margin: 0 !important;
+    font-family: @lucida_sans_serif-1;
+    color: @grey;
+  }
+  span.resultPublisher {
+    font-size: .75em;
+    color: @grey;
+    font-family: @lucida_sans_serif-6;
+    display: block;
+  }
+  span.resultType {
+    font-size: .6875em;
+  }
+  .bookcover {
+    width: 80px;
+    margin: 10px 10px 0 5px;
+    text-align: right;
+    overflow: hidden;
+  }
+  img {
+    height: 80px;
+    max-width: 75px;
+    width: 100%;
+  }
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+  .searchResultItem {
+    flex-wrap: nowrap;
+  }
+}

--- a/static/css/components/search-results-container.less
+++ b/static/css/components/search-results-container.less
@@ -1,0 +1,11 @@
+/**
+ * Search Results Container
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#searchresultcontainer
+ */
+@import (less) 'search-result-item.less';
+
+@media only screen and (min-width: @width-breakpoint-desktop) {
+  .resultsContainer {
+    .display-flex();
+  }
+}

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -247,15 +247,6 @@ var {
 
 li {
   span {
-    &.bookcover {
-      width: 80px;
-      margin: 10px 10px 0 5px;
-      text-align: right;
-      overflow: hidden;
-      img {
-        width: 100%;
-      }
-    }
     &.snippet {
       display: block;
       margin: 10px 0;
@@ -284,15 +275,6 @@ li {
         border: 5px solid @orange;
       }
     }
-  }
-  &.searchResultItem {
-    list-style-type: none;
-    background-color: @grey-fafafa;
-    border-radius: 5px;
-    padding: 10px;
-    margin-bottom: 3px;
-    border-bottom: 1px solid @light-beige;
-    flex-wrap: wrap;
   }
 }
 
@@ -657,15 +639,6 @@ span {
       font-size: .75em;
       font-family: @lucida_sans_serif-6;
       color: @brown;
-    }
-    h3.booktitle {
-      display: inline;
-      margin: 0;
-      padding: 0;
-      color: @dark-grey;
-      font-size: 1.0em;
-      font-weight: 700;
-      font-family: @lucida_sans_serif-6;
     }
     .bookauthor,
     .resultPublisher {
@@ -1770,10 +1743,6 @@ div#searchResults ul {
 }
 
 div#searchResults {
-  li img {
-    height: 80px;
-    max-width: 75px;
-  }
   .SRPCover {
     margin: 0 15px 20px 0;
     vertical-align: middle;
@@ -1847,13 +1816,6 @@ div#searchResults {
     margin-left: 15px;
     margin-right: 4px;
     position: relative;
-  }
-}
-
-.searchResultItem {
-  .details {
-    width: 100%;
-    padding: 5px;
   }
 }
 
@@ -2008,9 +1970,7 @@ div#searchResults {
 
 /* SEARCH FACETS */
 
-.resultsContainer {
-  .display-flex();
-}
+@import (less) 'components/search-results-container.less';
 
 div#searchFacets {
   width: 220px;
@@ -2923,33 +2883,6 @@ span.actions {
   }
 }
 
-ul#siteSearch {
-  > li {
-    .display-flex();
-    span.bookcover img {
-      width: 100%;
-    }
-  }
-  span.resultTitle {
-    display: block;
-    margin: 0 !important;
-    font-family: @lucida_sans_serif-1;
-    color: @grey;
-  }
-  span.resultTitle .bookauthor,
-  span.resultPublisher {
-    font-size: .75em;
-    color: @grey;
-    font-family: @lucida_sans_serif-6;
-  }
-  span.resultPublisher {
-    display: block;
-  }
-  span.resultType {
-    font-size: .6875em;
-  }
-}
-
 div.wide {
   ul#siteSearch {
     span.resultTitle {
@@ -2964,10 +2897,6 @@ div.narrow {
       max-width: 500px !important;
     }
   }
-}
-
-.bookauthor {
-  font-family: @lucida_sans_serif-6;
 }
 
 /* RESULTS CAROUSEL SKIN */
@@ -4095,12 +4024,6 @@ ul#myreads-paginator {
 @media only screen and (min-width: 35.5em) {
   .searchResultItemCTA {
     flex: unset;
-  }
-
-  li {
-    &.searchResultItem {
-      flex-wrap: nowrap;
-    }
   }
 }
 


### PR DESCRIPTION
A few changes have been made to the CSS:
* .resultTitle h3.booktitle only matches on the search
pages. Other pages which use booktitle do not match resultTitle, so
css rule can be expressed in terms of the new search-result-item component
* searchResultItemCTA is not going to be needed going forward, so although
right now this is used to style this component it will not do so in future.
A general padding/margin rule for direct descendants of search-result-item
will be used in its place.
* A new more descriptive class matching the component name will be used
going forward (search-results-container)

See: #1092
