### PR TITLE
integrates CiviCRM API for fetching patron's sponsored books

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -169,3 +169,9 @@ internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_v1_url: https://archive.org/services/loans/beta/loan/index.php
 ia_availability_api_v2_url: https://archive.org/services/availability/
 ia_base_url: https://archive.org
+
+plugin_civicrm:
+    url: http://localhost/internal/fake/civicrm
+    api_key: XXX
+    site_key: XXX
+    auth: XXX

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -170,7 +170,7 @@ ia_availability_api_v1_url: https://archive.org/services/loans/beta/loan/index.p
 ia_availability_api_v2_url: https://archive.org/services/availability/
 ia_base_url: https://archive.org
 
-plugin_civicrm:
+ia_civicrm_api:
     url: http://localhost/internal/fake/civicrm
     api_key: XXX
     site_key: XXX

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -53,6 +53,7 @@ config_ia_s3_auth_url = None
 config_ia_ol_metadata_write_s3 = None
 config_ia_users_loan_history = None
 config_ia_loan_api_developer_key = None
+config_ia_civicrm_api = None
 config_http_request_timeout = None
 config_loanstatus_url = None
 config_bookreader_host = None
@@ -72,7 +73,8 @@ def setup(config):
         config_ia_availability_api_v1_url, config_ia_availability_api_v2_url, \
         config_ia_ol_metadata_write_s3, config_ia_xauth_api_url, \
         config_http_request_timeout, config_ia_s3_auth_url, \
-        config_ia_users_loan_history, config_ia_loan_api_developer_key
+        config_ia_users_loan_history, config_ia_loan_api_developer_key, \
+        config_ia_civicrm_api
 
     config_loanstatus_url = config.get('loanstatus_url')
     config_bookreader_host = config.get('bookreader_host', 'archive.org')
@@ -88,6 +90,7 @@ def setup(config):
     config_ia_s3_auth_url = config.get('ia_s3_auth_url')
     config_ia_users_loan_history = config.get('ia_users_loan_history')
     config_ia_loan_api_developer_key = config.get('ia_loan_api_developer_key')
+    config_ia_civicrm_api = config.get('ia_civicrm_api')
     config_internal_tests_api_key = config.get('internal_tests_api_key')
     config_http_request_timeout = config.get('http_request_timeout')
     config_amz_api = config.get('amazon_api')

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -94,9 +94,10 @@ def qualifies_for_sponsorship(edition):
         dwwi = availability.get(work_id, {}).get('status', 'error') == 'error'
         if dwwi:
             bwb_price = get_betterworldbooks_metadata(isbn).get('price_amt')
-            scan_price = 3.0 + (.12 * num_pages)
-            total_price = scan_price + float(bwb_price)
-            return total_price <= PRICE_LIMIT
+            if bwb_price:
+                scan_price = 3.0 + (.12 * num_pages)
+                total_price = scan_price + float(bwb_price)
+                return total_price <= PRICE_LIMIT
     return False
 
 

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -1,27 +1,77 @@
+import json
+import urllib
 import requests
 from infogami import config
 from infogami.utils.view import public
 from openlibrary import accounts
 from openlibrary.core.lending import get_work_availability
 from openlibrary.core.vendors import get_betterworldbooks_metadata
+from openlibrary.accounts import get_internet_archive_id
 
+CIVI_SPONSOR_API = config.get('plugin_civicrm')
+CIVI_URL = CIVI_SPONSOR_API.get('url')
+CIVI_HEADERS = {'Authorization': 'Basic %s' % CIVI_SPONSOR_API.get('auth', '')}
+CIVI_ISBN = 'custom_52'
+CIVI_USERNAME = 'custom_51'
+CIVI_CONTEXT = 'custom_53'
 PRICE_LIMIT = 50.00
-CIVI_SPONSOR_API = '%s/internal/fake/civicrm' % config.get('servername', 'http://localhost')
 
-def get_all_sponsors():
-    """
-    Query civi for a list of all sponsorships, for all users.
-    These results will have to be summed by user for the
-    leader-board and then cached
-    """
-    pass  # todo, later
 
-def get_sponsored_editions(archive_username, limit=50, offset=0):
+def get_sponsored_editions(user):
     """
-    Gets a list of books from the civi API which internet archive 
+    Gets a list of books from the civi API which internet archive
     @archive_username has sponsored
     """
