### PR TITLE
Add link to GitHub tips for beginners.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 ## Installing Open Library
-For instructions on setting up a local developer's instance of Open Library, please refer to the [Installation Guide](https://github.com/internetarchive/openlibrary#installation). Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/Getting-Started).
+For instructions on setting up a local developer's instance of Open Library, please refer to the [Installation Guide](https://github.com/internetarchive/openlibrary#installation). Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/Getting-Started). [Here's a handy cheat sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) if you are new to using Git.
 
 ## Resources for Contributors
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Our `Docker` environment is in active development. Want to contribute? Here's ou
 
 ### Developer's Guide
 
-For instructions on administrating your Open Library instance, refer the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide. [Here are some handy tips](https://github.com/internetarchive/openlibrary/wiki/New-to-Git%3F) if you are new to Git.
+For instructions on administrating your Open Library instance, refer the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide. 
 
 You can also find more information regarding Developer Documentation for Open Library in the Open Library [Wiki](https://github.com/internetarchive/openlibrary/wiki/)
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Our `Docker` environment is in active development. Want to contribute? Here's ou
 
 ### Developer's Guide
 
-For instructions on administrating your Open Library instance, refer the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide.
+For instructions on administrating your Open Library instance, refer the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide. [Here are some handy tips](https://github.com/internetarchive/openlibrary/wiki/New-to-Git%3F) if you are new to Git.
 
 You can also find more information regarding Developer Documentation for Open Library in the Open Library [Wiki](https://github.com/internetarchive/openlibrary/wiki/)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2743

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a link from CONTRIBUTING.md to wiki page of GitHub tips for beginners. This was discussed on the community call held December 10, 2019.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->