### PR TITLE
Styles editTools block for mobile breakpoint

### DIFF
--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -24,9 +24,9 @@ div#editInfo {
     font-weight: normal;
     color: @brown!important;
     font-family: @lucida_sans_serif-1;
-    + div {
-      padding-top: .3rem;
-    }
+  }
+  .smallest {
+    padding-top: .3rem;
   }
 }
 

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -10,7 +10,13 @@ div#editHistory {
   width: auto;
 }
 
+div#editButton {
+  float: left;
+}
+
 div#editInfo {
+  float: right;
+  overflow: hidden;
   white-space: nowrap;
   text-align: right;
   > div {
@@ -18,11 +24,15 @@ div#editInfo {
     font-weight: normal;
     color: @brown!important;
     font-family: @lucida_sans_serif-1;
+    + div {
+      padding-top: .3rem;
+    }
   }
 }
 
 div#editTools {
   white-space: nowrap;
+  overflow: hidden;
+  padding: 1rem 0;
 }
-
 @import "components/buttonLink.less";

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -33,6 +33,6 @@ div#editInfo {
 div#editTools {
   white-space: nowrap;
   overflow: hidden;
-  padding: 1rem 0;
+  padding: 0 0 1rem 0;
 }
 @import "components/buttonLink.less";

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -987,23 +987,6 @@ div.revert.notice {
     font-size: 1.125em;
   }
 }
-@media all and (max-width: @width-breakpoint-tablet) {
-  div#editTools {
-    overflow: hidden;
-    padding: 1rem 0;
-  }
-
-  div#editButton {
-    float: left;
-  }
-
-  div#editInfo {
-    overflow: hidden;
-    > div + div {
-      padding-top: .3rem;
-    }
-  }
-}
 
 // openlibrary/templates/viewpage.html
 div#revertNotice {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -987,6 +987,23 @@ div.revert.notice {
     font-size: 1.125em;
   }
 }
+@media all and (max-width: @width-breakpoint-tablet) {
+  div#editTools {
+    overflow: hidden;
+    padding: 1rem 0;
+  }
+
+  div#editButton {
+    float: left;
+  }
+
+  div#editInfo {
+    overflow: hidden;
+    > div + div {
+      padding-top: .3rem;
+    }
+  }
+}
 
 // openlibrary/templates/viewpage.html
 div#revertNotice {


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]
Hotfix: Styles editTools block and child elements to be more mobile friendly

Closes #1874 

> **Technical**: What should be noted about the implementation?
Added code passes linter, but it seems code was introduced 2019/02/11 to static/css/components/search-result-items.less that throws errors.


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
Visit a title's show page within the mobile breakpoint (< 768px width)


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:
![screen shot 2019-02-13 at 6 48 08 am](https://user-images.githubusercontent.com/39553/52714132-1e6b5b80-2f67-11e9-9a3c-3dc67c6cd556.png)

