### PR TITLE
Fixes author add and remove controls

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -100,14 +100,14 @@
 
         update_visible();
 
-        container.find("a.remove").on("click", function() {
+        container.on("click", "a.remove", function() {
             if (container.find("div.input").length > 1) {
                 $(this).closest("div.input").remove();
                 update_visible();
             }
         });
 
-        container.find("a.add").on("click", function(event) {
+        container.on("click", "a.add", function(event) {
             event.preventDefault();
 
             var next_index = container.find("div.input").length;

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -31,8 +31,8 @@ $jsdef render_author(i, author):
     <div class="input">
         <input name="authors--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name"/>
         <input name="work--authors--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
-        <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this author')">[x]</a>&nbsp;
-        <a href="javascript:;" class="add hidden">$_("Add another author?")</a>
+        <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[x]</a>&nbsp;
+        <a href="javascript:;" class="add">$_("Add another author?")</a>
     </div>
 
 <div id="authors">


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #1901 

> **Technical**: What should be noted about the implementation?

Previous update to `live` methods did not properly bind click events to the parent container, so any newly added elements did not have click events bound or listening to the elements. Additionally, a class of "hidden" was present on the add author and remove links. Removing those classes allowed the controls to be visible.

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

![edit-book_add-author](https://user-images.githubusercontent.com/39553/53012450-008f7200-3411-11e9-850c-afe834bb6386.gif)

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

See above.