### PR TITLE
Fix templates/site/neck.html unicode error

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -381,11 +381,11 @@ class Metatag:
         self.attrs = attrs
 
     def __str__(self):
-        attrs = " ".join('%s="%s"' % (web.websafe(k), web.websafe(v)) for k, v in self.attrs.items())
-        return "<%s %s />" % (self.tag, attrs)
+        attrs = ' '.join('%s="%s"' % (k, websafe(v).encode('utf8')) for k, v in self.attrs.items())
+        return '<%s %s />' % (self.tag, attrs)
 
     def __repr__(self):
-        return "Metatag(%s)" % str(self)
+        return 'Metatag(%s)' % str(self)
 
 @public
 def add_metatag(tag="meta", **attrs):


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #2102 

Not 100% sure why this is casuing problems -- I think the issue is to do with  webpy's unicode support. This clears up the issue on affected items in dev -- they had HTML meta tag descriptions that included unicode characters, and something in the multiple 'websafe'-ing methods was complaining. This ensures the values are recognised as utf8 encoded.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
