### PR TITLE
Make dimension inputs "any" precision

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -540,12 +540,12 @@ window.q.push(function() {
                                 <input type="hidden" name="{{prefix}}classifications--{{index}}--name" value="{{name}}"/>
                                 <input type="hidden" name="{{prefix}}classifications--{{index}}--value" value="{{value}}"/>
                             </td>
-                            <td "><a href="javascript:;" class="repeat-remove red plain" title="$_('Remove this classification')">[x]</a></td>
+                            <td><a href="javascript:;" class="repeat-remove red plain" title="$_('Remove this classification')">[x]</a></td>
                         </tr>
                         $for i, id in enumerate(book.get_classifications().values()):
                         <tr id="classifications--$i" class="repeat-item">
                             <td align="right"><strong>$classification_labels.get(id.name, id.name)</strong></td>
-                            <td ">$id.value
+                            <td>$id.value
                                 <input type="hidden" name="edition--classifications--${i}--name" value="$id.name"/>
                                 <input type="hidden" name="edition--classifications--${i}--value" value="$id.value"/>
                             </td>
@@ -601,7 +601,8 @@ window.q.push(function() {
                 </div>
                 <div class="input">
                     $ weight = book.get_weight() or storage(value="", units="grams")
-                    <input name="edition--weight--value" type="number" id="edition--weight--value" value="$weight.value" size="6"/>
+                    <input name="edition--weight--value" type="number" step="any"
+                           id="edition--weight--value" size="6" value="$weight.value"/>
                     <span class="tip">
                         $:radiobuttons("edition--weight--units", ["grams", "kilos", "ounces", "pounds"], weight.units)
                     </span>
@@ -623,18 +624,18 @@ window.q.push(function() {
                             <tr>
                                 <td rowspan="3"><img src="/images/dimensions.png" alt="dimensions" width="107" height="69" align="left"/></td>
                                 <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="0.01"
-                                    id="dimensions-height" size="6" value="$dimensions.height"/></td>
+                                <td><input name="edition--physical_dimensions--height" type="number" step="any"
+                                           id="dimensions-height" size="6" value="$dimensions.height"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" step="0.01"
-                                        id="dimensions-width" size="6" value="$dimensions.width"/></td>
+                                <td><input name="edition--physical_dimensions--width" type="number" step="any"
+                                           id="dimensions-width" size="6" value="$dimensions.width"/></td>
                             </tr>
                             <tr>
                                 <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--depth" type="number"
-                                    step="0.01" id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
+                                <td><input name="edition--physical_dimensions--depth" type="number" step="any"
+                                           id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
                             </tr>
                         </tbody>
                         </table>

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -45,14 +45,13 @@
   }
 
   input[type=number] {
-    width: 50px;
+    width: 4em;
   }
 
-  input[type=number],
   input[type=email],
   input[type=password],
   .required {
-    height: 40px;
+    padding: 8px;
   }
 
   select {
@@ -132,8 +131,9 @@
       width: 220px;
     }
     .formBack:after {
-        content: '';
-        clear: both;
+      display: block;
+      content: '';
+      clear: both;
     }
   }
 }


### PR DESCRIPTION
## Description
Realized we missed the `weight` field in #2158 . Fixed that. Also learned about `step="any"`, which lets people enter any precision, and makes the up/down buttons move in steps of 1. Switched to that instead.

Closes #2095 

## Technical
Made some slight tweaks to css of these as well.

## Testing
Tested on Windows Firefox/Chrome/IE latest.

## Evidence
![fixing dimensions](https://user-images.githubusercontent.com/6251786/58767540-95e6ea00-855a-11e9-8dc6-d7d414546c43.gif)
