### PR TITLE
Change banner colour for accessibility

### DIFF
--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -1,6 +1,6 @@
 // blue
 @primary-blue: hsl(211, 97%, 61%);
-@link-blue: hsl(202, 97%, 34%);
+@link-blue: hsl(202, 96%, 28%);
 @mid-blue: hsl(204, 70%, 53%);
 @mid-blue-highlight: hsl(204, 64%, 44%);
 @mid-blue-highlight-hover: hsl(204, 98%, 61%);


### PR DESCRIPTION
> **Description**: What does this PR achieve?

The following pr changes the banner color (hsl of link-blue) to a darker one in order to make it more accessible.
 
> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

![sponsor-darker](https://user-images.githubusercontent.com/30471843/54496674-30e70500-4918-11e9-9f54-fbad11a42d39.png)

(As posted by @mekarpeles on slack)