### PR TITLE
added default styling to <a> tag 

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -114,7 +114,3 @@ div.head {
     display: inline-block;
   }
 }
-
-a.dropclick.plain {
-  text-decoration: none;
-}

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -114,3 +114,7 @@ div.head {
     display: inline-block;
   }
 }
+
+a.dropclick.plain {
+  text-decoration: none;
+}

--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -357,3 +357,10 @@ div.tools-override {
     margin: auto;
   }
 }
+
+a:hover > h3 {
+    text-decoration: underline;
+}
+a.dropclick.plain {
+  text-decoration: none;
+}


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #1968

> **Technical**: What should be noted about the implementation?

-webkit-any-links default styling was being applied to this link which is the source of the underline. I've added two properties to dropper.less.

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

visit openlib_url/subjects/fantasy#sort=date_published&ebooks=true . You should see a dropper with no underline. **Note**: I wasn't sure if it should be completely removed so I created an on hover property. The idea being users see there is functionality behind the button. ¯\_(ツ)_/¯

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

<img width="1142" alt="Screen Shot 2019-04-02 at 1 11 58 PM" src="https://user-images.githubusercontent.com/32860050/55428489-d02e0e00-554e-11e9-86d2-f565759f44c5.png">
