### PR TITLE
Use unique ids for graphs

### DIFF
--- a/openlibrary/plugins/openlibrary/js/graphs/index.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/index.js
@@ -14,11 +14,11 @@ export function plotAdminGraphs() {
 }
 
 export function initHomepageGraphs() {
-    loadGraphIfExists('visitors', {}, 'unique visitors on', '#e44028');
-    loadGraphIfExists('members', {}, 'new members on', '#748d36');
-    loadGraphIfExists('edits', {}, 'catalog edits on', '#00636a');
-    loadGraphIfExists('lists', {}, 'lists created on', '#ffa337');
-    loadGraphIfExists('ebooks', {}, 'ebooks borrowed on', '#35672e');
+    loadGraphIfExists('visitors-graph', {}, 'unique visitors on', '#e44028');
+    loadGraphIfExists('members-graph', {}, 'new members on', '#748d36');
+    loadGraphIfExists('edits-graph', {}, 'catalog edits on', '#00636a');
+    loadGraphIfExists('lists-graph', {}, 'lists created on', '#ffa337');
+    loadGraphIfExists('ebooks-graph', {}, 'ebooks borrowed on', '#35672e');
 }
 
 export function initPublishersGraph() {

--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -9,42 +9,42 @@ $if stats:
       <div id="home-stats-charts">
         <div class="statschart">
           <div class="chartShow" onClick="window.location.href='//archive.org/stats';" title="See all visitors to OpenLibrary.org">
-            <div id="visitors" style="width:150px;height:60px;"></div>
+            <div id="visitors-graph" style="width:150px;height:60px;"></div>
             <a href="//archive.org/stats" title="See all visitors to OpenLibrary.org"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">Unique Visitors</span></a>
           </div>
         </div>
 
         <div class="statschart">
           <div class="chartShow" onClick="window.location.href='/recentchanges';" title="How many new Open Library members have we welcomed?">
-            <div id="members" style="width:150px;height:60px;"></div>
+            <div id="members-graph" style="width:150px;height:60px;"></div>
             <a href="/recentchanges" title="How many new Open Library members have we welcomed?"><span class="ticks">$:commify(stats["members"].get_summary(28))</span><span class="label">New Members</span></a>
           </div>
         </div>
         <div class="statschart">
           <div class="chartShow" onClick="window.location.href='/recentchanges';" title="People are constantly updating the catalog">
-            <div id="edits" style="width:150px;height:60px;"></div>
+            <div id="edits-graph" style="width:150px;height:60px;"></div>
             <a href="/recentchanges" title="People are constantly updating the catalog"><span class="ticks">$:commify(stats["human_edits"].get_summary(28))</span><span class="label">Catalog Edits</span></a>
           </div>
         </div>
 
         <div class="statschart">
           <div class="chartShow" onClick="window.location.href='/lists';" title="Members can create Lists">
-            <div id="lists" style="width:150px;height:60px;"></div>
+            <div id="lists-graph" style="width:150px;height:60px;"></div>
             <a href="/lists" title="Members can create Lists"><span class="ticks">$:commify(stats["lists"].get_summary(28))</span><span class="label">Lists Created</span></a>
           </div>
         </div>
 
         <div class="statschart">
           <div class="chartShow" onClick="window.location.href='/borrow';" title="We're a library, so we lend books, too">
-            <div id="ebooks" style="width:150px;height:60px;"></div>
+            <div id="ebooks-graph" style="width:150px;height:60px;"></div>
             <a href="/borrow" title="We're a library, so we lend books, too"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">eBooks Borrowed</span></a>
           </div>
         </div>
       </div>
     </div>
 
-    <script type="text/json+graph" id="graph-json-visitors">$:json_encode(stats["visitors"].get_counts(28, True))</script>
-    <script type="text/json+graph" id="graph-json-members">$:json_encode(stats["members"].get_counts(28, True))</script>
-    <script type="text/json+graph" id="graph-json-edits">$:json_encode(stats["human_edits"].get_counts(28, True))</script>
-    <script type="text/json+graph" id="graph-json-lists">$:json_encode(stats["lists"].get_counts(28, True))</script>
-    <script type="text/json+graph" id="graph-json-ebooks">$:json_encode(stats["loans"].get_counts(28, True))</script>
+    <script type="text/json+graph" id="graph-json-visitors-graph">$:json_encode(stats["visitors"].get_counts(28, True))</script>
+    <script type="text/json+graph" id="graph-json-members-graph">$:json_encode(stats["members"].get_counts(28, True))</script>
+    <script type="text/json+graph" id="graph-json-edits-graph">$:json_encode(stats["human_edits"].get_counts(28, True))</script>
+    <script type="text/json+graph" id="graph-json-lists-graph">$:json_encode(stats["lists"].get_counts(28, True))</script>
+    <script type="text/json+graph" id="graph-json-ebooks-graph">$:json_encode(stats["loans"].get_counts(28, True))</script>


### PR DESCRIPTION
These ids are very generic - in fact the id ebooks is being used on
the publishers page and causing a bug

Fixes: #2519

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
1) Check the /stats page - and ensure all graphs render
2)  Visit a publishers page with ebooks available - https://openlibrary.org/publishers/MIT_Press and make sure no JS errors and graph renders.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
