### PR TITLE
fix compare button appearing once per every history row

### DIFF
--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -30,13 +30,13 @@ $var title: $name
             </tr>
         </thead>
         <tbody>
-            $for v in h:
             <tr>
                 <td colspan="4"></td>
                 <td colspan="1" style="text-align:center;">
                     <input type="submit" value="$_('Compare')"  name="_compare" title="$_('See Diff')"/>
                 </td>
             </tr>
+            $for v in h:
                 <tr>
                     <td class="number">$v.revision</td>
                     <td class="history"><a href="$page.get_url(v=v.revision)" title="$_('View revision %s', v.revision)">$datestr(v.created)</a></td>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical

### Testing
Tested history appears with only 2 buttons on http://192.168.99.100:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twainsadf?m=history

### Evidence
| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/6251786/67723088-2c97c580-f998-11e9-95c3-e9af3065ccae.png) | 
![image](https://user-images.githubusercontent.com/6251786/67723495-8220a200-f999-11e9-9ff7-e6c71fb0be3c.png) |
