### PR TITLE
Fix make reindex-solr commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ destroy:
 	rm -rf var usr env
 
 reindex-solr:
-	psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy
-	psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy
+	su postgres -c "psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy"
+	su postgres -c "psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy"
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
### Description
Fix. They were erroring when run with docker, because docker uses root, which psql doesn't recognized as a registered user.

### Technical

### Testing
Run `docker-compose exec web make reindex-solr`

### Evidence
