### PR TITLE
WIP requirements_common.txt: Upgrade Genshi==0.7.1

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -2,7 +2,7 @@ Babel==2.5.3
 beautifulsoup4==4.6.3
 DBUtils==1.3
 flake8==3.6.0
-Genshi==0.6
+Genshi==0.7.1
 gunicorn==19.9.0
 iptools==0.4.0
 internetarchive==1.8.1


### PR DESCRIPTION
https://pypi.org/project/Genshi is currently [failing our build process](https://travis-ci.org/internetarchive/openlibrary/jobs/464153243#L786) on Python 3 because of a syntax error.  Upgrading to this Python 3 compatible version of Genshi has been attempted before in #1454 but had to be reverted because [__our Python 2 tests failed on this upgrade__](https://travis-ci.org/internetarchive/openlibrary/jobs/464164656#L1136).