### PR TITLE
2531: show borrow CTA above fold on mobile

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -157,7 +157,9 @@ $if ctx.user and ctx.user.is_admin():
                 $if not page.is_fake_record():
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
-
+            <div class="mobile-borrow-cta">
+              $:macros.LoanStatus(page, ctx.user, editions_page=True)
+            </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.
             $if "lists" in ctx.features and not page.is_fake_record():

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -87,3 +87,13 @@ div.editionTools {
     display: inline-block;
   }
 }
+
+.mobile-borrow-cta {
+  display: block;
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+  .mobile-borrow-cta {
+    display: none;
+  }
+}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2531 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

**Feature:** Show the borrow CTA on mobile above the fold. Hide extra borrow CTA on tablet + desktop.

### Technical
<!-- What should be noted about the implementation? -->

Placed this above the `lists/widget` on the `templates/type/edition/view` template, but open to placing it elsewhere.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Navigate to an Edition page (such as [this one](https://openlibrary.org/books/OL25930651M/The_Three-Body_Problem))
2. Resize browser to mobile width (or open a mobile view with devtools)
3. See borrow button appear on mobile only

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

**Mobile view:**

<img width="479" alt="Screen Shot 2019-10-28 at 9 22 06 PM" src="https://user-images.githubusercontent.com/989784/67734598-74860f00-f9cf-11e9-8aaa-dc3f4b911357.png">

**Tablet:**
Chose to hide the button beginning with tablet breakpoints as I felt it wasn't necessary here.

<img width="553" alt="Screen Shot 2019-10-28 at 9 55 56 PM" src="https://user-images.githubusercontent.com/989784/67734612-7f40a400-f9cf-11e9-864f-c4e4e6c4cfc5.png">

**Note**
As you can see above, I chose to have the button `display: block` so it would expand the width of the `editionCover` div. Here's what it looks like with `display: inline-block`. I can do whichever one is preferred, I just thought `display: inline-block` looks odd with the centered rating stars.
<img width="483" alt="Screen Shot 2019-10-28 at 9 55 03 PM" src="https://user-images.githubusercontent.com/989784/67734682-abf4bb80-f9cf-11e9-9a3f-38e936b00eb3.png">
