### PR TITLE
Fix position of Yaxis label and make graph responsive on mobile phone…

### DIFF
--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -174,10 +174,10 @@ var _hash = parse_hash();
 </script>
 
     <div class="chart">
+        <div class="chartYaxis">$_("Editions Published")</div>
         <div id="chartPubHistory" class="thisChart">
             <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
         </div>
-        <div class="chartYaxis">$_("Editions Published")</div>
         <div class="chartXaxis">$_("Year of Publication")</div>
     </div>
 

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -129,10 +129,10 @@ window.q.push(function() {
 </script>
 
     <div class="chart">
+        <div class="chartYaxis">$_("Editions Published")</div>
         <div id="chartPubHistory" class="thisChart">
             <noscript>$_("You need to have JavaScript turned on to see the nifty chart!")</noscript>
         </div>
-        <div class="chartYaxis">$_("Editions Published")</div>
         <div class="chartXaxis">$_("Year of Publication")</div>
     </div>
 

--- a/static/css/components/chart.less
+++ b/static/css/components/chart.less
@@ -24,6 +24,8 @@
 
   &Yaxis {
     position: absolute;
+    left: -65px;
+    top:60px;
     text-align: center;
     vertical-align: middle;
     -webkit-transform: rotate(-90deg);
@@ -50,6 +52,7 @@
   .thisChart {
     height: @chart-height;
     width: 100%;
+    overflow-y: hidden;
   }
 }
 


### PR DESCRIPTION
> **Description**: What does this PR achieve?

Fix position of Yaxis label and make graph responsive on mobile phone by adding horizontal scrollbar.

Closes #1926 

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

Screenshots:

Earlier on desktop view:
![earlier-desktop](https://user-images.githubusercontent.com/32803230/53687562-1e879b80-3d5c-11e9-81cc-4a333254121a.png)

Earlier on mobile view:
![earlier-mobile](https://user-images.githubusercontent.com/32803230/53687576-3b23d380-3d5c-11e9-9b08-45226738396e.png)

Now on desktop view:
![now-desktop](https://user-images.githubusercontent.com/32803230/53687642-095f3c80-3d5d-11e9-8646-41cdfaad00ab.png)

Now on mobile view:
![now-mobile](https://user-images.githubusercontent.com/32803230/53687644-17ad5880-3d5d-11e9-9942-b07d0fc5a5b0.gif)


