### PR TITLE
Fix squished thumbnails on list pages

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -13,7 +13,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
         $ cover = "//archive.org/download/%s/page/cover_w60_h60.jpg" % doc.get('ocaid')
     $else:
         $ cover = "/images/icons/avatar_book-sm.png"
-    <a href="$book_url"><img itemprop="image" src="$cover" height="70" alt="Cover of: $doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')" title="Cover of: $doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')"/></a>
+    <a href="$book_url"><img itemprop="image" src="$cover" alt="Cover of: $doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')" title="Cover of: $doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')"/></a>
   </span>
 
 

--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -98,7 +98,7 @@ $else:
 <div id="contentBody">
     $if lists:
         <div class="mybooks-list">
-            <ul id="listResults">
+            <ul class="list-results" id="listResults">
             $for list in lists:
                 <li class="searchResultItem"
                     id="list-$loop.index">$:render_template("lists/preview", list)</li>

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -2,7 +2,7 @@ $def with (list)
             <span class="imageLg">
                 $ cover = list.get_cover() or list.get_default_cover()
                 $ cover_url = cover and cover.url("M") or "/images/icons/avatar_book-sm.png"
-                <a href="$list.key"><img src="$cover_url" height="110" alt="Cover of: $list.name" title="Cover of: $list"/></a>
+                <a href="$list.key"><img src="$cover_url" alt="Cover of: $list.name" title="Cover of: $list"/></a>
             </span>
             <span class="details">
                 $ owner = list.get_owner()

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -73,10 +73,10 @@
     width: 100%;
     margin: 10px 10px 0px 5px;
     text-align: left;
-		img {
-	    max-width: 100%;
+    img {
+      max-width: 100%;
       max-height: 110px;
-		}
+    }
   }
 }
 

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -62,17 +62,16 @@
   .bookcover {
     width: 100%;
     margin: 10px 10px 0 5px;
-    text-align: left;
+    text-align: center;
     overflow: hidden;
     img {
       max-width: 100%;
-      max-height: 70px;
+      max-height: 300px;
     }
   }
   .imageLg {
     width: 100%;
     margin: 10px 10px 0px 5px;
-    text-align: left;
     img {
       max-width: 100%;
       max-height: 110px;

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -21,6 +21,7 @@
   margin-bottom: 3px;
   border-bottom: 1px solid @light-beige;
   flex-wrap: wrap;
+  align-items: center;
 
   a {
     color: @black;
@@ -59,15 +60,23 @@
     font-size: .6875em;
   }
   .bookcover {
-    width: 80px;
-    margin: 10px 10px 0 5px;
-    text-align: right;
-    overflow: hidden;
-  }
-  img {
-    height: 80px;
-    max-width: 75px;
     width: 100%;
+    margin: 10px 10px 0 5px;
+    text-align: left;
+    overflow: hidden;
+    img {
+      max-width: 100%;
+      max-height: 70px;
+    }
+  }
+  .imageLg {
+    width: 100%;
+    margin: 10px 10px 0px 5px;
+    text-align: left;
+		img {
+	    max-width: 100%;
+      max-height: 110px;
+		}
   }
 }
 
@@ -97,7 +106,28 @@
 }
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
-  .searchResultItem {
-    flex-wrap: nowrap;
+  .list-books {
+    .searchResultItem {
+       flex-wrap: nowrap;
+      .bookcover {
+        width: 15%;
+        text-align: right;
+      }
+      .details {
+        width: 55%;
+      }
+    }
+  }
+  .list-results {
+    .searchResultItem {
+      flex-wrap: nowrap;
+      .imageLg {
+        width: 15%;
+        text-align: right;
+      }
+      .details {
+        width: 85%;
+      }
+    }
   }
 }

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -24,8 +24,10 @@
 }
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
-  .searchResultItemCTA {
-    width: 245px;
-    padding: 0 5px 0 15px;
+  .searchResultItem {
+    .searchResultItemCTA {
+      width: 30%;
+      padding: 0 5px 0 15px;
+    }
   }
 }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -2399,9 +2399,6 @@ span.actions {
 ul#siteSearch {
   > li {
     .display-flex();
-    span.bookcover img {
-      width: 100%;
-    }
   }
   span.resultTitle {
     display: block;


### PR DESCRIPTION
> **Description**: What does this PR achieve? [hotfix]

- Prevents thumbnails from getting squished in lists (mobile view)

- Thumbnails getting cut off resolved by PR #1838 by @jdlrobson 

Closes #1762 

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

http://0.0.0.0:8080/people/openlibrary/lists
http://0.0.0.0:8080/account/books/want-to-read


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

Lists (mobile view)
<img src="https://user-images.githubusercontent.com/30471843/51830073-ff3cbf00-2314-11e9-9258-d48ff030b4b7.png"  width="200"/>
Want to read
<img src="https://user-images.githubusercontent.com/30471843/51830400-c224fc80-2315-11e9-9e7d-ff5452b6ca31.png"  width="500"/>
Want to read (mobile view)
<img src="https://user-images.githubusercontent.com/30471843/51830226-63f81980-2315-11e9-90f9-e0b3239a4a74.png"  width="200"/>