### PR TITLE
Replace _. with i18n to fix rendering (but not functionality)

### DIFF
--- a/openlibrary/templates/type/i18n/edit.html
+++ b/openlibrary/templates/type/i18n/edit.html
@@ -67,8 +67,7 @@ $:render_template("lib/edit_head", page)
         $:macros.TypeChanger(page.type)
 
         <div class="clearfix"></div>
-
-        Change language: $:Dropdown('lang', _.get_languages(), onchange="changelang();", id="id_lang", value=lang).render()
+        Change language: $:Dropdown('lang', i18n.get_languages(), onchange="changelang();", id="id_lang", value=lang).render()
         <input type="hidden" name="ns" value="$namespace">
 
 
@@ -78,19 +77,19 @@ $:render_template("lib/edit_head", page)
 
             $ xnamespace = namespace or "/"
 
-            $for ns in _.get_namespaces():
+            $for ns in i18n.get_namespaces():
                 $if ns == xnamespace:
                     <span class="red">&rarr;</span>
                     $(ns or "root")
                 $else:
                     <a href="/i18n$ns/strings.$lang?m=edit" >$ns</a>
-                <span class="smaller">$(_.get_count(ns, lang))/$_.get_count(ns)</span>
+                <span class="smaller">$(i18n.get_count(ns, lang))/$i18n.get_count(ns)</span>
                 <br/>
 
             </td>
             <td style="vertical-align: top" width="100%">
                 <table id="strings_table">
-                $for key in _.getkeys(namespace, lang):
+                $for key in i18n.getkeys(namespace, lang):
                     <tr>
                         <td class="formheader-i18n">$key</td>
                         <td width="100%" style="padding-left: 20px">
@@ -100,10 +99,10 @@ $:render_template("lib/edit_head", page)
                 </table>
                 <br /><br />
                 <span class="darkgreen">
-                    $_.get('/type/i18n', 'add_new_key')
+                    $i18n.get('/type/i18n', 'add_new_key')
                     <input type="text" name="_newkey" id="newkey"/>
                 </span>
-                <button type="button" id="button_addkey" onclick="add_key()" name="_addkey" value="$_.get('/type/i18n', 'add')" class="addkey-small" />Add</button>
+                <button type="button" id="button_addkey" onclick="add_key()" name="_addkey" value="$i18n.get('/type/i18n', 'add')" class="addkey-small" />Add</button>
 
 
             </td>


### PR DESCRIPTION
Not sure how this broke but `_` doesn't refer to the thing it's
supposed to refer to. Possibly something set this as a global
before. There are likely many other pages impacted but this
fixes the reported one.

Fixes: #943

![Screenshot 2019-08-01 at 8 59 36 AM](https://user-images.githubusercontent.com/148752/62308705-bfc56b80-b43a-11e9-89c0-243508685c1b.png)
![Screenshot 2019-08-01 at 8 59 42 AM](https://user-images.githubusercontent.com/148752/62308708-bfc56b80-b43a-11e9-9513-494274df1065.png)

### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
