### PR TITLE
requirements_common.txt: Upgrade to web.py==0.40

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,8 @@ install:
   - make lint
   - pip install -r requirements_test.txt
   # if Travis is running Python 3, then
-  #   refresh the git submodule ./vendor/infogami
   #   create a legacy Python for npm/node until nodejs/node#25789 is resolved
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
-      pushd vendor/infogami && git pull origin master && popd;
       pyenv install 2.7.14;
     fi
   - npm install

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -54,7 +54,7 @@ def verify_hash(secret_key, text, hash):
 
 def generate_hash(secret_key, text, salt=None):
     salt = salt or hmac.HMAC(secret_key, str(random.random())).hexdigest()[:5]
-    hash = hmac.HMAC(secret_key, salt + web.utf8(text)).hexdigest()
+    hash = hmac.HMAC(secret_key, salt + web.safestr(text)).hexdigest()
     return '%s$%s' % (salt, hash)
 
 def get_secret_key():

--- a/openlibrary/mocks/mock_ol.py
+++ b/openlibrary/mocks/mock_ol.py
@@ -2,13 +2,10 @@ import os
 import pytest
 import re
 import web
+from web.browser import AppBrowser
 from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate
-try:  # newer versions of web.py
-    from web.browser import AppBrowser
-except ImportError:  # older versions of web.py
-    from web import AppBrowser
 
 from openlibrary.mocks.mock_infobase import mock_site, MockConnection
 from openlibrary.plugins import ol_infobase

--- a/openlibrary/mocks/mock_ol.py
+++ b/openlibrary/mocks/mock_ol.py
@@ -2,10 +2,13 @@ import os
 import pytest
 import re
 import web
-from web.browser import AppBrowser
 from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate
+try:  # newer versions of web.py
+    from web.browser import AppBrowser
+except ImportError:  # older versions of web.py
+    from web import AppBrowser
 
 from openlibrary.mocks.mock_infobase import mock_site, MockConnection
 from openlibrary.plugins import ol_infobase

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -11,8 +11,7 @@ Pillow==6.2.1
 pymarc==3.1.13
 python-memcached==1.59
 simplejson==3.16.0
-web.py==0.39; python_version < '3.0'
-web.py==0.40; python_version >= '3.0'
+web.py==0.40
 pystatsd==0.1.6
 PyYAML==4.2b4
 eventer==0.1.1


### PR DESCRIPTION
https://github.com/webpy/webpy/blob/master/ChangeLog.txt

Blocked by ~internetarchive/infogami#46~

Fails on:
```
infogami/utils/view.py:69: in <module>
    utf8=web.utf8,
E   AttributeError: 'module' object has no attribute 'utf8'
```
https://travis-ci.org/internetarchive/openlibrary/jobs/590405210#L773