### PR TITLE
Align edit text and edit icon correctly on mobile.

### DIFF
--- a/static/css/components/edit-toolbar--mobile.less
+++ b/static/css/components/edit-toolbar--mobile.less
@@ -1,0 +1,11 @@
+/**
+ * EditToolbar component
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#edit-toolbar
+ */
+
+/* stylelint-disable selector-max-specificity */                               
+div#editTools {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/static/css/less/breakpoints.less
+++ b/static/css/less/breakpoints.less
@@ -1,2 +1,3 @@
+@width-breakpoint-mobile: 480px; // 30em
 @width-breakpoint-tablet: 768px; // 48em
 @width-breakpoint-desktop: 960px; // 60em

--- a/static/css/page-book.less
+++ b/static/css/page-book.less
@@ -27,3 +27,7 @@
 @media only screen and (min-width: @width-breakpoint-tablet) {
   @import (less) "components/edit-toolbar--tablet.less";
 }
+
+@media only screen and (max-width: @width-breakpoint-mobile) {                
+  @import (less) "components/edit-toolbar--mobile.less";                      
+}


### PR DESCRIPTION
> **Description**:[hotfix]
Fixes the misaligned edit text and icon on mobile.


> **Technical**: 
Created a breakpoint variable to target mobile phones.
Sets the display to flex on #editTools , justify-content to space-between and align-items to center to vertically align both icon and text.


> **Evidence**: 

![2019-03-03-101452_954x1010_scrot](https://user-images.githubusercontent.com/15066223/53691098-42b79c80-3d9d-11e9-8bab-2adb218bbd95.png)
