### PR TITLE
move docker-compose to project root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ol-nodemodules:/openlibrary/node_modules
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
-      - ..:/openlibrary
+      - .:/openlibrary
     networks:
       - webnet
   solr:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Welcome to the new Docker based Open Library development environment!
 
-These current Dockerfiles are designed to be an alternative to the previous Vagrant based development environment.
+These Dockerfiles replace the previous Vagrant based development environment.
 
 ## Setup/Teardown Commands
 
@@ -37,13 +37,13 @@ If you get permission issues while executing these commands please run git bash 
 5. Continue setup as shown below.
 
 ### For All Users
-All commands are from the docker directory:
+All commands are from the project root directory:
 
 ```bash
 # build images
-docker build -t olbase:latest -f Dockerfile.olbase ..
-docker build -t oldev:latest -f Dockerfile.oldev ..
-docker build -t olsolr:latest -f Dockerfile.olsolr ..
+docker build -t olbase:latest -f docker/Dockerfile.olbase .
+docker build -t oldev:latest -f docker/Dockerfile.oldev .
+docker build -t olsolr:latest -f docker/Dockerfile.olsolr .
 
 # start the app
 docker-compose up # Ctrl-C to stop


### PR DESCRIPTION
> **Description**: Move Docker build and compose context to project root
Closes #1572

> **Technical**: What should be noted about the implementation?

This move will hopefully make the kind of tasks mentioned in #1545  (running `make` commands in containers from the host system) more convenient and adhere to Docker location conventions so new devs will be more likely to understand how our environment works. 

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

I have successfully built and run the images from the project root

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

