### PR TITLE
Hovering between header icon and menu should not hide it

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -49,7 +49,9 @@ header#header-bar {
       z-index: @z-index-level-5;
       text-align: right;
       width: 125px;
-      margin-top: 5px;
+      // Note, it must be padding so that the gap between the icon and
+      // the dropdown menu is included in the hover-trigger area (#1575)
+      padding-top: 5px;
       right: 11px;
 
       ul a li {


### PR DESCRIPTION
Use padding rather than margin, as padding is considered part of
the DOM element not outside it (box model)

Fixes: #1575

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

