### PR TITLE
Remove jQuery.toggleText and advanced_search template

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -12,7 +12,6 @@ import './jquery.columnize';
 import './jquery.dataTables';
 import './jquery.hoverIntent';
 import './jquery.jTruncate';
-import toggleText from './jquery.toggleText';
 import addFadeInFunctionsTojQuery from './jquery.customFade';
 import fadeToggle from './jquery.fadeToggle';
 import jQueryRepeat from './jquery.repeat';
@@ -31,7 +30,7 @@ import init, { closePop, bookCovers,
 import { commify } from './python';
 import { Subject, urlencode, renderTag, slice } from './subjects';
 import Template from './template.js';
-// Add $.fn.toggleText, $.fn.focusNextInputField, $.fn.ol_confirm_dialog, $.fn.tap
+// Add $.fn.focusNextInputField, $.fn.ol_confirm_dialog, $.fn.tap
 import { closePopup, initShowPasswords, truncate, cond } from './utils';
 import initValidate from './validate';
 import '../../../../static/css/js-all.less';
@@ -78,7 +77,6 @@ jQuery.fn.exists = function(){return jQuery(this).length>0;}
 jQuery.fn.removeHighlight = removeHighlight;
 jQuery.fn.highlight = highlight;
 jQuery.fn.fadeToggle = fadeToggle;
-jQuery.fn.toggleText = toggleText;
 
 // Initialise some things
 $(function () {

--- a/openlibrary/plugins/openlibrary/js/jquery.toggleText.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.toggleText.js
@@ -1,8 +1,0 @@
-/**
- * @this {jQuery}
- */
-export default function(a, b) {
-    return this.each(function() {
-        jQuery(this).text(jQuery(this).text() == a ? b : a);
-    });
-}

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -1,10 +1,3 @@
-// source: http://snipplr.com/view/8916/jquery-toggletext/
-$.fn.toggleText = function(a, b) {
-    return this.each(function() {
-        $(this).text($(this).text() == a ? b : a);
-    });
-};
-
 // http://jqueryminute.com/set-focus-to-the-next-input-field-with-jquery/
 $.fn.focusNextInputField = function() {
     return this.each(function() {

--- a/openlibrary/plugins/search/templates/advanced_search.html
+++ b/openlibrary/plugins/search/templates/advanced_search.html
@@ -1,3 +1,4 @@
+$# this template is likely unused.
 $def with (input, do_search, get_doc)
 
 $ facet_map = (
@@ -74,7 +75,12 @@ $if param:
                 <span class="small"><a href="$search_url()&$header=$k">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
         $if len(counts) > 5:
-            <div class="facetEntry"><span class="small"><a href="javascript:;"  onClick="\$(this).toggleText('more','less');jQuery('div.$header').toggle();false" class="orange">more</a></span></div>
+            <script type="text/javascript">
+            window.deprecatedToggleText = function ( a, b ) {
+                \$(this).text(\$(this).text() == a ? b : a);
+            };
+            </script>
+            <div class="facetEntry"><span class="small"><a href="javascript:;"  onClick="window.deprecatedToggleText('more','less');jQuery('div.$header').toggle();false" class="orange">more</a></span></div>
         </div>
 
     </div>


### PR DESCRIPTION
pending further testing and exploration I don't think the
advanced_search template is in use. If this is the case,
given that this template is the only consumer of jquery.toggleText
toggleText can be removed

@mekarpeles and @cdrini how can we determine which pages (if any?) use this template. Do we have any way to programatically do that from the site map?

Update: http://localhost:8080/developers/routes  suggests this route is not in use anywhere (assuming that is comprehensive list)

Fixes: #2243

### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
