### PR TITLE
Switch default to sanitize(encoding=utf8) Fixes #1758

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -45,9 +45,12 @@ __all__ = [
 ]
 __docformat__ = "restructuredtext en"
 
-def sanitize(html, encoding = None):
+def sanitize(html, encoding = "utf8"):
     """Removes unsafe tags and attributes from html and adds
     ``rel="nofollow"`` attribute to all external links.
+    Using encoding=None if passing unicode strings e.g. for Python 3.
+    encoding="utf8" matches default format for earlier versions of Genshi
+    https://genshi.readthedocs.io/en/latest/upgrade/#upgrading-from-genshi-0-6-x-to-the-development-version
     """
 
     # Can't sanitize unless genshi module is available


### PR DESCRIPTION
hotfix which switches the default encoding for sanitize from None to "utf8" where None means Python unicode strings (ie already decoded).

This needs a test, but creating the patch first since it's time critical.

Closes #1758 
