### PR TITLE
fixes availability.js, working waitlist on author pages

### DIFF
--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -202,11 +202,6 @@ function init() {
                         var work = response[_type][key];
                         var li = $(e).closest("li");
                         var cta = li.find(".searchResultItemCTA-lending");
-                        var msg = '';
-                        var link = '';
-                        var annotation = '';
-                        var tag = 'a';
-
                         var mode = filter ? localStorage.getItem('mode') : 'everything';
 
                         if (mode !== "printdisabled") {
@@ -215,37 +210,22 @@ function init() {
                                     li.remove();
                                 }
                             } else {
-                                var cls = 'borrow_available borrow-link';
-                                link = ' href="/books/' + work.openlibrary_edition + '/x/borrow" ';
-
-                                if (work.status === 'open') {
-                                    cls = 'cta-btn--available';
-                                    msg = 'Read';
-                                } else if (work.status === 'borrow_available') {
-                                    cls = 'cta-btn--available';
-                                    msg = 'Borrow';
+                                if (work.status === 'open' || work.status === 'borrow_available') {
+                                    $(cta).append('<a href="/books/' + work.openlibrary_edition + '/x/borrow" ' +
+                                                  'class="cta-btn cta-btn--available" ' +
+                                                  'data-ol-link-track="' + work.status + '">' +
+                                                  (work.status === 'open' ? 'Read' : ' Borrow') +
+                                                  '</a>');
                                 } else if (work.status === 'borrow_unavailable') {
-                                    tag = 'span';
-                                    link = '';
-                                    cls = 'cta-btn--unavailable';
-                                    msg = '<form method="POST" action="/books/' + work.openlibrary_edition + '/x/borrow?action=join-waitinglist" class="join-waitlist waitinglist-form"><input type="hidden" name="action" value="join-waitinglist">';
-                                    if (work.num_waitlist !== '0') {
-                                        msg += 'Join Waitlist <span class="cta-btn__badge">' + work.num_waitlist + '</span></form>';
-
-                                    } else {
-                                        msg += 'Join Waitlist</form>';
-                                        annotation = '<div class="waitlist-msg">You will be first in line!</div>';
-                                    }
-                                }
-                                $(cta).append(
-                                    '<' + tag + ' ' + link + ' class="' + cls +
-                                        ' ' + btnClassName + '" data-ol-link-track="' +
-                                        work.status
-                                        + '">' + msg + '</' + tag + '>'
-                                );
-
-                                if (annotation) {
-                                    $(cta).append(annotation);
+                                    $(cta).append('<form method="POST" ' +
+                                                  'action="/books/' + work.openlibrary_edition + '/x/borrow?action=join-waitinglist" ' +
+                                                  'class="join-waitlist waitinglist-form">' +
+                                                  '<input type="hidden" name="action" value="join-waitinglist">' +
+                                                  '<button type="submit" class="cta-btn cta-btn--unavailable" data-ol-link-track="' + work.status + '">' +
+                                                  'Join Waitlist' +
+                                                  (work.num_waitlist !== '0' ? ' <span class="cta-btn__badge">' + work.num_waitlist + '</span>' : '') +
+                                                  '</button></form>' +
+                                                  (work.num_waitlist === '0' ? '<div class="waitlist-msg">You will be first in line!</div>' : ''));
                                 }
                             }
                         }
@@ -253,13 +233,6 @@ function init() {
                 });
             });
         })
-        /* eslint-disable no-unused-vars */
-        // event object is passed to this function
-        $('.searchResultItemCTA-lending form.join-waitlist').on('click', function(e) {
-            // consider submitting form async and refreshing search results page
-            $(this).submit()
-        })
-        /* eslint-enable no-unused-vars */
         updateBookAvailability();
     }
 }


### PR DESCRIPTION
## Description
<!-- What does this PR achieve? [feature|hotfix|refactor] -->

Closes #2124 

## Technical
<!-- What should be noted about the implementation? -->

Removed the jquery event listener hack for the waiting list submit listen case, replaced with a button submit which doesn't require js.

## Testing
<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
go to authors page https://dev.openlibrary.org/authors/OL2674263A/Muriel_Jensen and click join waiting list

## Evidence
<!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
tested by @JeffKaplan 

## Note

Context: we discovered a bug where only on the authors book listing page the waitlist isn’t working. It’s because we’re using some funky JS to add the button after page load. Really, no js is needed (so this whole “hotfix” will soon get tossed)

I wouldn’t put too much emphasis on code style in (only) this case as I’m very confident in the next month the file is going to supplanted by availability checking done on the backend (a PR for this is WIP)