### PR TITLE
Adds sponsorship message to Edition page (refactors ia metadata call)

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -304,6 +304,9 @@ class Account(web.storage):
             if 'values' in act and 'email' in act['values']:
                 return InternetArchiveAccount.get(email=act['values']['email'])
 
+    def render_link(self):
+        return '<a href="/people/%s">%s</a>' % (self.username, web.net.htmlquote(self.displayname))
+
 class OpenLibraryAccount(Account):
 
     @classmethod
@@ -404,6 +407,9 @@ class OpenLibraryAccount(Account):
 
     @classmethod
     def get_by_link(cls, link, test=False):
+        """
+        :rtype: OpenLibraryAccount or None
+        """
         ol_accounts = web.ctx.site.store.values(
             type="account", name="internetarchive_itemname", value=link)
         return cls(ol_accounts[0]) if ol_accounts else None

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -57,7 +57,7 @@ def get_metadata_direct(itemid, only_metadata=True, cache=True):
     full_json = get_api_response(url, params)
     return extract_item_metadata(full_json) if only_metadata else full_json
 
-get_metadata = cache.memcache_memoize(get_metadata_direct, key_prefix='ia.get_metadata', timeout=5 * 60)
+get_metadata = cache.memcache_memoize(get_metadata_direct, key_prefix='ia.get_metadata', timeout=5 * cache.MINUTE_SECS)
 
 
 def extract_item_metadata(item_json):

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -263,15 +263,6 @@ def get_availability_of_editions(ol_edition_ids):
     """
     return get_availability('openlibrary_edition', ol_edition_ids)
 
-def get_edition_ia_metadata(ocaid):
-    url = 'https://archive.org/metadata/%s?dontcache=1' % ocaid
-    try:
-        content = urllib.urlopen(url=url, timeout=config_http_request_timeout).read()
-        return simplejson.loads(content).get('metadata', {})
-    except Exception as e:
-        logger.info("BEGIN sync_loan %s", e)
-    return {}
-
 @public
 def add_availability(editions):
     """

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -263,27 +263,14 @@ def get_availability_of_editions(ol_edition_ids):
     """
     return get_availability('openlibrary_edition', ol_edition_ids)
 
-@public
-def get_realtime_availability_of_ocaid(ocaid):
+def get_edition_ia_metadata(ocaid):
     url = 'https://archive.org/metadata/%s?dontcache=1' % ocaid
-    statuses = {
-        'available': 'borrow_available',
-        'unavailable': 'borrow_unavailable',
-        'private': 'private',
-        'error': 'error'
-    }
     try:
-        content = urllib.request.urlopen(url=url, timeout=config_http_request_timeout).read()
-        metadata = simplejson.loads(content).get('metadata', {})
-        statuses = {'available': 'borrow_available', 'unavailable': 'borrow_unavailable', 'error': 'error'}
-        status = metadata.get('loans__status__status', 'error').lower()
-        return {
-            'status': statuses[status],
-            'num_waitlist': int(metadata.get('loans__status__num_waitlist', 0)),
-            'num_loans': int(metadata.get('loans__status__num_loans', 0))
-        }
+        content = urllib.urlopen(url=url, timeout=config_http_request_timeout).read()
+        return simplejson.loads(content).get('metadata', {})
     except Exception as e:
-        return {'error': 'request_timeout'}
+        logger.info("BEGIN sync_loan %s", e)
+    return {}
 
 @public
 def add_availability(editions):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -300,7 +300,8 @@ class Edition(Thing):
     @property
     @cache.method_memoize
     def ia_metadata(self):
-        return get_metadata_direct(self.get('ocaid'), cache=False)
+        ocaid = self.get('ocaid')
+        return get_metadata_direct(ocaid, cache=False) if ocaid else {}
 
     @property
     @cache.method_memoize

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -296,27 +296,26 @@ class Edition(Thing):
         """Returns list of records for all users currently waiting for this book."""
         return waitinglist.get_waitinglist_for_book(self.key)
 
-    def inject_ia_metadata(self):
-        self.metadata = get_metadata_direct(self.get('ocaid'), cache=False)
-        self.donor = self.metadata.get('donor')
-        self.donor_msg = self.metadata.get('donor_msg')
+    @property
+    @cache.method_memoize
+    def ia_metadata(self):
+        return get_metadata_direct(self.get('ocaid'), cache=False)
 
-
-        def _set_realtime_availability():
-            statuses = {
-                'available': 'borrow_available',
-                'unavailable': 'borrow_unavailable',
-                'private': 'private',
-                'error': 'error'
-            }
-            status = self.metadata.get('loans__status__status', 'error').lower()
-            self.availability = {
-                'status': statuses[status],
-                'num_waitlist': int(self.metadata.get('loans__status__num_waitlist', 0)),
-                'num_loans': int(self.metadata.get('loans__status__num_loans', 0))
-            }
-        if not self.availability:
-            _set_realtime_availability()
+    @property
+    @cache.method_memoize
+    def availability(self):
+        statuses = {
+            'available': 'borrow_available',
+            'unavailable': 'borrow_unavailable',
+            'private': 'private',
+            'error': 'error'
+        }
+        status = self.ia_metadata.get('loans__status__status', 'error').lower()
+        return {
+            'status': statuses[status],
+            'num_waitlist': int(self.ia_metadata.get('loans__status__num_waitlist', 0)),
+            'num_loans': int(self.ia_metadata.get('loans__status__num_loans', 0))
+        }
 
     def get_waitinglist_size(self, ia=False):
         """Returns the number of people on waiting list to borrow this book.

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -25,6 +25,8 @@ from . import db, cache, iprange, inlibrary, loanstats, waitinglist, lending
 
 from six.moves import urllib
 
