### PR TITLE
Fix css in cover image modal

### DIFF
--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -50,6 +50,7 @@
     border-radius: 12px;
     -webkit-box-shadow: 1px 3px 10px @black;
     box-shadow: 1px 3px 10px @black;
+    box-sizing: content-box;
   }
   &LoadedContent {
     background: @white;
@@ -77,6 +78,10 @@
       background-position: 0 -32px;
     }
   }
+}
+
+div.imageIntro{
+  margin: 10px;
 }
 
 a.floater {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1818,11 +1818,6 @@ div#throbber {
   }
 }
 
-// openlibrary/templates/covers/change.html
-div.tabsPop {
-  margin-top: 31px;
-}
-
 div.pop {
   // openlibrary/templates/covers/add.html
   // openlibrary/templates/books/edit/addfield.html


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Fixes:    The cross button goes out of the box
Fixes:    The content inside the modal starts touching the border

Closes #1971 

> **Technical**: What should be noted about the implementation?
n/a

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
n/a

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

Earlier:
![cross-padding](https://user-images.githubusercontent.com/32803230/54125999-83ae5180-442c-11e9-8a45-494fc221aecc.gif)


Now:
![modal](https://user-images.githubusercontent.com/32803230/54125541-4e553400-442b-11e9-9902-3f2bd62843fe.png)

