### PR TITLE
Builtin basestring was removed in Python 3

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -44,6 +44,9 @@ from load_book import build_query, import_author, east_in_by_statement, InvalidL
 from merge import try_merge
 
 
+import six
+
+
 re_normalize = re.compile('[^[:alphanum:] ]', re.U)
 re_lang = re.compile('^/languages/([a-z]{3})$')
 
@@ -526,7 +529,7 @@ def load(rec):
         raise RequiredField('title')
     if not rec.get('source_records'):
         raise RequiredField('source_records')
-    if isinstance(rec['source_records'], basestring):
+    if isinstance(rec['source_records'], six.string_types):
         rec['source_records'] = [rec['source_records']]
 
     edition_pool = build_pool(rec)

--- a/openlibrary/catalog/amazon/import.py
+++ b/openlibrary/catalog/amazon/import.py
@@ -10,6 +10,9 @@ from catalog.merge.merge_marc import build_marc
 import catalog.marc.fast_parse as fast_parse
 import urllib2
 
+import six
+
+
 re_amazon = re.compile('^([A-Z0-9]{10}),(\d+):(.*)$', re.S)
 
 re_normalize = re.compile('[^\w ]')
@@ -132,7 +135,7 @@ def try_merge(edition, ekey, thing):
     else:
         authors = []
     a = amazon_merge.build_amazon(edition, authors)
-    assert isinstance(asin, basestring)
+    assert isinstance(asin, six.string_types)
     assert thing_type == '/type/edition'
     #print edition['asin'], ekey
     if 'source_records' in thing:

--- a/openlibrary/catalog/amazon/parse.py
+++ b/openlibrary/catalog/amazon/parse.py
@@ -6,6 +6,9 @@ from math import floor
 from pprint import pprint
 import htmlentitydefs
 
+import six
+
+
 class BrokenTitle(Exception):
     pass
 
@@ -597,7 +600,7 @@ def edition_to_ol(edition):
         print('publisher missing')
 
     for k, v in ol.iteritems():
-        if isinstance(v, basestring) and v[-1] == '(':
+        if isinstance(v, six.string_types) and v[-1] == '(':
             pprint(edition)
             print(('ends with "(":', repr(k, v)))
             sys.exit(0)

--- a/openlibrary/catalog/edition_merge/merge_works.py
+++ b/openlibrary/catalog/edition_merge/merge_works.py
@@ -4,6 +4,9 @@ sys.path.append('/1/src/openlibrary')
 from openlibrary.api import OpenLibrary, Reference
 from pprint import pprint
 
+import six
+
+
 conn = MySQLdb.connect(db='merge_editions')
 cur = conn.cursor()
 
@@ -50,7 +53,7 @@ def merge_works(works):
         for f in 'covers', 'subjects', 'subject_places', 'subject_people', 'subject_times', 'lc_classifications', 'dewey_number':
             if not w.get(f):
                 continue
-            assert not isinstance(w[f], basestring)
+            assert not isinstance(w[f], six.string_types)
             for i in w[f]:
                 if i not in master.setdefault(f, []):
                     master[f].append(i)

--- a/openlibrary/catalog/edition_merge/run_merge.py
+++ b/openlibrary/catalog/edition_merge/run_merge.py
@@ -3,6 +3,9 @@ import MySQLdb, datetime, re, sys
 from openlibrary.api import OpenLibrary, Reference
 from collections import defaultdict
 
+import six
+
+
 re_edition_key = re.compile('^/books/OL(\d+)M$')
 re_nonword = re.compile(r'\W', re.U)
 
@@ -159,7 +162,7 @@ for ia, ekeys, done in cur.fetchall():
         no_merge = True
     if no_merge:
         continue
-    if 'location' in master and isinstance(master['location'], basestring) and master['location'].startswith('/books/'):
+    if 'location' in master and isinstance(master['location'], six.string_types) and master['location'].startswith('/books/'):
         del master['location']
     updates.append(master)
     for e in editions[1:]:

--- a/openlibrary/catalog/importer/import_marc.py
+++ b/openlibrary/catalog/importer/import_marc.py
@@ -17,6 +17,7 @@ from openlibrary.catalog.merge.merge_marc import build_marc
 from openlibrary.catalog.importer.db_read import get_mc, withKey
 from openlibrary.catalog.marc.marc_subject import subjects_for_work
 from openlibrary.api import OpenLibrary, unmarshal
+import six
 
 from openlibrary.catalog.read_rc import read_rc
 
@@ -130,7 +131,7 @@ def author_from_data(loc, data):
         return {'key': a['key']}
     ret = ol.new(a, comment='new author')
     print('ret:', ret)
-    assert isinstance(ret, basestring)
+    assert isinstance(ret, six.string_types)
     return {'key': ret}
 
 def undelete_author(a):
