### PR TITLE
Multi-branch dev.openlibrary.org deploy flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,6 @@ endif
 test:
 	npm test
 	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests
+
+dev-merged:
+	./scripts/make-dev-merged.sh ./dev-merged.txt

--- a/dev-merged.txt
+++ b/dev-merged.txt
@@ -1,0 +1,11 @@
+# This file stores the branches to be merged into `dev-merged` for easy dev.openlibrary.org deploy
+# These are comments and can be left in
+#
+# To pull remote branches:
+# https://github.com/internetarchive/openlibrary.git feature/barcodescan
+#
+# Branches that are local:
+# 2138/feature/create-new-work-for-edition
+#
+# Branches from other forks:
+# https://github.com/cdrini/openlibrary.git 314/hotfix/limit-subject-results

--- a/scripts/make-dev-merged.sh
+++ b/scripts/make-dev-merged.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Util script to merge multiple branches as listed in a file into a new branch
+# Used for dev.openlibrary.org deploys
+
+NEW_BRANCH=dev-merged
+BRANCHES_FILE=$1
+
+git checkout master
+git pull origin master
+git branch -D $NEW_BRANCH
+git checkout -b $NEW_BRANCH
+
+while read branch; do
+    if [[ $branch == "#"* ]] ; then
+        :
+    elif [[ $branch == "https://"* ]] ; then
+        git pull $branch
+    else
+        git merge $branch
+    fi
+done <"$BRANCHES_FILE"


### PR DESCRIPTION
Feature: Makes it possible to place multiple branches on dev.openlibrary.org, without the fuss! All you have to do is put the branche names in `dev-merged.txt`, then run `make dev-merged`.

### Technical
- You still have to run like the build steps (see Deploy guide)
- I'll expand the Deploy wiki page to include these instructions

### Testing
Tested locally and on dev.

### Evidence
NA

### Stakeholders
@mekarpeles @hornc 