### PR TITLE
Disables availability.js for authors, fixes author availability

### DIFF
--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -1,8 +1,8 @@
 $def with(page, availability, user)
 
 $ ocaid = availability and availability.get('identifier')
-$ loan = ocaid and [loan for loan in user['loans'] if ocaid == loan.get('ocaid')]
-$ waiting_loan = ocaid and [request for request in user['waitlists'] if ocaid == request.get('identifier')]
+$ loan = ocaid and user and [loan for loan in user.get('loans') if loan and ocaid == loan.get('ocaid')]
+$ waiting_loan = ocaid and user and [request for request in user.get('waitlists') if request and ocaid == request.get('identifier')]
 $if loan:
   $ loan = loan[0]
 $if waiting_loan:

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -1,6 +1,12 @@
 $def with(page, availability, user)
 
 $ ocaid = availability and availability.get('identifier')
+$ loan = waiting_loan = None
+$if ocaid and user:
+  $ loans = [loan for loan in user.get('loans') if loan and ocaid == loan.get('ocaid')]
+  $ loan = loans and loans[0]
+  $ waiting_loans = [request for request in user.get('waitlists') if request and ocaid == request.get('identifier')]
+  $ waiting_loan = waiting_loans and waiting_loans[0]
 $ loan = ocaid and user and [loan for loan in user.get('loans') if loan and ocaid == loan.get('ocaid')]
 $ waiting_loan = ocaid and user and [request for request in user.get('waitlists') if request and ocaid == request.get('identifier')]
 $if loan:

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -20,8 +20,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
   <span class="details">
       <span class="resultTitle">
          <h3 class="booktitle">
-           $ url = book_url if is_bot() else '%s?edition=best' % book_url
-           <a itemprop="name" href="$url"
+           <a itemprop="name" href="$book_url"
               class="results">$doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')</a>
            $if doc.get('publish_date'):
              ($(doc['publish_date']))

--- a/openlibrary/macros/daisy.html
+++ b/openlibrary/macros/daisy.html
@@ -14,9 +14,9 @@ $else:
   $ prefix = ''
 
 <div class="cta-section print-disabled-download">
-  $if protected:
-    <img src="/images/icons/icon-encrypto-sm.png" class="daisy-lock" width="8" height="12" alt="Encrypted daisy lock"/>&nbsp;
   <a href="$(url or page.url('/daisy'))" title="Encrypted daisy download for authorized print-disabled patrons">
