### PR TITLE
requirements.txt: Remove unused OrderedDict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ kombu==1.5.1
 meld3==0.6.7
 ndg-httpsclient==0.4.2
 -e git+git@github.com:internetarchive/openlibrary.git@997a268222a2256876c1bd3296c96f982c29fd37#egg=openlibrary-origin/HEAD
-ordereddict==1.1
 pathlib2==2.1.0
 pexpect==4.2.1
 pickleshare==0.7.4


### PR DESCRIPTION
__ordereddict__ is part of the Python standard library in all versions of Python supported by OpenLibrary so a separate pip install is no longer required.  https://pypi.org/project/ordereddict

https://github.com/internetarchive/openlibrary/search?q=ordereddict