### PR TITLE
Remove vagrant from .ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.vagrant
 .git/objects/*
 solr-update*
 errors

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ TAGS
 env/
 .coverage
 htmlcov
-.vagrant
 .DS_Store
 .cache
 node_modules/


### PR DESCRIPTION
**Description**: Remove vagrant from .ignore files [refactor]

**Technical**: You should now delete the .vagrant folders (run `vagrant destroy` first!), if you still have them! Don't accidentally commit them :P

Progress towards #1134 