### PR TITLE
Orphans can now be edited + moving orphans won't create works

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -430,6 +430,9 @@ class SaveBookHelper:
                     self.work = self.new_work(self.edition)
                     edition_data.works = [{'key': self.work.key}]
                     work_data.key = self.work.key
+                elif self.work is not None and edition_work_key is None:
+                    # we're trying to create an orphan; let's not do that
+                    edition_data.works = [{'key': self.work.key}]
 
             if self.work is not None:
                 self.work.update(work_data)
@@ -639,11 +642,13 @@ class SaveBookHelper:
         :param web.storage formdata: form data (parsed into a nested dict)
         :rtype: bool
         """
-        if not 'edition' in formdata:
+        if 'edition' not in formdata:
             # No edition data -> just editing work, so work data matters
             return True
 
-        has_edition_work = 'works' in formdata.edition and formdata.edition.works
+        has_edition_work = 'works' in formdata.edition and \
+                           formdata.edition.works and \
+                           formdata.edition.works[0].key
 
         if has_edition_work:
             return formdata.edition.works[0].key == formdata.work.key

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -887,7 +887,7 @@ class works_autocomplete(delegate.page):
 
         for d in docs:
             # Required by the frontend
-            d['name'] = d['title']
+            d['name'] = d['key'].split('/')[-1]
             d['full_title'] = d['title']
             if 'subtitle' in d:
                 d['full_title'] += ": " + d['subtitle']

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -531,7 +531,7 @@ class SaveBookHelper:
         else:
             edition = None
 
-        if 'work' in i and self.is_work_data_important(i):
+        if 'work' in i and self.use_work_edits(i):
             work = self.process_work(i.work)
         else:
             work = None
@@ -632,10 +632,10 @@ class SaveBookHelper:
             raise ValidationException("Changing Internet Archive ID is not allowed.")
 
     @staticmethod
-    def is_work_data_important(formdata):
+    def use_work_edits(formdata):
         """
