### PR TITLE
2069/refactor/lazy load homepage

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -55,11 +55,14 @@ class browse(delegate.page):
     encoding = "json"
 
     def GET(self):
-        i = web.input(q=None, page=1, limit=100, subject=None,
-                      work_id=None, _type=None, sorts=None)
+        i = web.input(q='', page=1, limit=100, subject='',
+                      work_id='', _type='', sorts='')
+        sorts = i.sorts.split(',')
+        page = int(i.page)
+        limit = int(i.limit)
         url = lending.compose_ia_url(
-            query=i.q, limit=i.limit, page=i.page, subject=i.subject,
-            work_id=i.work_id, _type=i._type, sorts=i.sorts)
+            query=i.q, limit=limit, page=page, subject=i.subject,
+            work_id=i.work_id, _type=i._type, sorts=sorts)
         result = {
             'query': url,
             'works': [
@@ -246,7 +249,7 @@ class price_api(delegate.page):
     @jsonapi
     def GET(self):
         # @hornc, add: title='', asin='', authors=''
-        i = web.input(isbn='', asin='') 
+        i = web.input(isbn='', asin='')
 
         if not (i.isbn or i.asin):
             return simplejson.dumps({

--- a/openlibrary/plugins/openlibrary/js/carousels.js
+++ b/openlibrary/plugins/openlibrary/js/carousels.js
@@ -97,12 +97,15 @@ const Carousel = {
 
         // if a loadMore config is provided and it has a (required) url
         if (loadMore && loadMore.url) {
+            var url;
             try {
-                var url = new URL(loadMore.url);
+                // exception handling needed in case loadMore.url is relative path
+                url = new URL(loadMore.url);
             } catch (e) {
-                var url = new URL(window.location.origin + loadMore.url);
+                url = new URL(window.location.origin + loadMore.url);
             }
-            url.searchParams.set('limit', loadMore.limit || 18); // todo, define sane default
+            var default_limit = 18; // 3 pages of 6 books
+            url.searchParams.set('limit', loadMore.limit || default_limit);
             loadMore.pageMode = loadMore.pageMode === 'page' ? 'page' : 'offset'; // verify pagination mode
             loadMore.locked = false; // prevent additional calls when not in critical section
 

--- a/openlibrary/plugins/openlibrary/js/carousels.js
+++ b/openlibrary/plugins/openlibrary/js/carousels.js
@@ -1,6 +1,6 @@
 // used in templates/covers/add.html
 const Carousel = {
-    add: function(selector, a, b, c, d, e, f, key, loadMoreUrl) {
+    add: function(selector, a, b, c, d, e, f, loadMore) {
         a = a || 6;
         b = b || 5;
         c = c || 4;
@@ -39,9 +39,6 @@ const Carousel = {
                     slidesToScroll: e
                 }
             }
-            // You can unslick at a given breakpoint now by adding:
-            // settings: "unslick"
-            // instead of a settings object
         ];
         if (f) {
             responsive_settings.push({
@@ -70,6 +67,7 @@ const Carousel = {
 
         var addWork = function(work) {
             var availability = work.availability.status;
+            var cover_id = work.covers? work.covers[0] : work.cover_id;
             var ocaid = work.availability.identifier;
             var cls = availabilityStatuses[availability].cls;
             var url = (cls == 'cta-btn--available') ?
@@ -82,40 +80,74 @@ const Carousel = {
                 '"aria-hidden="false" role="option">' +
                 '<div class="book-cover">' +
                   '<a href="' + work.key + '" ' + isClickable + '>' +
-                    '<img class="bookcover" width="130" height="200" title="' + work.title + '" ' +
-                         'src="//covers.openlibrary.org/b/id/' + work.cover_id + '-M.jpg">' +
+                    '<img class="bookcover" width="130" height="200" title="' +
+                      work.title + '" ' +
+                      'src="//covers.openlibrary.org/b/id/' + cover_id + '-M.jpg">' +
                   '</a>' +
                 '</div>' +
                 '<div class="book-cta">' +
-                  '<a class="btn cta-btn ' + cls + '" href="' + url + '" data-ol-link-track="subjects" ' +
-                  'title="' + cta + ': ' + work.title + '" data-key="subjects" data-ocaid="' + ocaid + '">' + cta + '</a>' +
+                  '<a class="btn cta-btn ' + cls + '" href="' + url +
+                    '" data-ol-link-track="subjects" ' +
+                    'title="' + cta + ': ' + work.title +
+                    '" data-key="subjects" data-ocaid="' + ocaid + '">' + cta +
+                  '</a>' +
                 '</div>' +
               '</div>';
         }
 
-        $('.carousel-'+key).on('afterChange', function() {
-            var totalSlides = $('.carousel-' + key + '.slick-slider').slick("getSlick").$slides.length;
-            var numActiveSlides = $('.carousel-' + key + ' .slick-active').length;
-            var currentLastSlide = $('.carousel-' + key + '.slick-slider').slick('slickCurrentSlide') + numActiveSlides;
-            // this allows us to pre-load before hitting last page
-            var lastSlideOnSecondToLastPage = (totalSlides - numActiveSlides);
-
-            if (loadMoreUrl && (currentLastSlide >= lastSlideOnSecondToLastPage)) {
-                var limit = numActiveSlides * 3;
-                var url = loadMoreUrl + '?offset=' + totalSlides + '&limit=' + limit;
-                $.ajax({
-                    'url': url,
-                    'type': 'GET',
-                    success: function(subject_results) {
-                        $.each(subject_results.works, function(work_idx) {
-                            var work = subject_results.works[work_idx];
-                            var lastSlidePos = $('.carousel-' + key + '.slick-slider').slick("getSlick").$slides.length - 1;
-                            $('.carousel-' + key).slick('slickAdd', addWork(work), lastSlidePos);
-                        });
-                    }
-                });
+        // if a loadMore config is provided and it has a (required) url
+        if (loadMore && loadMore.url) {
+            try {
+                var url = new URL(loadMore.url);
+            } catch (e) {
+                var url = new URL(window.location.origin + loadMore.url);
             }
-        });
+            url.searchParams.set('limit', loadMore.limit || 18); // todo, define sane default
+            loadMore.pageMode = loadMore.pageMode === 'page' ? 'page' : 'offset'; // verify pagination mode
+            loadMore.locked = false; // prevent additional calls when not in critical section
+
+            // Bind an action listener to this carousel on resize or advance
+            $(selector).on('afterChange', function() {
+                var totalSlides = $(selector + '.slick-slider')
+                    .slick("getSlick").$slides.length;
+                var numActiveSlides = $(selector + ' .slick-active').length;
+                var currentLastSlide = $(selector + '.slick-slider')
+                    .slick('slickCurrentSlide') + numActiveSlides;
+                // this allows us to pre-load before hitting last page
+                var lastSlideOn2ndLastPage = (totalSlides - numActiveSlides);
+
+                if (!loadMore.locked && (currentLastSlide >= lastSlideOn2ndLastPage)) {
+                    loadMore.locked = true; // lock for critical section
+                    document.body.style.cursor='wait'; // change mouse to spin
+
+                    if (loadMore.pageMode == 'page') {
+                        // for first time, we're on page 1 already so initialize as page 2
+                        // otherwise advance to next page
+                        loadMore.page = loadMore.page ? loadMore.page + 1 : 2;
+                    } else { // i.e. offset, start from last slide
+                        loadMore.page = totalSlides;
+                    }
+
+                    // update the current page or offset within the URL
+                    url.searchParams.set(loadMore.pageMode, loadMore.page);
+
+                    $.ajax({
+                        'url': url,
+                        'type': 'GET',
+                        success: function(subject_results) {
+                            $.each(subject_results.works, function(work_idx) {
+                                var work = subject_results.works[work_idx];
+                                var lastSlidePos = $(selector + '.slick-slider')
+                                    .slick("getSlick").$slides.length - 1;
+                                $(selector).slick('slickAdd', addWork(work), lastSlidePos);
+                            });
+                            document.body.style.cursor='default'; // return cursor to ready
+                            loadMore.locked = false;
+                        }
+                    });
+                }
+            });
+        }
     }
 };
 export default Carousel;

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,4 +1,4 @@
-$def with(books=[], title="", url="", key="", min_books=1, test=False, load_more_url='')
+$def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False)
 
 $def render_carousel_cover(book, lazy):
   $ url = book.get('key') or book.url
@@ -71,7 +71,14 @@ $if test or (books and len(books) >= min_books):
         </div>
         <script type="text/javascript">
               window.q.push(function() {
-                Carousel.add('.carousel-$key', 6, 5, 4, 3, 2, 1, '$key', '$load_more_url');
+                Carousel.add(
+                  '.carousel-$key', // dom element to bind slick
+                  6, 5, 4, 3, 2, 1, { // num books per responsive breakpoint
+                  $if load_more:
+                     url: '$:(load_more["url"].replace("&amp;", "&"))',
+                     pageMode: '$(load_more.get("mode", "offset"))',
+                     limit: $(load_more.get("limit", 18))
+                  });
               });
         </script>
       </div>

--- a/openlibrary/templates/home/custom_ia_carousel.html
+++ b/openlibrary/templates/home/custom_ia_carousel.html
@@ -1,5 +1,7 @@
-$def with(title, key, query=None, subject=None, work_id=None, _type=None, sorts=None, limit=None, min_books=7, test=False)
+$def with(title, key, query='', subject='', work_id='', _type='', sorts='', limit=None, min_books=7, test=False)
 
 $ url = compose_ia_url(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit, advanced=False)
 $ books = generic_carousel(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit) if not test else []
-$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, test=test)
+$ sorts = ','.join(sorts) if sorts else ''
+$ load_more_url = '/browse.json?q=%s&subject=%s&work_id=%s&_type=%s&sorts=%s' % (query, subject, work_id, _type, sorts)
+$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more={"url": load_more_url, "mode": "page", "limit": limit}, test=test)

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -8,19 +8,19 @@ $var title: $_("Welcome to Open Library")
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title="Classic Books", url="/read", key="public_domain", test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Books We Love", key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=120, test=test)
+  $:render_template("home/custom_ia_carousel", title="Books We Love", key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=18)
 
-  $:render_template("home/custom_ia_carousel", title="Recently Returned", key="recently_returned", sorts=["loans__status__last_loan_date+desc"], limit=42, test=test)
+  $:render_template("home/custom_ia_carousel", title="Recently Returned", key="recently_returned", sorts=["loans__status__last_loan_date+desc"], limit=18)
 
-  $:render_template("home/custom_ia_carousel", title="Romance", key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date+desc"], limit=42, test=test)
+  $:render_template("home/custom_ia_carousel", title="Romance", key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date+desc"], limit=18)
 
-  $:render_template("home/custom_ia_carousel", title="Kids", key="children", query="preset:children", sorts=["loans__status__last_loan_date+desc"], limit=42, test=test)
+  $:render_template("home/custom_ia_carousel", title="Kids", key="children", query="preset:children", sorts=["loans__status__last_loan_date+desc"], limit=18)
 
-  $:render_template("home/custom_ia_carousel", title="Thrillers", key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=42, test=test)
+  $:render_template("home/custom_ia_carousel", title="Thrillers", key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=18)
 
-  $:render_template("home/custom_ia_carousel", title="Textbooks", key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date+desc"], limit=36, test=test)
+  $:render_template("home/custom_ia_carousel", title="Textbooks", key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date+desc"], limit=18)
 
-  $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=36, test=test)
+  $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18)
 
   $:render_template("home/stats", stats)
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -8,19 +8,19 @@ $var title: $_("Welcome to Open Library")
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title="Classic Books", url="/read", key="public_domain", test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Books We Love", key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=18)
+  $:render_template("home/custom_ia_carousel", title="Books We Love", key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Recently Returned", key="recently_returned", sorts=["loans__status__last_loan_date+desc"], limit=18)
+  $:render_template("home/custom_ia_carousel", title="Recently Returned", key="recently_returned", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Romance", key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date+desc"], limit=18)
+  $:render_template("home/custom_ia_carousel", title="Romance", key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Kids", key="children", query="preset:children", sorts=["loans__status__last_loan_date+desc"], limit=18)
+  $:render_template("home/custom_ia_carousel", title="Kids", key="children", query="preset:children", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Thrillers", key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=18)
+  $:render_template("home/custom_ia_carousel", title="Thrillers", key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Textbooks", key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date+desc"], limit=18)
+  $:render_template("home/custom_ia_carousel", title="Textbooks", key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18)
+  $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
 
   $:render_template("home/stats", stats)
 

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -33,7 +33,7 @@ window.q.push( function () {
 </script>
 <div class="contentBody">
 
-  $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more_url=page.key + ".json")
+  $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more={"url": page.key + ".json", "limit": len(page.works)})
 
   <div class="head">
     <h2 class="inline">

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     },
     {
       "path": "static/build/page-home.css",
-      "maxSize": "4.3KB"
+      "maxSize": "4.85KB"
     },
     {
       "path": "static/build/page-plain.css",
@@ -52,7 +52,7 @@
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "18.7KB"
+      "maxSize": "18.6KB"
     }
   ],
   "devDependencies": {

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -112,3 +112,4 @@
   }
 }
 @import (less) "category-item.less";
+@import (less) "components/read-panel.less";

--- a/static/css/page-subject.less
+++ b/static/css/page-subject.less
@@ -12,7 +12,6 @@
 @import (less) "components/header.less";
 @import (less) "components/page-heading-search-box.less";
 @import (less) "components/carousel.less";
-@import (less) "components/read-panel.less";
 @import (less) "components/chart.less";
 @import (less) "components/link-box.less";
 @import (less) "components/widget-box.less";


### PR DESCRIPTION
## Description
<!-- What does this PR achieve? [feature|hotfix|refactor] -->

Updated lazy-loading to work with both page counts (necessary for archive.org-backed carousels which use ElasticSearch) or offset (used by Open Library's APIs).

Dramatically reduces number of records books to load upfront on homepage (lazy-loads them instead).

Closes #2069 
