### PR TITLE
Remove dead JS

### DIFF
--- a/openlibrary/macros/EditButtonsMacros.html
+++ b/openlibrary/macros/EditButtonsMacros.html
@@ -1,9 +1,5 @@
 $def with (comment=None)
 
-<script type="text/javascript">
-\$().ready(Dialog);
-\$().ready(deleteVerify);
-</script>
 <div id="dialog" class="hidden" title="Really delete this macro?"><p>Are you sure you want to delete this?</p></div>
 
 <div class="formElement">

--- a/openlibrary/templates/type/edition-history/view.html
+++ b/openlibrary/templates/type/edition-history/view.html
@@ -54,10 +54,6 @@ $ web = ["download_url", "purchase_url"]
 
 </div>
 
-<script type="text/javascript">
-window.q.push(slidePanels);
-</script>
-
 <div id="contentBody">
 
     <div id="workDetails">


### PR DESCRIPTION
openlibrary/macros/EditButtonsMacros.html:
No references to Dialog or deleteVerify either in any templates
or the global namespace

edition-history/view.html
No global slidePanels function

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes dead code.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Grep. Confirm what I believe that this code is not used anywhere

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
