### PR TITLE
Updated docker/readme to include setup instructions on Windows

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # Welcome to the new Docker based Open Library development environment!
 
 These current Dockerfiles are designed to be an alternative to the previous Vagrant based development environment.
-The setup process and scripts are designed to *NOT* conflict with exisiting Vagrant provisioning, so you should be able to
+The setup process and scripts are designed to _NOT_ conflict with exisiting Vagrant provisioning, so you should be able to
 chose to develop using the exisiting Vagrant method, or try the new Docker approach if you prefer, using the same code branch.
 
 ## Planning
@@ -9,6 +9,38 @@ chose to develop using the exisiting Vagrant method, or try the new Docker appro
 You can read more about the planning and initial stages of migration from Vagrant developer instances to Docker here: https://github.com/internetarchive/openlibrary/pull/1012
 
 ## Setup/Teardown Commands
+
+### For Windows Users Only
+
+**Note:**
+If you get permission issues while executing these commands please run git bash shell as an Administrator.
+
+1. Set the line endings to type `input` by executing the following command:
+
+   ```bash
+   # Configure Git on Windows to properly handle line endings so Git will convert CRLF to LF on commit
+   git config --global core.autocrlf input
+   ```
+
+2. Check whether `symlinks` are enabled or not. `openlibrary` makes use of symlinks which, by default, git on Windows checks out as plain text files. You can check that by executing the following command:
+
+   ```bash
+   git config core.symlinks
+   ```
+
+3. If `symlinks` are enabled then go to the next step. If `symlinks` are not enabled then enable it by executing the following command:
+
+   ```bash
+   git config core.symlinks true
+   ```
+
+4. Then hard reset the repository so that git will create proper symlinks by executing the following command:
+
+   ```bash
+   git reset --hard HEAD
+   ```
+
+5. Continue setup as shown below.
 
 All commands are from the docker directory:
 
@@ -37,11 +69,11 @@ Note: You must build `olbase` first before `oldev`. `olbase` is intended to be t
 
 This exposes the following ports:
 
-Port | Service
----- | -------
-8080 | Open Library main site
-7000 | Infobase
-8983 | Solr
+| Port | Service                |
+| ---- | ---------------------- |
+| 8080 | Open Library main site |
+| 7000 | Infobase               |
+| 8983 | Solr                   |
 
 To access Solr admin:
 http://localhost:8983/solr/admin/
@@ -54,9 +86,9 @@ You can customise the host ports by modifying the `-p` publish mapping in the `d
 
 While running the `oldev` container, gunicorn is configured to auto-reload modified files. To see the effects of your changes in the running container, the following apply:
 
-* Editing python files or web templates => simply save the file, gunicorn will auto-reload it.
-* Working on frontend css or js => you must run `docker-compose exec web make css js`. This will re-generate the assets in the persistent `ol-build` volume mount, so the latest changes will be available between stopping / starting and removing `web` containers. Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
-* Adding or changing core dependencies => you will most likely need to rebuild both `olbase` and `oldev` images. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;)
+- Editing python files or web templates => simply save the file, gunicorn will auto-reload it.
+- Working on frontend css or js => you must run `docker-compose exec web make css js`. This will re-generate the assets in the persistent `ol-build` volume mount, so the latest changes will be available between stopping / starting and removing `web` containers. Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
+- Adding or changing core dependencies => you will most likely need to rebuild both `olbase` and `oldev` images. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;)
 
 ## Useful Runtime Commands
 
@@ -75,11 +107,12 @@ docker-compose exec web make test
 ```
 
 ## Other Commands
+
 ```bash
 # Run tests in a temporary container
 docker-compose run --rm web make test
 ```
 
 ## TODO
-* Fix symlinks that are causing a problem in Windows, see issue https://github.com/internetarchive/openlibrary/issues/1051 
 
+- Fix symlinks that are causing a problem in Windows, see issue https://github.com/internetarchive/openlibrary/issues/1051


### PR DESCRIPTION
Updates `docker/readme` file using PR #1404 to include Windows specific instructions when using Docker.

Closes #1696