### PR TITLE
Try to slim down Python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,35 +1,35 @@
 -r requirements_common.txt
 
-Fabric==1.10.1; python_version < '3.0'
+# Fabric==1.10.1; python_version < '3.0'
 Jinja2==2.10
 Pillow==5.3.0
-backports.shutil-get-terminal-size==1.0.0
-bottlenose==1.1.2
-clint==0.5.1
-decorator==4.0.10
-docopt==0.6.2
-docutils==0.8.1
-ecdsa==0.11
+# backports.shutil-get-terminal-size==1.0.0
+# bottlenose==1.1.2
+# clint==0.5.1
+# decorator==4.0.10
+# docopt==0.6.2
+# docutils==0.8.1
+# ecdsa==0.11
 enum34==1.1.6
 ipython==5.1.0
 ipython-genutils==0.1.0
-jsonpatch==0.4
-kombu==1.5.1
-meld3==0.6.7
-ndg-httpsclient==0.4.2
+# jsonpatch==0.4
+# kombu==1.5.1
+# meld3==0.6.7
+# ndg-httpsclient==0.4.2
 -e git+git@github.com:internetarchive/openlibrary.git@997a268222a2256876c1bd3296c96f982c29fd37#egg=openlibrary-origin/HEAD
-pathlib2==2.1.0
-pexpect==4.2.1
-pickleshare==0.7.4
-prompt-toolkit==1.0.9
-ptyprocess==0.5.1
+# pathlib2==2.1.0
+# pexpect==4.2.1
+# pickleshare==0.7.4
+# prompt-toolkit==1.0.9
+# ptyprocess==0.5.1
 py==1.4.5
-pyOpenSSL==17.5.0
+# pyOpenSSL==17.5.0
 pyasn1==0.1.9
 python-dateutil==1.5
 requests==2.20.0
 schema==0.5.0
-simplegeneric==0.8.1
-traitlets==4.3.1
-wcwidth==0.1.7
+# simplegeneric==0.8.1
+# traitlets==4.3.1
+# wcwidth==0.1.7
 wsgiref==0.1.2

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -7,11 +7,10 @@ gunicorn==19.9.0
 iptools==0.6.1; python_version < '3.0'
 internetarchive==1.8.1
 lxml==4.2.5
-pyflakes==2.0.0
 pymarc==3.1.11
 python-memcached==1.59
 simplejson==3.16.0
-supervisor==3.0a12; python_version < '3.0'
+# supervisor==3.0a12; python_version < '3.0'
 web.py==0.33; python_version < '3.0'
 web.py==0.40-dev1; python_version >= '3.0'
 pystatsd==0.1.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,5 @@
 
 -r requirements_common.txt
 flake8==3.6.0
-pytest==4.0.1
+pytest==4.0.2
 mockcache==1.0.3; python_version < '3.0'


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Try to remove unnecessary Python dependencies which are being loaded in our __requirements*.txt__ files.  This process takes the work done in #1771 combined with [what Python imports we make](https://github.com/cclauss/What-are-my-Python-imports/blob/master/output.txt) to try to remove unused dependencies.   The command __grep -r <module_name> .__ was also run to see if each  module was referred to anywhere in the repo.  A conservative approach was taken on modules like __ipython__ so perhaps further slimming is possible.

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

