### PR TITLE
Non-MARC import from archive.org

### DIFF
--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -57,7 +57,7 @@ def process_metadata_dict(metadata):
     non-list cases. This function makes sure the known multi-valued fields are
     always lists.
     """
-    mutlivalued = set(['collection', 'external-identifier', 'subject'])
+    mutlivalued = set(['collection', 'external-identifier', 'isbn', 'subject', 'oclc-id'])
     def process_item(k, v):
         if k in mutlivalued and not isinstance(v, list):
             v = [v]

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -1,6 +1,5 @@
 """Library for interacting wih archive.org.
 """
-from __future__ import print_function
 import os
 import urllib2
 import datetime
@@ -15,16 +14,15 @@ from openlibrary.utils.dateutil import date_n_days_ago
 
 import six
 
+logger = logging.getLogger('openlibrary.ia')
 
-logger = logging.getLogger("openlibrary.ia")
-
-VALID_READY_REPUB_STATES = ["4", "19", "20", "22"]
+VALID_READY_REPUB_STATES = ['4', '19', '20', '22']
 
 def get_item_json(itemid):
     itemid = web.safestr(itemid.strip())
     url = 'http://archive.org/metadata/%s' % itemid
     try:
-        stats.begin("archive.org", url=url)
+        stats.begin('archive.org', url=url)
         metadata_json = urllib2.urlopen(url).read()
         stats.end()
         return simplejson.loads(metadata_json)
@@ -33,12 +31,12 @@ def get_item_json(itemid):
         return {}
 
 def extract_item_metadata(item_json):
-    metadata = process_metadata_dict(item_json.get("metadata", {}))
+    metadata = process_metadata_dict(item_json.get('metadata', {}))
     if metadata:
         # if any of the files is access restricted, consider it as
         # an access-restricted item.
         files = item_json.get('files', [])
-        metadata['access-restricted'] = any(f.get("private") == "true" for f in files)
+        metadata['access-restricted'] = any(f.get('private') == 'true' for f in files)
 
         # remember the filenames to construct download links
         metadata['_filenames'] = [f['name'] for f in files]
@@ -48,7 +46,7 @@ def get_metadata(itemid):
     item_json = get_item_json(itemid)
     return extract_item_metadata(item_json)
 
-get_metadata = cache.memcache_memoize(get_metadata, key_prefix="ia.get_metadata", timeout=5*60)
+get_metadata = cache.memcache_memoize(get_metadata, key_prefix='ia.get_metadata', timeout=5*60)
 
 def process_metadata_dict(metadata):
     """Process metadata dict to make sure multi-valued fields like
@@ -59,7 +57,7 @@ def process_metadata_dict(metadata):
     non-list cases. This function makes sure the known multi-valued fields are
     always lists.
     """
-    mutlivalued = set(["collection", "external-identifier"])
+    mutlivalued = set(['collection', 'external-identifier', 'subject'])
     def process_item(k, v):
         if k in mutlivalued and not isinstance(v, list):
             v = [v]
@@ -74,7 +72,7 @@ def _old_get_meta_xml(itemid):
     itemid = web.safestr(itemid.strip())
     url = 'http://www.archive.org/download/%s/%s_meta.xml' % (itemid, itemid)
     try:
-        stats.begin("archive.org", url=url)
+        stats.begin('archive.org', url=url)
         metaxml = urllib2.urlopen(url).read()
         stats.end()
     except IOError:
@@ -130,7 +128,6 @@ def xml2dict(xml, **defaults):
 def _get_metadata(itemid):
     """Returns metadata by querying the archive.org metadata API.
     """
-    print("_get_metadata", itemid, file=web.debug)
     url = "http://www.archive.org/metadata/%s" % itemid
     try:
         stats.begin("archive.org", url=url)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -284,22 +284,31 @@ class ia_importapi(importapi):
         :rtype: dict
         :return: Edition record
         """
-        #TODO: include identifiers: isbn, oclc, lccn
         authors = [{'name': name} for name in metadata.get('creator', '').split(';')]
         description = metadata.get('description')
+        isbn = metadata.get('isbn')
         language = metadata.get('language')
