### PR TITLE
Fix solr not indexing work redirects

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1157,7 +1157,7 @@ def update_work(work):
                 if solr_doc.get('ia'):
                     requests.append(DeleteRequest(["/works/ia:" + iaid for iaid in solr_doc['ia']]))
                 requests.append(UpdateRequest(solr_doc))
-    elif work['type']['key'] == '/type/delete':
+    elif work['type']['key'] in ['/type/delete', '/type/redirect']:
         requests.append(DeleteRequest([wkey]))
     else:
         logger.error("unrecognized type while updating work %s", wkey, exc_info=True)

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -415,3 +415,9 @@ class TestUpdateWork:
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
         assert requests[0].toxml() == '<delete><query>key:/works/OL23M</query></delete>'
+
+    def test_redirects(self):
+        requests = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/redirect'}})
+        assert len(requests) == 1
+        assert isinstance(requests[0], update_work.DeleteRequest)
+        assert requests[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -398,13 +398,20 @@ class Test_update_items():
         for olid in olids:
             assert "<query>key:%s</query>" % olid in del_req.toxml()
 
+
+class TestUpdateWork:
+    @classmethod
+    def setup_class(cls):
+        update_work.data_provider = FakeDataProvider()
+
     def test_delete_work(self):
-        del_work = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/delete'}})
-        del_edition = update_work.update_work({'key': '/works/OL23M', 'type': {'key': '/type/delete'}})
-        assert len(del_work) == 1
-        assert len(del_edition) == 1
-        assert isinstance(del_work, list)
-        assert isinstance(del_work[0], update_work.DeleteRequest)
-        assert del_work[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'
-        assert isinstance(del_edition[0], update_work.DeleteRequest)
-        assert del_edition[0].toxml() == '<delete><query>key:/works/OL23M</query></delete>'
+        requests = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/delete'}})
+        assert len(requests) == 1
+        assert isinstance(requests[0], update_work.DeleteRequest)
+        assert requests[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'
+
+    def test_delete_editions(self):
+        requests = update_work.update_work({'key': '/works/OL23M', 'type': {'key': '/type/delete'}})
+        assert len(requests) == 1
+        assert isinstance(requests[0], update_work.DeleteRequest)
+        assert requests[0].toxml() == '<delete><query>key:/works/OL23M</query></delete>'


### PR DESCRIPTION
## Description
Fix: Make `update_work` handle redirected works. We still need an issue to fix all the ones that are currently missing, but that won't be an issue once we reindex.

Closes #2139 .

## Technical
First did a light refactor, so look at the commits separately for simplicity. We now also throw an error if an unexpected type is found.

## Testing
We can try forcing a re-index of the example on #2139 . I tested locally before/after the change, and it works as expected.