### PR TITLE
Drop non-functional on-colorbox close event usage

### DIFF
--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -84,20 +84,6 @@ $var title: $page.title
 
     <div class="clearfix"></div>
 
-    <script type="text/javascript">
-    <!--
-    window.q.push(function(){
-        var back = history.length;
-        \$().bind('cbox_closed', function(){
-            var page = back - history.length;
-            if (page < 0){
-                history.go(page);
-            }
-        });
-    });
-    //-->
-    </script>
-
     <div id="contentBody">
 
         <div class="workCover">


### PR DESCRIPTION
The colorbox triggers a cbox_closed event, but it must be associated with an element that is a colorbox.

$() will match nothing and will not run on every time a colorbox
is closed.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This is more dead code elimination. It should have no effect on the site.
Visit a works page, add a console.log and open and close all the dialogs on the page and verify this code has no purpose.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
