### PR TITLE
FIX: local_ids; don't assume every target field has the expected sub-field

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -217,7 +217,7 @@ class ia_importapi(importapi):
                 local_id_type = web.ctx.site.get('/local_ids/' + local_id)
                 prefix = local_id_type.urn_prefix
                 id_field, id_subfield = local_id_type.id_location.split('$')
-                _ids = [f if isinstance(f, str) else f[1].get_subfield_values(id_subfield)[0] for f in rec.read_fields([id_field])]
+                _ids = [f if isinstance(f, str) else f[1].get_subfield_values(id_subfield)[0] for f in rec.read_fields([id_field]) if f]
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
             result = add_book.load(edition)


### PR DESCRIPTION
When importing local_ids, some partner MARC records have multiple
fields, and not all have the expected subfield:

example: https://openlibrary.org/show-records/marc_openlibraries_sanfranciscopubliclibrary/sfpl_chq_2018_12_24_run05.mrc:26324164:8452
has a 945 field without the expected $i:
```
945    $a327.1273$bG8554n$d  -  -  $e  -  -  $f0$g0$h  -  -  $j0$00$k
-  -  $lm8aaa$ol$p$27.00$q-$r-$se
$t0$u0$v0$w0$x0$y.i78405312$z07-29-14
```

