### PR TITLE
WIP: Taking jQuery UI off the critical path

### DIFF
--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -2,22 +2,8 @@
  * Setup actions on document.ready for standard classNames.
  */
 export default function($) {
-    var options;
     // Flash messages are hidden by default so that CSS is not on the critical path.
     $('.flash-messages').show();
-
-    // tabs
-    options = {};
-    if ($.support.opacity){
-        options.fx = {opacity: 'toggle'};
-    }
-
-    if ($('.tabs:not(.ui-tabs)').tabs) {
-        $('.tabs:not(.ui-tabs)').tabs(options)
-        $('.tabs.autohash').bind('tabsselect', function(event, ui) {
-            document.location.hash = ui.panel.id;
-        });
-    }
 
     // validate forms
     $('form.validate').ol_validate();

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -1,3 +1,4 @@
+import initTabs from './tabs';
 
 /*
  * a confirm dialog for confirming actions
@@ -77,8 +78,16 @@ function initConfirmationDialogs() {
 export default function initDialogs() {
     $('.dialog--open').on('click', function () {
         const $link = $(this),
-            href = `#${$link.attr('aria-controls')}`;
+            href = `#${$link.attr('aria-controls')}`,
+            $dialogTabs = $(href).find('.tabs');
 
+        // setup any tabs inside dialog
+        // Note - in a perfect world these would not be so coupled, but this will require
+        // further work moving the HTML generation of the dialog from Python templates to JS
+        // Which we will get to soon!
+        if ($dialogTabs.length) {
+            initTabs($dialogTabs);
+        }
         $link.colorbox({ inline: true, opacity: '0.5', href,
             maxWidth: '640px', width: '100%' });
     });

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -1,3 +1,35 @@
+
+/*
+ * a confirm dialog for confirming actions
+ * @return {Function}
+ */
+function confirmDialog() {
+    /**
+    * @param {Function} callback
+    * @param {Object} options
+    * @return {jQuery.Object}
+    */
+    return function(callback, options) {
+        var _this = this;
+        var defaults = {
+            autoOpen: false,
+            width: 400,
+            modal: true,
+            resizable: false,
+            buttons: {
+                'Yes, I\'m sure': function() {
+                    callback.apply(_this);
+                },
+                'No, cancel': function() {
+                    $(_this).dialog('close');
+                }
+            }
+        };
+        options = $.extend(defaults, options);
+        return this.dialog(options);
+    };
+}
+
 /**
  * Wires up confirmation prompts.
  * In future this will be generalised.
@@ -33,6 +65,7 @@ function initConfirmationDialogs() {
             }
         })
     );
+    $.fn.ol_confirm_dialog = confirmDialog();
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -27,7 +27,7 @@ import * as Browser from './Browser';
 import { commify } from './python';
 import { Subject, urlencode, slice } from './subjects';
 import Template from './template.js';
-// Add $.fn.focusNextInputField, $.fn.ol_confirm_dialog
+// Add $.fn.focusNextInputField
 import { closePopup, truncate, cond } from './utils';
 import initValidate from './validate';
 import '../../../../static/css/js-all.less';
@@ -74,7 +74,7 @@ jQuery(function () {
     // Live NodeList is cast to static array to avoid infinite loops
     const $carouselElements = $('.carousel--progressively-enhanced');
     initDialogs();
-    initTabs($('#tabsAddbook,#tabsAddauthor'));
+    initTabs($('#tabsAddbook,#tabsAddauthor,.tabs:not(.ui-tabs)'));
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,10 +1,6 @@
 import 'jquery';
 import 'jquery-migrate';
 import 'jquery-validation';
-// npm jquery-ui@1.12.1 package does not match the one we have here, so for now we load from vendor
-import '../../../../vendor/js/jquery-ui/jquery-ui-1.12.1.min.js';
-// For dialog boxes (e.g. add to list)
-import '../../../../vendor/js/colorbox/1.5.14.js';
 // jquery.form#2.36 not on npm, no longer getting worked on
 import '../../../../vendor/js/jquery-form/jquery.form.js';
 // jquery-autocomplete#1.1 with modified
@@ -35,6 +31,8 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import initDialogs from './dialog';
 import initTabs from './tabs.js';
+import initManageCovers from './manageCovers.js';
+import jQueryUI from './jquery-ui';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -71,10 +69,12 @@ window.Promise = Promise;
 // Initialise some things
 jQuery(function () {
     const $markdownTextAreas = $('textarea.markdown');
-    // Live NodeList is cast to static array to avoid infinite loops
     const $carouselElements = $('.carousel--progressively-enhanced');
+
+    jQueryUI.stub();
     initDialogs();
     initTabs($('#tabsAddbook,#tabsAddauthor,.tabs:not(.ui-tabs)'));
+    initManageCovers();
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);

--- a/openlibrary/plugins/openlibrary/js/jquery-ui/index.js
+++ b/openlibrary/plugins/openlibrary/js/jquery-ui/index.js
@@ -1,0 +1,42 @@
+function init() {
+    return import(
+        /* webpackChunkName: "ui" */
+        './ui'
+    );
+}
+
+/**
+ * Returns a placeholder jQuery UI function which when invoked will
+ * load jQuery UI and make the element functional.
+ * @param {string} fnName to call when loaded e.g. sortable,tabs,colorbox
+ */
+export function placeholder(fnName) {
+    return function () {
+        // only if the selector matches load the additional code and wire it up.
+        if ($(this).length) {
+            init().then(() => {
+                if (fnName === 'colorbox') {
+                    // set option to open immediately since loading was delayed.
+                    arguments[0].open = true;
+                }
+                // apply it for real now this function has been replaced
+                $(this)[fnName].apply(this, arguments);
+            });
+        }
+        return $(this);
+    };
+}
+
+/**
+ * Create a stub of the jQuery UI interface that is conditionally
+ * loaded only when needed.
+ */
+function stub() {
+    $.fn.tabs = placeholder('tabs');
+    $.fn.colorbox = placeholder('colorbox');
+    $.fn.dialog = placeholder('dialog');
+    $.fn.sortable = placeholder('sortable');
+    $.fn.disableSelection = placeholder('disableSelection');
+}
+
+export default { stub };

