### PR TITLE
Raise new style exceptions in warc.py

### DIFF
--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -88,7 +88,7 @@ class HTTPFile:
         elif whence == 1:
             self.offset += offset
         else:
-            raise "Invalid whence", whence
+            raise Exception("Invalid whence {}".format(whence))
 
     def tell(self):
         return self.offset


### PR DESCRIPTION
This is yet another subset of #1466. Old style exceptions are syntax errors in Python 3 while new style exceptions work as expected in both Python 2 and Python 3.