### PR TITLE
add JSON response for subject search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -677,6 +677,20 @@ class subject_search(delegate.page):
 
         return results
 
+class subject_search_json(subject_search):
+    path = '/search/subjects'
+    encoding = 'json'
+
+    def GET(self):
+        i = web.input(q='', offset=0, limit=100)
+        offset = safeint(i.offset, 0)
+        limit = safeint(i.limit, 100)
+        limit = min(1000, limit)  # limit limit to 1000.
+
+        response = self.get_results(i.q, offset=offset, limit=limit)['response']
+        web.header('Content-Type', 'application/json')
+        return delegate.RawText(json.dumps(response))
+
 class author_search(delegate.page):
     path = '/search/authors'
     def GET(self):


### PR DESCRIPTION
Closes #2443 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: This adds a handler for subject search that provides `JSON` encoded documents.

The subjects search at https://openlibrary.org/search/subjects.json?q=teen will now return JSON instead of HTML.

### Technical
<!-- What should be noted about the implementation? -->
This is implemented in the same way that the `author_search` has been implemented to support `JSON` encoded results.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verified that the search works the same before and after the patch.  Verified that the search results page has the same results in both HTML and JSON encoded results pages.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

HTML View of the Astronauts Subject in Dev:
![Screenshot from 2019-10-04 14-11-12](https://user-images.githubusercontent.com/1551593/66230061-4d2e7180-e6b1-11e9-93b8-5950a1498293.png)

JSON View of the Same Page:
![Screenshot from 2019-10-04 13-33-29](https://user-images.githubusercontent.com/1551593/66230034-3be56500-e6b1-11e9-95d5-59ecf5e55e4c.png)
