### PR TITLE
Move markdown.textarea code from ol.js to feature folder

### DIFF
--- a/openlibrary/plugins/openlibrary/js/markdown-editor/index.js
+++ b/openlibrary/plugins/openlibrary/js/markdown-editor/index.js
@@ -6,7 +6,13 @@ import '../../../../../vendor/js/wmd/jquery.wmd.js'
  * @param {jQuery.Object} $textareas
  */
 export function initMarkdownEditor($textareas) {
-    $textareas.wmd({
+    $textareas.on('focus', function (){
+        // reveal the previous when the user focuses on the textarea for the first time
+        $('.wmd-preview').show();
+        if ($('#prevHead').length == 0) {
+            $('.wmd-preview').before('<h3 id="prevHead">Preview</h3>');
+        }
+    }).wmd({
         helpLink: '/help/markdown',
         helpHoverTitle: 'Formatting Help',
         helpTarget: '_new'

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -332,14 +332,6 @@ export default function init(){
         renderInstantSearchResults(val);
     }, 300, false));
 
-    $('textarea.markdown').focus(function(){
-        $('.wmd-preview').show();
-        if ($('#prevHead').length == 0) {
-            $('.wmd-preview').before('<h3 id="prevHead" style="margin:15px 0 10px;padding:0;">Preview</h3>');
-        }
-    });
-
-
     initReadingListFeature();
     initBorrowAndReadLinks();
     initPreviewButton();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     {
       "path": "static/build/markdown-editor.js",
-      "maxSize": "10.4KB"
+      "maxSize": "10.5KB"
     },
     {
       "path": "static/build/all.js",


### PR DESCRIPTION
As @cdrini points out this code can be moved here! Hurrah! This code makes sure the preview shows when you focus the textarea.

Closes #

### Technical
<!-- What should be noted about the implementation? -->

### Testing
http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain/edit


### Evidence


![Screenshot 2019-09-08 at 11 29 00 AM](https://user-images.githubusercontent.com/148752/64492725-f22d6a00-d22b-11e9-89e2-fcfb275693bf.png)
