### PR TITLE
Prevent bulk MARC import from importing non-books

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -225,6 +225,8 @@ class ia_importapi(importapi):
                 _ids = [get_subfield(f, id_subfield) for f in rec.read_fields([id_field]) if f and get_subfield(f, id_subfield)]
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
+            # Don't add the book if the MARC record is a non-book item
+            self.reject_non_book_marc(rec)
             result = add_book.load(edition)
 
             # Add next_data to the response as location of next record:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -89,25 +89,8 @@ def parse_data(data):
         format = 'marc'
 
     parse_meta_headers(edition_builder)
-
     return edition_builder.get_dict(), format
 
-def get_next_count():
-    store = web.ctx.site.store
-    counter = store.get('import_api_s3_counter')
-    if counter is None:
-        store['import_api_s3_counter'] = {'count':0}
-        return 0
-    else:
-        count = counter['count'] + 1
-        store['import_api_s3_counter'] = {'count':count, '_rev':counter['_rev']}
-        return count
-
-def queue_s3_upload(data, format):
-    # Anand - July 23, 2014
-    # Disabled this as we are not configured uploading MARC records.
-    # We probably don't want to do this at all.
-    return
 
 class importapi:
     """/api/import endpoint for general data formats.
@@ -137,20 +120,10 @@ class importapi:
         if not edition:
             return self.error('unknown_error', 'Failed to parse import data')
 
-        ## Anand - July 2014
-        ## This is adding source_records as [null] as queue_s3_upload is disabled.
-        ## Disabling this as well to fix the issue.
-        #source_url = None
-        # if 'source_records' not in edition:
-        #     source_url = queue_s3_upload(data, format)
-        #     edition['source_records'] = [source_url]
-
         try:
             reply = add_book.load(edition)
         except add_book.RequiredField as e:
             return self.error('missing-required-field', str(e))
-        #if source_url:
-        #    reply['source_record'] = source_url
         return json.dumps(reply)
 
     def reject_non_book_marc(self, marc_record, **kwargs):

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -217,7 +217,12 @@ class ia_importapi(importapi):
                 local_id_type = web.ctx.site.get('/local_ids/' + local_id)
                 prefix = local_id_type.urn_prefix
                 id_field, id_subfield = local_id_type.id_location.split('$')
-                _ids = [f if isinstance(f, str) else f[1].get_subfield_values(id_subfield)[0] for f in rec.read_fields([id_field]) if f]
+                def get_subfield(field, id_subfield):
+                    if isinstance(field, str):
+                        return field
+                    subfields = field[1].get_subfield_values(id_subfield)
+                    return subfields[0] if subfields else None
+                _ids = [get_subfield(f, id_subfield) for f in rec.read_fields([id_field]) if f and get_subfield(f, id_subfield)]
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
             result = add_book.load(edition)


### PR DESCRIPTION
## Description
<!-- What does this PR achieve? [feature|hotfix|refactor] -->
Fixes instances where non-book items were being imported from bulk MARC files.

Modifies existing reject non-book code to provide the offset and length of the next record which is required to allow the import process to continue.


## Testing
<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
Tested locally with SFPL data,

```
docker-compose exec web scripts/copydocs.py /type/local_id
docker-compose exec web scripts/copydocs.py /local_ids/sfpl
```
To set up the require local id
Tested with the following MARC item: https://openlibrary.org/show-records/marc_openlibraries_sanfranciscopubliclibrary/sfpl_chq_2018_12_24_run06.mrc:188734629:1625

With this PR the response becomes:
```
b'{"next_record_offset": 188737851, "error_code": "item-not-book", "next_record_length": 2541, "success": false, "error": "Item rejected"}'
```

Which is a clear rejection, no item imported, but provides the necessary offset and length to continue.



