### PR TITLE
Feature/coverstore

### DIFF
--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -8,4 +8,5 @@ data_root: "var/lib/coverstore"
 default_image: "static/images/empty.gif"
 
 # Redirects to this, if the requested cover is not found in the coverstore. Useful for dev-instance
+# XXX this should be deprecated now that coverstore is in docker!!!
 upstream_base_url: http://covers.openlibrary.org/

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -15,7 +15,7 @@ smtp_server: localhost
 dummy_sendmail: True
 debug: True
 
-coverstore_url: http://0.0.0.0/covers/
+coverstore_url: http://0.0.0.0:8081/
 
 state_dir: var/run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - 8080:80
       - 7000:7000
+      - 8081:8081
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
@@ -29,6 +30,7 @@ services:
     image: memcached
     networks:
       - webnet
+  #covers:
 networks:
   webnet:
 volumes:

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -20,7 +20,7 @@ RUN pip install -r requirements_test.txt
 RUN npm install
 
 # Expose Open Library and Infobase
-EXPOSE 80 7000
+EXPOSE 80 7000 8081
 
 # runs as root in order to access su to run as openlibrary and postgres users
 CMD docker/ol-docker-start.sh

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -4,6 +4,7 @@
 # inside an container, bypass all upstart/services
 
 CONFIG=conf/openlibrary.yml
+COVER_CONFIG=conf/coverstore.yml
 
 reindex-solr() {
   server=$1
@@ -36,7 +37,10 @@ su openlibrary -c "python scripts/new-solr-updater.py \
   --state-file solr-update.offset \
   --ol-url http://web/" &
 
+# In dev mode, run the coverstore locally (in the background)
+su openlibrary -c "scripts/coverstore-server $COVER_CONFIG \
+    --gunicorn --workers 1 --max-requests 250 --bind :8081" &
+
 # ol server, running in the foreground to avoid exiting container
 su openlibrary -c "authbind --deep scripts/openlibrary-server $CONFIG \
                      --gunicorn --reload --workers 4 --timeout 180 --bind :80"
-

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -116,7 +116,7 @@ class upload:
         raise web.seeother(success_url)
 
 class upload2:
-    """Temporary upload handler for handling upstream.openlibrary.org cover upload.
+    """openlibrary.org POSTs here via openlibrary/plugins/upstream/covers.py upload
     """
     def POST(self, category):
         i = web.input(olid=None, author=None, data=None, source_url=None, ip=None, _unicode=False)

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -55,9 +55,16 @@ class add_cover(delegate.page):
             i.url = ""
 
         user = accounts.get_current_user()
-        params = dict(author=user and user.key, data=data, source_url=i.url, olid=olid, ip=web.ctx.ip)
+        params = {
+            "author": user and user.key,
+            "data": data,
+            "source_url": i.url,
+            "olid": olid,
+            "ip": web.ctx.ip
+        }
 
-        upload_url = '%s/%s/upload2' % (get_coverstore_url(), self.cover_category)
+        upload_url = '%s/%s/upload2' % (
+            get_coverstore_url(), self.cover_category)
 
         if upload_url.startswith("//"):
             upload_url = "http:" + upload_url
@@ -66,7 +73,7 @@ class add_cover(delegate.page):
             response = urllib2.urlopen(upload_url, urllib.urlencode(params))
             out = response.read()
         except urllib2.HTTPError as e:
-            out = e.read()
+            out = {'error': e.read()}
 
         return web.storage(simplejson.loads(out))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 
 Fabric==1.10.1; python_version < '3.0'
 Jinja2==2.10
-Pillow==5.3.0
 backports.shutil-get-terminal-size==1.0.0
 bottlenose==1.1.2
 clint==0.5.1
@@ -33,3 +32,4 @@ simplegeneric==0.8.1
 traitlets==4.3.1
 wcwidth==0.1.7
 wsgiref==0.1.2
+supervisor==3.3.5; python_version < '3.0'

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -1,17 +1,15 @@
 Babel==2.5.3
 beautifulsoup4==4.6.3
 DBUtils==1.3
-flake8==3.6.0
 Genshi==0.7.1
 gunicorn==19.9.0
 iptools==0.6.1; python_version < '3.0'
 internetarchive==1.8.1
 lxml==4.2.5
-pyflakes==2.0.0
+Pillow==5.3.0
 pymarc==3.1.11
 python-memcached==1.59
 simplejson==3.16.0
-supervisor==3.3.5; python_version < '3.0'
 web.py==0.33; python_version < '3.0'
 web.py==0.40-dev1; python_version >= '3.0'
 pystatsd==0.1.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,6 @@
 
 -r requirements_common.txt
 flake8==3.6.0
+pyflakes==2.0.0
 pytest==4.0.1
 mockcache==1.0.3; python_version < '3.0'


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Partially fixes #1258 

> **Technical**: What should be noted about the implementation?

coverstore should still be converted into its own Dockerfile.olcovers image. Homepage is still failing to display overs on localhost (generating wrong coverstore urls in carousels), but the works page now displays correctly.

applying this fix requires rebuilding Dockerfile.oldev