@@ -296,7 +297,7 @@ def write_edition(loc, edition):
                 print(a)
                 raise
             print('ret:', ret)
-            assert isinstance(ret, basestring)
+            assert isinstance(ret, six.string_types)
 #            assert ret['status'] == 'ok'
 #            assert 'created' in ret and len(ret['created']) == 1
             authors.append({'key': ret})
@@ -343,7 +344,7 @@ def write_edition(loc, edition):
             raise
         break
     print('ret:', ret)
-    assert isinstance(ret, basestring)
+    assert isinstance(ret, six.string_types)
     key = '/b/' + re_edition_key.match(ret).group(1)
 #    assert ret['status'] == 'ok'
 #    assert 'created' in ret

--- a/openlibrary/catalog/importer/load_cornell.py
+++ b/openlibrary/catalog/importer/load_cornell.py
@@ -17,6 +17,9 @@ import openlibrary.catalog.marc.fast_parse as fast_parse
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, unmarshal
 
+import six
+
+
 rc = read_rc()
 ol = OpenLibrary("http://openlibrary.org")
 ol.login('ImportBot', rc['ImportBot'])
@@ -83,7 +86,7 @@ def write_edition(loc, edition):
                 print(a)
                 raise
             print('ret:', ret)
-            assert isinstance(ret, basestring)
+            assert isinstance(ret, six.string_types)
             authors.append({'key': ret})
     q['source_records'] = [loc]
     if authors:
@@ -102,7 +105,7 @@ def write_edition(loc, edition):
             raise
         break
     print('ret:', ret)
-    assert isinstance(ret, basestring)
+    assert isinstance(ret, six.string_types)
     key = ret
     pool.update(key, q)
 

--- a/openlibrary/catalog/importer/load_scribe.py
+++ b/openlibrary/catalog/importer/load_scribe.py
@@ -27,6 +27,9 @@ from pprint import pprint
 from subprocess import Popen, PIPE
 import argparse
 
+import six
+
+
 parser = argparse.ArgumentParser(description='scribe loader')
 parser.add_argument('--skip_hide_books', action='store_true')
 parser.add_argument('--item_id')
@@ -149,7 +152,7 @@ def write_edition(ia, edition, rec):
                 print(a)
                 raise
             print('ret:', ret)
-            assert isinstance(ret, basestring)
+            assert isinstance(ret, six.string_types)
             authors.append({'key': ret})
     q['source_records'] = [loc]
     if authors:
@@ -204,7 +207,7 @@ def write_edition(ia, edition, rec):
             raise
         break
     print('ret:', ret)
-    assert isinstance(ret, basestring)
+    assert isinstance(ret, six.string_types)
     key = '/b/' + re_edition_key.match(ret).group(1)
     pool.update(key, q)
 

--- a/openlibrary/catalog/importer/merge.py
+++ b/openlibrary/catalog/importer/merge.py
@@ -10,6 +10,9 @@ import xml.parsers.expat
 import web, sys
 from time import sleep
 
+import six
+
+
 rc = read_rc()
 
 ol = OpenLibrary("http://openlibrary.org")
@@ -34,7 +37,7 @@ def try_amazon(thing):
             if isinstance(a, dict):
                 akey = a['key']
             else:
-                assert isinstance(a, basestring)
+                assert isinstance(a, six.string_types)
                 akey = a
             author_thing = withKey(akey)
             if 'name' in author_thing:

--- a/openlibrary/catalog/marc/db/web_author.py
+++ b/openlibrary/catalog/marc/db/web_author.py
@@ -6,11 +6,14 @@ from catalog.read_rc import read_rc
 from catalog.marc.build_record import build_record
 from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
 
+import six
+
+
 trans = {'&':'amp','<':'lt','>':'gt'}
 re_html_replace = re.compile('([&<>])')
 
 def esc(s):
-    if not isinstance(s, basestring):
+    if not isinstance(s, six.string_types):
         return s
     return re_html_replace.sub(lambda m: "&%s;" % trans[m.group(1)], s.encode('utf8')).replace('\n', '<br>')
 

--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -9,6 +9,9 @@ import re, sys, os.path, web
 #from catalog.amazon.other_editions import find_others
 from catalog.utils import strip_count
 
+import six
+
+
 db = web.database(dbn='postgres', db='marc_lookup')
 db.printing = False
 
@@ -42,7 +45,7 @@ def list_to_html(l):
     return blue('[') + blue('|').join(l) + blue(']')
 
 def esc(s):
-    if not isinstance(s, basestring):
+    if not isinstance(s, six.string_types):
         return s
     return re_html_replace.sub(lambda m: "&%s;" % trans[m.group(1)], s.encode('utf8')).replace('\n', '<br>')
 
