### PR TITLE
set max subject API limit to 1000

### DIFF
--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -1,6 +1,6 @@
 """Language pages
 """
-from __future__ import print_function
+
 from infogami.utils import delegate, stats
 from infogami.utils.view import render_template, safeint
 import web
@@ -38,18 +38,6 @@ class languages_json(subjects.subjects_json):
     def process_key(self, key):
         return key.replace("_", " ")
 
-class language_works_json(subjects.subject_works_json):
-    path = '(/languages/[^/]+)/works'
-    encoding = "json"
-
-    def is_enabled(self):
-        return "languages" in web.ctx.features
-
-    def normalize_key(self, key):
-        return key
-
-    def process_key(self, key):
-        return key.replace("_", " ")
 
 class index(delegate.page):
     path = "/languages"
@@ -59,7 +47,6 @@ class index(delegate.page):
         result = search.get_solr().select('*:*', rows=0, facets=['language'], facet_limit=500)
         languages = [web.storage(name=get_language_name(row.value), key='/languages/' + row.value, count=row.count)
                     for row in result['facets']['language']]
-        print(languages[:10], file=web.debug)
         page = render_template("languages/index", languages)
         page.v2 = True
         return page

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -41,19 +41,6 @@ class publishers_json(subjects.subjects_json):
     def process_key(self, key):
         return key.replace("_", " ")
 
-class publisher_works_json(subjects.subject_works_json):
-    path = '(/publishers/[^/]+)/works'
-    encoding = "json"
-
-    def is_enabled(self):
-        return "publishers" in web.ctx.features
-
-    def normalize_key(self, key):
-        return key
-
-    def process_key(self, key):
-        return key.replace("_", " ")
-
 class index(delegate.page):
     path = "/publishers"
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -91,7 +91,7 @@ class subjects(delegate.page):
 
 class subjects_json(delegate.page):
     path = '(/subjects/[^/]+)'
-    encoding = "json"
+    encoding = 'json'
 
     @jsonapi
     def GET(self, key):
@@ -103,7 +103,7 @@ class subjects_json(delegate.page):
         # Does the key requires any processing before passing using it to query solr?
         key = self.process_key(key)
 
-        i = web.input(offset=0, limit=DEFAULT_RESULTS, details='false', has_fulltext='true',
+        i = web.input(offset=0, limit=DEFAULT_RESULTS, details='false', has_fulltext='false',
                       sort='editions', available='false')
 
         filters = {}

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -21,7 +21,7 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 </div>
 
 <div class="contentBody">
-  $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more={"url": page.key + "/works.json", "limit": len(page.works)})
+  $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more={"url": page.key + ".json", "limit": len(page.works)})
 
 	<div class="head">
 	    <h2>

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -280,7 +280,7 @@ def copy_list(src, dest, list_key, comment):
         elif seed['type'] == 'work':
             keys.add(seed['url'])
         elif seed['type'] == 'subject':
-            doc = jsonget(seed['url'] + "/works.json")
+            doc = jsonget(seed['url'] + '.json')
             keys.update(w['key'] for w in doc['works'])
 
     seeds = get_list_seeds(list_key)


### PR DESCRIPTION
closes #314
also
fixes #2249 
with this change
https://github.com/internetarchive/openlibrary/pull/2684/files#diff-6c3e80b6749b6b6a0af58257952db8aaR107

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

**Sets subject API limits:**

example, if client specified `limit=10000` , the site performs poorly.

https://openlibrary.org/subjects/history.json?limit=100&has_fulltext=false&sort=editions

This is a metadata subject value = "History" which has confused past attemtps at investigating this issue.

An equivalent URL is 

https://openlibrary.org/subjects/games.json


Without specifying a limit, the default response contains 12 results.

Now the API response will be:
```
{"error": "Specified limit exceeds maximum of 1000."}
```
with headers (from local env):
```
HTTP/1.1 400 Bad Request
Server: gunicorn/19.9.0
Date: Tue, 17 Dec 2019 04:57:14 GMT
Connection: close
Access-Control-Allow-Origin: *
Access-Control-Allow-Method: GET, OPTIONS
Access-Control-Max-Age: 86400
Content-Type: application/json
X-OL-Stats: ""
```
#### Removes duplicate API endpoints ####
There were a range of code duplicated endpoints that also showed a list of works, literally duplicated the same code, with minor lapses in updates over time, and aren't documented on the API page https://openlibrary.org/dev/docs/api/subjects

examples:

**This PR removes:**
https://openlibrary.org/subjects/incunabula/works.json

**And keeps:**
https://openlibrary.org/subjects/incunabula.json

The subjects endpoint provides a list of works, there is no reason to have an additional works path.

### Technical
<!-- What should be noted about the implementation? -->
We are using the 
 Inforgami `safeint` https://github.com/internetarchive/infogami/blob/f533845293f9af52b56065a827c797c943f389a3/infogami/utils/view.py#L87 , _not_

https://github.com/pelotoncycle/safeint which can limit digits for safety.

The infogami `safeint` does not provide a way to limit the range on the int.

This PR chooses the min of the `safeint` and 1000.

If there is a problem with the limit we can adjust `MAX_RESULTS`.
If there are other API endpoints that exhibit the same problem, this PR can be used as a template on how to solve.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

I have tested this locally, but local env does not have enough data to exhibit the problem. Proper test would be to deploy to dev and test with the original subject link.