### PR TITLE
Drop unnecessary $.prop polyfill

### DIFF
--- a/openlibrary/templates/site/donate.html
+++ b/openlibrary/templates/site/donate.html
@@ -1,12 +1,3 @@
 
 $if not is_bot():
   $:get_donation_include()
-
-<script type="text/javascript">
-// The donate javascript included via archive.org uses JQuery 1.6+.
-// The version of jquery used in OL is very old doesn't support .prop function used there.
-// This is a hack to support .prop('checked', true)
-\$.fn.prop = function(name, value) {
-  \$(this).attr(name, name);
-}
-</script>


### PR DESCRIPTION
Our jQuery version is much older than the comment suggests. Drop this polyfill.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Checkout my code.
Verify that $('body').prop still is a function.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
