### PR TITLE
Fix dev environment Coverstore upload

### DIFF
--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -4,7 +4,7 @@ db_parameters:
     dbn: "postgres"
     db: "coverstore"
 
-data_root: "var/lib/coverstore"
+data_root: "/var/lib/coverstore"
 default_image: "static/images/empty.gif"
 
 # Redirects to this, if the requested cover is not found in the coverstore. Useful for dev-instance

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -16,10 +16,15 @@ RUN /etc/init.d/postgresql start \
   && pg_ctlcluster 9.5 main stop
 
 USER root
+
+# oldev currently runs coverstore in the same container:
+RUN mkdir -p /var/lib/coverstore \
+    && chown openlibrary:openlibrary /var/lib/coverstore
+
 RUN pip install -r requirements_test.txt
 RUN npm install
 
-# Expose Open Library and Infobase
+# Expose Open Library, Infobase, and Coverstore
 EXPOSE 80 7000 8081
 
 # runs as root in order to access su to run as openlibrary and postgres users

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -75,6 +75,12 @@ type_map = {
     'number_of_pages': 'int',
 }
 
+class CoverNotSaved(Exception):
+    def __init__(self, f):
+        self.f = f
+    def __str__(self):
+        return "coverstore responded with: '%s'" % self.f
+
 class RequiredField(Exception):
     def __init__(self, f):
         self.f = f
@@ -458,6 +464,8 @@ def add_cover(cover_url, ekey, account=None):
             sleep(2)
             continue
         body = res.read()
+        if res.getcode() == 500:
+            raise CoverNotSaved(body)
         if body not in ['', 'None']:
             reply = json.loads(body)
             if res.getcode() == 200 and 'id' in reply:


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #1910

> **Technical**: What should be noted about the implementation?

developers will need to rebuild just the `oldev` image to use this fix locally:

    docker build -t oldev:latest -f docker/Dockerfile.oldev .


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

You can now POST directly to local dev coverstore using curl, e.g.:

    curl -XPOST --data "source_url=https://archive.org/download/9788578793319/9788578793319/page/title.jpg" http://0.0.0.0:8081/b/upload2

Expected response:

    {"ok": "true", "id": 1}

And the covers will be available at:

http://0.0.0.0:8081/b/id/1-S.jpg
http://0.0.0.0:8081/b/id/1-M.jpg
http://0.0.0.0:8081/b/id/1-L.jpg

