### PR TITLE
unicode() was removed in Python 3

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -25,6 +25,8 @@ import simplejson
 import web
 import logging
 
+import six
+
 logger = logging.getLogger("openlibrary.api")
 
 class OLError(Exception):
@@ -212,9 +214,9 @@ def marshal(data):
     elif isinstance(data, datetime.datetime):
         return {"type": "/type/datetime", "value": data.isoformat()}
     elif isinstance(data, Text):
-        return {"type": "/type/text", "value": unicode(data)}
+        return {"type": "/type/text", "value": six.text_type(data)}
     elif isinstance(data, Reference):
-        return {"key": unicode(data)}
+        return {"key": six.text_type(data)}
     else:
         return data
 
@@ -258,11 +260,11 @@ def parse_datetime(value):
         return datetime.datetime(*map(int, tokens))
 
 
-class Text(unicode):
+class Text(six.text_type):
     def __repr__(self):
-        return "<text: %s>" % unicode.__repr__(self)
+        return u"<text: %s>" % six.text_type.__repr__(self)
 
 
-class Reference(unicode):
+class Reference(six.text_type):
     def __repr__(self):
-        return "<ref: %s>" % unicode.__repr__(self)
+        return u"<ref: %s>" % six.text_type.__repr__(self)

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -35,6 +35,8 @@ from copy import copy
 import web
 from infogami import config
 
+import six
+
 from openlibrary.catalog.merge.merge_marc import build_marc
 from openlibrary.catalog.utils import mk_norm
 from openlibrary.core import lending
