### PR TITLE
Refresh the git submodule ./vendor/acs4_py in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ install:
   - pip install flake8
   - make lint
   - pip install -r requirements_test.txt
+  # refresh the git submodule ./vendor/acs4_py
+  - pushd vendor/acs4_py  && git pull origin master && popd
   # if Travis is running Python 3, then
-  #   refresh the git submodule ./vendor/acs4_py
   #   refresh the git submodule ./vendor/infogami
   #   git commit those changes into this pull request
   #   TODO: flake8 ./vendor --select=E9,F63,F7,F82 to unsure new versions pass
   #   create a legacy Python for npm/node until nodejs/node#25789 is resolved
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
-      pushd vendor/acs4_py  && git pull origin master && popd;
       pushd vendor/infogami && git pull origin master && popd;
       git status;
       git commit -am"Update git submodules in .vendor";


### PR DESCRIPTION
Apply #2320 on the git submodule __./vendor/acs4_py__ for both Python 2 and Python 3.  Also see: internetarchive/acs4_py#7

__./vendor/acs4_py__ is now completely ported to support both Python 2 and Python 3 so we should refresh that submodule in this repo.  This PR proves that it is safe to do so.  Once this PR is approved, the same change should be made at the repo level.

@db48x, your review please.

### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
