### PR TITLE
fixing wiki pages e.g. sponsorship to work on mobile

### DIFF
--- a/static/css/components/page-history.less
+++ b/static/css/components/page-history.less
@@ -6,7 +6,6 @@
 
 // stylelint-disable-next-line selector-max-specificity
 #pageHistory {
-  width: 100%;
   margin-top: 30px;
 }
 .pageHistory__list {

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -7,8 +7,8 @@
     margin: 0;
   }
 }
-div#contentBody,
-div.contentBody {
+div.contentBody,
+div#contentBody {
   padding: 0 20px 20px;
   img {
     max-width: 100%;

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -10,6 +10,9 @@
 div#contentBody,
 div.contentBody {
   padding: 0 20px 20px;
+  img {
+    max-width: 100%;
+  }
 }
 .section,
 section {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This makes all wiki pages (with large images) fit to the width of parent and not overflow.

Closes #2747