### PR TITLE
Clean up presentation form elements on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "7.1KB"
+      "maxSize": "7.2KB"
     },
     {
       "path": "static/build/page-edit.css",
@@ -52,7 +52,7 @@
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "18.6KB"
+      "maxSize": "18.7KB"
     }
   ],
   "devDependencies": {

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -112,5 +112,12 @@ div.head {
   }
   td {
     display: inline-block;
+
+    // if rowspan, make it full screen on mobile with margin
+    // e.g dimension editing on book edit page
+    &[rowspan] {
+      margin: 20px 0 30px;
+      width: 100%;
+    }
   }
 }

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -109,6 +109,8 @@
   // "You can search by author name (like j k rowling) or by Open Library ID (like OL23919A)."
   .tip {
     font-size: 11px;
+    display: inline-block;
+    min-width: 50px;
     color: @grey;
     font-family: @lucida_sans_serif-1!important;
   }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1492,6 +1492,7 @@ div.excerpt {
     color: @dark-grey;
     border-bottom: 1px solid @lighter-grey;
     padding: 5px;
+    font-size: .7em;
   }
   &.authors {
     td {
@@ -2156,8 +2157,11 @@ div#subjectLists {
       width: 400px;
     }
   }
-  table.identifiers {
+  .identifiers {
     width: 395px;
+    td {
+      font-size: inherit;
+    }
   }
   /**
   * Used on following pages:


### PR DESCRIPTION
Visit https://openlibrary.org/books/OL24211539M/Jungle_book/edit on mobile

Address UI problems in mobile described in
https://github.com/internetarchive/openlibrary/issues/2095#issuecomment-497313482
for edit form

Issue 1: height, width and depth are not aligned:
![Screen Shot 2019-05-30 at 2 31 51 PM](https://user-images.githubusercontent.com/148752/58633078-ba875b80-82e7-11e9-8474-534bd9b528c1.png)

Issue 2: Tips spill over to 2 lines - they could be rendered on a single line underneath in most cases
![Screenshot 2019-07-28 at 9 53 09 AM](https://user-images.githubusercontent.com/148752/62010264-8bda0580-b11d-11e9-8fd8-1e41c5360c94.png)

Issue 3: .identifiers spill onto multiple rows for long ID e.g. Internet Archive in this example:
![Screenshot 2019-07-28 at 9 58 30 AM](https://user-images.githubusercontent.com/148752/62010322-45d17180-b11e-11e9-89a3-b0c13b6e2acb.png)

## Description
3 proposed solutions (some better than others)
1) Makes td[rowspan] take up the full width of the page on mobile. This leaves a problem with the labels (which are .tip) - a 50px min width ensures these labels are aligned.

![Screenshot 2019-07-28 at 10 05 43 AM](https://user-images.githubusercontent.com/148752/62010417-4ae2f080-b11f-11e9-94fa-4bccdc603c2d.png)

2) It moves the tip onto a separate line (seems like a no brainer to me) using inline-block. A min-width is added to ensure a new line will always be present after the heading even if no tip is given to provide consistent spacing.
3) Shrink font size of identifiers (not attached to this one but can't work out a better way to do it)

## Technical
<!-- What should be noted about the implementation? -->

## Testing
<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->

## Evidence
<!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
