### PR TITLE
Raise new style exceptions in utils.py

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -58,7 +58,7 @@ class MultiDict(DictMixin):
         if values:
             return values[-1]
         else:
-            raise KeyError, key
+            raise KeyError(key)
 
     def __setitem__(self, key, value):
         self._items.append((key, value))


### PR DESCRIPTION
This is yet another subset of #1466. Old style exceptions are syntax errors in Python 3 while new style exceptions work as expected in both Python 2 and Python 3.