### PR TITLE
requirements_common.txt: Upgrade to pymarc==3.1.10

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -8,7 +8,7 @@ iptools==0.4.0
 internetarchive==1.8.1
 lxml==4.2.5
 pyflakes==2.0.0
-pymarc==2.8.4
+pymarc==3.1.10
 python-memcached==1.48
 simplejson==3.16.0
 supervisor==3.0a12


### PR DESCRIPTION
__pymarc__ does not yet have an official Python 3 release but this gets us as close as we can be without grabbing the HEAD.    Related to https://github.com/edsu/pymarc/pull/125

Closes #<IssueNumber>

<Optional Picture>

## Description:
In this Pull Request we have made the following changes:
