### PR TITLE
Make sure i.q doesnt' AttributeError on q

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -110,7 +110,7 @@ class borrow(delegate.page):
     def POST(self, key):
         """Called when the user wants to borrow the edition"""
 
-        i = web.input(action='borrow', format=None, ol_host=None, _autoReadAloud=None)
+        i = web.input(action='borrow', format=None, ol_host=None, _autoReadAloud=None, q="")
 
         if i.ol_host:
             ol_host = i.ol_host


### PR DESCRIPTION
We need to protect against the case where `i.q` is not defined (`AttributeError`) by setting its default in `web.input(q="")`