### PR TITLE
Improve borrow button accessibility

### DIFF
--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -5,7 +5,7 @@
 .cta-btn,
 // override default anchor styles
 a.cta-btn {
-  font-size: 14px;
+  font-size: 16px;
   color: @white;
   width: 100%;
   display: block;

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -1,5 +1,5 @@
 // blue
-@primary-blue: hsl(211, 97%, 61%);
+@primary-blue: hsl(202, 96%, 37%);
 @link-blue: hsl(202, 96%, 28%);
 @mid-blue: hsl(204, 70%, 53%);
 @mid-blue-highlight: hsl(204, 64%, 44%);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2610 
It includes an increase on the font size as mentioned on the issue comments.

### Evidence
Both the borrow button and the arrows are affected (but the arrows have lower opacity). 
![image](https://user-images.githubusercontent.com/15196342/71320535-e1d48e80-24ac-11ea-80c9-78bccef2e027.png)

Chrome insists on using #0376b8 although the correct hsl value was given on the file: hsl(202, 96%, 37%):
![image](https://user-images.githubusercontent.com/15196342/71320593-8e167500-24ad-11ea-87a4-2360752e85aa.png)

Audit results:
![image](https://user-images.githubusercontent.com/15196342/71320603-c3bb5e00-24ad-11ea-9f81-5a6959058193.png)


