### PR TITLE
Clearer stats and fix img validation errors

### DIFF
--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -108,49 +108,49 @@ $ stats = get_admin_stats()
 
   <table class="measurements stripeEven">
     <tr>
-      <th></th>
+      <th><h2>Items Added</h2></th>
       <th>Last 7 days</th>
       <th>Last 28 days</th>
       <th>Trend</th>
       <th>Total</th>
     </tr>
     <tr class="major">
-      <td>Works</td>
+      <td>Works Added</td>
       <td class="amount">$commify(counts.works.get_summary(7))</td>
       <td class="amount">$commify(counts.works.get_summary(28))</td>
       <td><div class="sparkDisplay"><div id="works_minigraph" class="stats-spacer"></div></div></td>
       <td class="amount">$commify(counts.works.total)</td>
     </tr>
     <tr class="major">
-      <td>Editions</td>
+      <td>Editions Added</td>
       <td class="amount">$commify(counts.editions.get_summary(7))</td>
       <td class="amount">$commify(counts.editions.get_summary(28))</td>
       <td><div class="sparkDisplay"><div id="editions_minigraph" class="stats-spacer"></div></div></td>
       <td class="amount">$commify(counts.editions.total)</td>
     </tr>
     <tr class="major even">
-      <td>Authors</td>
+      <td>Authors Added</td>
       <td class="amount">$commify(counts.authors.get_summary(7))</td>
       <td class="amount">$commify(counts.authors.get_summary(28))</td>
       <td><div class="sparkDisplay"><div id="authors_minigraph" class="stats-spacer"></div></div></td>
       <td class="amount">$commify(counts.authors.total)</td>
     </tr>
     <tr class="major even">
-      <td>Covers</td>
+      <td>Covers Added</td>
       <td class="amount">$commify(counts.covers.get_summary(7))</td>
       <td class="amount">$commify(counts.covers.get_summary(28))</td>
       <td><div class="sparkDisplay"><div id="covers_minigraph" class="stats-spacer"></div></div></td>
       <td class="amount">$commify(counts.covers.total)</td>
     </tr>
     <tr class="major">
-      <td>Members</td>
+      <td>New Members</td>
       <td class="amount">$commify(counts.members.get_summary(7))</td>
       <td class="amount">$commify(counts.members.get_summary(28))</td>
       <td><div class="sparkDisplay"><div id="members_minigraph" class="stats-spacer"></div></div></td>
       <td class="amount">$commify(counts.members.total)</td>
     </tr>
     <tr class="major">
-      <td>Lists</td>
+      <td>Lists Added</td>
       <td class="amount">$commify(counts.lists.get_summary(7))</td>
       <td class="amount">$commify(counts.lists.get_summary(28))</td>
       <td><div class="sparkDisplay"><div id="lists_minigraph" class="stats-spacer"></div></div></td>
@@ -175,11 +175,11 @@ $ stats = get_admin_stats()
   <div class="clearfix"></div>
 
   <h2>Unique Visitors</h2>
-  <img src="http://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-60days"/>
+  <img alt="Unique visitors IPs per day graph" src="http://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-60days"/>
 
   <h2>Borrows</h2>
-  <img src="http://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-3months&tz=UTC&width=900"/>
-  <img src="http://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-24months&tz=UTC&width=900"/>
+  <img alt="Borrows, last 3 months graph" src="http://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-3months&tz=UTC&width=900"/>
+  <img alt="Borrows, last 2 years graph" src="http://graphite.us.archive.org/render?target=hitcount(stats.ol.loans.bookreader,%221d%22)&from=-24months&tz=UTC&width=900"/>
 
   <div class="contentSpacer"></div>
 


### PR DESCRIPTION

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the stats on https://openlibrary.org/stats clearer and fixes some HTML validation errors raised by
https://validator.w3.org/nu/?doc=https%3A%2F%2Fopenlibrary.org%2Fstats

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/905545/68561452-73161580-04aa-11ea-92ee-cf266b0672f5.png)
