### PR TITLE
Fixes issue with accounts made previous to reading logs erroring when viewing profiles

### DIFF
--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -39,7 +39,7 @@ $else:
     $:sanitize(format(page.description))
 
     <h2>Reading Log</h2>
-    $if settings.get('public_readlog') == "yes":
+    $if settings and settings.get('public_readlog', 'no') == "yes":
       <p>This user has chosen to publicly share the books they are <a href="$(page.key)/books/currently-reading">currently reading</a>, <a href="$(page.key)/books/already-read">have already read</a>, and <a href="$(page.key)/books/want-to-read">want to read</a>!</p>
     $else:
       <p>This user has chosen to keep their Reading Log private</p>


### PR DESCRIPTION
### Description
Fixes issue with accounts made previous to readlogs when viewing profiles.

Closes #2347 

### Technical
Updated the condition on line 42 of view.html to make sure settings is not null and replaced settings.get('public_readlog') == "yes" with settings.get('public_readlog', 'no') == "yes".

### Testing
1. Do not log in and view the account of someone with readlog set to not public.
2. Do not log in and view the account of someone with readlog set to public.
3. Log in and view the account of someone with readlog set to not public.
4. Log in and view the account of someone with readlog set to public.
5. Log in and view your account with readlog set to not public.
6. Log in and view your account with readlog set to public.

### Evidence
Public:
![readlog_public](https://user-images.githubusercontent.com/7445503/66092577-7ab4d700-e55a-11e9-86c3-b4dab5e44ec1.png)
Not Public:
![readlog_not_public](https://user-images.githubusercontent.com/7445503/66092586-830d1200-e55a-11e9-944e-4e6d69d78b25.png)
