### PR TITLE
make lint -- Add more flake8 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ reindex-solr:
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor/*  --select=E901,E999,F822,F823 --show-source --statistics
+	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor/*  --select=E9,F63,F7,F822,F823 --show-source --statistics
 	# TODO: Add --select=F821 below into the line above as soon as the Undefined Name issues have been fixed
 	$(PYTHON) -m flake8 . --exit-zero --count --exclude=./.*,scripts/20*,vendor/*  --select=F821 --show-source --statistics
 ifndef CONTINUOUS_INTEGRATION

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ reindex-solr:
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor/*  --select=E9,F63,F7,F822,F823 --show-source --statistics
+	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor/*,*/acs4.py  --select=E9,F63,F7,F822,F823 --show-source --statistics
 	# TODO: Add --select=F821 below into the line above as soon as the Undefined Name issues have been fixed
 	$(PYTHON) -m flake8 . --exit-zero --count --exclude=./.*,scripts/20*,vendor/*  --select=F821 --show-source --statistics
 ifndef CONTINUOUS_INTEGRATION

--- a/openlibrary/catalog/onix/xmltramp.py
+++ b/openlibrary/catalog/onix/xmltramp.py
@@ -192,7 +192,7 @@ class Element:
         if len(_pos) > 1:
             for i in range(0, len(_pos), 2):
                 self._attrs[_pos[i]] = _pos[i+1]
-        if len(_pos) == 1 is not None:
+        if len(_pos) == 1:
             return self._attrs[_pos[0]]
         if len(_pos) == 0:
             return self._attrs

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -46,7 +46,7 @@ class TestSaveBookHelper:
         s = addbook.SaveBookHelper(None, edition)
         s.save(formdata)
 
-        assert len(web.ctx.site.docs) is 2
+        assert len(web.ctx.site.docs) == 2
         assert web.ctx.site.get("/works/OL1W") is not None
         assert web.ctx.site.get("/works/OL1W").title == "Original Edition Title"
 
@@ -105,7 +105,7 @@ class TestSaveBookHelper:
         s = addbook.SaveBookHelper(None, edition)
         s.save(formdata)
 
-        assert len(web.ctx.site.docs) is 1
+        assert len(web.ctx.site.docs) == 1
         assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL1W"
 
     def test_moving_orphan_ignores_work_edits(self, monkeypatch):

--- a/openlibrary/tests/core/test_init.py
+++ b/openlibrary/tests/core/test_init.py
@@ -40,7 +40,7 @@ class TestService:
         s.start()
         assert s.poll() is None
         assert s.wait() == 0
-        assert s.poll() is 0
+        assert s.poll() == 0
 
     def test_stop(self, tmpdir):
         s = self.create_service("sleep", {


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This adds more tests about runtime safety and correctness to our flake8 run in __make lint__ which is executed by Travis CI on all code changes and can also be run locally by contributors.  E9 runs all E9xx tests, E63 runs all E63x tests, etc.  https://lintlyci.github.io/Flake8Rules

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these __tests are focused on runtime safety and correctness__:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  __Use ==/!= to compare str, bytes, and int literals__ is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
