### PR TITLE
Hotfix/style regressions

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -50,7 +50,7 @@ $def render_carousel_cover(book, lazy):
       </a>
     </div>
     $if cta:
-      <div class="book-cta"><a class="btn primary $modifier" href="$cta_url" data-ol-link-track="$key" title="$cta $book.title"
+      <div class="book-cta"><a class="cta-btn cta-btn--available $modifier" href="$cta_url" data-ol-link-track="$key" title="$cta $book.title"
         data-key="$(key)" data-ocaid="$(book.get('ia'))">$cta</a></div>
   </div>
 

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -21,9 +21,6 @@ a.cta-btn {
   background-color: @mid-grey;
   line-height: 1.5em;
 
-  &:hover {
-    text-decoration: underline;
-  }
   &--available {
     background-color: @primary-blue;
   }

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -2,6 +2,8 @@
  * Carousel
  * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#carousel
  */
+
+@import (less) "components/read-panel.less";
 @import (less) "components/book.less";
 
 // Badly named. Should be renamed "carousel-heading" or similar.
@@ -112,4 +114,3 @@
   }
 }
 @import (less) "category-item.less";
-@import (less) "components/read-panel.less";


### PR DESCRIPTION
See commit messages, followup to #2078, standardizes cta-btn classes, removes cta-btn underline on hover, and removes underlines from categories carousel links 

This change potentially impacts style on any page which has carousels (as an include for a set of cta-btn styles changed order)