### PR TITLE
Add librarian option to create new work when moving edition

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -8,6 +8,7 @@ export default function($) {
      * @property{(boolean|Function)} [addnew] - when (or whether) to display a "Create new record"
      *     element in the autocomplete list. The function takes the query and should return a boolean.
      *     a boolean.
+     * @property{string} [new_name] - name to display when __new__ selected. Defaults to the query
      */
 
     /**
@@ -37,12 +38,13 @@ export default function($) {
 
                 // XXX: this won't work when _this is multiple values (like $("input"))
                 query = $(_this).val();
-                if (ol_ac_opts.addnew && ol_ac_opts.addnew(query)) {
+                if (ol_ac_opts.addnew == true || (ol_ac_opts.addnew && ol_ac_opts.addnew(query))) {
                     parsed = parsed.slice(0, ac_opts.max - 1);
+                    const name = ol_ac_opts.new_name || query;
                     parsed.push({
-                        data: {name: query, key: '__new__'},
-                        value: query,
-                        result: query
+                        data: {name, key: '__new__'},
+                        value: name,
+                        result: name
                     });
                 }
                 return parsed;

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -736,8 +736,7 @@ class SaveBookHelper:
 
         has_edition_work = 'works' in formdata.edition and \
                            formdata.edition.works and \
-                           formdata.edition.works[0].key and \
-                           formdata.edition.works[0].key != '__new__'
+                           formdata.edition.works[0].key
 
         if has_edition_work:
             old_work_key = formdata.work.key

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -521,9 +521,8 @@ class SaveBookHelper:
             # Create a new work if so desired
             new_work_key = (edition_data.get('works') or [{'key': None}])[0]['key']
             if new_work_key == "__new__" and self.work is not None:
-                new_key = web.ctx.site.new_key('/type/work')
-                self.work.update({'key': new_key})
-                edition_data.works = [{'key': new_key}]
+                self.work = self.new_work(self.edition)
+                edition_data.works = [{'key': self.work.key}]
                 saveutil.save(self.work)
 
             identifiers = edition_data.pop('identifiers', [])
@@ -554,6 +553,8 @@ class SaveBookHelper:
         work_key = web.ctx.site.new_key('/type/work')
         work = web.ctx.site.new(work_key, {
             'key': work_key,
+            'title': edition.get('title'),
+            'subtitle': edition.get('subtitle'),
             'type': {'key': '/type/work'},
             'covers': edition.get('covers', []),
         })

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -342,4 +342,6 @@ class TestSaveBookHelper:
 
         assert len(web.ctx.site.docs) == 3
         assert web.ctx.site.get("/works/OL1W") is not None
-        assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL1W"
+        new_work = web.ctx.site.get("/books/OL1M").works[0]
+        assert new_work.key == "/works/OL1W"
+        assert new_work.title == "Original Edition Title"

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -307,3 +307,39 @@ class TestSaveBookHelper:
         s.save(formdata)
 
         assert web.ctx.site.get("/works/OL1W").title == "Original Work Title"
+
+    def test_moving_edition_to_new_work(self, monkeypatch):
+        def mock_user():
+            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
+
+        monkeypatch.setattr(accounts, "get_current_user", mock_user)
+
+        web.ctx.site.save_many([
+            {
+                "type": {"key": "/type/work"},
+                "key": "/works/OL100W",
+                "title": "Original Work Title"
+            },
+            {
+                "type": {"key": "/type/edition"},
+                "key": "/books/OL1M",
+                "title": "Original Edition Title",
+                "works": [{"key": "/works/OL100W"}],
+            }])
+
+        work = web.ctx.site.get("/works/OL100W")
+        edition = web.ctx.site.get("/books/OL1M")
+
+        formdata = web.storage({
+            "work--key": "/works/OL100W",
+            "work--title": "Original Work Title",
+            "edition--title": "Original Edition Title",
+            "edition--works--0--key": "__new__",
+        })
+
+        s = addbook.SaveBookHelper(work, edition)
+        s.save(formdata)
+
+        assert len(web.ctx.site.docs) == 3
+        assert web.ctx.site.get("/works/OL1W") is not None
+        assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL1W"

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -332,7 +332,7 @@ class TestSaveBookHelper:
 
         formdata = web.storage({
             "work--key": "/works/OL100W",
-            "work--title": "Original Work Title",
+            "work--title": "FOO BAR",
             "edition--title": "Original Edition Title",
             "edition--works--0--key": "__new__",
         })
@@ -341,7 +341,10 @@ class TestSaveBookHelper:
         s.save(formdata)
 
         assert len(web.ctx.site.docs) == 3
+        # Should create new work with edition data
         assert web.ctx.site.get("/works/OL1W") is not None
         new_work = web.ctx.site.get("/books/OL1M").works[0]
         assert new_work.key == "/works/OL1W"
         assert new_work.title == "Original Edition Title"
+        # Should ignore edits to work data
+        assert web.ctx.site.get("/works/OL100W").title == "Original Work Title"

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -49,7 +49,7 @@ $jsdef render_work_field(i, work):
 $jsdef render_work_autocomplete_item(item):
     $if item.key == "__new__":
         <div class="ac_work ac_addnew">
-            <span class="action">$_('>> Move to a new work')</span>
+            <span class="action">$_('-- Move to a new work')</span>
         </div>
     $else:
         <div class="ac_work" title="Select this work">
@@ -100,7 +100,7 @@ window.q.push(function() {
         {
             endpoint: "/works/_autocomplete",
             addnew: $cond(is_privileged_user, 'true', 'false'),
-            new_name: '$_('Create new work')',
+            new_name: '$_('-- Move to a new work')',
         },
         {
             minChars: 2,

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -49,7 +49,7 @@ $jsdef render_work_field(i, work):
 $jsdef render_work_autocomplete_item(item):
     $if item.key == "__new__":
         <div class="ac_work ac_addnew">
-            <span class="action">$_('>> Move to a new work (copies work data from current work)')</span>
+            <span class="action">$_('>> Move to a new work')</span>
         </div>
     $else:
         <div class="ac_work" title="Select this work">
@@ -100,7 +100,7 @@ window.q.push(function() {
         {
             endpoint: "/works/_autocomplete",
             addnew: $cond(is_privileged_user, 'true', 'false'),
-            new_name: '$_('__new__')',
+            new_name: '$_('Create new work')',
         },
         {
             minChars: 2,

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -1,6 +1,7 @@
 $def with (work, book)
 
 $ edition_config = get_edition_config()
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 
 $def radiobuttons(name, options, value):
     $for v in options:
@@ -46,27 +47,32 @@ $jsdef render_work_field(i, work):
     </div>
 
 $jsdef render_work_autocomplete_item(item):
-    <div class="ac_work" title="Select this work">
-        <div class="cover">
-            $if item.cover_i:
-                <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="Cover of $item.title">
+    $if item.key == "__new__":
+        <div class="ac_work ac_addnew">
+            <span class="action">$_('>> Move to a new work (copies work data from current work)')</span>
         </div>
-        <span class="olid">$item.key.split('/')[2]</span>
-        <span class="name">
-            <span class="title">$item.full_title</span>
-            $if item.first_publish_year:
-            <span class="first_publish_year">($item.first_publish_year)</span>
-        </span>
-        <span class="byline">
-            $if item.author_name:
-                by <span class="authors">${', '.join(item.author_name)}</span>
-        </span>
-        &bull;
-        $if item.edition_count == 1:
-            <span class="edition_count">$item.edition_count edition</span>
-        $else:
-            <span class="edition_count">$item.edition_count editions</span>
-    </div>
+    $else:
+        <div class="ac_work" title="Select this work">
+            <div class="cover">
+                $if item.cover_i:
+                    <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="Cover of $item.title">
+            </div>
+            <span class="olid">$item.key.split('/')[2]</span>
+            <span class="name">
+                <span class="title">$item.full_title</span>
+                $if item.first_publish_year:
+                <span class="first_publish_year">($item.first_publish_year)</span>
+            </span>
+            <span class="byline">
+                $if item.author_name:
+                    by <span class="authors">${', '.join(item.author_name)}</span>
+            </span>
+            &bull;
+            $if item.edition_count == 1:
+                <span class="edition_count">$item.edition_count edition</span>
+            $else:
+                <span class="edition_count">$item.edition_count editions</span>
+        </div>
 
 <script type="text/javascript">
 window.q.push(function() {
@@ -91,7 +97,11 @@ window.q.push(function() {
     \$("#works").setup_multi_input_autocomplete(
         "input.work-autocomplete",
         render_work_field,
-        { endpoint: "/works/_autocomplete" },
+        {
+            endpoint: "/works/_autocomplete",
+            addnew: $cond(is_privileged_user, 'true', 'false'),
+            new_name: '$_('__new__')',
+        },
         {
             minChars: 2,
             max: 11,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2138 

Feature: Adds an option for librarians to create a new work when moving and edition.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
- Also now displays JSON errors that come up in addbook (previously just suppressed)


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
TODO: I've been trying to get this on OJF so that I don't have to do the testing all by my self, but am completely blocked by the fact that you can't create a new account in the local dev env (#2667) :(

- ✅ Moving edition from one work to another works
- ✅ Associating an orphan with an edition works
- ✅ Editing an orphan creates a work
- ✅ Select "move to new work" for an orphan creates a work
- ✅ Select "move to new work" for a regular edition creates a work

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/6251786/69659013-543b8580-104b-11ea-9387-25bc97634f6a.png)

### Stakeholders
@seabelis 