### PR TITLE
add amazon affiliate tag to ASIN id links

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -79,7 +79,7 @@ $def display_identifiers(label, ids, itemprop=None):
                 $if -1 != id.value.find('openlib-'):
                     $continue
                 $if id.url:
-                    <a href="$id.url">$id.value</a>$sep
+                    <a href="$id.url$('?tag=' + affiliate_id('amazon') if 'amazon.' in id.url else '')">$id.value</a>$sep
                 $else:
                     ${id.value}$sep
         </dd>


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Adds the correct affiliate tag to all ID Number links to Amazon domains from the Edition view page.

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

to test using this book with multiple international amazon identifiers: https://openlibrary.org/books/OL25443597M/City_Times_Other_Poems


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

