### PR TITLE
WIP: What breaks Py3 builds after Genshi, iptools, python-memcached, …

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -2,16 +2,16 @@ Babel==2.5.3
 beautifulsoup4==4.6.3
 DBUtils==1.3
 flake8==3.6.0
-Genshi==0.6
+# Genshi==0.6
 gunicorn==19.9.0
-iptools==0.4.0
+# iptools==0.4.0
 internetarchive==1.8.1
 lxml==4.2.5
 pyflakes==2.0.0
 pymarc==3.1.11
-python-memcached==1.48
+# python-memcached==1.48
 simplejson==3.16.0
-supervisor==3.0a12
+# supervisor==3.0a12
 web.py==0.33
 pystatsd==0.1.6
 PyYAML==3.10


### PR DESCRIPTION
…and supervisor?

Let's assume that #1679, #1680, #1685, and supervisor v4 have all landed (they have NOT)... What dependency next blocks the Python 3 build on Travis CI?  __Answer: mockcache==1.0.3__

https://travis-ci.org/internetarchive/openlibrary/jobs/464577602#L822