### PR TITLE
Allow validation errors to display when editing identifiers

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -432,7 +432,7 @@ window.q.push(function() {
     <legend>$_("ID Numbers")</legend>
     <div class="formBack">
 
-        <div id="id-errors" class="note hidden"></div>
+        <div id="id-errors" class="note" style="display: none"></div>
         <div class="formElement">
             <div class="label">
                 <label for="select-id">$_("Do you know any identifiers for this edition?")</label>


### PR DESCRIPTION
Fixes: #2090

### Description
An element needs to be revealed using JS so using display: none
![Screenshot 2019-07-31 at 5 24 51 PM](https://user-images.githubusercontent.com/148752/62256944-38cfaf00-b3b8-11e9-9ca2-62005f16f240.png)

Closes #

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
