### PR TITLE
Improved viewing experience of openlibrary.org on mobile devices.

### DIFF
--- a/static/css/components/datatables.less
+++ b/static/css/components/datatables.less
@@ -107,10 +107,15 @@
  * DataTables display
  */
 table.display {
-  float: left;
   margin: 0 auto;
-  width: 918px;
+  width: 100%;
   clear: both;
+}
+@media all and ( min-width: @width-breakpoint-desktop ) {
+table.display {
+  float: left;
+  width: 918px;
+}
 }
 
 table.display thead th {

--- a/static/css/components/form.olform--desktop.less
+++ b/static/css/components/form.olform--desktop.less
@@ -19,6 +19,32 @@ form.olform {
     fieldset.major input[type=email],
     fieldset.major input[type=password],
     fieldset.major textarea {
+      width: 100%;
+    }
+
+    .TitleAuthor {
+      input#work-title {
+        width: 100% !important;
+      }
+
+      input#author {
+        width: 550px !important;
+      }
+    }
+  }
+}
+
+@media all and ( min-width: @width-breakpoint-desktop ) {
+form.olform {
+  input[type=text],
+  input[type=email],
+  input[type=password],
+
+  &.books {
+    fieldset.major input[type=text],
+    fieldset.major input[type=email],
+    fieldset.major input[type=password],
+    fieldset.major textarea {
       width: 848px;
     }
 
@@ -27,9 +53,7 @@ form.olform {
         width: 900px !important;
       }
 
-      input#author {
-        width: 550px !important;
-      }
     }
   }
+}
 }

--- a/static/css/components/header-legacy.less
+++ b/static/css/components/header-legacy.less
@@ -1,7 +1,7 @@
 @import (less) "less/z-index.less";
 
 div#header {
-  width: 960px;
+  width: 100%;
   &Search {
     width: 316px;
     padding: 9px;
@@ -148,4 +148,9 @@ div#header {
     }
     /* stylelint-enable selector-max-specificity */
   }
+}
+@media all and ( min-width: @width-breakpoint-desktop ) {
+div#header {
+  width: 960px;
+}
 }

--- a/static/css/components/iaBar.less
+++ b/static/css/components/iaBar.less
@@ -30,7 +30,13 @@
   margin-bottom: 5px;
   .topNotice-container {
     margin: 0 auto;
+    width: 100%;
+  }
+  @media all and ( min-width: @width-breakpoint-desktop ) {
+  .topNotice-container {
+    margin: 0 auto;
     width: 958px;
+  }
   }
   .topNotice-left {
     float: left;
@@ -51,3 +57,4 @@
     font-size: 24px;
   }
 }
+

--- a/static/css/components/wmd.less
+++ b/static/css/components/wmd.less
@@ -28,26 +28,45 @@
 }
 
 .formElement .input .wmd-preview {
-  width: 906px;
+  width: 100%;
   min-height: 47px;
   padding: 5px;
-  float: left;
   clear: both;
+}
+
+@media all and ( min-width: @width-breakpoint-desktop ) {
+.formElement .input .wmd-preview {
+  width: 906px;
+  float: left;
+}
 }
 
 /* stylelint-disable no-descending-specificity */
 fieldset.major .wmd-preview,
 form.olform.books .formElement .input .wmd-preview {
-  width: 848px;
+  width: 100%;
   min-height: 47px;
   padding: 3px;
 }
+
+@media all and ( min-width: @width-breakpoint-desktop ) {
+fieldset.major .wmd-preview,
+form.olform.books .formElement .input .wmd-preview {
+  width: 848px;
+}
+}
+
 /* stylelint-enable no-descending-specificity */
 
 form.olform.books .formElement.librarian .input .wmd-preview {
-  width: 798px;
+  width: 100%;
   min-height: 47px;
   padding: 3px;
+}
+@media all and ( min-width: @width-breakpoint-desktop ) {
+form.olform.books .formElement.librarian .input .wmd-preview {
+  width: 798px;
+}
 }
 
 form#addAuthor.olform .wmd-preview {


### PR DESCRIPTION
Rescoped width styles to the tablet threshold for .less files in components folder.

> **Description**: What does this PR achieve? [feature|hotfix|refactor]
This PR aims to improve the viewing experience of openlibrary.org on mobile devices. 

Fixes #1585 by adding new size categories within 

> **Technical**: What should be noted about the implementation?
The individual changes were not tested independently of each other but should not impact the functionality of the pages - just the rendering.


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
Run the docker version of this project (using instructions within the docker directory) and load up individual book page or book list on Firefox browser. Using inspect element, select the mobile device simulator and try adjusting the screen size of the simulator.


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:
Before: 
<img width="319" alt="screen shot 2018-12-04 at 7 50 45 pm" src="https://user-images.githubusercontent.com/23226524/49483867-ec20dd80-f802-11e8-8ab7-733d6e3f81da.png">
<img width="321" alt="screen shot 2018-12-04 at 7 50 53 pm" src="https://user-images.githubusercontent.com/23226524/49483880-f216be80-f802-11e8-990e-a0e37fae2a4d.png">

After:
<img width="322" alt="screen shot 2018-12-04 at 7 51 02 pm" src="https://user-images.githubusercontent.com/23226524/49483888-f8a53600-f802-11e8-82f6-526cefce24c0.png">


