### PR TITLE
Remove underline and increase touchable area on dialog close button

### DIFF
--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -93,9 +93,19 @@ div.imageIntro{
 }
 
 .dialog--close {
-  text-decoration: none;
   color: @dark-grey;
   font-size: 1.2em;
+  // Increase clickable are to the recommended size (44x44px) according to
+  // https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
+  // but avoid modifing the UI
+  display: inline-block;
+  position: relative;
+  z-index: 1;
+  padding: 11px 17px;
+  margin: -11px -17px;
+  &:visited, &:link, &:hover {
+    text-decoration: none;
+  }
 }
 
 /* VIEW LARGER COVER POP-UP */


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2583 

### Technical
Just increasing the padding to increase the touch area would have misaligned the dialog title and made the header bigger:
![image](https://user-images.githubusercontent.com/15196342/71320982-8fe33700-24b3-11ea-83b0-817ad4a0865a.png)
Instead we have left the title and close button in the same place as before the fix:
![image](https://user-images.githubusercontent.com/15196342/71321018-eea8b080-24b3-11ea-80d4-c75c29138f1d.png)

### Evidence
It would be possible to make the click area exactly 44x44 by using decimals on the margin/padding values but seems unnecessary since as mentioned [here](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html) _"Ensuring that touch targets are at least 44 by 44 CSS pixels."_ is enough.
![image](https://user-images.githubusercontent.com/15196342/71320988-a38e9d80-24b3-11ea-8131-86c52c16c1b9.png)
