### PR TITLE
Python: Fix multiple imports on one line

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -20,7 +20,8 @@ import os
 import re
 import datetime
 from ConfigParser import ConfigParser
-import urllib, urllib2
+import urllib
+import urllib2
 import simplejson
 import web
 import logging

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -1,4 +1,6 @@
-import web, re, os
+import web
+import re
+import os
 from openlibrary.catalog.utils import flip_name, author_dates_match, key_int
 
 def east_in_by_statement(rec, author):

--- a/openlibrary/catalog/amazon/arc_view.py
+++ b/openlibrary/catalog/amazon/arc_view.py
@@ -1,4 +1,5 @@
-import web, os
+import web
+import os
 from StringIO import StringIO
 
 arc_dir = '/2/edward/amazon/arc'

--- a/openlibrary/catalog/amazon/crawl.py
+++ b/openlibrary/catalog/amazon/crawl.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 from lxml.html import parse, tostring, fromstring
-import re, sys, os, socket
+import re
+import sys
+import os
+import socket
 from urllib import unquote
 from urllib2 import urlopen
 from time import sleep

--- a/openlibrary/catalog/amazon/get_other_editions.py
+++ b/openlibrary/catalog/amazon/get_other_editions.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 from catalog.read_rc import read_rc
-import web, urllib2, sys, os.path
+import web
+import urllib2
+import sys
+import os.path
 from time import time
 
 rc = read_rc()

--- a/openlibrary/catalog/amazon/import.py
+++ b/openlibrary/catalog/amazon/import.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import sys,re, os
+import sys
+import re
+import os
 from parse import read_edition
 from lxml.html import fromstring
 import catalog.importer.pool as pool

--- a/openlibrary/catalog/amazon/list_done.py
+++ b/openlibrary/catalog/amazon/list_done.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 from lxml.html import fromstring, tostring
 from openlibrary.catalog.utils.arc import read_arc, read_body
-import re, os, sys
+import re
+import os
+import sys
 
 arc_dir = '/2/edward/amazon/arc'
 total = 0

--- a/openlibrary/catalog/amazon/other_editions.py
+++ b/openlibrary/catalog/amazon/other_editions.py
@@ -1,4 +1,6 @@
-import re, os.path, urllib2
+import re
+import os.path
+import urllib2
 from bs4 import BeautifulSoup
 
 # http://amazon.com/other-editions/dp/0312153325 has:

--- a/openlibrary/catalog/amazon/parse.py
+++ b/openlibrary/catalog/amazon/parse.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 from lxml.html import parse, tostring
-import re, os, sys, web
+import re
+import os
+import sys
+import web
 from warnings import warn
 from math import floor
 from pprint import pprint

--- a/openlibrary/catalog/amazon/read_serp.py
+++ b/openlibrary/catalog/amazon/read_serp.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 from lxml.html import fromstring
 from openlibrary.catalog.utils.arc import read_arc, read_body
-import os, re
+import os
+import re
 
 arc_dir = '/2/edward/amazon/arc'
 

--- a/openlibrary/catalog/amazon/upload.py
+++ b/openlibrary/catalog/amazon/upload.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 from catalog.read_rc import read_rc
-import httplib, web, time, sys
+import httplib
+import web
+import time
+import sys
 from datetime import date, timedelta
 
 rc = read_rc()

--- a/openlibrary/catalog/amazon/upload_arc.py
+++ b/openlibrary/catalog/amazon/upload_arc.py
@@ -1,6 +1,10 @@
 from __future__ import print_function
 from openlibrary.catalog.read_rc import read_rc
-import httplib, web, time, sys, os
+import httplib
+import web
+import time
+import sys
+import os
 
 rc = read_rc()
 accesskey = rc['s3_accesskey']

--- a/openlibrary/catalog/author/merge.py
+++ b/openlibrary/catalog/author/merge.py
@@ -4,7 +4,11 @@ from openlibrary.catalog.importer.db_read import withKey, get_things, get_mc
 from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.utils import key_int, match_with_bad_chars, pick_best_author, remove_trailing_number_dot
 from unicodedata import normalize
-import web, re, sys, codecs, urllib
+import web
+import re
+import sys
+import codecs
+import urllib
 
 import six
 

--- a/openlibrary/catalog/author/noble.py
+++ b/openlibrary/catalog/author/noble.py
@@ -4,7 +4,11 @@ from catalog.get_ia import read_marc_file
 from catalog.read_rc import read_rc
 from time import time
 from catalog.marc.fast_parse import index_fields, get_tag_lines, get_first_tag, get_all_subfields
