### PR TITLE
don't set height auto on images

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -71,7 +71,6 @@ div#contentBody {
 
   img {
     max-width: 100%;
-    height: auto;
   }
 }
 // Note more heading styles can be found in components/headings.less


### PR DESCRIPTION
Height: auto was added in 0a5052ca9 but is not needed alongside
max-width. It would only be needed if we were using `width`

Removing this has no impact on the stats page so let's fix the
regression.

Fixes: #1642