### PR TITLE
Dialogs: Move click handler from templates to JS

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -8,7 +8,6 @@ $def with (ocaid)
       <div class="floaterHead">
         <h2>$_('Preview Book')</h2>
         <a class="floaterShut" data-key="book_preview" data-ol-link-track="book_preview"
-           href="javascript:;" onclick="\$.fn.colorbox.close();"
            title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
       </div>
       <div id="bookPreviewIframe" class="lazyIframe">

--- a/openlibrary/macros/databarAuthor.html
+++ b/openlibrary/macros/databarAuthor.html
@@ -27,7 +27,7 @@ $if ctx.user:
             <div class="floaterAdd" id="addList">
                 <div class="floaterHead">
                     <h2>Create a new list</h2>
-                    <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("×")</span></a>
+                    <a class="floaterShut">&times;<span class="shift">$_("×")</span></a>
                 </div>
                 <form method="post" action="" class="floatform">
                 <div class="formElement">
@@ -58,7 +58,7 @@ $if ctx.user:
                     <div class="input">
                         <button type="button" class="larger">Add new list</button>
                         &nbsp; &nbsp;
-                        <a href="javascript:;" onclick="\$.fn.colorbox.close();" class="small plain red">Cancel</a>
+                        <a class="small plain red floaterShut">Cancel</a>
                     </div>
                     <div class="label"></div>
                 </div>

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -1,0 +1,9 @@
+/**
+ * Wires up dialog close buttons
+ */
+export default function initDialogs() {
+    // This will close the dialog in the current page.
+    $('.floaterShut').attr('href', 'javascript:;').on('click', () => $.fn.colorbox.close());
+    // This will close the colorbox from the parent.
+    $('.floaterShut--parent').on('click', () => parent.$.fn.colorbox.close());
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -33,6 +33,7 @@ import initValidate from './validate';
 import '../../../../static/css/js-all.less';
 // polyfill Promise support for IE11
 import Promise from 'promise-polyfill';
+import initDialogs from './dialog';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -73,6 +74,7 @@ jQuery(function () {
     const $markdownTextAreas = $('textarea.markdown');
     // Live NodeList is cast to static array to avoid infinite loops
     const $carouselElements = $('.carousel--progressively-enhanced');
+    initDialogs();
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);

--- a/openlibrary/templates/books/edit/addcover.html
+++ b/openlibrary/templates/books/edit/addcover.html
@@ -4,7 +4,7 @@ $def with (book)
     <div class="floater" id="addCover">
         <div class="floaterHead">
             <h2>Book Covers</h2>
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+            <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <form class="floatform" id="addcover-form" name="bookcover" method="POST" enctype="multipart/form-data" action="/uploadcover">
             <div id="popThisUp2" class="floaterAlert hidden"><strong>Ahem.</strong> You appear not to have specified an image. Please choose one?</div>
@@ -29,7 +29,7 @@ $def with (book)
 
             <div class="formButtons">
                 <button type="submit" name="coverUpload" id="coverUpload" value="Upload" style="width:auto!important;">$_("Upload")</button>
-                <a id="coverClose" href="javascript:;" onclick="parent.\$.fn.colorbox.close();">$_("Cancel")</a>
+                <a id="coverClose" class="floaterShut">$_("Cancel")</a>
             </div>
         </form>
     </div>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -126,7 +126,7 @@ window.q.push(function(){
 
             <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == "/type/work" else '50px 0px 0px 30px;')">
                 <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest">$_("Submit")</button>
-                <a class="close-popup floaterClose" href="javascript:;" onclick="parent.\$.fn.colorbox.close();">$_("Cancel")</a>
+                <a class="close-popup floaterClose floaterShut--parent" href="javascript:;">$_("Cancel")</a>
             </div>
 
         </div>

--- a/openlibrary/templates/covers/author_photo.html
+++ b/openlibrary/templates/covers/author_photo.html
@@ -13,9 +13,9 @@ $if author_thumbnail_url:
         <div class="coverFloat" id="seeImage">
             <div class="coverFloatHead">
                 <h2>$truncate(author.name or "", 60)</h2>
-                <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+                <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
             </div>
-            <a href="javascript:;" onclick="\$.fn.colorbox.close();" title="Click to close"><img src="$author_photo_url" class="cover" alt="Photo of $author.name"/></a>
+            <a class="floaterShut" title="Click to close"><img src="$author_photo_url" class="cover" alt="Photo of $author.name"/></a>
         </div>
     </div>
 $else:

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -31,8 +31,8 @@ $else:
     <div class="coverFloat" id="seeImage">
         <div class="coverFloatHead">
             <h2>$:macros.TruncateString(title, 70)</h2>
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+            <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <a href="javascript:;" onclick="\$.fn.colorbox.close();"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
+        <a class="floaterShut"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
     </div>
 </div>

--- a/openlibrary/templates/covers/book_cover_single_edition.html
+++ b/openlibrary/templates/covers/book_cover_single_edition.html
@@ -26,8 +26,8 @@ $else:
 <div class="hidden">
     <div class="coverFloat" id="seeImage">
         <div class="coverFloatHead">
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+            <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <a href="javascript:;" onclick="\$.fn.colorbox.close();"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
+        <a class="floaterShut"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
     </div>
 </div>

--- a/openlibrary/templates/covers/book_cover_work.html
+++ b/openlibrary/templates/covers/book_cover_work.html
@@ -22,8 +22,8 @@ $else:
 <div class="hidden">
     <div class="coverFloat" id="seeImage">
         <div class="coverFloatHead">
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+            <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <a href="javascript:;" onclick="\$.fn.colorbox.close();"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
+        <a class="floaterShut"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
     </div>
 </div>

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -121,7 +121,7 @@ window.q.push(function(){
     <div class="floater" id="addImage">
         <div class="floaterHead">
             <h2>$title</h2>
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+            <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
         </div>
 
         <div id="tabsImages" class="tabs tabsPop">

--- a/openlibrary/templates/covers/manage.html
+++ b/openlibrary/templates/covers/manage.html
@@ -58,7 +58,7 @@ window.q.push(function () {
 
     <div class="formElement" style="margin:40px 0 0 30px;">
         <button type="submit" value="Save" class="largest">$_("Save")</button>
-        <a class="floaterClose close-popup" href="javascript:;" onclick="parent.\$.fn.colorbox.close();">$_("Cancel")</a>
+        <a class="floaterClose floaterShut--parent close-popup">$_("Cancel")</a>
     </div>
 
 </form>

--- a/openlibrary/templates/lib/markdown.html
+++ b/openlibrary/templates/lib/markdown.html
@@ -10,7 +10,7 @@ window.q.push(function(){
     <div class="floater" id="markdown">
         <div class="floaterHead">
             <h2>Formatting Help</h2>
-            <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+            <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div class="floaterBody">
 
@@ -75,7 +75,7 @@ window.q.push(function(){
         </table>
 
         <p>$_('To "escape" any Markdown tags (i.e. use an asterisk as an asterisk rather than emphasizing text) place a backslash \ prior to the character.')</p>
-        <div class="small"><a href="javascript:;" onclick="\$.fn.colorbox.close();" class="red">Close</a></div>
+        <div class="small"><a class="red floaterShut">Close</a></div>
 
         </div>
     </div>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -274,7 +274,7 @@ $if ctx.user:
         <div class="floaterAdd" id="addList">
             <div class="floaterHead">
                 <h2>Create a new list</h2>
-                <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">$_("Close")</span></a>
+                <a class="floaterShut">&times;<span class="shift">$_("Close")</span></a>
             </div>
             <form method="post" class="floatform" name="new-list" id="new-list">
             <div class="formElement">
@@ -297,7 +297,7 @@ $if ctx.user:
                 <div class="input">
                     <button type="submit" class="larger">Create new list</button>
                     &nbsp; &nbsp;
-                    <a href="javascript:;" onclick="\$.fn.colorbox.close();" class="small plain red">Cancel</a>
+                    <a class="small floaterShut plain red">Cancel</a>
                 </div>
                 <div class="label"></div>
             </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -372,7 +372,7 @@ $if ctx.user and ctx.user.is_admin():
         <div class="coverFloat" id="wikicode">
             <div class="coverFloatHead">
               <h2>Wikipedia citation</h2>
-              <a class="floaterShut" href="javascript:;" onclick="\$.fn.colorbox.close();">&times;<span class="shift">Close</span></a>
+              <a class="floaterShut">&times;<span class="shift">Close</span></a>
             </div>
             <p>Copy and paste this code into your Wikipedia page. <a href="http://en.wikipedia.org/wiki/Template:Cite#Citing_books" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
             <form method="get">


### PR DESCRIPTION
### Description
From now on simply adding a class .floaterShut to an element will make it close an open dialog.
.floaterShut--parent will request the parent element closes it.

Previously we did this via inline JavaScript which made it really hard to determine which pages should run this code. Having it in a central place also allows us in future to defer the loading of jquery ui off the critical path. This is the most simple first step!

### Testing
Visit http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain#addImage and click "change cover". The close icon should close the dialog

