### PR TITLE
add appropriate action tags on import to show recent-edits

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -575,7 +575,7 @@ def load_data(rec, account=None):
     edition['key'] = ekey
     edits.append(edition)
 
-    web.ctx.site.save_many(edits, 'import new book')
+    web.ctx.site.save_many(edits, comment='import new book', action='add-book')
 
     # Writes back `openlibrary_edition` and `openlibrary_work` to
     # archive.org item after successful import:
@@ -725,7 +725,7 @@ def load(rec, account=None):
         reply['work']['status'] = 'created' if work_created else 'modified'
         edits.append(w)
     if edits:
-        web.ctx.site.save_many(edits, 'import existing book')
+        web.ctx.site.save_many(edits, comment='import existing book', action='edit-book')
     if 'ocaid' in rec:
         update_ia_metadata_for_ol_edition(match.split('/')[-1])
     return reply


### PR DESCRIPTION
closes #2297
Now import added books _and_ other edits will show in existing stats

Looks good on https://dev.openlibrary.org/recentchanges/add-book#bots
![image](https://user-images.githubusercontent.com/905545/69108290-0e297380-0ad9-11ea-83f3-9d0a7fb0cb1d.png)

Now import bot newly added books (by isbn) show up on the Books added Bots tab