-import web, os, os.path, re, sys
+import web
+import os
+import os.path
+import re
+import sys
 
 titles = [ "Accolade", "Adi", "Aetheling", "Aga Khan", "Ajaw", "Ali'i",
         "Allamah", "Altgrave", "Ammaveedu", "Anji", "Ryūkyū", "Archtreasurer",

--- a/openlibrary/catalog/author/rename.py
+++ b/openlibrary/catalog/author/rename.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 
 from __future__ import print_function
-import web, re, sys, codecs
+import web
+import re
+import sys
+import codecs
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/openlibrary/catalog/author/web_merge2.py
+++ b/openlibrary/catalog/author/web_merge2.py
@@ -1,4 +1,5 @@
-import web, re
+import web
+import re
 from urllib2 import urlopen
 import simplejson as json
 from pprint import pformat

--- a/openlibrary/catalog/dup/authors.py
+++ b/openlibrary/catalog/dup/authors.py
@@ -1,7 +1,11 @@
 from __future__ import print_function
 from catalog.infostore import get_site
 from catalog.read_rc import read_rc
-import web, sys, codecs, os.path, re
+import web
+import sys
+import codecs
+import os.path
+import re
 from catalog.olwrite import Infogami
 site = get_site()
 

--- a/openlibrary/catalog/dup/find.py
+++ b/openlibrary/catalog/dup/find.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import web, sys, codecs, os.path
+import web
+import sys
+import codecs
+import os.path
 from catalog.read_rc import read_rc
 import psycopg2
 from catalog.infostore import get_site

--- a/openlibrary/catalog/edition_merge/find_easy.py
+++ b/openlibrary/catalog/edition_merge/find_easy.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import MySQLdb, datetime, re, sys
+import MySQLdb
+import datetime
+import re
+import sys
 sys.path.append('/1/src/openlibrary')
 from openlibrary.api import OpenLibrary, Reference
 from collections import defaultdict

--- a/openlibrary/catalog/edition_merge/merge.py
+++ b/openlibrary/catalog/edition_merge/merge.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 
-import MySQLdb, datetime, re, sys
+import MySQLdb
+import datetime
+import re
+import sys
 sys.path.append('/1/src/openlibrary')
 from openlibrary.api import OpenLibrary, Reference
 from flask import Flask, render_template, request, flash, redirect, url_for, g

--- a/openlibrary/catalog/edition_merge/merge_works.py
+++ b/openlibrary/catalog/edition_merge/merge_works.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import MySQLdb, datetime, re, sys
+import MySQLdb
+import datetime
+import re
+import sys
 from openlibrary.catalog.utils import cmp
 sys.path.append('/1/src/openlibrary')
 from openlibrary.api import OpenLibrary, Reference

--- a/openlibrary/catalog/edition_merge/run_merge.py
+++ b/openlibrary/catalog/edition_merge/run_merge.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import MySQLdb, datetime, re, sys
+import MySQLdb
+import datetime
+import re
+import sys
 from openlibrary.api import OpenLibrary, Reference
 from collections import defaultdict
 

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -5,7 +5,9 @@ from openlibrary.catalog.marc import fast_parse, parse
 from infogami import config
 from lxml import etree
 import xml.parsers.expat
-import urllib2, os.path, socket
+import urllib2
+import os.path
+import socket
 from time import sleep
 import traceback
 from openlibrary.core import ia

--- a/openlibrary/catalog/ia/count_archive_books.py
+++ b/openlibrary/catalog/ia/count_archive_books.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from catalog.read_rc import read_rc
-import web, sys
+import web
+import sys
 rc = read_rc()
 web.config.db_parameters = dict(dbn='mysql', db='archive', user=rc['ia_db_user'], pw=rc['ia_db_pass'], host=rc['ia_db_host'])
 web.load()

--- a/openlibrary/catalog/ia/extract_paragraphs.py
+++ b/openlibrary/catalog/ia/extract_paragraphs.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from xml.etree.cElementTree import iterparse, tostring, Element
-import sys, re
+import sys
+import re
 
 ns = '{http://www.abbyy.com/FineReader_xml/FineReader6-schema-v1.xml}'
 page_tag = ns + 'page'

--- a/openlibrary/catalog/ia/get_loaded.py
+++ b/openlibrary/catalog/ia/get_loaded.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from catalog.read_rc import read_rc
-import web, sys
+import web
+import sys
 rc = read_rc()
 web.config.db_parameters = dict(dbn='postgres', db=rc['db'], user=rc['user'], pw=rc['pw'], host=rc['host'])
 web.load()

--- a/openlibrary/catalog/ia/scan_img.py
+++ b/openlibrary/catalog/ia/scan_img.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
 import httplib
 import xml.etree.ElementTree as et
-import xml.parsers.expat, socket # for exceptions
-import urllib, re
+import xml.parsers.expat
+import socket # for exceptions
+import urllib
+import re
 from openlibrary.catalog.get_ia import urlopen_keep_trying
 from openlibrary.utils.ia import find_item
 

--- a/openlibrary/catalog/ia/scanned_identifiers.py
+++ b/openlibrary/catalog/ia/scanned_identifiers.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from catalog.read_rc import read_rc
-import web, sys
+import web
+import sys
 rc = read_rc()
 web.config.db_parameters = dict(dbn='mysql', db='archive', user=rc['ia_db_user'], pw=rc['ia_db_pass'], host=rc['ia_db_host'])
 web.load()

--- a/openlibrary/catalog/importer/add_source_records.py
+++ b/openlibrary/catalog/importer/add_source_records.py
@@ -2,7 +2,10 @@
 from __future__ import print_function
 from time import time, sleep
 import catalog.marc.fast_parse as fast_parse
-import web, sys, codecs, re
+import web
+import sys
+import codecs
+import re
 import catalog.importer.pool as pool
 from catalog.utils.query import query_iter
 from catalog.importer.merge import try_merge

--- a/openlibrary/catalog/importer/from_scribe.py
+++ b/openlibrary/catalog/importer/from_scribe.py
@@ -11,7 +11,9 @@ from merge import try_merge
 from db_read import get_things
 from catalog.get_ia import get_ia, urlopen_keep_trying
 from catalog.merge.merge_marc import build_marc
-import pool, sys, urllib2
+import pool
+import sys
+import urllib2
 
 archive_url = "http://archive.org/download/"
 

--- a/openlibrary/catalog/importer/import_imagepdf.py
+++ b/openlibrary/catalog/importer/import_imagepdf.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import web,  sys
+import web
+import sys
 from catalog.utils.query import query, withKey
 from catalog.read_rc import read_rc
 sys.path.append('/home/edward/src/olapi')

--- a/openlibrary/catalog/importer/import_marc.py
+++ b/openlibrary/catalog/importer/import_marc.py
@@ -3,7 +3,12 @@ from __future__ import print_function
 from time import time, sleep
 import openlibrary.catalog.marc.fast_parse as fast_parse
 from openlibrary.catalog.marc.marc_binary import MarcBinary
-import web, sys, codecs, re, urllib2, httplib
+import web
+import sys
+import codecs
+import re
+import urllib2
+import httplib
 from openlibrary.catalog.importer import pool
 import simplejson as json
 from openlibrary.catalog.utils.query import query_iter

--- a/openlibrary/catalog/importer/import_server.py
+++ b/openlibrary/catalog/importer/import_server.py
@@ -1,6 +1,8 @@
 #!/usr/local/bin/python2.5
 from __future__ import print_function
-import web, dbhash, sys
+import web
+import dbhash
+import sys
 import simplejson as json
 from openlibrary.catalog.load import add_keys
 from copy import deepcopy

--- a/openlibrary/catalog/importer/load.py
+++ b/openlibrary/catalog/importer/load.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import web, re, os
+import web
+import re
+import os
 from db_read import withKey
 from openlibrary.catalog.utils import flip_name, author_dates_match, key_int
 from openlibrary.catalog.utils.query import query_iter

--- a/openlibrary/catalog/importer/load_cornell.py
+++ b/openlibrary/catalog/importer/load_cornell.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
-import web, re, httplib, sys, urllib2
+import web
+import re
+import httplib
+import sys
+import urllib2
 import simplejson as json
 import openlibrary.catalog.importer.pool as pool
 from openlibrary.catalog.merge.merge_marc import build_marc

--- a/openlibrary/catalog/importer/load_scribe.py
+++ b/openlibrary/catalog/importer/load_scribe.py
@@ -1,5 +1,11 @@
 from __future__ import print_function
-import os, web, re, httplib, sys, urllib2, threading
+import os
+import web
+import re
+import httplib
+import sys
+import urllib2
+import threading
 import simplejson as json
 from lxml import etree
 import openlibrary.catalog.importer.pool as pool

--- a/openlibrary/catalog/importer/merge.py
+++ b/openlibrary/catalog/importer/merge.py
@@ -7,7 +7,8 @@ from openlibrary.catalog.importer.db_read import withKey, get_mc
 from openlibrary.api import OpenLibrary, Reference
 import openlibrary.catalog.marc.fast_parse as fast_parse
 import xml.parsers.expat
-import web, sys
+import web
+import sys
 from time import sleep
 
 import six

--- a/openlibrary/catalog/importer/scribe.py
+++ b/openlibrary/catalog/importer/scribe.py
@@ -9,7 +9,13 @@ from openlibrary.catalog.marc import is_display_marc
 from time import sleep, time
 
 import MySQLdb
-import re, urllib2, httplib, json, codecs, socket, sys
+import re
+import urllib2
+import httplib
+import json
+import codecs
+import socket
+import sys
 
 ol = OpenLibrary('http://openlibrary.org/')
 

--- a/openlibrary/catalog/importer/status.py
+++ b/openlibrary/catalog/importer/status.py
@@ -1,4 +1,5 @@
-import web, urllib2
+import web
+import urllib2
 import simplejson as json
 from pprint import pformat
 from time import time

--- a/openlibrary/catalog/importer/update.py
+++ b/openlibrary/catalog/importer/update.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import re, web, sys
+import re
+import web
+import sys
 import simplejson as json
 from urllib2 import urlopen, URLError
 from openlibrary.catalog.read_rc import read_rc

--- a/openlibrary/catalog/improve/improve_data.py
+++ b/openlibrary/catalog/improve/improve_data.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from catalog.infostore import get_site
-import sys, codecs
+import sys
+import codecs
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/openlibrary/catalog/lang.py
+++ b/openlibrary/catalog/lang.py
@@ -1,6 +1,7 @@
 import sys
 from StringIO import StringIO
-import time, re
+import time
+import re
 
 def cftime():
     t,m = divmod(time.time(), 1.0)

--- a/openlibrary/catalog/lc_updates/update.py
+++ b/openlibrary/catalog/lc_updates/update.py
@@ -2,7 +2,10 @@ from __future__ import print_function
 from urllib2 import urlopen
 from lxml.html import parse
 from openlibrary.catalog.read_rc import read_rc
-import os, sys, httplib, subprocess
+import os
+import sys
+import httplib
+import subprocess
 from time import sleep
 
 # httplib.HTTPConnection.debuglevel = 1

--- a/openlibrary/catalog/marc/all.py
+++ b/openlibrary/catalog/marc/all.py
@@ -1,6 +1,7 @@
 from openlibrary.catalog.get_ia import read_marc_file
 from openlibrary.catalog.read_rc import read_rc
-import web, os.path
+import web
+import os.path
 
 # iterate through every MARC record on disk
 

--- a/openlibrary/catalog/marc/build_db.py
+++ b/openlibrary/catalog/marc/build_db.py
@@ -4,7 +4,8 @@ from catalog.marc.fast_parse import index_fields, read_file
 from catalog.get_ia import files
 from catalog.read_rc import read_rc
 from time import time
-import os, web
+import os
+import web
 
 rc = read_rc()
 

--- a/openlibrary/catalog/marc/cmdline.py
+++ b/openlibrary/catalog/marc/cmdline.py
@@ -2,7 +2,9 @@
 from __future__ import print_function
 from openlibrary.catalog.marc.fast_parse import *
 from openlibrary.catalog.get_ia import get_from_archive
-import sys, codecs, re
+import sys
+import codecs
+import re
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/openlibrary/catalog/marc/db/by_author.py
+++ b/openlibrary/catalog/marc/db/by_author.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python2.5
-import web, re
+import web
+import re
 from catalog.utils.query import query_iter, withKey
 from web_marc_db import search_query, marc_data, esc
 from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields

--- a/openlibrary/catalog/marc/db/db_index.py
+++ b/openlibrary/catalog/marc/db/db_index.py
@@ -2,7 +2,9 @@ from __future__ import print_function
 from catalog.get_ia import read_marc_file
 from time import time
 from catalog.marc.fast_parse import index_fields, get_tag_lines
-import os, os.path, re
+import os
+import os.path
+import re
 from catalog.marc.all import all_files
 from catalog.read_rc import read_rc
 

--- a/openlibrary/catalog/marc/db/find_bad_isbn.py
+++ b/openlibrary/catalog/marc/db/find_bad_isbn.py
@@ -5,7 +5,10 @@ from catalog.read_rc import read_rc
 #from sources import sources
 from time import time
 from catalog.marc.fast_parse import index_fields, get_tag_lines
-import web, os, os.path, re
+import web
+import os
+import os.path
+import re
 
 # build an index of ISBN to MARC records
 

--- a/openlibrary/catalog/marc/db/lookup.py
+++ b/openlibrary/catalog/marc/db/lookup.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import dbhash, sys
+import dbhash
+import sys
 from catalog.read_rc import read_rc
 
 rc = read_rc()

--- a/openlibrary/catalog/marc/db/web_author.py
+++ b/openlibrary/catalog/marc/db/web_author.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import web, dbhash, re
+import web
+import dbhash
+import re
 from catalog.infostore import get_site
 from catalog.get_ia import get_data
 from catalog.read_rc import read_rc

--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -5,7 +5,10 @@ from catalog.get_ia import get_data
 from catalog.marc.build_record import build_record
 from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
 from openlibrary.catalog.utils import cmp
-import re, sys, os.path, web
+import re
+import sys
+import os.path
+import web
 from catalog.amazon.other_editions import find_others
 from catalog.utils import strip_count
 

--- a/openlibrary/catalog/marc/find_translation.py
+++ b/openlibrary/catalog/marc/find_translation.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python2.5
 from __future__ import print_function
 from catalog.marc.fast_parse import *
-import sys, codecs
+import sys
+import codecs
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/openlibrary/catalog/marc/has_001.py
+++ b/openlibrary/catalog/marc/has_001.py
@@ -4,7 +4,8 @@ from catalog.marc.fast_parse import *
 from catalog.read_rc import read_rc
 from catalog.get_ia import files
 from sources import sources
-import sys, os
+import sys
+import os
 
 rc = read_rc()
 read_count = 10000

--- a/openlibrary/catalog/marc/read_xml.py
+++ b/openlibrary/catalog/marc/read_xml.py
@@ -1,6 +1,8 @@
 import xml.etree.ElementTree as et
 import xml.parsers.expat
-import re, sys, codecs
+import re
+import sys
+import codecs
 from time import sleep
 from unicodedata import normalize
 

--- a/openlibrary/catalog/marc/simple.py
+++ b/openlibrary/catalog/marc/simple.py
@@ -5,7 +5,9 @@ from marc_binary import MarcBinary
 from pprint import pprint
 import parse
 #from parse import read_edition, SeeAlsoAsTitle, NoTitle
-import sys, codecs, re
+import sys
+import codecs
+import re
 from getopt import getopt
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)

