### PR TITLE
Correct status and detailed response for merge_authors API

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -5,6 +5,7 @@ import re
 import simplejson
 from infogami.utils import delegate
 from infogami.utils.view import render_template, safeint
+from infogami.infobase.client import ClientException
 
 from openlibrary.plugins.worksearch.code import top_books_from_author
 from openlibrary.utils import uniq, dicthash
@@ -269,8 +270,11 @@ class merge_authors_json(delegate.page):
         duplicates = data['duplicates']
 
         engine = AuthorMergeEngine()
-        result = engine.merge(master, duplicates)
-        return delegate.RawText(simplejson.dumps(result),  content_type="application/json")
+        try:
+            result = engine.merge(master, duplicates)
+        except ClientException as e:
+            raise web.badrequest(simplejson.loads(e.json))
+        return delegate.RawText(simplejson.dumps(result), content_type="application/json")
 
 def setup():
     pass


### PR DESCRIPTION
This will help help troubleshooting author merge problems, and enable further API use.
relates to #2248

The UI does not test for the success of this request, because the js is now v2 and async with #1609.

I'll need to join up the response, but at least the js has something to sensible to look for. Previously this error was not properly handled, causing a 500 HTTP reponse with no details, so all info was lost, and the 500 error was swallowed by the view page.

Now the JSON error details are at least visible in browser network tab on the
POST to merge.json

This relates to the author's view page, with parameters
/authors/OL..A?merge=true&duplicates=OL..A

example response on error (for the example in #2248):

```
{
  'message': 'expected /type/author, found /type/redirect',
  'at': {'property': 'authors', 'key': '/books/OL11122403M'},
  'value': '/authors/OL47923A',
  'error': 'bad_data'
}
```
Previously this was a HTML 500 error page, with a pointer to a server log where an admin could only extract `expected /type/author, found /type/redirect`. The above is an improvement :)