### PR TITLE
Python 3: Fix tuple_params

### DIFF
--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -239,7 +239,7 @@ class search(delegate.page):
 
         # we have somehow gotten some queries for facet tokens with no
         # inverse.  remove these from the list.
-        ft_pairs = filter(lambda (a,b): b, ft_pairs)
+        ft_pairs = filter(lambda a_b: a_b[1], ft_pairs)
 
         if not q0 and not qtokens:
             errortext = 'You need to enter some search terms.'
@@ -364,7 +364,7 @@ def collect_works(result_list):
 
     # print >> web.debug, ('collect works', rs,wds)
 
-    s_works = sorted(wds.items(), key=lambda (a,b): len(b), reverse=True)
+    s_works = sorted(wds.items(), key=lambda a_b1: len(a_b1[1]), reverse=True)
     return rs, [(web.ctx.site.get(a), b) for a,b in s_works]
 
 

--- a/openlibrary/plugins/search/collapse.py
+++ b/openlibrary/plugins/search/collapse.py
@@ -17,7 +17,7 @@ def collapse_groups(page_numbers):
     # for another example of this construction
 
     g_iter = groupby(enumerate(sorted(page_numbers)),
-                     lambda (i,n): i-n)
+                     lambda i_n: i_n[0]-i_n[1])
 
     # now flatten that iterator into a list of lists of leaf numbers
     groups = list(list(z for _, z in y) for _, y in g_iter)

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -419,7 +419,7 @@ def facet_counts(result_list, facet_fields):
                 facets_k[x] += 1
 
     return filter(snd, ((f, sorted(facets[f].items(),
-                                   key=lambda (a,b): (-b,a)))
+                                   key=lambda a_b: (-a_b[1],a_b[0])))
                         for f in facet_fields))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Yet another subset of #1466 which deals with the fact that Python 3 prohibits parentheses around lambda parameters.

This PR represents the output of __futurize -f tuple_params -w .__ which works as expected in both Python 2 and Python 3.  https://github.com/python/cpython/blob/master/Lib/lib2to3/fixes/fix_tuple_params.py

