### PR TITLE
add JSON format to list search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -661,7 +661,7 @@ class list_search_json(list_search):
         i = web.input(q='', offset=0, limit=10)
         offset = safeint(i.offset, 0)
         limit = safeint(i.limit, 10)
-        limit = min(100, limit)  # limit limit to 1000.
+        limit = min(100, limit)
 
         docs = self.get_results(i.q, offset=offset, limit=limit)
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -666,22 +666,7 @@ class list_search_json(list_search):
         docs = self.get_results(i.q, offset=offset, limit=limit)
 
         response = {
-            'docs': [
-                {
-                    'key': doc.key,
-                    'url': doc.url(),
-                    'name': doc.name,
-                    'description': str(doc.description),
-                    'last_modified': doc.last_modified.isoformat() if doc.last_modified else None,
-                    'seed_count': len(doc.seeds),
-                    'edition_count': doc.edition_count,
-                    'owner': {
-                        'key': doc.get_owner().key,
-                    },
-                    'top_subjects': [{"key": s.key, "url": s.url, "name": s.name} for s in doc.get_top_subjects(limit=5)],
-                }
-                for doc in docs
-            ]
+            'docs': [doc.preview() for doc in docs]
         }
 
         web.header('Content-Type', 'application/json')

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -647,8 +647,10 @@ class list_search(delegate.page):
             delegate.fakeload()
 
         keys = web.ctx.site.things({
-            "type": "/type/list", "name~": q,
-            "limit": int(limit), "offset": int(offset)
+            "type": "/type/list",
+            "name~": q,
+            "limit": int(limit),
+            "offset": int(offset)
         })
 
         return web.ctx.site.get_many(keys)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -668,6 +668,7 @@ class list_search_json(list_search):
         docs = self.get_results(i.q, offset=offset, limit=limit)
 
         response = {
+            'start': offset,
             'docs': [doc.preview() for doc in docs]
         }
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -672,19 +672,19 @@ class list_search_json(list_search):
 
         response['docs'] = [
             {
-                'key': list.key,
-                'url': list.url(),
-                'name': list.name,
-                'description': str(list.description),
-                'last_modified': list.last_modified.isoformat() if list.last_modified else None,
-                'seed_count': len(list.seeds),
-                'edition_count': list.edition_count,
+                'key': doc.key,
+                'url': doc.url(),
+                'name': doc.name,
+                'description': str(doc.description),
+                'last_modified': doc.last_modified.isoformat() if doc.last_modified else None,
+                'seed_count': len(doc.seeds),
+                'edition_count': doc.edition_count,
                 'owner': {
-                    'key': list.get_owner().key,
+                    'key': doc.get_owner().key,
                 },
-                'top_subjects': [{"key": s.key, "url": s.url, "name": s.name} for s in list.get_top_subjects(limit=5)],
+                'top_subjects': [{"key": s.key, "url": s.url, "name": s.name} for s in doc.get_top_subjects(limit=5)],
             }
-            for list in response['docs']
+            for doc in response['docs']
         ]
 
         web.header('Content-Type', 'application/json')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #2443

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature:  This adds a handler for `lists` search that provides JSON encoded documents.

The subjects search at https://openlibrary.org/search/lists.json?q=beauty will now return JSON instead of HTML.

### Technical
<!-- What should be noted about the implementation? -->
The `lists` return is very different from the values returned from SOLR for `subjects` because it's pulled from the database models instead of from SOLR.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested the search in the docker-compose development environment.

### Evidence
HTML
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2019-10-04 16-57-58](https://user-images.githubusercontent.com/1551593/66239828-def5a900-e6c8-11e9-949e-c735788486a3.png)

JSON
![Screenshot from 2019-10-10 12-18-14](https://user-images.githubusercontent.com/1551593/66587323-2d3afa00-eb58-11e9-813f-ffd02100cd02.png)

