### PR TITLE
Fixing homepage bookcover height

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -71,7 +71,6 @@ div#contentBody {
 
   img {
     max-width: 100%;
-    height: auto;
   }
 }
 // Note more heading styles can be found in components/headings.less


### PR DESCRIPTION
Fixes #1642
 
## Description:
In this Pull Request we have made the following changes:

Removed `height:auto` from `static/css/base/common.less`