--- a/openlibrary/plugins/openlibrary/js/jquery-ui/ui.js
+++ b/openlibrary/plugins/openlibrary/js/jquery-ui/ui.js
@@ -1,0 +1,4 @@
+// npm jquery-ui@1.12.1 package does not match the one we have here, so for now we load from vendor
+import '../../../../../vendor/js/jquery-ui/jquery-ui-1.12.1.min.js';
+// For dialog boxes (e.g. add to list)
+import '../../../../../vendor/js/colorbox/1.5.14.js';

--- a/openlibrary/plugins/openlibrary/js/manageCovers.js
+++ b/openlibrary/plugins/openlibrary/js/manageCovers.js
@@ -1,0 +1,15 @@
+import { placeholder } from './jquery-ui';
+
+/**
+ * Prepares the manage covers form that is displayed inside
+ * openlibrary/templates/covers/manage.html.
+ */
+export default function initManageCovers() {
+    const $container = $('.manage-covers-form');
+    if ($container.length) {
+        $container.find('.column').sortable({ connectWith: '.trash' });
+        $container.find('.trash').sortable({ connectWith: '.column' });
+        $container.find('.column').disableSelection();
+        $container.find('.trash').disableSelection();
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -2,4 +2,7 @@ const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
 
 export default function initTabs($node) {
     $node.tabs(TABS_OPTIONS);
+    $node.filter('.autohash').bind('tabsselect', function(event, ui) {
+        document.location.hash = ui.panel.id;
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -1,3 +1,5 @@
+import { placeholder } from './jquery-ui';
+
 const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
 
 export default function initTabs($node) {

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -10,27 +10,6 @@ $.fn.focusNextInputField = function() {
     });
 };
 
-// Confirm dialog with OL styles.
-$.fn.ol_confirm_dialog = function(callback, options) {
-    var _this = this;
-    var defaults = {
-        autoOpen: false,
-        width: 400,
-        modal: true,
-        resizable: false,
-        buttons: {
-            'Yes, I\'m sure': function() {
-                callback.apply(_this);
-            },
-            'No, cancel': function() {
-                $(_this).dialog('close');
-            }
-        }
-    };
-    options = $.extend(defaults, options);
-    this.dialog(options);
-}
-
 // closes active popup
 // used in templates/covers/saved.html
 export function closePopup() {

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -103,7 +103,7 @@ window.q.push(function(){
             <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
         </div>
 
-        <div id="tabsImages" class="tabs tabsPop">
+        <div id="tabsImages" class="tabs tabsPop ui-tabs">
             <ul>
                 <li><a href="#imagesAdd">Add</a></li>
                 <li><a href="#imagesManage">Manage</a></li>

--- a/openlibrary/templates/covers/manage.html
+++ b/openlibrary/templates/covers/manage.html
@@ -5,14 +5,6 @@ $putctx('robots', 'noindex,nofollow')
 
 <script type="text/javascript">
 window.q.push(function () {
-    \$(".column").sortable({
-        connectWith: '.trash'
-    });
-    \$(".trash").sortable({
-        connectWith: '.column'
-    });
-    \$(".column").disableSelection();
-    \$(".trash").disableSelection();
     \$("#topNotice").hide();
 });
 </script>
@@ -21,7 +13,7 @@ window.q.push(function () {
     $_("You can drag and drop thumbnails to reorder, or into the trash to delete them.")
 </div>
 
-<form class="floatform" action="" method="post">
+<form class="floatform manage-covers-form" action="" method="post">
     <div class="column">
     $for image in images:
         <div class="portlet">

--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -27,21 +27,20 @@ $if "type" in doc and doc.type.key == "/type/user":
                     .find(".listDelete a")
                     .click(function() {
                         \$('#delete-dialog')
+                            .ol_confirm_dialog(function(){
+                                var list_id = "#" + \$(this).data("list-id");
+                                var key = \$(list_id + " a:first").attr("href");
+                                var dialog = this;
+
+                                \$.post(key + "/delete.json", function() {
+                                    \$(list_id).remove();
+                                    \$(dialog).dialog("close");
+                                });
+                            })
                             .data("list-id", \$(this).closest("li").attr("id"))
                             .dialog('open');
                         return false;
                     });
-
-                \$("#delete-dialog").ol_confirm_dialog(function(){
-                    var list_id = "#" + \$(this).data("list-id");
-                    var key = \$(list_id + " a:first").attr("href");
-                    var dialog = this;
-
-                    \$.post(key + "/delete.json", function() {
-                        \$(list_id).remove();
-                        \$(dialog).dialog("close");
-                    });
-                });
             });
         </script>
         <div id="delete-dialog" class="hidden" title="Delete list">Are you sure you want to delete this list?</div>
@@ -56,22 +55,21 @@ $else:
             .find(".listDelete a")
             .click(function() {
                 \$('#remove-dialog')
+                    .ol_confirm_dialog(function() {
+                        var seed = $:json_encode(seed);
+                        var list_id = "#" + \$(this).data("list-id");
+                        var key = \$(list_id + " a:first").attr("href");
+
+                        var dialog = this;
+
+                        remove_seed(key, seed, function() {
+                            \$(list_id).remove();
+                            \$(dialog).dialog("×");
+                        });
+                    })
                     .data("list-id", \$(this).closest("li").attr("id"))
                     .dialog('open');
                 return false;
-            });
-
-            \$("#remove-dialog").ol_confirm_dialog(function() {
-                var seed = $:json_encode(seed);
-                var list_id = "#" + \$(this).data("list-id");
-                var key = \$(list_id + " a:first").attr("href");
-
-                var dialog = this;
-
-                remove_seed(key, seed, function() {
-                    \$(list_id).remove();
-                    \$(dialog).dialog("×");
-                });
             });
         });
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -494,6 +494,7 @@ $if ctx.user:
         \$("a.remove-from-list").click(function(event) {
             event.preventDefault();
             var id = \$(this).attr("id");
+            setup_dialog();
 
             \$("#remove-dialog")
                 .data("list-id", id)
@@ -526,7 +527,6 @@ $if ctx.user:
     window.q.push(function(){
         setup_submit_event();
         setup_events();
-        setup_dialog();
 
         var mylist = \$('.dropdown');
         var listitems = mylist.children('p.list').get();

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   },
   "bundlesize": [
     {
+      "path": "static/build/ui.js",
+      "maxSize": "70.4KB"
+    },
+    {
       "path": "static/build/editions-table.js",
       "maxSize": "16.7KB"
     },
@@ -33,7 +37,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "146.3KB"
+      "maxSize": "75.3KB"
     },
     {
       "path": "static/build/page-admin.css",


### PR DESCRIPTION
### Description
I'm working towards pulling jquery off the critical path. To make code review manageable I will be splitting off pieces of code review one by one.

See: #2421 for first code review.

Closes #2340

### Technical
<!-- What should be noted about the implementation? -->

### Testing
* It should be possible to click "change cover" on http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain# and it should open a dialog. The dialog should contain tabs and the 2nd tab should allow removing covers via the trash can.
* Add the book to a list and click the X next to the list name - a confirm dialog should show

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
