### PR TITLE
Fix highlight on category items inside carousel

### DIFF
--- a/static/css/components/category-item.less
+++ b/static/css/components/category-item.less
@@ -10,6 +10,7 @@
 a {
   &.category-nostyle {
     text-decoration: none;
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Description
<!-- What does this PR achieve? [feature|hotfix|refactor] -->
When tapping a category a single box is shown instead of 3 boxes like before.

Closes #1195

## Technical
<!-- What should be noted about the implementation? -->
Just added display:block to the anchor element as suggested

## Testing
<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
All tests passed

## Evidence
<!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
Before
![Schermata 2019-04-24 alle 12 03 41](https://user-images.githubusercontent.com/496417/56651727-02341b00-668a-11e9-8aeb-0ca299b512c4.png)

After
![Schermata 2019-04-24 alle 12 06 08](https://user-images.githubusercontent.com/496417/56651734-05c7a200-668a-11e9-9fbc-9e54220a7487.png)

