### PR TITLE
Define cmp() in Python 3

### DIFF
--- a/openlibrary/catalog/edition_merge/merge_works.py
+++ b/openlibrary/catalog/edition_merge/merge_works.py
@@ -6,6 +6,11 @@ from pprint import pprint
 
 import six
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
 
 conn = MySQLdb.connect(db='merge_editions')
 cur = conn.cursor()
@@ -144,4 +149,3 @@ for ia, ekeys, done, unmerge_count in cur.fetchall():
     assert all(author0 == w['authors'][0]['author'] for w in works)
     merge_works(works)
     print()
-

--- a/openlibrary/catalog/edition_merge/merge_works.py
+++ b/openlibrary/catalog/edition_merge/merge_works.py
@@ -2,15 +2,11 @@ from __future__ import print_function
 import MySQLdb, datetime, re, sys
 sys.path.append('/1/src/openlibrary')
 from openlibrary.api import OpenLibrary, Reference
+from openlibrary.catalog.utils import cmp
 from pprint import pprint
 
 import six
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
 
 conn = MySQLdb.connect(db='merge_editions')
 cur = conn.cursor()

--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -11,6 +11,11 @@ from catalog.utils import strip_count
 
 import six
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
 
 db = web.database(dbn='postgres', db='marc_lookup')
 db.printing = False

--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -4,6 +4,7 @@ from catalog.read_rc import read_rc
 from catalog.get_ia import get_data
 from catalog.marc.build_record import build_record
 from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
+from openlibrary.catalog.utils import cmp
 from pprint import pprint
 import re, sys, os.path, web
 #from catalog.amazon.other_editions import find_others
@@ -11,11 +12,6 @@ from catalog.utils import strip_count
 
 import six
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
 
 db = web.database(dbn='postgres', db='marc_lookup')
 db.printing = False

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -6,6 +6,12 @@ import openlibrary.catalog.merge.normalize as merge
 import six
 from six.moves import range
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
+
 re_date = map (re.compile, [
     '(?P<birth_date>\d+\??)-(?P<death_date>\d+\??)',
     '(?P<birth_date>\d+\??)-',
@@ -254,4 +260,3 @@ bad MARC: %s
     server = smtplib.SMTP('mail.archive.org')
     server.sendmail(msg_from, [msg_to], msg)
     server.quit()
-

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -7,7 +7,7 @@ import six
 from six.moves import range
 
 try:
-    cmp             # Python 2
+    cmp = cmp       # Python 2
 except NameError:
     def cmp(x, y):  # Python 3
         return (x > y) - (x < y)

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -16,6 +16,11 @@ import olapi
 
 import six
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
 
 rc = read_rc()
 

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -4,7 +4,7 @@ import re, sys, codecs, web
 from openlibrary.catalog.get_ia import get_from_archive
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields
 from openlibrary.catalog.utils.query import query_iter, set_staging, query
-from openlibrary.catalog.utils import mk_norm
+from openlibrary.catalog.utils import cmp, mk_norm
 from openlibrary.catalog.read_rc import read_rc
 from collections import defaultdict
 from pprint import pprint, pformat
@@ -16,11 +16,6 @@ import olapi
 
 import six
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
 
 rc = read_rc()
 

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -23,6 +23,11 @@ import simplejson as json
 
 import six
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
 
 ol = OpenLibrary("http://openlibrary.org")
 

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -7,8 +7,8 @@ import re, sys, web, urllib2
 from openlibrary.solr.update_work import update_work, solr_update, update_author
 from openlibrary.catalog.get_ia import get_from_archive, get_data
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary
+from openlibrary.catalog.utils import cmp, mk_norm
 from openlibrary.catalog.utils.query import query_iter, withKey
-from openlibrary.catalog.utils import mk_norm
 from openlibrary.catalog.read_rc import read_rc
 from collections import defaultdict
 from pprint import pprint, pformat
@@ -23,11 +23,6 @@ import simplejson as json
 
 import six
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
 
 ol = OpenLibrary("http://openlibrary.org")
 

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -20,6 +20,11 @@ from time import sleep, time
 
 import six
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
 
 rc = read_rc()
 

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -7,7 +7,7 @@ import re, sys, codecs, web
 from openlibrary.catalog.get_ia import get_from_archive, get_data
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary
 from openlibrary.catalog.utils.query import query_iter, set_staging, query
-from openlibrary.catalog.utils import mk_norm
+from openlibrary.catalog.utils import cmp, mk_norm
 from openlibrary.catalog.read_rc import read_rc
 from collections import defaultdict
 from pprint import pprint, pformat
@@ -20,11 +20,6 @@ from time import sleep, time
 
 import six
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
 
 rc = read_rc()
 


### PR DESCRIPTION
Related to #890

__cmp()__ was removed in Python 3 so this PR conditionally defines in Python 3.