### PR TITLE
Make issue templates compliant with #2671 (Replaces #2672)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,10 +2,10 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "Type: Bug"
+labels: ["Type: Bug", "State: Backlogged", "Needs: Triage"]
 assignees: ''
-
 ---
+
 <!-- What problem are we solving? What does the experience look like today? What are the symptoms? -->
 
 ### Evidence / Screenshot (if possible)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,10 +2,11 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: "Type: Feature"
+labels: ["Type: Feature", "State: Backlogged", "Needs: Triage"]
 assignees: ''
 
 ---
+
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ### Describe the solution you'd like
@@ -21,3 +22,5 @@ assignees: ''
 
 ### Stakeholders
 <!-- @ tag stakeholders of this bug -->
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-### Describe the solution you'd like
+### Describe the problem that you'd like solved
 <!-- A clear and concise description of what you want to happen. -->
 
 ### Proposal & Constraints

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -1,0 +1,18 @@
+---
+name: Question
+about: Propose an answerable question
+title: ''
+labels: ["Type: Question", "State: Backlogged", "Needs: Triage"]
+assignees: ''
+---
+
+### Question
+<!-- What question needs to be answered to close this issue? This should be one sentence. -->
+
+
+### Additional context
+<!-- Add any other context or details here. -->
+
+
+### Stakeholders
+<!-- @ tag stakeholders of this bug -->


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2671

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
The validity of the `State: Backlogged` label is still be discussed so this PR is still blocked by #2671 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@brad2014 