### PR TITLE
dev environment copydocs script to use port 80 as the local default to match Docker environment

### DIFF
--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -4,7 +4,7 @@ Typically used to copy templates, macros, css and js from
 openlibrary.org to dev instance.
 
 USAGE:
-    ./scripts/copydocs.py --src http://openlibrary.org --dest http://0.0.0.0:8080 /templates/*
+    ./scripts/copydocs.py --src http://openlibrary.org --dest http://0.0.0.0 /templates/*
 
 This script can also be used to copy books and authors from OL to dev instance.
 
@@ -54,7 +54,7 @@ def parse_args():
     parser = OptionParser("usage: %s [options] path1 path2" % sys.argv[0], description=desc, version=__version__)
     parser.add_option("-c", "--comment", dest="comment", default="", help="comment")
     parser.add_option("--src", dest="src", metavar="SOURCE_URL", default="http://openlibrary.org/", help="URL of the source server (default: %default)")
-    parser.add_option("--dest", dest="dest", metavar="DEST_URL", default="http://0.0.0.0:8080/", help="URL of the destination server (default: %default)")
+    parser.add_option("--dest", dest="dest", metavar="DEST_URL", default="http://0.0.0.0/", help="URL of the destination server (default: %default)")
     parser.add_option("-r", "--recursive", dest="recursive", action='store_true', default=False, help="Recursively fetch all the referred docs.")
     parser.add_option("-l", "--list", dest="lists", action="append", default=[], help="copy docs from a list.")
     return parser.parse_args()


### PR DESCRIPTION
Closes #1587 

The problem was that the copydocs script used the default port 8080 for the destination, rather than 80.
This PR corrects that.

The Docker container does have external network access

