### PR TITLE
Reinstate recommended Docker-Compose v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 services:
   web:
     image: oldev


### PR DESCRIPTION
based on discussion https://github.com/internetarchive/openlibrary/pull/1856/files#r253220282

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Uses the latest spec recommended spec for docker-compose. I'm not sure what problem the downgrade to 2 was solving, but I think @cdrini, me, and anyone else who edited the docker-compose.yml were relying on v3 definitions. If there is something in there that isn't valid as part of v3, it should be updated to be valid in v3.

See https://docs.docker.com/compose/compose-file/compose-versioning/  for official statement on recommended version and a link to the spec.