### PR TITLE
add JSON response encoding for edition search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -721,6 +721,20 @@ class edition_search(delegate.page):
 
         return render_template('search/editions.tmpl', get_results)
 
+class edition_search_json(edition_search):
+    path = '/search/editions'
+    encoding = 'json'
+
+    def GET(self):
+        i = web.input(q='', offset=0, limit=100)
+        offset = safeint(i.offset, 0)
+        limit = safeint(i.limit, 100)
+        limit = min(1000, limit)  # limit limit to 1000.
+
+        response = self.get_results(i.q, offset=offset, limit=limit)['response']
+        web.header('Content-Type', 'application/json')
+        return delegate.RawText(json.dumps(response))
+
 class search_json(delegate.page):
     path = "/search"
     encoding = "json"


### PR DESCRIPTION
Related to #2443 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: This adds a handler for edition search that provides `JSON` encoded documents.

The subjects search at https://openlibrary.org/search/editions.json?q=teen will now return JSON instead of HTML.

### Technical
<!-- What should be noted about the implementation? -->
This is implemented in the same way that the `author_search` has been implemented to support `JSON` encoded results.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verified that the search works the same before and after the patch.  Verified that the search results page has the same results in both HTML and JSON encoded results pages.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

HTML View of the Astronauts Subject in Dev:


JSON View of the Same Page:
