### PR TITLE
HTML5 img width

### DIFF
--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -5,7 +5,7 @@ $if not is_bot():
   <div class="page-banner page-banner-black page-banner-center">
     <div class="iaBar">
       <div class="iaBarLogo">
-	<a href="https://archive.org"><img alt="Internet Archive logo" src="/static/images/ia-logo.svg" width="160px"></a>
+	<a href="https://archive.org"><img alt="Internet Archive logo" src="/static/images/ia-logo.svg" width="160"></a>
       </div>
       <div class="iaBarMessage">
         <a class="ghost-btn" style="text-underline" href="https://archive.org/donate?platform=ol" data-ol-link-track="IABar|DonateButton">Donate <span class="heart" aria-hidden="true">♥</span></a>


### PR DESCRIPTION
### Description
Another small change, helps with HTML5 compatibility on all site pages. HTML5 img width are all in pixels, `px` gives a validation error.