### PR TITLE
Experimental amazon lookup API and existing API refactor

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -65,6 +65,23 @@ def _serialize_amazon_product(product):
         'cover': product.large_image_url,
         'product_group': product.product_group,
     }
+    if product._safe_get_element('OfferSummary'):
+     data['offer_summary'] = {
+         'total_new': int(product._safe_get_element_text('OfferSummary.TotalNew')),
+         'total_used': int(product._safe_get_element_text('OfferSummary.TotalUsed')),
+         'total_collectible': int(product._safe_get_element_text('OfferSummary.TotalCollectible')),
+     }
+     collectible = product._safe_get_element_text('OfferSummary.LowestCollectiblePrice.Amount')
+     if new:
+         data['offer_summary']['lowest_new'] = int(new)
+     if used:
+         data['offer_summary']['lowest_used'] = int(used)
+     if collectible:
+         data['offer_summary']['lowest_collectible'] = int(collectible)
+     amazon_offers = product._safe_get_element_text('Offers.TotalOffers')
+     if amazon_offers:
+         data['offer_summary']['amazon_offers'] = int(amazon_offers)
+
     if product.publication_date:
         # TODO: Don't populate false month and day for older products
         data['publish_date'] = (product.publication_date.strftime('%b %d, %Y') if product.publication_date.year > 1900
@@ -92,6 +109,7 @@ def _get_amazon_metadata(id_=None, id_type='isbn'):
         id_ = normalize_isbn(id_)
         kwargs = {'SearchIndex': 'Books', 'IdType': 'ISBN'}
     kwargs['ItemId'] = id_
+    kwargs['MerchantId'] = 'Amazon'  # Only affects Offers Response Group, does Amazon sell this directly?
     try:
         if not lending.amazon_api:
             raise Exception

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -2,6 +2,7 @@ import re
 import web
 import urllib2
 import simplejson
+from amazon.api import SearchException
 from infogami import config
 from infogami.utils.view import public
 from . import lending, cache, helpers as h
@@ -26,8 +27,11 @@ def get_amazon_search(title='', author=''):
     kwargs = {'Title': title, 'Author': author, 'SearchIndex': 'Books'}
     results = lending.amazon_api.search(**kwargs)
     data = []
-    for product in results:
-        data.append(_serialize_amazon_product(product))
+    try:
+        for product in results:
+            data.append(_serialize_amazon_product(product))
+    except SearchException:
+        data = {'error': 'no results'}
     return data
 
 def _serialize_amazon_product(product):

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -33,7 +33,7 @@ def get_amazon_metadata(id_, id_type='isbn'):
         return None
 
 
-def amazon_search(title='', author=''):
+def search_amazon(title='', author=''):
     """Uses the Amazon Product Advertising API ItemSearch endpoint to search for
     books by author and/or title.
     https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
@@ -44,8 +44,7 @@ def amazon_search(title='', author=''):
     :rtype: dict
     """
 
-    kwargs = {'Title': title, 'Author': author, 'SearchIndex': 'Books'}
-    results = lending.amazon_api.search(**kwargs)
+    results = lending.amazon_api.search('Title': title, 'Author': author, 'SearchIndex': 'Books')
     data = {'results': []}
     try:
         for product in results:

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -66,21 +66,21 @@ def _serialize_amazon_product(product):
         'product_group': product.product_group,
     }
     if product._safe_get_element('OfferSummary') is not None:
-     data['offer_summary'] = {
-         'total_new': int(product._safe_get_element_text('OfferSummary.TotalNew')),
-         'total_used': int(product._safe_get_element_text('OfferSummary.TotalUsed')),
-         'total_collectible': int(product._safe_get_element_text('OfferSummary.TotalCollectible')),
-     }
-     collectible = product._safe_get_element_text('OfferSummary.LowestCollectiblePrice.Amount')
-     if new:
-         data['offer_summary']['lowest_new'] = int(new)
-     if used:
-         data['offer_summary']['lowest_used'] = int(used)
-     if collectible:
-         data['offer_summary']['lowest_collectible'] = int(collectible)
-     amazon_offers = product._safe_get_element_text('Offers.TotalOffers')
-     if amazon_offers:
-         data['offer_summary']['amazon_offers'] = int(amazon_offers)
+        data['offer_summary'] = {
+            'total_new': int(product._safe_get_element_text('OfferSummary.TotalNew')),
+            'total_used': int(product._safe_get_element_text('OfferSummary.TotalUsed')),
+            'total_collectible': int(product._safe_get_element_text('OfferSummary.TotalCollectible')),
+        }
+        collectible = product._safe_get_element_text('OfferSummary.LowestCollectiblePrice.Amount')
+        if new:
+            data['offer_summary']['lowest_new'] = int(new)
+        if used:
+            data['offer_summary']['lowest_used'] = int(used)
+        if collectible:
+            data['offer_summary']['lowest_collectible'] = int(collectible)
+        amazon_offers = product._safe_get_element_text('Offers.TotalOffers')
+        if amazon_offers:
+            data['offer_summary']['amazon_offers'] = int(amazon_offers)
 
     if product.publication_date:
         # TODO: Don't populate false month and day for older products

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -21,6 +21,15 @@ def get_amazon_metadata(id_, id_type='isbn'):
     except Exception:
         return None
 
