### PR TITLE
Don't break words in table

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -96,6 +96,7 @@ div.head {
 table {
   overflow: auto;
   display: block;
+  word-break: normal;
 }
 @media only screen and (min-width: @width-breakpoint-tablet) {
   table {


### PR DESCRIPTION
Follow up to 63fc4afec
This impacts the
https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#revisionhistorytable
component

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
