### PR TITLE
Revert "Add revert access for librarians (#2228)"

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -190,7 +190,8 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         user = accounts.get_current_user()
-        if not (user and (user.is_admin() or user.is_librarian()) and web.ctx.site.can_write(key)):
+        is_admin = user and user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
+        if not (is_admin and web.ctx.site.can_write(key)):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $ v = query_param("v", None)
 
-$if ctx.user and ctx.user.is_admin() or ctx.user.is_librarian():
+$if ctx.user and ctx.user.is_admin():
     $if v and not page.key.startswith("/books/ia:"):
         <div id="revertNotice">
             <form name="revert" method="POST" action="$changequery(m='revert')">


### PR DESCRIPTION
This reverts commit 4b4f8a9c5477e211b3c438a4f50c6ee33cf3aca4.
The commit makes references to undeclared variables and should
never have been merged.

Fixes: #2261
