### PR TITLE
Force memcache eviction on save

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -78,7 +78,7 @@ def force_invalidate_cache(docs):
     """
     docs = [dict(doc) for doc in docs if doc]
     keys = [doc['key'] for doc in docs if doc.has_key('key')]
-    keys += ["d" + k for k in keys]
+    keys += ["d" + k for k in keys]  # also clear doc 'metadata'
     logger.info("force-invalidating %s", keys)
     cache.get_memcache().delete_multi(keys)
 
@@ -692,7 +692,6 @@ class book_edit(delegate.page):
 
         add = (edition.revision == 1 and work and work.revision == 1 and work.edition_count == 1)
 
-        # Invalidate the cache; temporary fix to #
         force_invalidate_cache([edition, work])
 
         try:


### PR DESCRIPTION
Hotfix to close #2040 .

## Technical
Directly access memcache and evicts the keys when an edit occurs (synchronously). This isn't great practice, but would buy us some time so we can work on this at a slower pace.

## Testing

- Checking the history endpoint is a quick way to see if the page it up-to-date.

Manual Test | Done on Local | Done on Dev
-- | -- | --
Edit author | ✅ | 🔲 |
Edit work | ✅ | ✅ |
Edit edition | ✅ | ✅ |
Edit work/edition at same time | ✅ | ✅ |
Move an edition to a different work | 🔲 | 🔲 |
Edit an oprhaned edition | 🔲 | 🔲 |
move an oprhan to a work | 🔲 | 🔲 |
Is it noticeably slower to save a work? | 🔲 | 🔲 |
Is it noticeably slower to save a edition? | 🔲 | 🔲 |
Is it noticeably slower to save a author? | 🔲 | 🔲 |