### PR TITLE
Development cover url

### DIFF
--- a/conf/openlibrary-docker.yml
+++ b/conf/openlibrary-docker.yml
@@ -15,7 +15,7 @@ smtp_server: localhost
 dummy_sendmail: True
 debug: True
 
-coverstore_url: http://0.0.0.0/covers/
+coverstore_url: https://covers.openlibrary.org
 
 state_dir: var/run
 


### PR DESCRIPTION
Right now when working locally with OpenLibrary, by default
covers show as broken images. This is particularly important to fix
as we refactor the frontend.

This changes the default to the production cover service which is guaranteed
to be available.

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