+        lccn = metadata.get('lccn')
         subject = metadata.get('subject')
+        oclc = metadata.get('oclc-id')
         d = {
             'title': metadata.get('title', ''),
             'authors': authors,
             'publish_date': metadata.get('date'),
+            'publisher': metadata.get('publisher'),
         }
         if description:
             d['description'] = description
+        if isbn:
+            d['isbn'] = isbn
         if language and len(language) == 3:
             d['languages'] = [language]
+        if lccn:
+            d['lccn'] = [lccn]
         if subject:
             d['subjects'] = subject
+        if oclc:
+            d['oclc'] = oclc
         return d
 
     def load_book(self, edition_data):

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -292,6 +292,7 @@ class ia_importapi(importapi):
         d = {
             'title': metadata.get('title', ''),
             'authors': authors,
+            'publish_date': metadata.get('date'),
         }
         if description:
             d['description'] = description

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -296,7 +296,7 @@ class ia_importapi(importapi):
         if description:
             d['description'] = {'type': '/type/text', 'value': description}
         if language and len(language) == 3:
-            d['languages'] = ['key': '/languages/%s' % language]
+            d['languages'] = [{'key': '/languages/%s' % language}]
         if subject:
             d['subjects'] = subject
         return d

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -294,9 +294,9 @@ class ia_importapi(importapi):
             'authors': authors,
         }
         if description:
-            d['description'] = {'type': '/type/text', 'value': description}
+            d['description'] = description
         if language and len(language) == 3:
-            d['languages'] = [{'key': '/languages/%s' % language}]
+            d['languages'] = [language]
         if subject:
             d['subjects'] = subject
         return d

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -286,14 +286,19 @@ class ia_importapi(importapi):
         """
         #TODO: include identifiers: isbn, oclc, lccn
         authors = [{'name': name} for name in metadata.get('creator', '').split(';')]
+        description = metadata.get('description')
+        language = metadata.get('language')
         subject = metadata.get('subject')
         d = {
-            "title": metadata.get('title', ''),
-            "authors": authors,
-            "language": metadata.get('language', ''),
+            'title': metadata.get('title', ''),
+            'authors': authors,
         }
+        if description:
+            d['description'] = {'type': '/type/text', 'value': description}
+        if language and len(language) == 3:
+            d['languages'] = ['key': '/languages/%s' % language]
         if subject:
-            d["subjects"] = isinstance(subject, list) and subject or [subject]
+            d['subjects'] = subject
         return d
 
     def load_book(self, edition_data):

--- a/openlibrary/templates/history/comment.html
+++ b/openlibrary/templates/history/comment.html
@@ -14,7 +14,8 @@ $if record_id:
         $if record.source_name == "amazon.com":
              Inital record created, from an $:link(record.source_url, "amazon.com") <a href="$record.url">record</a>.
         $else:
-            Initial record created, from $:link(record.source_url, record.source_name) <a href="$record.url">MARC record</a>.
+            $ record_type = 'item' if record.source_name == 'Internet Archive' else 'MARC'
+            Initial record created, from $:link(record.source_url, record.source_name) <a href="$record.url">$record_type record</a>.
     $else:
         Found a <a href="$record.url">matching record</a> from $:link(record.source_url, record.source_name).
 $elif "history_v2" in ctx.features:


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Improves the metadata importing from Archive.org items that do no have MARC records.

The following item,  https://openlibrary.org/books/OL26746219M , was imported using the https://github.com/internetarchive/openlibrary/wiki/Endpoints#importing `POST /api/import/ia` endoint `"require_marc": "false"` option, and had some issues / missing metadata. This PR fixes those.

* Correct language format: `/languages/por` instead of `por`
* Import _all_ subjects
* Import description, if available
* Import publisher and publication date
* Import other identifiers if avaialable (ISBN, OCLC, LCCN)
* Change history message for archive.org imported items to: "Initial record created, from Internet Archive item record." to avoid saying MARC when there may have been no MARC involved.

Tagging @tfmorris who noticed these issues too.

> **Technical**: What should be noted about the implementation?

Requires #1979 (for local testing), wait until that PR is merged before merging this one.

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

