### PR TITLE
Make edit button edit work even if only has 1 edition

### DIFF
--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -1,8 +1,6 @@
 $def with (page)
 
-$if page.type.key == '/type/work' and page.edition_count == 1:
-    $ edit_url = page.get_one_edition().get_url(suffix="/edit") or page.url(suffix="/edit")
-$elif page.type.key in ["/type/work", "/type/edition", "/type/author"]:
+$if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
     $ edit_url = page.url(suffix="/edit")
 $else:
     $ edit_url = page.key + "?m=edit"


### PR DESCRIPTION
### Description
Fix; edit button now consistently edits the object being viewed.

Closes #2033

### Technical
- Nothing to note.

### Testing
- Tested edit button functions for works with more than one edition
- Locally removed an edition from http://192.168.99.100:8080/works/OL61982W/Odyssey and tested the button behaved as expected

### Evidence
- No UI change.