### PR TITLE
Add google analytics to ShareEmbed button + misc cleanups

### DIFF
--- a/openlibrary/macros/SocialShare.html
+++ b/openlibrary/macros/SocialShare.html
@@ -1,25 +1,31 @@
-$def with(page)
+$def with (share_links, page_url)
+$# :param list[dict] share_links:
+$# :param str page_url: absolute url excluding params
 
-$ share_links = ctx.get('share_links')
-$if share_links:
-  <hr>
-  <div class="shareLinks cta-section">
-    <p class="cta-section-title">Share this book</p>
-    <ul class="shareLinks-list">
-      $for share_link in share_links:
-        $ track_tag = share_link['text'].replace(' ', '-')
-        <li>
-          <a href="$share_link['url']" class="sansserif large" target="_blank" data-ol-link-track="Share|$track_tag"><img title="Share on $(share_link['text'])" alt="$(share_link['text'])" class="share-link" src="/static/images/$(share_link['text'].lower()).svg"/></a>
-          <div class="share-source">$share_link['text']</div>
-        </li>
+$def embed_iframe(page_url):
+  <iframe frameborder="0" width="165" height="400" src="$(page_url)/widget"></iframe>
+
+<div class="shareLinks cta-section">
+  <p class="cta-section-title">Share this book</p>
+  <ul class="shareLinks-list">
+    $for share_link in share_links:
+      $ track_tag = share_link['text'].replace(' ', '-')
       <li>
-        $# rm special characters from url such as single quote which break js prompt/iframe
-        $ clean_url = page.url().replace("'", "\\'")
-        <a title="Embed this book in your website" class="embed-work-btn" onclick="prompt('Copy embed code to clipboard:', '&lt;iframe width=&quot;165&quot; frameBorder=&quot;0&quot; height=&quot;400&quot; src=&quot;' + location.protocol + '//' + location.hostname + (location.port ? ':' + location.port: '') +
-'$(clean_url)/widget&quot;&gt;&lt;/iframe&gt;' );" >
-        <img alt="Embed this book" class="share-link" src="/static/images/embed.png">
+        <a href="$share_link['url']" class="sansserif large" target="_blank" data-ol-link-track="Share|$track_tag">
+          <img title="Share on $(share_link['text'])" alt="$(share_link['text'])" class="share-link" src="$static_url('images/%s.svg' % share_link['text'].lower())"/>
         </a>
-        <div class="share-source">Embed</div>
+        <div class="share-source">$share_link['text']</div>
       </li>
-    </ul>
-  </div>
+
+    <li>
+      $# rm special characters from url such as single quote which break js prompt/iframe
+      $ clean_url = page_url.replace("'", "\\'")
+      $ iframe_html = str(embed_iframe(clean_url)).strip()
+      <a class="embed-work-btn" title="Embed this book in your website" data-ol-link-track="Share|Embed"
+         onclick="prompt('Copy embed code to clipboard:', '$iframe_html');">
+        <img alt="Embed icon" class="share-link" src="$static_url('images/embed.png')">
+      </a>
+      <div class="share-source">Embed</div>
+    </li>
+  </ul>
+</div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -62,7 +62,9 @@ $if isbn_10 and not asin:
           $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
         </div>
 
-        $:macros.SocialShare(page)
+        $if ctx.get('share_links'):
+          <hr>
+          $:macros.SocialShare(ctx.get('share_links'), request.home + page.key)
 
       </div>
     </div>


### PR DESCRIPTION
Fix: Add GA tracking to share embed button

See diff w/o whitespace: https://github.com/internetarchive/openlibrary/pull/2764/files?utf8=%E2%9C%93&diff=split&w=1

### Technical
- also some small refactoring/code quality fixes

### Testing
Go to http://192.168.99.100:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain and click "embed" button

### Evidence
No changes

### Stakeholders
<!-- @ tag stakeholders of this bug -->