### PR TITLE
requirements.txt: Remove unused args==0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Jinja2==2.10
 PIL==1.1.7
 amqplib==1.0.2
 anyjson==0.3.1
-args==0.1.0
 backports.shutil-get-terminal-size==1.0.0
 bottlenose==1.1.2
 clint==0.5.1


### PR DESCRIPTION
https://github.com/kennethreitz/args is an archived repo that was last released 6 years ago and no code in this repo imports __args__:
* __grep -r "import args" .__  # returns no hits
* __grep -r "from args" .__  # returns no hits