### PR TITLE
Load norobots.txt when in a dev instance

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -333,7 +333,8 @@ class robotstxt(delegate.page):
     def GET(self):
         web.header('Content-Type', 'text/plain')
         try:
-            data = open('static/robots.txt').read()
+            robots_file = 'norobots.txt' if 'dev' in infogami.config.features else 'robots.txt'
+            data = open('static/' + robots_file).read()
             raise web.HTTPError("200 OK", {}, data)
         except IOError:
             raise web.notfound()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2706 ; Fix dev.openlibrary.org appearing in search results

### Technical
<!-- What should be noted about the implementation? -->
- uses the `feature.dev` option in `openlibrary.yml` to determine which robots file to load.
- Checked this config is enabled for dev.openlibrary.org, and not present for prod

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to `http://localhost:8080/robots.txt` ; should disallow all
2. Change `openlibrary.yml` to remove `feature.dev: enabled`, and restart dev instance
3. Go to `http://localhost:8080/robots.txt` ; should not disallow everything

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No UI changes

### Stakeholders
@mekarpeles 