### PR TITLE
Handle invalid OCAID availability response

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1,5 +1,6 @@
 """Module for providing core functionality of lending on Open Library.
 """
+
 import web
 import simplejson
 import datetime
@@ -235,9 +236,10 @@ def get_available(limit=None, page=1, subject=None, query=None,
     except Exception as e:
         return {'error': 'request_timeout'}
 
+
 def get_availability(key, ids):
     """
-    :param str key:
+    :param str key: the type of identifier
     :param list of str ids:
     :rtype: dict
     """
@@ -296,8 +298,8 @@ def add_availability(editions):
     availabilities = get_availability_of_ocaids(ocaids)
     for ed in editions:
         ocaid = get_ocaid(ed)
-        errored = (ocaid is None) or (availabilities.get(ocaid) is None)
-        ed['availability'] = availabilities.get(ocaid) if not errored else {'status': 'error'}
+        success = ocaid and availabilities.get(ocaid)
+        ed['availability'] = availabilities.get(ocaid) if success else {'status': 'error'}
     return editions
 
 @public
@@ -306,7 +308,11 @@ def get_availability_of_ocaid(ocaid):
     return get_availability('identifier', [ocaid])
 
 def get_availability_of_ocaids(ocaids):
-    """Retrieves availability based on ocaids/archive.org identifiers"""
+    """
+    Retrieves availability based on ocaids/archive.org identifiers
+    :param list[str] ocaids:
+    :rtype: dict
+    """
     return get_availability('identifier', ocaids)
 
 def get_work_availability(ol_work_id):

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -66,6 +66,6 @@ $else:
   <form>
     <input type="button" class="cta-btn--missing cta-btn" disabled value="No ebook available">
   </form>
-  $if availability_status != 'error' and page.ia:
+  $if page.ia:
     $ daisy_url = "/ia/%s/daisy" % page.ia[0]
     $:macros.daisy(page, url=daisy_url, msg=_("Print-disabled access available"))

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -32,7 +32,7 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
         <span data-ol-link-track="leave_waitlist">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="leave-waitlist waitinglist-form">
             <input type="hidden" name="action" value="leave-waitinglist"/>
-            <input type="submit" class="cta-btn cta-btn--missing id="unwaitlist_ebook" value="Leave Waitlist"/>
+            <input type="submit" class="cta-btn cta-btn--missing" id="unwaitlist_ebook" value="Leave Waitlist"/>
           </form>
         </span>
         <div class="waitlist-msg">
@@ -66,7 +66,6 @@ $else:
   <form>
     <input type="button" class="cta-btn--missing cta-btn" disabled value="No ebook available">
   </form>
-  $if page.ia:
+  $if availability_status != 'error' and page.ia:
     $ daisy_url = "/ia/%s/daisy" % page.ia[0]
     $:macros.daisy(page, url=daisy_url, msg=_("Print-disabled access available"))
-

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -1,0 +1,26 @@
+from openlibrary.core import lending
+
+
+class TestAddAvailability:
+    def test_reads_ocaids(self, monkeypatch):
+        def mock_get_availability_of_ocaids(ocaids):
+            return {'foo': {'status': 'available'}}
+        monkeypatch.setattr(lending, "get_availability_of_ocaids", mock_get_availability_of_ocaids)
+
+        f = lending.add_availability
+        assert f([{'ocaid': 'foo'}]) == [{'ocaid': 'foo', 'availability': {'status': 'available'}}]
+        assert f([{'identifier': 'foo'}]) == [{'identifier': 'foo', 'availability': {'status': 'available'}}]
+        assert f([{'ia': 'foo'}]) == [{'ia': 'foo', 'availability': {'status': 'available'}}]
+        assert f([{'ia': ['foo']}]) == [{'ia': ['foo'], 'availability': {'status': 'available'}}]
+
+    def test_handles_ocaid_none(self):
+        f = lending.add_availability
+        assert f([{}]) == [{'availability': {'status': 'error'}}]
+
+    def test_handles_availability_none(self, monkeypatch):
+        def mock_get_availability_of_ocaids(ocaids):
+            return {'foo': None}
+        monkeypatch.setattr(lending, "get_availability_of_ocaids", mock_get_availability_of_ocaids)
+
+        f = lending.add_availability
+        assert f([{'ocaid': 'foo'}]) == [{'ocaid': 'foo', 'availability': {'status': 'error'}}]


### PR DESCRIPTION
## Description
fix: handles the case where an OCAID is invalid so that search still renders correctly.

Closes #2001 

## Testing
Added some test!