### PR TITLE
remove non-Docker non OL requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -r requirements_common.txt
 
-Fabric==1.10.1; python_version < '3.0'
 Jinja2==2.10
 backports.shutil-get-terminal-size==1.0.0
 bottlenose==1.1.2
@@ -32,4 +31,3 @@ simplegeneric==0.8.1
 traitlets==4.3.1
 wcwidth==0.1.7
 wsgiref==0.1.2
-supervisor==3.3.5; python_version < '3.0'


### PR DESCRIPTION
based on comments on https://github.com/internetarchive/openlibrary/pull/1634

> **Description**: What does this PR achieve? [refactor]

Removes requirement dependencies that are only used for the specific production setup we are trying to deprecate and standardise. I believe these particular requirements are overridden by the specifics of olsystem / the production environment anyway, so they are just noise in this codebase.

> **Technical**: What should be noted about the implementation?

There are probably other items from this requirements.txt that can be removed -- due to either an oversight, or deliberate policy of only moving known used requirements to `requirements_common.txt` the `requirements.txt` file is never actually used in creating any of the Docker images for the dev environment, so why any of them are there is an open question :) 

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

