### PR TITLE
Do not split out vendors into separate bundles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,15 @@ module.exports = {
         } ]
     },
     optimization: {
+        splitChunks: {
+            cacheGroups: {
+                // Turn off webpack's default 'vendors' cache group. If this is desired
+                // later on, we can explicitly turn this on for clarity.
+                // https://webpack.js.org/plugins/split-chunks-plugin/#optimization-splitchunks
+                vendors: false,
+
+            }
+        },
         // Don't produce production output when a build error occurs.
         noEmitOnErrors: prod
     },
@@ -86,6 +95,7 @@ module.exports = {
     // The source map is intentionally exposed
     // to users via sourceMapFilename for prod debugging.
     devtool: 'source-map',
+    mode: prod,
 
     performance: {
         maxAssetSize: 703 * 1024,


### PR DESCRIPTION
When viewing the homepage I see requests for carousel.js and
vendors~carousel.js. This was not intended and adds an additional
request. `vendors-carousel` is also not listed in package.json so
we're not tracking the bundlesize correctly without this.

<!-- What issue does this PR close? -->
I didn't raise a ticket. Can raise one if needed.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
Webpack configuration yay!

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Load homepage and look at network tab. Before this patch you should see requests for carousel.js and vendors~carousel.js

After this you'll only see one (larger) request.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
