### PR TITLE
make issue and PR templates clearer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,8 +6,6 @@ labels: "Type: Bug"
 assignees: ''
 
 ---
-
-### Description
 <!-- What problem are we solving? What does the experience look like today? What are the symptoms? -->
 
 ### Evidence / Screenshot (if possible)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,8 +6,6 @@ labels: "Type: Feature"
 assignees: ''
 
 ---
-
-### Is your feature request related to a problem? Please describe.
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ### Describe the solution you'd like

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,6 @@ Closes #
 
 <!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
 
-
 ### Technical
 <!-- What should be noted about the implementation? -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
-### Description
+<!-- What issue does this PR close? -->
+Closes #
+
 <!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
 
-Closes #
 
 ### Technical
 <!-- What should be noted about the implementation? -->


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2239 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
this moves the `Closes` text to the top of the PR template
this also removes the "fluff" header before description so it's
easier to see the actual description in the tooltip

### Technical
<!-- What should be noted about the implementation? -->
There is no code implementation within this PR.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I used the template from the PR to create this PR.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2019-10-04 01-53-09](https://user-images.githubusercontent.com/1551593/66184335-c2fef280-e649-11e9-9bd7-537ffc18a14a.png)
