### PR TITLE
suppress pip version warning when creating docker images

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -44,7 +44,7 @@ RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
 COPY --chown=openlibrary:openlibrary . /openlibrary
 WORKDIR /openlibrary
 
-RUN pip install --default-timeout=100 -r requirements_common.txt
+RUN pip install --disable-pip-version-check --default-timeout=100 -r requirements_common.txt
 RUN npm install && npm install -g less
 
 USER openlibrary

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -21,7 +21,7 @@ USER root
 RUN mkdir -p /var/lib/coverstore \
     && chown openlibrary:openlibrary /var/lib/coverstore
 
-RUN pip install -r requirements_test.txt
+RUN pip install --disable-pip-version-check -r requirements_test.txt
 RUN npm install
 
 # Expose Open Library, Infobase, and Coverstore


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature]

HIdes a version warning in the docker image building logs that has made a number of contributors think there is a problem with setting up docker. Reduces noise in the logs to help trouble shoot real problems.

