### PR TITLE
center profile image in header

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -482,6 +482,7 @@
       border: none;
       margin-right: 5px;
       background-size: cover;
+      background-position: center;
       width: 45px;
       height: 45px;
       background-color: @mid-grey;


### PR DESCRIPTION
Closes #1881 ; fix profile image appearing uneven if not square

### Technical
Just set the CSS to `background-position: center`

### Testing
Go to any page logged in; e.g. http://localhost:8080/books/add

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/6251786/71315380-8614f180-2429-11ea-87a3-dd049e88d096.png)

### Stakeholders
@jdlrobson 