### PR TITLE
corrects avatar for public reading log + works for logged out user

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -5,7 +5,7 @@ $ urlbase = ctx.path.rsplit('/', 1)[0]
 $ owners_page = not urlbase.startswith('/people')
 $ header_title = key.title().replace('-', ' ')
 $ username = user.key.split('/')[-1]
-$ meta_photo_url = "https://archive.org/services/img/%s"%get_internet_archive_id(ctx.user.key)
+$ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
 
 $if user:
   $ displayName = user.displayname


### PR DESCRIPTION
Public reading log broken on production https://openlibrary.org/people/mekBot/books/want-to-read?debug=true because the open graph avatar tries to call the currently logged in user's archive.org id (to fetch avatar) -- i.e. `ctx.user.id` rather than use the user passed in to the template. 