-        Check if the form data's work matches the form data's edition's work.
-        If they're not, then we ignore the work edits.
+        Check if the form data's work OLID matches the form data's edition's work OLID.
+        If they don't, then we ignore the work edits.
         :param web.storage formdata: form data (parsed into a nested dict)
         :rtype: bool
         """

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -2,15 +2,18 @@
 import web
 from .. import addbook
 from openlibrary import accounts
+from openlibrary.mocks.mock_infobase import MockSite
 
 def strip_nones(d):
     return dict((k, v) for k, v in d.items() if v is not None)
 
 class TestSaveBookHelper:
+    def setup_method(self, method):
+        web.ctx.site = MockSite()
+
     def test_authors(self, monkeypatch):
         def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda self: False})()
-
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         s = addbook.SaveBookHelper(None, None)
@@ -20,3 +23,255 @@ class TestSaveBookHelper:
         assert f({}) == {}
         assert f({"authors": []}) == {}
         assert f({"authors": [{"type": "/type/author_role"}]}) == {}
+
+    def test_editing_orphan_creates_work(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+            }])
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "",
+            "work--title": "Original Edition Title",
+            "edition--title": "Original Edition Title"
+        })
+
+        s = addbook.SaveBookHelper(None, edition)
+        s.save(formdata)
+
+        assert len(web.ctx.site.docs) is 2
+        assert web.ctx.site.get("/works/OL1W") is not None
+        assert web.ctx.site.get("/works/OL1W").title == "Original Edition Title"
+
+    def test_moving_orphan(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+            }])
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "",
+            "work--title": "Original Edition Title",
+            "edition--title": "Original Edition Title",
+            "edition--works--0--key": "/works/OL1W",
+        })
+
+        s = addbook.SaveBookHelper(None, edition)
+        s.save(formdata)
+
+        assert len(web.ctx.site.docs) is 1
+        assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL1W"
+
+    def test_moving_orphan_ignores_work_edits(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL1W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+            }])
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "",
+            "work--title": "Modified Work Title",
+            "edition--title": "Original Edition Title",
+            "edition--works--0--key": "/works/OL1W",
+        })
+
+        s = addbook.SaveBookHelper(None, edition)
+        s.save(formdata)
+
+        assert web.ctx.site.get("/works/OL1W").title == "Original Work Title"
+
+    def test_editing_work(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL1W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+                "works": [{"key": "/works/OL1W"}],
+            }])
+
+        work = web.ctx.site.get("/works/OL1W")
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "/works/OL1W",
+            "work--title": "Modified Work Title",
+            "edition--title": "Original Edition Title",
+            "edition--works--0--key": "/works/OL1W",
+        })
+
+        s = addbook.SaveBookHelper(work, edition)
+        s.save(formdata)
+
+        assert web.ctx.site.get("/works/OL1W").title == "Modified Work Title"
+        assert web.ctx.site.get("/books/OL1M").title == "Original Edition Title"
+
+    def test_editing_edition(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL1W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+                "works": [{"key": "/works/OL1W"}],
+            }])
+
+        work = web.ctx.site.get("/works/OL1W")
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "/works/OL1W",
+            "work--title": "Original Work Title",
+            "edition--title": "Modified Edition Title",
+            "edition--works--0--key": "/works/OL1W",
+        })
+
+        s = addbook.SaveBookHelper(work, edition)
+        s.save(formdata)
+
+        assert web.ctx.site.get("/works/OL1W").title == "Original Work Title"
+        assert web.ctx.site.get("/books/OL1M").title == "Modified Edition Title"
+
+    def test_editing_work_and_edition(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL1W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+                "works": [{"key": "/works/OL1W"}],
+            }])
+
+        work = web.ctx.site.get("/works/OL1W")
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "/works/OL1W",
+            "work--title": "Modified Work Title",
+            "edition--title": "Modified Edition Title",
+            "edition--works--0--key": "/works/OL1W",
+        })
+
+        s = addbook.SaveBookHelper(work, edition)
+        s.save(formdata)
+
+        assert web.ctx.site.get("/works/OL1W").title == "Modified Work Title"
+        assert web.ctx.site.get("/books/OL1M").title == "Modified Edition Title"
+
+    def test_moving_edition(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL1W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+                "works": [{"key": "/works/OL1W"}],
+            }])
+
+        work = web.ctx.site.get("/works/OL1W")
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "/works/OL1W",
+            "work--title": "Original Work Title",
+            "edition--title": "Original Edition Title",
+            "edition--works--0--key": "/works/OL2W",
+        })
+
+        s = addbook.SaveBookHelper(work, edition)
+        s.save(formdata)
+
+        assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL2W"
+
+    def test_moving_edition_ignores_changes_to_work(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL1W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+                "works": [{"key": "/works/OL1W"}],
+            }])
+
+        work = web.ctx.site.get("/works/OL1W")
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "/works/OL1W",
+            "work--title": "Modified Work Title",
+            "edition--title": "Original Edition Title",
+            "edition--works--0--key": "/works/OL2W",  # Changing work
+        })
+
+        s = addbook.SaveBookHelper(work, edition)
+        s.save(formdata)
+
+        assert web.ctx.site.get("/works/OL1W").title == "Original Work Title"

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -38,7 +38,7 @@ $jsdef render_translated_from_language_field(i, language):
 $# Render the ith work input field
 $jsdef render_work_field(i, work):
     <div class="input">
-        <input name="works--$i" class="work work-autocomplete" type="text" id="work-$i" value="$work.title"/>
+        <input name="works--$i" class="work work-autocomplete" type="text" id="work-$i" value="$work.key.split('/')[-1]"/>
         <input name="edition--works--$i--key" type="hidden" id="work-$i-key" value="$work.key" />
         <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this work')">[x]</a>
         $# Limit to only 1


### PR DESCRIPTION
## Description
Fix (NOT A HOTFIX). Would like this FULLY tested on dev and code reviewed before going to prod. I don't want to have this turn into another P0 bug :P 

Closes #961; closes #730; closes #1891 

## Technical
Unless I'm missing something, it seems like orphan editing never worked? Could someone confirm/deny this?

## Testing

Lisa's list of broken orphans for testing: https://openlibrary.org/people/seabelis/lists/OL129155L/broken

| Test | Local | Dev | Testing Cases? |
|------|-------|-----|----------|
| Editing a work | ✔️ |  | ✔️ |
| Editing an edition | ✔️ |  | ✔️ |
| Moving Edition | ✔️ |  | ️️✔️ |
| Edits to Work are ignored when moving an edition | ️️✔️ |  | ✔️ |
| Editing a work and an edition at the same time | ️️✔️ |  | ✔️ |
| Editing orphan (should create new work) | ️️️️️️️✔️️️️️ ️| ✔️️️️️ | ️️️️️️️✔️️️️️ ️|
| Move orphan (should NOT create new work) | ️️✔️ | ✔️️️️️ | ✔️ |
| Cannot create an orphan | ️️✔️ |  | ✔️ |