### PR TITLE
Fix reveal of translation information

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -369,9 +369,9 @@ window.q.push(function() {
                 $ checked_yes = cond(translation, 'checked="checked"', '')
                 $ checked_no = cond(not translation, 'checked="checked"', '')
                 $if translation:
-                    $ trans_class = "transYes"
+                    $ style_hidden = ""
                 $else:
-                    $ trans_class = "hidden transYes"
+                    $ style_hidden = "display: none;"
 
                 <div class="input">
                     <br/>
@@ -383,7 +383,7 @@ window.q.push(function() {
                     <label for="is-translation2">$_("Yes, it's a translation")</label>
                 </div>
 
-                <div class="$trans_class">
+                <div class="transYes" style="$style_hidden">
                     <div class="label">
                         <span class="tip">$_("What's the original book?")</span>
                     </div>
@@ -392,7 +392,7 @@ window.q.push(function() {
                     </div>
                 </div>
 
-                <div class="$trans_class" id="translated_from_languages">
+                <div class="transYes" id="translated_from_languages" style="$style_hidden">
                     <div class="label">
                         <label for="edition-translated_from"><span class="tip">$_("What language was the original written in?")</span></label>
                     </div>


### PR DESCRIPTION
I don't like having these events hidden in the templates but I'm
not quite sure how to generalise this code right now.

The `hidden` class now applies !important so needs to be removed
when ever doing this fadeIn/out programmatically.

Fixes: #1892

### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

![Screenshot 2019-07-22 at 9 53 59 AM](https://user-images.githubusercontent.com/148752/61649603-a6683680-ac66-11e9-8c71-7d2169179c47.png)
Closes #

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
