### PR TITLE
Add aggregate rating microdata to editions page + small microdata fix

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -146,8 +146,9 @@ $if ctx.user and ctx.user.is_admin():
 </div>
 
 <div id="contentBody" role="main" itemscope itemtype="https://schema.org/Book">
-
     <div class="workDetails">
+        $if work:
+            <link itemprop="exampleOfWork" href="$work.key">
 
         <div class="editionCover">
 
@@ -196,13 +197,14 @@ $if ctx.user and ctx.user.is_admin():
               $ rating_stats = work.get_rating_stats() if work else {}
               $ stats_by_bookshelf = work.get_num_users_by_bookshelf() if work else {}
               $if rating_stats or stats_by_bookshelf:
-                <ul class="readers-stats">
-                  $if rating_stats and rating_stats['avg_rating'] > 0 and rating_stats['num_ratings'] > 1:
+                $ show_ratings = rating_stats and rating_stats['avg_rating'] > 0 and rating_stats['num_ratings'] > 1
+                <ul class="readers-stats" $:cond(show_ratings, 'itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating"', '')>
+                  $if show_ratings:
                     <li class="avg-ratings">
-                      $:('<span class="readers-stats__star">★</span>' * int(rating_stats['avg_rating'])) $(rating_stats['avg_rating'])
+                        $:('<span class="readers-stats__star">★</span>' * int(rating_stats['avg_rating'])) <span itemprop="ratingValue">$(rating_stats['avg_rating'])</span>
                     </li>
                     <li>
-                      $rating_stats['num_ratings'] Ratings
+                        <span itemprop="reviewCount">$rating_stats['num_ratings']</span> Ratings
                     </li>
                   $if stats_by_bookshelf.get('want-to-read', 0) > 1:
                     <li class="reading-log-stat">$stats_by_bookshelf['want-to-read'] Want to read</li>
@@ -231,7 +233,7 @@ $if ctx.user and ctx.user.is_admin():
                                  <a href="/search/subjects?q=$p.replace('&','%26')" title="$_('Search for subjects about') $p">$p</a>$cond(loop.last, "", ", ")
                         <span class="adjust">.</span>
                     $if page.languages:
-                    <br/>Written in <span itemprop="In language">$:thingrepr(page.languages)</span>.
+                    <br/>Written in <span itemprop="inLanguage">$:thingrepr(page.languages)</span>.
               </h4>
 
           $if work:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2405

Feature: AggregateRating microdata

### Technical
- Corrected `itemprop` `In language` to `inLanguage` as per spec.
- Added `exampleOfWork` microdata linking back to the work

### Testing
- Forced the ratings to appear by adding `$ rating_stats = {'avg_rating': 4.6, 'num_ratings': 12}` to html template
- Copied the rendered HTML into https://search.google.com/structured-data/testing-tool/u/0/ ; got:
![image](https://user-images.githubusercontent.com/6251786/68887883-d17c0780-06e7-11ea-9b31-e830095534b8.png)

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
- No visible changes

### Stakeholders
@jdlrobson 