### PR TITLE
Travis CI: When on Python 3, do a pyenv install 2.7.14 for nmp/node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,7 @@ install:
   - pip install flake8
   - make lint
   - pip install -r requirements_test.txt
+  # if Travis is running Python 3, then create a legacy Python for npm/node
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then pyenv install 2.7.14; fi
   - npm install
 script: make test


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

If Travis is running Python 3, then create a legacy Python instance to enable the installation of npm/node.
Helps with #2293

After this PR lands, our progress on Python 3 will be blocked because this repo contains a __stale__ symlink into the __internetarchive/infogami__ repo which contained a legacy __print__ statement back when that symlink was created.  This Python 3 syntax error has since been fixed in that repo but the symlink needs to be updated to access that newer version.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

This is Travis CI so it is all about testing.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

See the Travis results.