### PR TITLE
Disable problematic requirements only on Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -r requirements_common.txt
 
-Fabric==1.10.1
+Fabric==1.10.1; python_version < '3.0'
 Jinja2==2.10
 Pillow==5.3.0
 backports.shutil-get-terminal-size==1.0.0

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -4,7 +4,7 @@ DBUtils==1.3
 flake8==3.6.0
 Genshi==0.6; python_version < '3.0'
 gunicorn==19.9.0
-iptools==0.4.0
+iptools==0.4.0; python_version < '3.0'
 internetarchive==1.8.1
 lxml==4.2.5
 pyflakes==2.0.0

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -2,7 +2,7 @@ Babel==2.5.3
 beautifulsoup4==4.6.3
 DBUtils==1.3
 flake8==3.6.0
-Genshi==0.6
+Genshi==0.6; python_version < '3.0'
 gunicorn==19.9.0
 iptools==0.4.0
 internetarchive==1.8.1
@@ -11,7 +11,7 @@ pyflakes==2.0.0
 pymarc==3.1.11
 python-memcached==1.59
 simplejson==3.16.0
-supervisor==3.0a12  # Let's pretend that supervisor v4 has landed (it has NOT)
+supervisor==3.0a12; python_version < '3.0'
 web.py==0.33
 pystatsd==0.1.6
 PyYAML==3.10

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -20,7 +20,7 @@ lepl==5.1.3
 six==1.11.0
 sixpack-client==1.1.0
 psycopg2==2.7.3.2
-OL-GeoIP==1.2.4
+OL-GeoIP==1.2.4; python_version < '3.0'
 Pygments==1.4
 python-amazon-simple-product-api==2.2.11
 isbnlib==3.9.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,4 @@
 -r requirements_common.txt
 flake8==3.6.0
 pytest==4.0.1
-mockcache==1.0.3
+mockcache==1.0.3; python_version < '3.0'


### PR DESCRIPTION
This issue is directly related to #1679, #1680, #1638, #1694, #1687 and indirectly related to #1522 and #1634.

Certain Python dependencies do not currently have an acceptable Python 3 equivalent and they block our Travis CI build process in the install step.  This PR proposes to use the conditional capabilities of _requirements.txt_ files to only install these modules on legacy Python and not install them on Python.  This _should_ allow us to get past the install step and start running our PyTests.

[__$ pip install -r requirements_test.txt__](https://travis-ci.org/internetarchive/openlibrary/jobs/465262458#L745)
```
Ignoring Genshi: markers 'python_version < "3.0"' don't match your environment
Ignoring iptools: markers 'python_version < "3.0"' don't match your environment
Ignoring supervisor: markers 'python_version < "3.0"' don't match your environment
Ignoring OL-GeoIP: markers 'python_version < "3.0"' don't match your environment
Ignoring mockcache: markers 'python_version < "3.0"' don't match your environment
```