@@ -55,7 +57,7 @@ def strip_accents(s):
     """
     if isinstance(s, str):
         return s
-    assert isinstance(s, unicode)
+    assert isinstance(s, six.text_type)
     return ''.join((c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn'))
 
 def normalize(s): # strip non-alphanums and truncate at 25 chars

--- a/openlibrary/catalog/author/merge.py
+++ b/openlibrary/catalog/author/merge.py
@@ -5,6 +5,9 @@ from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.utils import key_int, match_with_bad_chars, pick_best_author, remove_trailing_number_dot
 from unicodedata import normalize
 import web, re, sys, codecs, urllib
+
+import six
+
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, unmarshal, Reference
 from openlibrary.catalog.utils.edit import fix_edition
@@ -113,7 +116,7 @@ def do_normalize(author_key, best_key, authors):
                 if m:
                     need_update = True
                     v = v[:-len(m.group(1))]
-            if not isinstance(v, unicode):
+            if not isinstance(v, six.text_type):
                 continue
             norm_v = norm(v)
             if v == norm_v:
@@ -126,7 +129,7 @@ def do_normalize(author_key, best_key, authors):
         for k in author_keys:
             if k not in best:
                 v = a[k]
-                if not isinstance(v, unicode):
+                if not isinstance(v, six.text_type):
                     continue
                 norm_v = norm(v)
                 if v == norm_v:
@@ -137,7 +140,7 @@ def do_normalize(author_key, best_key, authors):
             v = best[k]
             if 'date' in k:
                 v = remove_trailing_number_dot(v)
-            if isinstance(v, unicode):
+            if isinstance(v, six.text_type):
                 v = norm(v)
             if k not in a or v != a[k]:
                 a[k] = v

--- a/openlibrary/catalog/importer/add_source_records.py
+++ b/openlibrary/catalog/importer/add_source_records.py
@@ -15,6 +15,8 @@ from openlibrary.api import OpenLibrary
 
 from catalog.read_rc import read_rc
 
+import six
+
 rc = read_rc()
 
 marc_index = web.database(dbn='postgres', db='marc_index')
@@ -82,7 +84,7 @@ def fix_toc(e):
         return
     if isinstance(toc[0], dict) and toc[0]['type'] == '/type/toc_item':
         return
-    return [{'title': unicode(i), 'type': '/type/toc_item'} for i in toc if i != u'']
+    return [{'title': six.text_type(i), 'type': '/type/toc_item'} for i in toc if i != u'']
 
 re_skip = re.compile('\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
 

--- a/openlibrary/catalog/importer/import_marc.py
+++ b/openlibrary/catalog/importer/import_marc.py
@@ -113,7 +113,7 @@ def fix_toc(e):
         return
     if isinstance(toc[0], dict) and toc[0]['type'] == '/type/toc_item':
         return
-    return [{'title': unicode(i), 'type': '/type/toc_item'} for i in toc if i != u'']
+    return [{'title': six.text_type(i), 'type': '/type/toc_item'} for i in toc if i != u'']
 
 re_skip = re.compile('\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
 

--- a/openlibrary/catalog/importer/update.py
+++ b/openlibrary/catalog/importer/update.py
@@ -9,6 +9,8 @@ from openlibrary.catalog.title_page_img.load import add_cover_image
 from openlibrary.api import OpenLibrary, unmarshal, marshal
 from pprint import pprint
 
+import six
+
 rc = read_rc()
 ol = OpenLibrary("http://openlibrary.org")
 ol.login('ImportBot', rc['ImportBot'])
@@ -28,7 +30,7 @@ def fix_toc(e):
     # http://openlibrary.org/books/OL789133M - /type/toc_item missing from table_of_contents
     if isinstance(toc[0], dict) and ('pagenum' in toc[0] or toc[0]['type'] == '/type/toc_item'):
         return
-    return [{'title': unicode(i), 'type': '/type/toc_item'} for i in toc if i != u'']
+    return [{'title': six.text_type(i), 'type': '/type/toc_item'} for i in toc if i != u'']
 
 re_skip = re.compile('\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
 

--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -14,7 +14,7 @@ class BadLength(MarcException):
     pass
 
 def norm(s):
-    return normalize('NFC', unicode(s))
+    return normalize('NFC', six.text_type(s))
 
 class BinaryDataField():
     def __init__(self, rec, line):

--- a/openlibrary/catalog/marc/marc_xml.py
+++ b/openlibrary/catalog/marc/marc_xml.py
@@ -2,6 +2,8 @@ from lxml import etree
 from marc_base import MarcBase, MarcException
 from unicodedata import normalize
 
+import six
+
 data_tag = '{http://www.loc.gov/MARC21/slim}datafield'
 control_tag = '{http://www.loc.gov/MARC21/slim}controlfield'
 subfield_tag = '{http://www.loc.gov/MARC21/slim}subfield'
@@ -21,7 +23,7 @@ def read_marc_file(f):
         elem.clear()
 
 def norm(s):
-    return normalize('NFC', unicode(s.replace(u'\xa0', ' ')))
+    return normalize('NFC', six.text_type(s.replace(u'\xa0', ' ')))
 
 def get_text(e):
     return norm(e.text) if e.text else u''

--- a/openlibrary/catalog/marc/parse_xml.py
+++ b/openlibrary/catalog/marc/parse_xml.py
@@ -4,6 +4,8 @@ import xml.parsers.expat
 from parse import read_edition
 from unicodedata import normalize
 
+import six
+
 slim = '{http://www.loc.gov/MARC21/slim}'
 leader_tag = slim + 'leader'
 data_tag = slim + 'datafield'
@@ -13,7 +15,7 @@ collection_tag = slim + 'collection'
 record_tag = slim + 'record'
 
 def norm(s):
-    return normalize('NFC', unicode(s))
+    return normalize('NFC', six.text_type(s))
 
 class BadSubtag:
     pass

--- a/openlibrary/catalog/marc/read_xml.py
+++ b/openlibrary/catalog/marc/read_xml.py
@@ -5,6 +5,8 @@ import re, sys, codecs
 from time import sleep
 from unicodedata import normalize
 
+import six
+
 re_question = re.compile('^\?+$')
 re_lccn = re.compile('(...\d+).*')
 re_letters = re.compile('[A-Za-z]')
@@ -155,10 +157,10 @@ def read_edition(f):
         #        return None
         #    continue
         if tag == '008':
-            publish_date = unicode(line)[7:11]
+            publish_date = six.text_type(line)[7:11]
             if publish_date.isdigit():
                 edition["publish_date"] = publish_date
-            publish_country = unicode(line)[15:18]
+            publish_country = six.text_type(line)[15:18]
             if publish_country not in ('|||', '   '):
                 edition["publish_country"] = publish_country
             continue

--- a/openlibrary/catalog/marc/simple_html.py
+++ b/openlibrary/catalog/marc/simple_html.py
@@ -5,6 +5,8 @@ from html import as_html
 from build_record import build_record
 import sys, re
 
+import six
+
 trans = {'&':'&amp;','<':'&lt;','>':'&gt;','\n':'<br>'}
 re_html_replace = re.compile('([&<>\n])')
 
@@ -84,7 +86,7 @@ def output_record_as_html(rec):
         elif rec[k] is None:
             v = '<em>empty</em>'
         else:
-            v = esc(unicode(rec[k]))
+            v = esc(six.text_type(rec[k]))
         rows.append('<tr><th>%s</th><td>%s</td></tr>\n' % (label, v))
 
     return '<table>' + ''.join(rows) + '</table>'

--- a/openlibrary/catalog/merge/amazon.py
+++ b/openlibrary/catalog/merge/amazon.py
@@ -3,6 +3,8 @@ import re
 from names import match_name
 from normalize import normalize
 
+import six
+
 re_year = re.compile('(\d{4})$')
 re_amazon_title_paren = re.compile('^(.*) \([^)]+?\)$')
 re_and_of_space = re.compile(' and | of | ')
@@ -291,7 +293,7 @@ def test_merge_titles():
         'title': 'Spytime',
     }
 
-    amazon = build_titles(unicode(full_title(amazon)))
+    amazon = build_titles(six.text_type(full_title(amazon)))
     marc = build_titles(marc['title_with_subtitles'])
     assert amazon['short_title'] == marc['short_title']
     assert compare_title(amazon, marc) == ('full-title', 'containted within other title', 350)
@@ -303,7 +305,7 @@ def test_merge_titles2():
         'title': u'seabirds of Britain and Ireland',
         'full_title': u'The seabirds of Britain and Ireland',
     }
-    amazon = build_titles(unicode(full_title(amazon)))
+    amazon = build_titles(six.text_type(full_title(amazon)))
     marc = build_titles(marc['title_with_subtitles'])
     assert compare_title(amazon, marc) == ('full-title', 'exact match', 600)
 

--- a/openlibrary/catalog/merge/merge.py
+++ b/openlibrary/catalog/merge/merge.py
@@ -3,6 +3,8 @@ import re
 from names import match_name
 from normalize import normalize
 
+import six
+
 re_year = re.compile('(\d{4})$')
 re_amazon_title_paren = re.compile('^(.*) \([^)]+?\)$')
 re_and_of_space = re.compile(' and | of | ')
@@ -285,7 +287,7 @@ def test_merge_titles():
         'title': 'Spytime',
     }
 
-    amazon = build_titles(unicode(full_title(amazon)))
+    amazon = build_titles(six.text_type(full_title(amazon)))
     marc = build_titles(marc['title_with_subtitles'])
     assert amazon['short_title'] == marc['short_title']
     assert compare_title(amazon, marc) == ('full-title', 'containted within other title', 350)
@@ -297,7 +299,7 @@ def test_merge_titles2():
         'title': u'seabirds of Britain and Ireland',
         'full_title': u'The seabirds of Britain and Ireland',
     }
-    amazon = build_titles(unicode(full_title(amazon)))
+    amazon = build_titles(six.text_type(full_title(amazon)))
     marc = build_titles(marc['title_with_subtitles'])
     assert compare_title(amazon, marc) == ('full-title', 'exact match', 600)
 

--- a/openlibrary/catalog/merge/normalize.py
+++ b/openlibrary/catalog/merge/normalize.py
@@ -1,11 +1,13 @@
 import re, unicodedata
 
+import six
+
 #re_brace = re.compile('{[^{}]+?}')
 re_normalize = re.compile('[^[:alpha:] ]', re.I)
 re_whitespace = re.compile('[-\s,;.]+')
 
 def normalize(s):
-    if isinstance(s, unicode):
+    if isinstance(s, six.text_type):
         s = unicodedata.normalize('NFC', s.replace(u'\u0142', u'l'))
     s = s.replace(' & ', ' and ')
     # remove {mlrhring} and friends
@@ -23,4 +25,3 @@ def normalize(s):
 #    a = "Tha{mllhring}{macr}alib{macr}i, {mllhring}Abd al-Malik ibn Mu{dotb}hammad 961 or 2-1037 or 8."
 #    b = u"Tha\xb0\xe5alib\xe5i, \xb0Abd al-Malik ibn Mu\xf2hammad 961 or 2-1037 or 8."
 #    assert normalize(a) == normalize(b)
-

--- a/openlibrary/catalog/onix/parse.py
+++ b/openlibrary/catalog/onix/parse.py
@@ -13,6 +13,8 @@ from xml.sax.saxutils import prepare_input_source
 from thread_utils import AsyncChannel, threaded_generator
 from onix import OnixProduct, OnixHandler, onix_codelists
 
+import six
+
 def parser (input):
 	# returns a generator that produces dicts representing Open Library items
 
@@ -262,11 +264,9 @@ def person_name (x):
 	return name
 
 def elt_get (e, tag, reference_name):
-       ee = e.get (tag) or e.get (reference_name.lower ())
-       if ee:
-               return unicode (ee)
-       else:
-               return None
+     ee = e.get (tag) or e.get (reference_name.lower ())
+     return six.text_type(ee) if ee else None
+
 
 re_by = re.compile ("^\s*by\s+", re.IGNORECASE)
 re_iname = re.compile ("^(.*),\s*(.*)$")
@@ -274,4 +274,3 @@ re_iname = re.compile ("^(.*),\s*(.*)$")
 def add_val (o, key, val):
 	if val is not None:
 		o.setdefault (key, []).append (val)
-

--- a/openlibrary/catalog/onix/xmltramp.py
+++ b/openlibrary/catalog/onix/xmltramp.py
@@ -5,6 +5,8 @@ __author__ = "Aaron Swartz"
 __credits__ = "Many thanks to pjz, bitsko, and DanC."
 __copyright__ = "(C) 2003-2006 Aaron Swartz. GNU GPL 2."
 
+import six
+
 def isstr(f): return isinstance(f, type('')) or isinstance(f, type(u''))
 def islst(f): return isinstance(f, type(())) or isinstance(f, type([]))
 
@@ -16,6 +18,7 @@ def quote(x, elt=True):
     if not elt: x = x.replace('"', '&quot;')
     return x
 
+@six.python_2_unicode_compatible
 class Element:
     def __init__(self, name, attrs=None, children=None, prefixes=None, line=None):
         if islst(name) and name[0] == None: name = name[1]
@@ -97,14 +100,11 @@ class Element:
 
         return out
 
-    def __unicode__(self):
+    def __str__(self):
         text = ''
         for x in self._dir:
-            text += unicode(x)
+            text += six.text_type(x)
         return ' '.join(text.split())
-
-    def __str__(self):
-        return self.__unicode__().encode('utf-8')
 
     def __getattr__(self, n):
         if n[0] == '_': raise AttributeError("Use foo['"+n+"'] to access the child element.")

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -4,7 +4,6 @@ from unicodedata import normalize
 import openlibrary.catalog.merge.normalize as merge
 
 import six
-from six.moves import range
 
 re_date = map (re.compile, [
     '(?P<birth_date>\d+\??)-(?P<death_date>\d+\??)',
@@ -123,15 +122,15 @@ def pick_first_date(dates):
     return { 'date': fix_l_in_date(' '.join([remove_trailing_number_dot(d) for d in dates])) }
 
 def strip_accents(s):
-    return normalize('NFKD', unicode(s)).encode('ASCII', 'ignore')
+    return normalize('NFKD', six.text_type(s)).encode('ASCII', 'ignore')
 
 re_drop = re.compile('[?,]')
 
 def match_with_bad_chars(a, b):
-    if unicode(a) == unicode(b):
+    if six.text_type(a) == six.text_type(b):
         return True
-    a = normalize('NFKD', unicode(a)).lower()
-    b = normalize('NFKD', unicode(b)).lower()
+    a = normalize('NFKD', six.text_type(a)).lower()
+    b = normalize('NFKD', six.text_type(b)).lower()
     if a == b:
         return True
     a = a.encode('ASCII', 'ignore')
@@ -146,7 +145,7 @@ def accent_count(s):
     return len([c for c in norm(s) if ord(c) > 127])
 
 def norm(s):
-    return normalize('NFC', s) if isinstance(s, unicode) else s
+    return normalize('NFC', s) if isinstance(s, six.text_type) else s
 
 def pick_best_name(names):
     names = [norm(n) for n in names]
@@ -254,4 +253,3 @@ bad MARC: %s
     server = smtplib.SMTP('mail.archive.org')
     server.sendmail(msg_from, [msg_to], msg)
     server.quit()
-

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -6,6 +6,8 @@ from openlibrary.catalog.importer.db_read import get_mc
 from openlibrary.api import unmarshal
 from time import sleep
 
+import six
+
 re_meta_mrc = re.compile('([^/]+)_(meta|marc).(mrc|xml)')
 re_skip = re.compile('\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
 
@@ -43,7 +45,7 @@ def fix_toc(e):
         if len(toc) == 1 and 'title' not in toc[0]:
             del e['table_of_contents'] # remove empty toc
         return
-    new_toc = [{'title': unicode(i), 'type': '/type/toc_item'} for i in toc if i != u'']
+    new_toc = [{'title': six.text_type(i), 'type': '/type/toc_item'} for i in toc if i]
     e['table_of_contents'] = new_toc
 
 def fix_subject(e):

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -221,7 +221,7 @@ def print_works(works):
         print(len(w['editions']), w['title'])
 
 def toc_items(toc_list):
-    return [{'title': unicode(item), 'type': Reference('/type/toc_item')} for item in toc_list]
+    return [{'title': six.text_type(item), 'type': Reference('/type/toc_item')} for item in toc_list]
 
 def add_works(akey, works):
     queue = []

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -442,7 +442,7 @@ def add_subjects_to_work(subjects, w):
         existing_subjects = set(w.get(k, []))
         w.setdefault(k, []).extend(s for s in subjects if s not in existing_subjects)
         if w.get(k):
-            w[k] = [unicode(i) for i in w[k]]
+            w[k] = [six.text_type(i) for i in w[k]]
         try:
             assert all(i != '' and not i.endswith(' ') for i in w[k])
         except AssertionError:
@@ -551,7 +551,7 @@ def fix_toc(e):
         print('toc')
         print(toc)
         print(repr(toc))
-    return [{'title': unicode(i), 'type': '/type/toc_item'} for i in toc if i != u'']
+    return [{'title': six.text_type(i), 'type': '/type/toc_item'} for i in toc if i]
 
 def update_work_with_best_match(akey, w, work_to_edition, do_updates, fh_log):
     work_updated = []

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -307,7 +307,7 @@ def print_works(works):
         print(len(w['editions']), w['title'])
 
 def toc_items(toc_list):
-    return [{'title': unicode(item), 'type': Reference('/type/toc_item')} for item in toc_list]
+    return [{'title': six.text_type(item), 'type': Reference('/type/toc_item')} for item in toc_list]
 
 def add_works(works):
     q = []

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -4,6 +4,8 @@ import glob
 import pytest
 import web
 
+import six
+
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 from infogami.utils.view import render_template as infobase_render_template
@@ -61,8 +63,5 @@ def render_template(request):
     def render(name, *a, **kw):
         as_string = kw.pop("as_string", True)
         d = infobase_render_template(name, *a, **kw)
-        if as_string:
-            return unicode(d)
-        else:
-            return d
+        return six.text_type(d) if as_string else d
     return render

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     BeautifulSoup = None
 
+import six
+
 from infogami import config
 
 # handy utility to parse ISO date strings
@@ -163,7 +165,7 @@ def commify(number, lang=None):
         lang = lang or web.ctx.get("lang") or "en"
         return babel.numbers.format_number(int(number), lang)
     except:
-        return unicode(number)
+        return six.text_type(number)
 
 
 def truncate(text, limit):

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -137,7 +137,7 @@ class MockSite:
                 d[k] = self._process(v)
             return client.create_thing(self, d.get('key'), d)
         elif isinstance(value, common.Reference):
-            return client.create_thing(self, unicode(value), None)
+            return client.create_thing(self, six.text_type(value), None)
         else:
             return value
 

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -480,7 +480,7 @@ class OLIndexer(_Indexer):
         if isinstance(title, str):
             title = title.decode('utf-8', "ignore")
 
-        if not isinstance(title, unicode):
+        if not isinstance(title, six.text_type):
             return ""
 
         # http://stackoverflow.com/questions/517923/what-is-the-best-way-to-remove-accents-in-a-python-unicode-string

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -7,6 +7,8 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template, public
 from infogami.infobase import client, common
 
+import six
+
 from openlibrary.core import formats, cache
 import openlibrary.core.helpers as h
 from openlibrary.utils import dateutil
@@ -228,7 +230,7 @@ class list_view_json(delegate.page):
                 "editions": lst.key + "/editions",
             },
             "name": lst.name or None,
-            "description": lst.description and unicode(lst.description) or None,
+            "description": lst.description and six.text_type(lst.description) or None,
             "seed_count": len(lst.seeds),
             "edition_count": lst.edition_count,
 

--- a/openlibrary/plugins/openlibrary/opds.py
+++ b/openlibrary/plugins/openlibrary/opds.py
@@ -6,6 +6,8 @@ A lightweight version of github.com/internetarchive/bookserver
 import lxml.etree as ET
 from infogami.infobase.utils import parse_datetime
 
+import six
+
 class OPDS():
     xmlns_atom    = 'http://www.w3.org/2005/Atom'
     xmlns_dcterms = 'http://purl.org/dc/terms/'
@@ -61,9 +63,9 @@ class OPDS():
     def add_list(self, name, values, prefix='', attrs={}):
         if isinstance(values, list) or isinstance(values, tuple):
             for v in values:
-                self.add(name, prefix+unicode(v), attrs)
+                self.add(name, prefix+six.text_type(v), attrs)
         elif values:
-            self.add(name, prefix+unicode(values), attrs)
+            self.add(name, prefix+six.text_type(values), attrs)
 
     # add_author()
     #___________________________________________________________________________
@@ -254,4 +256,3 @@ def xmlsafe(s):
         s = s.decode('utf-8')
     # ignore the first 32 bytes of ASCII, which are not allowd in XML
     return u"".join(c for c in s if ord(c) >= 0x20)
-

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -9,6 +9,8 @@ from openlibrary.i18n import gettext
 from openlibrary.core.admin import Stats
 from bs4 import BeautifulSoup
 
+import six
+
 from openlibrary import core
 from openlibrary.plugins.openlibrary import home
 
@@ -25,7 +27,7 @@ class MockDoc(dict):
 
 class TestHomeTemplates:
     def test_about_template(self, render_template):
-        html = unicode(render_template("home/about"))
+        html = six.text_type(render_template("home/about"))
         assert "About the Project" in html
 
         blog = BeautifulSoup(html, "lxml").find("ul", {"id": "olBlog"})
@@ -37,7 +39,7 @@ class TestHomeTemplates:
             "link": "http://blog.openlibrary.org/2011/01/01/blog-post-0",
             "pubdate": datetime.datetime(2011, 1, 1)
         })]
-        html = unicode(render_template("home/about", blog_posts=posts))
+        html = six.text_type(render_template("home/about", blog_posts=posts))
         assert "About the Project" in html
         assert "Blog-post-0" in html
         assert "http://blog.openlibrary.org/2011/01/01/blog-post-0" in html
@@ -48,7 +50,7 @@ class TestHomeTemplates:
 
     def test_stats_template(self, render_template):
         # Make sure that it works fine without any input (skipping section)
-        html = unicode(render_template("home/stats"))
+        html = six.text_type(render_template("home/stats"))
         assert html == ""
 
     def test_read_template(self, render_template, monkeypatch):
@@ -56,7 +58,7 @@ class TestHomeTemplates:
         # Empty list should be returned when there is error.
         monkeypatch.setattr(home, 'random_ebooks', lambda: None)
         books = home.readonline_carousel()
-        html = unicode(render_template("books/custom_carousel", books=books, title="Classic Books", url="/read",
+        html = six.text_type(render_template("books/custom_carousel", books=books, title="Classic Books", url="/read",
                                        key="public_domain"))
         assert html.strip() == ""
 
@@ -93,7 +95,7 @@ class TestHomeTemplates:
                 "inlibrary_borrow_url": "/books/OL1M/foo/borrow",
                 "cover_url": ""
             }]
-        html = unicode(render_template("home/index", stats=stats, test=True))
+        html = six.text_type(render_template("home/index", stats=stats, test=True))
         headers = ["Books We Love", "Recently Returned", "Kids",
                    "Thrillers", "Romance", "Classic Books", "Textbooks"]
         for h in headers:

--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -19,6 +19,8 @@ from gzip import open as gzopen
 import cPickle
 from collections import defaultdict
 
+import six
+
 render = template.render
 
 sconfig = web.storage()
@@ -322,7 +324,7 @@ def munch_qresults_stored(qresults):
                 self.__dict__[a] = v
 
         authortype = Thing(web.ctx.site,u'/type/author')
-        d = Pseudo_thing(web.ctx.site, unicode(ak))
+        d = Pseudo_thing(web.ctx.site, six.text_type(ak))
         d.name = a
         d.type = authortype
         # print >> web.debug, ('mk_author made', d)

--- a/openlibrary/plugins/search/facet_hash.py
+++ b/openlibrary/plugins/search/facet_hash.py
@@ -1,6 +1,7 @@
 import string
 from hashlib import sha1 as mkhash
 
+import six
 from six.moves import range
 
 
@@ -21,10 +22,10 @@ facet_token_length = 12
 # turn v into a str object, by encoding from unicode or numeric
 # if necessary.
 def coerce_str(v):
-    if isinstance(v, unicode):
-        v=v.encode('utf-8')
+    if isinstance(v, six.text_type):
+        v = v.encode('utf-8')
     v = str(v)    # in case v is a numeric type
-    assert isinstance(v, str),(type(v),v)
+    assert isinstance(v, str), (type(v), v)
     return v
 
 # str, str -> str

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -10,7 +10,7 @@ import simplejson
 from facet_hash import facet_token
 import pdb
 
-from six import reraise
+import six
 
 php_location = "/petabox/setup.inc"
 
@@ -194,7 +194,7 @@ class Solr_client(object):
                 kfs = k in facet_set
                 # if not kfs: continue
                 vvx = {str:(vx,), list:vx}.get(type(vx),())
-                for v in map(unicode, vvx):
+                for v in map(six.text_type, vvx):
                     if facet_token(k,v) == token:
                         return (k,v)
         return None
@@ -250,7 +250,7 @@ class Solr_client(object):
             for d in r.find('metadata'):
                 for x in list(d.getiterator()):
                     if x.tag == "identifier":
-                        xid = unicode(x.text).encode('utf-8')
+                        xid = six.text_type(x.text).encode('utf-8')
                         if xid.startswith('OCA/'):
                             xid = xid[4:]
                         elif xid.endswith('.txt'):
@@ -336,7 +336,7 @@ class Solr_client(object):
             h1 = simplejson.loads(result_set)
         except SyntaxError as e:   # we got a solr stack dump
             # print >> web.debug, '*** syntax error result_set=(%r)'% result_set
-            reraise(SolrError, e, result_set)
+            six.reraise(SolrError, e, result_set)
 
         docs = h1['response']['docs']
         r = facet_counts(docs, facet_list)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -607,7 +607,7 @@ class Work(models.Work):
             if (_subject not in blacklist and
                 (not filter_unicode or (
                     subject.replace(' ', '').isalnum() and 
-                    not isinstance(subject, unicode))) and
+                    not isinstance(subject, six.text_type))) and
                 all([char not in subject for char in blacklist_chars])):
                 ok_subjects.append(subject)
         return ok_subjects        

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -13,6 +13,8 @@ import StringIO
 import logging
 from HTMLParser import HTMLParser
 
+import six
+
 from infogami import config
 from infogami.utils import view, delegate, stats
 from infogami.utils.view import render, get_template, public
@@ -394,7 +396,7 @@ def add_metatag(tag="meta", **attrs):
 
 @public
 def url_quote(text):
-    if isinstance(text, unicode):
+    if isinstance(text, six.text_type):
         text = text.encode('utf8')
     return urllib.quote_plus(text)
 
@@ -503,12 +505,12 @@ def get_markdown(text, safe_mode=False):
     return md
 
 
-class HTML(unicode):
+class HTML(six.text_type):
     def __init__(self, html):
-        unicode.__init__(self, web.safeunicode(html))
+        six.text_type.__init__(self, web.safeunicode(html))
 
     def __repr__(self):
-        return "<html: %s>" % unicode.__repr__(self)
+        return "<html: %s>" % six.text_type.__repr__(self)
 
 _websafe = web.websafe
 def websafe(text):

--- a/openlibrary/solr/facet_hash.py
+++ b/openlibrary/solr/facet_hash.py
@@ -1,6 +1,7 @@
 import string
 from hashlib import sha1 as mkhash
 
+import six
 from six.moves import range
 
 
@@ -21,10 +22,10 @@ facet_token_length = 12
 # turn v into a str object, by encoding from unicode or numeric
 # if necessary.
 def coerce_str(v):
-    if isinstance(v, unicode):
-        v=v.encode('utf-8')
+    if isinstance(v, six.text_type):
+        v = v.encode('utf-8')
     v = str(v)    # in case v is a numeric type
-    assert isinstance(v, str),(type(v),v)
+    assert isinstance(v, str), (type(v), v)
     return v
 
 # str, str -> str

--- a/openlibrary/solr/inside/index_all.py
+++ b/openlibrary/solr/inside/index_all.py
@@ -8,9 +8,11 @@ from time import sleep, time
 from lxml.etree import Element, tostring
 from unicodedata import normalize
 
+import six
+
 def add_field(doc, name, value):
     field = Element("field", name=name)
-    field.text = normalize('NFC', unicode(value))
+    field.text = normalize('NFC', six.text_type(value))
     doc.append(field)
 
 solr_host = 'ia331509:8984'

--- a/openlibrary/solr/inside/index_gevent.py
+++ b/openlibrary/solr/inside/index_gevent.py
@@ -11,6 +11,8 @@ from lxml.etree import Element, tostring, parse, fromstring
 import urllib2
 from unicodedata import normalize
 
+import six
+
 scan_list = '/home/edward/scans/book_data_2011-01-07'
 input_count = 0
 current_book = None
@@ -300,7 +302,7 @@ def run_find_item():
 
 def add_field(doc, name, value):
     field = Element("field", name=name)
-    field.text = normalize('NFC', unicode(value))
+    field.text = normalize('NFC', six.text_type(value))
     doc.append(field)
 
 def build_doc(ia, body, page_count):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -122,7 +122,7 @@ def add_field(doc, name, value):
     """
     field = Element("field", name=name)
     try:
