### PR TITLE
Fix search box rendering

### DIFF
--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -21,20 +21,18 @@ $if q:
         $ response = results['response']
         $ num_found = int(response['numFound'])
         <p class="sansserif darkgreen collapse"><strong>$commify(response['numFound']) hit$("s" if response['numFound'] != 1 else "")</strong></p>
-
-
-
-<div class="section">
-
-<form class="siteSearch olform" action="">
-    <input type="text" class="larger" name="q" size="100" value="$q"/>
-    <input type="submit" class="large" value="$_('Search')"/>
-</form>
-
-</div>
 </div>
 
-<div id="contentMeta">
+<div id="contentBody">
+
+    <div class="section">
+
+    <form class="siteSearch olform" action="">
+        <input type="text" class="larger" name="q" size="100" value="$q"/>
+        <input type="submit" class="large" value="$_('Search')"/>
+    </form>
+
+    </div>
 
 $if q and 'error' in results:
     <strong>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -21,18 +21,20 @@ $if q:
         $ response = results['response']
         $ num_found = int(response['numFound'])
         <p class="sansserif darkgreen collapse"><strong>$commify(response['numFound']) hit$("s" if response['numFound'] != 1 else "")</strong></p>
+
+
+
+<div class="section">
+
+<form class="siteSearch olform" action="">
+    <input type="text" class="larger" name="q" size="100" value="$q"/>
+    <input type="submit" class="large" value="$_('Search')"/>
+</form>
+
+</div>
 </div>
 
 <div id="contentMeta">
-
-    <div class="section">
-
-    <form class="siteSearch olform" action="">
-        <input type="text" class="larger" name="q" size="100" value="$q"/>
-        <input type="submit" class="large" value="$_('Search')"/>
-    </form>
-
-    </div>
 
 $if q and 'error' in results:
     <strong>


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #1821
hotfix for the search bar rendering incorrectly in subjects.

> **Technical**: What should be noted about the implementation?
Nothing. Just used another CSS class.
contentBody instead of contentMeta


> **Testing**: Steps for reviewer to reproduce/verify this PR fixes the problem?

Simply open /search/subjects?q=sub


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

![screenshot from 2019-01-17 13-37-19](https://user-images.githubusercontent.com/12556455/51304192-75ac0800-1a5d-11e9-97bc-3d9726f33a45.png)
