### PR TITLE
Fix edition becoming an orphan when moving to subtitled work

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -858,8 +858,9 @@ class works_autocomplete(delegate.page):
         for d in docs:
             # Required by the frontend
             d['name'] = d['title']
+            d['full_title'] = d['title']
             if 'subtitle' in d:
-                d['name'] += ": " + d['subtitle']
+                d['full_title'] += ": " + d['subtitle']
         return to_json(docs)
 
 class authors_autocomplete(delegate.page):

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -48,7 +48,7 @@ $jsdef render_work_field(i, work):
 $jsdef render_work_autocomplete_item(item):
     <div class="ac_work" title="Select this work">
         <span class="name">
-            <span class="title">$item.name</span>
+            <span class="title">$item.full_title</span>
             $if item.first_publish_year:
             <span class="first_publish_year">($item.first_publish_year)</span>
         </span>


### PR DESCRIPTION
## Description
Fix: Makes it possible to move an edition to a work which has a subtitle. Closes #2111 .

## Technical
When an item was selected, it was triggering a new solr query which would yield 0 results. This would make nothing be selected, so on save the edition became an orphan.