### PR TITLE
Upgrade to Genshi 0.7.1

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -45,7 +45,7 @@ __all__ = [
 ]
 __docformat__ = "restructuredtext en"
 
-def sanitize(html):
+def sanitize(html, encoding = None):
     """Removes unsafe tags and attributes from html and adds
     ``rel="nofollow"`` attribute to all external links.
     """
@@ -65,8 +65,11 @@ def sanitize(html):
                 return 'nofollow'
 
     try:
-        html = genshi.HTML(html)
-    except (genshi.ParseError, UnicodeDecodeError, UnicodeError):
+        html = genshi.HTML(html, encoding = encoding)
+
+    # except (genshi.ParseError, UnicodeDecodeError, UnicodeError) as e:
+    # don't catch Unicode errors so we can tell if we're getting bytes
+    except genshi.ParseError:
         if BeautifulSoup:
             # Bad html. Tidy it up using BeautifulSoup
             html = str(BeautifulSoup(html, "lxml"))

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -3,28 +3,28 @@ from openlibrary.core import helpers as h
 
 def test_sanitize():
     # plain html should pass through
-    assert h.sanitize("hello") == "hello"
-    assert h.sanitize("<p>hello</p>") == "<p>hello</p>"
+    assert h.sanitize(u"hello") == u"hello"
+    assert h.sanitize(u"<p>hello</p>") == u"<p>hello</p>"
 
     # broken html must be corrected
-    assert h.sanitize("<p>hello") == "<p>hello</p>"
+    assert h.sanitize(u"<p>hello") == u"<p>hello</p>"
 
     # css class is fine
-    assert h.sanitize('<p class="foo">hello</p>') == '<p class="foo">hello</p>'
+    assert h.sanitize(u'<p class="foo">hello</p>') == u'<p class="foo">hello</p>'
 
     # style attribute must be stripped
-    assert h.sanitize('<p style="color: red">hello</p>') == '<p>hello</p>'
+    assert h.sanitize(u'<p style="color: red">hello</p>') == u'<p>hello</p>'
 
     # style tags must be stripped
-    assert h.sanitize('<style type="text/css">p{color: red;}</style><p>hello</p>') == '<p>hello</p>'
+    assert h.sanitize(u'<style type="text/css">p{color: red;}</style><p>hello</p>') == u'<p>hello</p>'
 
     # script tags must be stripped
-    assert h.sanitize('<script>alert("dhoom")</script>hello') == 'hello'
+    assert h.sanitize(u'<script>alert("dhoom")</script>hello') == u'hello'
 
     # rel="nofollow" must be added absolute links
-    assert h.sanitize('<a href="https://example.com">hello</a>') == '<a href="https://example.com" rel="nofollow">hello</a>'
+    assert h.sanitize(u'<a href="https://example.com">hello</a>') == u'<a href="https://example.com" rel="nofollow">hello</a>'
     # relative links should pass through
-    assert h.sanitize('<a href="relpath">hello</a>') == '<a href="relpath">hello</a>'
+    assert h.sanitize(u'<a href="relpath">hello</a>') == u'<a href="relpath">hello</a>'
 
 def test_safesort():
     from datetime import datetime

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -8,18 +8,18 @@ def test_olmarkdown():
         # markdown always wraps the result in <p>.
         return "<p>%s\n</p>" % html
 
-    assert md("**foo**") == p("<strong>foo</strong>")
-    assert md("<b>foo</b>") == p('<b>foo</b>')
-    assert md("https://openlibrary.org") == p(
-            '<a href="https://openlibrary.org" rel="nofollow">' +
-                'https://openlibrary.org' +
-            '</a>'
+    assert md(u"**foo**") == p(u"<strong>foo</strong>")
+    assert md(u"<b>foo</b>") == p(u'<b>foo</b>')
+    assert md(u"https://openlibrary.org") == p(
+            u'<a href="https://openlibrary.org" rel="nofollow">' +
+                u'https://openlibrary.org' +
+            u'</a>'
         )
-    assert md("http://example.org") == p(
-            '<a href="http://example.org" rel="nofollow">' +
-                'http://example.org' +
-            '</a>'
+    assert md(u"http://example.org") == p(
+            u'<a href="http://example.org" rel="nofollow">' +
+                u'http://example.org' +
+            u'</a>'
         )
 
     # why extra spaces?
-    assert md("a\nb") == p("a<br/>\n   b")
+    assert md(u"a\nb") == p(u"a<br/>\n   b")

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -2,7 +2,7 @@ Babel==2.5.3
 beautifulsoup4==4.6.3
 DBUtils==1.3
 flake8==3.6.0
-Genshi==0.6; python_version < '3.0'
+Genshi==0.7.1
 gunicorn==19.9.0
 iptools==0.6.1; python_version < '3.0'
 internetarchive==1.8.1

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -12,7 +12,8 @@ pymarc==3.1.11
 python-memcached==1.59
 simplejson==3.16.0
 supervisor==3.0a12; python_version < '3.0'
-web.py==0.33
+web.py==0.33; python_version < '3.0'
+web.py==0.40-dev1; python_version >= '3.0'
 pystatsd==0.1.6
 PyYAML==3.10
 eventer==0.1.1


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #1455

> **Technical**: What should be noted about the implementation?

This adds an optional encoding parameter to `helpers.sanitize()` with a default value of None (same as Genshi 0.7.1). Normally callers should provide unicode strings, but this may allow them to specify the encoding easily if they have bytes. The test suite has been updated to pass Unicode strings, but I have *not* inspected all the calls to `sanitize()` to see if there are any likely problems spots. Since they're often using the results of some other code, inspection won't be easy, so we'll probably just need to find problems as we go.

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

