### PR TITLE
Remote debugging of openlibrary site in docker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Attach",
+      "type": "python",
+      "request": "attach",
+      "port": 3000,
+      "host": "localhost",
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/openlibrary/"
+        }
+      ]
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - 8080:80
       - 7000:7000
       - 8081:8081
+      - 3000:3000
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -26,7 +26,7 @@ COPY package*.json ./
 RUN npm install
 
 # Expose Open Library, Infobase, and Coverstore
-EXPOSE 80 7000 8081
+EXPOSE 80 7000 8081 3000
 
 # runs as root in order to access su to run as openlibrary and postgres users
 CMD docker/ol-docker-start.sh

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -642,6 +642,24 @@ class permissions:
         add_flash_message("info", "Edit policy has been updated!")
         return self.GET()
 
+class attach_debugger:
+    def GET(self):
+        return render_template("admin/attach_debugger")
+
+    def POST(self):
+        import ptvsd
+
+        i = web.input()
+        # Allow other computers to attach to ptvsd at this IP address and port.
+        logger.info("Enabling debugger attachment")
+        ptvsd.enable_attach(address=('0.0.0.0', 3000))
+        logger.info("Waiting for debugger to attach...")
+        ptvsd.wait_for_attach()
+        logger.info("Debugger attached to port 3000")
+        add_flash_message("info", "Debugger attached!")
+
+        return self.GET()
+
 class solr:
     def GET(self):
         return render_template("admin/solr")
@@ -694,6 +712,7 @@ def setup():
     register_admin_page('/admin/stats/(\d\d\d\d-\d\d-\d\d)', stats, label='Stats JSON')
     register_admin_page('/admin/ipstats', ipstats, label='IP Stats JSON')
     register_admin_page('/admin/block', block, label='')
+    register_admin_page('/admin/attach_debugger', attach_debugger, label='Attach Debugger')
     register_admin_page('/admin/loans', loans_admin, label='')
     register_admin_page('/admin/waitinglists', waitinglists_admin, label='')
     register_admin_page('/admin/status', service_status, label = "Open Library services")

--- a/openlibrary/templates/admin/attach_debugger.html
+++ b/openlibrary/templates/admin/attach_debugger.html
@@ -1,0 +1,22 @@
+$def with (keys="", error="")
+
+$var title: Attach Debugger
+
+<div id="contentHead">
+    $:render_template("admin/menu")
+    <h1>Attach Debugger</h1>
+</div>
+
+<div id="contentBody">
+    <div>
+        Start a debugger on port 3000.<br/>
+    </div>
+
+    <form method="POST" class="olform">
+        <div class="formElement">
+            <div class="formElement collapse">
+                <button type="submit" class="larger" name="_start" onclick='this.disabled = true; this.textContent="$_("Waiting for debugger to attach...")"'>$_("Start")</button>
+            </div>
+        </div>
+    </form>
+</div>

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,6 @@
 
 -r requirements_common.txt
 flake8==3.7.7
-pytest==4.4.0
 mockcache==1.0.3; python_version < '3.0'
+ptvsd==4.2.8
+pytest==4.4.0


### PR DESCRIPTION
## Description
Feature. Allow for remote debugging the local site. Closes #2076 . Logging in doesn't seem to work with only 1 gunicorn worker (for some reason), so the flow is a bit awks, but I think still useful.

In action (sorry mouse is invisible):
![ezgif-3-dd6048656c11](https://user-images.githubusercontent.com/6251786/56706388-bd889e00-66e2-11e9-9d9b-449f0458305a.gif)

Not crazy over the magic `/attach_debugger` endpoint; ideally I'd like to show a "Dev Tools" button visible on the homepage toolbar if the site is running locally, but not sure how to access configs from the template (if anyone has info on that). I think still this is worth merging as is, BUT WANT SOMEONE TO TRY IT BEFORE IT GETS MERGED. @hornc @mekarpeles One of you would be great candidates :)

## Technical
This requires VS Code + its Python extension. To use:
1. `docker-compose up -d` as usual and login as admin. Then `docker-compose down`.
2. Open the repo in VS Code
3. Edit the last line of `docker/ol-docker-start.sh` to say `workers 1` instead of `4`
4. `docker-compose up -d`
5. Edit `.vscode/launch.json`:
  a. if using a docker machine (or docker toolbox), update `host` (run `docker-machine ip`)
  b. on Windows, I had to change `localRoot` to be `c:/Users/MyUser/openlibrary/`; if you get "file not found" errors, you might have to do the same.
6. Go to http://localhost:8080/admin/attach_debugger (or whatever your docker ip is) and click "Start"
7. Go to the debug panel (Ctrl+Shift+D) in VS Code, and click "Python: Attach"
8. Debug!