### PR TITLE
replace block quotes with html comments in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,28 +8,28 @@ assignees: ''
 ---
 
 **Description**
-> What problem are we solving? What does the experience look like today? What are the symptoms?
+<!-- What problem are we solving? What does the experience look like today? What are the symptoms? -->
 
 **Evidence / Screenshot (if possible)**
 
 **Relevant url?**
->`https://openlibrary.org/...`
+<!-- `https://openlibrary.org/...` -->
 
 **Expectation**
-> What should by happening? What will it look like / how will it behave?
+<!-- What should by happening? What will it look like / how will it behave? -->
 
 **Details**
 
-> Logged in (Y/N)?
+<!-- Logged in (Y/N)? -->
 
-> Browser type/version?
+<!-- Browser type/version? -->
 
-> Operating system?
+<!-- Operating system? -->
 
 **Proposal & Constraints**
 
-> What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere?
+<!-- What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere? -->
 
 
 **Stakeholders**
-> @ tag stakeholders of this bug
+<!-- @ tag stakeholders of this bug -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,18 +7,18 @@ assignees: ''
 
 ---
 
-**Description**
+## Description
 <!-- What problem are we solving? What does the experience look like today? What are the symptoms? -->
 
-**Evidence / Screenshot (if possible)**
+## Evidence / Screenshot (if possible)
 
-**Relevant url?**
+## Relevant url?
 <!-- `https://openlibrary.org/...` -->
 
-**Expectation**
+## Expectation
 <!-- What should by happening? What will it look like / how will it behave? -->
 
-**Details**
+## Details
 
 <!-- Logged in (Y/N)? -->
 
@@ -26,10 +26,10 @@ assignees: ''
 
 <!-- Operating system? -->
 
-**Proposal & Constraints**
+## Proposal & Constraints
 
 <!-- What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere? -->
 
 
-**Stakeholders**
+## Stakeholders
 <!-- @ tag stakeholders of this bug -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,16 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 <!-- A clear and concise description of what you want to happen. -->
 
-**Proposal & Constraints**
+## Proposal & Constraints
 <!-- What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere? -->
 
 <!-- Which suggestions or requirements should be considered for how feature needs to appear or be implemented? -->
 
-**Additional context**
+## Additional context
 <!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,15 +8,15 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-> A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-> A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Proposal & Constraints**
-> What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere?
+<!-- What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere? -->
 
-> Which suggestions or requirements should be considered for how feature needs to appear or be implemented?
+<!-- Which suggestions or requirements should be considered for how feature needs to appear or be implemented? -->
 
 **Additional context**
-> Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,18 @@
-> **Description**: What does this PR achieve? [feature|hotfix|refactor]
+ ## Description
+ <!-- What does this PR achieve? [feature|hotfix|refactor] -->
 
 Closes #
 
-> **Technical**: What should be noted about the implementation?
+ ## Technical
+ <!-- What should be noted about the implementation? -->
 
 
 
-> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
+ ## Testing
+ <!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
 
 
 
-> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:
+ ## Evidence
+ <!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,13 @@
- ## Description
- <!-- What does this PR achieve? [feature|hotfix|refactor] -->
+## Description
+<!-- What does this PR achieve? [feature|hotfix|refactor] -->
 
 Closes #
 
- ## Technical
- <!-- What should be noted about the implementation? -->
+## Technical
+<!-- What should be noted about the implementation? -->
 
+## Testing
+<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
 
-
- ## Testing
- <!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
-
-
-
- ## Evidence
- <!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
-
+## Evidence
+<!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Replaces block quotes in issue templates with HTML comments. 
Closes #2010 
