### PR TITLE
Enable `vars-on-top` eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,22 +5,22 @@
     "jquery": true
   },
   "parserOptions": {
-		"sourceType": "module",
-		"ecmaVersion": 6
-	},
-  "globals": {
+    "sourceType": "module",
+    "ecmaVersion": 6
   },
+  "globals": {},
   "rules": {
+    "eol-last": ["error", "always"],
     "indent": 2,
     "no-console": "error",
-    "no-trailing-spaces": "error",
-    "space-in-parens": "error",
-    "no-undef": "error",
     "no-extra-semi": "error",
-    "eol-last": ["error", "always"],
-    "no-redeclare": "error",
     "no-mixed-spaces-and-tabs": "error",
+    "no-redeclare": "error",
+    "no-trailing-spaces": "error",
+    "no-undef": "error",
+    "no-unused-vars": "error",
     "no-useless-escape": "error",
-    "no-unused-vars": "error"
+    "space-in-parens": "error",
+    "vars-on-top": "error"
   }
 }

--- a/openlibrary/plugins/openlibrary/js/account.js
+++ b/openlibrary/plugins/openlibrary/js/account.js
@@ -3,8 +3,9 @@ export function validateEmail() {
     $("form.email").validate({
         invalidHandler: function(form, validator) {
             var errors = validator.numberOfInvalids();
+            var message;
             if (errors) {
-                var message = errors == 1 ? 'Hang on... You forgot to provide an updated email address.' : 'Hang on... You forgot to provide an updated email address.';
+                message = errors == 1 ? 'Hang on... You forgot to provide an updated email address.' : 'Hang on... You forgot to provide an updated email address.';
                 $("div#contentMsg span").html(message);
                 $("div#contentMsg").show().fadeTo(3000, 1).slideUp();
                 $("span.remind").css("font-weight", "700").css("text-decoration", "underline");
@@ -35,8 +36,9 @@ export function validatePassword() {
     $("form.password").validate({
         invalidHandler: function(form, validator) {
             var errors = validator.numberOfInvalids();
+            var message;
             if (errors) {
-                var message = (errors == 1? 'Hang on... you missed a field.': 'Hang on... to change your password, we need your current and your new one.');
+                message = errors == 1 ? 'Hang on... you missed a field.': 'Hang on... to change your password, we need your current and your new one.';
                 $("div#contentMsg span").html(message);
                 $("div#contentMsg").show().fadeTo(3000, 1).slideUp();
                 $("span.remind").css("font-weight", "700").css("text-decoration", "underline");

--- a/openlibrary/plugins/openlibrary/js/add_new_field.js
+++ b/openlibrary/plugins/openlibrary/js/add_new_field.js
@@ -55,13 +55,14 @@ export default function($){
 
             // handle submit
             $("form:first", $(options.href)).submit(function(event) {
+                var array, d, i, data;
                 event.preventDefault();
 
                 // extract data
-                var array = $(this).serializeArray();
-                var d = {};
+                array = $(this).serializeArray();
+                d = {};
 
-                for (var i in array) {
+                for (i in array) {
                     d[array[i].name] = $.trim(array[i].value);
                 }
 
@@ -81,7 +82,7 @@ export default function($){
                     .parent().val(d.value);
 
                 // add JSON to hidden field
-                var data = null;
+                data = null;
                 try {
                     data = JSON.parse($json.val());
                 }

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -25,8 +25,9 @@ export default function($) {
                 // in v2, text IS the JSON
                 var rows = typeof text === 'string' ? JSON.parse(text) : text;
                 var parsed = [];
-                for (var i=0; i < rows.length; i++) {
-                    var row = rows[i];
+                var i, row, query;
+                for (i=0; i < rows.length; i++) {
+                    row = rows[i];
                     parsed.push({
                         data: row,
                         value: row.name,
@@ -35,7 +36,7 @@ export default function($) {
                 }
 
                 // XXX: this won't work when _this is multiple values (like $("input"))
-                var query = $(_this).val();
+                query = $(_this).val();
                 if (ol_ac_opts.addnew && ol_ac_opts.addnew(query)) {
                     parsed = parsed.slice(0, ac_opts.max - 1);
                     parsed.push({
@@ -51,8 +52,10 @@ export default function($) {
         $(_this)
             .autocomplete(ol_ac_opts.endpoint, $.extend(default_ac_opts, ac_opts))
             .result(function(event, item) {
+                var $this;
+
                 $("#" + this.id + "-key").val(item.key);
-                var $this = $(this);
+                $this = $(this);
 
                 //adding class directly is not working when tab is pressed. setTimeout seems to be working!
                 setTimeout(function() {
@@ -105,10 +108,11 @@ export default function($) {
         });
 
         container.on("click", "a.add", function(event) {
+            var next_index, new_input;
             event.preventDefault();
 
-            var next_index = container.find("div.input").length;
-            var new_input = $(input_renderer(next_index, {key:"", name: ""}));
+            next_index = container.find("div.input").length;
+            new_input = $(input_renderer(next_index, {key:"", name: ""}));
             container.append(new_input);
             setup_autocomplete(
                 new_input.find(autocomplete_selector)[0],

--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -2,6 +2,7 @@
  * Setup actions on document.ready for standard classNames.
  */
 export default function($) {
+    var options;
     // Flash messages are hidden by default so that CSS is not on the critical path.
     $(".flash-messages").show();
     // close-popup
@@ -17,7 +18,7 @@ export default function($) {
     });
 
     // tabs
-    var options = {};
+    options = {};
     if($.support.opacity){
         options.fx = {"opacity": "toggle"};
     }

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -38,10 +38,11 @@ function init() {
     }
 
     getAvailabilityV2 = function(_type, _ids, callback) {
+        var url;
         if (!_ids.length) {
             return callback({});
         }
-        var url = '/availability/v2?type=' + _type;
+        url = '/availability/v2?type=' + _type;
         $.ajax({
             url: url,
             type: "POST",
@@ -68,21 +69,23 @@ function init() {
      * copies.
      */
     updateBookAvailability = function(selector) {
+        var books, ocaids;
         selector = (selector || '') + '[data-ocaid]';
-        var books = {};  // lets us keep track of which ocaids came from
+        books = {};  // lets us keep track of which ocaids came from
         // which book (i.e. edition or work). As we learn
         // ocaids are available, we'll need a way to
         // determine which edition or work this ocaid
         // comes from.
-        var ocaids = [];  // a full set of ocaids spanning all books
+        ocaids = [];  // a full set of ocaids spanning all books
         // which can be checked in a single request
         // to the availability API.
         $(selector).each(function(index, elem) {
             var data_ocaid = $(elem).attr('data-ocaid');
+            var book_ocaids, book_key;
             if(data_ocaid) {
-                var book_ocaids = data_ocaid.split(',')
+                book_ocaids = data_ocaid.split(',')
                     .filter(function(book) { return book !== "" });
-                var book_key = $(elem).attr('data-key');
+                book_key = $(elem).attr('data-key');
 
                 if(book_ocaids.length) {
                     books[book_key] = book_ocaids;
@@ -94,7 +97,8 @@ function init() {
         getAvailabilityV2('identifier', ocaids, function(response) {
             var book_key = null;
             var book_ocaids = null;
-            for (var book_ocaid in response) {
+            var book_ocaid;
+            for (book_ocaid in response) {
                 if (response[book_ocaid].status === "borrow_available") {
                     // check all the books on this page
                     for (book_key in books) {
@@ -157,7 +161,8 @@ function init() {
         // Determine whether availability check necessary for page
         var checkAvailability = false;
         var filter = false;
-        for (var page in whitelist) {
+        var page, daisies, editions, works, results;
+        for (page in whitelist) {
             if (window.location.pathname.match(page)) {
                 checkAvailability = true;
                 filter = whitelist[page].filter;
@@ -168,16 +173,16 @@ function init() {
         }
 
         if (localStorage.getItem('mode') === "printdisabled") {
-            var daisies = $('.print-disabled-only');
+            daisies = $('.print-disabled-only');
             $.each(daisies, function() {
                 $(this).removeClass('hidden');
             });
             return;
         }
 
-        var editions = [];
-        var works = [];
-        var results = $('a.results');
+        editions = [];
+        works = [];
+        results = $('a.results');
         $.each(results, function(index, e) {
             var href = $(e).attr('href');
             var _type_key_slug = href.split('/')
@@ -198,11 +203,12 @@ function init() {
                     var _type_key_slug = href.split('/')
                     var _type = _type_key_slug[1];
                     var key = _type_key_slug[2];
+                    var work, li, cta, mode;
                     if (response[_type]) {
-                        var work = response[_type][key];
-                        var li = $(e).closest("li");
-                        var cta = li.find(".searchResultItemCTA-lending");
-                        var mode = filter ? localStorage.getItem('mode') : 'everything';
+                        work = response[_type][key];
+                        li = $(e).closest("li");
+                        cta = li.find(".searchResultItemCTA-lending");
+                        mode = filter ? localStorage.getItem('mode') : 'everything';
 
                         if (mode !== "printdisabled") {
                             if (work.status === 'error' || work.status === 'private') {

--- a/openlibrary/plugins/openlibrary/js/bookreader_direct.js
+++ b/openlibrary/plugins/openlibrary/js/bookreader_direct.js
@@ -1,10 +1,11 @@
 // Make Borrow links act as if POSTing to Borrow page
 export default function() {
     $('.borrow-link').on('click', function(event) {
+        var $this, borrowUrl, borrowFormString;
         event.preventDefault();
-        var $this = $(this);
-        var borrowUrl = $this.attr('href').replace(/'/g, '%27');
-        var borrowFormString = "<form action='" + borrowUrl + "' method='POST'>\n" +
+        $this = $(this);
+        borrowUrl = $this.attr('href').replace(/'/g, '%27');
+        borrowFormString = "<form action='" + borrowUrl + "' method='POST'>\n" +
       "<input type='hidden' name='action' value='borrow' />\n" +
       "<input type='hidden' name='format' value='bookreader' />\n" +
       "<input type='hidden' name='ol_host' value='" + location.host + "' />\n" +

--- a/openlibrary/plugins/openlibrary/js/carousels.js
+++ b/openlibrary/plugins/openlibrary/js/carousels.js
@@ -1,6 +1,8 @@
 // used in templates/covers/add.html
 const Carousel = {
     add: function(selector, a, b, c, d, e, f, loadMore) {
+        var responsive_settings, availabilityStatuses, addWork, url, default_limit;
+
         a = a || 6;
         b = b || 5;
         c = c || 4;
@@ -8,7 +10,7 @@ const Carousel = {
         e = e || 2;
         f = f || 1;
 
-        var responsive_settings = [
+        responsive_settings = [
             {
                 breakpoint: 1200,
                 settings: {
@@ -58,14 +60,14 @@ const Carousel = {
             responsive: responsive_settings
         });
 
-        var availabilityStatuses = {
+        availabilityStatuses = {
             'open': {cls: 'cta-btn--available', cta: 'Read'},
             'borrow_available': {cls: 'cta-btn--available', cta: 'Borrow'},
             'borrow_unavailable': {cls: 'cta-btn--unavailable', cta: 'Join Waitlist'},
             'error': {cls: 'cta-btn--missing', cta: 'No eBook'}
         };
 
-        var addWork = function(work) {
+        addWork = function(work) {
             var availability = work.availability.status;
             var cover_id = work.covers? work.covers[0] : work.cover_id;
             var ocaid = work.availability.identifier;
@@ -97,14 +99,14 @@ const Carousel = {
 
         // if a loadMore config is provided and it has a (required) url
         if (loadMore && loadMore.url) {
-            var url;
+            url;
             try {
                 // exception handling needed in case loadMore.url is relative path
                 url = new URL(loadMore.url);
             } catch (e) {
                 url = new URL(window.location.origin + loadMore.url);
             }
-            var default_limit = 18; // 3 pages of 6 books
+            default_limit = 18; // 3 pages of 6 books
             url.searchParams.set('limit', loadMore.limit || default_limit);
             loadMore.pageMode = loadMore.pageMode === 'page' ? 'page' : 'offset'; // verify pagination mode
             loadMore.locked = false; // prevent additional calls when not in critical section

--- a/openlibrary/plugins/openlibrary/js/jquery.repeat.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.repeat.js
@@ -7,11 +7,11 @@ export default function($){
     // For v2 and v1 page support. Can be removed when no v1 support needed
     var isOldJQuery = $('body').on === undefined;
     $.fn.repeat = function(options) {
-        var addSelector, removeSelector;
+        var addSelector, removeSelector, id, elems, t, code;
         options = options || {};
 
-        var id = "#" + this.attr("id");
-        var elems = {
+        id = "#" + this.attr("id");
+        elems = {
             '_this': this,
             'add': $(id + '-add'),
             'form': $(id + '-form'),
@@ -20,7 +20,7 @@ export default function($){
         }
 
         function createTemplate(selector) {
-            var code = $(selector).html()
+            code = $(selector).html()
                 .replace(/%7B%7B/gi, "<%=")
                 .replace(/%7D%7D/gi, "%>")
                 .replace(/{{/g, "<%=")
@@ -30,7 +30,7 @@ export default function($){
             return Template(code);
         }
 
-        var t = createTemplate(id + "-template");
+        t = createTemplate(id + "-template");
 
         /**
          * Search elems.form for input fields and create an
@@ -60,10 +60,11 @@ export default function($){
          * @param {jQuery.Event} event
          */
         function onAdd(event) {
+            var index, data, newid;
             event.preventDefault();
 
-            var index = elems.display.children().length;
-            var data = formdata();
+            index = elems.display.children().length;
+            data = formdata();
             data.index = index;
 
             if (options.validate && options.validate(data) == false) {
@@ -72,7 +73,7 @@ export default function($){
 
             $.extend(data, options.vars || {});
 
-            var newid = elems._this.attr("id") + "--" + index;
+            newid = elems._this.attr("id") + "--" + index;
             // Create the HTML of a hidden input
             elems.template
                 .clone()

--- a/openlibrary/plugins/openlibrary/js/jsdef.js
+++ b/openlibrary/plugins/openlibrary/js/jsdef.js
@@ -18,14 +18,15 @@
 
 //used in templates/lib/pagination.html
 export function range(begin, end, step) {
+    var r, i;
     step = step || 1;
     if (end == undefined) {
         end = begin;
         begin = 0;
     }
 
-    var r = [];
-    for (var i=begin; i<end; i += step) {
+    r = [];
+    for (i=begin; i<end; i += step) {
         r[r.length] = i;
     }
     return r;
@@ -53,7 +54,8 @@ export function len(array) {
 // used in templates/type/permission/edit.html
 export function enumerate(a) {
     var b = new Array(a.length);
-    for (var i in a) {
+    var i;
+    for (i in a) {
         b[i] = [i, a[i]];
     }
     return b;
@@ -87,15 +89,16 @@ ForLoop.prototype.next = function() {
 // used in plugins/upstream/jsdef.py
 export function foreach(seq, parent_loop, callback) {
     var loop = new ForLoop(parent_loop, seq);
+    var i, args, j;
 
-    for (var i=0; i<seq.length; i++) {
+    for (i=0; i<seq.length; i++) {
         loop.next();
 
-        var args = [loop];
+        args = [loop];
 
         // case of "for a, b in ..."
         if (callback.length > 2) {
-            for (var j in seq[i]) {
+            for (j in seq[i]) {
                 args.push(seq[i][j]);
             }
         }

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -15,8 +15,9 @@
 // We are blindly concatenating JS. The ; protects us in case the concatenation
 // goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
 export function Subject(data, options) {
+    var defaults;
     options = options || {};
-    var defaults = {
+    defaults = {
         pagesize: 12
     }
     this.settings = $.extend(defaults, options);
@@ -33,7 +34,8 @@ export function Subject(data, options) {
 // Implementation of Python urllib.urlencode in Javascript.
 export function urlencode(query) {
     var parts = [];
-    for (var k in query) {
+    var k;
+    for (k in query) {
         parts.push(k + "=" + query[k]);
     }
     return parts.join("&");
@@ -42,8 +44,9 @@ export function urlencode(query) {
 /* Should really use createElement() */
 export function renderTag(tag, keyvals, child) {
     var html = '<' + tag + ' ';
-    for (var key in keyvals) {
-        var val =  keyvals[key];
+    var key, val;
+    for (key in keyvals) {
+        val =  keyvals[key];
         if (val == '') {
             html += key + ' ';
         } else {
@@ -63,7 +66,8 @@ export function renderTag(tag, keyvals, child) {
 
 export function slice(array, begin, end) {
     var a = [];
-    for (var i=begin; i < Math.min(array.length, end); i++) {
+    var i;
+    for (i=begin; i < Math.min(array.length, end); i++) {
         a.push(array[i]);
     }
     return a;
@@ -97,17 +101,19 @@ $.extend(Subject.prototype, {
 
     renderWork: function(work) {
         var authors = [];
-        for (var author in work.authors)
+        var author;
+        var ed, titlestring, bookcover_url, format, bookread_url, html
+        for (author in work.authors)
             authors.push(work.authors[author].name);
-        var ed = 'edition' + (work.edition_count > 1 ? 's' : '');
-        var titlestring = work.title + " by " + authors.join(', ') +
+        ed = 'edition' + (work.edition_count > 1 ? 's' : '');
+        titlestring = work.title + " by " + authors.join(', ') +
         ' (' + work.edition_count + ' ' + ed + ')';
-        var bookcover_url = '//covers.openlibrary.org/b/id/' + work.cover_id + '-M.jpg';
-        var format = work.public_scan ? 'public' : (work.printdisabled && !work.ia_collection.includes('inlibrary')) ? 'daisy' : 'borrow';
-        var bookread_url = work.public_scan ?
+        bookcover_url = '//covers.openlibrary.org/b/id/' + work.cover_id + '-M.jpg';
+        format = work.public_scan ? 'public' : (work.printdisabled && !work.ia_collection.includes('inlibrary')) ? 'daisy' : 'borrow';
+        bookread_url = work.public_scan ?
             ('//archive.org/stream/' + work.ia + '?ref=ol') :
             '/borrow/ia/' + work.ia;
-        var html = renderTag('div', {'class': 'coverMagic'},
+        html = renderTag('div', {'class': 'coverMagic'},
             renderTag('span', {
                 'itemtype': 'https://schema.org/Book',
                 'itemscope': ''},
@@ -133,6 +139,7 @@ $.extend(Subject.prototype, {
     loadPage: function(pagenum, callback) {
         var offset = pagenum * this.settings.pagesize;
         var limit = this.settings.pagesize;
+        var params, key, url, t;
 
         if (offset > this.bookCount) {
             callback && callback([]);
@@ -142,7 +149,7 @@ $.extend(Subject.prototype, {
             callback(this._pages[pagenum]);
         }
         else {
-            var params = {
+            params = {
                 "limit": limit,
                 "offset": offset,
                 "has_fulltext": this.has_fulltext,
@@ -153,9 +160,9 @@ $.extend(Subject.prototype, {
             }
             $.extend(params, this.filter);
 
-            var key = this.key.replace(/\s+/g, '_');
-            var url = key + ".json?" + urlencode(params);
-            var t = this;
+            key = this.key.replace(/\s+/g, '_');
+            url = key + ".json?" + urlencode(params);
+            t = this;
 
             $.getJSON(url, function(data) {
                 t._pages[pagenum] = data;
@@ -165,22 +172,24 @@ $.extend(Subject.prototype, {
     },
 
     _ajax: function(params, callback) {
+        var key, url;
         params = $.extend({"limit": this.settings.pagesize, "offset": 0},
             this.filter, params);
-        var key = this.key.replace(/\s+/g, '_');
-        var url = key + ".json?" + urlencode(params);
+        key = this.key.replace(/\s+/g, '_');
+        url = key + ".json?" + urlencode(params);
         $.getJSON(url, callback);
     },
 
     setFilter: function(filter, callback) {
-        for (var k in filter) {
+        var k, _this;
+        for (k in filter) {
             if (filter[k] == null) {
                 delete filter[k];
             }
         }
         this.filter = filter;
 
-        var _this = this;
+        _this = this;
         this._ajax({"details": "true"}, function(data) {
             _this.init(data);
             callback && callback();

--- a/openlibrary/plugins/openlibrary/js/template.js
+++ b/openlibrary/plugins/openlibrary/js/template.js
@@ -6,6 +6,7 @@
 export default function Template(tmpl_text) {
     var s = [];
     var js = ["var _p=[];", "with(env) {"];
+    var tokens, i, t, f, g;
 
     function addCode(text) {
         js.push(text);
@@ -18,11 +19,11 @@ export default function Template(tmpl_text) {
         s.push(text);
     }
 
-    var tokens = tmpl_text.split("<%");
+    tokens = tmpl_text.split("<%");
 
     addText(tokens[0]);
-    for (var i=1; i < tokens.length; i++) {
-        var t = tokens[i].split('%>');
+    for (i=1; i < tokens.length; i++) {
+        t = tokens[i].split('%>');
 
         if (t[0][0] == "=") {
             addExpr(t[0].substr(1));
@@ -34,8 +35,8 @@ export default function Template(tmpl_text) {
     }
     js.push("}", "return _p.join('');");
 
-    var f = new Function(["__s", "env"], js.join("\n"));
-    var g = function(env) {
+    f = new Function(["__s", "env"], js.join("\n"));
+    g = function(env) {
         return f(s, env);
     };
     g.toString = function() { return tmpl_text; };

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -85,8 +85,9 @@ export function initShowPasswords($) {
         showPasswords: function(f) {
             return this.each(function() {
                 var c = function(a) {
+                    var b;
                     a = $(a);
-                    var b = $("<input type='text' />");
+                    b = $("<input type='text' />");
                     b.insertAfter(a).attr({
                         'class': a.attr('class'),
                         'style': a.attr('style')

--- a/openlibrary/plugins/openlibrary/js/validate.js
+++ b/openlibrary/plugins/openlibrary/js/validate.js
@@ -40,10 +40,11 @@ export default function initValidate() {
             errorElement: "span",
             invalidHandler: function(form, validator) {
                 var errors = validator.numberOfInvalids();
+                var message;
                 if (errors) {
                     // ungettext is defined in openlibrary\plugins\openlibrary\js\i18n.js
                     // eslint-disable-next-line no-undef
-                    var message = ungettext(
+                    message = ungettext(
                         "Hang on... you missed a bit. It's highlighted below.",
                         "Hang on...you missed some fields. They're highlighted below.",
                         errors);

--- a/package.json
+++ b/package.json
@@ -69,9 +69,9 @@
     "less-loader": "4.1.0",
     "node-gyp": "^3.8.0",
     "prebuild-install": "^5.2.1",
+    "style-loader": "0.23.1",
     "stylelint": "^9.5.0",
     "stylelint-declaration-use-variable": "^1.7.0",
-    "style-loader": "0.23.1",
     "svgo": "1.1.1",
     "webpack": "4.27.1",
     "webpack-cli": "3.1.2"


### PR DESCRIPTION
### Description
Refactor moving variable declarations to top of function block.

Closes #2086

### Technical
Regarding comments in the issue thread, I leaned toward resolving linting violations by doing the exact equivalent of what Javascript would do (go back and define the variable at the top of scope) rather than the cleaner way (e.g. moving `event.preventDefault();` down past variable declarations that are probably fine but technically different)

### Testing
Ran `npm test` and came back with same css linting errors that previously existed.