+from .ia import get_metadata_direct
+
 
 def _get_ol_base_url():
     # Anand Oct 2013
@@ -295,7 +297,7 @@ class Edition(Thing):
         return waitinglist.get_waitinglist_for_book(self.key)
 
     def inject_ia_metadata(self):
-        self.metadata = lending.get_edition_ia_metadata(self.get('ocaid'))
+        self.metadata = get_metadata_direct(self.get('ocaid'), cache=False)
         self.donor = self.metadata.get('donor')
         self.donor_msg = self.metadata.get('donor_msg')
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -12,8 +12,7 @@ $ meta_fields = page.get_ia_meta_fields() or {}
 $ user_loan = None
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
-$ availability = page.availability or page.get_realtime_availability()
-$ availability_status = availability.get('status', 'error')
+$ availability_status = page.availability.get('status', 'error')
 $ current_and_available_loans = []
 
 $if ocaid:
@@ -51,7 +50,7 @@ $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
   $:macros.ReadButton(ocaid, borrow=True, listen=True)
 
 $elif (availability_status == 'borrow_unavailable'):
-  $ wlsize = availability.get('num_waitlist', 0)
+  $ wlsize = page.availability.get('num_waitlist', 0)
   $if waiting_loan:
     <p class="waitinglist-message">
       $ spot = ctx.user.get_waiting_loan_for(page)['position']
@@ -74,7 +73,7 @@ $elif (availability_status == 'borrow_unavailable'):
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $ sponsorship = qualifies_for_sponsorship(page)
-  $if  sponsorship.get('is_eligible'):
+  $if sponsorship.get('is_eligible'):
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -817,7 +817,7 @@ def user_can_borrow_edition(user, edition, resource_type):
     if user.get_loan_count() >= user_max_loans:
         return False
 
-    realtime_availability = edition.get_realtime_availability()
+    realtime_availability = edition.availability
     availability_status = realtime_availability['status']
     waitlist_size = realtime_availability['num_waitlist']
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -353,15 +353,18 @@ $if ctx.user and ctx.user.is_admin():
         <div class="editionTools">
             $:macros.databarWork(page, editions_page=True)
 
-            $if 'openlibraryscanningteam' in page.ia_metadata.get('collection', []):
+            $if page.sponsorship_data:
               <div class="sponsorship-card">
-              $if 'donor' in page.ia_metadata:
-                $_('This book was generously donated by %(donor)s', donor=page.ia_metadata['donor'])
+              $if page.sponsorship_data.donor:
+                $ donor = page.sponsorship_data.donor
+                $if page.sponsorship_data.donor_account:
+                  $ donor = page.sponsorship_data.donor_account.render_link()
+                $:_('This book was generously donated by %(donor)s', donor=donor)
               $else:
                 $_('This book was generously donated anonymously')
               <hr>
-              $if 'donor_msg' in page.ia_metadata:
-                <q>$page.ia_metadata['donor_msg']</q>
+              $if page.sponsorship_data.donor_msg:
+                <q>$page.sponsorship_data.donor_msg</q>
                 <hr>
               <a href="/sponsorship" class="learn-more">$_("Learn more about Book Sponsorship")</a>
               </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -353,14 +353,17 @@ $if ctx.user and ctx.user.is_admin():
         <div class="editionTools">
             $:macros.databarWork(page, editions_page=True)
 
-            $if 'donor' in page.ia_metadata:
-              <div class="Tools read-options">
-                <p class="cta-section-title">Dedication</p>
-                <p>This book generously <a href="/sponsorship">sponsored</a>
-                  by: $page.ia_metadata['donor']
-                </p>
-                $if 'donor_msg' in page.ia_metadata:
-                <p>"$page.ia_metadata['donor_msg']"</p>
+            $if 'openlibraryscanningteam' in page.ia_metadata.get('collection', []):
+              <div class="sponsorship-card">
+              $if 'donor' in page.ia_metadata:
+                $_('This book was generously donated by %(donor)s', donor=page.ia_metadata['donor'])
+              $else:
+                $_('This book was generously donated anonymously')
+              <hr>
+              $if 'donor_msg' in page.ia_metadata:
+                <q>$page.ia_metadata['donor_msg']</q>
+                <hr>
+              <a href="/sponsorship" class="learn-more">$_("Learn more about Book Sponsorship")</a>
               </div>
         </div>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,7 +1,6 @@
 $def with (page, show_other_editions=False)
 
 $ work = page.works and page.works[0] or None
