### PR TITLE
Edit instructions on merging pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,17 @@ Follow these rules when creating a PR:
 3. **Resolve all code review (CR) comments**: Treat comments as a todo list. Most PRs will require some edits before getting merged, so don't get discouraged if you have to make some changes!
 4. **Reply when resolving CR comments**: When resolving a comment, reply with either "DONE" or "WON'T FIX because ...". A reviewer will unresolve a comment if they feel it's necessary.
 
-## Merging Pull Requests
+## QA Testing
 
-For maintainers: we use assignee to denote PR ownership. If you are the assignee, then you should have the PR on your todo list until you merge it.
+Once a Pull Request has been subitted, ask an approved member of staff to spin up an isolated kubernetes Open Library pod for the branch that you're working on. They will give you a link which will let you test your branch's current code against a near-production environment. Read more about our [Plans for Kubernetes](https://github.com/internetarchive/openlibrary/wiki/Kubernetes)
+
+# Maintainers
+
+Guidelines for repo maintainers.
+
+## Pull Requests
+
+We use assignee to denote PR ownership. If you are the assignee, then you should have the PR on your todo list until you merge or close it.
 - **Assign yourself** to a PR if you have the time to take on the responsibilities of ownership (described below).
 - **Don't assign others** to a PR. Feel free to ask someone to take ownership, but respect others time restrictions.
 - **Avoid assignee=author**. In the case where the PR author is also a maintainer, we will strive to have another maintainer own and merge the PR to ensure these steps are followed fairly by all.
@@ -87,10 +95,6 @@ The assignee of a PR is responsible for:
 - **getting the PR code reviewed** either by yourself (often so) or by someone else.
 - **getting merge approval**. If a PR requires a special deploy, label as `Needs: Deploy Approval` and get that approval before merging.
 - **testing the PR** before merging. Comment about how you tested in the PR. If _any_ changes are made to the PR code, you will have to test it again before merging.
-- **merging** the PR.
+- **merging (or closing)** the PR.
 
 We strive for every PR to have an assignee so that nothing gets stuck.
-
-## QA Testing
-
-Once a Pull Request has been subitted, ask an approved member of staff to spin up an isolated kubernetes Open Library pod for the branch that you're working on. They will give you a link which will let you test your branch's current code against a near-production environment. Read more about our [Plans for Kubernetes](https://github.com/internetarchive/openlibrary/wiki/Kubernetes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,16 +75,18 @@ Follow these rules when creating a PR:
 
 ## Merging Pull Requests
 
-For members who have been given permission to merge, we use assignee to denote PR ownership. If you are the assignee, then you should have the PR on your todo list until you merge it.
-- **Assigned yourself** to the PR if you have the time to take on the responsibilities of ownership (described below).
-- **Don't assign others** unless there's a technical requirement (e.g. This PR requires changes to our deploy process, and only Mek can make those changes).
+For maintainers: we use assignee to denote PR ownership. If you are the assignee, then you should have the PR on your todo list until you merge it.
+- **Assign yourself** to a PR if you have the time to take on the responsibilities of ownership (described below).
+- **Don't assign others** to a PR. Feel free to ask someone to take ownership, but respect others time restrictions.
+- **Avoid assignee=author**. In the case where the PR author is also a maintainer, we will strive to have another maintainer own and merge the PR to ensure these steps are followed fairly by all.
 
 The assignee of a PR is responsible for:
 - **being the primary contact** for the PR author. Be polite; you're the face of the community to this contributor.
-- **managing the PR's labels**. Add `Needs: Author Input`, or `Needs: Review`, etc. as neccessary.
-- **ensuring the PR doesn't get stuck**. Avoid leaving the author wondering about the state of the PR. If you don't have time right now, saying "I'm a little swamped now but will try to get to this in _" is better than radio silence for a week.
+- **managing the PR's labels**. Add `Needs: Author Input` or `Needs: Review` as necessary.
+- **ensuring the PR doesn't get stuck**. Avoid leaving the author wondering about the state of the PR. If you don't have time right now, saying "I'm a little swamped now but will try to get to this in \_" is better than radio silence for a week.
 - **getting the PR code reviewed** either by yourself (often so) or by someone else.
-- **testing the PR** before merging. Comment about how you tested in the PR. Note if _any_ changes are made to the PR code, you will have to test it again before merging.
+- **getting merge approval**. If a PR requires a special deploy, label as `Needs: Deploy Approval` and get that approval before merging.
+- **testing the PR** before merging. Comment about how you tested in the PR. If _any_ changes are made to the PR code, you will have to test it again before merging.
 - **merging** the PR.
 
 We strive for every PR to have an assignee so that nothing gets stuck.


### PR DESCRIPTION
### Description
Feature. Edit contributing to:
1. Limit merge/PR owner access to maintainers
2. Avoid having author=assignee
3. In the case where a special deploy is required, the assignee will label it as `Needs: Deploy Approval`. The assignee must then get confirmation from the deployer before merging in the PR.

(As discussed on slack)