### PR TITLE
Use large images on author and books page for og:image tag

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -41,7 +41,7 @@ $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and qu
 
 $ title = page.get('name', 'name missing')
 $ title_with_site = title + " | Open Library"
-$ meta_photo_url = item_image(page.get_photo_url("M"), "https://openlibrary.org/images/icons/avatar_author-lg.png")
+$ meta_photo_url = item_image(page.get_photo_url("L"), "https://openlibrary.org/images/icons/avatar_author-lg.png")
 
 $var title: $title
 $var history: $page.history

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -7,7 +7,7 @@ $ book_subtitle = page.subtitle if page.get('subtitle') else (work.subtitle if w
 $ title_suffix = cond(page.publish_date, u"({0} edition)".format(page.publish_date), "(edition)")
 $ title = book_title + " " + title_suffix
 $ title_with_site = title + " | Open Library"
-$ meta_cover_url = item_image(page.get_cover_url("M"), default="https://openlibrary.org/images/icons/avatar_book-sm.png")
+$ meta_cover_url = item_image(page.get_cover_url("L"), default="https://openlibrary.org/images/icons/avatar_book-sm.png")
 $ _x = ctx.setdefault('bodyid', 'book')
 $var title: $title
 


### PR DESCRIPTION
The medium sized images falls under the guidelines for Facebook
and on social media the better quality the image the better (clients
for both Facebook and Twitter scale these down as necessary)

Fixes: #1778

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

