### PR TITLE
coverstore_url updated to latest URL

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -15,7 +15,7 @@ smtp_server: localhost
 dummy_sendmail: True
 debug: True
 
-coverstore_url: http://0.0.0.0:8081/
+coverstore_url: https://covers.openlibrary.org/
 
 state_dir: var/run
 


### PR DESCRIPTION
Book covers wont load locally. New URL was inserted

> **Description**:  This PR updates the URL of the coverstore so that book covers start loading locally


