### PR TITLE
Header-bar class to avoid donate banner hack

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,6 +1,6 @@
 $def with (page)
 
-<header id="header-bar">
+<header id="header-bar" class="header-bar">
   <div class="hamburger-component">
     <button type="button" class="hamburger-button"><img src="/static/images/menu.png" alt="additional options menu"/></button>
     <div class="hamburger-dropdown-component navigation-dropdown-component">

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -109,5 +109,3 @@ table {
     display: table;
   }
 }
-
-#donate_banner { max-width:100%; }

--- a/static/css/components/header-bar--desktop.less
+++ b/static/css/components/header-bar--desktop.less
@@ -1,4 +1,4 @@
-header {
+.header-bar {
   margin: 20px auto;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
@@ -46,7 +46,7 @@ header {
       display: block;
     }
     li {
-      // stylelint-disable-next-line max-nesting-depth
+      // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
       .dropdown-menu {
         width: auto;
         white-space: nowrap;

--- a/static/css/components/header-bar--tablet.less
+++ b/static/css/components/header-bar--tablet.less
@@ -1,4 +1,4 @@
-header {
+.header-bar {
   .auth-component {
     .hide-me {
       display: inline;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -10,7 +10,7 @@
 
 @import (less) "less/z-index.less";
 
-header {
+.header-bar {
   max-width: 960px;
   min-width: 300px;
   margin: 0 auto;
@@ -54,7 +54,7 @@ header {
       padding-top: 5px;
       right: 11px;
 
-      // stylelint-disable-next-line max-nesting-depth
+      // stylelint-disable-next-line max-nesting-depth, selector-max-specificity
       ul a li {
         width: 150px;
         text-decoration: none;
@@ -103,7 +103,7 @@ header {
       border-bottom: 1px solid @beige-two;
       padding-right: 20px;
 
-      // stylelint-disable max-nesting-depth
+      // stylelint-disable max-nesting-depth, selector-max-specificity
       &:last-child {
         border: none;
       }
@@ -119,7 +119,7 @@ header {
         padding: 10px;
         display: block;
       }
-      // stylelint-enable max-nesting-depth
+      // stylelint-enable max-nesting-depth, selector-max-specificity
     }
   }
 
@@ -186,7 +186,7 @@ header {
       padding: 5px 0;
       font-size: 1em;
 
-      // stylelint-disable max-nesting-depth
+      // stylelint-disable max-nesting-depth, selector-max-specificity
       a {
         color: @dark-grey;
         text-decoration: none;
@@ -214,7 +214,7 @@ header {
         position: relative;
       }
     }
-    // stylelint-enable max-nesting-depth
+    // stylelint-enable max-nesting-depth, selector-max-specificity
   }
 
   .search-component {
@@ -386,6 +386,7 @@ header {
       font-weight: 500;
       color: @grey;
 
+      // stylelint-disable-next-line selector-max-specificity
       select {
         font-size: inherit;
         font-family: inherit;
@@ -407,6 +408,7 @@ header {
       min-width: 20px;
 
       padding-right: 10px;
+      // stylelint-disable-next-line selector-max-specificity
       &::after {
         position: absolute;
         top: 50%;


### PR DESCRIPTION
Follow up to f0514f94
The donate banner hack uses a header element so the styles inside
header-bar are too generic. We don't want to restore the id selector
as id's are restrictive and not reusable rules (while we probably don't want more
than one header-bar... you never know.

So instead, we add a new class header-bar on the element and use that
for styling

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

