### PR TITLE
Dependabot: Add JavaScript dependency checking

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,9 @@
 version: 1
 
 update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"
   - package_manager: "python"
     directory: "/"
     update_schedule: "monthly"


### PR DESCRIPTION
Make automated PRs for JavaScript dependencies like we already have for Python.
https://github.com/internetarchive/openlibrary/pulls/app%2Fdependabot-preview