### PR TITLE
Resolve undefined name “doc” in site map.py

### DIFF
--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -73,11 +73,11 @@ def find_path(key, type, json):
     if type in ['/type/edition', '/type/work']:
         data = simplejson.loads(json)
         return key + '/' + urlsafe(data.get('title', 'untitled'))
-    elif doc.type == '/type/author':
+    elif type == '/type/author':
         data = simplejson.loads(json)
         return key + '/' + urlsafe(data.get('name', 'unnamed'))
     else:
-        return doc.key
+        return key
 
 def gzwrite(path, data):
     f = gzopen(path, 'w')

--- a/openlibrary/data/sitemap.py
+++ b/openlibrary/data/sitemap.py
@@ -69,15 +69,6 @@ $for path, title in docs:
 </ul>
 """)
 
-def find_path(key, type, json):
-    if type in ['/type/edition', '/type/work']:
-        data = simplejson.loads(json)
-        return key + '/' + urlsafe(data.get('title', 'untitled'))
-    elif type == '/type/author':
-        data = simplejson.loads(json)
-        return key + '/' + urlsafe(data.get('name', 'unnamed'))
-    else:
-        return key
 
 def gzwrite(path, data):
     f = gzopen(path, 'w')


### PR DESCRIPTION
### Description
Refactor. Fix `flake8` error: `./openlibrary/data/sitemap.py:76:10: F821 undefined name 'doc'` ( https://travis-ci.org/internetarchive/openlibrary/jobs/571136885#L286 )

Related to #1684

### Technical
- Removed the entire `find_path` method; PyCharm found no references, and the string `find_path` does not appear anywhere in the repo.

### Testing
No special testing required.

### Evidence
No UI changes.