### PR TITLE
Undefined name: BadImport

### DIFF
--- a/scripts/lc_marc_update.py
+++ b/scripts/lc_marc_update.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
+from openlibrary.catalog.importer.scribe import BadImport
 from openlibrary.catalog.read_rc import read_rc
 from openlibrary import config
 from ftplib import FTP


### PR DESCRIPTION
__from openlibrary.catalog.importer.scribe import BadImport__ resolves four _undefined names_ from #1508 and #1684  @YBthebest, your review please.