### PR TITLE
Cleanup/document dropclicker behaviour

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -394,6 +394,14 @@ $(function(){
             $('.wmd-preview').before('<h3 id="prevHead" style="margin:15px 0 10px;padding:0;">Preview</h3>');
         }
     });
+    /**
+     * close an open dropdown in a given container
+     * @param {jQuery.Object} $container
+     */
+    function closeDropdown($container) {
+        $container.find('.dropdown').slideUp(25);
+        $container.find('.arrow').removeClass('up');
+    }
     $('.dropclick').on('click', debounce(function(){
         $(this).next('.dropdown').slideToggle(25);
         $(this).parent().next('.dropdown').slideToggle(25);
@@ -405,12 +413,14 @@ $(function(){
         $(this).closest('.arrow').toggleClass("up");
     }, 300, false));
 
-    $(document).on('click', function(e) {
-        var container = $("#widget-add");
-        if (!container.is(e.target) && container.has(e.target).length === 0) {
-            $(container).find('.dropdown').slideUp(25);
-            $(container).find('.arrow').removeClass("up");
-        }
+    // Close any open dropdown list if the user clicks outside...
+    $(document).on('click', function() {
+        closeDropdown($('#widget-add'));
+    });
+
+    // ... but don't let that happen if user is clicking inside dropdown
+    $('#widget-add').on('click', function(e) {
+        e.stopPropagation();
     });
 
     /* eslint-disable no-unused-vars */


### PR DESCRIPTION
Follow up to 0466a9a584718b507c925bf815f9e351f57aff9f
Rely on stopPropagation to close the reading list drop down
for better performance and readability

Additional changes:
* switch from double quotes to single quotes (the standard in this
repo)

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

