### PR TITLE
Prevent work edits when moving an edition

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -91,6 +91,7 @@ window.q.push( function(){
 <div id="contentBody">
     <form method="post" id="addWork" class="olform books validate" name="edit" action="">
 
+        <input type="hidden" name="work--key" value="$work.key">
     <div class="formElement title">
         <div class="TitleAuthor sansserif">
             <div class="label">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -175,7 +175,7 @@ window.q.push(function() {
                     ($("like")
                     <a href="/works/OL262757W" target="_blank"><em>OL262757W</em></a>).
                     <br/>
-                    $:_("WARNING: Any edits made to the work from this page will be applied to the <b>old work</b>.")
+                    $:_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
             <div id="works">


### PR DESCRIPTION
**Description**: Edits to a work are ignored if moving an edition.

Closes #1662

**Testing**: I'll run the following manual tests on dev as well. @hornc Any direction on how/where these tests could be added to the code?

| Test | Local | Dev |
|------|-------|-----|
| Editing a work | ✔️ | |
| Editing an edition | ✔️ | |
| Moving Edition | ✔️ | |
| Edits to Work are ignored when moving an edition | ✔️ | |
| Spamming save button when moving edition doesn't strip work of data | ✔️ | |
| Editing a work and an edition at the same time | ✔️ | |