-    return requests.get(CIVI_SPONSOR_API).json()["works"]
+    archive_id = get_internet_archive_id(user.key if 'key' in user else user._key)
+    contact_id = get_contact_id_by_username(archive_id)
+    return contact_id and {
+        'username': archive_id,
+        'sponsorships': get_sponsorships_by_contact_id(contact_id)
+    }
+
+
+def get_contact_id_by_username(username):
+    """TODO: Use CiviCRM Explorer to replace with call to get contact_id by username"""
+    data = {
+        'entity': 'Contact',
+        'action': 'get',
+        'api_key': CIVI_SPONSOR_API.get('api_key', ''),
+        'key': CIVI_SPONSOR_API.get('site_key', ''),
+        'json': {
+            "sequential": 1,
+            CIVI_USERNAME: username
+        }
+    }
+    data['json'] = json.dumps(data['json'])  # flatten the json field as a string
+    r = requests.get(CIVI_URL, params=urllib.urlencode(data), headers=CIVI_HEADERS)
+    contacts = r.json().get('values', None)
+    return contacts and contacts[0].get('contact_id')
+
+
+def get_sponsorships_by_contact_id(contact_id, isbn=None):
+    data = {
+        'entity': 'Contribution',
+        'action': 'get',
+        'api_key': CIVI_SPONSOR_API.get('api_key', ''),
+        'key': CIVI_SPONSOR_API.get('site_key', ''),
+        'json': {
+            "sequential": 1,
+            "financial_type_id": "Book Sponsorship",
+            "contact_id": contact_id
+        }
+    }
+    if isbn:
+        data['json'][CIVI_ISBN] = isbn
+    data['json'] = json.dumps(data['json'])  # flatten the json field as a string
+    r = requests.get(CIVI_URL, params=urllib.urlencode(data), headers=CIVI_HEADERS)
+    txs = r.json().get('values')
+    return [{
+        'isbn': t.pop(CIVI_ISBN),
+        'context': t.pop(CIVI_CONTEXT),
+        'receive_date': t.pop('receive_date'),
+        'total_amount': t.pop('total_amount')
+    } for t in txs]
+
 
 @public
 def qualifies_for_sponsorship(edition):
@@ -43,8 +93,11 @@ def qualifies_for_sponsorship(edition):
             total_price = scan_price + float(bwb_price)
             return total_price <= PRICE_LIMIT
     return False
