### PR TITLE
Hotfix/isbn canonicalization

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -3,7 +3,6 @@ $def with (page, opts)
 $ prices = opts.get('prices')
 $ isbn = opts.get('isbn')
 $ asin = opts.get('asin')
-$ scribd = opts.get('scribd')
 
 <ul class="buy-options-table">
   $if not is_bot():
@@ -29,11 +28,5 @@ $ scribd = opts.get('scribd')
               $ amazon_metadata = get_amazon_metadata(isbn)
               $if amazon_metadata and 'price' in amazon_metadata and amazon_metadata['price']:
                   <span name="price">$(amazon_metadata['price'])</span>
-      </li>
-    $if scribd and not (isbn or asin):
-      <li>
-          <a href="https://www.scribd.com/doc/$scribd" title="Look for this edition for sale at Scribd" target="_blank">Scribd</a>
-          <br />
-          <span class="gray smaller">eBook in browser</span>
       </li>
 </ul>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -12,8 +12,7 @@ $ prices = page.key.startswith('/books/')
 
 $ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
 $ isbn_13 = page.get_isbn13()
-$ isbn_10 = isbn_13 and isbn_13_to_isbn_10(isbn_13)
-$ isbn = isbn_10 or isbn_13
+$ isbn_10 = page.get_isbn10()
 
 $ asin = None
 $if page.get('identifiers'):
@@ -55,12 +54,12 @@ $if isbn_10 and not asin:
         $if page.get('ocaid') and not page.is_access_restricted():
             $:macros.DownloadOptions(page)
 
-        $:macros.WorldcatLink(isbn=isbn, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+        $:macros.WorldcatLink(isbn=isbn_13, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
 
         <hr>
         <div class="cta-section">
           <p class="cta-section-title">Buy this book</p>
-          $:macros.AffiliateLinks(page, {'isbn': isbn, 'asin': asin, 'prices': prices})
+          $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
         </div>
 
         $:macros.SocialShare(page)

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -16,10 +16,7 @@ $ isbn_10 = isbn_13 and isbn_13_to_isbn_10(isbn_13)
 $ isbn = isbn_10 or isbn_13
 
 $ asin = None
-$ scribd = None
 $if page.get('identifiers'):
-    $if page.identifiers.get('scribd'):
-        $ scribd = page.identifiers.scribd[0]
     $if page.identifiers.get('amazon'):
         $ asin = page.identifiers.amazon[0]
 
@@ -63,7 +60,7 @@ $if isbn_10 and not asin:
         <hr>
         <div class="cta-section">
           <p class="cta-section-title">Buy this book</p>
-          $:macros.AffiliateLinks(page, {'isbn': isbn, 'asin': asin, 'scribd': scribd, 'prices': prices})
+          $:macros.AffiliateLinks(page, {'isbn': isbn, 'asin': asin, 'prices': prices})
         </div>
 
         $:macros.SocialShare(page)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -18,7 +18,7 @@ from openlibrary.core import lending
 
 from openlibrary.plugins.search.code import SearchProcessor
 from openlibrary.plugins.worksearch.code import works_by_author, sorted_work_editions
-from openlibrary.utils.isbn import isbn_10_to_isbn_13
+from openlibrary.utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10
 from openlibrary.utils.solr import Solr
 
 from utils import get_coverstore_url, MultiDict, parse_toc, get_edition_config
@@ -113,13 +113,23 @@ class Edition(models.Edition):
         w, h = image_sizes[size.upper()]
         return "https://archive.org/download/%s/page/cover_w%s_h%s.jpg" % (itemid, w, h)
 
-    def get_isbn13(self):
-        """Fetches either isbn10 or isbn13 from record and returns canonical
-        isbn13
+    def get_isbn10(self):
+        """Fetches either isbn_10 or isbn_13 from record and returns canonical
+        isbn_10
         """
-        isbn_13 = self.isbn_13 and canonical(self.isbn_13[0]) or ""
-        if not isbn_13:            
-            isbn_10 = self.isbn_10 and self.isbn_10[0] or ""
+        isbn_10 = self.isbn_10 and canonical(self.isbn_10[0])
+        if not isbn_10:
+            isbn_13 = self.get_isbn13()
+            return isbn_13 and isbn_13_to_isbn_10(isbn_13)
+        return isbn_10
+
+    def get_isbn13(self):
+        """Fetches either isbn_13 or isbn_10 from record and returns canonical
+        isbn_13
+        """
+        isbn_13 = self.isbn_13 and canonical(self.isbn_13[0])
+        if not isbn_13:
+            isbn_10 = self.isbn_10 and self.isbn_10[0]
             return isbn_10 and isbn_10_to_isbn_13(isbn_10)
         return isbn_13
     

--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -54,5 +54,10 @@ def opposite_isbn(isbn): # ISBN10 -> ISBN13 and ISBN13 -> ISBN10
             return alt
 
 def normalize_isbn(isbn):
-    """Removes spaces and dashes from isbn and ensures length."""
-    return canonical(isbn) or None
+    """Removes spaces and dashes from isbn and ensures length.
+
+    :param: str isbn: An isbn to normalize
+    :rtype: str|None
+    :return: A valid isbn, or None
+    """
+    return isbn and canonical(isbn) or None

--- a/openlibrary/utils/tests/test_isbn.py
+++ b/openlibrary/utils/tests/test_isbn.py
@@ -17,6 +17,7 @@ def test_opposite_isbn():
     assert opposite_isbn('BAD-ISBN') is None
 
 def test_normalize_isbn():
+    assert normalize_isbn(None) is None
     assert normalize_isbn('a') is None
     assert normalize_isbn('1841151866') == '1841151866'
     assert normalize_isbn('184115186x') == '184115186X'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2473

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->
Removed scribd code which was in the way and being appropriated special cased to show up in the AffiliateLinks sidebar. Scribd still shows up under identifiers, yet no longer erroneously shows up as a buy option.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Add an invalid `isbn_10` (e.g. `9198990604`) to an edition (which has no `isbn_13`). The live website edition page should throw the error below in https://github.com/internetarchive/openlibrary/pull/2475#issuecomment-539239357. Now it should load correctly. The invalid `isbn_10` should be shown correctly in the ID table. I believe an amazon link will appear (if you're on a kube w/ the right credentials).

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://openlibrary.org/books/OL27328216M/Gabriel's_Children -- if you look at the history, this page has only an `isbn_10` (`9198990604` -- which was invalid and) which should have been `0919899064` (since been fixed). The `isbn_10_to_isbn_13` was running `normalize_isbn` on the `isbn_10` which was causing an exception
