### PR TITLE
Remove residual json2 README

### DIFF
--- a/vendor/js/json2/Readme.txt
+++ b/vendor/js/json2/Readme.txt
@@ -1,3 +1,0 @@
-JSON2.js
-
-Source: http://www.json.org/json2.js


### PR DESCRIPTION
### Description
Refactor. The JSON2 js library has been removed, so this file is no longer needed.

### Technical

### Testing
- Documentation change, so no testing

### Evidence
