### PR TITLE
Author search fixes

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -11,6 +11,7 @@ $ offset = (page - 1) * results_per_page
 
 $var title: Search Open Library for "$q"
 
+<div id="contentBody">
 <div id="contentHead">
     $if q:
         $ results = get_results(q, offset=offset, limit=results_per_page)
@@ -74,4 +75,6 @@ $var title: Search Open Library for "$q"
         </ul>
 
         $:macros.Pager(page, num_found, results_per_page)
+</div>
+<div class="clearfix"></div>
 </div>

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1736,11 +1736,12 @@ div#searchResults {
   }
 }
 
+// Results on /search/authors
 .authorList {
   margin-top: 30px;
   li {
     margin-bottom: 1.5em;
-    width: 800px;
+    max-width: 800px;
     font-size: 1em;
     color: @grey;
   }


### PR DESCRIPTION
Search results on authors should not break mobile display
    
Fixes: #1786

Wrap Author search results in contentBody

A clear fix is added to cancel floating on tablets/desktop
Fixes: #1790
