### PR TITLE
Raise new style exceptions in form.py

### DIFF
--- a/openlibrary/utils/form.py
+++ b/openlibrary/utils/form.py
@@ -119,14 +119,15 @@ class Form:
         for i in self.inputs:
             if i.name == key:
                 return i
-        raise KeyError, key
+        raise KeyError(key)
 
     def __getattr__(self, name):
         # don't interfere with deepcopy
         inputs = self.__dict__.get('inputs') or []
         for x in inputs:
-            if x.name == name: return x
-        raise AttributeError, name
+            if x.name == name:
+                return x
+        raise AttributeError(name)
 
     def render(self):
         return render.form(self)


### PR DESCRIPTION
This is yet another subset of #1466.  Old style exceptions are syntax errors in Python 3 while new style exceptions work as expected in both Python 2 and Python 3.