### PR TITLE
Create readonly postgres user for solrupdater

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ config
 build
 **.pyc
 **__pycache__
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ htmlcov
 .cache
 node_modules/
 .idea/
-
+venv/

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -26,7 +26,7 @@ admin_password: admin123
 errorlog: /var/log/openlibrary/ol-errors
 login_cookie_name: session
 
-infobase_server: localhost:7000
+infobase_server: web:7000
 
 # contents of this file are assigned to config["infobase"]
 # Path can be relative to this file

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -5,8 +5,10 @@ ENV LANG en_US.UTF-8
 # required for postgres
 ENV LC_ALL POSIX
 
-# add openlibrary user
-RUN groupadd -r openlibrary && useradd --no-log-init -r -g openlibrary openlibrary
+# add openlibrary users
+RUN groupadd --system openlibrary \
+  && useradd --no-log-init --system --gid openlibrary openlibrary \
+  && useradd --no-log-init --system --gid openlibrary solrupdater
 
 RUN apt-get -qq update && apt-get install -y \
     nginx \

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -7,6 +7,7 @@ USER postgres
 RUN /etc/init.d/postgresql start \
   && createuser -s openlibrary \
   && createdb openlibrary \
+  && psql openlibrary < openlibrary/core/users.sql \
   && psql openlibrary < openlibrary/core/schema.sql \
   && createdb coverstore \
   && psql coverstore < openlibrary/coverstore/schema.sql \

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -32,7 +32,7 @@ export -f reindex-solr
 su openlibrary -c "until pg_isready; do sleep 5; done && reindex-solr localhost $CONFIG" &
 
 # solr updater
-su openlibrary -c "python scripts/new-solr-updater.py \
+su solrupdater -c "python scripts/new-solr-updater.py \
   -c $CONFIG \
   --state-file solr-update.offset \
   --ol-url http://web/" &

--- a/openlibrary/core/users.sql
+++ b/openlibrary/core/users.sql
@@ -1,0 +1,12 @@
+CREATE ROLE readcreateaccess;
+
+-- Grant access to existing tables
+GRANT USAGE ON SCHEMA public TO readcreateaccess;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readcreateaccess;
+
+-- Grant access to future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readcreateaccess;
+
+-- Create user for solr-updater
+CREATE USER solrupdater;
+GRANT readcreateaccess TO solrupdater;


### PR DESCRIPTION
## Description
Fix: Creates a readonly postgres user for solrupdater so there's a stronger guarantee that when we run this on logs ~1mo out-of-date (for the last phase of #1843 ) it won't be causing any unintentional database edits.

## Technical
- In our local environment, the default authentication for users is [`peer`](https://www.postgresql.org/docs/9.5/auth-methods.html#AUTH-PEER); this requires us to create a system user but means we don't need a password (good for dev). On production we'll have to give the postgres user a password somehow?
- Solution based on https://gist.github.com/oinopion/4a207726edba8b99fd0be31cb28124d0
- Note that it's a `readcreate` user; it can still create new tables. Removing this seemed like more trouble than it's worth (especially if we want to keep prod in sync), so didn't bother.

## Testing
- I tried running `web.ctx.site.save`, but this never worked from solrupdater because there's no ol account associated with it.
- I used the debugger to ensure that when it connects to infobase it connects with username `solrupdater`
- I tried giving the new postgres user 0 permissions, and `new-solr-updater` failed (as expected).