### PR TITLE
Undefined name: unichr() --> six.unichr()

### DIFF
--- a/openlibrary/catalog/amazon/parse.py
+++ b/openlibrary/catalog/amazon/parse.py
@@ -50,15 +50,15 @@ def unescape(text):
             # character reference
             try:
                 if text[:3] == "&#x":
-                    return unichr(int(text[3:-1], 16))
+                    return six.unichr(int(text[3:-1], 16))
                 else:
-                    return unichr(int(text[2:-1]))
+                    return six.unichr(int(text[2:-1]))
             except ValueError:
                 pass
         else:
             # named entity
             try:
-                text = unichr(htmlentitydefs.name2codepoint[text[1:-1]])
+                text =  six.unichr(htmlentitydefs.name2codepoint[text[1:-1]])
             except KeyError:
                 pass
         return text # leave as is


### PR DESCRIPTION
__unichr__ was removed in Python 3 so this PR proposes to use [__six.unichr__](https://six.readthedocs.io/#six.unichr) instead.