### PR TITLE
Code splitting: Carousels

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -1,5 +1,18 @@
 // used in templates/covers/add.html
 const Carousel = {
+    /**
+     * @param {String} selector (CSS) referring to the node to be enhanced
+     * @param {Number} [a] number of books to show (default)
+     * @param {Number} [b] number of books to show @1200px or more
+     * @param {Number} [c] number of books to show @1024px or more
+     * @param {Number} [d] number of books to show @600px or more
+     * @param {Number} [e] number of books to show @480px or more
+     * @param {Number} [f] number of books to show @360px or more
+     * @param {Object} [loadMore] configuration
+     * @param {String} loadMore.url to use to load more items
+     * @param {Number} loadMore.limit of new items to receive
+     * @param {String} loadMore.pageMode of page e.g. `offset`
+     */
     add: function(selector, a, b, c, d, e, f, loadMore) {
         var responsive_settings, availabilityStatuses, addWork, url, default_limit;
 
@@ -155,4 +168,5 @@ const Carousel = {
         }
     }
 };
+
 export default Carousel;

--- a/openlibrary/plugins/openlibrary/js/carousel/index.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/index.js
@@ -1,0 +1,15 @@
+// Slick#1.6.0 is not on npm
+import '../../../../../vendor/js/slick/slick-1.6.0.min.js';
+import '../../../../../static/css/components/carousel--js.less';
+import Carousel from './Carousel';
+
+/**
+ * @param {jQuery.Object} $carouselElements
+ */
+export function init($carouselElements) {
+    $carouselElements.each(function (_i, carouselElement) {
+        Carousel.add.apply(Carousel,
+            JSON.parse(carouselElement.dataset.config)
+        );
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,7 +1,5 @@
 import 'jquery';
 import 'jquery-migrate';
-// Slick#1.6.0 is not on npm
-import '../../../../vendor/js/slick/slick-1.6.0.min.js';
 // npm jquery-ui@1.12.1 package does not match the one we have here, so for now we load from vendor
 import '../../../../vendor/js/jquery-ui/jquery-ui-1.12.1.min.js';
 // For dialog boxes (e.g. add to list)
@@ -27,7 +25,6 @@ import automaticInit from './automatic';
 import { getAvailabilityV2,
     updateBookAvailability, updateWorkAvailability } from './availability';
 import bookReaderInit from './bookreader_direct';
-import Carousel from './carousels';
 import { ungettext, ugettext,  sprintf } from './i18n';
 import addFadeInFunctionsTojQuery from './jquery.customFade';
 import jQueryRepeat from './jquery.repeat';
@@ -78,7 +75,6 @@ window.ungettext = ungettext;
 window.uggettext = ugettext;
 
 window.Browser = Browser;
-window.Carousel = Carousel;
 window.Subject = Subject;
 window.Template = Template;
 
@@ -93,6 +89,8 @@ window.Promise = Promise;
 // Initialise some things
 jQuery(function () {
     const $markdownTextAreas = $('textarea.markdown');
+    // Live NodeList is cast to static array to avoid infinite loops
+    const $carouselElements = $('.carousel--progressively-enhanced');
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);
@@ -112,5 +110,10 @@ jQuery(function () {
     if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
         import(/* webpackChunkName: "editions-table" */ './editions-table')
             .then(module => module.initEditionsTable());
+    }
+    // Enable any carousels in the page
+    if ($carouselElements.length) {
+        import(/* webpackChunkName: "carousel" */ './carousel')
+            .then((module) => module.init($carouselElements));
     }
 });

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -62,24 +62,22 @@ $if test or (books and len(books) >= min_books):
         </div>
       <div class="carousel-container carousel-container-decorated">
         $ attrs = ''
-        <div class="carousel carousel-$key">
+        $if load_more:
+          $ load_more_config = {
+          $  "url": load_more["url"].replace("&amp;", "&"),
+          $  "pageMode": load_more.get("mode", "offset"),
+          $  "limit": load_more.get("limit", 18)
+          $ }
+        $else:
+          $ load_more_config = {}
+        $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
+        <div class="carousel carousel-$key carousel--progressively-enhanced"
+          data-config="$json_encode(config)">
           $ cover_host = '//covers.openlibrary.org'
           $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
 
           $for index, book in enumerate(books or []):
               $:render_carousel_cover(book, index > 5)
         </div>
-        <script type="text/javascript">
-              window.q.push(function() {
-                Carousel.add(
-                  '.carousel-$key', // dom element to bind slick
-                  6, 5, 4, 3, 2, 1, { // num books per responsive breakpoint
-                  $if load_more:
-                     url: '$:(load_more["url"].replace("&amp;", "&"))',
-                     pageMode: '$(load_more.get("mode", "offset"))',
-                     limit: $(load_more.get("limit", 18))
-                  });
-              });
-        </script>
       </div>
     </div>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -78,7 +78,8 @@ window.q.push(function(){
                         </div>
                         <div class="carousel-section">
                             <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
-                                <div id="popcovers" class="carousel">
+                                <div id="popcovers" class="carousel carousel--progressively-enhanced"
+                                    data-config="$json_encode(['#popcovers'])">
                                 $for cover in doc.get_edition_covers():
                                     <div class="book carousel__item" data-id="$cover.id">
                                         <div class="book-cover">
@@ -92,7 +93,6 @@ window.q.push(function(){
                         <input type="hidden" id="coverid" name="coverid" value=""/>
                         <script type="text/javascript">
                         window.q.push( function () {
-                            Carousel.add('#popcovers');
                             // Clicking a cover should set the form value to the data-id of that cover
                             \$("#popcovers .book").click(function() {
                                 \$(this).toggleClass("selected").siblings().removeClass("selected");

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -8,7 +8,8 @@ $if subjects:
     </div>
     <hr>
     <div class="carousel-container">
-      <div class="carousel" id="categories_carousel">
+      <div class="carousel carousel--progressively-enhanced" id="categories_carousel"
+        data-config="$json_encode(['#categories_carousel', 6, 5, 4, 3, 2])">
         $for subject_name in subjects:
           $ subject = subjects[subject_name]
           $ presentable_subject_name = subject_name.replace('_', ' ').title()
@@ -28,8 +29,4 @@ $if subjects:
       </div>
     </div>
   </div>
-  <script type="text/javascript">
-  window.q.push(function() {
-    Carousel.add('#categories_carousel', 6, 5, 4, 3, 2);
-  });
-  </script>
+

--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
       "maxSize": "10.4KB"
     },
     {
+      "path": "static/build/carousel.js",
+      "maxSize": "12.1KB"
+    },
+    {
       "path": "static/build/all.js",
-      "maxSize": "173.0KB"
+      "maxSize": "151.5KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/static/css/components/carousel--js.less
+++ b/static/css/components/carousel--js.less
@@ -2,6 +2,7 @@
 // (this is a lot of bytes for just an icon so should be revisited asap)
 @import (less) '../lib/slick.css';
 @import (less) '../lib/slick-theme.css';
+@import (less) '../less/index.less';
 
 .carousel-container {
   .slick-slider {

--- a/static/css/js-all.less
+++ b/static/css/js-all.less
@@ -9,7 +9,6 @@
 
 @import (less) 'legacy-jquery-ui.less';
 
-@import (less) 'components/carousel--js.less';
 @import (less) 'components/header-bar--js.less';
 @import (less) 'components/cbox.less';
 @import (less) 'components/flash-messages.less';


### PR DESCRIPTION
### Description
Carousel code will no longer be loaded on pages that do not have Carousels. A lightweight Carousel object is created that will lazy load the code when invoked. Less JS is loaded for pages that do not feature carousels.

### Technical
Some code inside openlibrary/templates/covers/add.html unrelated to
carousels is intentionally ignored for the time being as it doesn't relate to the carousels themselves.

A carousel can be registered now using a data-config attribute and the class `carousel--progressively-enhanced`

Note the additive approach might cause problems where we cache HTML as the carousels will not load on pages without the data attribute/class. Carousels do degrade gracefully however so they are still useable, and a refresh will deal with these. I think it's is acceptable but we may need to coordinate with deployers to clear the home page server cache. 

### Testing
Verify that the carousels work on the home, subject pages and when you click "Add cover" when logged in on a books page.

* https://openlibrary.org/subjects/romance
* https://openlibrary.org/ (remember there's 2 of them!)
* https://openlibrary.org/works/OL17829905W/Seveneves/add-cover


### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
