### PR TITLE
Add link to pagination help FAQ

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -586,7 +586,7 @@ window.q.push(function() {
             <div class="formElement">
                 <div class="label">
                     <label for="edition--pagination">$_("Pagination?")</label>
-                    <span class="tip">$_("Note the highest number in each pagination pattern.")</span>
+                    <span class="tip">$_("Note the highest number in each pagination pattern.") <a href="https://openlibrary.org/help/faq/editing#physical-object" target="_blank">Help</a></span>
                 </div>
                 <div class="input">
                     <input name="edition--pagination" type="text" id="edition--pagination" value="$book.pagination"/>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -586,7 +586,7 @@ window.q.push(function() {
             <div class="formElement">
                 <div class="label">
                     <label for="edition--pagination">$_("Pagination?")</label>
-                    <span class="tip">$_("Note the highest number in each pagination pattern.") <a href="https://openlibrary.org/help/faq/editing#physical-object" target="_blank">Help</a></span>
+                    <span class="tip">$_("Note the highest number in each pagination pattern.") <a href="/help/faq/editing#physical-object" target="_blank">$_("Help")</a></span>
                 </div>
                 <div class="input">
                     <input name="edition--pagination" type="text" id="edition--pagination" value="$book.pagination"/>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2454 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes lack of detail in help text of edit form.
### Technical
<!-- What should be noted about the implementation? -->
The wording of the FAQs is likely to change, but the link should be added in any case.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to edition edit form pagination section. You should see a 'Help' link to FAQs wiki.
http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain/edit
### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="537" alt="Screenshot 2019-12-11 at 13 25 06" src="https://user-images.githubusercontent.com/17739465/70623077-8e954d00-1c1d-11ea-8ccc-334a69a3ff8b.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->