### PR TITLE
fixing click-outside readinglog btn

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -405,6 +405,14 @@ $(function(){
         $(this).closest('.arrow').toggleClass("up");
     }, 300, false));
 
+    $(document).on('click', function(e) {
+        var container = $("#widget-add");
+        if (!container.is(e.target) && container.has(e.target).length === 0) {
+            $(container).find('.dropdown').slideUp(25);
+            $(container).find('.arrow').removeClass("up");
+        }
+    });
+
     /* eslint-disable no-unused-vars */
     // success function receives data on successful request
     $('.reading-log-lite select').change(function(e) {


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

It used to be the case that if you had the reading log / lists dropdown expanded and clicked outside of the area, that it would not collapse. Now it does!

> **Technical**: What should be noted about the implementation?

It uses a `$(document).on('click', ...)` which maybe isn't an ideal implementation as it will run on all clicks. This should only be included on certain pages but is currently in `plugins/openlibrary/js/ol.js`