--- a/openlibrary/catalog/marc/simple_html.py
+++ b/openlibrary/catalog/marc/simple_html.py
@@ -3,7 +3,8 @@ from __future__ import print_function
 from catalog.marc.fast_parse import *
 from html import as_html
 from build_record import build_record
-import sys, re
+import sys
+import re
 
 import six
 

--- a/openlibrary/catalog/marc/sources.py
+++ b/openlibrary/catalog/marc/sources.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 
 def find_sources():
     for p in sys.path:

--- a/openlibrary/catalog/merge/build_db.py
+++ b/openlibrary/catalog/merge/build_db.py
@@ -2,7 +2,8 @@
 # converts from text files containing MARC tags to text versions of merge pools
 
 from __future__ import print_function
-import re, anydbm
+import re
+import anydbm
 from time import time
 from collections import defaultdict
 

--- a/openlibrary/catalog/merge/load_from_json.py
+++ b/openlibrary/catalog/merge/load_from_json.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 # build a merge database from JSON dump
 
-import simplejson, re
+import simplejson
+import re
 from normalize import normalize
 from time import time
 

--- a/openlibrary/catalog/merge/merge_bot/bot.py
+++ b/openlibrary/catalog/merge/merge_bot/bot.py
@@ -3,7 +3,8 @@
 from __future__ import print_function
 import sys
 import web
