### PR TITLE
refresh the git submodules in ./vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,16 @@ install:
   - pip install flake8
   - make lint
   - pip install -r requirements_test.txt
+  # refresh the git submodule ./vendor/acs4_py
+  # refresh the git submodule ./vendor/infogami
+  # git commit those changes into this pull request
   # if Travis is running Python 3, then
-  #   refresh the git submodule ./vendor/acs4_py
-  #   refresh the git submodule ./vendor/infogami
-  #   git commit those changes into this pull request
-  #   TODO: flake8 ./vendor --select=E9,F63,F7,F82 to unsure new versions pass
   #   create a legacy Python for npm/node until nodejs/node#25789 is resolved
+  - pushd vendor/acs4_py  && git pull origin master && popd
+  - pushd vendor/infogami && git pull origin master && popd
+  - git status
+  - git commit -am"Update git submodules in .vendor"
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
-      pushd vendor/acs4_py  && git pull origin master && popd;
-      pushd vendor/infogami && git pull origin master && popd;
-      git status;
-      git commit -am"Update git submodules in .vendor";
       pyenv install 2.7.14;
     fi
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # if Travis is running Python 3, then
   #   create a legacy Python for npm/node until nodejs/node#25789 is resolved
   - pushd vendor/acs4_py  && git pull origin master && popd
-  - pushd vendor/infogami && git pull origin master && popd
+  # - pushd vendor/infogami && git pull origin master && popd
   - git status
   - git commit -am"Update git submodules in .vendor"
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Apply #2320 on both Python 2 and Python 3

Allows the Travis CI runs on both Python 2 and Python 3 to test against the current __acs4_py__ and __infogami__ git submodules instead of continuing to use the stale versions.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
