### PR TITLE
Add a Reading Log option for "Stopped Reading"

### DIFF
--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -39,3 +39,4 @@ CREATE TABLE bookshelves_votes (
 INSERT INTO bookshelves (name, description) VALUES ('Want to Read', 'A list of books I want to read');
 INSERT INTO bookshelves (name, description) VALUES ('Currently Reading', 'A list of books I am currently reading');
 INSERT INTO bookshelves (name, description) VALUES ('Already Read', 'A list of books I have finished reading');
+INSERT INTO bookshelves (name, description) VALUES ('Stopped Reading', 'A list of books I have stopped reading');

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1396,6 +1396,10 @@ msgstr ""
 msgid "Finished"
 msgstr ""
 
+#: saved.html:42
+msgid "Stopped"
+msgstr ""
+
 #: comment.html:28
 msgid "Edited without comment."
 msgstr ""

--- a/openlibrary/templates/email/waitinglist_people_waiting.html
+++ b/openlibrary/templates/email/waitinglist_people_waiting.html
@@ -1,9 +1,9 @@
 $def with (user, book, expiry_days)
-$var subject: Have you finished reading $book.title?
+$var subject: Have you finished or stopped reading $book.title?
 
 Hello $user.displayname,
 
-Some people are waiting to borrow "$book.title", a book you have currently borrowed from Open Library. Your loan is scheduled to last for $expiry_days more days, but if you're finished reading the book, please feel free to return it early so that the next person can borrow it. To return the book, please visit:
+Some people are waiting to borrow "$book.title", a book you have currently borrowed from Open Library. Your loan is scheduled to last for $expiry_days more days, but if you're finished or stopped reading the book, please feel free to return it early so that the next person can borrow it. To return the book, please visit:
 
 $book.url("/borrow", relative=False)
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -104,6 +104,8 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                     $ message = "Already Read"
                 $elif users_work_read_status == 2:
                     $ message = "Currently Reading"
+                $elif users_work_read_status == 4:
+                    $ message = "Stopped Reading"
                 $else:
                     $ message = "Want to Read"
                 $if users_work_read_status:


### PR DESCRIPTION
### Description

Fix https://github.com/internetarchive/openlibrary/issues/2016. [feature]

### Technical
Enabled a stopped reading option.

### Testing
- The user should see stopped reading in reading log option and messages.

### Evidence
- [ ] Add a screenshot - @tapaswenipathak
