### PR TITLE
Fixes #2334, Amazon API results give overspecific (made up) day and month for older books

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -14,6 +14,7 @@ from openlibrary import accounts
 
 
 BETTERWORLDBOOKS_API_URL = 'http://products.betterworldbooks.com/service.aspx?ItemId='
+amazon_full_date = re.compile('\d{4}-\d\d-\d\d')
 
 
 @public
@@ -112,6 +113,8 @@ def _serialize_amazon_product(product):
 
     if product.publication_date:
         data['publish_date'] = product._safe_get_element_text('ItemAttributes.PublicationDate')
+        if re.match(amazon_full_date, data['publish_date']):
+            data['publish_date'] = product.publication_date.strftime('%b %d, %Y')
 
     if product.binding:
         data['physical_format'] = product.binding.lower()

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -14,7 +14,7 @@ from openlibrary import accounts
 
 
 BETTERWORLDBOOKS_API_URL = 'http://products.betterworldbooks.com/service.aspx?ItemId='
-amazon_full_date = re.compile('\d{4}-\d\d-\d\d')
+AMAZON_FULL_DATE_RE = re.compile('\d{4}-\d\d-\d\d')
 
 
 @public
@@ -113,7 +113,7 @@ def _serialize_amazon_product(product):
 
     if product.publication_date:
         data['publish_date'] = product._safe_get_element_text('ItemAttributes.PublicationDate')
-        if re.match(amazon_full_date, data['publish_date']):
+        if re.match(AMAZON_FULL_DATE_RE, data['publish_date']):
             data['publish_date'] = product.publication_date.strftime('%b %d, %Y')
 
     if product.binding:

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -111,9 +111,8 @@ def _serialize_amazon_product(product):
             data['offer_summary']['amazon_offers'] = int(amazon_offers)
 
     if product.publication_date:
-        # TODO: Don't populate false month and day for older products
-        data['publish_date'] = (product.publication_date.strftime('%b %d, %Y') if product.publication_date.year > 1900
-                               else str(product.publication_date.year))
+        data['publish_date'] = product._safe_get_element_text('ItemAttributes.PublicationDate')
+
     if product.binding:
         data['physical_format'] = product.binding.lower()
     if product.edition:


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #2334 

### Technical
<!-- What should be noted about the implementation? -->
need to confirm that `product._safe_get_element_text('ItemAttributes.PublicationDate')` is the correct way to access the raw string form of `product.publication_date`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Needs deployment and testing on dev.openlibrary.org

* [x] Search for older book by ASIN, ensure the date value is year only and matches what is in the source data. Confirm that the current day and month are NOT added to the year.
* [x] Search for a recent book (which has day + month precision publication date). confirm that all those details are brought through from the source record. 

Test examples:
Search for https://dev.openlibrary.org/_tools/amazon_search?title=Tax%20Credits%20Bill
The results will NOT contain `publish_date: "Sep 09, 2019",` where `Sep 09` is today's date. The correct and expected result is `publish_date: "2019",`  for item `amazon:B07QVK7X22`

https://dev.openlibrary.org/_tools/amazon_search?title=The%20Water%20Dancer for a recent book with day and month publish date.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
