### PR TITLE
Make dev.openlibrary.org visually distinct from production openlibrary

### DIFF
--- a/static/css/page-dev.less
+++ b/static/css/page-dev.less
@@ -1,4 +1,9 @@
+@import (less) "less/index.less";
+
 /**
+ * NOT FOR PRODUCTION. If this stylesheet is loading on openlibrary.org please raise a github issue:
+ * https://github.com/internetarchive/openlibrary/issues/new
+ *
  * This is the entry for CSS for developers to use for debugging.
  * Any CSS loaded here will be render blocking but will not load
  * in production. This stylesheet can be enabled on test servers if
@@ -8,4 +13,33 @@
  * the page. For instance on the homepage, `page-home.less` will apply but
  * this stylesheet will be loaded afterwards.
  */
-// Do not commit CSS into the repo using this file :-)
+
+// Make banners less prominent for developers so they don't get in their way.
+// This is particularly important during fundraising season!
+#donate_banner {
+  min-height: 50px !important;
+  overflow: hidden;
+  display: block !important;
+  opacity: .2;
+  height: 50px;
+}
+
+.logo-txt {
+  position: relative;
+
+  &:after {
+    content: "development version";
+    position: absolute;
+    background: #C6FFE0;
+    pointer-events: none;
+    padding: 0 .7em;
+    font-size: 0.8em;
+    line-height: 1.75;
+    border-radius: 2px;
+    box-shadow: 1px 1px 1px rgba(0,0,0,.1);
+    left: 40px;
+    top: 36px;
+    z-index: @z-index-level-2;
+    transform: rotate(0deg);
+  }
+}

--- a/static/css/page-dev.less
+++ b/static/css/page-dev.less
@@ -30,10 +30,10 @@
   &:after {
     content: "development version";
     position: absolute;
-    background: #C6FFE0;
+    background: @mid-baby-green;
     pointer-events: none;
     padding: 0 .7em;
-    font-size: 0.8em;
+    font-size: .8em;
     line-height: 1.75;
     border-radius: 2px;
     box-shadow: 1px 1px 1px rgba(0,0,0,.1);


### PR DESCRIPTION
The dev stylesheet is only loaded when dev is enabled in
openlibrary.yaml

This is explicitly disabled on production (note that no page-dev.css
file loads)

Additional change:
* Limit banner styling so it's easier to develop.

Fixes: #2129 
<img width="701" alt="Screen Shot 2019-12-13 at 2 34 50 PM" src="https://user-images.githubusercontent.com/148752/70836650-bddec200-1db5-11ea-848d-d27b872babe5.png">


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->