### PR TITLE
refactor listen experience, add to search page

### DIFF
--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -23,15 +23,11 @@ $ current_and_available_loans = []
 $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
   $ read_link = '/borrow/ia/%s' % availability['identifier']
 
-  $if loan:
-    <a href="$read_link" title="Borrow"
-       data-userid="$(loan['userid'])" id="read_ebook"
-       class="cta-btn--available cta-btn" >Read</a>
+  $if loan or (availability_status == 'open'):
+    $:macros.ReadButton(ocaid, listen=True, loan=loan)
 
   $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
-    <a href="$read_link" class="cta-btn--available cta-btn" title="Borrow" id="borrow_ebook">
-      Borrow
-    </a>
+    $:macros.ReadButton(ocaid, borrow=True, listen=True)
 
   $elif (availability_status == 'borrow_unavailable'):
     $if waiting_loan:
@@ -65,9 +61,6 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
             Be first in line!
           </div>
 
-  $elif (availability_status == 'open'):
-    <a href="$read_link" data-ol-link-track="read_unrestricted" title="Use BookReader to read online"
-       id="read_ebook" class="cta-btn--available cta-btn">Read</a>
 $else:
   <a href="$page.key" class="cta-btn--missing cta-btn">No ebook available</a>
   $if page.ia:

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -23,8 +23,11 @@ $ current_and_available_loans = []
 $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
   $ read_link = '/borrow/ia/%s' % availability['identifier']
 
-  $if loan or (availability_status == 'open'):
+  $if loan:
     $:macros.ReadButton(ocaid, listen=True, loan=loan)
+
+  $elif availability_status == 'open':
+    $:macros.ReadButton(ocaid, listen=True)
 
   $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
     $:macros.ReadButton(ocaid, borrow=True, listen=True)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -5,12 +5,6 @@ $# * user
 $# * editions_page renders additional data if you're seeing LoanStatus rendered in the sidebar of an edition page v. in the work's table.
 $# * block_name is a BEM block name
 
-$def listen_button(book_url, title):
-    <a href="$(book_url)_autoReadAloud=show" title="$title" class="cta-btn cta-btn--available">
-        <span class="btn-icon read-aloud"></span>
-        <span class="btn-label">Listen</span>
-    </a>
-
 $ ocaid = page.get('ocaid')
 $ work = page.works and page.works[0]
 $ meta_fields = page.get_ia_meta_fields() or {}

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -14,7 +14,6 @@ $def listen_button(book_url, title):
 $ ocaid = page.get('ocaid')
 $ work = page.works and page.works[0]
 $ meta_fields = page.get_ia_meta_fields() or {}
-$ contributor = meta_fields.get('contributor')
 $ user_loan = None
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -22,7 +22,6 @@ $ availability = page.availability or page.get_realtime_availability()
 $ availability_status = availability.get('status', 'error')
 $ current_and_available_loans = []
 
-
 $if ocaid:
   $ current_and_available_loans = page.get_current_and_available_loans()
   $ user_loan = None
@@ -43,9 +42,7 @@ $if user:
 $ borrow_link = page.url() + '/borrow'
 
 $if user_loan:
-  <a href="$borrow_link" title="Borrow from $contributor"
-     data-userid="$(user_loan['userid'])" id="read_ebook"
-     class="cta-btn cta-btn--available">Read eBook</a>
+  $:macros.ReadButton(ocaid, loan=user_loan, listen=True)
   $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">
     <input type="hidden" name="action" value="return" />
@@ -53,19 +50,10 @@ $if user_loan:
   </form>
 
 $elif ocaid and not page.is_access_restricted() and editions_page:
-  $ stream_url = "//%s/stream/%s?ref=ol" % (bookreader_host(), ocaid)
-  <div class="cta-button-group">
-    <a href="$stream_url" title="Use BookReader to read online" class="cta-btn cta-btn--available">Read</a>
-    $:listen_button(stream_url + "&", "Listen to this book using text-to-speech")
-  </div>
-
-
+  $:macros.ReadButton(ocaid, listen=True)
 
 $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
