### PR TITLE
Ensure `select` elements are not larger than viewport

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -579,7 +579,8 @@ window.q.push(function() {
                     <span class="tip"></span>
                 </div>
                 <div class="input">
-                    <input name="edition--number_of_pages" type="text" id="edition--number_of_pages" value="$book.number_of_pages"/>
+                    <input name="edition--number_of_pages" type="number"
+                        step="1" id="edition--number_of_pages" value="$book.number_of_pages"/>
                 </div>
             </div>
             <div class="formElement">
@@ -622,15 +623,18 @@ window.q.push(function() {
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="dimensions" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" id="dimensions-height" size="6" value="$dimensions.height"/></td>
+                                <td><input name="edition--physical_dimensions--height" type="number" step="0.1"
+                                    id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" id="dimensions-width" size="6" value="$dimensions.width"/></td>
+                                <td><input name="edition--physical_dimensions--width" type="number" step="0.1"
+                                        id="dimensions-width" size="6" value="$dimensions.width"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--depth" type="number" id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
+                                <td><input name="edition--physical_dimensions--depth" type="number"
+                                    step="0.1" id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
                             </tr>
                         </tbody>
                         </table>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -623,18 +623,18 @@ window.q.push(function() {
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="dimensions" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="0.1"
+                                <td><input name="edition--physical_dimensions--height" type="number" step="0.01"
                                     id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" step="0.1"
+                                <td><input name="edition--physical_dimensions--width" type="number" step="0.01"
                                         id="dimensions-width" size="6" value="$dimensions.width"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
                                 <td><input name="edition--physical_dimensions--depth" type="number"
-                                    step="0.1" id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
+                                    step="0.01" id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
                             </tr>
                         </tbody>
                         </table>

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -56,6 +56,7 @@
   }
 
   select {
+    width: 100%;
     font-size: 1.125em;
     font-family: @lucida_sans_serif-1;
     padding: 3px;


### PR DESCRIPTION
ol.form `select` elements should be 100% unless otherwise specified
so that they do not spill outside the viewport
(see https://github.com/internetarchive/openlibrary/issues/2100#issuecomment-497307864)

Fixes: #2100

Closes #2100

