### PR TITLE
Restore orange select border in change cover dialog / add responsive behaviour

### DIFF
--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -67,9 +67,8 @@ window.q.push(function(){
 
 <form class="floatform" id="addcover-form" name="bookcover" method="post" enctype="multipart/form-data" action="$action">
 
-    <div align="center" style="width:100%;">
-        <div class="centerIt">
-
+    <div class="floatform__body">
+        <div>
             $if doc.type.key == "/type/work":
                 $if doc.get_edition_covers():
                     <div class="formElement">

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -72,7 +72,7 @@ window.q.push(function(){
             \$("#imagesAdd").html("");
             \$("#imagesManage").html("");
             $if doc.type.key == "/type/work":
-                \$('#imagesAdd').prepend('<div id="throbber"><h3>$_("One sec, we\'re searching for covers...")</h3></div>');
+                \$('#imagesAdd').prepend('<div class="throbber"><h3>$_("One sec, we\'re searching for covers...")</h3></div>');
             setTimeout(function() {
                 // add iframe to add images
                 add_iframe("#imagesAdd", "$:add_url");
@@ -85,7 +85,7 @@ window.q.push(function(){
             \$("#imagesManage").html("");
         });
     // Add function to close throbber
-    closeThrobber = function() {\$("#throbber").customFadeOut();};
+    closeThrobber = function() {\$(".throbber").customFadeOut();};
 });
 //-->
 </script>

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -31,6 +31,17 @@
     height: 100%;
     margin: 0 10px;
     min-height: 1px;
+    overflow: hidden;
+    box-sizing: border-box;
+
+    // :focus state for when selected
+    // e.g. "pick one of existing covers" on change cover.
+    // Is .selected redundant?
+    &:focus,
+    &.selected {
+      border: 5px solid @orange;
+      outline: 0;
+    }
   }
 
   // Modifiers

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -18,6 +18,16 @@
   > * {
     box-sizing: content-box;
   }
+
+  // In lightboxes for displaying current cover, important the image
+  // is not larger than available space.
+  img {
+    height: auto;
+  }
+  img,
+  iframe {
+    width: 100%;
+  }
 }
 
 #cbox {
@@ -88,10 +98,6 @@
   }
 }
 
-div.imageIntro{
-  margin: 10px;
-}
-
 .dialog--close {
   text-decoration: none;
   color: @dark-grey;
@@ -121,6 +127,7 @@ div.coverFloat {
     }
   }
 }
