### PR TITLE
fix ReadTimeOutError while installing python packages

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -46,7 +46,7 @@ RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
 COPY --chown=openlibrary:openlibrary . /openlibrary
 WORKDIR /openlibrary
 
-RUN pip install -r requirements_common.txt
+RUN pip install --default-timeout=100 -r requirements_common.txt
 
 USER openlibrary
 RUN ln -s vendor/infogami/infogami infogami


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

While installing the python packages (through Dockerfile.olbase) if the net connection is slow then the installation of packages fails due to [ReadTimeoutError: HTTPSConnectionPool(host='pypi.python.org', port=443)].
 Thus to overcome this problem if we make the changes in the image file(Dockerfile.olbase) then the packages will be installed smoothly without any error

Closes #

> **Technical**: What should be noted about the implementation?

In the **dockerfile.olbase** I changed

RUN pip install -r requirements_common.txt
to-
RUN pip install --default-timeout=100 -r requirements_common.txt

(100 is the the number of seconds pip'll wait for the reconnect after losing connection)




