### PR TITLE
Fixes find_matching_work()

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -170,7 +170,7 @@ def build_author_reply(author_in, edits):
         author_reply.append({
             'key': a['key'],
             'name': a['name'],
-            'status': ('created' if new_author else 'modified'),
+            'status': ('created' if new_author else 'matched'),
         })
     return (authors, author_reply)
 
@@ -507,7 +507,7 @@ def load_data(rec, account=None):
             "success": True,
             "work": {"key": <key>, "status": "created" | "modified" | "matched"},
             "edition": {"key": <key>, "status": "created"},
-            "authors": [{"status": "modified", "name": "John Smith", "key": <key>}, ...]
+            "authors": [{"status": "matched", "name": "John Smith", "key": <key>}, ...]
         }
     """
 

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -132,8 +132,8 @@ def find_matching_work(e):
     seen = set()
     for a in e['authors']:
         q = {
-            'type':'/type/work',
-            'authors.author': a['key'],
+            'type': '/type/work',
+            'authors': {'author': {'key': a['key']}}
         }
         work_keys = list(web.ctx.site.things(q))
         for wkey in work_keys:

--- a/openlibrary/catalog/add_book/test_add_book.py
+++ b/openlibrary/catalog/add_book/test_add_book.py
@@ -781,14 +781,47 @@ def test_existing_work(mock_site, add_languages):
     existing_work = {
         'authors': [{'author': '/authors/OL20A', 'type': {'key': '/type/author_role'}}],
         'key': '/works/OL16W',
-        'title': "Finding existing works",
+        'title': 'Finding existing works',
         'type': {'key': '/type/work'},
     }
     mock_site.save(author)
     mock_site.save(existing_work)
     rec = {
             'source_records': 'non-marc:test',
-            'title': "Finding Existing Works",
+            'title': 'Finding Existing Works',
+            'authors': [{'name': 'John Smith'}],
+            'publishers': ['Black Spot'],
+            'publish_date': 'Jan 09, 2011',
+            'isbn_10': ['1250144051'],
+           }
+
+    reply = load(rec)
+    assert reply['success'] is True
+    assert reply['edition']['status'] == 'created'
+    assert reply['work']['status'] == 'matched'
+    assert reply['work']['key'] == '/works/OL16W'
+    assert reply['authors'][0]['status'] == 'matched'
+    e = mock_site.get(reply['edition']['key'])
+    assert e.works[0]['key'] == '/works/OL16W'
+
+
+def test_existing_work_with_subtitle(mock_site, add_languages):
+    author = {
+        'type': {'key': '/type/author'},
+        'name': 'John Smith',
+        'key': '/authors/OL20A'}
+    existing_work = {
+        'authors': [{'author': '/authors/OL20A', 'type': {'key': '/type/author_role'}}],
+        'key': '/works/OL16W',
+        'title': 'Finding existing works',
+        'type': {'key': '/type/work'},
+    }
+    mock_site.save(author)
+    mock_site.save(existing_work)
+    rec = {
+            'source_records': 'non-marc:test',
+            'title': 'Finding Existing Works',
+            'subtitle': 'the ongoing saga!',
             'authors': [{'name': 'John Smith'}],
             'publishers': ['Black Spot'],
             'publish_date': 'Jan 09, 2011',

--- a/openlibrary/catalog/add_book/test_add_book.py
+++ b/openlibrary/catalog/add_book/test_add_book.py
@@ -757,6 +757,7 @@ def test_don_quixote(mock_site):
     print("Work status counts: %s" % work_status_counts)
     print("Author status counts: %s" % author_status_counts)
 
+
 def test_same_twice(mock_site, add_languages):
     rec = {
             'source_records': ['ia:test_item'],
@@ -785,7 +786,6 @@ def test_existing_work(mock_site, add_languages):
     }
     mock_site.save(author)
     mock_site.save(existing_work)
-
     rec = {
             'source_records': 'non-marc:test',
             'title': "Finding Existing Works",
@@ -799,4 +799,7 @@ def test_existing_work(mock_site, add_languages):
     assert reply['success'] is True
     assert reply['edition']['status'] == 'created'
     assert reply['work']['status'] == 'matched'
+    assert reply['work']['key'] == '/works/OL16W'
     assert reply['authors'][0]['status'] == 'matched'
+    e = mock_site.get(reply['edition']['key'])
+    assert e.works[0]['key'] == '/works/OL16W'

--- a/openlibrary/catalog/add_book/test_add_book.py
+++ b/openlibrary/catalog/add_book/test_add_book.py
@@ -162,8 +162,16 @@ def test_load_with_new_author(mock_site, ia_writeback):
     assert reply['success'] is True
     assert reply['edition']['status'] == 'created'
     assert reply['work']['status'] == 'created'
-    assert reply['authors'][0]['status'] == 'modified'
     akey2 = reply['authors'][0]['key']
+
+    # TODO: There is no code that modifies an author if more data is provided.
+    # previously the status implied the record was always 'modified', when a match was found.
+    #assert reply['authors'][0]['status'] == 'modified'
+    #a = mock_site.get(akey2)
+    #assert 'entity_type' in a
+    #assert a.entity_type == 'person'
+
+    assert reply['authors'][0]['status'] == 'matched'
     assert akey1 == akey2 == '/authors/OL1A'
 
     # Tests same title with different ocaid and author is not overwritten
@@ -762,3 +770,33 @@ def test_same_twice(mock_site, add_languages):
     assert reply['success'] is True
     assert reply['edition']['status'] == 'matched'
     assert reply['work']['status'] == 'matched'
+
+
+def test_existing_work(mock_site, add_languages):
+    author = {
+        'type': {'key': '/type/author'},
+        'name': 'John Smith',
+        'key': '/authors/OL20A'}
+    existing_work = {
+        'authors': [{'author': '/authors/OL20A', 'type': {'key': '/type/author_role'}}],
+        'key': '/works/OL16W',
+        'title': "Finding existing works",
+        'type': {'key': '/type/work'},
+    }
+    mock_site.save(author)
+    mock_site.save(existing_work)
+
+    rec = {
+            'source_records': 'non-marc:test',
+            'title': "Finding Existing Works",
+            'authors': [{'name': 'John Smith'}],
+            'publishers': ['Black Spot'],
+            'publish_date': 'Jan 09, 2011',
+            'isbn_10': ['1250144051'],
+           }
+
+    reply = load(rec)
+    assert reply['success'] is True
+    assert reply['edition']['status'] == 'created'
+    assert reply['work']['status'] == 'matched'
+    assert reply['authors'][0]['status'] == 'matched'

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -157,6 +157,13 @@ class MockSite:
         keys = set(self.docs.keys())
 
         for k, v in query.items():
+            if isinstance(v, dict):
+                # query keys need to be flattened properly,
+                # this corrects any nested keys that have been included
+                # in values.
+                flat = common.flatten_dict(v)[0]
+                k += '.' + web.rstrips(flat[0], '.key')
+                v = flat[1]
             keys = set(k for k in self.filter_index(self.index, k, v) if k in keys)
 
         keys = sorted(keys)

--- a/openlibrary/mocks/tests/test_mock_infobase.py
+++ b/openlibrary/mocks/tests/test_mock_infobase.py
@@ -90,10 +90,17 @@ class TestMockSite:
         assert a.dict() == a2.dict()
 
 
-        assert a.key == "/authors/OL2A"
-        assert a.type.key == "/type/author"
-        assert a.name == "A2"
+        assert a.key == '/authors/OL2A'
+        assert a.type.key == '/type/author'
+        assert a.name == 'A2'
 
         assert [a.type.key for a in work.get_authors()] == ['/type/author']
         assert [a.type.key for a in work.get_authors()] == ['/type/author']
 
+        # this is the query format used in openlibrary/openlibrary/catalog/works/find_works.py get_existing_works(akey)
+        # and https://github.com/internetarchive/openlibrary/blob/dabd7b8c0c42e3ac2700779da9f303a6344073f6/openlibrary/plugins/openlibrary/api.py#L228
+        author_works_q = {
+            'type':'/type/work',
+            'authors': {'author': {'key': a.key}}
+        }
+        assert mock_site.things(author_works_q) == ['/works/OL1W']

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -116,3 +116,12 @@ mk_norm_conversions = [
 @pytest.mark.parametrize('title,expected', mk_norm_conversions)
 def test_mk_norm(title, expected):
     assert mk_norm(title) == expected
+
+mk_norm_matches = [
+        ("Your Baby's First Word Will Be DADA",
+         "Your baby's first word will be DADA"),
+        ]
+
+@pytest.mark.parametrize('a,b', mk_norm_matches)
+def test_mk_norm_equality(a, b):
+    assert mk_norm(a) == mk_norm(b)

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -62,12 +62,15 @@ amazon_titles = [
         ['Last Days at Hot Slit: The Radical Feminism of Andrea Dworkin (Semiotext(e) / Native Agents)',
             'Last Days at Hot Slit',
             'The Radical Feminism of Andrea Dworkin'],
-
-        ]
+        ['Bloody Times: The Funeral of Abraham Lincoln and the Manhunt for Jefferson Davis',
+            'Bloody Times',
+            'The Funeral of Abraham Lincoln and the Manhunt for Jefferson Davis'],
+]
 
 @pytest.mark.parametrize('amazon,title,subtitle', amazon_titles)
 def test_split_amazon_title(amazon, title, subtitle):
     assert split_amazon_title(amazon) == (title, subtitle)
+
 
 def test_clean_amazon_metadata_for_load_subtitle():
     amazon = {"publishers": ["Vintage"], "price": "$4.12 (used)", "physical_format": "paperback", "edition": "Reprint", "authors": [{"name": "David Grann"}], "isbn_13": ["9780307742483"], "price_amt": "4.12", "source_records": ["amazon:0307742482"], "title": "Killers of the Flower Moon: The Osage Murders and the Birth of the FBI", "url": "https://www.amazon.com/dp/0307742482/?tag=internetarchi-20", "offer_summary": {"lowest_new": 869, "amazon_offers": 1, "total_new": 57, "lowest_used": 412, "total_collectible": 2, "total_used": 133, "lowest_collectible": 1475}, "number_of_pages": "400", "cover": "https://images-na.ssl-images-amazon.com/images/I/51PP3iTK8DL.jpg", "languages": ["english"], "isbn_10": ["0307742482"], "publish_date": "Apr 03, 2018", "product_group": "Book", "qlt": "used"}
@@ -76,7 +79,6 @@ def test_clean_amazon_metadata_for_load_subtitle():
     assert result.get('subtitle') == 'The Osage Murders and the Birth of the FBI'
     assert result.get('full_title') == 'Killers of the Flower Moon : The Osage Murders and the Birth of the FBI'
     #TODO: test for, and implement languages
-
 
 # Test cases to add:
 # Multiple authors


### PR DESCRIPTION
### Description
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Using the results of investigating #2436 , this PR uses the correct method of forming a 'all works by an author' infobase query when checking for existing works.

It also modifies the `mock_site` test mock used in many tests to behave the same way in this respect. Previously tests were showing works were being matched because the query worked for the mocked object when they didn't on the real site. 

Added a direct test to test work matching and confirmation that the saved objects do actually match, not just that the returned status is as expected, since that was fake in the case of Author `modified`. 

Fixes #2434 
Closes #2436 

Hopefully it also
Closes #1621
Closes #947 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Here is one book imported on dev that found an existing work match, prior to this code, the test batch of 100 did not find a single work match when multiple should have. https://dev.openlibrary.org/books/OL27325722M/Speak_No_Evil