-import sys, codecs
+import sys
+import codecs
 from catalog.utils.query import query_iter, set_staging, withKey
 
 from catalog.merge.merge_marc import *

--- a/openlibrary/catalog/merge/normalize.py
+++ b/openlibrary/catalog/merge/normalize.py
@@ -1,4 +1,5 @@
-import re, unicodedata
+import re
+import unicodedata
 
 import six
 

--- a/openlibrary/catalog/scratch/add_source_records.py
+++ b/openlibrary/catalog/scratch/add_source_records.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import os, re, sys, codecs
+import os
+import re
+import sys
+import codecs
 from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.importer.db_read import get_mc
 

--- a/openlibrary/catalog/scratch/count_41.py
+++ b/openlibrary/catalog/scratch/count_41.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import web, os.path
+import web
+import os.path
 from catalog.get_ia import read_marc_file
 from catalog.read_rc import read_rc
 from catalog.marc.fast_parse import get_first_tag, get_all_subfields

--- a/openlibrary/catalog/scratch/get_651.py
+++ b/openlibrary/catalog/scratch/get_651.py
@@ -1,7 +1,8 @@
 from catalog.importer.db_read import get_mc, withKey
 from catalog.get_ia import get_from_local
 from catalog.marc.fast_parse import get_tag_lines, get_all_subfields
