### PR TITLE
enable archive.org-ers to test promo banners w/o reload

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -3,6 +3,7 @@ import simplejson
 import babel, babel.core, babel.dates
 from UserDict import DictMixin
 from collections import defaultdict
+import re
 import random
 import urllib
 import urllib2
@@ -676,9 +677,8 @@ def get_donation_include(include):
     # The following allows archive.org staff to test banners without
     # needing to reload openlibrary services:
     dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
-    if dev_host:
+    if dev_host and re.match('^[a-zA-Z0-9-.]+$', dev_host):
         dev_host += "."   # e.g. `www-user.`
-
     url_banner_source = "https://%sarchive.org/includes/donate.php" % dev_host
     param = '?platform=ol'
     if 'ymd' in web_input:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -672,7 +672,14 @@ _get_blog_feeds = cache.memcache_memoize(_get_blog_feeds, key_prefix="upstream.g
 
 def get_donation_include(include):
     web_input = web.input()
-    url_banner_source = "https://archive.org/includes/donate.php"
+
+    # The following allows archive.org staff to test banners without
+    # needing to reload openlibrary services:
+    dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
+    if dev_host:
+        dev_host += "."   # e.g. `www-user.`
+
+    url_banner_source = "https://%sarchive.org/includes/donate.php" % dev_host
     param = '?platform=ol'
     if 'ymd' in web_input:
         param += '&ymd=' + web_input.ymd


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Feature, Closes #1671 

> **Technical**: What should be noted about the implementation?

There are security consequences (people being able to load code into openlibrary from their client)

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

Change your local archive.org VM (e.g. www-brenton) and add `dev_host` as a GET parameter:
e.g. https://openlibrary.org/?ymd=2018-11-28&dev_host=www-brenton

You should see your version of `includes/donate.php` (from petabox)

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

![screen shot 2018-12-03 at 12 16 40pmpst](https://user-images.githubusercontent.com/978325/49399158-62cfb500-f6f5-11e8-9037-a7e4bc96bcf2.png)

