### PR TITLE
Search-Inside button on Editions for unrestricted books

### DIFF
--- a/openlibrary/macros/BookSearchInside.html
+++ b/openlibrary/macros/BookSearchInside.html
@@ -1,0 +1,6 @@
+$def with(ocaid, q="")
+  <form action="/borrow/ia/$(ocaid)">
+    <input class="cta-btn cta-btn--preview" type="text" name="q"
+           data-ol-link-track="CTALink|ReadSearchInside"
+           placeholder="$_('Search Inside')">
+  </form>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -44,6 +44,7 @@ $if user_loan:
 
 $elif ocaid and not page.is_access_restricted() and editions_page:
   $:macros.ReadButton(ocaid, listen=True)
+  $:macros.BookSearchInside(ocaid)
 
 $elif (availability_status == 'borrow_available') or my_turn_to_borrow:
   $:macros.ReadButton(ocaid, borrow=True, listen=True)

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -16,7 +16,7 @@ $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
   $if listen:
     <a href="$(stream_url)&_autoReadAloud=show"
        title="$title using Read Aloud"
-       data-ol-link-track="listen""
+       data-ol-link-track="CTALink|$(action.capitalize())Listen"
        class="cta-btn cta-btn--available">
       <span class="btn-icon read-aloud"></span>
       <span class="btn-label">Listen</span>

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -41,7 +41,6 @@ class read_singleget(delegate.page):
             result = []
         return simplejson.dumps(result)
 
-
 class read_multiget(delegate.page):
     """Handle the multi-lookup form of the Hathi-style API
     """

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -129,6 +129,9 @@ class borrow(delegate.page):
         if i._autoReadAloud is not None:
             archive_url += '&_autoReadAloud=show'
 
+        if i.q:
+            archive_url += "#page/-/mode/2up/search/%s" % i.q
+
         if availability and availability['status'] == 'open':
             raise web.seeother(archive_url)
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -130,7 +130,8 @@ class borrow(delegate.page):
             archive_url += '&_autoReadAloud=show'
 
         if i.q:
-            archive_url += "#page/-/mode/2up/search/%s" % i.q
+            _q = urllib.quote(i.q, safe='')
+            archive_url += "#page/-/mode/2up/search/%s" % _q
 
         if availability and availability['status'] == 'open':
             raise web.seeother(archive_url)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2590 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
For public domain and open/unrestricted editions, a new button appears which enables patrons to go directly into the archive.org book using a search query.

### Technical
<!-- What should be noted about the implementation? -->

We leverage the openlibrary.org/borrow/ia endpoint by passing along a GET parameter of `q=` in order to pass/propagate a search-inside query along to the archive.org/stream bookreader. This further DRY's our process so `/borrow/ia` is the only way to read, borrow, or search inside. We couldn't just form submit a GET from the editions page to /stream because the BookReader uses/hijacks the `#` operator to denote search (e.g. `#page/104/mode/2up/search/thinking`) and forms (at least w/o javascript) can only submit form and GET parameters, not dynamically map an input to the hash (and encode, decode).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- only shows up on open pages (though should technically work on borrowable books, but -- unless we introduced a search-inside preview -- it would initiate a borrow, which is probably not desirable)

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/978325/68058848-90cbc980-fcb7-11e9-891e-6fb618e267af.png)
