### PR TITLE
Fix edition table's sort by publication date + small cleanups

### DIFF
--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -3,17 +3,6 @@ import '../../../../../static/css/legacy-datatables.less';
 
 export function initEditionsTable() {
     var rowCount;
-    $('#editions span.count').each(function(i){
-        var myLength = $(this).text().length;
-        $(this).text(i+1);
-        if (myLength == 1) {
-            $(this).prepend('000');
-        } else if (myLength == 2) {
-            $(this).prepend('00');
-        } else if (myLength == 3) {
-            $(this).prepend('0');
-        }
-    });
     $('#editions th.title').mouseover(function(){
         if ($(this).hasClass('sorting_asc')) {
             $(this).attr('title','Sort latest to earliest');

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -1,4 +1,6 @@
-$def with (book)
+$def with (book, sort_key)
+$# :param Edition book:
+$# :param str sort_key:
 
 $ availability = book.get('availability', {})
 
@@ -26,7 +28,7 @@ $ asin = isbn_10 or None
 $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
 
     <td class="book">
-      <span class="hidden count"></span>
+      <span class="hidden sort-key">$sort_key</span>
       <div class="cover">
           <a href="$book.url()"><img src="$url" alt="Cover of: $book.title" title="Cover of: $book.title"/></a>
       </div>
@@ -41,17 +43,16 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           </a>
 
 
-        $if book.publishers or book.publish_date:
-          <div class="published">
-            $if book.publishers and book.publish_date:
-              $book.publish_date, $(', '.join(book.publishers))
-            $elif book.publish_date:
-              $book.publish_date
-            $elif book.publishers:
-              Publish date unknown, $(', '.join(book.publishers))
-            $else:
-              Publisher unknown
-          </div>
+        <div class="published">
+          $if book.publishers and book.publish_date:
+            $book.publish_date, $(', '.join(book.publishers))
+          $elif book.publish_date:
+            $book.publish_date
+          $elif book.publishers:
+            Publish date unknown, $(', '.join(book.publishers))
+          $else:
+            Publisher unknown
+        </div>
 
         <div class="format">
           $book.physical_format.replace('[', '').replace(']','')

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -24,9 +24,11 @@ $ book_keys = []
     <tbody>
         $ edition_list_start = time()
         $ editions = page.get_sorted_editions()
+        $ index_padding = len(str(len(editions)))
         $for book in editions:
             $ book_keys.append(book['key'].replace('/books/', ''))
-            <tr>$:render_template("books/edition-sort", book)</tr>
+            $ sort_key = str(loop.index0).zfill(index_padding)
+            <tr>$:render_template("books/edition-sort", book, sort_key)</tr>
         $ edition_list_secs = time() - edition_list_start
     </tbody>
 </table>


### PR DESCRIPTION
Closes #806

Fix: Edition tables now sort as intended (although still using only year data).

### Technical
<!-- What should be noted about the implementation? -->
- fix edition table's sort by publication date (I think it was a race condition where the JS was trying to change the ordering of the HTML elements by setting the `count` element's HTML, while the dataTables library was also simultaneously re-ordering them)
- refactor Work.get_sorted_editions for better readability and to actually do what it says
- always show publisher section in editions table, since the code handles all the cases

### Testing
- Copydocs some data:
```sh
docker-compose exec web python scripts/copydocs.py -r /works/OL1100007W /books/OL6904901M /books/OL23349009M /books/OL11088183M /books/OL13936862M /books/OL9207799M /books/OL16819841M /books/OL7189111M /books/OL7111251M /books/OL6942515M /books/OL7076985M /books/OL9199612M /books/OL12998201M /books/OL13263296M /books/OL13068684M /books/OL13191403M /books/OL12956686M /books/OL10976640M /books/OL18369724M /books/OL10956292M /books/OL13056700M /books/OL13056898M /books/OL10977874M /books/OL13001553M /books/OL7811385M /books/OL15067640M /books/OL11038232M /books/OL6195573M /books/OL25438005M /books/OL7050533M /books/OL20630374M /books/OL6778846M /books/OL13936581M /books/OL3683888M /books/OL13830544M /books/OL5847018M /books/OL3253482M /books/OL6107112M /books/OL8501849M /books/OL23267204M /books/OL3383804M /books/OL24237305M /books/OL10174341M /books/OL13867110M /books/OL17721537M /books/OL13748382M /books/OL8501743M /books/OL8978465M /books/OL20896529M /books/OL23229178M /books/OL5057340M
```
- Go to http://localhost:8080/works/OL1100007W/Le_tour_du_monde_en_quatre-vingts_jours and check order

Tested:
- ✅ Works when hitting solr for edition keys
- ✅ Works when hitting infobase for edition keys

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6251786/70386601-4d284780-1968-11ea-8968-dbe5ec6cdcd9.png) | ![image](https://user-images.githubusercontent.com/6251786/70386603-59aca000-1968-11ea-92fa-9d728029042d.png) |

### Stakeholders
<!-- @ tag stakeholders of this bug -->