### PR TITLE
Fix v2 list page

### DIFF
--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -18,7 +18,7 @@ $if "type" in doc and doc.type.key == "/type/user":
     </style>
     $if ctx.user and ctx.user.key == doc.key:
         <script type="text/javascript">
-            \$(function() {
+            window.q.push(function() {
                 \$("#listResults .resultTitle")
                     .prepend('' +
                         '<span class="listDelete sansserif small">' +
@@ -47,7 +47,7 @@ $if "type" in doc and doc.type.key == "/type/user":
         <div id="delete-dialog" class="hidden" title="Delete list">Are you sure you want to delete this list?</div>
 $else:
     <script type="text/javascript">
-        \$(function() {
+        window.q.push(function() {
             \$("#listResults .resultTitle.my-list")
             .prepend('' +
                 '<span class="listDelete sansserif smaller">' +

--- a/openlibrary/templates/type/list/embed.html
+++ b/openlibrary/templates/type/list/embed.html
@@ -120,34 +120,3 @@ $def render_seed_count(seed_count):
 });
 </script>
 
-<style type="text/css">
-ul#listResults span.actions span.image {
-    display: block;
-    height: 24px;
-    width: 24px;
-    margin: 0 auto;
-    float: none;
-}
-span.actions {
-    max-width: none;
-}
-ul#listResults span.actions a span.checked-out {
-    height: 32px;
-    width: 32px;
-}
-ul#listResults li:last {
-    border-bottom: 1px dotted #ebebeb;
-}
-div {
-    max-width: 100% !important;
-    box-sizing: border-box;
-}
-body#form {
-    overflow: auto;
-    width: 100%;
-}
-ul.narrow li span.resultTitle {
-    width: auto;
-    max-width: 525px;
-}
-</style>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -46,7 +46,7 @@ $jsdef render_seed_count(seed_count):
 
 <script type="text/javascript">
 <!--
-\$().ready(function(){
+window.q.push(function(){
     \$('ul#listResults li:last').css('border-bottom','1px dotted #ebebeb');
 });
 
@@ -76,7 +76,7 @@ function get_seed_count() {
     return \$("ul#listResults").children().length;
 }
 
-\$(function(){
+window.q.push(function(){
     \$(".listDelete a").click(function() {
         var seed_id = \$(this).closest("li").attr("id");
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -2384,12 +2384,6 @@ ul {
       }
     }
   }
-  &.narrow {
-    li span.resultTitle {
-      width: 525px;
-      max-width: 525px;
-    }
-  }
   &.clean {
     border-top: none !important;
     li {


### PR DESCRIPTION
The list page has transitioned to v2 (accidentally?)
but it's JS is broken.

This patch fixes the JS calls and removes some unnecessary CSS
that breaks mobile (and desktop!) display

Fixes: #1427

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
