### PR TITLE
Revert "Fixes Publishers page displaying only 2 pages of works (#2471)"

### DIFF
--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -326,15 +326,6 @@ class SubjectEngine:
                     subject[meta.key].pop(i)
                     break
 
-        # Fetch more works until offset is > than work_count.
-        # This ensures that we render the correct ammount of works.
-        if offset < subject.work_count:
-            rest_subject = get_subject(
-                key, details=details, offset=limit + offset, sort=sort,
-                limit=limit, **filters)
-            if len(rest_subject.works) > 0:
-                subject.works.extend(rest_subject.works)
-            
         return subject
 
     def get_meta(self, key):


### PR DESCRIPTION
hotfix. This reverts commit 2d54f0662a6fc44b80370ad9f30b6d5c88187ce2.

Getting 504s on prod, and `maximum recursion` exceed errors when trying to view large subjects/publisher pages.
