### PR TITLE
Component CtaBtn: Consolidate cta-btn rules

### DIFF
--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -20,10 +20,10 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
   $if loan:
     <a href="$read_link" title="Borrow"
        data-userid="$(loan['userid'])" id="read_ebook"
-       class="borrow_available borrow-link cta-btn">Read</a>
+       class="cta-btn--available cta-btn">Read</a>
 
   $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
-    <a href="$read_link" class="borrow_available borrow-link cta-btn btn--large" title="Borrow" id="borrow_ebook">
+    <a href="$read_link" class="cta-btn--available cta-btn" title="Borrow" id="borrow_ebook">
       Borrow
     </a>
 
@@ -32,7 +32,7 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
         <span data-ol-link-track="leave_waitlist">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="leave-waitlist waitinglist-form">
             <input type="hidden" name="action" value="leave-waitinglist"/>
-            <input type="submit" class="unwait-btn btn--large" id="unwaitlist_ebook" value="Leave Waitlist"/>
+            <input type="submit" class="cta-btn cta-btn--missing id="unwaitlist_ebook" value="Leave Waitlist"/>
           </form>
         </span>
         <div class="waitlist-msg">
@@ -47,10 +47,10 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
         <span class="borrow_unavailable" data-ol-link-track="borrow_unavailable">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="join-waitlist waitinglist-form">
             <input type="hidden" name="action" value="join-waitinglist"/>
-            <button type="submit" class="wait-btn btn--large" id="waitlist_ebook">
+            <button type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook">
               Join Waitlist
               $if wlsize and int(wlsize):
-                <span class="badge">$wlsize</span>
+                <span class="cta-btn__badge">$wlsize</span>
             </button>
           </form>
         </span>
@@ -61,8 +61,8 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
 
   $elif (availability_status == 'open'):
     <a href="$read_link" data-ol-link-track="read_unrestricted" title="Use BookReader to read online"
-       id="read_ebook" class="borrow_available btn--large borrow-link cta-btn">Read</a>
+       id="read_ebook" class="cta-btn--available cta-btn">Read</a>
 $else:
   <form>
-    <input type="button" class="unwait-btn borrow_missing cta-btn btn--large" disabled value="No ebook available">
+    <input type="button" class="cta-btn--missing cta-btn" disabled value="No ebook available">
   </form>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -37,17 +37,17 @@ $ borrow_link = page.url() + '/borrow'
 $if user_loan:
   <a href="$borrow_link" title="Borrow from $contributor"
      data-userid="$(user_loan['userid'])" id="read_ebook"
-     class="borrow-btn borrow-link btn--large btn primary">Read eBook</a>
+     class="cta-btn cta-btn--available">Read eBook</a>
 
     $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
     <form action="$return_url" method="post" class="waitinglist-form return-book">
       <input type="hidden" name="action" value="return" />
-      <input type="submit" value="Return eBook" class="submit unwait-btn" id="return_ebook"/>
+      <input type="submit" value="Return eBook" class="cta-btn cta-btn--available" id="return_ebook"/>
     </form>
 
 $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
   <a href="$borrow_link" title="Borrow from $contributor" id="borrow_ebook"
-     class="borrow-btn borrow-link btn primary btn--large">
+     class="cta-btn cta-btn--available">
     Borrow eBook
   </a>
 
@@ -63,7 +63,7 @@ $elif (availability_status == 'borrow_unavailable'):
         </p>
         <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
           <input type="hidden" name="action" value="leave-waitinglist"/>
-          <input type="submit" class="unwait-btn btn primary borrow_missing btn--large" id="unwaitlist_ebook" value="Leave waiting list"/>
+          <input type="submit" class="cta-btn" id="unwaitlist_ebook" value="Leave waiting list"/>
         </form>
 
     $else:  
@@ -72,16 +72,16 @@ $elif (availability_status == 'borrow_unavailable'):
         </p>
         <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
           <input type="hidden" name="action" value="join-waitinglist"/>
-          <input type="submit" class="borrow_unavailable primary btn btn--large submit wait-btn" id="waitlist_ebook" value="Join waiting list"/>
+          <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="Join waiting list"/>
         </form>
 
 $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
-    <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="btn--large btn primary">Read eBook</a>
+    <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read eBook</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
     <form>
-      <input type="submit" class="unwait-btn btn primary borrow_missing btn--large" disabled value="No ebook available">
+      <input type="submit" class="cta-btn" disabled value="No ebook available">
     </form>
 
 

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -91,7 +91,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           </ul>
         $else:
           <form>
