### PR TITLE
fixing bwb new price

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -292,8 +292,8 @@ def _get_betterworldbooks_metadata(isbn):
             qlt = 'used'
 
         if new_qty and new_qty[0] and new_qty[0] != '0':
-            _price = used_price[0] if used_price else None
-            if price and _price and _price < price:
+            _price = new_price[0] if new_price else None
+            if _price and (not price or _price < price):
                 price = _price
                 qlt = 'new'
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -293,7 +293,7 @@ def _get_betterworldbooks_metadata(isbn):
 
         if new_qty and new_qty[0] and new_qty[0] != '0':
             _price = new_price[0] if new_price else None
-            if _price and (not price or _price < price):
+            if _price and (not price or float(_price) < float(price)):
                 price = _price
                 qlt = 'new'
 


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

If BWB only has a new price book (new used) then the vendor code previously failed `if` condition to return price info.