### PR TITLE
fixes price API, isbn now passed as GET param

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -19,7 +19,9 @@ def get_amazon_metadata(isbn):
     except Exception:
         return None
 
-def _get_amazon_metadata(isbn):
+def _get_amazon_metadata(isbn=None):
+    # XXX @hornc, you should be extending this to work with
+    # isbn=, asin=, title=, authors=, etc
     isbn = normalize_isbn(isbn)
     try:
         if not lending.amazon_api:


### PR DESCRIPTION
Fixes /prices API (it used to be /prices/isbn/xxx and is now /prices?isbn= or ?asin=). Currently, asin doesn't work, however the plan is for @hornc to extend this to work with isbn, asin, title, authors.

This patch needs to be merged because otherwise the /prices API physically breaks when importing new amazon works.