### PR TITLE
Remove misleading duplicated text

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -52,7 +52,7 @@ $else:
         <div class="formElement">
             <div class="label">
                 <label for="password">$("Choose a password")</label>
-                <span class="smaller lighter">$_("Letters and numbers only please, and at least 3 characters.")</span></div>
+            </div>
             <div class="input">
                 <input value="" type="password" class="required" name="password" id="password"/>
                 <span class="invalid clearfix" htmlfor="password">$form.password.note</span>
@@ -61,7 +61,7 @@ $else:
         <div class="formElement">
             <div class="label">
               <label for="password">$("Confirm password")</label>
-              <span class="smaller lighter">$_("Letters and numbers only please, and at least 3 characters.")</span></div>
+            </div>
             <div class="input">
               <input value="" type="password" class="required" name="password2" id="password2"/>
               <span class="invalid clearfix" htmlfor="password2">$form.password2.note</span>


### PR DESCRIPTION
# Description
Fix.

Remove the text next to the _password_ and _confirm password_ inputs on the account creation page. It's misleading, because the site does in fact allow symbols in passwords.