### PR TITLE
Make solr-updater not error on malformed authors

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -365,7 +365,11 @@ class SolrProcessor:
         :param dict w:
         :rtype: list[dict]
         """
-        authors = [self.get_author(a) for a in w.get("authors", [])]
+        authors = [
+            self.get_author(a)
+            for a in w.get("authors", [])
+            if 'author' in a  # TODO: Remove after https://github.com/internetarchive/openlibrary-client/issues/126
+        ]
 
         if any(a['type']['key'] == '/type/redirect' for a in authors):
             if self.resolve_redirects:


### PR DESCRIPTION
## Description
Fix; I noticed solr updater erroring a lot a while back at this line locally. Possibly related to #870 . Found this while working on #1843 .

This is a workaround because of https://github.com/internetarchive/openlibrary-client/issues/126

Sample error:
```
2019-01-03 17:55:37,202 [ERROR] failed to update work /works/OL17807410W
Traceback (most recent call last):
 File "/openlibrary/openlibrary/solr/update_work.py", line 1149, in update_work
   d = build_data(w)
 File "/openlibrary/openlibrary/solr/update_work.py", line 679, in build_data
   authors = SolrProcessor().extract_authors(w)
 File "/openlibrary/openlibrary/solr/update_work.py", line 370, in extract_authors
   if any(a['type']['key'] == '/type/redirect' for a in authors):
 File "/openlibrary/openlibrary/solr/update_work.py", line 370, in <genexpr>
   if any(a['type']['key'] == '/type/redirect' for a in authors):
TypeError: 'NoneType' object has no attribute '__getitem__'
```

## Testing
- Check the solr-updater logs locally; there will be a lot less errors. TODO include the error you had.