### PR TITLE
Tab dialog code organisation

### DIFF
--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -2,22 +2,8 @@
  * Setup actions on document.ready for standard classNames.
  */
 export default function($) {
-    var options;
     // Flash messages are hidden by default so that CSS is not on the critical path.
     $('.flash-messages').show();
-
-    // tabs
-    options = {};
-    if ($.support.opacity){
-        options.fx = {opacity: 'toggle'};
-    }
-
-    if ($('.tabs:not(.ui-tabs)').tabs) {
-        $('.tabs:not(.ui-tabs)').tabs(options)
-        $('.tabs.autohash').bind('tabsselect', function(event, ui) {
-            document.location.hash = ui.panel.id;
-        });
-    }
 
     // validate forms
     $('form.validate').ol_validate();

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -1,6 +1,35 @@
+
+/**
+ * a confirm dialog for confirming actions
+ * @this jQuery.Object
+ * @param {Function} callback
+ * @param {Object} options
+ * @return {jQuery.Object}
+ */
+export function confirmDialog(callback, options) {
+    var _this = this;
+    var defaults = {
+        autoOpen: false,
+        width: 400,
+        modal: true,
+        resizable: false,
+        buttons: {
+            'Yes, I\'m sure': function() {
+                callback.apply(_this);
+            },
+            'No, cancel': function() {
+                $(_this).dialog('close');
+            }
+        }
+    };
+    options = $.extend(defaults, options);
+    return this.dialog(options);
+}
+
 /**
  * Wires up confirmation prompts.
  * In future this will be generalised.
+ * @return {Function} for creating a confirm dialog
  */
 function initConfirmationDialogs() {
     const CONFIRMATION_PROMPT_DEFAULTS = { autoOpen: false, modal: true };
@@ -41,7 +70,7 @@ function initConfirmationDialogs() {
  * opening of a dialog. The `aria-controls` attribute on that same element
  * communicates where the HTML of that dialog lives.
  */
-export default function initDialogs() {
+export function initDialogs() {
     $('.dialog--open').on('click', function () {
         const $link = $(this),
             href = `#${$link.attr('aria-controls')}`;

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -27,13 +27,13 @@ import * as Browser from './Browser';
 import { commify } from './python';
 import { Subject, urlencode, slice } from './subjects';
 import Template from './template.js';
-// Add $.fn.focusNextInputField, $.fn.ol_confirm_dialog
+// Add $.fn.focusNextInputField
 import { closePopup, truncate, cond } from './utils';
 import initValidate from './validate';
 import '../../../../static/css/js-all.less';
 // polyfill Promise support for IE11
 import Promise from 'promise-polyfill';
-import initDialogs from './dialog';
+import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
 
 // Eventually we will export all these to a single global ol, but in the mean time
@@ -74,7 +74,9 @@ jQuery(function () {
     // Live NodeList is cast to static array to avoid infinite loops
     const $carouselElements = $('.carousel--progressively-enhanced');
     initDialogs();
-    initTabs($('#tabsAddbook,#tabsAddauthor'));
+    // expose ol_confirm_dialog method
+    $.fn.ol_confirm_dialog = confirmDialog;
+    initTabs($('#tabsAddbook,#tabsAddauthor,.tabs:not(.ui-tabs)'));
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -2,4 +2,7 @@ const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
 
 export default function initTabs($node) {
     $node.tabs(TABS_OPTIONS);
+    $node.filter('.autohash').bind('tabsselect', function(event, ui) {
+        document.location.hash = ui.panel.id;
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -10,27 +10,6 @@ $.fn.focusNextInputField = function() {
     });
 };
 
-// Confirm dialog with OL styles.
-$.fn.ol_confirm_dialog = function(callback, options) {
-    var _this = this;
-    var defaults = {
-        autoOpen: false,
-        width: 400,
-        modal: true,
-        resizable: false,
-        buttons: {
-            'Yes, I\'m sure': function() {
-                callback.apply(_this);
-            },
-            'No, cancel': function() {
-                $(_this).dialog('close');
-            }
-        }
-    };
-    options = $.extend(defaults, options);
-    this.dialog(options);
-}
-
 // closes active popup
 // used in templates/covers/saved.html
 export function closePopup() {

--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -27,21 +27,20 @@ $if "type" in doc and doc.type.key == "/type/user":
                     .find(".listDelete a")
                     .click(function() {
                         \$('#delete-dialog')
+                            .ol_confirm_dialog(function(){
+                                var list_id = "#" + \$(this).data("list-id");
+                                var key = \$(list_id + " a:first").attr("href");
+                                var dialog = this;
+
+                                \$.post(key + "/delete.json", function() {
+                                    \$(list_id).remove();
+                                    \$(dialog).dialog("close");
+                                });
+                            })
                             .data("list-id", \$(this).closest("li").attr("id"))
                             .dialog('open');
                         return false;
                     });
-
-                \$("#delete-dialog").ol_confirm_dialog(function(){
-                    var list_id = "#" + \$(this).data("list-id");
-                    var key = \$(list_id + " a:first").attr("href");
-                    var dialog = this;
-
-                    \$.post(key + "/delete.json", function() {
-                        \$(list_id).remove();
-                        \$(dialog).dialog("close");
-                    });
-                });
             });
         </script>
         <div id="delete-dialog" class="hidden" title="Delete list">Are you sure you want to delete this list?</div>
@@ -56,22 +55,21 @@ $else:
             .find(".listDelete a")
             .click(function() {
                 \$('#remove-dialog')
+                    .ol_confirm_dialog(function() {
+                        var seed = $:json_encode(seed);
+                        var list_id = "#" + \$(this).data("list-id");
+                        var key = \$(list_id + " a:first").attr("href");
+
+                        var dialog = this;
+
+                        remove_seed(key, seed, function() {
+                            \$(list_id).remove();
+                            \$(dialog).dialog("×");
+                        });
+                    })
                     .data("list-id", \$(this).closest("li").attr("id"))
                     .dialog('open');
                 return false;
-            });
-
-            \$("#remove-dialog").ol_confirm_dialog(function() {
-                var seed = $:json_encode(seed);
-                var list_id = "#" + \$(this).data("list-id");
-                var key = \$(list_id + " a:first").attr("href");
-
-                var dialog = this;
-
-                remove_seed(key, seed, function() {
-                    \$(list_id).remove();
-                    \$(dialog).dialog("×");
-                });
             });
         });
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -494,6 +494,7 @@ $if ctx.user:
         \$("a.remove-from-list").click(function(event) {
             event.preventDefault();
             var id = \$(this).attr("id");
+            setup_dialog();
 
             \$("#remove-dialog")
                 .data("list-id", id)
@@ -526,7 +527,6 @@ $if ctx.user:
     window.q.push(function(){
         setup_submit_event();
         setup_events();
-        setup_dialog();
 
         var mylist = \$('.dropdown');
         var listitems = mylist.children('p.list').get();


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This sets up the stage for finally moving jQuery UI off the critical path (#2340) and moving the large major JS feature into webpack (#2468). This reorganises code relating to tabs and dialogs to more suitable logical places.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
This shifts code. The important change it makes is that dialogs will now only be initialised when they are clicked rather than on initial JS execution.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Make sure you test the add cover workflow and tabs therein.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cdrini 