### PR TITLE
Remove dead code

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -13,7 +13,6 @@ $var title: $_("Sign Up to Open Library")
 
 <script type="text/javascript">
 window.q.push( function(){
-    validateForms();
     \$('#username').keyup(function(){
         var value = \$(this).val();
         \$('#userUrl').addClass('darkgreen').text(value).css('font-weight','700');

--- a/openlibrary/templates/account/email.html
+++ b/openlibrary/templates/account/email.html
@@ -10,7 +10,6 @@ $def with (email, form)
 
 <script type="text/javascript">
 window.q.push(function () {
-    validateForms();
     validateEmail();
 );
 </script>

--- a/openlibrary/templates/account/password.html
+++ b/openlibrary/templates/account/password.html
@@ -11,7 +11,6 @@ $def with (form)
 
 <script type="text/javascript">
 window.q.push( function () {
-    validateForms();
     validatePassword();
 } );
 </script>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -8,13 +8,11 @@ $putctx("robots", "noindex,nofollow")
 <script type="text/javascript">
 <!--
 window.q.push( function () {
-    Tabs();
     if(jQuery.support.opacity){
         \$("#tabsAddbook").tabs({fx:{opacity:'toggle'}});
     } else {
         \$("#tabsAddbook").tabs();
     };
-    boxPop();
     \$("#coverPop").colorbox({inline:true, opacity:"0.5", href:"#addCover"});
 } );
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bundlesize": [
     {
       "path": "static/build/vendor-v2.js",
-      "maxSize": "172KB"
+      "maxSize": "164KB"
     },
     {
       "path": "static/build/all.js",

--- a/static/js/vendor.jsh
+++ b/static/js/vendor.jsh
@@ -29,7 +29,6 @@ xcat $VENDORJS/jquery-autocomplete/jquery.autocomplete-modified.js | $JSMIN
 
 xcat $VENDORJS/wmd/jquery.wmd.min.js 
 
-xcat $VENDORJS/flot/excanvas.min.js
 xcat $VENDORJS/flot/jquery.flot.min.js
 xcat $VENDORJS/flot/jquery.flot.selection.min.js
 xcat $VENDORJS/flot/jquery.flot.crosshair.min.js

--- a/static/js/vendor.jsh
+++ b/static/js/vendor.jsh
@@ -35,24 +35,3 @@ xcat $VENDORJS/flot/jquery.flot.crosshair.min.js
 xcat $VENDORJS/flot/jquery.flot.stack.min.js
 xcat $VENDORJS/flot/jquery.flot.pie.min.js
 
-# for backward compatability
-xcat <<END
-function DragDrop() {}
-function Resizable() {}
-function Selectable() {}
-function Sortable() {}
-function Accordtion() {}
-function Dialog() {}
-function Slider() {}
-function Tabs() {}
-function Datepicker() {}
-function Progressbar() {}
-
-function boxPop() {}
-function bigCharts() {}
-function smallCharts() {}
-function passwordMask() {}
-function passwordsMask() {}
-function feedLoader() {}
-function validateForms(){}
-END


### PR DESCRIPTION
### Description
refactor:
This is some pre-work for 2305.

- [ ] excanvas.min.js gives canvas support for browsers < IE8. According to .browserslistrc we do not support this browser.
- [ ] Dropped "backwards compatibility functions" in static/js/vendor.jsh b/static/js/vendor.jsh

Closes #
No bug associated.

### Technical
This is removing dead code that's not being utilised anywhere.

### Testing
- [ ] I've grepped the codebase for the functions I've removed in static/js/vendor.jsh b/static/js/vendor.jsh and updated. I suggest reviewer does same (2 heads better than one)
- [ ]There should be no need to test other than to confirm graphs still render (i have checked this - see subjects or publishers page to confirm (for some reason home graphs are not rendering on my local instance due to a lack of data before and after this change)
- [ ] Optional: You can also confirm the graphs no longer work in IE8 if you really want.

### Evidence
Not sure what evidence would be useful for this.
