### PR TITLE
Remove ineffective i18n placeholders from JS files

### DIFF
--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -79,10 +79,10 @@ export function loadEditionsGraph() {
                 y = item.datapoint[1].toFixed(0);
                 if (y == 1) {
                     showTooltip(item.pageX, item.pageY,
-                        `${y} $_('edition in') ${x}`);
+                        `${y} edition in ${x}`);
                 } else {
                     showTooltip(item.pageX, item.pageY,
-                        `${y} $_('editions in') ${x}`);
+                        `${y} editions in ${x}`);
                 }
             }
         }
@@ -102,9 +102,9 @@ export function loadEditionsGraph() {
     }
 
     if (dateFrom == (dateTo - 1)) {
-        $('.clickdata').text(`$_('published in') ${dateFrom}`);
+        $('.clickdata').text(`Published in ${dateFrom}`);
     } else {
-        $('.clickdata').text(`$_('published between') ${dateFrom} & ${dateTo-1}.`);
+        $('.clickdata').text(`Published between ${dateFrom} & ${dateTo-1}.`);
     }
 }
 


### PR DESCRIPTION
Closes #2483 

Replaces non-working i18n placeholders in JS files with the actual English string, until a proper frontend i18n system is implemented. This obviously bypasses any translation system, but it's still better than cryptic placeholders for now.

### Technical
The python babel i18n that is currently in use fundamentally does not work with JS files. I.e. even if you could statically replace the placeholders before the JS files get delivered, it could cause problems with dynamic language switching and caching.... A separate system for the client-side should be evaluated and implemented (#2353 seems to be a collection of issues/ideas about that).

### Testing
Follow the steps described in issue #2483 .