### PR TITLE
[DISCUSS] Add separate issue templates for feature report and bug report (#1974)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,24 @@
-## Description
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Description**
 > What problem are we solving? What does the experience look like today? What are the symptoms?
 
-## Evidence 
+**Evidence / Screenshot (if possible)**
 
-> Relevant url?
-`https://openlibrary.org/...`
+**Relevant url?**
+>`https://openlibrary.org/...`
 
-> Screenshot (if possible):
-
-## Expectation
+**Expectation**
 > What should by happening? What will it look like / how will it behave?
 
-## Details
+**Details**
 
 > Logged in (Y/N)?
 
@@ -19,11 +26,10 @@
 
 > Operating system?
 
-## Proposal & Constraints
+**Proposal & Constraints**
 
 > What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere?
 
-> Which suggestions or requirements should be considered for how feature needs to appear or be implemented?
 
-## Stakeholders
-> @ tag stakeholders of this bug / feature
+**Stakeholders**
+> @ tag stakeholders of this bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+> A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+> A clear and concise description of what you want to happen.
+
+**Proposal & Constraints**
+> What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere?
+
+> Which suggestions or requirements should be considered for how feature needs to appear or be implemented?
+
+**Additional context**
+> Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

[feature] 

Making use of github's feature of having separate issue template for bug report and feature request.
These templates have more features which can utilized by editing the YAML part in the templates.

Closes #1974 

> **Technical**: What should be noted about the implementation?
n/a

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

This is can be tested on master branch by creating a new issue. Github will prompt for type of issue. Issue opener can even opt for a blank issue template.

![new-issue-page-with-multiple-templates](https://user-images.githubusercontent.com/32803230/54234617-7cbf3600-4535-11e9-9fe8-be66f4e0fda0.png)

**Screenshots**

feature request template:

![feature-new](https://user-images.githubusercontent.com/32803230/54235051-6c5b8b00-4536-11e9-9764-7204b89bf6d2.png)

bug report template:

![bug-new](https://user-images.githubusercontent.com/32803230/54235069-74b3c600-4536-11e9-8872-52890c532ccd.png)
