### PR TITLE
Changed 'no ebook available' to 'not in library'

### DIFF
--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -65,7 +65,7 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
           </div>
 
 $else:
-  <a href="$page.key" class="cta-btn--missing cta-btn">No ebook available</a>
+  <a href="$page.key" class="cta-btn--missing cta-btn">$_('Not in Library')</a>
   $if page.ia:
     $ daisy_url = "/ia/%s/daisy" % page.ia[0]
     $:macros.daisy(page, url=daisy_url, protected=True, msg=_("Print-disabled access available"))

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -85,7 +85,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
       <a href="/sponsorship" target="_blank">Learn More</a>
     </p>
   $else:
-    <a href="$work.key" class="cta-btn cta-btn--missing">No ebook available</a>
+    <a href="$work.key" class="cta-btn cta-btn--missing">$_('Not in Library')</a>
 
 $if ocaid and page.is_access_restricted() and availability_status.startswith('borrow') and editions_page:
   $:macros.BookPreview(ocaid, render_preview_floater)

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -83,7 +83,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           </ul>
         $else:
           <form>
-            <input type="submit" class="cta-btn cta-btn--missing" disabled value="Not in Library">
+            <input type="submit" class="cta-btn cta-btn--missing" disabled value="$_('Not in Library')">
           </form>
           $if book.ocaid:
             $:macros.daisy(book, protected=True)

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -83,7 +83,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           </ul>
         $else:
           <form>
-            <input type="submit" class="cta-btn cta-btn--missing" disabled value="No ebook available">
+            <input type="submit" class="cta-btn cta-btn--missing" disabled value="Not in Library">
           </form>
           $if book.ocaid:
             $:macros.daisy(book, protected=True)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2346

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes confusing text.
### Technical
<!-- What should be noted about the implementation? -->
I have changed the text from "No ebook available" to "Not in Library".

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to a Work page to see if "Not in Library" text appears for editions that are not in Open Library.
http://localhost:8080/works/OL54120W/The_wit_wisdom_of_Mark_Twain
http://localhost:8080/books/OL3421846M/The_wit_and_wisdom_of_Mark_Twain
http://localhost:8080/search?q=title%3A+%22the%22&mode=everything
### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1136" alt="Screenshot 2019-12-10 at 20 27 15" src="https://user-images.githubusercontent.com/17739465/70561861-868ccd00-1b8b-11ea-9c30-907005574f10.png">

### Stakeholders
@cdrini 