### PR TITLE
Dev: Drop jquery ui file in static folder

### DIFF
--- a/static/js/jquery-ui-1.12.1.min.js
+++ b/static/js/jquery-ui-1.12.1.min.js
@@ -1,1 +1,0 @@
-../../vendor/js/jquery-ui/jquery-ui-1.12.1.min.js


### PR DESCRIPTION
This is built from vendor. Having this file here leads to confusion that it can be used.
This file is currently unused. We use the one in vendor folder.
No PR. Removing it was easier than writing an issue.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cdrini 