### PR TITLE
Replace onclick handler with a JS wireup.

### DIFF
--- a/openlibrary/macros/BorrowTrouble.html
+++ b/openlibrary/macros/BorrowTrouble.html
@@ -3,8 +3,9 @@ $def with(expiry)
 $if expiry is None:
     <h3>Trouble Downloading?</h3>
     <p class="small sansserif">Our records indicate that you've borrowed a book, but have <span class="red">not yet downloaded</span> it. In order to keep our books available to everyone, you'll have a 5-minute window to load your borrowed book into Adobe Digital Editions. After that period, we return the book to the shelf.</p>
-    <p class="small sansserif"><a href="javascript:;" onclick="\$('#borrowHelp').slideToggle();">Need help</a>?</p>
-    <div class="hidden" id="borrowHelp">
+    <p class="small sansserif"><a href="javascript:;"
+        aria-haspopup="true" aria-controls="borrowHelp" class="slide-toggle">Need help</a>?</p>
+    <div style="display: none" id="borrowHelp">
     <ol class="small sansserif">
         <li><a href="http://www.adobe.com/products/digitaleditions/#fp" title="Get the reader" target="new_window">Digital Editions</a> is required for this book. Adobe provides support for <a href="http://kb2.adobe.com/cps/403/kb403051.html" target="new_window">installation problems</a>.</li>
         <li>To download the application, Adobe also requires that <a href="http://get.adobe.com/flashplayer/" target="new_window">Adobe Flash Player</a> is installed in your web browser.</li>

--- a/openlibrary/macros/TypeChanger.html
+++ b/openlibrary/macros/TypeChanger.html
@@ -1,5 +1,6 @@
 $def with (type, usetable=0)
-
+$# Used on http://localhost:8080/about?m=edit for blank page
+$# and any generic page in the admin UI; e.g. creating a page.
 <div class="formElement pagetype collapse adminOnly" id="pageType">
     $if ctx.user and ctx.user.is_admin():
         <script>
@@ -10,9 +11,10 @@ $def with (type, usetable=0)
         </script>
         <div class="label">
             <label for="type.key">$_("Page Type")</label>
-            <span class="small gray">&nbsp;<a href="javascript:;" onclick="\$('#typeSplain').slideToggle();">Huh</a>?</span>
+            <span class="small gray">&nbsp;<a href="javascript:;"
+                aria-haspopup="true" aria-controls="typeSplain" class="slide-toggle">Huh</a>?</span>
         </div>
-        <div class="hidden" id="typeSplain">
+        <div style="display:none;" id="typeSplain">
             <p class="smaller">Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content. <span class="red">Please use caution changing Page Type!</span></p><p class="smaller">(Simplest solution: If you aren't sure whether this should be changed, don't change it.)</p>
         </div>
         <div class="input">

--- a/openlibrary/macros/WorkInfo.html
+++ b/openlibrary/macros/WorkInfo.html
@@ -58,8 +58,9 @@ $if links:
                 Simple English: <a href="$simple.url">$(simple.title or simple.url)</a>
                 </span>
         $if len(wikipedia):
-            <span class="tag"><a href="javascript:;" onclick="\$('#full_list').slideToggle();">Other languages</a></span>
-            <div class="hidden" id="full_list"><span class="tag">
+            <span class="tag"><a href="javascript:;" class="slide-toggle"
+                aria-haspopup="true" aria-controls="full_list">Other languages</a></span>
+            <div style="display: none" id="full_list"><span class="tag">
             $for link in wikipedia:
                 $link.lang: <a href="$link.url">$(link.title or link.url)</a>&nbsp;
             </span></div>

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -103,4 +103,7 @@ jQuery(function () {
     }
     validateEmail();
     validatePassword();
+    $(document).on('click', '.slide-toggle', function () {
+        $(`#${$(this).attr('aria-controls')}`).slideToggle();
+    });
 });


### PR DESCRIPTION
Use `aria` attributes to describe the relationship between these links and the elements they reveal. Remove a `hidden` class when
impacts its functionality.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This fixes a bug in 3 "slideToggle" links hidden in obscure parts of the UI. It gets more JS out of templates and into the entry point.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Visit http://localhost:8080/about.en?m=edit and click "Huh?"
and ensure it reveals information


### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
