### PR TITLE
Editor code is limited to pages with textarea.markdown

### DIFF
--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -10,13 +10,6 @@ export default function($) {
         $.fn.colorbox.close();
     });
 
-    // wmd editor
-    $('textarea.markdown').wmd({
-        helpLink: '/help/markdown',
-        helpHoverTitle: 'Formatting Help',
-        helpTarget: '_new'
-    });
-
     // tabs
     options = {};
     if($.support.opacity){

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -14,8 +14,6 @@ import '../../../../vendor/js/jquery-form/jquery.form.js';
 import '../../../../vendor/js/jquery-validate/jquery.validate.js';
 // jquery-autocomplete#1.1 with modified
 import '../../../../vendor/js/jquery-autocomplete/jquery.autocomplete-modified.js';
-// unversioned.
-import '../../../../vendor/js/wmd/jquery.wmd.js'
 // jquery-flot 0.7.0
 import '../../../../vendor/js/flot/jquery.flot.js';
 import '../../../../vendor/js/flot/jquery.flot.selection.js';
@@ -94,10 +92,16 @@ window.Promise = Promise;
 
 // Initialise some things
 jQuery(function () {
+    const $markdownTextAreas = $('textarea.markdown');
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);
     automaticInit($);
+    // wmd editor
+    if ($markdownTextAreas.length) {
+        import(/* webpackChunkName: "markdown-editor" */ './markdown-editor')
+            .then((module) => module.initMarkdownEditor($markdownTextAreas));
+    }
     bookReaderInit($);
     addFadeInFunctionsTojQuery($);
     jQueryRepeat($);

--- a/openlibrary/plugins/openlibrary/js/markdown-editor/index.js
+++ b/openlibrary/plugins/openlibrary/js/markdown-editor/index.js
@@ -1,0 +1,14 @@
+// unversioned.
+import '../../../../../vendor/js/wmd/jquery.wmd.js'
+
+/**
+ * Sets up Wikitext markdown editor interface inside $textarea
+ * @param {jQuery.Object} $textareas
+ */
+export function initMarkdownEditor($textareas) {
+    $textareas.wmd({
+        helpLink: '/help/markdown',
+        helpHoverTitle: 'Formatting Help',
+        helpTarget: '_new'
+    });
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
       "maxSize": "16.7KB"
     },
     {
+      "path": "static/build/markdown-editor.js",
+      "maxSize": "10.4KB"
+    },
+    {
       "path": "static/build/all.js",
       "maxSize": "173.0KB"
     },
@@ -63,7 +67,7 @@
     "@babel/register": "7.0.0",
     "babel-eslint": "10.0.2",
     "babel-loader": "8.0.5",
-    "bundlesize": "^0.17.0",
+    "bundlesize": "^0.17.2",
     "css-loader": "2.1.1",
     "detect-libc": "^1.0.3",
     "eslint": "^5.16.0",


### PR DESCRIPTION
### Description
Previously wmd code was run on an empty jquery set. We can check the
length of the set before enabling the code and pull out a modest
bit of JS from the critical path for all pages that do not have an editor.

Size is crucial in this entry point. Especially as we add to it!

### Technical
I considered adding a class 'markdown--progressively-enhanced' but I favoured doing the minimum possible to get this working.

### Testing
markdown elements appear on all editing interfaces
Editing a book or edition
Make sure the preview works when you focus the text area.
I've been using this code:
```
test **test**
````
on these pages:
* http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain/edit
* http://localhost:8080/people/openlibrary?m=edit