-$ page.inject_ia_metadata()
 $ ocaid = page.get('ocaid')
 $ book_title = page.get('title', '') if page.title else (work.title if work else '')
 $ work_title = work.title if work else page.get('title', '')
@@ -354,13 +353,14 @@ $if ctx.user and ctx.user.is_admin():
         <div class="editionTools">
             $:macros.databarWork(page, editions_page=True)
 
-            $if page.donor and page.donor_msg:
+            $if 'donor' in page.ia_metadata:
               <div class="Tools read-options">
                 <p class="cta-section-title">Dedication</p>
                 <p>This book generously <a href="/sponsorship">sponsored</a>
-                  by: $page.donor
+                  by: $page.ia_metadata['donor']
                 </p>
-                <p>"$page.donor_msg"</p>
+                $if 'donor_msg' in page.ia_metadata:
+                <p>"$page.ia_metadata['donor_msg']"</p>
               </div>
         </div>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,6 +1,7 @@
 $def with (page, show_other_editions=False)
 
 $ work = page.works and page.works[0] or None
+$ page.inject_ia_metadata()
 $ ocaid = page.get('ocaid')
 $ book_title = page.get('title', '') if page.title else (work.title if work else '')
 $ work_title = work.title if work else page.get('title', '')
@@ -10,6 +11,7 @@ $ title = book_title + " " + title_suffix
 $ title_with_site = title + " | Open Library"
 $ meta_cover_url = item_image(page.get_cover_url("L"), default="https://openlibrary.org/images/icons/avatar_book-sm.png")
 $ _x = ctx.setdefault('bodyid', 'book')
+
 $var title: $title
 
 $code:
@@ -185,6 +187,7 @@ $if ctx.user and ctx.user.is_admin():
         </div>
 
         <div class="editionAbout">
+
             <div class="book-overview section sansserif">
               <h1 class="work-title" itemprop="name">$book_title</h1>
               $if book_subtitle:
@@ -350,6 +353,15 @@ $if ctx.user and ctx.user.is_admin():
 
         <div class="editionTools">
             $:macros.databarWork(page, editions_page=True)
+
+            $if page.donor and page.donor_msg:
+              <div class="Tools read-options">
+                <p class="cta-section-title">Dedication</p>
+                <p>This book generously <a href="/sponsorship">sponsored</a>
+                  by: $page.donor
+                </p>
+                <p>"$page.donor_msg"</p>
+              </div>
         </div>
 
     </div>

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -9,7 +9,7 @@ def test_get_metadata(monkeypatch, mock_memcache):
         }
     }
 
-    monkeypatch.setattr(ia, '_get_metadata', lambda _id: metadata)
+    monkeypatch.setattr(ia, 'get_api_response', lambda *args: metadata)
     assert ia.get_metadata('foo00bar') == {
         "title": "Foo",
         "identifier": "foo00bar",
@@ -19,5 +19,5 @@ def test_get_metadata(monkeypatch, mock_memcache):
     }
 
 def test_get_metadata_empty(monkeypatch, mock_memcache):
-    monkeypatch.setattr(ia, '_get_metadata', lambda _id: {})
+    monkeypatch.setattr(ia, 'get_api_response', lambda *args: {})
     assert ia.get_metadata('foo02bar') == {}

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -68,6 +68,24 @@
   // stylelint-enable selector-max-specificity
 }
 
+.sponsorship-card {
+  border-radius: 5px;
+  padding: 10px;
+  border: 2px solid fade(@link-blue, 20%);
+  background: fade(lighten(desaturate(@link-blue, 56%), 67%), 50%);
+  font-size: 0.8em;
+  text-align: center;
+
+  q {
+    display: block;
+    font-style: oblique;
+    text-align: center;
+  }
+
+  hr { background: fade(@link-blue, 35%); }
+  a.learn-more { font-size: 0.9em; }
+}
+
 .Tools .booklinks li {
   list-style: none;
   font-size: 12px;


### PR DESCRIPTION
Adds a visual indication that a book has been sponsored

<!-- What issue does this PR close? -->
Closes #2567 of #2566

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

This needs to piggy-back on the existing availability check which OL is doing for the edition (to avoid 2 http requests being made to/for archive.org metadata). Refactors book availability check by injecting ia metadata call into edition template (rather than later/burried deeper in the LoanStatus macro)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

You can see the changes on https://dev.openlibrary.org/books/OL25448615M/Reinventing_Organizations

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![dev openlibrary org_books_ol25448615m_reinventing_organizations](https://user-images.githubusercontent.com/978325/67630090-217d5200-f83f-11e9-913e-608c0ea2ca77.png)
