### PR TITLE
Travis CI: Update vendored submodules only on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,18 @@ install:
   - pip install flake8
   - make lint
   - pip install -r requirements_test.txt
-  # if Travis is running Python 3, then create a legacy Python for npm/node
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then pyenv install 2.7.14; fi
+  # if Travis is running Python 3, then
+  #   refresh the git submodule ./vendor/acs4_py
+  #   refresh the git submodule ./vendor/infogami
+  #   git commit those changes into this pull request
+  #   TODO: flake8 ./vendor --select=E9,F63,F7,F82 to unsure new versions pass
+  #   create a legacy Python for npm/node until nodejs/node#25789 is resolved
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+      pushd vendor/acs4_py  && git pull origin master && popd;
+      pushd vendor/infogami && git pull origin master && popd;
+      git status;
+      git commit -am"Update git submodules in .vendor";
+      pyenv install 2.7.14;
+    fi
   - npm install
 script: make test


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Allows the Travis CI run on Python 3 (only) to test against the current __acs4_py__ and __infogami__ git submodules while the Python 2 runs continue to use the stale versions.  This allows the Travis CI Python 3 to pass __npm install__ and attempt __make test__ while leaving the Python 2 runs unaffected.  Special thanks to @cdrini for syntax suggestions at https://github.com/internetarchive/infogami/issues/25#issuecomment-521358254
```
if Travis is running Python 3, then
     refresh the git submodule ./vendor/acs4_py
     refresh the git submodule ./vendor/infogami
     git commit those changes into this pull request
     TODO: flake8 ./vendor --select=E9,F63,F7,F82 to unsure new versions pass
     create a legacy Python for npm/node until nodejs/node#25789 is resolved
```

### Technical
<!-- What should be noted about the implementation? -->

This is stopgap code that will hopefully be removed later this year when all three repos are Python 3 compatible.  Both acs4_py and infogami have TabErrors that Python 3 will treat as syntax errors.  internetarchive/acs4_py#4 and internetarchive/infogami#26

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Yes.  These are tests.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