-            <input type="submit" class="unwait-btn btn borrow_missing btn--large" disabled value="No ebook available">
+            <input type="submit" class="cta-btn cta-btn--missing" disabled value="No ebook available">
           </form>
       </div>
     </td>

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -1,6 +1,6 @@
 // A standard list of helpers
 .hidden {
-  display: none;
+  display: none !important;
 }
 .inline {
   display: inline;

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -1,28 +1,39 @@
-a {
-  &.cta-btn {
-    color: @white;
-    width: 100%;
-    border: 0;
-    border-radius: 5px;
-    box-sizing: border-box;
-    cursor: pointer;
-    text-decoration: none;
-    font-family: @lucida_sans_serif-1;
-    text-align: center;
-    padding: 5px 20px;
-  }
-}
-.primary {
+/**
+ * CtaBtn
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#ctabtn
+ */
+.cta-btn,
+// override default anchor styles
+a.cta-btn {
+  font-size: 14px;
+  color: @white;
+  width: 100%;
+  display: block;
+  border: 0;
+  border-radius: 5px;
+  box-sizing: border-box;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: @lucida_sans_serif-1;
+  text-align: center;
+  padding: 7px 20px;
   white-space: nowrap;
-  &.borrow_ {
-    &available {
-      background-color: @primary-blue;
-    }
-    &unavailable {
-      background-color: @orange;
-    }
-    &missing {
-      background-color: @mid-grey;
-    }
+  background-color: @mid-grey;
+  line-height: 1.5em;
+
+  &:hover {
+    text-decoration: underline;
+  }
+  &--available {
+    background-color: @primary-blue;
+  }
+  &--unavailable {
+    background-color: @orange;
+  }
+  &__badge {
+    background-color: @orange-two;
+    padding: 4px 7px;
+    border-radius: 5px;
+    font-size: .7em;
   }
 }

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -14,50 +14,6 @@
     cursor: pointer;
     text-align: center;
     font-family: @lucida_sans_serif-1;
-
-    /* stylelint-disable selector-max-specificity */
-    #waitlist_ebook {
-      padding: 7px 0;
-    }
-
-    #return_ebook,
-    #unwaitlist_ebook {
-      width: 100%;
-      font-size: .8em;
-    }
-    /* stylelint-enable selector-max-specificity */
-
-    .cta-btn {
-      font-size: 14px;
-    }
-
-    .cta-btn:hover {
-      text-decoration: none;
-    }
-
-    .borrow_unavailable {
-      border: 0;
-      border-radius: 5px;
-      box-sizing: border-box;
-      color: @white;
-      width: 100%;
-      cursor: pointer;
-      text-decoration: none;
-      text-align: center;
-      padding: 5px 0;
-      font-size: .8em;
-      /* stylelint-disable max-nesting-depth */
-      .badge {
-        background-color: @orange-two;
-        padding: 4px 7px;
-        border-radius: 5px;
-        font-size: .7em;
-      }
-      button {
-        padding: 0;
-      }
-      /* stylelint-enable max-nesting-depth */
-    }
   }
 }
 

--- a/static/css/legacy-tools.less
+++ b/static/css/legacy-tools.less
@@ -323,15 +323,6 @@
   }
 }
 
-.Tools div.btn-notice p a.borrow-btn,
-#read-options input[type=submit].wait-btn,
-#read-options input[type=submit].unwait-btn {
-  font-size: 14px;
-  padding: 7px 20px;
-  text-align: center;
-  margin-top: 8px;
-}
-
 div.tools-override {
   min-height: 45px;
   margin: 0 auto;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1563,19 +1563,6 @@ div#searchResults {
   }
 }
 
-// openlibrary/plugins/openlibrary/js/availability.js
-.borrow_ {
-  &available {
-    background-color: @primary-blue;
-  }
-  &unavailable {
-    background-color: @orange;
-  }
-  &missing {
-    background-color: @mid-grey;
-  }
-}
-
 .print-disabled-only {
   background-color: @purple;
 }
@@ -1933,51 +1920,6 @@ select {
   ul li.read-option a {
     display: block;
     text-align: center;
-  }
-}
-
-// for backwards compatibility
-// please use btn--large instead
-.borrow-btn,
-.wait-btn,
-.unwait-btn {
-  margin: 1px auto;
-  color: @white;
-  background: @primary-blue;
-  border-radius: 5px;
-  padding: 7px 20px;
-  cursor: pointer;
-  display: inline-block;
-  font-size: 1.1em;
-  line-height: 1.5em;
-  &:link,
-  &:visited {
-    color: @white;
-    text-decoration: none;
-  }
-  &:hover {
-    color: @white;
-    text-decoration: underline;
-  }
-}
-
-.wait-btn {
-  background: @mid-blue;
-  border: none;
-  background-color: @orange;
-}
-
-.unwait-btn {
-  background: @mid-grey;
-  border: none;
-}
-
-.waitinglist-form {
-  input[type=submit].wait-btn {
-    background-color: @orange;
-  }
-  input[type=submit] {
-    line-height: 1.5em;
   }
 }
 


### PR DESCRIPTION
Styling a cta-btn is complicated. This minimises the number of
classes needed and changes the classes to use BEM notation

It should be easier going forward. While it was tempting to create
a macro, it didn't seem to add much given the fact that cta-btn's can
be inputs or anchor tags and thus have various other attributes.
