### PR TITLE
Changed copydocs default destination to localhost

### DIFF
--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 """Script to copy docs from one OL instance to another.
 Typically used to copy templates, macros, css and js from
-openlibrary.org to dev instance.
+openlibrary.org to dev instance, defaulting to localhost.
 
 USAGE:
-    ./scripts/copydocs.py --src http://openlibrary.org --dest http://0.0.0.0 /templates/*
+    ./scripts/copydocs.py --src http://openlibrary.org /templates/*
 
 This script can also be used to copy books and authors from OL to dev instance.
 
@@ -56,7 +56,7 @@ def parse_args():
     parser = OptionParser("usage: %s [options] path1 path2" % sys.argv[0], description=desc, version=__version__)
     parser.add_option("-c", "--comment", dest="comment", default="", help="comment")
     parser.add_option("--src", dest="src", metavar="SOURCE_URL", default="http://openlibrary.org/", help="URL of the source server (default: %default)")
-    parser.add_option("--dest", dest="dest", metavar="DEST_URL", default="http://0.0.0.0/", help="URL of the destination server (default: %default)")
+    parser.add_option("--dest", dest="dest", metavar="DEST_URL", default="http://localhost", help="URL of the destination server (default: %default)")
     parser.add_option("-r", "--recursive", dest="recursive", action='store_true', default=False, help="Recursively fetch all the referred docs.")
     parser.add_option("-l", "--list", dest="lists", action="append", default=[], help="copy docs from a list.")
     return parser.parse_args()


### PR DESCRIPTION
> **Description**: Changes copydocs script default destination to `localhost`, as it is more convenient for users.

Closes #1906 

> **Testing**: use `copydocs.py` without any dest argument. It should copy to localhost.

I also changed the usage of copydocs in the wiki.