### PR TITLE
hotfix: edition and work swapped in eligibility API

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -117,8 +117,8 @@ def qualifies_for_sponsorship(edition):
         "cover": "https://covers.openlibrary.org/b/id/2353907-L.jpg",
         "title": "Lords of the Ring",
         "isbn": "9780299204204"
-        "openlibrary_edition": "OL2347684W",
-        "openlibrary_work": "OL10317216M"
+        "openlibrary_edition": "OL2347684M",
+        "openlibrary_work": "OL10317216W"
        },
        "price": {
           "scan_price_cents": 3444,
@@ -177,8 +177,8 @@ def qualifies_for_sponsorship(edition):
             'values': matches
         }
     edition_data.update({
-        'openlibrary_edition': work_id,
-        'openlibrary_work': edition_id
+        'openlibrary_edition': edition_id,
+        'openlibrary_work': work_id
     })
     resp.update({
         'edition': edition_data,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
The openlibrary_edition and openlibrary_work were swapped in the eligibility API

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->

n/a/

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Hit the eligibility API (e.g. https://openlibrary.org/sponsorship/eligibility/OL25211152M) and ensure that the edition ends with an `M` and the work ends with a `W`

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

See testing link above