-import sys, web
+import sys
+import web
 import simplejson as json
 
 def get_src(key):

--- a/openlibrary/catalog/scratch/remove_subject_period.py
+++ b/openlibrary/catalog/scratch/remove_subject_period.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 from catalog.utils.query import query_iter, set_staging, withKey
-import sys, codecs, re
+import sys
+import codecs
+import re
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, Reference
 from catalog.read_rc import read_rc

--- a/openlibrary/catalog/scratch/work_author_role.py
+++ b/openlibrary/catalog/scratch/work_author_role.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import sys, codecs
+import sys
+import codecs
 from openlibrary.catalog.utils.query import query_iter, set_staging, query
 from openlibrary.api import OpenLibrary, Reference
 from openlibrary.catalog.read_rc import read_rc

--- a/openlibrary/catalog/solr/solr.py
+++ b/openlibrary/catalog/solr/solr.py
@@ -2,7 +2,10 @@
 
 from __future__ import print_function
 from time import sleep, time
-import urllib, web, subprocess, sys
+import urllib
+import web
+import subprocess
+import sys
 from catalog.read_rc import read_rc
 
 rc = read_rc()

--- a/openlibrary/catalog/title_page_img/load.py
+++ b/openlibrary/catalog/title_page_img/load.py
@@ -1,5 +1,7 @@
 from openlibrary.catalog.read_rc import read_rc
-import urllib, httplib, json
+import urllib
+import httplib
+import json
 
 rc = read_rc()
 

--- a/openlibrary/catalog/title_page_img/replace_cover_with_title.py
+++ b/openlibrary/catalog/title_page_img/replace_cover_with_title.py
@@ -3,9 +3,13 @@ from openlibrary.utils.ia import find_item
 from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.utils.query import query, withKey, has_cover
 from subprocess import Popen, PIPE
-import web, re, urllib, sys
+import web
+import re
+import urllib
+import sys
 import xml.etree.ElementTree as et
-import xml.parsers.expat, socket # for exceptions
+import xml.parsers.expat
+import socket  # for exceptions
 import httplib
 from time import sleep
 

--- a/openlibrary/catalog/treasury/parse.py
+++ b/openlibrary/catalog/treasury/parse.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import re, sys
+import re
+import sys
 import xml.etree.ElementTree as et
 from pprint import pprint
 

--- a/openlibrary/catalog/update_count.py
+++ b/openlibrary/catalog/update_count.py
@@ -1,7 +1,10 @@
 from olwrite import Infogami, add_to_database
-import web, dbhash
+import web
+import dbhash
 from read_rc import read_rc
-import cjson, re, sys
+import cjson
+import re
+import sys
 from time import time
 
 def commify(n):

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-import re, web
+import re
+import web
 from unicodedata import normalize
 import openlibrary.catalog.merge.normalize as merge
 

--- a/openlibrary/catalog/utils/authority.py
+++ b/openlibrary/catalog/utils/authority.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from mechanize import Browser
-import re, os.path
+import re
+import os.path
 from openlibrary.catalog.read_rc import read_rc
 
 rc = read_rc()

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import re, web
+import re
+import web
 import json
 import urllib2
 from openlibrary.catalog.importer.db_read import get_mc

--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import urllib, urllib2
+import urllib
+import urllib2
 import web
 import simplejson as json
 from time import sleep

--- a/openlibrary/catalog/wikipedia/find_ol_authors.py
+++ b/openlibrary/catalog/wikipedia/find_ol_authors.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 from catalog.utils import pick_first_date
-import web, re, sys, codecs
+import web
+import re
+import sys
+import codecs
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
 re_marc_name = re.compile('^(.*), (.*)$')

--- a/openlibrary/catalog/wikipedia/lookup.py
+++ b/openlibrary/catalog/wikipedia/lookup.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import web, re, codecs, sys
+import web
+import re
+import codecs
+import sys
 from time import time
 from catalog.marc.fast_parse import get_subfields, get_all_subfields, get_subfield_values
 from catalog.utils import pick_first_date

--- a/openlibrary/catalog/wikipedia/process.py
+++ b/openlibrary/catalog/wikipedia/process.py
@@ -1,6 +1,9 @@
 # coding=utf8
 from __future__ import print_function
-import bz2, codecs, sys, re
+import bz2
+import codecs
+import sys
+import re
 import simplejson as json
 from catalog.marc.fast_parse import get_subfields, get_all_subfields, get_subfield_values
 from unicodedata import normalize

--- a/openlibrary/catalog/wikipedia/read.py
+++ b/openlibrary/catalog/wikipedia/read.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import sys, codecs, re
+import sys
+import codecs
+import re
 from catalog.marc.fast_parse import translate
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/openlibrary/catalog/wikipedia/tidy.py
+++ b/openlibrary/catalog/wikipedia/tidy.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import bz2, codecs, sys, re
+import bz2
+import codecs
+import sys
+import re
 import simplejson as json
 from catalog.marc.fast_parse import get_subfields, get_all_subfields, get_subfield_values
 from unicodedata import normalize

