### PR TITLE
Make facebook preview and twitter preview uniform, use Open Graph tag…

### DIFF
--- a/openlibrary/macros/Metatags.html
+++ b/openlibrary/macros/Metatags.html
@@ -1,11 +1,6 @@
 $def with(title, image, description)
 
-$add_metatag(property="twitter:card", content="summary")
-$add_metatag(property="twitter:site", content="@openlibrary")
-$add_metatag(property="twitter:title", content=title)
-$add_metatag(property="twitter:description", content="View the book on Open Library.")
-$add_metatag(property="twitter:image", content=image)
-
+<!-- Open graph tags handle card for both twitter and facebook -->
 $add_metatag(property="og:title", content=title)
 $add_metatag(property="og:type", content="books.book")
 $add_metatag(property="og:image", content=image)

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -53,16 +53,10 @@ $ book_list_excerpt = ''
 $if books and books.works:
     $ book_titles_excerpt = [work.title for work in books.works[:8]]
     $ book_list_excerpt = ', '.join(book_titles_excerpt)
-$ description = "Books by " + page.get("name", "") + ', ' + book_list_excerpt
+$ description = "Author of " + book_list_excerpt
 $putctx("description", description)
 
 $ library = (get_library() if 'inlibrary' in ctx.features else None)
-
-$add_metatag(property="twitter:card", content="summary")
-$add_metatag(property="twitter:site", content="@openlibrary")
-$add_metatag(property="twitter:title", content=title_with_site)
-$add_metatag(property="twitter:description", content="View the author on Open Library.")
-$add_metatag(property="twitter:image", content=meta_photo_url)
 
 $add_metatag(property="og:title", content=title_with_site)
 $add_metatag(property="og:type", content="books.author")


### PR DESCRIPTION
Make facebook preview and twitter preview uniform, use Open Graph tags only for uniformity.

> **Description**: What does this PR achieve? [feature|hotfix|refactor]

hotfix
Closes #1842
Open Graph tags work for facebook and twitter both. 
This PR:
- Removes redundant twitter meta tags.
- Modifies the author description as suggested by @tfmorris in #1842.
- Now both the cards render the exact same data! 


> **Technical**: What should be noted about the implementation?
n/a


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
To test working the working, I used a localhost tunneling tool [serveo.net](https://serveo.net/). I tested author cards for both twitter and facebook. 


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:
Screenshots:




Earlier twitter and facebook preview looked different 
Earliler Twitter preview:
![twitter-old](https://user-images.githubusercontent.com/32803230/54628671-0920aa00-4a9c-11e9-9dd8-895b74ece9f6.png)
Earliler Facebook preview:
![fb-old](https://user-images.githubusercontent.com/32803230/54628912-7e8c7a80-4a9c-11e9-9bd0-b6cf1397f039.png)

The description in twitter is now more informative and same as earlier facebook preview.
Twitter preview now:
![twitter-final](https://user-images.githubusercontent.com/32803230/54629175-007ca380-4a9d-11e9-94f3-7d1fc9906ceb.png)