+def get_amazon_search(title='', author=''):
+    # uncached for now, cache later
+    kwargs = {'Title': title, 'Author': author, 'SearchIndex': 'Books'}
+    results = lending.amazon_api.search(**kwargs)
+    data = []
+    for product in results:
+        data.append(product)
+    return data
+
 def _get_amazon_metadata(id_=None, id_type='isbn'):
     # TODO: extend this to work with
     # isbn=, asin=, title=, authors=, etc

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -34,7 +34,7 @@ def get_amazon_metadata(id_, id_type='isbn'):
 
 
 def search_amazon(title='', author=''):
-    """Uses the Amazon Product Advertising API ItemSearch endpoint to search for
+    """Uses the Amazon Product Advertising API ItemSearch operation to search for
     books by author and/or title.
     https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
 
@@ -133,7 +133,7 @@ def _serialize_amazon_product(product):
 
 
 def _get_amazon_metadata(id_=None, id_type='isbn'):
-    """Uses the Amazon Product Advertising API ItemLookup endpoint to locatate a
+    """Uses the Amazon Product Advertising API ItemLookup operation to locatate a
     specific book by identifier; either 'isbn' or 'asin'.
     https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemLookup.html
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -63,7 +63,8 @@ def _serialize_amazon_product(product):
     }
     if product.publication_date:
         # TODO: Don't populate false month and day for older products
-        data['publish_date'] = product.publication_date.strftime('%b %d, %Y')
+        data['publish_date'] = (product.publication_date.strftime('%b %d, %Y') if product.publication_date.year > 1900
+                               else str(product.publication_date.year))
     if product.binding:
         data['physical_format'] = product.binding.lower()
     if product.edition:

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -65,7 +65,7 @@ def _serialize_amazon_product(product):
         'cover': product.large_image_url,
         'product_group': product.product_group,
     }