+    $if protected:
+      <img src="/images/icons/icon-encrypto-sm.png" class="daisy-lock" width="8" height="12" alt="Encrypted daisy lock"/>
     <meta itemprop="bookFormat" content="EBook/DAISY3"/>
     $msg
   </a>

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -26,9 +26,6 @@ function initAvailability() {
         '^/account/books/[^/]+': { // readinglog
             filter: false
         },
-        '^/authors/[^/]+': { // authors
-            filter: true
-        },
         '^/people/[^/]+': { // lists
             filter: false,
         },

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -499,13 +499,15 @@ class Author(models.Author):
         return self.key.split('/')[-1]
 
     def get_books(self):
-        i = web.input(sort='editions', page=1)
+        i = web.input(sort='editions', page=1, rows=20, mode="")
         try:
             # safegaurd from passing zero/negative offsets to solr
             page = max(1, int(i.page))
         except ValueError:
             page = 1
-        return works_by_author(self.get_olid(), sort=i.sort, page=page, rows=100)
+        return works_by_author(self.get_olid(), sort=i.sort,
+                               page=page, rows=i.rows,
+                               has_fulltext=i.mode=="ebooks")
 
     def get_work_count(self):
         """Returns the number of works by this author.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -178,13 +178,6 @@ class subject_works_json(delegate.page):
     def process_key(self, key):
         return key
 
-def inject_availability(subject_results):
-    works = add_availability(subject_results.works)
-    for work in works:
-        ocaid = work.ia if work.ia else None
-        availability = work.get('availability', {}).get('status')
-    subject_results.works = works
-    return subject_results
 
 def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filters):
     """Returns data related to a subject.
@@ -259,7 +252,7 @@ def get_subject(key, details=False, offset=0, sort='editions', limit=12, **filte
     subject_results = engine.get_subject(
         key, details=details, offset=offset, sort=sort_order,
         limit=limit, **filters)
-    return inject_availability(subject_results)
+    return subject_results
 
 class SubjectEngine:
     def get_subject(self, key, details=False, offset=0, limit=12, sort='first_publish_year desc', **filters):
@@ -298,7 +291,7 @@ class SubjectEngine:
             name=name,
             subject_type=subject_type,
             work_count = result['num_found'],
-            works=result['docs']
+            works=add_availability(result['docs'])
         )
 
         if details:

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -35,8 +35,6 @@ $def render_carousel_cover(book, lazy):
     $ cta = 'Borrow'
   $else:
     $ cta = 'Read'
-    $if not is_bot():
-      $ url += '?edition=best'
     $ cta_url = url
 
   $if lazy:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -162,12 +162,16 @@ window.q.push(function(){\$("#coverPop").colorbox({inline:true, opacity:"0.5", h
                     by this author?
                 </p>
 
+                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
+
                 <div id="searchResults">
                     <ul id="siteSearch" class="list-books">
                       $for doc in books.works:
                          $:macros.SearchResultsWork(doc)
                     </ul>
                 </div>
+
+                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
         </div>
     </div>
     <div class="contentOnethird">
@@ -231,38 +235,6 @@ window.q.push(function(){\$("#coverPop").colorbox({inline:true, opacity:"0.5", h
                 </div>
 
     </div>
-
-    $ pages = (books.num_found / 100) + 1
-    $ page_num = safeint(query_param('page'), default=1)
-        $if pages != 1:
-            $ pages_in_set = 10
-            $ half = pages_in_set/2
-            $if pages < pages_in_set:
-                $ first_page_in_set = 1
-                $ last_page_in_set = pages
-            $elif page_num < half:
-                $ first_page_in_set = 1
-                $ last_page_in_set = min((pages_in_set, pages))
-            $elif page_num > (pages-half):
-                $ first_page_in_set = pages-pages_in_set
-                $ last_page_in_set = pages
-            $else:
-                $ first_page_in_set = page_num-half
-                $ last_page_in_set = page_num+half
-            <div class="clearfix"></div>
-            <div class="pagination">
-            $if page_num != 1:
-                <a href="$changequery(page=None)" class="ChoosePage">&laquo;&nbsp;First</a>
-                <a href="$changequery(page=page_num-1)" class="ChoosePage">&lt;&nbsp;Previous</a>
-            $for p in range(first_page_in_set, last_page_in_set+1):
-                $if p == page_num:
-                    <span class="this">$p</span>
-                $else:
-                    <a href="$changequery(page=p)" class="ChoosePage">$p</a>
-            $if page_num < pages:
-                <a href="$changequery(page=page_num+1)" class="ChoosePage">Next&nbsp;&gt;</a>
-                <a href="$changequery(page=pages)" class="ChoosePage">Last&nbsp;&raquo;</a>
-            </div>
 
     $:render_template("lib/history", page)
 </div>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -152,16 +152,15 @@ window.q.push(function(){\$("#coverPop").colorbox({inline:true, opacity:"0.5", h
                         <a href="$changequery(sort=None)#editions">Most Editions</a> |  <a href="$changequery(sort='old')#editions">First Published</a> | <a href="$changequery(sort='new')#editions">Most Recent</a> | <strong class="lightgreen">Title</strong>
                 </span>
 
-                <span class="mode-options">
-                  <input type="radio" name="mode" value="everything" id="mode-search-everything" class="search-mode">
-                  <label for="mode-search-everything">Everything</label>
-                  <input type="radio" name="mode" value="ebooks" id="mode-search-ebooks" class="search-mode">
-                  <label for="mode-search-ebooks">Ebooks</label>
-                  <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
-                  <label for="mode-search-printdisabled">Print Disabled</label>
-                </span>
-</p>
-
+                <p>
+                  $if input(mode="everything").mode == "everything":
+                    Showing all works by author. Would you like to
+                    see <a href="$changequery(mode='ebooks')">only ebooks</a>?
+                  $else:
+                    Showing ebooks only. Would you like to see
+                    <a href="$changequery(mode='everything')">everything</a>
+                    by this author?
+                </p>
 
                 <div id="searchResults">
                     <ul id="siteSearch" class="list-books">
@@ -170,10 +169,8 @@ window.q.push(function(){\$("#coverPop").colorbox({inline:true, opacity:"0.5", h
                     </ul>
                 </div>
         </div>
-
     </div>
     <div class="contentOnethird">
-
         <div class="illustration">
             $:render_template("covers/author_photo", page)
             $:render_template("covers/change", page, ".bookCover img")

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -26,8 +26,8 @@
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .searchResultItem {
     .searchResultItemCTA {
-      width: 70%;
-      min-width: 30%;
+      width: 200px;
+      min-width: 200px;
       padding: 0 5px 0 15px;
     }
   }

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -26,7 +26,7 @@
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .searchResultItem {
     .searchResultItemCTA {
-      width: 30%;
+      width: 70%;
       min-width: 30%;
       padding: 0 5px 0 15px;
     }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -484,11 +484,12 @@ p {
 }
 
 .print-disabled-download {
+  a {
+    flex: 1;
+  }
   display: flex;
   font-size: 10px;
-  text-align: center;
-  margin-top: 5px;
-  padding: 5px;
+  align-items: center;
 }
 
 input[type=text],
@@ -2004,13 +2005,6 @@ div#subjectLists {
 // openlibrary/macros/databarWork.html
 #read.panel {
   margin-bottom: 10px;
-}
-
-// openlibrary/macros/daisy.html
-// openlibrary/templates/books/edition-sort.html
-.daisy-lock {
-  position: relative;
-  top: 1px;
 }
 
 // openlibrary/macros/SearchResultsWork.html


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #623 
Closes #2177 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Availability.js has been disabled for authors pages. Availability is injected directly into author's works on the backend. Page-size for authors works has been reduced to 20 (from 100) to avoid overflowing the availability v2 API w/ too many IDs.

This PR also removes `?edition=best` resolver as this was likely interfering w/ Availability js lookups (as noted by @jdlrobson in #2541 which should likely also be merged, though we're close to being able to deprecate availability.js :tada: )

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

https://dev.openlibrary.org/authors/OL31353A/Ursula_K._Le_Guin

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![dev openlibrary org_authors_OL31353A_Ursula_K _Le_Guin_debug=true mode=everything](https://user-images.githubusercontent.com/978325/67632315-25b96780-f85f-11e9-8d77-95d1760f9f10.png)