### PR TITLE
search results go to edition, everyone in sponsorship

### DIFF
--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -140,6 +140,16 @@ def get_readable_path(site, path, patterns, encoding=None):
 
     thing = _get_object(site, prefix)
 
+    # XXX For a 1-week trial ~Oct 23 2019
+    # if ?edition qualifier present on work url, redirect patron to
+    # "best" representative edition
+    if thing.key.startswith('/works/'):
+        i = web.input(edition="")
+        if i.edition:
+            ed = thing.get_representative_edition()
+            if ed:
+                raise web.seeother(ed)
+
     # get_object may handle redirections.
     if thing:
         prefix = thing.key

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -63,9 +63,7 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
     <a href="$read_link" data-ol-link-track="read_unrestricted" title="Use BookReader to read online"
        id="read_ebook" class="cta-btn--available cta-btn">Read</a>
 $else:
-  <form>
-    <input type="button" class="cta-btn--missing cta-btn" disabled value="No ebook available">
-  </form>
+  <a href="$page.key" class="cta-btn--missing cta-btn">No ebook available</a>
   $if page.ia:
     $ daisy_url = "/ia/%s/daisy" % page.ia[0]
     $:macros.daisy(page, url=daisy_url, protected=True, msg=_("Print-disabled access available"))

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -81,10 +81,9 @@ $elif (availability_status == 'borrow_unavailable'):
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $ sponsorship = qualifies_for_sponsorship(page)
-  $if user and sponsorship.get('is_eligible'):
+  $if  sponsorship.get('is_eligible'):
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
-    $ user_id = user.key.split("/")[-1] if user else ''
-    <a href="$(sponsorship['sponsor_url'])&userid=$(user_id)"
+    <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"
        data-ol-link-track="book-sponsorship">Sponsor eBook</a>
     <p>
@@ -93,9 +92,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
       <a href="/sponsorship" target="_blank">Learn More</a>
     </p>
   $else:
-    <form>
-      <input type="submit" class="cta-btn" disabled value="No ebook available">
-    </form>
+    <a href="$work.key" class="cta-btn cta-btn--missing">No ebook available</a>
 
 $if ocaid and page.is_access_restricted() and availability_status.startswith('borrow') and editions_page:
   $:macros.BookPreview(ocaid)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -81,7 +81,7 @@ $elif (availability_status == 'borrow_unavailable'):
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $ sponsorship = qualifies_for_sponsorship(page)
-  $if (input(sponsorship=None).sponsorship or user and user.in_sponsorship_beta()) and sponsorship.get('is_eligible'):
+  $if user and sponsorship.get('is_eligible'):
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     $ user_id = user.key.split("/")[-1] if user else ''
     <a href="$(sponsorship['sponsor_url'])&userid=$(user_id)"

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -20,7 +20,8 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
   <span class="details">
       <span class="resultTitle">
          <h3 class="booktitle">
-           <a itemprop="name" href="$(book_url)/-/resolve"
+           $ url = book_url if is_bot() else '%s?edition=best' % book_url
+           <a itemprop="name" href="$url"
               class="results">$doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')</a>
            $if doc.get('publish_date'):
              ($(doc['publish_date']))

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -20,7 +20,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
   <span class="details">
       <span class="resultTitle">
          <h3 class="booktitle">
-           <a itemprop="name" href="$(book_url)"
+           <a itemprop="name" href="$(book_url)/-/resolve"
               class="results">$doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')</a>
            $if doc.get('publish_date'):
              ($(doc['publish_date']))

--- a/openlibrary/macros/SponsorCarousel.html
+++ b/openlibrary/macros/SponsorCarousel.html
@@ -1,0 +1,1 @@
+$:render_template("books/custom_carousel", books=get_cached_sponsorable_editions(), title="Books to Sponsor", url="/sponsorship", key="sponsor_books")

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -353,6 +353,9 @@ class work2edition_resolver(delegate.page):
         matches = doc.get_ebook_info().get('ia', [])
         if matches:
             raise web.seeother('/ia/' + matches[0])
+        ed = doc.get_one_edition()
+        if ed:
+            raise web.seeother(ed.key)
         raise web.seeother(work_key)
 
 class bookpage(delegate.page):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -344,20 +344,6 @@ class health(delegate.page):
         web.header('Content-Type', 'text/plain')
         raise web.HTTPError("200 OK", {}, 'OK')
 
