### PR TITLE
Now any eligible book can be sponsored (no cost limit)

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -26,7 +26,6 @@ logger = logging.getLogger("openlibrary.sponsorship")
 CIVI_ISBN = 'custom_52'
 CIVI_USERNAME = 'custom_51'
 CIVI_CONTEXT = 'custom_53'
-PRICE_LIMIT_CENTS = 5000
 
 
 def get_sponsored_editions(user):
@@ -166,19 +165,13 @@ def qualifies_for_sponsorship(edition):
             resp['price'] = {
                 'book_cost_cents': book_cost_cents,
                 'scan_price_cents': scan_price_cents,
-                'total_price_cents': total_price_cents
+                'total_price_cents': total_price_cents,
             }
-            if total_price_cents <= PRICE_LIMIT_CENTS:
-                resp['is_eligible'] = eligibility_check(edition)
-            else:
-                resp['error'] = {
-                    'reason': 'cost exceeds %s' % PRICE_LIMIT_CENTS,
-                    'values': total_price_cents
-                }
+            resp['is_eligible'] = eligibility_check(edition)
     else:
         resp['error'] = {
             'reason': 'matches',
-            'values': maches
+            'values': matches
         }
     resp.update({
         'url': config_ia_domain + '/donate?' + urllib.urlencode({

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -89,7 +89,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
        data-ol-link-track="book-sponsorship">Sponsor eBook</a>
     <p>
       We don’t have this book yet. You can add it to our Lending
-      Library with a \$50 tax deductible donation.
+      Library with a $('${:,.2f}'.format(sponsorship['price']['total_price_cents'] / 100.)) tax deductible donation.
       <a href="/sponsorship" target="_blank">Learn More</a>
     </p>
   $else:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactors books sponsorship to relax $50 limit. Cost of book + scanning is presented to the user.

### Technical
<!-- What should be noted about the implementation? -->

N/A, removed $50 limit

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

https://dev.openlibrary.org/books/OL27351643M/The_Subtle_Art_of_Not_Giving_a_! should display as sponsorable (despire being > $50)

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![2019-10-10-184128_1600x900_scrot](https://user-images.githubusercontent.com/978325/66618347-a9036980-eb8d-11e9-8cad-3e9deac363bf.png)