@@ -54,7 +57,7 @@ def marc_data(loc):
 
 def counts_html(v):
     count = {}
-    lens = [len(i) for i, loc in v if i and isinstance(i, basestring)]
+    lens = [len(i) for i, loc in v if i and isinstance(i, six.string_types)]
     sep = '<br>' if lens and max(lens) > 20 else ' '
     for i, loc in v:
         count.setdefault(i, []).append(loc)

--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -5,6 +5,9 @@ from unicodedata import normalize
 from pymarc import MARC8ToUnicode
 from openlibrary.catalog.marc import mnemonics
 
+import six
+
+
 marc8 = MARC8ToUnicode(quiet=True)
 
 class BadLength(MarcException):
@@ -82,7 +85,7 @@ class BinaryDataField():
 class MarcBinary(MarcBase):
     def __init__(self, data):
         try:
-            assert len(data) and isinstance(data, basestring)
+            assert len(data) and isinstance(data, six.string_types)
             length = int(data[:5])
         except:
             raise BadMARC("No MARC data found")

--- a/openlibrary/catalog/scratch/remove_subject_period.py
+++ b/openlibrary/catalog/scratch/remove_subject_period.py
@@ -4,6 +4,10 @@ import sys, codecs, re
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, Reference
 from catalog.read_rc import read_rc
+
+import six
+
+
 rc = read_rc()
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
@@ -30,9 +34,9 @@ for e in query_iter(q):
     }
     # need to fix table_of_contents to pass validation
     toc = e['table_of_contents']
-    if toc and (isinstance(toc[0], basestring) or toc[0]['type'] == '/type/text'):
-        if isinstance(toc[0], basestring):
-            assert all(isinstance(i, basestring) for i in toc)
+    if toc and (isinstance(toc[0], six.string_types) or toc[0]['type'] == '/type/text'):
+        if isinstance(toc[0], six.string_types):
+            assert all(isinstance(i, six.string_types) for i in toc)
             new_toc = [{'title': i, 'type': '/type/toc_item'} for i in toc]
         else:
             assert all(i['type'] == '/type/text' for i in toc)

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -3,6 +3,7 @@ import re, web
 from unicodedata import normalize
 import openlibrary.catalog.merge.normalize as merge
 
