### PR TITLE
Prevent imports from duplicating subjects

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -67,6 +67,8 @@ def normalize(s): # strip non-alphanums and truncate at 25 chars
         norm = norm[4:]
     elif norm.startswith('a '):
         norm = norm[2:]
+    # strip bracketed text
+    norm = re.sub(r' ?\(.*\)', '', norm)
     return norm.replace(' ', '')[:25]
 
 type_map = {

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -229,7 +229,7 @@ def load_data(rec, account=None):
             if k not in rec:
                 continue
             for s in rec[k]:
-                if s not in w.get(k, []):
+                if s.lower() not in [existing.lower() for existing in w.get(k, [])]:
                     w.setdefault(k, []).append(s)
                     need_update = True
         if cover_id:

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -229,7 +229,7 @@ def load_data(rec, account=None):
             if k not in rec:
                 continue
             for s in rec[k]:
-                if s.lower() not in [existing.lower() for existing in w.get(k, [])]:
+                if normalize(s) not in [normalize(existing) for existing in w.get(k, [])]:
                     w.setdefault(k, []).append(s)
                     need_update = True
         if cover_id:

--- a/openlibrary/templates/books/edit/about.html
+++ b/openlibrary/templates/books/edit/about.html
@@ -13,7 +13,7 @@ $def with (work)
 
     <div class="formElement">
         <div class="label">
-            <label for="about-tags">$_("Some tags perhaps?")</label>
+            <label for="about-subjects">$_("Subject keywords?")</label>
             <span class="tip"><span class="highlight">$_("Please separate with commas.")</span> $_("For example:") <i><a href="/subjects/cheese">cheese</a>, <a href="/subjects/roman_empire">Roman Empire</a>, <a href="/subjects/psychology">psychology</a></i></span>
         </div>
         <div class="input">
@@ -21,7 +21,7 @@ $def with (work)
             $for s in work.get_subjects():
                 $ s = s.replace('"', '""')
                 $subjects.append('"' + s + '"' if ',' in s else s)
-            <input type="text" name="work--subjects" id="about-tags" value="$', '.join(subjects)" tabindex="0"/>
+            <input type="text" name="work--subjects" id="about-subjects" value="$', '.join(subjects)" tabindex="0"/>
         </div>
     </div>
 


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Will prevent case differences from creating duplicate subject keywords when importing new books. It will also remove parenthesised text from comparisons (but not from the eventually added subject)
Closes #2029 

### Technical
<!-- What should be noted about the implementation? -->
Subject comparisons are now normalised using the existing method that is used to normalize titles for comparison.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

I have changed the edit form to refer to the subjects as "Subject keywords" rather than tags. @seabelis , hopefully that is better now -- what do you think?


