### PR TITLE
more eligible books, pulls missing metadata from amz

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -149,12 +149,12 @@ def qualifies_for_sponsorship(edition):
 
     amz_metadata = get_amazon_metadata(edition.isbn13) or {}
     req_fields = ['publishers', 'title', 'publish_date', 'cover', 'number_of_pages']
-    fields = dict((field, (edition.get(field) or amz_metadata.get(field))) for field in req_fields)    
+    edition_data = dict((field, (edition.get(field) or amz_metadata.get(field))) for field in req_fields)
     work = edition.works and edition.works[0]
-    if not (work and all(fields.values())):
+    if not (work and all(edition_data.values())):
         resp['error'] = {
             'reason': 'Open Library is missing book metadata necessary for sponsorship',
-            'values': fields
+            'values': edition_data
         }
         return resp
 
@@ -166,7 +166,7 @@ def qualifies_for_sponsorship(edition):
         if bwb_price:
             SETUP_COST_CENTS = 300
             PAGE_COST_CENTS = 12
-            num_pages = int(fields['number_of_pages'])
+            num_pages = int(edition_data['number_of_pages'])
             scan_price_cents = SETUP_COST_CENTS + (PAGE_COST_CENTS * num_pages)
             book_cost_cents = int(float(bwb_price) * 100)
             total_price_cents = scan_price_cents + book_cost_cents
@@ -181,9 +181,9 @@ def qualifies_for_sponsorship(edition):
             'reason': 'matches',
             'values': matches
         }
-    resp.update(fields)
     resp.update({
-        'url': config_ia_domain + '/donate?' + urllib.urlencode({
+        'edition': edition_data,
+        'sponsor_url': config_ia_domain + '/donate?' + urllib.urlencode({
             'campaign': 'pilot',
             'type': 'sponsorship',
             'context': 'ol',

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -84,7 +84,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $if (input(sponsorship=None) or user and user.is_sponsor()) and sponsorship.get('is_eligible'):
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     $ user_id = user.key.split("/")[-1] if user else ''
-    <a href="$(sponsorship['url'])&userid=$(user_id)"
+    <a href="$(sponsorship['sponsor_url'])&userid=$(user_id)"
        class="cta-btn cta-btn--sponsor"
        data-ol-link-track="book-sponsorship">Sponsor eBook</a>
     <p>


### PR DESCRIPTION
Followup on #2485
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->

eligibility endpoint now pulls data from amazon to augment the archive.org edition if insufficient metadata available to make a decision (e.g. no cover or number_of_pages)

The result is many more books will become available for sponsorship

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

https://dev.openlibrary.org/sponsorship/eligibility/0062884026