-           
 
 
-
-        
+def get_all_sponsors():
+    """TODO: Query civi for a list of all sponsorships, for all users. These
+    results will have to be summed by user for the leader-board and
+    then cached
+    """
+    pass

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -24,10 +24,7 @@ def get_sponsored_editions(user):
     """
     archive_id = get_internet_archive_id(user.key if 'key' in user else user._key)
     contact_id = get_contact_id_by_username(archive_id)
-    return contact_id and {
-        'username': archive_id,
-        'sponsorships': get_sponsorships_by_contact_id(contact_id)
-    }
+    return contact_id and get_sponsorships_by_contact_id(contact_id)
 
 
 def get_contact_id_by_username(username):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -81,7 +81,7 @@ $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:   
-  $if user and user.is_sponsor() and qualifies_for_sponsorship(page):
+  $if user and (input('sponsorship') or user.is_sponsor()) and qualifies_for_sponsorship(page):
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     $ user_id = user.key.split("/")[-1]
     $ donate_url = "https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)"

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -770,7 +770,7 @@ class public_my_books(delegate.page):
         if user.preferences().get('public_readlog', 'no') == 'yes':
             readlog = ReadingLog(user=user)
             books = readlog.get_works(key)
-            sponsorships = get_sponsored_editions(user).get('sponsorships')
+            sponsorships = get_sponsored_editions(user)
             page = render['account/books'](
                 books, key, sponsorship_count=len(sponsorships),
                 reading_log=readlog.reading_log_counts,
@@ -792,17 +792,22 @@ class fake_civi(delegate.page):
 
     @require_login
     def GET(self):
-        return delegate.RawText(simplejson.dumps({
-            "username": "@mekarpeles",
-            "transactions": [
-                {
-                    "receive_date": "2019-07-31 08:57:00",
-                    "isbn": "9780062457714",
-                    "total_amount": "50.00",
-                    "context": "ol"
-                }
-            ]
-        }), content_type="application/json")
+        i = web.input(entity='Contact')
+        contact = {
+            'values': [{
+                'contact_id': '270430'
+            }]
+        }
+        contributions = {
+            'values': [{
+                "receive_date": "2019-07-31 08:57:00",
+                "custom_52": "9780062457714",
+                "total_amount": "50.00",
+                "custom_54": "ol"
+            }]
+        }
+        entity = contributions if i.entity == 'Contribution' else contact
+        return delegate.RawText(simplejson.dumps(entity), content_type="application/json")
 
 class account_my_books(delegate.page):
     path = "/account/books/([a-zA-Z_-]+)"
@@ -812,7 +817,7 @@ class account_my_books(delegate.page):
         user = accounts.get_current_user()
         is_public = user.preferences().get('public_readlog', 'no') == 'yes'
         readlog = ReadingLog()
-        sponsorships = get_sponsored_editions(user).get('sponsorships')
+        sponsorships = get_sponsored_editions(user)
         if key == 'sponsorships':
             books = (web.ctx.site.get(
                 web.ctx.site.things({

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -1,4 +1,4 @@
-$def with (items, key, sponsorship_count, loans=None, waitlists=None, reading_log=None, lists=None, loan_history=None, user=None, public=False)
+$def with (items, key, sponsorship_count=None, loans=None, waitlists=None, reading_log=None, lists=None, loan_history=None, user=None, public=False)
 
 $ title = "My Books"
 $ urlbase = ctx.path.rsplit('/', 1)[0]
@@ -51,7 +51,7 @@ $if og_title:
 
     $if owners_page:
       <h3>
-        Your reading log is currently set to $("public" if public else "private") &mdash;          
+        Your reading log is currently set to $("public" if public else "private") &mdash;
         $if public:
           <button onclick="prompt('Copy share link to clipboard:', window.location.protocol + '//' + window.location.hostname + '/people/$(username)/books/$(key)');">Share</button> or
         <a href="/account/privacy">Manage your privacy settings</a>
@@ -59,13 +59,18 @@ $if og_title:
 
     <div class="mybooks">
       <div class="mybooks-menu">
-        <ul class="preset-lists">          
+        <ul class="preset-lists">
           <li class="subsection">Reading Log</li>
           <li><a href="$urlbase/currently-reading" $('class=selected' if key == 'currently-reading' else '')>Currently Reading ($(reading_log['currently-reading']))</a></li>
           <li><a href="$urlbase/want-to-read" $('class=selected' if key == 'want-to-read' else '')>Want to Read ($(reading_log['want-to-read']))</a></li>
           <li><a href="$urlbase/already-read" $('class=selected' if key == 'already-read' else '')>Already Read ($(reading_log['already-read']))</a></li>
-          <li><a href="$urlbase/sponsorships" $('class=selected' if key == 'sponsorships' else '')>Books I'm Sponsoring ($sponsorship_count)</a></li>
         </ul>
+        $if urlbase.startswith('/account') and ctx.user and ctx.user.is_sponsor():
+          <!-- only show to owners -->
+          <ul class="preset-lists">
+            <li class="subsection">Sponsorships</li>
+            <li><a href="$urlbase/sponsorships" $('class=selected' if key == 'sponsorships' else '')>Sponsoring ($sponsorship_count)</a></li>
+          </ul>
         $if lists:
           <ul class="user-lists">
             <li class="subsection">Lists</li>


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #2199 and Re-closes #2168 and #2163 

### Technical
<!-- What should be noted about the implementation? -->

By default openlibrary repo openlibrary.yml now has an API endpoint for civi crm which is pinned to https://dev.openlibrary.org/internal/fake/civicrm. You can add `entity=Contact` or `entity=Contribution` to emulate which necessary fields + format would be returned by production CiviCRM.

On production, olsystem overrides openlibrary.yml and uses the official civicrm API endpoint w/ credentials. So theoretically this feature should be primed to work on localhost or dev + production.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This is currently not yet possibly to fully test on localhost (because it requires `/usergroup/sponsors` to work, which only exists in the prod db). Also, the example book isn't in the local instance by default. To test on dev/production:
1. have an admin add your user to the `/usergroup/sponsors` permission group
2. go to your `/account/books/sponsorships` page and it shouldn't break. on dev/prod, the user should see an empty list (because there are likely no books they've sponsored yet). On localhost, they'll either see an error (because `user.is_sponsor()` won't work because the `/usergroup/sponsors` isn't setup) or they'll see a hardcoded book entry returned by the `/internal/fake/civicrm` API.