### PR TITLE
don't show donation banner for bots, seo

### DIFF
--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -1,4 +1,5 @@
-$:get_donation_include('true')
+$if not is_bot():
+  $:get_donation_include('true')
 
 <div id="topNotice">
   <div class="page-banner page-banner-black page-banner-center">

--- a/openlibrary/templates/site/donate.html
+++ b/openlibrary/templates/site/donate.html
@@ -1,5 +1,6 @@
 
-$:get_donation_include()
+$if not is_bot():
+  $:get_donation_include()
 
 <script type="text/javascript">
 // The donate javascript included via archive.org uses JQuery 1.6+.


### PR DESCRIPTION
In the past, we've had issues with search engines (bots) indexing our donation banner code. Ideally we'd have the right metadata so donations banners don't show up. In this PR, we don't render donation banner code if the useragent is a known bot.