### PR TITLE
hotfix: preview button doesn't open floater

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,27 +1,30 @@
-$def with (ocaid)
+$def with (ocaid, render_floater=True)
+$# :param str ocaid:
+$# :param bool render_floater: whether to render the floater's HTML
 
-<a class="cta-btn cta-btn--preview" href="#bookPreview"
-   id="bookPreviewButton">$_('Preview')</a>
-<div class="hidden">
-  <div class="floater" id="bookPreview">
-    <div class="book-preview">
-      <div class="floaterHead">
-        <h2>$_('Preview Book')</h2>
-        <a class="dialog--close" data-key="book_preview" data-ol-link-track="book_preview"
-           title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
+<a class="cta-btn cta-btn--shell cta-btn--preview" href="#bookPreview">$_('Preview')</a>
+
+$if render_floater:
+  <div class="hidden">
+    <div class="floater" id="bookPreview">
+      <div class="book-preview">
+        <div class="floaterHead">
+          <h2>$_('Preview Book')</h2>
+          <a class="dialog--close" data-key="book_preview" data-ol-link-track="book_preview"
+             title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
+        </div>
+        <div id="bookPreviewIframe" class="lazyIframe">
+          <iframe width="100%" height="515"
+                  data-src="https://archive.org/stream/$ocaid?wrapper=false">
+          </iframe>
+        </div>
+        <p class="learn-more">
+          <a href="https://archive.org/details/$ocaid"
+             data-key="book_preview_learn_more"
+             data-ol-link-track="book_preview_learn_more">
+            $("See more about this book on Archive.org")
+          </a>
+        </p>
       </div>
-      <div id="bookPreviewIframe" class="lazyIframe">
-        <iframe width="100%" height="515"
-                data-src="https://archive.org/stream/$ocaid?wrapper=false">
-        </iframe>
-      </div>
-      <p class="learn-more">
-        <a href="https://archive.org/details/$ocaid"
-           data-key="book_preview_learn_more"
-           data-ol-link-track="book_preview_learn_more">
-          $("See more about this book on Archive.org")
-        </a>
-      </p>
     </div>
   </div>
-</div>

--- a/openlibrary/macros/BookSearchInside.html
+++ b/openlibrary/macros/BookSearchInside.html
@@ -1,6 +1,6 @@
 $def with(ocaid, q="")
   <form action="/borrow/ia/$(ocaid)">
-    <input class="cta-btn cta-btn--preview" type="text" name="q"
+    <input class="cta-btn cta-btn--shell" type="text" name="q"
            data-ol-link-track="CTALink|ReadSearchInside"
            placeholder="$_('Search Inside')">
   </form>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,9 +1,10 @@
-$def with (page, user, editions_page=False, block_name='')
+$def with (page, user, editions_page=False, block_name='', render_preview_floater=True)
 $# Takes following parameters:
 $# * page
 $# * user
 $# * editions_page renders additional data if you're seeing LoanStatus rendered in the sidebar of an edition page v. in the work's table.
 $# * block_name is a BEM block name
+$# * render_preview_floater whether to render the HTML for the preview floater
 
 $ ocaid = page.get('ocaid')
 $ work = page.works and page.works[0]
@@ -87,7 +88,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
     <a href="$work.key" class="cta-btn cta-btn--missing">No ebook available</a>
 
 $if ocaid and page.is_access_restricted() and availability_status.startswith('borrow') and editions_page:
-  $:macros.BookPreview(ocaid)
+  $:macros.BookPreview(ocaid, render_preview_floater)
 
 $if ocaid and page.is_access_restricted():
   $:macros.daisy(page, protected=page.is_access_restricted(), block_name=block_name)

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -399,7 +399,7 @@ export function initPreviewButton() {
     /**
      * Colorbox modal + iframe for Book Preview Button
      */
-    $('#bookPreviewButton').colorbox({
+    $('.cta-btn--preview').colorbox({
         width: '100%',
         maxWidth: '640px',
         inline: true,

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -158,7 +158,7 @@ $if ctx.user and ctx.user.is_admin():
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, editions_page=True)
+              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -53,7 +53,7 @@ a.cta-btn {
     color: @white;
     &:hover { background-color: darken(@orange, 20%); }
   }
-  &--preview, &--preview:link, &--preview:visited {
+  &--shell, &--shell:link, &--shell:visited {
     background-color: @white;
     border: 2px solid @primary-blue;
     color: @primary-blue;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2612

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix: Fixes preview button not opening floater

**Recommend [hiding whitespace changes](https://github.com/internetarchive/openlibrary/pull/2614/files?utf8=%E2%9C%93&diff=split&w=1)**; the diff looks larger than it is.

### Technical
<!-- What should be noted about the implementation? -->
The issue was that there were 2 floaters being rendered with the same ID, and that one of them was inside the `mobile-borrow-cta` div. This div is hidden on desktop, so it the floater would never display.

Fixed by:
- Add option to render the floater; not super elegant, but gets the job done with minimal tech debt
- Remove id on preview button; since that is bound via jquery, it's technically undefined behaviour to try to select multiple elements with the same ID, so it's uncertain what would happen
- made the class `cta-btn--preview` exclusive to the preview button

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested:
- 192.168.99.100:8080/books/OL2058361M
  - ✅ preview button works on desktop
  - ✅ preview button works on mobile
- http://192.168.99.100:8080/books/OL24197475M/The_complete_works_of_Mark_Twain.
  - ✅ read button works
  - ✅ listen button works
  - ✅ search inside works

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
