### PR TITLE
populates node_modules for production on make js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ css:
 
 js:
 	mkdir -p $(BUILD)
+        mkdir -p node_modules
+        npm install  # necessary for production (which cleans node_modules upon deploy)
 	bash static/js/vendor.jsh > $(BUILD)/vendor-v2.js
 	npm run build-assets:webpack
 


### PR DESCRIPTION
Deployment on production is broken because our fabfile runs:
`xrun("cd /opt/openlibrary/deploys && rsync -a $rsync_url --delete /opt/openlibrary/deploys/$name/$githash")`

Which wipes out untracked files in our production server openlibrary repo (which we want because this cleans up stale js, css, etc, but which we don't want because it **clobbers** our node_modules).

Interim solution is create `node_modules` dir + run `npm install` within `make js` but this may have undesirable consequences for `docker`

@hornc -- handing off to you for review please! 