-        field.text = normalize('NFC', unicode(strip_bad_char(value)))
+        field.text = normalize('NFC', six.text_type(strip_bad_char(value)))
     except:
         logger.error('Error in normalizing %r', value)
         raise

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -96,7 +96,7 @@ class TestGetIA():
             "%s: expected instanceof MarcBinary, got %s" % (item, type(result))
         print("%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item,
                                                      result.leader()[9],
-                                                     unicode.encode(result.read_fields(['245']).next()[1].get_all_subfields().next()[1], 'utf8')))
+                                                     result.read_fields(['245']).next()[1].get_all_subfields().next()[1].encode('utf8')))
 
     @pytest.mark.parametrize('bad_marc', bad_marcs)
     def test_incorrect_length_marcs(self, bad_marc, monkeypatch):

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -22,6 +22,8 @@ import web
 from openlibrary.api import OpenLibrary, marshal, unmarshal
 from optparse import OptionParser
 
+import six
+
 __version__ = "0.2"
 
 def find(server, prefix):
@@ -31,7 +33,7 @@ def find(server, prefix):
     if prefix == '/type':
         q['type'] = '/type/type'
 
-    return [unicode(x) for x in server.query(q)]
+    return [six.text_type(x) for x in server.query(q)]
 
 def expand(server, keys):
     if isinstance(server, Disk):
@@ -246,4 +248,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
Related to #890

__unicode()__ was removed in Python 3 because all __str__ are Unicode.  This PR mostly proposes using [__six.text_type__](https://six.readthedocs.io/#six.text_type) instead.  Fixes issues flagged by __make lint | grep unicode__