### PR TITLE
Add revert access for librarians

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -191,7 +191,7 @@ class revert(delegate.mode):
 
         user = accounts.get_current_user()
         is_admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
-        if not (user.is_librarian() and is_admin and web.ctx.site.can_write(key)):
+        if not (user and (is_admin or user.is_librarian()) and web.ctx.site.can_write(key)):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -191,7 +191,7 @@ class revert(delegate.mode):
 
         user = accounts.get_current_user()
         is_admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
-        if not (is_admin and web.ctx.site.can_write(key)):
+        if not (user.is_librarian() and is_admin and web.ctx.site.can_write(key)):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -190,8 +190,7 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         user = accounts.get_current_user()
-        is_admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
-        if not (user and (is_admin or user.is_librarian()) and web.ctx.site.can_write(key)):
+        if not (user and (user.is_admin() or user.is_librarian()) and web.ctx.site.can_write(key)):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $ v = query_param("v", None)
 
-$if ctx.user and ctx.user.is_admin():
+$if ctx.user and ctx.user.is_admin() or ctx.user.is_librarian():
     $if v and not page.key.startswith("/books/ia:"):
         <div id="revertNotice">
             <form name="revert" method="POST" action="$changequery(m='revert')">


### PR DESCRIPTION
### Description

Fix #2217. [feature]

### Technical
Gives revert access for librarians.

### Testing
- Librarians should see history on top right side
- They can revert till a revision listed

### Evidence

- [ ] A little minute, adding a screenshot.