-class work2edition_resolver(delegate.page):
-    path = r"(/works/OL[0-9]+W)/resolve"
-
-    def GET(self, work_key):
-        """Resolves a work url to an editions page"""
-        doc = web.ctx.site.get(work_key)
-        matches = doc.get_ebook_info().get('ia', [])
-        if matches:
-            raise web.seeother('/ia/' + matches[0])
-        ed = doc.get_one_edition()
-        if ed:
-            raise web.seeother(ed.key)
-        raise web.seeother(work_key)
-
 class bookpage(delegate.page):
     path = r"/(isbn|oclc|lccn|ia|ISBN|OCLC|LCCN|IA)/([^/]*)(/.*)?"
 

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -58,11 +58,11 @@ class TestHomeTemplates:
         # Empty list should be returned when there is error.
         monkeypatch.setattr(home, 'random_ebooks', lambda: None)
         books = home.readonline_carousel()
-        html = six.text_type(render_template("books/custom_carousel", books=books, title="Classic Books", url="/read",
-                                       key="public_domain"))
+        html = six.text_type(render_template("books/custom_carousel", books=books, title="Classic Books",
+                                             url="/read", key="public_domain"))
         assert html.strip() == ""
 
-    def test_home_template(self, render_template, mock_site):
+    def test_home_template(self, render_template, mock_site, monkeypatch):
         docs = [MockDoc(_id=datetime.datetime.now().strftime("counts-%Y-%m-%d"),
                         human_edits=1, bot_edits=1, lists=1,
                         visitors=1, loans=1, members=1,
@@ -95,8 +95,10 @@ class TestHomeTemplates:
                 "inlibrary_borrow_url": "/books/OL1M/foo/borrow",
                 "cover_url": ""
             }]
+
+        monkeypatch.setattr(home, 'get_cachable_sponsorable_editions', lambda: [])
         html = six.text_type(render_template("home/index", stats=stats, test=True))
