### PR TITLE
fixing sponsor carousel cacheing

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -111,6 +111,9 @@ def get_featured_subjects():
 
 
 def get_cachable_sponsorable_editions():
+    if 'env' not in web.ctx:
+        delegate.fakeload()
+
     return [format_book_data(ed) for ed in get_sponsorable_editions()]
 
 @public


### PR DESCRIPTION
<!-- What issue does this PR close? -->
web.ctx.env is (classic problem) not available within the ThreadedDict cacheable version of the cached sponsorable books function. We added the `if not 'env' in web.ctx` logic (as is customary in such cacheable methods which require using web.ctx.site) to get around this.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

forced re-caching of the homepage

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
