### PR TITLE
Improvements to ISBN search code

### DIFF
--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -11,11 +11,6 @@ def str_to_key(s):
 def url_quote(s):
     return quote_plus(s.encode('utf-8')) if s else ''
 
-re_isbn = re.compile('^([0-9]{9}[0-9Xx]|[0-9]{13})$')
-def read_isbn(s): # doesn't validate checksums
-    s = s.replace('-', '')
-    return s if re_isbn.match(s) else None
-
 def finddict(dicts, **filters):
     """Find a dictionary that matches given filter conditions.
 

--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -1,14 +1,7 @@
-import re
-import isbnlib
 from isbnlib import canonical
-import logging
-
-logger = logging.getLogger("openlibrary")
 
 def check_digit_10(isbn):
-    """I believe this is checking the case where ISBNs start with a
-    leading X? It only appears to be used in isbn_13_to_isbn_10 and
-    isbn_10_to_isbn_13"""
+    """Takes the first 9 digits of an ISBN10 and returns the calculated final checkdigit."""
     if len(isbn) != 9:
         raise ValueError("%s is not a valid ISBN 10" % isbn)
     sum = 0
@@ -23,9 +16,7 @@ def check_digit_10(isbn):
         return str(r)
 
 def check_digit_13(isbn):
-    """I believe this is checking the case where ISBNs start with a
-    leading X? It only appears to be used in isbn_13_to_isbn_10 and
-    isbn_10_to_isbn_13"""
+    """Takes the first 12 digits of an ISBN13 and returns the calculated final checkdigit."""
     if len(isbn) != 12:
         raise ValueError
     sum = 0
@@ -42,27 +33,17 @@ def check_digit_13(isbn):
 
 def isbn_13_to_isbn_10(isbn_13):
     isbn_13 = canonical(isbn_13)
-    try:
-        if len(isbn_13) != 13 or not isbn_13.isdigit()\
+    if len(isbn_13) != 13 or not isbn_13.isdigit()\
         or not isbn_13.startswith('978')\
         or check_digit_13(isbn_13[:-1]) != isbn_13[-1]:
-            raise ValueError("%s is not a valid ISBN 13" % isbn_13)
-    except ValueError as e:
-        logger.info("Exception caught in ISBN transformation: %s" % e)
-        return
+           return
     return isbn_13[3:-1] + check_digit_10(isbn_13[3:-1])
 
 def isbn_10_to_isbn_13(isbn_10):
     isbn_10 = canonical(isbn_10)
-    if len(isbn_10) == 13:
-        return isbn_10
-    try:
-        if len(isbn_10) != 10 or not isbn_10[:-1].isdigit()\
+    if len(isbn_10) != 10 or not isbn_10[:-1].isdigit()\
         or check_digit_10(isbn_10[:-1]) != isbn_10[-1]:
-            raise ValueError("%s is not a valid ISBN 10" % isbn_10)
-    except ValueError as e:
-        logger.info("Exception caught in ISBN transformation: %s" % e)
-        return
+            return
     isbn_13 = '978' + isbn_10[:-1]
     return isbn_13 + check_digit_13(isbn_13)
 

--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -55,4 +55,4 @@ def opposite_isbn(isbn): # ISBN10 -> ISBN13 and ISBN13 -> ISBN10
 
 def normalize_isbn(isbn):
     """Removes spaces and dashes from isbn and ensures length."""
-    return canonical(isbn)
+    return canonical(isbn) or None

--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -54,8 +54,5 @@ def opposite_isbn(isbn): # ISBN10 -> ISBN13 and ISBN13 -> ISBN10
             return alt
 
 def normalize_isbn(isbn):
-    """removes spaces and dashes from isbn and ensures length
-
-    XXX deprecated, just use isbnlib.canonical
-    """
+    """Removes spaces and dashes from isbn and ensures length."""
     return canonical(isbn)

--- a/openlibrary/utils/tests/test_isbn.py
+++ b/openlibrary/utils/tests/test_isbn.py
@@ -1,16 +1,26 @@
-from .. import isbn
+from ..isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10, \
+    normalize_isbn, opposite_isbn
 
 def test_isbn_13_to_isbn_10():
-    assert isbn.isbn_13_to_isbn_10("978-0-940787-08-7") == "0940787083"
-    assert isbn.isbn_13_to_isbn_10("9780940787087") == "0940787083"
-    assert isbn.isbn_13_to_isbn_10("BAD-ISBN") is None
+    assert isbn_13_to_isbn_10('978-0-940787-08-7') == '0940787083'
+    assert isbn_13_to_isbn_10('9780940787087') == '0940787083'
+    assert isbn_13_to_isbn_10('BAD-ISBN') is None
 
 def test_isbn_10_to_isbn_13():
-    assert isbn.isbn_10_to_isbn_13("0-940787-08-3") == "9780940787087"
-    assert isbn.isbn_10_to_isbn_13("0940787083") == "9780940787087"
-    assert isbn.isbn_10_to_isbn_13("BAD-ISBN") is None
+    assert isbn_10_to_isbn_13('0-940787-08-3') == '9780940787087'
+    assert isbn_10_to_isbn_13('0940787083') == '9780940787087'
+    assert isbn_10_to_isbn_13('BAD-ISBN') is None
 
 def test_opposite_isbn():
-    assert isbn.opposite_isbn("0-940787-08-3") == "9780940787087"
-    assert isbn.opposite_isbn("978-0-940787-08-7") == "0940787083"
-    assert isbn.opposite_isbn("BAD-ISBN") is None
+    assert opposite_isbn('0-940787-08-3') == '9780940787087'
+    assert opposite_isbn('978-0-940787-08-7') == '0940787083'
+    assert opposite_isbn('BAD-ISBN') is None
+
+def test_normalize_isbn():
+    assert normalize_isbn('a') is None
+    assert normalize_isbn('1841151866') == '1841151866'
+    assert normalize_isbn('184115186x') == '184115186X'
+    assert normalize_isbn('184115186X') == '184115186X'
+    assert normalize_isbn('184-115-1866') == '1841151866'
+    assert normalize_isbn('9781841151861') == '9781841151861'
+    assert normalize_isbn('978-1841151861') == '9781841151861'

--- a/openlibrary/utils/tests/test_utils.py
+++ b/openlibrary/utils/tests/test_utils.py
@@ -1,15 +1,6 @@
 # coding=utf-8
-from openlibrary.utils import str_to_key, read_isbn, url_quote, \
+from openlibrary.utils import str_to_key, url_quote, \
     finddict, escape_bracket, extract_numeric_id_from_olid
-
-def test_isbn():
-    assert read_isbn('x') is None
-    assert read_isbn('1841151866') == '1841151866'
-    assert read_isbn('184115186x') == '184115186x'
-    assert read_isbn('184115186X') == '184115186X'
-    assert read_isbn('184-115-1866') == '1841151866'
-    assert read_isbn('9781841151861') == '9781841151861'
-    assert read_isbn('978-1841151861') == '9781841151861'
 
 def test_str_to_key():
     assert str_to_key('x') == 'x'


### PR DESCRIPTION
## Description
<!-- What does this PR achieve? [feature|hotfix|refactor] -->
Refactor and improvements to allow /isbn/ search to locate either form (ISBN10 / ISBN13) of isbn in the metadata when searching for a single ISBN.

An example which failed:
https://openlibrary.org/isbn/9780679744825 => 404
should find
https://openlibrary.org/isbn/0679744827

## Testing
<!-- Steps for reviewer to reproduce / verify this PR fixes the problem? -->
Existing tests moved and renamed to confirm exisiting functionliaty

## Evidence
<!-- If this PR touches UI, please post evidence (screenshot) of it behaving correctly: -->
