### PR TITLE
Publishers and subject pages use page-heading-search-box component

### DIFF
--- a/openlibrary/templates/publishers/notfound.html
+++ b/openlibrary/templates/publishers/notfound.html
@@ -2,11 +2,9 @@ $def with (key)
 
 $ name = key.split("/")[-1].replace('_', ' ')
 
-<div id="contentHead">
+<div class="page-heading-search-box">
     <span class="tools"><a href="/publishers" class="plain">$_("Publishers")</a> /</span>
     <h1>$name</h1>
-</div>
-<div id="contentBody">
 
     <p>$_("We couldn't find any books published by %s.", name)</p>
 

--- a/openlibrary/templates/subjects/notfound.html
+++ b/openlibrary/templates/subjects/notfound.html
@@ -3,12 +3,9 @@ $def with (key)
 
 $ name = key.split("/")[-1].replace('_', ' ')
 
-<div id="contentHead">
+<div class="page-heading-search-box">
     <span class="tools"><a href="/subjects" class="plain">$_("Subjects")</a> /</span>
     <h1>$name</h1>
-</div>
-<div id="contentBody">
-
     <p>$_("We couldn't find any books about") $name.</p>
 
     <h3 class="collapse">$_("Try something else?")</h3>


### PR DESCRIPTION
by not using them, in the v2 format where certain styles are not loading
, they become misaligned.

Fixes: #1605