-        headers = ["Books We Love", "Recently Returned", "Kids",
+        headers = ["Books We Love", "Recently Returned", "Kids", "Books to Sponsor",
                    "Thrillers", "Romance", "Classic Books", "Textbooks"]
         for h in headers:
             assert h in html

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -637,6 +637,20 @@ class Work(models.Work):
     def get_related_books_subjects(self, filter_unicode=True):
         return self.filter_problematic_subjects(self.get_subjects())
 
+    def get_representative_edition(self):
+        """When we have confidence we can direct patrons to the best edition
+        of a work (for them), return qualifying edition key. Attempts
+        to find best (most available) edition of work using
+        archive.org work availability API. May be extended to support language
+
+        :rtype str: infogami edition key or url which resolves to an edition
+        """
+        work_id = self.key.replace('/works/', '')
+        availability = lending.get_work_availability(work_id)
+        if work_id in availability:
+            if 'openlibrary_edition' in availability[work_id]:
+                return '/books/%s' % availability[work_id]['openlibrary_edition']
+
     def get_sorted_editions(self):
         """Return a list of works sorted by publish date"""
         w = self._solr_data

--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -61,19 +61,16 @@ window.q.push(function(){
 });
 //-->
 </script>
-
 <div id="contentHead">
-    <div class="small sansserif grey" style="margin-bottom:5px;""><a href="$ctx.user.key">$ctx.user.displayname</a> /</div>
-    <h1>$_("Books You've Checked Out")</h1>
-
+  <div class="small sansserif grey" style="margin-bottom:5px;"><a href="$ctx.user.key">$ctx.user.displayname</a> /</div>
 </div>
-
 <div id="contentBody">
-$if len(loans) == 0:
+  <h1>$_("Books You've Checked Out")</h1>
+  $if len(loans) == 0:
     <div><em>You've not checked out any books at this moment.</em></div>
 $else:
-    $# Have current loans
-    <div id="borrowTable" class="borrow collapse">
+  $# Have current loans
+  <div id="borrowTable" class="borrow collapse">
     <table>
         <thead>
             <tr>
@@ -90,10 +87,9 @@ $else:
         <tbody>
         <!-- for each borrow -->
         $for loan in loans:
-            $ book = get_document(loan['book'])
-            $if book is None:
-                $continue
-            <tr data-userid="$(loan['userid'])">
+          $ book = get_document(loan['book'])
+          $if book:
+              <tr data-userid="$(loan['userid'])">
                 <td class="cover">
                 $:render_template('covers/book_cover_small', book)
                 </td>
@@ -133,8 +129,8 @@ $else:
             </tr>
         </tbody>
     </table>
-    </div>
-    <!--
+  </div>
+  <!--
     $for loan in loans:
         $:macros.BorrowTrouble(loan['expiry'])
     <h3>How To Return eBooks through Adobe Digital Editions</h3>
@@ -149,12 +145,14 @@ $else:
     </ol>
     -->
 
+
 <h1>$_("Books You're Waiting For")</h1>
 $ waitinglist = user.get_waitinglist()
 $if len(waitinglist) == 0:
     <div><em>You are not waiting for any books at this moment.</em></div>
 $else:
-    <div id="leave-waitinglist-dialog" class="hidden dialog" title="Leave the Waiting List">Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?</div>
+    <div id="leave-waitinglist-dialog" class="hidden dialog"
+         title="Leave the Waiting List">Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?</div>
     <script type="text/javascript">
     window.q.push(function() {
         \$("#leave-waitinglist-dialog").dialog({
@@ -196,8 +194,9 @@ $else:
         </thead>
         <tbody>
         $for record in waitinglist:
-            $ book = record.get_book()
-            $ status = record['status']
+          $ book = record.get_book()
+          $ status = record['status']
+          $if book:
             <tr class="row-$status">
                 <td class="cover">
                 $:render_template('covers/book_cover_small', book)

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -18,7 +18,12 @@ $def render_carousel_cover(book, lazy):
     $ byline = ''
   $ modifier = ''
   $ cta = None
-  $if book.get('ocaid'):
+  $ cta_cls = 'available'
+  $if book.get('eligibility', {}).get('is_eligible'):
+    $ cta_url = book['eligibility']['sponsor_url']
+    $ cta = 'Sponsor'
+    $ cta_cls = 'sponsor'
+  $elif book.get('ocaid'):
     $ modifier = 'borrow-link'
     $ cta_url = '/borrow/ia/%s' % book.ocaid
     $ cta = 'Borrow'
@@ -30,7 +35,8 @@ $def render_carousel_cover(book, lazy):
     $ cta = 'Borrow'
   $else:
     $ cta = 'Read'
-    $ url += '/x/resolve'
+    $if not is_bot():
+      $ url += '?edition=best'
     $ cta_url = url
 
   $if lazy:
@@ -48,7 +54,7 @@ $def render_carousel_cover(book, lazy):
       </a>
     </div>
     $if cta:
-      <div class="book-cta"><a class="cta-btn cta-btn--available $modifier" href="$cta_url" data-ol-link-track="$key" title="$cta $book.title"
+      <div class="book-cta"><a class="cta-btn cta-btn--$(cta_cls) $modifier" href="$cta_url" data-ol-link-track="$key" title="$cta $book.title"
         data-key="$(key)" data-ocaid="$(book.get('ia'))">$cta</a></div>
   </div>
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -6,6 +6,8 @@ $var title: $_("Welcome to Open Library")
 <div id="contentBody">
   $:render_template("home/categories", test=test)
 
+  $:render_template("books/custom_carousel", books=get_cached_sponsorable_editions(), title="Books to Sponsor", url="/sponsorship", key="sponsor_books", test=test)
+
   $:render_template("books/custom_carousel", books=readonline_carousel(), title="Classic Books", url="/read", key="public_domain", test=test)
 
   $:render_template("home/custom_ia_carousel", title="Books We Love", key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -24,7 +24,7 @@ $ show_banners = bodyid != 'form'
       </div>
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
-      $ announcement = ''
+      $ announcement = '<strong>Together</strong>, let\'s build an Open Library for the World. <a class="cta-btn cta-btn--available" style="display: inline;" href="/sponsorship">Sponsor a Book</a>'
       $if announcement:
         <div class="page-banner page-banner-body">     
          $:announcement

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -42,7 +42,7 @@ a.cta-btn {
   }
   &--sponsor {
     border: 2px solid @link-blue;
-    background: lighten(desaturate(@link-blue, 50%), 78%);
+    background: lighten(desaturate(@link-blue, 56%), 67%);
     transition: background-color 0.2s;
   }
 


### PR DESCRIPTION
Changes for this weekend + week of October 23 (celebration). Goal is to make it easier (but not too easy) to discover book sponsorship (by eliminating work v. edition confusion).

Search results link to "best" edition instead of work (experiment)

This also fixes a tiny bug with sponsorship (where you get added to the waitlist of a book which is not in lending, breaking the https://openlibrary.org/account/loans page