### PR TITLE
updated infobase config to point to memcache server

### DIFF
--- a/conf/infobase.yml
+++ b/conf/infobase.yml
@@ -17,7 +17,7 @@ plugins:
 cache:
     type: memcache
     servers:
-        - "127.0.0.1:11211"
+        - "memcached:11211"
 
 errorlog: /var/log/openlibrary/infobase-errors
 writelog: /var/lib/openlibrary/infobase-writelog


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Only fixes the dev instance issues relating to #2040 _but_ I believe the cause of #2040 was a similar overlooking of the infobase.yml config with the recent addition of `ol-mem4`. It seems the server settings have to be entered in two places, and match. This isn't obvious and is a  bit fragile. Let's look into this and see if we can simplify.

**EDIT** I have checked the changes the @mekarpeles has reverted on `olsystem` and they did have the corresponding edits made to infobase.yml, so this is not the smoking gun I thought it was :(
All I can think of is that somehow one or more of the multiple changes required hadn't propagated to the running code and updates were missed -- that's going to be hard to check or prove in retrospect. 

I think we are going to have to go through the memcache 4 addition again and check everything very thoroughly, and be prepared for another revert :( 

> **Technical**: What should be noted about the implementation?



> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?



> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