--- a/openlibrary/catalog/works/add_fields_to_works.py
+++ b/openlibrary/catalog/works/add_fields_to_works.py
@@ -1,6 +1,9 @@
 #!/usr/local/bin/python2.5
 from __future__ import print_function
-import sys, urllib, re, codecs
+import sys
+import urllib
+import re
+import codecs
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary
 import simplejson as json

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -1,6 +1,9 @@
 #!/usr/local/bin/python2.5
 from __future__ import print_function
-import re, sys, codecs, web
+import re
+import sys
+import codecs
+import web
 from openlibrary.catalog.get_ia import get_from_archive
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields
 from openlibrary.catalog.utils.query import query_iter, set_staging, query

--- a/openlibrary/catalog/works/find.py
+++ b/openlibrary/catalog/works/find.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-import web, re, sys
+import web
+import re
+import sys
 from catalog.read_rc import read_rc
 from catalog.infostore import get_site
 #from catalog.db_read import get_things, withKey

--- a/openlibrary/catalog/works/find_other_editions.py
+++ b/openlibrary/catalog/works/find_other_editions.py
@@ -1,6 +1,7 @@
 #!/usr/local/bin/python2.5
 from __future__ import print_function
-import sys, codecs
+import sys
+import codecs
 from catalog.merge.names import match_name
 from catalog.utils import fmt_author, get_title, mk_norm
 from catalog.utils.query import query_iter, set_staging, withKey

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -3,7 +3,10 @@
 # find works and create pages on production
 
 from __future__ import print_function
-import re, sys, web, urllib2
+import re
+import sys
+import web
+import urllib2
 from openlibrary.solr.update_work import update_work, solr_update, update_author
 from openlibrary.catalog.get_ia import get_from_archive, get_data
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary

--- a/openlibrary/catalog/works/from_sample.py
+++ b/openlibrary/catalog/works/from_sample.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-import web, re, sys, codecs
+import web
+import re
+import sys
+import codecs
 from catalog.marc.fast_parse import *
 from catalog.utils import pick_first_date
 import catalog.marc.new_parser as parser

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -3,7 +3,10 @@
 # find works and create pages on production
 
 from __future__ import print_function
-import re, sys, codecs, web
+import re
+import sys
+import codecs
+import web
 from openlibrary.catalog.get_ia import get_from_archive, get_data
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary
 from openlibrary.catalog.utils.query import query_iter, set_staging, query

--- a/openlibrary/catalog/works/load_to_staging.py
+++ b/openlibrary/catalog/works/load_to_staging.py
@@ -4,7 +4,9 @@ sys.path.remove('/usr/local/lib/python2.5/site-packages/web.py-0.23-py2.5.egg')
 from staging_save import Infogami
 from catalog.read_rc import read_rc
 import catalog.importer.db_read as db_read
-import re, sys, codecs
+import re
+import sys
+import codecs
 
 db_read.set_staging(True)
 

--- a/openlibrary/catalog/works/use_amazon.py
+++ b/openlibrary/catalog/works/use_amazon.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
-import os, re, sys, codecs, dbhash
+import os
+import re
+import sys
+import codecs
+import dbhash
 from catalog.amazon.other_editions import find_others
 from catalog.infostore import get_site
 from catalog.read_rc import read_rc

--- a/openlibrary/catalog/works/use_amazon2.py
+++ b/openlibrary/catalog/works/use_amazon2.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
-import os, re, sys, codecs, dbhash
+import os
+import re
+import sys
+import codecs
+import dbhash
 from catalog.amazon.other_editions import find_others
 from catalog.infostore import get_site
 from catalog.read_rc import read_rc

--- a/openlibrary/catalog/works/web_ui.py
+++ b/openlibrary/catalog/works/web_ui.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import web, re
+import web
+import re
 from time import time
 from catalog.read_rc import read_rc
 from catalog.infostore import get_site

--- a/openlibrary/code.py
+++ b/openlibrary/code.py
@@ -3,8 +3,10 @@
 Loaded from Infogami plugin mechanism.
 """
 from __future__ import print_function
-import sys, os
-import logging, logging.config
+import sys
+import os
+import logging
+import logging.config
 
 from infogami.utils import template, macro, i18n, delegate
 import infogami

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -6,7 +6,10 @@ import urlparse
 import string
 import re
 
-import babel, babel.core, babel.dates, babel.numbers
+import babel
+import babel.core
+import babel.dates
+import babel.numbers
 
 try:
     import genshi

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 import datetime
 import re
 import time
-import urllib, urllib2
+import urllib
+import urllib2
 
 import simplejson
 import web

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1,6 +1,7 @@
 """Models of various OL objects.
 """
-import urllib, urllib2
+import urllib
+import urllib2
 import simplejson
 import web
 import re

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -14,7 +14,8 @@ Each waiting instance is represented as a document in the store as follows:
 """
 import datetime
 import logging
-import urllib, urllib2
+import urllib
+import urllib2
 import json
 import web
 from infogami import config

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -8,7 +8,8 @@ Glossary:
 """
 from __future__ import print_function
 
-import sys, os
+import sys
+import os
 import web
 import re
 import time

--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -14,7 +14,8 @@ http://www.archive.org/download/ol-sitemaps/sitindex-subjects.xml.gz
 """
 from __future__ import print_function
 
-import sys, os
+import sys
+import os
 import web
 import datetime
 from gzip import open as gzopen

