### PR TITLE
fixes misc python errors

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -257,13 +257,18 @@ def get_realtime_availability_of_ocaid(ocaid):
 def add_availability(editions):
     """Adds API v2 availability info to editions, e.g. for work's editions table
     """
-
-    ocaids = [ed.get('ocaid') or ed.ia[0] for ed in editions if (ed.get('ia') or ed.get('ocaid'))]
+    ocaids = [
+        (ed.get('ocaid') or ed.ia[0]) for ed in editions if
+        (ed.get('ia') or ed.get('ocaid'))
+    ]
     availability = get_availability_of_ocaids(ocaids)
     for i, ed in enumerate(editions):
+        ocaid = None
         if ed.get('ocaid') or ed.get('ia'):
             ocaid = ed.get('ocaid') or ed.get('ia')[0]
-            editions[i]['availability'] = availability.get(ocaid)
+        editions[i]['availability'] = availability.get(ocaid) if ocaid else {
+            'status': 'error'
+        }
     return editions
 
 @public

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -14,7 +14,7 @@ from openlibrary import accounts
 from openlibrary.utils.isbn import isbn_10_to_isbn_13, normalize_isbn
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.plugins.worksearch.subjects import get_subject
-from openlibrary.core import ia, db, models, lending, cache, helpers as h
+from openlibrary.core import ia, db, models, lending, helpers as h
 from openlibrary.catalog.add_book import load
 from openlibrary.core.vendors import (
     get_amazon_metadata, clean_amazon_metadata_for_load,

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -103,7 +103,11 @@ def generic_carousel(query=None, subject=None, work_id=None, _type=None,
     books = cached_ia_carousel_books(
         query=query, subject=subject, work_id=work_id, _type=_type,
         sorts=sorts, limit=limit)
-    return storify(books)
+    if not books:
+        books = cached_ia_carousel_books.update(
+            query=query, subject=subject, work_id=work_id, _type=_type,
+            sorts=sorts, limit=limit)[0]
+    return storify(books) if books else books
 
 @public
 def readonline_carousel():

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -620,12 +620,12 @@ class Work(models.Work):
         w = self._solr_data
         editions = w.get('edition_key') if w else []
 
-        # solr is stale
-        if len(editions) != self.edition_count:
-            q = {"type": "/type/edition", "works": self.key, "limit": 10000}
-            editions = [k[len("/books/"):] for k in web.ctx.site.things(q)]
-
         if editions:
+            # solr is stale
+            if len(editions) != self.edition_count:
+                q = {"type": "/type/edition", "works": self.key, "limit": 10000}
+                editions = [k[len("/books/"):] for k in web.ctx.site.things(q)]
+
             books = web.ctx.site.get_many(["/books/" + olid for olid in editions])
 
             availability = lending.get_availability_of_ocaids([

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,4 +1,4 @@
-$def with(books=None, title="", url="", key="", min_books=1, test=False)
+$def with(books=[], title="", url="", key="", min_books=1, test=False)
 
 $def render_carousel_cover(book, lazy):
   $ url = book.get('key') or book.url

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -1,7 +1,7 @@
 $def with (page)
 <div class="head">
     <h2>
-    $commify(page.edition_count) $cond(page.edition_count > 1, "editions", "edition")
+    $commify(page.edition_count) $cond(page.edition_count != 1, "editions", "edition")
     $if page.first_publish_year:
         <span class="count">$_("First published in %s", page.first_publish_year)</span>
     </h2>


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

- python errors due to cache miss
- len(editions) check when editions None
- editions pluralization on works page (for len(works)==1)
- prepares search results for showing "no ebook available" disabled btn