### PR TITLE
Use docker-compose build + reorganize Dockerfile layers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: "3"
 services:
   web:
-    image: oldev
+    image: oldev:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
     ports:
       - 8080:80
       - 7000:7000
@@ -19,7 +22,10 @@ services:
     networks:
       - webnet
   solr:
-    image: olsolr
+    image: olsolr:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.olsolr
     ports:
       - 8983:8080
     volumes:

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -28,8 +28,8 @@ RUN apt-get -qq update && apt-get install -y \
     python-yaml
 
 # Install LTS version of node.js
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt-get install -y nodejs
 
 # enable users to bind to port 80
 RUN touch /etc/authbind/byport/80 && chmod 777 /etc/authbind/byport/80
@@ -41,11 +41,16 @@ RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/si
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
     && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary
 
-COPY --chown=openlibrary:openlibrary . /openlibrary
+RUN mkdir /openlibrary && chown openlibrary:openlibrary /openlibrary
 WORKDIR /openlibrary
 
+COPY requirements*.txt ./
 RUN pip install --disable-pip-version-check --default-timeout=100 -r requirements_common.txt
+
+COPY package*.json ./
 RUN npm install && npm install -g less
+
+COPY --chown=openlibrary:openlibrary . /openlibrary
 
 USER openlibrary
 RUN ln -s vendor/infogami/infogami infogami

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -2,8 +2,6 @@ FROM olbase
 
 WORKDIR /openlibrary
 
-USER openlibrary
-
 # Setup db
 USER postgres
 RUN /etc/init.d/postgresql start \
@@ -21,7 +19,10 @@ USER root
 RUN mkdir -p /var/lib/coverstore \
     && chown openlibrary:openlibrary /var/lib/coverstore
 
+COPY requirements*.txt ./
 RUN pip install --disable-pip-version-check -r requirements_test.txt
+
+COPY package*.json ./
 RUN npm install
 
 # Expose Open Library, Infobase, and Coverstore

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,8 +37,8 @@ docker-machine start default # Start the docker daemon
 
 # build images
 docker build -t olbase:latest -f docker/Dockerfile.olbase . # 30+ min (Win10Home/Dec 2018)
-docker build -t oldev:latest -f docker/Dockerfile.oldev .   # 10+ min (Win10Home/Dec 2018)
-docker build -t olsolr:latest -f docker/Dockerfile.olsolr . # 5+ min (Win10Home/Dec 2018)
+docker-compose build web # 10+ min (Win10Home/Dec 2018)
+docker-compose build solr # 5+ min (Win10Home/Dec 2018)
 
 # start the app
 docker-compose up    # Ctrl-C to stop
@@ -73,9 +73,11 @@ If you are using Docker for Mac or Docker for Windows (or the older Docker Toolb
 
 While running the `oldev` container, gunicorn is configured to auto-reload modified files. To see the effects of your changes in the running container, the following apply:
 
-- Editing python files or web templates => simply save the file, gunicorn will auto-reload it.
-- Working on frontend css or js => you must run `docker-compose exec web make css js`. This will re-generate the assets in the persistent `ol-build` volume mount, so the latest changes will be available between stopping / starting and removing `web` containers. Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
-- Adding or changing core dependencies => you will most likely need to rebuild both `olbase` and `oldev` images. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;)
+- **Editing python files or web templates?** Simply save the file; gunicorn will auto-reload it.
+- **Editing frontend css or js?** Run `docker-compose exec web npm run-script build-assets`. This will re-generate the assets in the persistent `ol-build` volume mount (so the latest changes will be available between stopping / starting  `web` containers). Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
+- **Editing pip packages?** Rebuild the `web` service: `docker-compose build web`
+- **Editing npm packages?** Run `docker-compose exec web npm install` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)
+- **Editing core dependencies?** You will most likely need to do a full rebuild. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;)
 
 ## Useful Runtime Commands
 


### PR DESCRIPTION
## Description
Refactor. Simplify docker build by:
- Use `docker-compose build` commands where possible
- Reorganize Dockerfile layers so pip/npm installation is only required when `requirements*.txt` or `package*.json` changes are made. This means rebuilding the images will be much faster if only a random file in the repo has been changed.
- Updated docs