### PR TITLE
Prevent import from undeleting bad authors

### DIFF
--- a/openlibrary/catalog/add_book/merge.py
+++ b/openlibrary/catalog/add_book/merge.py
@@ -36,18 +36,12 @@ def try_merge(e1, edition_key, existing):
         rec2['authors'] = []
         for a in existing.authors:
             author_type = a.type.key
-            while author_type == '/type/delete' or author_type == '/type/redirect':
-                if author_type == '/type/delete':
-                    a = undelete_author(a)
-                    author_type = a.type.key
-                    continue
-                if author_type == '/type/redirect':
-                    a = web.ctx.site.get(a.location)
-                    author_type = a.type.key
-                    continue
-            assert author_type == '/type/author'
-            assert a['name']
-            rec2['authors'].append({'name': a['name'], 'db_name': db_name(a)})
-
+            while author_type == '/type/redirect':
+                a = web.ctx.site.get(a.location)
+                author_type = a.type.key
+                continue
+            if author_type == '/type/author':
+                assert a['name']
+                rec2['authors'].append({'name': a['name'], 'db_name': db_name(a)})
     e2 = build_marc(rec2)
     return attempt_merge(e1, e2, threshold, debug=False)

--- a/openlibrary/catalog/add_book/merge.py
+++ b/openlibrary/catalog/add_book/merge.py
@@ -12,13 +12,6 @@ def db_name(a):
         date = a.date
     return ' '.join([a['name'], date]) if date else a['name']
 
-def undelete_author(a):
-    a = web.ctx.site.get(a.key, revision=a.revision-1)
-    author_type = a.type.key
-    assert author_type == '/type/author'
-    web.ctx.site.save(a.dict(), comment='undelete author')
-    return web.ctx.site.get(a.key)
-
 def try_merge(e1, edition_key, existing):
     thing_type = existing.type.key
     if thing_type == '/type/delete':
@@ -44,4 +37,4 @@ def try_merge(e1, edition_key, existing):
                 assert a['name']
                 rec2['authors'].append({'name': a['name'], 'db_name': db_name(a)})
     e2 = build_marc(rec2)
-    return attempt_merge(e1, e2, threshold, debug=False)
+    return attempt_merge(e1, e2, threshold)


### PR DESCRIPTION
## Description
<!-- What does this PR achieve? [feature|hotfix|refactor] -->
fix, some imports are failing because the code is undeleting authors from potentially matching editions, example:  https://openlibrary.org/authors/OL3963499A?b=3&a=2&_compare=Compare&m=diff

Which seems to be because an almost matching edition was found https://openlibrary.org/books/OL12620372M?v=1 when trying to import this MARC record:
https://openlibrary.org/show-records/marc_openlibraries_phillipsacademy/PANO_FOR_IA_05072019.mrc:47968820:954

The correct record to match has the same title: https://openlibrary.org/works/OL7578514W/Schumann, and I believe the problematic record would have been discarded from the matching pool. 

I can't see the reason for modifying an edition that is part of the potential matching pool. Deleted authors were deleted for a reason, and un-deleting them in passing is going to cause more problems.

This PR retains the Author redirect following behaviour, but ignores `/type/delete`s and will not consider them when making existing item checks.

Closes #

## Technical
<!-- What should be noted about the implementation? -->

## Testing
<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->

## Evidence
<!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
