### PR TITLE
hotfixing urllib2 + bwb API

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -2,6 +2,7 @@ import re
 import web
 import urllib2
 import simplejson
+import requests
 from amazon.api import SearchException
 from infogami import config
 from infogami.utils.view import public
@@ -13,7 +14,7 @@ from openlibrary.catalog.add_book import load
 from openlibrary import accounts
 
 
-BETTERWORLDBOOKS_API_URL = 'http://products.betterworldbooks.com/service.aspx?ItemId='
+BETTERWORLDBOOKS_API_URL = 'https://products.betterworldbooks.com/service.aspx?ItemId='
 AMAZON_FULL_DATE_RE = re.compile('\d{4}-\d\d-\d\d')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 
@@ -291,10 +292,8 @@ def _get_betterworldbooks_metadata(isbn):
 
     url = BETTERWORLDBOOKS_API_URL + isbn
     try:
-        req = urllib2.Request(url)
-        f = urllib2.urlopen(req)
-        response = f.read()
-        f.close()
+        r = requests.get(url)
+        response = r.content
         product_url = re.findall("<DetailURLPage>\$(.+)</DetailURLPage>", response)
         new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", response)
         new_price = re.findall("<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", response)


### PR DESCRIPTION
A regression either on OL or BWB's side (relating to urllib2) is causing BWB API calls to fail. This PR is a `P0` hotfix which  switches `urllib2` to use `requests` in `core/vendors.py`.

## Repro

Minimum repro case:

```
import urllib2
BWB_API = 'https://products.betterworldbooks.com/service.aspx?ItemId='  # or "http"
req = urllib2.Request(BWB_API + '9780375806704')
f = urllib2.urlopen(req)
```

results in:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 404, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 422, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1222, in https_open
    return self.do_open(httplib.HTTPSConnection, req)
  File "/usr/lib/python2.7/urllib2.py", line 1184, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>
```

## Test

https://dev.openlibrary.org/books/OL24658622M/Measuring_the_world has BWB price whereas https://openlibrary.org/books/OL24658622M/Measuring_the_world does not


## Stakeholders

cc @bfalling, @cdrini 