### PR TITLE
Normalise ISBNs early on load() attempt,

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -303,6 +303,19 @@ def update_ia_metadata_for_ol_edition(edition_id):
     return data
 
 
+def normalise_isbns(rec):
+    """
+    Returns the Edition import record with all ISBN fields cleaned.
+
+    :param dict rec: Edition import record
+    :rtype: dict
+    """
+    for field in ('isbn_13', 'isbn_10', 'isbn'):
+        if rec.get(field):
+            rec[field] = [isbn.replace('-', '').strip() for isbn in rec.get(field)]
+    return rec
+
+
 def isbns_from_record(rec):
     """
     Returns a list of all isbns from the various possible isbn fields.
@@ -311,7 +324,6 @@ def isbns_from_record(rec):
     :rtype: list
     """
     isbns = rec.get('isbn', []) + rec.get('isbn_10', []) + rec.get('isbn_13', [])
-    isbns = [isbn.replace('-', '').strip() for isbn in isbns]
     return isbns
 
 
@@ -607,6 +619,8 @@ def load(rec, account=None):
         raise RequiredField('source_records')
     if isinstance(rec['source_records'], six.string_types):
         rec['source_records'] = [rec['source_records']]
+
+    rec = normalise_isbns(rec)
 
     edition_pool = build_pool(rec)
     if not edition_pool:

--- a/openlibrary/olbase/tests/test_ol_infobase.py
+++ b/openlibrary/olbase/tests/test_ol_infobase.py
@@ -1,15 +1,12 @@
 from openlibrary.plugins.ol_infobase import OLIndexer
 
 class TestOLIndexer:
-    def test_normalize_isbn(self):
-        indexer = OLIndexer()
-        assert indexer.normalize_isbn("123456789X") == "123456789X"
-        assert indexer.normalize_isbn("123-456-789-X") == "123456789X"
-        assert indexer.normalize_isbn("123-456-789-X ") == "123456789X"
-
     def test_expand_isbns(self):
         indexer = OLIndexer()
+        isbn_10 = ['123456789X']
+        isbn_13 = ['9781234567897']
+        both = isbn_10 + isbn_13
         assert indexer.expand_isbns([]) == []
-        assert indexer.expand_isbns(["123456789X"]) == ["123456789X", "9781234567897"]
-        assert indexer.expand_isbns(["9781234567897"]) == ["123456789X", "9781234567897"]
-        assert indexer.expand_isbns(["123456789X", "9781234567897"]) == ["123456789X", "9781234567897"]
+        assert indexer.expand_isbns(isbn_10) == both
+        assert indexer.expand_isbns(isbn_13) == both
+        assert indexer.expand_isbns(both) == both

--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -63,10 +63,12 @@ def opposite_isbn(isbn): # ISBN10 -> ISBN13 and ISBN13 -> ISBN10
             return alt
 
 def normalize_isbn(isbn):
-    """Removes spaces and dashes from isbn and ensures length.
+    """
+    Keep only numbers and X/x to return an ISBN-like string.
+    Does NOT validate length or checkdigits.
 
-    :param: str isbn: An isbn to normalize
+    :param: str isbn: An isbnlike string to normalize
     :rtype: str|None
-    :return: A valid isbn, or None
+    :return: isbnlike string containing only valid ISBN characters, or None
     """
     return isbn and canonical(isbn) or None

--- a/openlibrary/utils/tests/test_isbn.py
+++ b/openlibrary/utils/tests/test_isbn.py
@@ -1,4 +1,5 @@
-from ..isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10, \
+import pytest
+from openlibrary.utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10, \
     normalize_isbn, opposite_isbn
 
 def test_isbn_13_to_isbn_10():
@@ -16,12 +17,23 @@ def test_opposite_isbn():
     assert opposite_isbn('978-0-940787-08-7') == '0940787083'
     assert opposite_isbn('BAD-ISBN') is None
 
-def test_normalize_isbn():
+def test_normalize_isbn_returns_None():
     assert normalize_isbn(None) is None
+    assert normalize_isbn('') is None
     assert normalize_isbn('a') is None
-    assert normalize_isbn('1841151866') == '1841151866'
-    assert normalize_isbn('184115186x') == '184115186X'
-    assert normalize_isbn('184115186X') == '184115186X'
-    assert normalize_isbn('184-115-1866') == '1841151866'
-    assert normalize_isbn('9781841151861') == '9781841151861'
-    assert normalize_isbn('978-1841151861') == '9781841151861'
+
+isbn_cases = [
+        ('1841151866', '1841151866'),
+        ('184115186x', '184115186X'),
+        ('184115186X', '184115186X'),
+        ('184-115-1866', '1841151866'),
+        ('9781841151861', '9781841151861'),
+        ('978-1841151861', '9781841151861'),
+        ('123-456-789-X ', '123456789X'),
+        ('ISBN: 123-456-789-X ', '123456789X'),
+        ('56', '56'), # does NOT check length
+]
+
+@pytest.mark.parametrize('isbnlike,expected', isbn_cases)
+def test_normalize_isbn(isbnlike, expected):
+    assert normalize_isbn(isbnlike) == expected

--- a/openlibrary/utils/tests/test_utils.py
+++ b/openlibrary/utils/tests/test_utils.py
@@ -16,7 +16,7 @@ def test_url_quote():
     assert url_quote('test string') == 'test+string'
 
 def test_finddict():
-    dicts = [{"x": 1, "y": 2}, {"x": 3, "y": 4}]
+    dicts = [{'x': 1, 'y': 2}, {'x': 3, 'y': 4}]
     assert finddict(dicts, x=1) == {'x': 1, 'y': 2}
 
 def test_escape_bracket():


### PR DESCRIPTION
 to aid with matching _and_ ensure correct format ISBNs are saved if a
new record is created.

<!-- What issue does this PR close? -->
Closes #49 

Investigating the remaining tasks I added on #49, I have discovered:
* openlibrary/plugins/importapi/code.py DOES NOT perform any ISBN cleanup or validation. (this is probably ok)
* Next part of the import openlibrary/catalog/add_book/__init__.py only temporarily cleans the ISBNs for comparing with existing records...
* it DOES NOT strip hyphens when / if the ISBNs are saved

This PR moves the hyphen stripping code to an early point in the `load()` matching process so the stripping is only done once, and is retained if the edition is actually saved.


This fix is somewhat hypothetical since the original problem was reported specifically on code that has not run in years, and I cannot find any import sources that contain hyphenated ISBNs,
The MARC records I have encountered recently appear to have non-hyphenated ISBNs, and that seems to be the standard for the other sources.

This change does make things more consistent, and applies exisiting code in a more sensible way that actually will protect the data for ever having inconsistently represented ISBNs.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->