### PR TITLE
requirements_test.txt: Remove mockcache for Python 3

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,3 @@
 -r requirements_common.txt
 flake8==3.6.0
 pytest==4.0.1
-mockcache==1.0.3


### PR DESCRIPTION
It breaks our Py3 Travis builds https://travis-ci.org/internetarchive/openlibrary/jobs/464577602#L822
There is currently no Python 3 compatible release... https://github.com/lunant/mockcache/issues/8
We need to find a Python 3 compatible alternative to https://pypi.org/project/mockcache
Help wanted.  @okken Do you have any hints?