### PR TITLE
hotfix for reading log

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -726,19 +726,19 @@ class ReadingLog(object):
             editions[i].waitlist_record = keyed_waitlists[editions[i].ocaid]
         return editions
 
-    def get_want_to_read(self, page=1, limit=100):
+    def get_want_to_read(self, page=1, limit=500):
         work_ids = ['/works/OL%sW' % i['work_id'] for i in Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Want to Read'],
             page=page, limit=limit)]
         return web.ctx.site.get_many(work_ids)
 
-    def get_currently_reading(self, page=1, limit=100):
+    def get_currently_reading(self, page=1, limit=500):
         work_ids = ['/works/OL%sW' % i['work_id'] for i in Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Currently Reading'],
             page=page, limit=limit)]
         return web.ctx.site.get_many(work_ids)
 
-    def get_already_read(self, page=1, limit=100):
+    def get_already_read(self, page=1, limit=500):
         work_ids = ['/works/OL%sW' % i['work_id'] for i in Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
             page=page, limit=limit)]


### PR DESCRIPTION
### Description
hotfix

Temporary hotfixes #1740

### Technical
<!-- What should be noted about the implementation? -->
The reading log limit has been increased to 500

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Check any reading log whose number of books is greater than 100 and see that more than 100 books are being rendered on the page or not 
