### PR TITLE
Optimise loans page for mobile

### DIFF
--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -256,7 +256,7 @@ $else:
 $# XXX borrow history not yet recorded so we show instructions if no current loans
 <!-- if no borrow history -->
 $if len(loans) == 0 and len(waitinglist) == 0:
-    <div class="contentHalf" style="padding-right:20px;width:419px;">
+    <div class="contentHalf">
         <p>
         $_("There are 2 different sources for borrowing books through Open Library:")</p>
         <p style="line-height:1em;margin:1.5em 0 1em;">

--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -42,7 +42,7 @@ th.status {
 $if len(loans) >= 5:
     <script type="text/javascript">
     <!--
-    \$().ready(function(){
+    window.q.push(function(){
         \$("#contentMsg").show();
         \$(".alert span").css({'font-size':'.6875em','color':'#333'})
         \$(".alert span").text("You have 5 ebooks out at the moment. That's the limit! You can free up slots by returning books early.");
@@ -52,7 +52,7 @@ $if len(loans) >= 5:
 
 <script type="text/javascript">
 <!--
-\$().ready(function(){
+window.q.push(function(){
     \$(".local-date-time").each(function() {
         var expiry_utc = \$(this).attr("data-expiry-utc");
         var options = {hour: '2-digit', minute:'2-digit', month:'2-digit', day:'2-digit', year:'numeric'};
@@ -156,7 +156,7 @@ $if len(waitinglist) == 0:
 $else:
     <div id="leave-waitinglist-dialog" class="hidden dialog" title="Leave the Waiting List">Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?</div>
     <script type="text/javascript">
-    \$(function() {
+    window.q.push(function() {
         \$("#leave-waitinglist-dialog").dialog({
             autoOpen: false,
             width: 450,


### PR DESCRIPTION
Remove an inline style.
contentHalf has a max-width of 439px on tablet devices defined
in the stylesheet so this is unnecessary

This completes the optimisation of the loans page

Fixes: #1510

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