+import six
 from six.moves import range
 
 re_date = map (re.compile, [
@@ -190,7 +191,7 @@ def tidy_isbn(input):
 def strip_count(counts):
     foo = {}
     for i, j in counts:
-        foo.setdefault(i.rstrip('.').lower() if isinstance(i, basestring) else i, []).append((i, j))
+        foo.setdefault(i.rstrip('.').lower() if isinstance(i, six.string_types) else i, []).append((i, j))
     ret = {}
     for k, v in foo.iteritems():
         m = max(v, key=lambda x: len(x[1]))[0]

--- a/openlibrary/catalog/works/add_fields_to_works.py
+++ b/openlibrary/catalog/works/add_fields_to_works.py
@@ -9,6 +9,9 @@ from catalog.read_rc import read_rc
 from catalog.utils.query import query, query_iter, set_staging, base_url
 from catalog.utils import mk_norm, get_title
 
+import six
+
+
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 set_staging(True)
 
@@ -139,7 +142,7 @@ def add_fields():
                         print(e['key'], toc)
                         print(e)
                         print()
-                        if isinstance(toc[0], basestring):
+                        if isinstance(toc[0], six.string_types):
                             found_list.append(toc_items(toc))
                         else:
                             assert isinstance(toc[0], dict)

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -14,6 +14,9 @@ sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, Reference
 import olapi
 
+import six
+
+
 rc = read_rc()
 
 ol = OpenLibrary("http://dev.openlibrary.org")
@@ -123,7 +126,7 @@ def get_books(akey):
             book['lang'] = [l['key'][3:] for l in e['languages']]
 
         if e.get('table_of_contents', None):
-            if isinstance(e['table_of_contents'][0], basestring):
+            if isinstance(e['table_of_contents'][0], six.string_types):
                 book['table_of_contents'] = e['table_of_contents']
             else:
                 assert isinstance(e['table_of_contents'][0], dict)

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -21,6 +21,9 @@ from time import sleep, time, strftime
 from openlibrary.catalog.marc.marc_subject import get_work_subjects, four_types
 import simplejson as json
 
+import six
+
+
 ol = OpenLibrary("http://openlibrary.org")
 
 re_skip = re.compile(r'\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon|etc)\.$')
@@ -198,7 +201,7 @@ def get_books(akey, query, do_get_mc=True):
             book['lang'] = [re_lang_key.match(l['key']).group(1) for l in lang]
 
         if e.get('table_of_contents', None):
-            if isinstance(e['table_of_contents'][0], basestring):
+            if isinstance(e['table_of_contents'][0], six.string_types):
                 book['table_of_contents'] = e['table_of_contents']
             else:
                 assert isinstance(e['table_of_contents'][0], dict)

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -18,6 +18,9 @@ from openlibrary.api import OpenLibrary, Reference
 from lxml import etree
 from time import sleep, time
 
+import six
+
+
 rc = read_rc()
 
 ol = OpenLibrary("http://openlibrary.org")
@@ -209,7 +212,7 @@ def get_books(akey, query):
             book['lang'] = [l['key'][3:] for l in lang]
 
         if e.get('table_of_contents', None):
-            if isinstance(e['table_of_contents'][0], basestring):
+            if isinstance(e['table_of_contents'][0], six.string_types):
                 book['table_of_contents'] = e['table_of_contents']
             else:
                 assert isinstance(e['table_of_contents'][0], dict)
@@ -335,7 +338,7 @@ def add_work(akey, w):
         print(q)
         raise
     write_log('work', wkey, w['title'])
-    assert isinstance(wkey, basestring)
+    assert isinstance(wkey, six.string_types)
     for ekey in w['editions']:
         e = ol.get(ekey)
         fix_edition(ekey, e, ol)

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -16,6 +16,9 @@ from infogami.utils import stats
 from openlibrary.utils import olmemcache
 from openlibrary.utils.dateutil import MINUTE_SECS
 
+import six
+
+
 __all__ = [
     "cached_property",
     "Cache", "MemoryCache", "MemcacheCache", "RequestCache",
@@ -425,7 +428,7 @@ class memoize:
         self.expires = expires
 
     def _make_key_func(self, key):
-        if isinstance(key, basestring):
+        if isinstance(key, six.string_types):
             return PrefixKeyFunc(key)
         else:
             return key

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -13,6 +13,9 @@ from infogami.utils import stats
 import cache
 from openlibrary.utils.dateutil import date_n_days_ago
 
+import six
+
+
 logger = logging.getLogger("openlibrary.ia")
 
 VALID_READY_REPUB_STATES = ["4", "19", "20", "22"]
@@ -284,7 +287,7 @@ class ItemEdition(dict):
             if isinstance(value, list):
                 value = [v for v in value if v != {}]
                 if value:
-                    if isinstance(value[0], basestring):
+                    if isinstance(value[0], six.string_types):
                         value = "\n\n".join(value)
                     else:
                         value = value[0]

--- a/openlibrary/core/iprange.py
+++ b/openlibrary/core/iprange.py
@@ -3,6 +3,9 @@
 import re
 import iptools
 
+import six
+
+
 four_octet = r'(\d+\.\d+\.\d+\.\d+)'
 re_range_star = re.compile(r'^(\d+\.\d+)\.(\d+)\s*-\s*(\d+)\.\*$')
 re_three = re.compile(r'^(\d+\.\d+\.\d+)\.$')
@@ -132,7 +135,7 @@ class IPDict:
             ("1.2.3.4", "1.2.3.44")
         """
         # Convert ranges in CIDR format into (start, end) tuple
-        if isinstance(ip_range, basestring) and "/" in ip_range:
+        if isinstance(ip_range, six.string_types) and "/" in ip_range:
             # ignore bad value
             if not iptools.validate_cidr(ip_range):
                 return

--- a/openlibrary/core/lists/engine.py
+++ b/openlibrary/core/lists/engine.py
@@ -7,6 +7,9 @@ import re
 import simplejson
 import web
 
+import six
+
+
 def reduce_seeds(values):
     """Function to reduce the seed values got from works db.
     """
@@ -36,7 +39,7 @@ def get_seeds(work):
         return [a['author'] for a in work.get('authors', []) if 'author' in a]
 
     def _get_subject(subject, prefix):
-        if isinstance(subject, basestring):
+        if isinstance(subject, six.string_types):
             key = prefix + RE_SUBJECT.sub("_", subject.lower()).strip("_")
             return {"key": key, "name": subject}
 
@@ -86,7 +89,7 @@ class SubjectProcessor:
             self.subjects[s['key']].append(s['name'])
 
     def _get_subject(self, prefix, subject_name):
-        if isinstance(subject_name, basestring):
+        if isinstance(subject_name, six.string_types):
             key = prefix + RE_SUBJECT.sub("_", subject_name.lower()).strip("_")
             return {"key": key, "name": subject_name}
 

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -19,6 +19,9 @@ from openlibrary.core import cache
 
 from openlibrary.plugins.worksearch.search import get_solr
 
+import six
+
+
 logger = logging.getLogger("openlibrary.lists.model")
 
 # this will be imported on demand to avoid circular dependency
@@ -51,7 +54,7 @@ def cached_property(name, getter):
 class ListMixin:
     def _get_rawseeds(self):
         def process(seed):
-            if isinstance(seed, basestring):
+            if isinstance(seed, six.string_types):
                 return seed
             else:
                 return seed.key
@@ -318,7 +321,7 @@ class Seed:
         self._list = list
 
         self.value = value
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             self.key = value
             self.type = "subject"
         else:
@@ -327,7 +330,7 @@ class Seed:
         self._solrdata = None
 
     def get_document(self):
-        if isinstance(self.value, basestring):
+        if isinstance(self.value, six.string_types):
             doc = get_subject(self.get_subject_url(self.value))
         else:
             doc = self.value

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -10,6 +10,9 @@ import time
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import find_image_path
 
+import six
+
+
 #logfile = open('log.txt', 'a')
 
 def log(*args):
@@ -107,7 +110,7 @@ def archive():
                 print("Missing image file for %010d" % cover.id, file=web.debug)
                 continue
 
-            if isinstance(cover.created, basestring):
+            if isinstance(cover.created, six.string_types):
                 from infogami.infobase import utils
                 cover.created = utils.parse_datetime(cover.created)
 

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -18,6 +18,9 @@ import gzip
 
 import db
 
+import six
+
+
 def print_dump(json_records, filter=None):
     """Print the given json_records in the dump format.
     """
@@ -63,7 +66,7 @@ def xopen(path, mode='r'):
 def read_tsv(file, strip=True):
     """Read a tab seperated file and return an iterator over rows."""
     log("reading", file)
-    if isinstance(file, basestring):
+    if isinstance(file, six.string_types):
         file = xopen(file)
 
     for i, line in enumerate(file):

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -9,6 +9,9 @@ import simplejson
 from infogami.infobase import client, common, account, config as infobase_config
 from infogami import config
 
+import six
+
+
 key_patterns = {
     'work': '/works/OL%dW',
     'edition': '/books/OL%dM',
@@ -161,7 +164,7 @@ class MockSite:
 
     def filter_index(self, index, name, value):
         operations = {
-            "~": lambda i, value: isinstance(i.value, basestring) and i.value.startswith(web.rstrips(value, "*")),
+            "~": lambda i, value: isinstance(i.value, six.string_types) and i.value.startswith(web.rstrips(value, "*")),
             "<": lambda i, value: i.value < value,
             ">": lambda i, value: i.value > value,
             "!": lambda i, value: i.value != value,
@@ -199,7 +202,7 @@ class MockSite:
 
             if k.endswith(".key"):
                 yield web.storage(key=key, datatype="ref", name=web.rstrips(k, ".key"), value=v)
-            elif isinstance(v, basestring):
+            elif isinstance(v, six.string_types):
                 yield web.storage(key=key, datatype="str", name=k, value=v)
             elif isinstance(v, int):
                 yield web.storage(key=key, datatype="int", name=k, value=v)

--- a/openlibrary/plugins/admin/mem.py
+++ b/openlibrary/plugins/admin/mem.py
@@ -4,6 +4,9 @@ import memory
 import web
 import gc
 
+import six
+
+
 def render_template(name, *a, **kw):
     return render[name](*a, **kw)
 
@@ -44,7 +47,7 @@ class Object:
             elif isinstance(o, dict): # other dict types
                 name = web.dictfind(o, self.obj)
 
-            if not isinstance(name, basestring):
+            if not isinstance(name, six.string_types):
                 name = None
 
             d.append(Object(o, name))

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -7,6 +7,7 @@ import traceback
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.core import helpers as h
 from openlibrary.core import ia
+import six
 
 from infogami.utils.delegate import register_exception
 
@@ -210,7 +211,7 @@ class DataProcessor:
         def format_table_of_contents(toc):
             # after openlibrary.plugins.upstream.models.get_table_of_contents
             def row(r):
-                if isinstance(r, basestring):
+                if isinstance(r, six.string_types):
                     level = 0
                     label = ""
                     title = r

--- a/openlibrary/plugins/importapi/import_opds.py
+++ b/openlibrary/plugins/importapi/import_opds.py
@@ -4,6 +4,9 @@ OL Import API OPDS parser
 
 import import_edition_builder
 
+import six
+
+
 def parse_string(e, key):
     return (key, e.text)
 
@@ -50,7 +53,7 @@ def parse(root):
     edition_builder = import_edition_builder.import_edition_builder()
 
     for e in root:
-        if isinstance(e.tag, basestring):
+        if isinstance(e.tag, six.string_types):
             #print e.tag
             if e.tag in parser_map:
                 key = parser_map[e.tag][0]

--- a/openlibrary/plugins/importapi/import_rdf.py
+++ b/openlibrary/plugins/importapi/import_rdf.py
@@ -4,6 +4,9 @@ OL Import API RDF parser
 
 import import_edition_builder
 
+import six
+
+
 def parse_string(e, key):
     return (key, e.text)
 
@@ -67,7 +70,7 @@ def parse(root):
     edition_builder = import_edition_builder.import_edition_builder()
 
     for e in root.iter():
-        if isinstance(e.tag, basestring):
+        if isinstance(e.tag, six.string_types):
             #print e.tag
             if e.tag in parser_map:
                 key = parser_map[e.tag][0]

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -11,6 +11,7 @@ import sys
 import traceback
 import re, unicodedata
 
+import six
 import web
 from infogami.infobase import config, common, server, cache, dbstore
 
@@ -403,7 +404,7 @@ def fix_table_of_contents(table_of_contents):
     """Some books have bad table_of_contents. This function converts them in to correct format.
     """
     def row(r):
-        if isinstance(r, basestring):
+        if isinstance(r, six.string_types):
             level = 0
             label = ""
             title = web.safeunicode(r)

--- a/openlibrary/plugins/openlibrary/connection.py
+++ b/openlibrary/plugins/openlibrary/connection.py
@@ -12,6 +12,9 @@ from openlibrary.core import ia
 
 import logging
 
+import six
+
+
 logger = logging.getLogger("openlibrary")
 
 class ConnectionMiddleware:
@@ -318,7 +321,7 @@ class MemcacheMiddleware(ConnectionMiddleware):
 
         #@@ too many JSON conversions
         for k in result:
-            if isinstance(result[k], basestring):
+            if isinstance(result[k], six.string_types):
                 result[k] = simplejson.loads(result[k])
 
         return simplejson.dumps(result)

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -20,6 +20,9 @@ from openlibrary.plugins.worksearch import search, subjects
 from openlibrary.plugins.openlibrary import lists
 
 
+import six
+
+
 logger = logging.getLogger("openlibrary.home")
 
 CAROUSELS_PRESETS = {
@@ -175,7 +178,7 @@ def format_list_editions(key):
 
     editions = {}
     for seed in seed_list.seeds:
-        if not isinstance(seed, basestring):
+        if not isinstance(seed, six.string_types):
             if seed.type.key == "/type/edition":
                 editions[seed.key] = seed
             else:

--- a/openlibrary/plugins/openlibrary/merge_editions.py
+++ b/openlibrary/plugins/openlibrary/merge_editions.py
@@ -5,6 +5,9 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template
 from collections import defaultdict
 
+import six
+
+
 re_nonword = re.compile(r'\W', re.U)
 
 class merge_editions(delegate.page):
@@ -89,7 +92,7 @@ class merge_editions(delegate.page):
         for k in 'source_records', 'ia_box_id':
             merged[k] = []
             for e in editions:
-                if e.get(k) and isinstance(e[k], basestring):
+                if e.get(k) and isinstance(e[k], six.string_types):
                     e[k] = [e[k]]
                 if e.get(k):
                     assert isinstance(e[k], list)

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -3,6 +3,7 @@
 import web
 
 from openlibrary.core.processors import ReadableUrlProcessor
+import six
 
 from openlibrary.core import helpers as h
 
@@ -19,7 +20,7 @@ class ProfileProcessor:
             if isinstance(out, web.template.TemplateResult):
                 out.__body__ = out.get('__body__', '') + '<pre class="profile">' + web.websafe(result) + '</pre>'
                 return out
-            elif isinstance(out, basestring):
+            elif isinstance(out, six.string_types):
                 return out + '<br/>' + '<pre class="profile">' + web.websafe(result) + '</pre>'
             else:
                 # don't know how to handle this.

--- a/openlibrary/plugins/upstream/adapter.py
+++ b/openlibrary/plugins/upstream/adapter.py
@@ -12,6 +12,9 @@ import urllib, urllib2
 import simplejson
 import web
 
+import six
+
+
 urls = (
     '/([^/]*)/get', 'get',
     '/([^/]*)/get_many', 'get_many',
@@ -172,7 +175,7 @@ class things(proxy):
                     return dict((k, convert_keys(v)) for k, v in q.items())
                 elif isinstance(q, list):
                     return [convert_keys(x) for x in q]
-                elif isinstance(q, basestring):
+                elif isinstance(q, six.string_types):
                     return convert_key(q)
                 else:
                     return q

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -29,6 +29,9 @@ from account import as_admin
 from openlibrary.plugins.recaptcha import recaptcha
 from . import spamcheck
 
+import six
+
+
 logger = logging.getLogger("openlibrary.book")
 
 SYSTEM_SUBJECTS = ["Accessible Book", "Lending Library", "In Library", "Protected DAISY"]
@@ -348,7 +351,7 @@ def trim_value(value):
         >>> trim_value({'x': [""]})
         None
     """
-    if isinstance(value, basestring):
+    if isinstance(value, six.string_types):
         value = value.strip()
         return value or None
     elif isinstance(value, list):
@@ -569,7 +572,7 @@ class SaveBookHelper:
         old_subjects = self.work and self.work.get("subjects") or []
 
         # If condition is added to handle the possibility of bad data
-        set_old_subjects = set(s.lower() for s in old_subjects if isinstance(s, basestring))
+        set_old_subjects = set(s.lower() for s in old_subjects if isinstance(s, six.string_types))
         set_new_subjects = set(s.lower() for s in work.subjects)
 
         for s in SYSTEM_SUBJECTS:

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -8,6 +8,9 @@ from infogami.utils.view import render_template, safeint
 from openlibrary.plugins.worksearch.code import top_books_from_author
 from openlibrary.utils import uniq, dicthash
 
+import six
+
+
 class BasicMergeEngine:
     """Generic merge functionality useful for all types of merges.
     """
@@ -180,7 +183,7 @@ def fix_table_of_contents(table_of_contents):
     """Some books have bad table_of_contents. This function converts them in to correct format.
     """
     def row(r):
-        if isinstance(r, basestring):
+        if isinstance(r, six.string_types):
             level = 0
             label = ""
             title = web.safeunicode(r)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -24,8 +24,11 @@ import account
 import borrow
 import logging
 
+import six
+
+
 def follow_redirect(doc):
-    if isinstance(doc, basestring) and doc.startswith("/a/"):
+    if isinstance(doc, six.string_types) and doc.startswith("/a/"):
         #Some edition records have authors as ["/a/OL1A""] insead of [{"key": "/a/OL1A"}].
         # Hack to fix it temporarily.
         doc = web.ctx.site.get(doc.replace("/a/", "/authors/"))
@@ -377,7 +380,7 @@ class Edition(models.Edition):
 
     def get_table_of_contents(self):
         def row(r):
-            if isinstance(r, basestring):
+            if isinstance(r, six.string_types):
                 level = 0
                 label = ""
                 title = r
@@ -560,7 +563,7 @@ class Work(models.Work):
     def get_author_names(self, blacklist=None):
         author_names = []
         for author in self.get_authors():
-            author_name = (author if isinstance(author, basestring)
+            author_name = (author if isinstance(author, six.string_types)
                            else author.name)
             if not blacklist or author_name.lower() not in blacklist:
                 author_names.append(author_name)
@@ -582,7 +585,7 @@ class Work(models.Work):
                 return b.strip() + " " + a.strip()
             return name
 
-        if subjects and not isinstance(subjects[0], basestring):
+        if subjects and not isinstance(subjects[0], six.string_types):
             subjects = [flip(s.name) for s in subjects]
         return subjects
 

--- a/openlibrary/solr/solrwriter.py
+++ b/openlibrary/solr/solrwriter.py
@@ -7,6 +7,9 @@ import re
 from lxml.etree import tostring, Element
 from unicodedata import normalize
 
+import six
+
+
 logger = logging.getLogger("openlibrary.solrwriter")
 
 class SolrWriter(object):
@@ -77,7 +80,7 @@ class SolrWriter(object):
 
 re_bad_char = re.compile('[\x01\x0b\x1a-\x1e]')
 def strip_bad_char(s):
-    if not isinstance(s, basestring):
+    if not isinstance(s, six.string_types):
         return s
     return re_bad_char.sub('', s)
 
@@ -88,7 +91,7 @@ def add_field(doc, name, value):
         return
     else:
         field = Element("field", name=name)
-        if not isinstance(value, basestring):
+        if not isinstance(value, six.string_types):
             value = str(value)
         try:
             value = strip_bad_char(value)

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from unicodedata import normalize
 
 import simplejson as json
+import six
 import web
 from lxml.etree import tostring, Element, SubElement
 
@@ -102,7 +103,7 @@ class AuthorRedirect (Exception):
     pass
 
 def strip_bad_char(s):
-    if not isinstance(s, basestring):
+    if not isinstance(s, six.string_types):
         return s
     return re_bad_char.sub('', s)
 
@@ -292,7 +293,7 @@ class SolrProcessor:
                 ia = e['ocaid']
             elif 'ia_loaded_id' in e:
                 loaded = e['ia_loaded_id']
-                ia = loaded if isinstance(loaded, basestring) else loaded[0]
+                ia = loaded if isinstance(loaded, six.string_types) else loaded[0]
 
             # If the _ia_meta field is already set in the edition, use it instead of querying archive.org.
             # This is useful to when doing complete reindexing of solr.
@@ -305,7 +306,7 @@ class SolrProcessor:
 
             if ia_meta_fields:
                 collection = ia_meta_fields['collection']
-                if 'ia_box_id' in e and isinstance(e['ia_box_id'], basestring):
+                if 'ia_box_id' in e and isinstance(e['ia_box_id'], six.string_types):
                     e['ia_box_id'] = [e['ia_box_id']]
                 if ia_meta_fields.get('boxid'):
                     box_id = list(ia_meta_fields['boxid'])[0]
@@ -615,7 +616,7 @@ class SolrProcessor:
             if 'printdisabled' in e.get('ia_collection', []):
                 printdisabled.add(re_edition_key.match(e['key']).group(1))
             all_collection.update(e.get('ia_collection', []))
-            assert isinstance(e['ocaid'], basestring)
+            assert isinstance(e['ocaid'], six.string_types)
             i = e['ocaid'].strip()
             if e.get('public_scan'):
                 public_scan = True
@@ -745,21 +746,21 @@ def build_data2(w, editions, authors, ia, duplicates):
             m = re_lang_key.match(l['key'] if isinstance(l, dict) else l)
             lang.add(m.group(1))
         if e.get('ia_loaded_id'):
-            if isinstance(e['ia_loaded_id'], basestring):
+            if isinstance(e['ia_loaded_id'], six.string_types):
                 ia_loaded_id.add(e['ia_loaded_id'])
             else:
                 try:
-                    assert isinstance(e['ia_loaded_id'], list) and isinstance(e['ia_loaded_id'][0], basestring)
+                    assert isinstance(e['ia_loaded_id'], list) and isinstance(e['ia_loaded_id'][0], six.string_types)
                 except AssertionError:
                     logger.error("AssertionError: ia=%s, ia_loaded_id=%s", e.get("ia"), e['ia_loaded_id'])
                     raise
                 ia_loaded_id.update(e['ia_loaded_id'])
         if e.get('ia_box_id'):
-            if isinstance(e['ia_box_id'], basestring):
+            if isinstance(e['ia_box_id'], six.string_types):
                 ia_box_id.add(e['ia_box_id'])
             else:
                 try:
-                    assert isinstance(e['ia_box_id'], list) and isinstance(e['ia_box_id'][0], basestring)
+                    assert isinstance(e['ia_box_id'], list) and isinstance(e['ia_box_id'][0], six.string_types)
                 except AssertionError:
                     logger.error("AssertionError: %s", e['key'])
                     raise
@@ -819,7 +820,7 @@ def solr_update(requests, debug=False, commitWithin=60000):
 
     h1.connect()
     for r in requests:
-        if not isinstance(r, basestring):
+        if not isinstance(r, six.string_types):
             # Assuming it is either UpdateRequest or DeleteRequest
             r = r.toxml()
         if not r:
@@ -827,7 +828,7 @@ def solr_update(requests, debug=False, commitWithin=60000):
 
         if debug:
             logger.info('request: %r', r[:65] + '...' if len(r) > 65 else r)
-        assert isinstance(r, basestring)
+        assert isinstance(r, six.string_types)
         h1.request('POST', url, r.encode('utf8'), { 'Content-type': 'text/xml;charset=utf-8'})
         response = h1.getresponse()
         response_body = response.read()
@@ -890,7 +891,7 @@ class BaseDocBuilder:
         return [self.get_subject_key(prefix, s) for s in subject_names]
 
     def get_subject_key(self, prefix, subject):
-        if isinstance(subject, basestring):
+        if isinstance(subject, six.string_types):
             key = prefix + self.re_subject.sub("_", subject.lower()).strip("_")
             return key
 

--- a/openlibrary/utils/bulkimport.py
+++ b/openlibrary/utils/bulkimport.py
@@ -9,6 +9,9 @@ import datetime
 import simplejson
 from collections import defaultdict
 
+import six
+
+
 class DocumentLoader:
     def __init__(self, **params):
         params = params.copy()
@@ -367,7 +370,7 @@ class Reindexer:
         """
         if isinstance(value, int):
             return 'int'
-        elif isinstance(value, basestring):
+        elif isinstance(value, six.string_types):
             return 'str'
         elif isinstance(value, dict):
             if 'key' in value:

--- a/scripts/jsondump.py
+++ b/scripts/jsondump.py
@@ -43,6 +43,9 @@ import re
 import time
 import os
 
+import six
+
+
 commands = {}
 def command(f):
     commands[f.__name__] = f
@@ -238,7 +241,7 @@ def read_json(file):
     for json in xopen(file):
         d = simplejson.loads(json)
         ret = (d['key'], d['type']['key'], json)
-        if not all(isinstance(i, basestring) for i in ret):
+        if not all(isinstance(i, six.string_types) for i in ret):
             print('not all strings:')
             print(json)
         yield ret


### PR DESCRIPTION
The builtin __basestring__ was removed in Python 3 so this PR uses __six.string_types__ as a replacement that works as expected in both Python 2 and Python 3.  This is the output of __[sixer --write basestring .](https://github.com/vstinner/sixer)__