### PR TITLE
Read-Panel price table

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -90,10 +90,6 @@ div.head {
     font-size: 12px;
   }
 }
-table {
-  overflow: auto;
-  display: block;
-}
 
 #contentBody {
   li {
@@ -104,8 +100,14 @@ table {
   }
 }
 
-@media only screen and (min-width: @width-breakpoint-tablet) {
+@media only screen and (max-width: @width-breakpoint-tablet) {
+  tr,
+  tbody,
   table {
-    display: table;
+    overflow: auto;
+    display: block;
+  }
+  td {
+    display: inline-block;
   }
 }

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -60,6 +60,7 @@
   }
   td {
     text-align: left;
+    width: 49%;
     &.price {
       text-align: right;
     }


### PR DESCRIPTION
Alter the rules around tables on mobile - they remain display
block but we reverse the media query and apply block to the other
table elements.

A rule is needed in read-panel to ensure that the columns take up
50% of the space for the price table.

Fixes: #1752

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