--- a/openlibrary/data/solr.py
+++ b/openlibrary/data/solr.py
@@ -1,7 +1,8 @@
 """Library to process edition, work and author records and emit (key, property, value) triples that can be combined later for solr indexing.
 """
 from __future__ import print_function
-import os, sys
+import os
+import sys
 import re
 import web
 import simplejson

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -5,7 +5,8 @@ import sys
 import web
 import subprocess
 import datetime
-import urllib, urllib2
+import urllib
+import urllib2
 import traceback
 import logging
 import simplejson

--- a/openlibrary/plugins/akismet/akismet.py
+++ b/openlibrary/plugins/akismet/akismet.py
@@ -37,7 +37,8 @@ Whatever you pass in, will replace the *Python Interface by Fuzzyman* part.
 
 """
 from __future__ import print_function
-import os, sys
+import os
+import sys
 import urllib2
 from urllib import urlencode
 

--- a/openlibrary/plugins/bookrev/code.py
+++ b/openlibrary/plugins/bookrev/code.py
@@ -1,11 +1,16 @@
 """
 Book reviews plugin.
 """
-import web, infogami
+import web
+import infogami
 from infogami.utils import delegate
 from infogami.utils.template import render
 
-import db, dev, forms, reviewsources, utils
+import db
+import dev
+import forms
+import reviewsources
+import utils
 import schema as _
 
 @infogami.action

--- a/openlibrary/plugins/bookrev/dev.py
+++ b/openlibrary/plugins/bookrev/dev.py
@@ -1,8 +1,11 @@
 from __future__ import print_function
-import web, infogami
+import web
+import infogami
 from infogami import tdb
 
-import db, reviewsources, utils
+import db
+import reviewsources
+import utils
 
 from six.moves import input
 

--- a/openlibrary/plugins/copyright/copyrightstatus/__init__.py
+++ b/openlibrary/plugins/copyright/copyrightstatus/__init__.py
@@ -28,7 +28,8 @@ of assumptions made in calculating this.
 
 import os
 
-import ca, us
+import ca
+import us
 _countries = {'ca': ca, 'us': us}
 
 # Walk through country-level public domain tests

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -6,10 +6,12 @@ import os
 import datetime
 import urllib
 import simplejson
-import logging, logging.config
+import logging
+import logging.config
 import sys
 import traceback
-import re, unicodedata
+import re
+import unicodedata
 
 import six
 import web

--- a/openlibrary/plugins/openlibrary/merge_editions.py
+++ b/openlibrary/plugins/openlibrary/merge_editions.py
@@ -1,5 +1,6 @@
 'Merge editions'
-import web, re
+import web
+import re
 from openlibrary.utils import uniq, dicthash
 from infogami.utils import delegate
 from infogami.utils.view import render_template

--- a/openlibrary/plugins/openlibrary/tests/test_listapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_listapi.py
@@ -3,7 +3,8 @@ from py.test import config
 import web
 import simplejson
 
-import urllib, urllib2
+import urllib
+import urllib2
 import cookielib
 
 def pytest_funcarg__config(request):

--- a/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
@@ -2,7 +2,8 @@ from py.test import config
 import web
 import simplejson
 
-import urllib, urllib2
+import urllib
+import urllib2
 import cookielib
 
 from openlibrary.plugins.openlibrary.api import ratings

--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -10,7 +10,8 @@ from infogami.utils import view, template
 from infogami import config
 from infogami.plugins.api.code import jsonapi
 
-import re, web
+import re
+import web
 import solr_client
 import time
 import simplejson

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -2,7 +2,8 @@
 from urllib import quote_plus, urlopen
 from xml.etree.cElementTree import ElementTree
 from cStringIO import StringIO
-import os, re
+import os
+import re
 from collections import defaultdict
 import cgi
 import web

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -4,7 +4,8 @@ import logging
 import random
 import urllib
 import uuid
-import datetime, time
+import datetime
+import time
 import simplejson
 
 from infogami.utils import delegate

--- a/openlibrary/plugins/upstream/adapter.py
+++ b/openlibrary/plugins/upstream/adapter.py
@@ -8,7 +8,8 @@ Upstream requires:
 
 This adapter module is a filter that sits above an Infobase server and fakes the new URL structure.
 """
-import urllib, urllib2
+import urllib
+import urllib2
 import simplejson
 import web
 
@@ -249,7 +250,8 @@ class account(proxy):
             i.username = convert_key(i.username)
 
 def main():
-    import sys, os
+    import sys
+    import os
     web.config.infobase_server = sys.argv[1].rstrip('/')
     os.environ['REAL_SCRIPT_NAME'] = ''
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1,7 +1,8 @@
 """Handlers for adding and editing books."""
 
 import web
-import urllib, urllib2
+import urllib
+import urllib2
 import simplejson
 from collections import defaultdict
 from StringIO import StringIO

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -1,7 +1,8 @@
 """Handlers for borrowing books"""
 
 import copy
-import datetime, time
+import datetime
+import time
 import hmac
 import re
 import simplejson

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -1,6 +1,7 @@
 """Handle book cover/author photo upload.
 """
-import urllib, urllib2
+import urllib
+import urllib2
 import web
 import simplejson
 

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -1,6 +1,7 @@
 """Merge authors.
 """
-import web, re
+import web
+import re
 import simplejson
 from infogami.utils import delegate
 from infogami.utils.view import render_template, safeint

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1,6 +1,8 @@
 import web
 import simplejson
-import babel, babel.core, babel.dates
+import babel
+import babel.core
+import babel.dates
 from UserDict import DictMixin
 from collections import defaultdict
 import re

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1,4 +1,7 @@
-import web, re, urllib, urllib2
+import web
+import re
+import urllib
+import urllib2
 from lxml.etree import XML, XMLSyntaxError
 from infogami.utils import delegate, stats
 from infogami import config

