### PR TITLE
Revert "Cleanup/document dropclicker behaviour"

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -392,14 +392,6 @@ export default function init(){
             $('.wmd-preview').before('<h3 id="prevHead" style="margin:15px 0 10px;padding:0;">Preview</h3>');
         }
     });
-    /**
-     * close an open dropdown in a given container
-     * @param {jQuery.Object} $container
-     */
-    function closeDropdown($container) {
-        $container.find('.dropdown').slideUp(25);
-        $container.find('.arrow').removeClass('up');
-    }
     $('.dropclick').on('click', debounce(function(){
         $(this).next('.dropdown').slideToggle(25);
         $(this).parent().next('.dropdown').slideToggle(25);
@@ -411,14 +403,12 @@ export default function init(){
         $(this).closest('.arrow').toggleClass("up");
     }, 300, false));
 
-    // Close any open dropdown list if the user clicks outside...
-    $(document).on('click', function() {
-        closeDropdown($('#widget-add'));
-    });
-
-    // ... but don't let that happen if user is clicking inside dropdown
-    $('#widget-add').on('click', function(e) {
-        e.stopPropagation();
+    $(document).on('click', function(e) {
+        var container = $("#widget-add");
+        if (!container.is(e.target) && container.has(e.target).length === 0) {
+            $(container).find('.dropdown').slideUp(25);
+            $(container).find('.arrow').removeClass("up");
+        }
     });
 
     /* eslint-disable no-unused-vars */


### PR DESCRIPTION
This reverts commit f990541030f061c4d5e461b01433e5f9d8ba255b.

> **Description**: What does this PR achieve? [feature|hotfix|refactor]
Quick fix not final solution

Related to #1970 

> **Technical**: What should be noted about the implementation?

Please note this is not the final solution. The real objective [f9905410](https://github.com/internetarchive/openlibrary/commit/f990541030f061c4d5e461b01433e5f9d8ba255b) needs to be fulfilled. 
Please do not close #1970. @jdlrobson is helping me find resolve the actual problem.
The PR is because hundreds of list are not able to created. 
![src-list](https://user-images.githubusercontent.com/32803230/54797085-c5cf6280-4c78-11e9-946d-86131de47b8c.png)


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
n/a


> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

![create-list](https://user-images.githubusercontent.com/32803230/54722794-765f3880-4b8b-11e9-9c01-6dd5da43a6df.gif)
