### PR TITLE
npm install using package.json for base Docker image

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -31,8 +31,6 @@ RUN apt-get -qq update && apt-get install -y \
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
 
-RUN npm install less -g
-
 # enable users to bind to port 80
 RUN touch /etc/authbind/byport/80 && chmod 777 /etc/authbind/byport/80
 
@@ -47,6 +45,7 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 WORKDIR /openlibrary
 
 RUN pip install --default-timeout=100 -r requirements_common.txt
+RUN npm install && npm install -g less
 
 USER openlibrary
 RUN ln -s vendor/infogami/infogami infogami


### PR DESCRIPTION
webpack is required for production too (used in the Makefile js task)
this installs webpack from package.json
less is installed globally separately because not doing so results in
errors from vendor submodules vendor/js/wmd

> **Description**: What does this PR achieve? [feature|hotfix]

Allows the base Docker image to be successfully built after the addition of webpack to the js Makefile task.

> **Technical**: What should be noted about the implementation?
I'm not completely certain that `npm install` needs to be in the Dockerfile.oldev file. Perhaps we should audit what npm dependencies are required for production vs. dev. It's probably ok for now, and not urgent.

There are probably other ways to get the same effect as `&& npm install -g less` but it is required because without it installing  vendor submodules vendor/js/wmd fails with:

```
Synchronizing submodule url for 'vendor/js/wmd'
git submodule update
Cloning into 'vendor/acs4_py'...
Submodule path 'vendor/acs4_py': checked out '913a6351fc1cf4bff713f0995a0a6f63a2146958'
Cloning into 'vendor/infogami'...
Submodule path 'vendor/infogami': checked out '7595ae764b045c58c762d303da519e00cfe06078'
Cloning into 'vendor/js/wmd'...
Submodule path 'vendor/js/wmd': checked out 'eca6a892c6c4f210a80d887c17e7c9d9f8746283'
mkdir -p static/build
for asset in admin book edit form home lists plain subject user book-widget design dev; do \
		echo Compressing page-page-$asset.less; lessc -x static/css/page-$asset.less static/build/page-$asset.css; \
done
Compressing page-page-admin.less
Compressing page-page-book.less
Compressing page-page-edit.less
Compressing page-page-form.less
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
Compressing page-page-home.less
/bin/sh: 2: lessc: not found
Compressing page-page-lists.less
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
/bin/sh: 2: lessc: not found
Compressing page-page-plain.less
Compressing page-page-subject.less
Compressing page-page-user.less
Compressing page-page-book-widget.less
Compressing page-page-design.less
/bin/sh: 2: lessc: not found
Compressing page-page-dev.less
/bin/sh: 2: lessc: not found
Makefile:27: recipe for target 'css' failed
make: *** [css] Error 127
The command '/bin/sh -c make' returned a non-zero code: 2

```


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