-    if product._safe_get_element('OfferSummary'):
+    if product._safe_get_element('OfferSummary') is not None:
      data['offer_summary'] = {
          'total_new': int(product._safe_get_element_text('OfferSummary.TotalNew')),
          'total_used': int(product._safe_get_element_text('OfferSummary.TotalUsed')),

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -44,7 +44,7 @@ def search_amazon(title='', author=''):
     :rtype: dict
     """
 
-    results = lending.amazon_api.search('Title': title, 'Author': author, 'SearchIndex': 'Books')
+    results = lending.amazon_api.search(Title=title, Author=author, SearchIndex='Books')
     data = {'results': []}
     try:
         for product in results:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -17,7 +17,7 @@ from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.core import ia, db, models, lending, helpers as h
 from openlibrary.core.vendors import (
     get_amazon_metadata, create_edition_from_amazon_metadata,
-    amazon_search, get_betterworldbooks_metadata)
+    search_amazon, get_betterworldbooks_metadata)
 
 
 class book_availability(delegate.page):
@@ -273,7 +273,7 @@ class amazon_search_api(delegate.page):
             return simplejson.dumps({
                 'error': 'author or title required'
             })
-        results = amazon_search(title=i.title, author=i.author)
+        results = search_amazon(title=i.title, author=i.author)
         return simplejson.dumps(results)
 
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -17,7 +17,8 @@ from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.core import ia, db, models, lending, helpers as h
 from openlibrary.core.vendors import (
     get_amazon_metadata, create_edition_from_amazon_metadata,
-    get_amazon_search, get_betterworldbooks_metadata)
+    amazon_search, get_betterworldbooks_metadata)
+
 
 class book_availability(delegate.page):
     path = "/availability/v2"
@@ -49,6 +50,7 @@ class book_availability(delegate.page):
             else []
         )
 
+
 class browse(delegate.page):
     path = "/browse"
     encoding = "json"
@@ -73,6 +75,7 @@ class browse(delegate.page):
         return delegate.RawText(
             simplejson.dumps(result),
             content_type="application/json")
+
 
 class ratings(delegate.page):
     path = "/works/OL(\d+)W/ratings"
@@ -201,6 +204,7 @@ class work_editions(delegate.page):
             "entries": editions
         }
 
+
 class author_works(delegate.page):
     path = "(/authors/OL\d+A)/works"
     encoding = "json"
@@ -242,8 +246,22 @@ class author_works(delegate.page):
             "entries": works
         }
 
-class external_search_api(delegate.page):
-    path = '/ext'
+
+class amazon_search_api(delegate.page):
+    """Librarian + admin only endpoint to check for books
+    avaialable on Amazon via the Product Advertising API
+    ItemSearch operation.
+
+    https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
+
+    Currently experimental to explore what data is avaialable to affiliates.
+
+    :return: JSON {"results": []} containing Amazon product metadata
+             for items matching the title and author search parameters.
+    :rtype: str
+    """
+
+    path = '/_tools/amazon_search'
 
     @jsonapi
     def GET(self):
@@ -255,8 +273,9 @@ class external_search_api(delegate.page):
             return simplejson.dumps({
                 'error': 'author or title required'
             })
-        results = get_amazon_search(title=i.title, author=i.author)
+        results = amazon_search(title=i.title, author=i.author)
         return simplejson.dumps(results)
+
 
 class price_api(delegate.page):
     path = r'/prices'

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -247,6 +247,9 @@ class external_search_api(delegate.page):
 
     @jsonapi
     def GET(self):
+        user = accounts.get_current_user()
+        if not (user and (user.is_admin() or user.is_librarian())):
+            return web.HTTPError('403 Forbidden')
         i = web.input(title='', author='')
         if not (i.author or i.title):
             return simplejson.dumps({

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -17,7 +17,7 @@ from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.core import ia, db, models, lending, helpers as h
 from openlibrary.core.vendors import (
     get_amazon_metadata, create_edition_from_amazon_metadata,
-    get_betterworldbooks_metadata)
+    get_amazon_search, get_betterworldbooks_metadata)
 
 class book_availability(delegate.page):
     path = "/availability/v2"
@@ -242,12 +242,24 @@ class author_works(delegate.page):
             "entries": works
         }
 
+class external_search_api(delegate.page):
+    path = '/ext'
+
+    @jsonapi
+    def GET(self):
+        i = web.input(title='', author='')
+        if not (i.author or i.title):
+            return simplejson.dumps({
+                'error': 'author or title required'
+            })
+        results = get_amazon_search(title=i.title, author=i.author)
+        return simplejson.dumps(results)
+
 class price_api(delegate.page):
     path = r'/prices'
 
     @jsonapi
     def GET(self):
-        # TODO: add: title='', authors='' for lookup
         i = web.input(isbn='', asin='')
         if not (i.isbn or i.asin):
             return simplejson.dumps({


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

* Adds an admin / librarian only endpoint that can be used to look up book prices by title and author (for investigating what data is provided from the Amazon search API)
* Refactors the existing price lookup API to make this possible (split some code out to a new `_serialize_amazon_product()` method) and structure the code in a more usable fashion. This is potentially going to help with #2332, and unifying our data source usage
* Minor improvements around date handling, results not found exception handling, and API response format, which will also apply to the standard price lookup results, which does affect every Edition page for books with ISBN.

I did this work as part of a data investigation task, and it seems a shame to throw away the code. The refactor is the main useful aspect of this PR, although the debugging and extra insight into the capabilities of the Amazon API has potential to be useful later.

Does _not_ fully fix #2334 (Import data format issues), although it has helped gather data on the problem.  I will raise a separate PR once this is merged. This sort of librarian tool will help trouble-shoot similar issues, or develop new features, in future.

Closes #

### Technical
<!-- What should be noted about the implementation? -->

The current endpoint is at `/ext?title=foo&author=bar`  It should have a better name. 'ext' is short for 'external search', so perhaps `/external_search?title=foo&author=bar` is more appropriate.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
