### PR TITLE
hotfix to restrict access to sponsorship beta

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -81,7 +81,7 @@ $elif (availability_status == 'borrow_unavailable'):
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $ sponsorship = qualifies_for_sponsorship(page)
-  $if (input(sponsorship=None) or user and user.in_sponsorship_beta()) and sponsorship.get('is_eligible'):
+  $if (input(sponsorship=None).sponsorship or user and user.in_sponsorship_beta()) and sponsorship.get('is_eligible'):
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     $ user_id = user.key.split("/")[-1] if user else ''
     <a href="$(sponsorship['sponsor_url'])&userid=$(user_id)"


### PR DESCRIPTION
Sponsorship deploy went smoothly overall, except that the button (which is not fully hooked up) is appearing for all users because a check to permit`?sponsorship` which was misconfigured.

This fix has been tested on dev.openlibrary.org and resolves the issue. As a stop-gap, the fix was done on ol-web3 and ol-web4 (so things are currently behaving correctly in production).