### PR TITLE
work-level availability check and hotfix sponsorship button

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -315,6 +315,7 @@ def get_availability_of_ocaids(ocaids):
     """
     return get_availability('identifier', ocaids)
 
+@public
 def get_work_availability(ol_work_id):
     return get_availability_of_works([ol_work_id])
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -82,7 +82,8 @@ $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:   
   $ betterworldbooks_metadata = get_betterworldbooks_metadata(isbn)
-  $if user and user.is_sponsor() and isbn and all(page.get(x) for x in ['publishers', 'title', 'publish_date', 'covers']) and page.works and page.works[0].get('authors') and betterworldbooks_metadata and ('price_amt' in betterworldbooks_metadata) and (float(betterworldbooks_metadata['price_amt']) < 15.00):
+  $ availability = get_work_availability(work.key.split("/")[-1])
+  $if user and user.is_sponsor() and isbn and all(page.get(x) for x in ['publishers', 'title', 'publish_date', 'covers']) and page.works and page.works[0].get('authors') and betterworldbooks_metadata and ('price_amt' in betterworldbooks_metadata) and (float(betterworldbooks_metadata['price_amt']) < 15.00) and not(availability[work.key.split("/")[-1]]['status']=='open'):
     $ user_id = user.key.split("/")[-1] if user.key else ''
     <a href="https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)" class="cta-btn cta-btn--sponsor">Sponsor eBook</a>
     <p>We don’t have this book yet. You can add it to our Lending Library with a \$50 tax deductible donation.

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -80,23 +80,15 @@ $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:   
-  $if (user and user.is_sponsor()):
-    <button href="#sponsorshipModal" class="cta-btn cta-btn--sponsor">Sponsor eBook</button>
+  $if True:
+    $ key = page.key[page.key.rfind('/')+1:]
+    $ user_id = user.key.split("/")[-1]
+    $ url = 'https://archive.org/donate?context=ol&userid='+str(user.key.split("/")[-1])+'&campaign=pilot&type=book-sponsorship&openlibrary_edition='+str(key)
+    <button onclick="location.href='$url'" class="cta-btn cta-btn--sponsor">Sponsor eBook</button>
   $else:
     <form>
       <input type="submit" class="cta-btn" disabled value="No ebook available">
     </form>
-
-
-<div class="hidden">
-  <div class="floater" id="sponsorshipModal">
-      <div class="floaterHead">
-          <h2>Sponsor This eBook</h2>
-          <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>      
-      </div>
-  </div>
-</div>
-
 
 $if editions_page and page.get('ocaid'):
   $:macros.daisy(page, block_name=block_name)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -81,9 +81,9 @@ $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:   
-  $if (user and user.is_sponsor()):
+  $if True:
     $ user_id = user.key.split("/")[-1] if user.key else ''
-    <button onclick="location.href='https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)'" class="cta-btn cta-btn--sponsor">Sponsor eBook</button>
+    <a href="https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)" class="cta-btn cta-btn--sponsor">Sponsor eBook</a>
     <p>We don’t have this book yet. You can add it to our Lending Library with a \$50 tax deductible donation.
       <a href="https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)">Learn More</a>
     </p>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -14,6 +14,7 @@ $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and
 $ availability = page.availability or page.get_realtime_availability()
 $ availability_status = availability.get('status', 'error')
 $ current_and_available_loans = []
+$ isbn = page.isbn_13[0] if page.isbn_13 else page.isbn_10[0] if page.isbn_10 else ''
 
 $if page.get('ocaid'):
   $ current_and_available_loans = page.get_current_and_available_loans()
@@ -80,12 +81,12 @@ $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:   
-  $if True:
-    $ key = page.key[page.key.rfind('/')+1:]
-    $ user_id = user.key.split("/")[-1]
-    $ url = 'https://archive.org/donate?context=ol&userid='+str(user.key.split("/")[-1])+'&campaign=pilot&type=book-sponsorship&openlibrary_edition='+str(key)
-    <button onclick="location.href='$url'" class="cta-btn cta-btn--sponsor">Sponsor eBook</button>
-    <p>We don’t have this book yet. You can add it to our Lending Library with a \$50 tax deductible donation.</p>
+  $if (user and user.is_sponsor()):
+    $ user_id = user.key.split("/")[-1] if user.key else ''
+    <button onclick="location.href='https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)'" class="cta-btn cta-btn--sponsor">Sponsor eBook</button>
+    <p>We don’t have this book yet. You can add it to our Lending Library with a \$50 tax deductible donation.
+      <a href="https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)">Learn More</a>
+    </p>
   $else:
     <form>
       <input type="submit" class="cta-btn" disabled value="No ebook available">

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -85,6 +85,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
     $ user_id = user.key.split("/")[-1]
     $ url = 'https://archive.org/donate?context=ol&userid='+str(user.key.split("/")[-1])+'&campaign=pilot&type=book-sponsorship&openlibrary_edition='+str(key)
     <button onclick="location.href='$url'" class="cta-btn cta-btn--sponsor">Sponsor eBook</button>
+    <p>We don’t have this book yet. You can add it to our Lending Library with a \$50 tax deductible donation.</p>
   $else:
     <form>
       <input type="submit" class="cta-btn" disabled value="No ebook available">

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -81,7 +81,7 @@ $elif page.get('ocaid') and not page.is_access_restricted() and editions_page:
     <a href="$viewbook.replace('XXX', page.ocaid)" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read</a>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:   
-  $if True:
+  $if (user and user.is_sponsor()):
     $ user_id = user.key.split("/")[-1] if user.key else ''
     <a href="https://archive.org/donate?context=ol&userid=$(user_id)&campaign=pilot&type=book-sponsorship&isbn=$(isbn)" class="cta-btn cta-btn--sponsor">Sponsor eBook</a>
     <p>We don’t have this book yet. You can add it to our Lending Library with a \$50 tax deductible donation.

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -446,11 +446,6 @@ export default function init(){
         e.preventDefault();
     });
 
-    // For Book Sponsorship Button
-    $(document).ready(function(){
-        $(".cta-btn--sponsor").colorbox({inline: true, opacity: "0.5", href: "#sponsorshipModal"})
-    })
-
     // LOADING ONCLICK FUNCTIONS FOR BORROW AND READ LINKS
     /* eslint-disable no-unused-vars */
     // used in openlibrary/macros/AvailabilityButton.html and openlibrary/macros/LoanStatus.html

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     },
     {
       "path": "static/build/page-admin.css",
-      "maxSize": "19.1KB"
+      "maxSize": "19.2KB"
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "7.17KB"
+      "maxSize": "7.18KB"
     },
     {
       "path": "static/build/page-edit.css",
@@ -48,11 +48,11 @@
     },
     {
       "path": "static/build/page-subject.css",
-      "maxSize": "6.73KB"
+      "maxSize": "6.74KB"
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "18.66KB"
+      "maxSize": "18.67KB"
     }
   ],
   "devDependencies": {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -44,8 +44,12 @@ a.cta-btn {
   &--sponsor {
     background: @white-blue;
     border: 2px solid @link-blue;
-    color: @link-blue;
   }
+
+  &--sponsor:link {
+      color: @link-blue;
+  }
+  
   &--sponsor:visited {
     color: @link-blue;
   }


### PR DESCRIPTION
### Description
feature

Updates #2194 

### Technical
<!-- What should be noted about the implementation? -->
This piece of code checks for qualifying editions. An edition is work-level qualifiable if itself and any other editions of the work are unavailable

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This is a false positive so `Sponsor ebook` button should not be shown on any of its `non available editions` https://dev.openlibrary.org/works/OL5735363W/The_Hunger_Games
