### PR TITLE
For work carousels, resolve 'best' edition

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -344,6 +344,16 @@ class health(delegate.page):
         web.header('Content-Type', 'text/plain')
         raise web.HTTPError("200 OK", {}, 'OK')
 
+class work2edition_resolver(delegate.page):
+    path = r"(/works/OL[0-9]+W)/resolve"
+
+    def GET(self, work_key):
+        """Resolves a work url to an editions page"""
+        doc = web.ctx.site.get(work_key)
+        matches = doc.get_ebook_info().get('ia', [])
+        if matches:
+            raise web.seeother('/ia/' + matches[0])
+        raise web.seeother(work_key)
 
 class bookpage(delegate.page):
     path = r"/(isbn|oclc|lccn|ia|ISBN|OCLC|LCCN|IA)/([^/]*)(/.*)?"

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -28,11 +28,9 @@ $def render_carousel_cover(book, lazy):
   $elif book.get('lending_edition'):
     $ cta_url = "/books/%s/x/borrow"%book.get('lending_edition')
     $ cta = 'Borrow'
-  $elif book.get('lending_edition'):
-    $ cta_url = book.get('read_url')
-    $ cta = 'Read'
   $else:
     $ cta = 'Read'
+    $ url += '/x/resolve'
     $ cta_url = url
 
   $if lazy:


### PR DESCRIPTION
### Description

An endpoint for determining the "best" edition to show a user (given only a work ID). e.g. a readable edition, an available edition, an edition w/ a certain isbn, an edition in a certain language