--- a/openlibrary/solr/db_load_authors.py
+++ b/openlibrary/solr/db_load_authors.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import simplejson as json
-import web, re
+import web
+import re
 
 re_author_key = re.compile('^/a/OL(\d+)A$')
 

--- a/openlibrary/solr/db_load_works.py
+++ b/openlibrary/solr/db_load_works.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import web, re
+import web
+import re
 import simplejson as json
 
 db = web.database(dbn='mysql', user='root', passwd='', db='openlibrary')

--- a/openlibrary/solr/inside/index_all.py
+++ b/openlibrary/solr/inside/index_all.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 from Queue import Queue
-import threading, datetime, re, httplib
+import threading
+import datetime
+import re
+import httplib
 from collections import defaultdict
 from socket import socket, AF_INET, SOCK_DGRAM, SOL_UDP, SO_BROADCAST, timeout
 from urllib import urlopen

--- a/openlibrary/solr/inside/index_gevent.py
+++ b/openlibrary/solr/inside/index_gevent.py
@@ -3,7 +3,12 @@ from gevent import sleep, spawn, spawn_link_exception, monkey
 from gevent.queue import JoinableQueue
 from datetime import datetime
 monkey.patch_socket()
-import re, httplib, json, sys, os, codecs
+import re
+import httplib
+import json
+import sys
+import os
+import codecs
 from openlibrary.utils.ia import find_item
 from time import time
 from collections import defaultdict

--- a/openlibrary/solr/work_subject.py
+++ b/openlibrary/solr/work_subject.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import re, urllib2
+import re
+import urllib2
 from openlibrary.catalog.marc.fast_parse import get_tag_lines, get_all_subfields, get_subfield_values, get_subfields, BadDictionary
 from openlibrary.catalog.utils import remove_trailing_dot, remove_trailing_number_dot, flip_name
 from openlibrary.catalog.importer.db_read import get_mc

--- a/openlibrary/tests/core/mocklib.py
+++ b/openlibrary/tests/core/mocklib.py
@@ -1,6 +1,7 @@
 """Simple mock utility.
 """
-import urllib, urllib2
+import urllib
+import urllib2
 from StringIO import StringIO
 
 class Mock:

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -1,7 +1,8 @@
 """Python library for accessing Solr.
 """
 import urlparse
-import urllib, urllib2
+import urllib
+import urllib2
 import re
 import web
 import simplejson

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -6,7 +6,8 @@ from .. import app
 import web
 import urllib2
 import os.path
-import sys, re
+import sys
+import re
 
 class old_show_marc(app.view):
     path = "/show-marc/(.*)"

--- a/scripts/lc_marc_update.py
+++ b/scripts/lc_marc_update.py
@@ -7,7 +7,11 @@ from openlibrary import config
 from ftplib import FTP
 from time import sleep
 from lxml import etree
-import os, sys, httplib, json, argparse
+import os
+import sys
+import httplib
+import json
+import argparse
 
 parser = argparse.ArgumentParser(description='Library of Congress MARC update')
 parser.add_argument('--config', default='openlibrary.yml')

--- a/scripts/mail_bad_author_query.py
+++ b/scripts/mail_bad_author_query.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
-import web, os, smtplib, sys
+import web
+import os
+import smtplib
+import sys
 from email.mime.text import MIMEText
 
 password = open(os.path.expanduser('~/.openlibrary_db_password')).read()

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -13,7 +13,8 @@ import _init_path
 import yaml
 import logging
 import json
-import urllib, urllib2
+import urllib
+import urllib2
 import argparse
 import datetime
 import time

--- a/scripts/ol-solr-indexer.py
+++ b/scripts/ol-solr-indexer.py
@@ -14,7 +14,9 @@ __version__ = "0.1"
 
 import _init_path
 
-import sys, os, re
+import sys
+import os
+import re
 import logging
 import argparse
 import math

--- a/scripts/solr_author_merge_work_finder.py
+++ b/scripts/solr_author_merge_work_finder.py
@@ -4,7 +4,9 @@ from __future__ import print_function
 import _init_path
 
 from openlibrary import config
-import argparse, simplejson, re
+import argparse
+import simplejson
+import re
 import sys
 from urllib import urlopen
 from urllib2 import URLError

--- a/scripts/view_marc.py
+++ b/scripts/view_marc.py
@@ -2,7 +2,9 @@
 from __future__ import print_function
 from openlibrary.catalog.marc.fast_parse import *
 from openlibrary.catalog.get_ia import get_from_archive
-import sys, codecs, re
+import sys
+import codecs
+import re
 
 sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 

--- a/scripts/z3950_view.py
+++ b/scripts/z3950_view.py
@@ -1,7 +1,8 @@
 import web
 from PyZ3950 import zoom
 from lxml import etree
-import sys, re
+import sys
+import re
 from urllib import urlopen
 from openlibrary.catalog.marc.html import html_record
 from openlibrary.catalog.marc import xml_to_html

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
-import glob, os
+import glob
+import os
 from stat import *
 
 def executable(path):


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Fixes the Python anti-pattern of multiple imports on one line.
* https://lintlyci.github.io/Flake8Rules/rules/E401.html

> **Technical**: What should be noted about the implementation?

This helps us understand [which dependencies are actually imported](https://github.com/cclauss/What-are-my-Python-imports/blob/master/output.txt).

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

Test: __flake8 --exclude=./scripts/20* --select=E401 .__

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:
