### PR TITLE
Remove from __future__ import with_statement

### DIFF
--- a/openlibrary/plugins/copyright/copyrightstatus/ca.py
+++ b/openlibrary/plugins/copyright/copyrightstatus/ca.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import time
 
 OLDEST_PERSON_EVER_IN_CANADA = 117
@@ -108,4 +107,3 @@ and therefore died no later than the year %d, since we have no known death date.
 if __name__ == '__main__':
   import doctest
   doctest.testmod()
-

--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from __future__ import print_function
 import web
 import stopword

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# from __future__ import with_statement
 from urllib import quote_plus, urlopen
 from xml.etree.cElementTree import ElementTree
 from cStringIO import StringIO


### PR DESCRIPTION
The __with__ syntax is supported Python >= 2.6 so this anachronistic import statement is not longer required in currently supported versions of Python.  https://docs.python.org/2/library/__future__.html