### PR TITLE
Transition simple pages to v2

### DIFF
--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -43,7 +43,7 @@ class ReadableUrlProcessor:
         web.ctx.path = real_path
         web.ctx.fullpath = web.ctx.path + web.ctx.query
         out = handler()
-        V2_TYPES = ['works', 'books', 'people', 'publishers', 'languages']
+        V2_TYPES = ['works', 'books', 'people', 'publishers', 'languages', 'account']
         if out and any(web.ctx.path.startswith('/%s/' % _type) for _type in V2_TYPES):
             out.v2 = True
         return out

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -11,7 +11,9 @@ class home(delegate.page):
     path = "/developers/design"
 
     def GET(self):
-        return render_template("design")
+        template = render_template("design")
+        template.v2 = True
+        return template
 
 def setup():
     pass

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -13,7 +13,9 @@ feature_flags = {}
 
 class status(delegate.page):
     def GET(self):
-        return render_template("status", status_info, feature_flags)
+        template = render_template("status", status_info, feature_flags)
+        template.v2 = True
+        return template
 
 @public
 def get_git_revision_short_hash():

--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -17,7 +17,9 @@ class contact(delegate.page):
         i = web.input(path=None)
         user = accounts.get_current_user()
         email = user and user.email
-        return render_template("support", email=email, url=i.path)
+        template = render_template("support", email=email, url=i.path)
+        template.v2 = True
+        return template
 
     def POST(self):
         form = web.input()

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -581,13 +581,17 @@ class improve_search(delegate.page):
     def GET(self):
         i = web.input(q=None)
         boost = dict((f, i[f]) for f in search_fields if f in i)
-        return render.improve_search(search_fields, boost, i.q, simple_search)
+        template = render.improve_search(search_fields, boost, i.q, simple_search)
+        template.v2 = True
+        return template
 
 class advancedsearch(delegate.page):
     path = "/advancedsearch"
 
     def GET(self):
-        return render_template("search/advancedsearch.html")
+        template = render_template("search/advancedsearch.html")
+        template.v2 = True
+        return template
 
 class merge_author_works(delegate.page):
     path = "/authors/(OL\d+A)/merge-works"

--- a/openlibrary/templates/design.html
+++ b/openlibrary/templates/design.html
@@ -1,4 +1,5 @@
 $def with()
+$# /developers/design
 $ _x = ctx.setdefault('bodyid', 'design')
 
 <div class="design-pattern-library">

--- a/openlibrary/templates/forgot_password.html
+++ b/openlibrary/templates/forgot_password.html
@@ -1,5 +1,5 @@
 $def with (f)
-
+$# Template entry point for /account/forgot_password
 $ _ = i18n.get_namespace('/account/forgot_password')
 
 $var title: $_.forgot_password

--- a/openlibrary/templates/improve_search.html
+++ b/openlibrary/templates/improve_search.html
@@ -1,4 +1,5 @@
 $def with (search_fields, boost, q, search)
+$# Template entry point for http://localhost:8080/improve_search
 <style>th { font-weight: bold }</style>
 <div id="contentBody">
 <form>

--- a/openlibrary/templates/showamazon.html
+++ b/openlibrary/templates/showamazon.html
@@ -1,5 +1,6 @@
 $def with (asin)
-
+$# Template entry point for MARC record (amazon)
+$# e.g. /show-records/amazon:0803226616
 $var title: $_("Record details of amazon:")$asin
 
 <div id="contentHead">

--- a/openlibrary/templates/showia.html
+++ b/openlibrary/templates/showia.html
@@ -1,5 +1,5 @@
 $def with (ia, record, books)
-
+$# e.g. /show-records/ia:isbn_9781555531799
 $ title = "MARC record from Internet Archive"
 
 $var title: $title

--- a/openlibrary/templates/showmarc.html
+++ b/openlibrary/templates/showmarc.html
@@ -1,5 +1,6 @@
 $def with (record, filename, begin, length, books)
-
+$# Template entry point for MARC record's that are not amazon or IA.
+$# e.g. /show-records/marc_upei/marc-for-openlibrary-bigset.mrc:4980114:1308
 $ format = query_param('format')
 $if format == 'raw':
     $var content_type: application/marc

--- a/openlibrary/templates/status.html
+++ b/openlibrary/templates/status.html
@@ -1,5 +1,5 @@
 $def with (status = {}, flags = {})
-
+$# Template entry point for /status page
 $var title: Open Library server status
 
 <style type="text/css">

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -1,5 +1,5 @@
 $def with (email=None, url=None, done = False)
-
+$# Template entry point for /contact page
 $var title: How can we help?
 
 <div id="contentHead">

--- a/openlibrary/templates/widget.html
+++ b/openlibrary/templates/widget.html
@@ -1,5 +1,5 @@
 $def with (item=None)
-
+$# Template for widget displayed at /books/OL9737752M/The_Odyssey/widget
 $ cover_url = ("//covers.openlibrary.org/w/id/%s-M.jpg" % item['covers'][0]) if len(item.get('covers', [])) else ""
 $ canonical_url = lambda uri: '//%s%s' % (ctx.site, uri)
 $ book_status = item["availability"]["status"]

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -60,13 +60,17 @@ class show_ia(app.view):
         except ValueError:
             record = None
 
-        return app.render_template("showia", ia, record, books)
+        template = app.render_template("showia", ia, record, books)
+        template.v2 = True
+        return template
 
 class show_amazon(app.view):
     path = "/show-records/amazon:(.*)"
 
     def GET(self, asin):
-        return app.render_template("showamazon", asin)
+        template = app.render_template("showamazon", asin)
+        template.v2 = True
+        return template
 
 re_bad_meta_mrc = re.compile('^([^/]+)_meta\.mrc$')
 re_lc_sanfranpl = re.compile('^sanfranpl(\d+)/sanfranpl(\d+)\.out')
@@ -122,4 +126,6 @@ class show_marc(app.view):
         except ValueError:
             record = None
 
-        return app.render_template("showmarc", record, filename, offset, length, books)
+        template = app.render_template("showmarc", record, filename, offset, length, books)
+        template.v2 = True
+        return template

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -67,6 +67,8 @@ a {
 div.contentBody,
 div#contentBody {
   padding: 0 20px 20px;
+  word-break: break-word;
+
   img {
     max-width: 100%;
     height: auto;


### PR DESCRIPTION
The following pages are now v2
* /status
* /support
* /show-records/<id>
* /developers/design
* /improve_search
* /advancedsearch

Given there lack of JavaScript the transition to v2 was
trivial.

Additional changes:
* A style is added to ensure that long words are broken onto new
lines where necessary
* Document how certain templates are accessed

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
