### PR TITLE
Legacy rules cleanup

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -197,7 +197,7 @@ $if ctx.user and ctx.user.is_admin():
                 <ul class="readers-stats">
                   $if rating_stats and rating_stats['avg_rating'] > 0 and rating_stats['num_ratings'] > 1:
                     <li class="avg-ratings">
-                      $:('<span class="star">★</span>' * int(rating_stats['avg_rating'])) $(rating_stats['avg_rating'])
+                      $:('<span class="readers-stats__star">★</span>' * int(rating_stats['avg_rating'])) $(rating_stats['avg_rating'])
                     </li>
                     <li>
                       $rating_stats['num_ratings'] Ratings

--- a/static/css/components/illustration.less
+++ b/static/css/components/illustration.less
@@ -10,6 +10,8 @@
   position: relative;
   img {
     width: 180px;
+    border-radius: 5px;
+    box-shadow: 1px 1px 2px 0 @book-cover-shadow-color;
   }
   .SRPCoverBlank {
     position: relative;

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -18,4 +18,8 @@
       margin: 0 5px;
     }
   }
+  &__star {
+    color: @steel-blue;
+    font-size: 1.3em;
+  }
 }

--- a/static/css/components/ui-tabs.less
+++ b/static/css/components/ui-tabs.less
@@ -133,3 +133,12 @@
     padding: 15px 30px 20px !important;
   }
 }
+
+/* Caution! Ensure accessibility in print and other media types... */
+@media projection, screen, print {
+  /* Use class for showing/hiding tab content,
+  so that visibility can be better controlled in different media types... */
+  .ui-tabs-hide {
+    display: none;
+  }
+}

--- a/static/css/js-all.less
+++ b/static/css/js-all.less
@@ -8,6 +8,7 @@
 @import (less) 'less/index.less';
 
 @import (less) 'legacy-datatables.less';
+@import (less) 'legacy-jquery-ui.less';
 
 @import (less) 'components/carousel--js.less';
 @import (less) 'components/header-bar--js.less';

--- a/static/css/js-all.less
+++ b/static/css/js-all.less
@@ -27,6 +27,23 @@
 
 @import (less) 'components/wmd-prompt-dialog--js.less';
 
+// openlibrary/plugins/openlibrary/js/subjects.js
+.coverEbook {
+  cursor: pointer;
+  z-index: @z-index-level-6;
+  img {
+    opacity: .85;
+    filter: alpha(opacity=85);
+  }
+  a.cta-btn {
+    position: absolute;
+    padding: 0 5px;
+    right: 0;
+    bottom: 3px;
+    border-radius: 3px;
+  }
+}
+
 // Not clear if these are needed. please review.
 .tools a {
   // The on class is added inside openlibrary/plugins/openlibrary/js/ol.js

--- a/static/css/legacy-jquery-ui.less
+++ b/static/css/legacy-jquery-ui.less
@@ -1,0 +1,36 @@
+/**
+ * DO NOT ADD NEW CSS here
+ * Unless... you are removing an inline style and moving it into here.
+ *
+ * We are currently in the process of:
+ * - moving styles from this file into the components
+ * - removing dead code
+ * - removing redundant CSS in favor of common reusable styles
+ *
+ * DO NOT ADD NEW CSS HERE
+ */
+.ui-widget-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: @black;
+  opacity: .5;
+  filter: alpha(opacity=50);
+  z-index: @z-index-level-13 !important;
+}
+.ui-sortable {
+  min-height: 90px;
+  max-height: 270px;
+  overflow: auto;
+  &-placeholder {
+    border: 1px dotted @mid-grey;
+    visibility: visible !important;
+    height: 70px !important;
+    border-radius: 6px;
+    * {
+      visibility: hidden;
+    }
+  }
+}

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -3457,13 +3457,6 @@ ul#myreads-paginator {
 
 @import (less) "components/rating-form.less";
 
-.responsive button.slick-prev,
-.slick-next {
-  &:before {
-    color: @white;
-  }
-}
-
 .searchInsideForm {
   input[type=text] {
     margin: 0;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1910,11 +1910,6 @@ tr {
   }
 }
 
-img.cover {
-  border-radius: 5px;
-  box-shadow: 1px 1px 2px 0 @book-cover-shadow-color;
-}
-
 #cover {
   border: 2px solid @brown;
   background-color: @white;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1563,20 +1563,7 @@ div#searchResults {
   }
 }
 
-.coverEbook {
-  img {
-    opacity: .85;
-    filter: alpha(opacity=85);
-  }
-  a.cta-btn {
-    position: absolute;
-    padding: 0 5px;
-    right: 0;
-    bottom: 3px;
-    border-radius: 3px;
-  }
-}
-
+// openlibrary/plugins/openlibrary/js/availability.js
 .borrow_ {
   &available {
     background-color: @primary-blue;
@@ -2302,13 +2289,7 @@ div#history {
   }
 }
 
-.coverMagic {
-  .coverEbook {
-    cursor: pointer;
-    z-index: @z-index-level-6;
-  }
-}
-
+// unused?
 #contentLists {
   &.results {
     .coverMagic {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -3404,11 +3404,6 @@ ul#myreads-paginator {
   margin-bottom: 15px;
 }
 
-.star {
-  color: @steel-blue;
-  font-size: 1.3em;
-}
-
 @import (less) "components/rating-form.less";
 
 .searchInsideForm {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1202,17 +1202,6 @@ div.searchOptions {
 }
 
 /* DIALOGS */
-.ui-widget-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: @black;
-  opacity: .5;
-  filter: alpha(opacity=50);
-  z-index: @z-index-level-13 !important;
-}
 
 div.cclicense {
   font-family: @lucida_sans_serif-2;
@@ -2608,22 +2597,6 @@ div.addfield {
   }
 }
 
-// Probably not used. Please review.
-.ui-sortable {
-  min-height: 90px;
-  max-height: 270px;
-  overflow: auto;
-  &-placeholder {
-    border: 1px dotted @mid-grey;
-    visibility: visible !important;
-    height: 70px !important;
-    border-radius: 6px;
-    * {
-      visibility: hidden;
-    }
-  }
-}
-
 /* TABS */
 
 /* Skin */
@@ -3572,21 +3545,5 @@ ul#myreads-paginator {
     &Spacer {
       float: left;
     }
-  }
-}
-
-/* Caution! Ensure accessibility in print and other media types... */
-@media projection, screen {
-  /* Use class for showing/hiding tab content,
-  so that visibility can be better controlled in different media types... */
-  .ui-tabs-hide {
-    display: none;
-  }
-}
-
-/* Hide useless elements in print layouts... */
-@media print {
-  .ui-tabs-nav {
-    display: none;
   }
 }


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

This tidies up legacy.less  a little, moving JS specific styles off the critical path and restoring a subtle styles for the rating stars.

Before:
![screen shot 2019-01-15 at 10 45 33 pm](https://user-images.githubusercontent.com/148752/51231173-6622a700-1917-11e9-91fb-b4458857db03.png)
After:
![screen shot 2019-01-15 at 10 46 05 pm](https://user-images.githubusercontent.com/148752/51231175-691d9780-1917-11e9-8c85-9ff66196cbb3.png)
