### PR TITLE
fixing bookcover size on editions page

### DIFF
--- a/static/css/components/illustration.less
+++ b/static/css/components/illustration.less
@@ -71,3 +71,9 @@
     margin: 10px auto;
   }
 }
+.editionCover {
+  .SRPCoverBlank {
+    width: auto;
+    height: auto;
+  }
+}


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

hotfix Closes #1704 

> **Technical**: What should be noted about the implementation?

May not be the best css solution

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

See issue: go to any editions page, the bookcover

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

Before:
![2018-12-10-131902_1600x900_scrot](https://user-images.githubusercontent.com/978325/49764294-e2283000-fc83-11e8-80db-3f364b9057e6.png)

After:
![2018-12-10-131855_1600x900_scrot](https://user-images.githubusercontent.com/978325/49764288-ddfc1280-fc83-11e8-8846-f8a277ff80ee.png)
