### PR TITLE
When no cover show title and author

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -11,7 +11,7 @@ $def render_carousel_cover(book, lazy):
   $elif book.get('cover_id'):
     $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id'))
   $elif book.get('ia'):
-    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], False)
+    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
   $else:
      $ cover_url = False
   $if book.get('authors'):
@@ -55,11 +55,9 @@ $def render_carousel_cover(book, lazy):
             $img_attr="$(cover_url)"/>
         $else:
           <div class="carousel__item__blankcover">
-              <div>
-                  <div>$:macros.TruncateString(title, 70)
-                    <em>$:macros.TruncateString(', '.join(author_names), 30)</em>
-                  </div>
-              </div>
+            <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
+            $if author_names:
+              <div class="carousel__item__blankcover--authors">$:macros.TruncateString(', '.join(author_names), 30)</div>
           </div>
       </a>
     </div>
@@ -87,9 +85,6 @@ $if test or (books and len(books) >= min_books):
         $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
         <div class="carousel carousel-$key carousel--progressively-enhanced"
           data-config="$json_encode(config)">
-          $ cover_host = '//covers.openlibrary.org'
-          $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
-
           $for index, book in enumerate(books or []):
               $:render_carousel_cover(book, index > 5)
         </div>

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -19,7 +19,7 @@ $def render_carousel_cover(book, lazy):
     $ byline = ' by ' + ', '.join(author_names)
   $else:
     $ byline = ''
-    $ author_names = False
+    $ author_names = ''
   $ modifier = ''
   $ cta = None
   $ cta_cls = 'available'

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -19,6 +19,7 @@ $def render_carousel_cover(book, lazy):
     $ byline = ' by ' + ', '.join(author_names)
   $else:
     $ byline = ''
+    $ author_names = False
   $ modifier = ''
   $ cta = None
   $ cta_cls = 'available'

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,16 +1,19 @@
 $def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False)
 
 $def render_carousel_cover(book, lazy):
+  $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
+  $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
   $ title = book.title
+
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
   $elif book.get('cover_id'):
     $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id'))
   $elif book.get('ia'):
-    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
+    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], False)
   $else:
-     $ cover_url = fallback_cover
+     $ cover_url = False
   $if book.get('authors'):
     $ author_names = [author.name for author in book.authors]
     $ byline = ' by ' + ', '.join(author_names)
@@ -45,10 +48,19 @@ $def render_carousel_cover(book, lazy):
   <div class="book carousel__item">
     <div class="book-cover">
       <a href="$(url)">
-        <img class="bookcover"
-          width="130" height="200"
-          title="$('%s%s'%(title,byline))"
-          $img_attr="$(cover_url)"/>
+        $if cover_url:
+          <img class="bookcover"
+            width="130" height="200"
+            title="$('%s%s'%(title,byline))"
+            $img_attr="$(cover_url)"/>
+        $else:
+          <div class="carousel__item__blankcover">
+              <div>
+                  <div>$:macros.TruncateString(title, 70)
+                    <em>$:macros.TruncateString(', '.join(author_names), 30)</em>
+                  </div>
+              </div>
+          </div>
       </a>
     </div>
     $if cta:

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "19KB"
+      "maxSize": "19.5KB"
     }
   ],
   "devDependencies": {

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -26,6 +26,11 @@
   overflow-x: scroll;
   padding: 10px 20px;
 
+  a,
+  a:link {
+    text-decoration: none;
+  }
+
   &__item {
     float: left;
     height: 100%;
@@ -113,4 +118,27 @@
     overflow: hidden;
   }
 }
+
+@padding-blank-cover: 15px;
+@height-blank-cover: 200px - (@padding-blank-cover * 2);
+.carousel__item__blankcover {
+  position: relative;
+  padding: @padding-blank-cover;
+  text-align: center;
+  background: @lighter-grey;
+  font-size: 1em;
+
+  > div {
+    border: 2px solid @white;
+    height: @height-blank-cover;
+    margin: 0 auto;
+  }
+
+  em {
+    color: hsl(0,0%,40%);
+    padding: 4px 4px 0;
+    font-size: 0.6875em;
+  }
+}
+
 @import (less) "category-item.less";

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -119,25 +119,40 @@
   }
 }
 
-@padding-blank-cover: 15px;
-@height-blank-cover: 200px - (@padding-blank-cover * 2);
+@height-blank-cover: 200px;
 .carousel__item__blankcover {
   position: relative;
-  padding: @padding-blank-cover;
+  padding: 33% 10px 10px 10px;
   text-align: center;
   background: @lighter-grey;
   font-size: 1em;
+  color: black;
+  height: @height-blank-cover;
 
-  > div {
-    border: 2px solid @white;
-    height: @height-blank-cover;
-    margin: 0 auto;
+  // White border
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    border: 2px solid fade(@white, 50%);
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    margin: 10px;
   }
 
-  em {
+  &--title {
+    position: relative;
+    font-size: 0.9em;
+  }
+
+  &--authors {
+    position: relative;
     color: hsl(0,0%,40%);
     padding: 4px 4px 0;
     font-size: 0.6875em;
+    font-style: oblique;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2247 (continuation of #2368)

Fix: Works without covers now get an HTML-cover with title/author text.

### Technical
Note this only affects cases where there is no cover; not cases where the cover errors.

### Testing
1. Go to a subjects page e.g. http://localhost:8080/subjects/science
2. Observe that instead of blank covers, covers with text are displayed.

### Evidence
e.g. http://localhost:8080/subjects/science
![image](https://user-images.githubusercontent.com/6251786/70829832-b0790600-1dbc-11ea-8022-d49bc07fae2d.png)


### Stakeholders
@hornc @jdlrobson 