### PR TITLE
prevent unnecessary redirects on data dump links

### DIFF
--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -1,31 +1,40 @@
 """Code for handling /data/*.txt.gz URLs.
 """
 import web
+from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import public
 
 import simplejson
 import urllib2
 
+
+IA_BASE_URL = config.get('ia_base_url')
+
+
 def wget(url):
     return urllib2.urlopen(url).read()
 
-def get_ol_dumps():
-    """Get list of all archive.org items in the in the ol_exports collection uploaded of archive.org staff."""
-    url = 'http://www.archive.org/advancedsearch.php?q=(ol_dump+OR+ol_cdump)+AND+collection:ol_exports&fl[]=identifier&output=json&rows=1000'
 
+def get_ol_dumps():
+    """Get list of all archive.org items in the ol_exports collection uploaded by archive.org staff."""
+    url = IA_BASE_URL + '/advancedsearch.php?q=(ol_dump+OR+ol_cdump)+AND+collection:ol_exports&fl[]=identifier&output=json&rows=1000'
     d = simplejson.loads(wget(url))
     return sorted(doc['identifier'] for doc in d['response']['docs'])
+
 
 # cache the result for half an hour
 get_ol_dumps = web.memoize(get_ol_dumps, 30*60, background=True)
 #public(get_ol_dumps)
 
+
 def download_url(item, filename):
-    return "http://www.archive.org/download/%s/%s" % (item, filename)
+    return "%s/download/%s/%s" % (IA_BASE_URL, item, filename)
+
 
 class ol_dump_latest(delegate.page):
     path = "/data/ol_dump(|_authors|_editions|_works|_deworks)_latest.txt.gz"
+
     def GET(self, prefix):
         items = [item for item in get_ol_dumps() if item.startswith("ol_dump")]
         if not items:
@@ -34,6 +43,7 @@ class ol_dump_latest(delegate.page):
         item = items[-1]
         filename = item.replace("dump", "dump" + prefix) + ".txt.gz"
         raise web.found(download_url(item, filename))
+
 
 class ol_cdump_latest(delegate.page):
     path = "/data/ol_cdump_latest.txt.gz"
@@ -46,6 +56,7 @@ class ol_cdump_latest(delegate.page):
         item = items[-1]
         raise web.found(download_url(item, item + ".txt.gz"))
 
+
 class ol_dumps(delegate.page):
     path = "/data/ol_dump(|_authors|_editions|_works)_(\d\d\d\d-\d\d-\d\d).txt.gz"
 
@@ -57,14 +68,17 @@ class ol_dumps(delegate.page):
             filename = "ol_dump" + prefix + "_" + date + ".txt.gz"
             raise web.found(download_url(item, filename))
 
+
 class ol_cdumps(delegate.page):
     path = "/data/ol_cdump_(\d\d\d\d-\d\d-\d\d).txt.gz"
+
     def GET(self, date):
         item = "ol_cdump_" + date
         if item not in get_ol_dumps():
             raise web.notfound()
         else:
             raise web.found(download_url(item, item + ".txt.gz"))
+
 
 def setup():
     pass

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -8,7 +8,7 @@ $def with (page)
         <ul>
           <li><a href="/about/vision" title="$_('Vision')">Vision</a></li>
           <li><a href="https://archive.org/about/jobs.php" title="$_('Jobs')">Careers</a></li>
-          <li><a href="http://blog.openlibrary.org/" title="$_('blog')">Blog</a></li>
+          <li><a href="https://blog.openlibrary.org/" title="$_('Blog')">Blog</a></li>
           <li><a href="https://archive.org/about/terms.php" title="$_('Terms of Service')">Terms of Service</a></li>
           <li><a href="https://archive.org/donate/?platform=ol" title="$_('Donate')">Donate</a></li>
         </ul>
@@ -29,7 +29,7 @@ $def with (page)
         <ul>
           <li><a href="/developers" title="$_('Explore Open Library Development Center')">Development Center</a></li>
           <li><a href="/developers/api" title="$_('Explore Open Library APIs')">API Documentation</a></li>
-          <li><a href="/data" title="$_('Bulk OL Data')">Bulk Data Dumps</a></li>
+          <li><a href="/developers/dumps" title="$_('Bulk Open Library data')">Bulk Data Dumps</a></li>
           <li><a href="https://github.com/internetarchive/openlibrary/wiki/Writing-Bots" title="$_('Write a bot')">Writing Bots</a></li>
           <li><a href="/books/add" title="$_('Add a new book to Open Library')">Add a Book</a></li>
         </ul>


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
While debugging issues with the ol data dumps https://openlibrary.org/developers/dumps I noticed they were cycling through an unnecessary layer of redirects, caused by the hardcoded URLs `www.archive.org`  which redirects to `archive.org`

This PR uses the `openlibrary.yml` configured value, which uses https. 

Also corrects the link to the data dumps on the nav footer to link directly to https://openlibrary.org/developers/dumps

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested in local dev, check that Archive.org URL does not have the `www.` prefix.


### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
