### PR TITLE
Don't use target blank in list embed

### DIFF
--- a/openlibrary/templates/type/list/embed.html
+++ b/openlibrary/templates/type/list/embed.html
@@ -114,9 +114,4 @@ $def render_seed_count(seed_count):
     $:macros.Pager(page+1, len(list.seeds), page_size)
 </div>
 
-<script type="text/javascript">
-window.q.push(function() {
-    \$('a').not('.pagination a').attr('target','_blank');
-});
-</script>
 


### PR DESCRIPTION
There are very few reasons to use this especially we shouldn't do it in
such a blanket way for all links in a page. Respect the users
browser defaults...

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit https://openlibrary.org/people/maggien/lists/OL127552L/Never_Read_Again/embed equivalent.
Links should open in the current page.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
