### PR TITLE
Show pagination directly below search results

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ static/build/vendor.js
 provisioning/
 vendor/
 tests/screenshots/
+venv/

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -239,6 +239,7 @@ $ )
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):
                     $:macros.SearchResultsWork(work, user=user)
           </ul>
+          $:macros.Pager(page, num_found, rows)
         </div>
 <!-- /results -->
 
@@ -247,10 +248,8 @@ $ )
 $if error:
     <h3>BARF! Search engine ERROR!</h3>
     <pre>$error.decode('utf-8', 'ignore')</pre>
-
-$elif param and not error:
-    $if len(docs) != 0:
-        <div id="searchFacets">
+$elif param and len(docs):
+    <div id="searchFacets">
         <h3 class="collapse">$_("Zoom In")</h3>
         <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">$_("Focus your results using these") <a href="/search/howto">$_("filters")</a></div>
         $for header, label in facet_map:
@@ -287,8 +286,6 @@ $elif param and not error:
     </div>
 
     $if param and not error and len(docs):
-        $:macros.Pager(page, num_found, rows)
-
         $ readapi_percent = 100
         $if ctx.user and ctx.user.is_admin():
             <div id="adminTiming" class="small sansserif clearfix"><br/><span class="adminOnly">Searching solr took $("%.2f" % search_secs) seconds</span></div>

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -325,8 +325,9 @@ q {
 // openlibrary/templates/type/author/view.html
 .pagination {
   font-size: .75em;
-  margin: 5px 0;
+  margin: 0 15px;
   .display-flex();
+  justify-content: flex-end;
   flex-wrap: wrap;
   a {
     display: block;
@@ -1102,6 +1103,7 @@ div#searchResults,
 div#searchResults ul {
   flex: 1;
   margin-left: 0;
+  margin-bottom: 0;
 }
 
 // openlibrary/macros/FulltextResults.html


### PR DESCRIPTION
## Description
Fix: Display pagination directly below results instead of below facet search on mobile.

Closes #2015

## Technical
- Only moved the paginator; the facets being hard to access is still a problem.

## Testing
- Only tested on Firefox 67 (latest), but there aren't any big CSS changes, so I expect it should be fine.

## Evidence

| Platform | Picture | Picture 2 |
|---|---|---|
| Desktop | ![image](https://user-images.githubusercontent.com/6251786/58364901-94962d00-7e89-11e9-8f6e-ee466ef8e114.png) | ![image](https://user-images.githubusercontent.com/6251786/58364945-52212000-7e8a-11e9-978d-72d3430dfbab.png) |
| Mobile | ![image](https://user-images.githubusercontent.com/6251786/58364897-7a5c4f00-7e89-11e9-99d5-02d00b6b160d.png) | ![image](https://user-images.githubusercontent.com/6251786/58364916-e939a800-7e89-11e9-9f97-115716fd4fa1.png) |