### PR TITLE
ReadPanel alignment issues

### DIFF
--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -23,6 +23,15 @@
   li {
     margin: 5px 10px 0;
   }
+  table {
+    width: 100%;
+    td {
+      text-align: left;
+      &.price {
+        text-align: right;
+      }
+    }
+  }
 }
 // For the button at the top
 @import (less) "components/buttonCta.less";


### PR DESCRIPTION
This style makes the table take up 100% of the width of the component
and aligns the price to the right. This maximises the space between
the label and the price.

Fixes: #1752

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