-  <div class="cta-button-group">
-    <a href="$borrow_link" title="Borrow from $contributor" id="borrow_ebook" class="cta-btn cta-btn--available">Borrow</a>
-    $:listen_button(borrow_link + "?", "Borrow this book and listen to it using text-to-speech")
-  </div>
+  $:macros.ReadButton(ocaid, borrow=True, listen=True)
 
 $elif (availability_status == 'borrow_unavailable'):
   $ wlsize = availability.get('num_waitlist', 0)

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,0 +1,24 @@
+$def with(ocaid, borrow=False, listen=False, contributor="Internet Archive", loan=None)
+
+$ action = "borrow" if (borrow and not loan) else "read"
+$ title = "%s ebook from %s" % (action, contributor)
+$ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
+
+<div class="cta-button-group">
+  <a href="$(stream_url)" title="$title" id="$(action)_ebook"
+     $if loan:
+       data-userid="$(loan['userid'])"
+     $elif borrow:
+       data-ol-link-track="borrow"
+     $else:
+       data-ol-link-track="read_unrestricted"
+     class="cta-btn cta-btn--available">$action.capitalize()</a>
+  $if listen:
+    <a href="$(stream_url)&_autoReadAloud=show"
+       title="$title using Read Aloud"
+       data-ol-link-track="listen""
+       class="cta-btn cta-btn--available">
+      <span class="btn-icon read-aloud"></span>
+      <span class="btn-label">Listen</span>
+    </a>
+</div>

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,7 +1,7 @@
-$def with(ocaid, borrow=False, listen=False, contributor="Internet Archive", loan=None)
+$def with(ocaid, borrow=False, listen=False, loan=None)
 
 $ action = "borrow" if (borrow and not loan) else "read"
-$ title = "%s ebook from %s" % (action, contributor)
+$ title = "%s ebook from Internet Archive" % action
 $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
 <div class="cta-button-group">

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -85,10 +85,12 @@ class checkout_with_ocaid(delegate.page):
         """Redirect shim: Translate an IA identifier into an OL identifier and
         then redirects user to the canonical OL borrow page.
         """
+        i = web.input()
+        params = urllib.urlencode(i)
         ia_edition = web.ctx.site.get('/books/ia:%s' % ocaid)
         edition = web.ctx.site.get(ia_edition.location)
         url = '%s/x/borrow' % (edition.key)
-        raise web.seeother(url)
+        raise web.seeother(url + '?' + params)
 
     def POST(self, ocaid):
         """Redirect shim: Translate an IA identifier into an OL identifier and

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -94,7 +94,6 @@ a.cta-btn {
   display: flex;
   align-items: center;
   position: relative;
-  width: 180px;
 
   .cta-btn {
     margin: 0;

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -94,6 +94,7 @@ a.cta-btn {
   display: flex;
   align-items: center;
   position: relative;
+  width: 180px;
 
   .cta-btn {
     margin: 0;

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -10,6 +10,7 @@ table#editions,
   clear: both;
   font-family: @lucida_sans_serif-1;
 
+
   th {
     font-family: @news_gothic_sans_serif-2;
     font-size: 11px;
@@ -134,6 +135,10 @@ table#editions,
 
     div.cover {
       float: left;
+    }
+
+    .cta-button-group {
+      width: 180px;
     }
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This PR allows us to generically use/apply the "Listen" button decoration to Read and Borrow buttons across the website.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Refactors read/borrow button into a macro

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Go to editions, works, and search page on dev.openlibrary.org

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![Screen Shot 2019-10-23 at 10 01 33AMPDT](https://user-images.githubusercontent.com/978325/67416912-8d7c6380-f57c-11e9-9167-71b28e5ff67f.png)