+
 
 /* ADD IMAGE/COVER POP-UP */
 div.floater {
@@ -155,8 +162,6 @@ div.floater {
   font-family: @lucida_sans_serif-2;
 
   .label {
-    width: 560px;
-    padding-top: 20px;
     label {
       font-size: 1.0em;
       font-family: @lucida_sans_serif-5;
@@ -166,21 +171,14 @@ div.floater {
       font-weight: normal;
     }
   }
-  .input {
-    width: 560px;
-    padding-top: 20px;
-  }
   div#covers.input {
-    width: 560px;
     max-height: 132px;
     overflow: hidden;
-    padding-top: 20px;
     margin-left: -80px;
     text-align: center;
   }
   input[type=text],
   input[type=file] {
-    width: 350px;
     font-size: 1.125em;
     font-family: @lucida_sans_serif-1;
     padding: 3px;
@@ -191,6 +189,22 @@ div.floater {
     width: auto !important;
   }
 }
+
+.floatform__body {
+  text-align: center;
+  width: 100%;
+  position: relative;
+
+  .carousel-section {
+    padding: 0 20px;
+  }
+}
+
+div.imageIntro{
+  margin: 0 0 10px;
+}
+
+
 /* ADD ROLES, ETC. */
 div.floaterAdd {
   position: relative;
@@ -202,11 +216,9 @@ div.floaterAdd {
   }
   form.floatform {
     .input {
-      width: 560px;
       padding-top: 5px;
     }
     .label {
-      width: 560px;
       padding-top: 20px;
       // stylelint-disable-next-line max-nesting-depth
       label {
@@ -217,11 +229,47 @@ div.floaterAdd {
     }
     input[type=text],
     textarea {
-      width: 560px;
       margin-left: 0;
     }
     textarea {
       padding: 3px;
+    }
+  }
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+  .floatform {
+    div#covers.input,
+    .label,
+    .input {
+      width: 560px;
+      padding-top: 20px;
+    }
+
+    > div {
+      margin: 0 80px;
+      text-align: left;
+    }
+
+    input[type=text],
+    input[type=file] {
+      width: 350px;
+    }
+  }
+
+  div.imageIntro{
+    margin: 10px;
+  }
+
+  .floatform__body > div {
+    margin: 0 80px;
+  }
+  div.floaterAdd {
+    .input,
+    .label,
+    input[type=text],
+    textarea {
+      width: 560px;
     }
   }
 }

--- a/static/css/components/throbber.less
+++ b/static/css/components/throbber.less
@@ -1,0 +1,27 @@
+/**
+ * Throbber
+ * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#throbber
+ * Used in openlibrary/templates/covers/change.html
+ */
+
+.throbber {
+    position: absolute;
+    width: 220px;
+    height: 19px;
+    top: 120px;
+    left: 0;
+    text-align: center;
+    background-color: transparent;
+    background-image: url(/images/ajax-loader-bar.gif);
+    background-repeat: no-repeat;
+    h3 {
+      margin-top: 35px;
+    }
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+    .throbber {
+      top: 280px;
+      left: 210px;
+    }
+}

--- a/static/css/components/ui-tabs.less
+++ b/static/css/components/ui-tabs.less
@@ -96,8 +96,6 @@
 .floater {
   .ui-tabs-panel {
     border: none;
-    border-top: 3px solid @lightest-grey;
-    padding: 15px 30px !important;
     background: @white;
     /* declare background color for container to avoid distorted fonts in IE while fading */
   }
@@ -115,6 +113,12 @@
 }
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
+  .floater {
+    .ui-tabs-panel {
+      border-top: 3px solid @lightest-grey;
+    }
+  }
+
   .tabs-panel {
     padding: 15px 30px 20px !important;
   }
@@ -130,6 +134,12 @@
       a {
         padding: 2px 8px 3px;
       }
+    }
+  }
+  .floater {
+    .ui-tabs-panel {
+      padding: 15px 30px !important;
+      /* declare background color for container to avoid distorted fonts in IE while fading */
     }
   }
 }

--- a/static/css/js-all.less
+++ b/static/css/js-all.less
@@ -16,6 +16,7 @@
 
 @import (less) 'components/read-statuses.less';
 @import (less) 'components/manage-covers.less';
+@import (less) 'components/throbber.less';
 
 // Loading indicators
 @import (less) 'components/buttonCta--js.less';

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -192,14 +192,6 @@ li {
       }
     }
   }
-  &.selected {
-    img {
-      border: 5px solid @orange;
-      &:hover {
-        border: 5px solid @orange;
-      }
-    }
-  }
 }
 
 caption,

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1732,22 +1732,6 @@ div.narrow {
   }
 }
 
-// openlibrary/templates/covers/change.html
-div#throbber {
-  position: absolute;
-  width: 220px;
-  height: 19px;
-  top: 280px;
-  left: 210px;
-  text-align: center;
-  background-color: transparent;
-  background-image: url(/images/ajax-loader-bar.gif);
-  background-repeat: no-repeat;
-  h3 {
-    margin-top: 35px;
-  }
-}
-
 div.pop {
   // openlibrary/templates/covers/add.html
   // openlibrary/templates/books/edit/addfield.html

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -31,10 +31,6 @@ body#form {
     left: 0;
     text-align: center;
   }
-  div.centerIt {
-    margin: 0 80px;
-    text-align: left;
-  }
   .column {
     min-height: 90px;
     margin: 10px;


### PR DESCRIPTION
Fixes: #2132 #2373

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restores the orange border to selected carousel covers. Improves display on mobile.
Note: if you don't like the design - this is out of scope - that can be done as a follow up :)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Click the change cover button and select different covers.



### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2019-12-06 at 2 38 08 PM](https://user-images.githubusercontent.com/148752/70361380-31bd1f80-1836-11ea-9499-eabec98924fc.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->