### PR TITLE
Travis CI: Remove redundant apt install of lxml and yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ addons:
   apt:
     packages:
       - libgeoip-dev
-      - python-lxml
-      - python-yaml
 python:
     - "2.7"
     - "3.6"


### PR DESCRIPTION
Before this change apt installs the older python-lxml and python-yaml and then [pip reinstalls lxml and PyYAML](https://github.com/internetarchive/openlibrary/blob/master/requirements_common.txt#L9-L17).  This PR proposes to reduce the clutter by removing the former and keeping the latter because that gives us more control over which versions get installed.