### PR TITLE
Fix librarylink isbns

### DIFF
--- a/openlibrary/macros/WorldcatLink.html
+++ b/openlibrary/macros/WorldcatLink.html
@@ -6,7 +6,7 @@ $if oclc_numbers or isbn:
     <p class="cta-section-title">Check nearby libraries</p>
     <ul class="book-locate-options">
       $if isbn:
-        <li><a href="https://labs.library.link/services/borrow/?isbn=$(isbn_10_to_isbn_13(isbn))&embed=True&radius=500&refer=$(referer)">Library.link</a></li>
+        <li><a href="https://labs.library.link/services/borrow/?isbn=$isbn&embed=True&radius=500&refer=$(referer)">Library.link</a></li>
       <li><a class="worldcat-link" data-ol-link-track="worldcat-search" href="$macros.WorldcatUrl(isbn=isbn, oclc_numbers=oclc_numbers)" title="Check WorldCat for an edition near you">WorldCat</a></li>
     </ul>
   </div>


### PR DESCRIPTION
Hotfix required by our partners @ librarylink. The current isbn10to13 is failing because we have since normalized edition pages to use (i.e. pass in) isbn13.