### PR TITLE
Use local_id type lookup for partner bulk_marc sources

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -212,9 +212,10 @@ class ia_importapi(importapi):
             actual_length = int(rec.leader()[:MARC_LENGTH_POS])
             edition['source_records'] = 'marc:%s/%s:%s:%d' % (ocaid, filename, offset, actual_length)
 
-            #TODO: Look up URN prefixes to support more sources, extend openlibrary/catalog/marc/sources?
-            if ocaid == 'OpenLibraries-Trent-MARCs':
-                prefix = 'trent'
+            local_id = i.get('local_id')
+            if local_id:
+                local_id_type = web.ctx.site.get('/local_ids/' + local_id)
+                prefix = local_id_type.urn_prefix
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in rec.get_fields('001')]
 
             result = add_book.load(edition)

--- a/openlibrary/plugins/openlibrary/types/local_id.type
+++ b/openlibrary/plugins/openlibrary/types/local_id.type
@@ -1,0 +1,1 @@
+{"name": "Local ID", "key": "/type/local_id", "type": {"key": "/type/type"}, "properties": [{"index": "0", "expected_type": {"key": "/type/string"}, "unique": true, "type": {"key": "/type/property"}, "name": "source_ocaid"}, {"index": "1", "expected_type": {"key": "/type/string"}, "unique": true, "type": {"key": "/type/property"}, "name": "urn_prefix"}]}

--- a/openlibrary/templates/type/local_id/view.html
+++ b/openlibrary/templates/type/local_id/view.html
@@ -1,0 +1,40 @@
+$def with (page)
+
+$var title: $page.name
+
+<div id="contentHead">
+    $:macros.databarView(page)
+
+    <span class="tag">
+        / <a href="/local_ids">Local IDs</a> / $page.urn_prefix
+    </span>
+
+    <h1>$page.name</h1>
+</div>
+
+<div id="contentBody">
+
+    <div>
+       <span class="title">$_("Source Item")</span>
+       <span class="tag"><a href="//archive.org/details/$page.source_ocaid">$page.source_ocaid</a></span>
+    </div>
+
+    <div>
+       <span class="title">URN $_("prefix")</span>
+       <span class="tag">$page.urn_prefix</span>
+    </div>
+    <div>
+       <span class="title">$_("Example") URN</span>
+       <span class="tag">urn:$page.urn_prefix:{local_id}</span>
+    </div>
+    <div>
+       <span class="title">$_("Search")</span>
+       <span class="tag">
+          <a href="/api/books.json?bibkeys=local_id:urn:$page.urn_prefix:{local_id}">
+	      /api/books.json?bibkeys=local_id:urn:$page.urn_prefix:{local_id}
+	  </a>
+       </span>
+    </div>
+    $:render_template("lib/history", page)
+
+</div>


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Generalises the local_id importing to store searchable organisation `local_ids` with MARC records imported from that organisation. 

> **Technical**: What should be noted about the implementation?

New optional API param: https://github.com/internetarchive/openlibrary/wiki/Endpoints#importing for bulk MARC imports.
```
"local_id": <id>
```

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

