### PR TITLE
Pull dialog and tabs code from templates

### DIFF
--- a/openlibrary/macros/databarAuthor.html
+++ b/openlibrary/macros/databarAuthor.html
@@ -19,7 +19,8 @@ $if ctx.user:
                 <div class="dropdown">
                     <p><span>Add to</span> <a href="javascript:;">This is a List Name</a></p>
                     <p><span>Add to</span> <a href="javascript:;">This is Another List Name Which is Longer!</a></p>
-                    <p><a href="javascript:;" class="listClick">Create a new list</a></p>
+                    <p><a aria-controls="addList"
+                        class="listClick dialog--open">Create a new list</a></p>
                 </div>
             </div>
         </div>
@@ -65,9 +66,6 @@ $if ctx.user:
                 </form>
             </div>
         </div>
-        <script type="text/javascript">
-        \$().ready(function(){\$(".listClick").colorbox({inline: true, opacity: "0.5", href: "#addList"})});
-        </script>
 
 </div>
 <!-- IF on a list: -->

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -1,7 +1,56 @@
 /**
+ * Wires up confirmation prompts.
+ * In future this will be generalised.
+ */
+function initConfirmationDialogs() {
+    const CONFIRMATION_PROMPT_DEFAULTS = { autoOpen: false, modal: true };
+    $('#noMaster').dialog(CONFIRMATION_PROMPT_DEFAULTS);
+    $('#confirmMerge').dialog(
+        $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
+            buttons: {
+                'Yes, Merge': function() {
+                    $('#mergeForm').submit();
+                    $(this).parents().find('button').attr('disabled','disabled');
+                },
+                'No, Cancel': function() {
+                    $(this).dialog('close');
+                }
+            }
+        })
+    );
+    $('#leave-waitinglist-dialog').dialog(
+        $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
+            width: 450,
+            resizable: false,
+            buttons: {
+                'Yes, I\'m sure': function() {
+                    $(this).dialog('close');
+                    $(this).data('origin').closest('td').find('form').submit();
+                },
+                'No, cancel': function() {
+                    $(this).dialog('close');
+                }
+            }
+        })
+    );
+}
+
+/**
  * Wires up dialog close buttons
+ * If an element has the class dialog--open it will trigger the
+ * opening of a dialog. The `aria-controls` attribute on that same element
+ * communicates where the HTML of that dialog lives.
  */
 export default function initDialogs() {
+    $('.dialog--open').on('click', function () {
+        const $link = $(this),
+            href = `#${$link.attr('aria-controls')}`;
+
+        $link.colorbox({ inline: true, opacity: '0.5', href,
+            maxWidth: '640px', width: '100%' });
+    });
+    initConfirmationDialogs();
+
     // This will close the dialog in the current page.
     $('.dialog--close').attr('href', 'javascript:;').on('click', () => $.fn.colorbox.close());
     // This will close the colorbox from the parent.

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -34,6 +34,7 @@ import '../../../../static/css/js-all.less';
 // polyfill Promise support for IE11
 import Promise from 'promise-polyfill';
 import initDialogs from './dialog';
+import initTabs from './tabs.js';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -73,6 +74,7 @@ jQuery(function () {
     // Live NodeList is cast to static array to avoid infinite loops
     const $carouselElements = $('.carousel--progressively-enhanced');
     initDialogs();
+    initTabs($('#tabsAddbook,#tabsAddauthor'));
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -1,0 +1,5 @@
+const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
+
+export default function initTabs($node) {
+    $node.tabs(TABS_OPTIONS);
+}

--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -155,25 +155,8 @@ $else:
          title="Leave the Waiting List">Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?</div>
     <script type="text/javascript">
     window.q.push(function() {
-        \$("#leave-waitinglist-dialog").dialog({
-            autoOpen: false,
-            width: 450,
-            modal: true,
-            resizable: false,
-            buttons: {
-                "Yes, I'm sure": function() {
-                    \$(this).dialog("close");
-                    \$(this).data("origin").closest("td").find("form").submit();
-                },
-                "No, cancel": function() {
-                    \$(this).dialog("close");
-                }
-            }
-        });
         \$("a.leave").click(function() {
             var title = \$(this).parents("tr").find(".book").text();
-            console.log("click");
-            console.log([title, \$(this), \$(this).parents("tr")[0]]);
             \$("#leave-waitinglist-dialog strong").text(title);
             \$("#leave-waitinglist-dialog")
                 .data("origin", \$(this))

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -7,20 +7,6 @@ $putctx("robots", "noindex,nofollow")
 
 <script type="text/javascript">
 <!--
-window.q.push( function () {
-    if(jQuery.support.opacity){
-        \$('#tabsAddbook').tabs({fx:{opacity:'toggle'}});
-    } else {
-        \$('#tabsAddbook').tabs();
-    };
-    \$('#coverPop').colorbox({
-      width: '100%',
-      maxWidth: '640px',
-      inline:true,
-      opacity: '0.5',
-      href:'#addCover'
-    });
-} );
 
 function limitChars(textid, limit, infodiv) {
     var text = \$('#'+textid).val();

--- a/openlibrary/templates/covers/author_photo.html
+++ b/openlibrary/templates/covers/author_photo.html
@@ -6,7 +6,7 @@ $ author_photo_url = author.get_photo_url("L")
 $if author_thumbnail_url:
     <div class="author coverMagic">
         <div class="SRPCover bookCover">
-            <a href="#seeImage" class="coverLook" title="Pull up a larger author photo"><img src="$author_thumbnail_url" class="cover" alt="Photo of $author.name"/></a>
+            <a aria-controls="seeImage" class="coverLook dialog--open" title="Pull up a larger author photo"><img src="$author_thumbnail_url" class="cover" alt="Photo of $author.name"/></a>
         </div>
     </div>
     <div class="hidden">

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -14,7 +14,8 @@ $ cover_lg = book.get_cover_url("L")
 $if size == "M":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
-                <a href="$cover_lg" class="coverLook" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" class="cover" alt="Cover of: $title | $author_names"/></a>
+                <a href="$cover_lg" aria-controls="seeImage"
+                    class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" class="cover" alt="Cover of: $title | $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">

--- a/openlibrary/templates/covers/book_cover_single_edition.html
+++ b/openlibrary/templates/covers/book_cover_single_edition.html
@@ -10,7 +10,8 @@ $ cover_lg = book.get_cover_url("L")
 $if size == "M":
     <div class="coverMagic">
         <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
-            <a href="$cover_lg" class="coverLook" title="View a larger book cover"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
+            <a href="$cover_lg" aria-controls="seeImage"
+                class="coverLook dialog--open" title="View a larger book cover"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
         </div>
         <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
             <div class="innerBorder">

--- a/openlibrary/templates/covers/book_cover_work.html
+++ b/openlibrary/templates/covers/book_cover_work.html
@@ -10,7 +10,8 @@ $ cover_lg = book.get_cover_url("L")
 $if size == "M":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
-                <a href="$cover_lg" class="coverLook" title="View a larger book cover"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
+                <a href="$cover_lg" aria-controls="seeImage"
+                    class="coverLook dialog--open" title="View a larger book cover"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <img src="/images/icons/avatar_book-sm.png" height="58" alt="We need a book cover for: $title"/>

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -28,15 +28,6 @@ $else:
         $ size = "smallest"
 
 <script type="text/javascript">
-<!--
-window.q.push(function(){
-    if(jQuery.support.opacity){
-        \$("#tabsImages").tabs({fx:{opacity:'toggle'}});
-    } else {
-        \$("#tabsImages").tabs();
-    };
-});
-
 function update_image(image) {
     var url;
 
@@ -75,13 +66,7 @@ window.q.push(function(){
 
     // Add iframes lazily when the popup is loaded.
     // This avoids fetching the iframes along with main page.
-    \$('.coverPop').colorbox({
-        inline: true,
-        opacity: '0.5',
-        href: '#addImage',
-        width: '100%',
-        maxWidth: '640px'
-    })
+    \$('.coverPop')
         .bind("click", function() {
             // clear the content of #imagesAdd and #imagesManage before adding new
             \$("#imagesAdd").html("");
@@ -101,18 +86,12 @@ window.q.push(function(){
         });
     // Add function to close throbber
     closeThrobber = function() {\$("#throbber").customFadeOut();};
-    // Open larger cover image
-    \$(".coverLook").colorbox({
-        inline: true,
-        opacity:"0.5",
-        href: "#seeImage"
-    });
 });
 //-->
 </script>
 
 <div class="$size sansserif manageCoversContainer hidden--nojs">
-  <a href="#addImage" class="coverPop">
+  <a aria-controls="addImage" class="coverPop dialog--open">
     <div class="manageCovers">$change</div>
   </a>
 </div>

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -44,7 +44,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                     /
                     <a rel="nofollow" href="$opds">OPDS</a>
                 $if show_wikipedia_citation_link:
-                    | <a aria-controls="wikicode" id="wikilink" class="dialog--open" title="Cite this on Wikipedia">Wikipedia citation</a>
+                    | <a aria-controls="wikicode" id="wikilink" class="dialog--open" title="Cite this on Wikipedia" href="javascript:;">Wikipedia citation</a>
             </span>
 
             $if show_wikipedia_citation_link:

--- a/openlibrary/templates/lib/markdown.html
+++ b/openlibrary/templates/lib/markdown.html
@@ -1,11 +1,5 @@
-<span class="small brown">Need <a href="javascript:;" id="markdownPop">help with formatting</a>?</span>
-<script type="text/javascript">
-window.q.push(function(){
-    \$("#markdownPop").colorbox({
-        inline:true, opacity:"0.5", href:"#markdown"
-    });
-});
-</script>
+<span class="small brown">Need <a href="javascript:;"
+    aria-controls="markdown" class="dialog--open" id="markdownPop">help with formatting</a>?</span>
 <div class="hidden">
     <div class="floater" id="markdown">
         <div class="floaterHead">

--- a/openlibrary/templates/lib/message_addbook.html
+++ b/openlibrary/templates/lib/message_addbook.html
@@ -9,7 +9,7 @@ $else:
 
         <h3 class="congrats"><em>Super!</em> Your new record is in the library. Thank you!</h3>
         <p class="brown">There are a few other simple things you can add while you&#8217;re here to improve your new record quickly, and make it much easier for other people to find later.</p>
-        <p class="list"><span class="red">*</span>&nbsp;&nbsp;<a href="#addImage" class="coverPop">Upload a cover image</a> <span class="small sansserif brown">&nbsp;Snap a quick photo of the cover to share?</span></p>
+        <p class="list"><span class="red">*</span>&nbsp;&nbsp;<a aria-controls="addImage" class="coverPop dialog--open">Upload a cover image</a> <span class="small sansserif brown">&nbsp;Snap a quick photo of the cover to share?</span></p>
         <p class="list"><span class="red">*</span>&nbsp;&nbsp;Add an ISBN <span class="small sansserif brown">&nbsp;Help the library connect with other systems, like Amazon.</span></p>
         <p class="list"><span class="red">*</span>&nbsp;&nbsp;Add some subjects <span class="small sansserif brown">&nbsp;They&#8217;re just like tags.</span></p>
         <p class="list"><span class="red">*</span>&nbsp;&nbsp;<a href="$edit_url">Describe what the book&#8217;s about</a> <span class="small sansserif brown">&nbsp;Just a sentence or two is gold.</span></p>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -176,7 +176,8 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                         <p class="list"><a href="$list.key" class="add-to-list" id="list_$i">$list.name</a></p>
                   </div>
                   <p class="create"><a href="javascript:;" id="create-new-list">Create a new list</a>
-                    <a href="javascript:;" class="hidden listClick"></a>
+                    <a aria-controls="addList"
+                      class="hidden listClick dialog--open"></a>
                   </p>
                 </div>
             </div>

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -2,20 +2,6 @@ $def with (keys, top_books_from_author, formdata=None)
 
 <script type="text/javascript">
 window.q.push(function(){
-    \$('#noMaster').dialog({autoOpen:false,modal:true});
-    \$('#confirmMerge').dialog({
-        autoOpen: false,
-        modal: true,
-        buttons: {
-            "Yes, Merge": function() {
-                \$('#mergeForm').submit();
-                \$(this).parents().find('button').attr('disabled','disabled');
-            },
-            "No, Cancel": function() {
-                \$(this).dialog("close");
-            }
-        }
-    });
     \$('#save').click(function(){
         var n = \$("#mergeForm input[type=radio]:checked").length;
         if (n == 0) {

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -4,18 +4,6 @@ $var title: $page.name
 
 $putctx("robots", "noindex,nofollow")
 
-<script type="text/javascript">
-// enable tabs for author page
-window.q.push(function(){
-    if(jQuery.support.opacity){
-        \$("#tabsAddauthor").tabs({fx:{opacity:'toggle'}});
-    } else {
-        \$("#tabsAddauthor").tabs();
-    };
-    \$("#coverPop").colorbox({inline:true, opacity:"0.5", href:"#addCover"});
-});
-</script>
-
 <div id="contentHead">
     $:macros.databarEdit(page)
     <h1>$_("Edit Author")</h1>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -80,13 +80,6 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             $page.date
     </h2>
 </div>
-
-<script type="text/javascript">
-<!--
-window.q.push(function(){\$("#coverPop").colorbox({inline:true, opacity:"0.5", href:"#addImage"});});
-//-->
-</script>
-
 <div id="contentBody">
 
     $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':

--- a/openlibrary/templates/type/edition-history/view.html
+++ b/openlibrary/templates/type/edition-history/view.html
@@ -62,7 +62,8 @@ $ web = ["download_url", "purchase_url"]
 
         <div class="illustration">
             $:macros.CoverImage(page)
-            <div class="smaller sansserif"><a href="javascript:;" id="coverPop">Change Cover</a></div>
+            <div class="smaller sansserif"><a aria-controls="addImage"
+                class="dialog--open" id="coverPop">Change Cover</a></div>
         </div>
 
     $if ids:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -364,8 +364,7 @@ $if ctx.user and ctx.user.is_admin():
     <script type="text/javascript">
     <!--
     window.q.push(function(){
-        \$('#historyTools').append('| <a href="javascript:;" id="wikilink" title="Cite this on Wikipedia">Wikipedia citation</a>');
-        \$('#wikilink').colorbox({inline:true,opacity:"0.5",href:"#wikicode"});
+        \$('#historyTools').append('| <a aria-controls="wikicode" id="wikilink" class="dialog--open" title="Cite this on Wikipedia">Wikipedia citation</a>');
         \$('#wikiselect').focus(function(){\$(this).select();})
     });
     //-->

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "145.8KB"
+      "maxSize": "146.1KB"
     },
     {
       "path": "static/build/page-admin.css",


### PR DESCRIPTION
Inside various templates we call $.tabs, $.colorbox and $.dialog - these will now be invoked inside JavaScript and only when the element is clicked to minimise the intial JS execution.

In the case of the dialog for changing covers, the use of $.tabs is delayed until just before the dialog is presented to the user

<!-- What issue does this PR close? -->
This is helping us work towards fixing #2340

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This shifts code from templates to the client.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1) Confirm that the code moved from templates is now accounted for in the JS.

2) Visit https://openlibrary.org/books/OL18141225M/Snow_crash/edit and confirm that the tabs are shown and usable (what's it about? add excerpts links )

3) Confirm that when hovering over a cover shows "manage cover" on https://openlibrary.org/books/OL18141225M/Snow_crash . When clicked a dialog should open with add and manage tabs. In manage tabs I should be able to move covers between the trash can and normal area.

4) I should be able to edit the author see tabs. I should also be able to change the authors photo (all checks of 3 should apply to author page too)

5) When I click "Wikipedia citation" on https://openlibrary.org/books/OL18141225M/Snow_crash ensure a dialog shows with a textarea and source code.

6) When I attempt to merge authors I see a dialog asking me to confirm


### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
