### PR TITLE
Make dynamic JS files include cache-busting hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ css:
 
 js:
 	mkdir -p $(BUILD)
+	rm -f $(BUILD)/*.js $(BUILD)/*.js.map
 	npm run build-assets:webpack
 
 i18n:

--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
   },
   "bundlesize": [
     {
-      "path": "static/build/editions-table.js",
+      "path": "static/build/editions-table.*.js",
       "maxSize": "16.7KB"
     },
     {
-      "path": "static/build/graphs.js",
+      "path": "static/build/graphs.*.js",
       "maxSize": "17.2KB"
     },
     {
-      "path": "static/build/markdown-editor.js",
+      "path": "static/build/markdown-editor.*.js",
       "maxSize": "10.5KB"
     },
     {
-      "path": "static/build/carousel.js",
+      "path": "static/build/carousel.*.js",
       "maxSize": "12.1KB"
     },
     {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,9 @@ module.exports = {
         // itself, append .js to each ResourceLoader module entry name.
         filename: '[name].js',
 
+        // This option determines the name of **non-entry** chunk files.
+        chunkFilename: '[name].[contenthash].js',
+
         // Expose the module.exports of each module entry chunk through the global
         // ol (open library)
         library: [ 'ol' ],


### PR DESCRIPTION
Closes #2692 ; hotfix to make sure the latest JS files are loaded after a deploy

### Technical
- Two line change - ~2 hours of reading webpack docs 😅 
- docs: https://webpack.js.org/configuration/output/#outputchunkfilename

### Testing
1. Run `make js`
2. Confirm generated JS files have hashes
3. Confirm carousels load on http://192.168.99.100:8080/

### Evidence
No UI changes

### Stakeholders
@jdlrobson 