### PR TITLE
hot-fixing search results

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -30,7 +30,7 @@ $ error = None
 $if param:
     $ page = int(param.get('page', 1))
     $ sort = param.get('sort', None)
-    $ rows = 100
+    $ rows = 20
     $ search_start = time()
     $ results = do_search(param, sorts[sort] if sort else None, page, rows=rows, spellcheck_count=3)
     $ search_secs = time() - search_start


### PR DESCRIPTION
### Description
When `ebooks` mode selected, on the backend we filter OL items to display based on availability. This Archive.org availability API (e.g. ervices/availability/?identifier=p1diegesetzedera02greauoft,bookreadymadesp00bookgoog,bookhealth00bookgoog) should accept a list of 100 items. However, either because of a change/regresison/or other factors, it fails silently by responding that all items are "not found" if what it thinks of as "too many ids" are provided. When this happens, the openlibrary.org search results page interprets the error by hiding all the book results (assuming they are unavailable).

#search

The fix is to reduce the items returned from 100 to 20 (also closes #2151)

availability query was breaking, too many results, lowering SERP item…

Closes #2151