### PR TITLE
remove infogami dependency for coverstore doctests

### DIFF
--- a/openlibrary/coverstore/tests/test_doctests.py
+++ b/openlibrary/coverstore/tests/test_doctests.py
@@ -1,5 +1,5 @@
+import doctest
 import pytest
-from infogami.infobase.tests.test_doctests import find_doctests, run_doctest
 
 modules = [
     'openlibrary.coverstore.archive',
@@ -10,7 +10,14 @@ modules = [
     'openlibrary.coverstore.warc',
 ]
 
-@pytest.mark.parametrize('doctest', find_doctests(modules))
-def test_doctests(doctest):
-    # dummy function to make py.test think that test belongs in this module instead of run_doctest's module
-    run_doctest(doctest)
+@pytest.mark.parametrize('module', modules)
+def test_doctest(module):
+    mod = __import__(module, None, None, ['x'])
+    finder = doctest.DocTestFinder()
+    tests = finder.find(mod, mod.__name__)
+    print("Doctests found in %s: %s\n" % (module, [len(m.examples) for m in tests]))
+    for test in tests:
+        runner = doctest.DocTestRunner(verbose=True)
+        failures, tries = runner.run(test)
+        if failures:
+            pytest.fail("doctest failed: " + test.name)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Resloves the following errors that were noticed on dev.openlibrary after updating to the latest Infogami:

```
ImportError while importing test module '/opt/openlibrary/deploys/openlibrary/openlibrary/openlibrary/coverstore/tests/test_doctests.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../venv/local/lib/python2.7/site-packages/six.py:709: in exec_
    exec("""exec _code_ in _globs_, _locs_""")
openlibrary/coverstore/tests/test_doctests.py:2: in <module>
    from infogami.infobase.tests.test_doctests import find_doctests, run_doctest
E   ImportError: cannot import name find_doctests
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Removes the dependency on Infogami test helper methods (that were removed / refactored in the recent python3 / modern pytest updates)

### Technical
<!-- What should be noted about the implementation? -->
Now the coverstore tests runs its own doctests directly. Note that not all of the coverstore modules even have examples, so the 'passing' of some of these doesn't mean anything. Coverstore tests and coverstore itself probably needs some attention:

Here are the results of how many examples are actually found in each module:
```
Doctests found in openlibrary.coverstore.archive: [0, 0]
Doctests found in openlibrary.coverstore.code: [0, 0, 0, 0, 0, 0]
Doctests found in openlibrary.coverstore.db: [0]
Doctests found in openlibrary.coverstore.server: [0, 0]
Doctests found in openlibrary.coverstore.utils: [0, 1, 1, 3, 2, 0]
Doctests found in openlibrary.coverstore.warc: [0, 0, 0, 2, 6, 1, 11, 0, 0, 1, 9, 0]
```
Only `openlibrary.coverstore.utils` and `openlibrary.coverstore.warc` have examples / tests.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
