### PR TITLE
Refactor debounce into separate file

### DIFF
--- a/openlibrary/plugins/openlibrary/js/nonjquery_utils.js
+++ b/openlibrary/plugins/openlibrary/js/nonjquery_utils.js
@@ -19,4 +19,4 @@ export function debounce(func, threshold, execAsap) {
         }
         timeout = setTimeout(delayed, threshold || 100);
     };
-};
+}

--- a/openlibrary/plugins/openlibrary/js/nonjquery_utils.js
+++ b/openlibrary/plugins/openlibrary/js/nonjquery_utils.js
@@ -2,11 +2,21 @@
  * These methods are separate from utils.js because that file assumes a globel jQuery object.
  */
 
-export function debounce(func, threshold, execAsap) {
-    var timeout;
-    return function debounced () {
-        var obj = this, args = arguments;
-        function delayed () {
+/**
+ * Debounces func
+ * i.e. Returns a function, that, as long as it continues to be invoked, will not
+ * be triggered until it stops being called for `threshold` milliseconds. If
+ * `execAsap` is passed, trigger the function first, then block it.
+ * @param {Function} func
+ * @param {Number} [threshold]
+ * @param {Boolean} [execAsap]
+ * @returns {Function}
+ */
+export function debounce(func, threshold=100, execAsap=false) {
+    let timeout;
+    return function debounced() {
+        const obj = this, args = arguments;
+        function delayed() {
             if (!execAsap)
                 func.apply(obj, args);
             timeout = null;
@@ -17,6 +27,6 @@ export function debounce(func, threshold, execAsap) {
         } else if (execAsap) {
             func.apply(obj, args);
         }
-        timeout = setTimeout(delayed, threshold || 100);
+        timeout = setTimeout(delayed, threshold);
     };
 }

--- a/openlibrary/plugins/openlibrary/js/nonjquery_utils.js
+++ b/openlibrary/plugins/openlibrary/js/nonjquery_utils.js
@@ -1,0 +1,22 @@
+/**
+ * These methods are separate from utils.js because that file assumes a globel jQuery object.
+ */
+
+export function debounce(func, threshold, execAsap) {
+    var timeout;
+    return function debounced () {
+        var obj = this, args = arguments;
+        function delayed () {
+            if (!execAsap)
+                func.apply(obj, args);
+            timeout = null;
+        }
+
+        if (timeout) {
+            clearTimeout(timeout);
+        } else if (execAsap) {
+            func.apply(obj, args);
+        }
+        timeout = setTimeout(delayed, threshold || 100);
+    };
+};

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -1,3 +1,5 @@
+import { debounce } from './nonjquery_utils.js';
+
 export var Browser = {
     getJsonFromUrl: function () {
         var query = location.search.substr(1);
@@ -81,7 +83,7 @@ export default function init(){
     };
     // stores the state of the search result for resizing window
     var instantSearchResultState = false;
-    var searchModes, searchModeDefault, defaultFacet, searchFacets, composeSearchUrl, marshalBookSearchQuery, renderInstantSearchResults, setFacet, setMode, setSearchMode, options, q, parts, debounce, enteredSearchMinimized, searchExpansionActivated, toggleSearchbar, renderInstantSearchResult, val, facet_value;
+    var searchModes, searchModeDefault, defaultFacet, searchFacets, composeSearchUrl, marshalBookSearchQuery, renderInstantSearchResults, setFacet, setMode, setSearchMode, options, q, parts, enteredSearchMinimized, searchExpansionActivated, toggleSearchbar, renderInstantSearchResult, val, facet_value;
 
     // searches should be cancelled if you click anywhere in the page
     $('body').on('click', function () {
@@ -242,25 +244,6 @@ export default function init(){
     // updateWorkAvailability is defined in openlibrary\openlibrary\plugins\openlibrary\js\availability.js
     // eslint-disable-next-line no-undef
     updateWorkAvailability();
-
-    debounce = function (func, threshold, execAsap) {
-        var timeout;
-        return function debounced () {
-            var obj = this, args = arguments;
-            function delayed () {
-                if (!execAsap)
-                    func.apply(obj, args);
-                timeout = null;
-            }
-
-            if (timeout) {
-                clearTimeout(timeout);
-            } else if (execAsap) {
-                func.apply(obj, args);
-            }
-            timeout = setTimeout(delayed, threshold || 100);
-        };
-    };
 
     $(document).on('submit','.trigger', function(e) {
         e.preventDefault(e);

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -383,14 +383,11 @@ export default function init(){
             $('.wmd-preview').before('<h3 id="prevHead" style="margin:15px 0 10px;padding:0;">Preview</h3>');
         }
     });
-    initReadingListFeature(debounce);
+    initReadingListFeature();
     initBorrowAndReadLinks();
 }
 
-/**
- * @param {Function} debounce function
- */
-export function initReadingListFeature(debounce) {
+export function initReadingListFeature() {
     /**
      * close an open dropdown in a given container
      * @param {jQuery.Object} $container

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -12,8 +12,6 @@
 //          });
 //
 
-// We are blindly concatenating JS. The ; protects us in case the concatenation
-// goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
 export function Subject(data, options) {
     var defaults;
     options = options || {};

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -1,6 +1,3 @@
-// We are blindly concatenating JS. The ; protects us in case the concatenation
-// goes wrong. This can be removed when we make use of a JS bundler e.g. webpack
-
 // source: http://snipplr.com/view/8916/jquery-toggletext/
 $.fn.toggleText = function(a, b) {
     return this.each(function() {

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -1,4 +1,4 @@
-const editionIdentifiersSample = `<fieldset id="identifiers">
+export const editionIdentifiersSample = `<fieldset id="identifiers">
 <table class="identifiers">
     <tbody><tr id="identifiers-form">
         <td align="right">
@@ -65,6 +65,9 @@ const editionIdentifiersSample = `<fieldset id="identifiers">
 </table>
 </div>`;
 
-export default {
-    editionIdentifiersSample
-};
+/** Part/Simplification of the #widget-add element */
+export const bookDropdownSample = `
+    <a href="javascript:;" class="dropclick dropclick-unactivated">
+        <div class="arrow arrow-unactivated"></div>
+    </a>
+`;

--- a/tests/unit/js/test.jquery.repeat.js
+++ b/tests/unit/js/test.jquery.repeat.js
@@ -1,6 +1,6 @@
 import jquery from 'jquery';
 import sinon from 'sinon';
-import testData from './html-test-data';
+import * as testData from './html-test-data';
 import { htmlquote } from '../../../openlibrary/plugins/openlibrary/js/jsdef';
 import jQueryRepeat from '../../../openlibrary/plugins/openlibrary/js/jquery.repeat';
 

--- a/tests/unit/js/test.nonjquery_utils.js
+++ b/tests/unit/js/test.nonjquery_utils.js
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+import { debounce } from '../../../openlibrary/plugins/openlibrary/js/nonjquery_utils.js';
+
+describe('debounce', () => {
+    test('func not called during initialization', () => {
+        const spy = sinon.spy();
+        debounce(spy, 100, false);
+        expect(spy.callCount).toBe(0);
+    });
+
+    test('func called after threshold when !execAsap', () => {
+        const clock = sinon.useFakeTimers();
+        const spy = sinon.spy();
+        const debouncedSpy = debounce(spy, 100, false);
+        debouncedSpy();
+        expect(spy.callCount).toBe(0);
+        clock.tick(99);
+        expect(spy.callCount).toBe(0);
+        clock.tick(1);
+        expect(spy.callCount).toBe(1);
+        clock.restore();
+    });
+
+    test('func called immediately when execAsap', () => {
+        const clock = sinon.useFakeTimers();
+        const spy = sinon.spy();
+        const debouncedSpy = debounce(spy, 100, true);
+        debouncedSpy();
+        expect(spy.callCount).toBe(1);
+        clock.tick(100);
+        expect(spy.callCount).toBe(1);
+        clock.restore();
+    });
+
+    test('func called with correct context and arguments', () => {
+        const spy = sinon.spy();
+        const debouncedSpy = debounce(spy, 100, true);
+        const context = {};
+        debouncedSpy.call(context, 1, 2, 3);
+        expect(spy.thisValues[0]).toBe(context);
+        expect(spy.args[0]).toEqual([1, 2, 3]);
+    });
+
+    test('func only called once when spammed', () => {
+        const clock = sinon.useFakeTimers();
+        const spy = sinon.spy();
+        const debouncedSpy = debounce(spy, 100, false);
+        for (let i = 0; i < 10; i++) {
+            debouncedSpy();
+            expect(spy.callCount).toBe(0);
+        }
+        clock.tick(100);
+        expect(spy.callCount).toBe(1);
+        clock.restore();
+    });
+});

--- a/tests/unit/js/test.ol.js
+++ b/tests/unit/js/test.ol.js
@@ -10,19 +10,27 @@ beforeEach(() => {
     sandbox.stub(global, '$').callsFake(jquery);
 });
 
-test('initReadingListFeature binds events to HTML added after initialisation', () => {
-    const spy = sinon.spy();
-    initReadingListFeature(() => spy);
-    $(document.body).html(`<div>
-    <div class="dropclick">test</div>
-    <a class="add-to-list"></a>
-</div>
-    `);
-    // trigger a click event
-    $('.dropclick').trigger('click');
-    // check the event handler was called
-    expect(spy.callCount).toBe(1);
-    $('.dropclick').trigger('click');
-    // check the dropclick event handler was called
-    expect(spy.callCount).toBe(2);
+describe('initReadingList', () => {
+    test('dropdown changes arrow direction on click', () => {
+        const clock = sinon.useFakeTimers();
+        initReadingListFeature();
+        $(document.body).html(`
+            <a href="javascript:;" class="dropclick dropclick-unactivated">
+                <div class="arrow arrow-unactivated"></div>
+            </a>
+        `);
+
+        const $dropclick = $('.dropclick');
+        const $arrow = $dropclick.find('.arrow');
+
+        for (let i = 0; i < 2; i++) {
+            $dropclick.trigger('click');
+            clock.next(); // need to step forward because using debounce
+            expect($arrow.hasClass('up')).toBe(true);
+            $dropclick.trigger('click');
+            clock.next();
+            expect($arrow.hasClass('up')).toBe(false);
+        }
+        clock.restore();
+    });
 });

--- a/tests/unit/js/test.ol.js
+++ b/tests/unit/js/test.ol.js
@@ -1,7 +1,8 @@
 import jquery from 'jquery';
 import sinon from 'sinon';
 import { initReadingListFeature } from '../../../openlibrary/plugins/openlibrary/js/ol';
-
+import { bookDropdownSample } from './html-test-data'
+import * as nonjquery_utils from '../../../openlibrary/plugins/openlibrary/js/nonjquery_utils.js';
 let sandbox;
 
 beforeEach(() => {
@@ -11,26 +12,23 @@ beforeEach(() => {
 });
 
 describe('initReadingList', () => {
-    test('dropdown changes arrow direction on click', () => {
-        const clock = sinon.useFakeTimers();
-        initReadingListFeature();
-        $(document.body).html(`
-            <a href="javascript:;" class="dropclick dropclick-unactivated">
-                <div class="arrow arrow-unactivated"></div>
-            </a>
-        `);
+    test.only('dropdown changes arrow direction on click', () => {
+        // Stub debounce to avoid have to manipulate time (!)
+        const stub = sinon.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
 
+        initReadingListFeature();
+        $(document.body).html(bookDropdownSample);
         const $dropclick = $('.dropclick');
         const $arrow = $dropclick.find('.arrow');
 
         for (let i = 0; i < 2; i++) {
             $dropclick.trigger('click');
-            clock.next(); // need to step forward because using debounce
             expect($arrow.hasClass('up')).toBe(true);
+
             $dropclick.trigger('click');
-            clock.next();
             expect($arrow.hasClass('up')).toBe(false);
         }
-        clock.restore();
+
+        stub.restore();
     });
 });


### PR DESCRIPTION
### Description
Refactor to remove the `debounce` dependency injection of `initReadingListFeature`, as discussed here: https://github.com/internetarchive/openlibrary/pull/2224#discussion_r306035603

### Technical
- Why does this have a debounce anyways? It causes the list to appear/vanish sluggishly.

### Testing
- Tested locally that the reading log still opens/closes correctly

### Evidence
![reading list working](https://user-images.githubusercontent.com/6251786/62081374-6da8fe00-b220-11e9-9edc-b384f59e0bd4.gif)