### PR TITLE
Move Browser object from ol.js into own file

### DIFF
--- a/openlibrary/plugins/openlibrary/js/Browser.js
+++ b/openlibrary/plugins/openlibrary/js/Browser.js
@@ -1,0 +1,49 @@
+/** @typedef {{ [param: string]: string }} UrlParams  */
+
+/**
+ * Convert url parameters to an object
+ * @returns {UrlParams}
+ */
+export function getJsonFromUrl() {
+    var query = location.search.substr(1);
+    var result = {};
+    query.split('&').forEach(function(part) {
+        var item = part.split('=');
+        result[item[0]] = decodeURIComponent(item[1]);
+    });
+    return result;
+}
+
+export function change_url(query) {
+    var getUrl = window.location;
+    var baseUrl = `${getUrl.protocol}//${getUrl.host
+    }/${getUrl.pathname.split('/')[1]}`;
+    window.history.pushState({
+        'html': document.html,
+        'pageTitle': `${document.title} ${query}`,
+    }, '', `${baseUrl}?id=${query}`);
+}
+
+export function removeURLParameter(url, parameter) {
+    var urlparts = url.split('?');
+    var prefix = urlparts[0];
+    var query, paramPrefix, params, i;
+    if (urlparts.length >= 2) {
+        query = urlparts[1];
+        paramPrefix = `${encodeURIComponent(parameter)}=`;
+        params = query.split(/[&;]/g);
+
+        //reverse iteration as may be destructive
+        for (i = params.length; i-- > 0;) {
+            //idiom for string.startsWith
+            if (params[i].lastIndexOf(paramPrefix, 0) !== -1) {
+                params.splice(i, 1);
+            }
+        }
+
+        url = prefix + (params.length > 0 ? `?${params.join('&')}` : '');
+        return url;
+    } else {
+        return url;
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/Browser.js
+++ b/openlibrary/plugins/openlibrary/js/Browser.js
@@ -2,28 +2,26 @@
 
 /**
  * Convert url parameters to an object
+ * @param {String} urlSearch everything after (and including) the '?' of the url
  * @returns {UrlParams}
  */
-export function getJsonFromUrl() {
-    var query = location.search.substr(1);
-    var result = {};
-    query.split('&').forEach(function(part) {
-        var item = part.split('=');
-        result[item[0]] = decodeURIComponent(item[1]);
-    });
+export function getJsonFromUrl(urlSearch) {
+    const query = urlSearch.substr(1);
+    const result = {};
+    if (query) {
+        query.split('&').forEach(part => {
+            const item = part.split('=');
+            result[item[0]] = decodeURIComponent(item[1]);
+        });
+    }
     return result;
 }
 
-export function change_url(query) {
-    var getUrl = window.location;
-    var baseUrl = `${getUrl.protocol}//${getUrl.host
-    }/${getUrl.pathname.split('/')[1]}`;
-    window.history.pushState({
-        'html': document.html,
-        'pageTitle': `${document.title} ${query}`,
-    }, '', `${baseUrl}?id=${query}`);
-}
-
+/**
+ * @param {String} url
+ * @param {String} parameter name of param to remove
+ * @returns {String}
+ */
 export function removeURLParameter(url, parameter) {
     var urlparts = url.split('?');
     var prefix = urlparts[0];

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -25,8 +25,8 @@ import removeHighlight from './removeHighlight';
 import highlight from './highlight';
 import initAnalytics from './ol.analytics';
 // Also pulls in jQuery.fn.exists
-import init, { closePop, bookCovers,
-    isScrolledIntoView, Browser } from './ol.js';
+import init, { closePop, bookCovers, isScrolledIntoView } from './ol.js';
+import * as Browser from './Browser';
 import { commify } from './python';
 import { Subject, urlencode, renderTag, slice } from './subjects';
 import Template from './template.js';

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -1,50 +1,5 @@
 import { debounce } from './nonjquery_utils.js';
-
-export var Browser = {
-    getJsonFromUrl: function () {
-        var query = location.search.substr(1);
-        var result = {};
-        query.split('&').forEach(function(part) {
-            var item = part.split('=');
-            result[item[0]] = decodeURIComponent(item[1]);
-        });
-        return result;
-    },
-
-    change_url: function(query) {
-        var getUrl = window.location;
-        var baseUrl = `${getUrl.protocol}//${getUrl.host
-        }/${getUrl.pathname.split('/')[1]}`;
-        window.history.pushState({
-            'html': document.html,
-            'pageTitle': `${document.title} ${query}`,
-        }, '', `${baseUrl}?id=${query}`);
-    },
-
-    removeURLParameter: function(url, parameter) {
-        var urlparts = url.split('?');
-        var prefix = urlparts[0];
-        var query, paramPrefix, params, i;
-        if (urlparts.length >= 2) {
-            query = urlparts[1];
-            paramPrefix = `${encodeURIComponent(parameter)}=`;
-            params = query.split(/[&;]/g);
-
-            //reverse iteration as may be destructive
-            for (i = params.length; i-- > 0;) {
-                //idiom for string.startsWith
-                if (params[i].lastIndexOf(paramPrefix, 0) !== -1) {
-                    params.splice(i, 1);
-                }
-            }
-
-            url = prefix + (params.length > 0 ? `?${params.join('&')}` : '');
-            return url;
-        } else {
-            return url;
-        }
-    }
-}
+import * as Browser from './Browser';
 
 export function isScrolledIntoView(elem) {
     var docViewTop = $(window).scrollTop();

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -177,7 +177,7 @@ export default function init(){
         setMode('.search-bar-input');
     }
 
-    options = Browser.getJsonFromUrl();
+    options = Browser.getJsonFromUrl(location.search);
 
     if (!searchFacets[localStorage.getItem('facet')]) {
         localStorage.setItem('facet', defaultFacet)

--- a/tests/unit/js/test.Browser.js
+++ b/tests/unit/js/test.Browser.js
@@ -1,0 +1,48 @@
+import { removeURLParameter, getJsonFromUrl } from '../../../openlibrary/plugins/openlibrary/js/Browser';
+
+describe('removeURLParameter', () => {
+    const fn = removeURLParameter;
+
+    test('URL with no parameters', () => {
+        expect(fn('http://foo.com', 'x')).toBe('http://foo.com');
+    });
+
+    test('URL with the given parameter', () => {
+        expect(fn('http://foo.com?x=3', 'x')).toBe('http://foo.com');
+        expect(fn('http://foo.com?x=3&y=4&z=5', 'x')).toBe('http://foo.com?y=4&z=5');
+        expect(fn('http://foo.com?x=3&y=4&z=5', 'y')).toBe('http://foo.com?x=3&z=5');
+        expect(fn('http://foo.com?x=3&y=4&z=5', 'z')).toBe('http://foo.com?x=3&y=4');
+    });
+
+    test('URL without the given parameter', () => {
+        expect(fn('http://foo.com?x=3', 'y')).toBe('http://foo.com?x=3');
+        expect(fn('http://foo.com?x=3&y=4&z=5', 'w')).toBe('http://foo.com?x=3&y=4&z=5');
+    });
+
+    test('URL with multiple occurences of param', () => {
+        expect(fn('http://foo.com?x=3&x=4&x=5', 'x')).toBe('http://foo.com');
+        expect(fn('http://foo.com?x=3&x=4&z=5', 'x')).toBe('http://foo.com?z=5');
+    })
+});
+
+describe('getJsonFromUrl', () => {
+    const fn = getJsonFromUrl;
+
+    test('Handles empty strings', () => {
+        expect(fn('')).toEqual({});
+        expect(fn('?')).toEqual({});
+    });
+
+    test('Handles normal params', () => {
+        expect(fn('?hello=world')).toEqual({hello: 'world'});
+        expect(fn('?x=3&y=4&z=5')).toEqual({x: '3', y: '4', z: '5'});
+    });
+
+    test('Decodes parameter values', () => {
+        expect(fn('?q=foo%20bar')).toEqual({q: 'foo bar'});
+    });
+
+    test('Parameters override each other', () => {
+        expect(fn('?x=1&x=2&x=3')).toEqual({x: '3'});
+    });
+});


### PR DESCRIPTION
### Description
Refactor. Move `Browser` object out of `ol.js` into own file.

Split from #2285

### Technical
Also wrote tests for the module and removed an unused function.

### Testing
Tested `&facet=author` on homepage updates search bar url parameter

### Evidence
No UI changes.
