### PR TITLE
Updates Sponsorship to scrape bwb site for price data if API fails (to include other sellers) 

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -142,7 +142,7 @@ def qualifies_for_sponsorship(edition):
     edition_id = edition.key.split('/')[-1]
     dwwi, matches = do_we_want_it(edition.isbn, work_id)
     if dwwi:
-        bwb_price = get_betterworldbooks_metadata(edition.isbn).get('price_amt')
+        bwb_price = get_betterworldbooks_metadata(edition.isbn, thirdparty=True).get('price_amt')
         if bwb_price:
             num_pages = int(edition_data['number_of_pages'])
             scan_price_cents = SETUP_COST_CENTS + (PAGE_COST_CENTS * num_pages)

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -14,7 +14,7 @@ from openlibrary.utils.isbn import (
 from openlibrary.catalog.add_book import load
 from openlibrary import accounts
 
-BWB_URL = 'https://betterworldbooks.com'
+BETTERWORLDBOOKS_BASE_URL = 'https://betterworldbooks.com'
 BETTERWORLDBOOKS_API_URL = 'https://products.betterworldbooks.com/service.aspx?ItemId='
 BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(h.affiliate_id('betterworldbooks'))
 AMAZON_FULL_DATE_RE = re.compile('\d{4}-\d\d-\d\d')
@@ -282,28 +282,25 @@ def get_betterworldbooks_metadata(isbn, thirdparty=False):
             return _get_betterworldbooks_thirdparty_metadata(isbn)
         return metadata
     except Exception:
-        return {}
+        return betterworldbooks_fmt(isbn)
 
 def _get_betterworldbooks_thirdparty_metadata(isbn):
     """Scrapes metadata from betterworldbooks website in the case the
     Product API returns no result (i.e. includes 3rd party vendor inventory)
 
-    :param str isbn: Unnormalisied ISBN10 or ISBN13
+    :param str isbn: Unnormalised ISBN10 or ISBN13
     :return: Metadata for a single BWB book, currently listed on their catalog, or error dict.
     :rtype: dict
     """
-    url = '%s/product/detail/-%s' % (BWB_URL, isbn)
-    try:
-        content = urllib2.urlopen(url).read()
-        results = [betterworldbooks_fmt(
-            isbn,
-            qlt=i[0].lower(),
-            price=i[1]
-        ) for i in re.findall('data-condition="(New|Used).*data-price=\"([0-9.]+)"', content)]
-        cheapest = sorted(results, key=lambda i: Decimal(i['price_amt']))[0]
-        return cheapest
-    except Exception:
-        return betterworldbooks_fmt(isbn)
+    url = '%s/product/detail/-%s' % (BETTERWORLDBOOKS_BASE_URL, isbn)
+    content = requests.get(url).text
+    results = [betterworldbooks_fmt(
+        isbn,
+        qlt=i[0].lower(),
+        price=i[1]
+    ) for i in re.findall('data-condition="(New|Used).*data-price="([0-9.]+)"', content)]
+    cheapest = sorted(results, key=lambda i: Decimal(i['price_amt']))[0]
+    return cheapest
 
 def _get_betterworldbooks_metadata(isbn):
     """Returns price and other metadata (currently minimal)
@@ -316,8 +313,7 @@ def _get_betterworldbooks_metadata(isbn):
 
     url = BETTERWORLDBOOKS_API_URL + isbn
     try:
-        responses = urllib2.urlopen(url).read()
-        product_url = re.findall("<DetailURLPage>\$(.+)</DetailURLPage>", response)
+        response = requests.get(url).content
         new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", response)
         new_price = re.findall("<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", response)
         used_price = re.findall("<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", response)
@@ -360,6 +356,21 @@ def betterworldbooks_fmt(isbn, qlt=None, price=None):
         'price_amt': price,
         'qlt': qlt
     }
+
+
+def check_bwb_scraper_status():
+    """
+    Check if the bwb scraper is still working; since it's checking
+    HTML, we want to know if it's stopped working.
+    :rtype: bool, str
+    """
+    # Pull a random (available) book from betterworldbooks
+    content = requests.get(BETTERWORLDBOOKS_BASE_URL).text
+    isbn = re.findall(r'isbn1="([0-9]+)"', content)[0]
+    if not isbn:
+        return False, 'ISBN missing from %s' % BETTERWORLDBOOKS_BASE_URL
+    data = _get_betterworldbooks_thirdparty_metadata(isbn)
+    return 'price_amt' in data, simplejson.dumps(data, indent=4 * ' ')
 
 
 cached_get_betterworldbooks_metadata = cache.memcache_memoize(

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -691,10 +691,18 @@ class show_log:
                 return f.read()
 
 class sponsorship_stats:
-
     def GET(self):
         from openlibrary.core.sponsorships import summary
         return render_template("admin/sponsorship", summary())
+
+class status:
+    def GET(self):
+        from openlibrary.core.vendors import check_bwb_scraper_status
+        statuses = [
+            ('BetterWorldBooks Scraper', check_bwb_scraper_status())
+        ]
+        return render_template("admin/status", statuses)
+
 
 def setup():
     register_admin_page('/admin/git-pull', gitpull, label='git-pull')
@@ -723,6 +731,7 @@ def setup():
     register_admin_page('/admin/imports/(\d\d\d\d-\d\d-\d\d)', imports_by_date, label="")
     register_admin_page('/admin/spamwords', spamwords, label="")
     register_admin_page('/admin/sponsorship', sponsorship_stats, label="Sponsorship")
+    register_admin_page('/admin/status', status, label="Status")
 
     import mem
 

--- a/openlibrary/templates/admin/menu.html
+++ b/openlibrary/templates/admin/menu.html
@@ -11,6 +11,7 @@ $def link(url, title):
 <div class="superNav">
     $:link("/admin", _("Admin Center"))
     | $:link("/admin/people", _("People"))
+    | $:link("/admin/sponsorship", _("Sponsorship"))
     | $:link("/admin/loans", _("Loans"))
     | $:link("/admin/waitinglists", _("Waiting Lists"))
     | $:link("/admin/block", _("Block IPs"))
@@ -21,4 +22,6 @@ $def link(url, title):
     $:link("/admin/graphs", _("Graphs"))
     | $:link("/admin/inspect/store", _("Inspect store"))
     | $:link("/admin/inspect/memcache", _("Inspect memcache"))
+    <strong style="padding: 0px 5px">•</strong>
+    $:link("/admin/status", _("Status"))
 </div>

--- a/openlibrary/templates/admin/status.html
+++ b/openlibrary/templates/admin/status.html
@@ -1,0 +1,18 @@
+$def with (statuses)
+$# :param list[(str, (bool, str))] statuses:
+
+$ _x = ctx.setdefault('bodyid', 'admin')
+$ _x = ctx.setdefault('usergroup', 'admin')
+
+<div id="contentHead">
+  $:render_template("admin/menu")
+  <h1>Admin Status</h1>
+</div>
+
+<div id="contentBody" class="page-admin--status">
+  $for name, (passing, details) in statuses:
+    <details>
+      <summary> $cond(passing, '✔', '❌') <b>$name</b></summary>
+      <pre>$:details</pre>
+    </details>
+</div>

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -1,9 +1,6 @@
 import pytest
-import re
-import requests
 from openlibrary.core.vendors import (
     split_amazon_title, clean_amazon_metadata_for_load,
-    _get_betterworldbooks_thirdparty_metadata, BWB_URL,
     betterworldbooks_fmt)
 
 def test_clean_amazon_metadata_for_load_non_ISBN():
@@ -85,13 +82,9 @@ def test_clean_amazon_metadata_for_load_subtitle():
     assert result.get('full_title') == 'Killers of the Flower Moon : The Osage Murders and the Birth of the FBI'
     #TODO: test for, and implement languages
 
-def test_get_betterworldbooks_thirdparty_metadata():
-    import urllib2
-    content = urllib2.urlopen(url=BWB_URL).read()
-    isbn = re.findall('isbn1=\"([0-9]+)\"', content)[0]
-    assert isbn    
-    data = _get_betterworldbooks_thirdparty_metadata(isbn)
-    assert data.get('price_amt')
+
+def test_betterworldbooks_fmt():
+    isbn = '9780393062274'
     bad_data = betterworldbooks_fmt(isbn)
     assert bad_data.get('isbn') == isbn
     assert bad_data.get('price') is None

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -1,5 +1,10 @@
 import pytest
-from openlibrary.core.vendors import split_amazon_title, clean_amazon_metadata_for_load
+import re
+import requests
+from openlibrary.core.vendors import (
+    split_amazon_title, clean_amazon_metadata_for_load,
+    _get_betterworldbooks_thirdparty_metadata, BWB_URL,
+    betterworldbooks_fmt)
 
 def test_clean_amazon_metadata_for_load_non_ISBN():
     # results from get_amazon_metadata() -> _serialize_amazon_product()
@@ -79,6 +84,19 @@ def test_clean_amazon_metadata_for_load_subtitle():
     assert result.get('subtitle') == 'The Osage Murders and the Birth of the FBI'
     assert result.get('full_title') == 'Killers of the Flower Moon : The Osage Murders and the Birth of the FBI'
     #TODO: test for, and implement languages
+
+def test_get_betterworldbooks_thirdparty_metadata():
+    import urllib2
+    content = urllib2.urlopen(url=BWB_URL).read()
+    isbn = re.findall('isbn1=\"([0-9]+)\"', content)[0]
+    assert isbn    
+    data = _get_betterworldbooks_thirdparty_metadata(isbn)
+    assert data.get('price_amt')
+    bad_data = betterworldbooks_fmt(isbn)
+    assert bad_data.get('isbn') == isbn
+    assert bad_data.get('price') is None
+    assert bad_data.get('price_amt') is None
+    assert bad_data.get('qlt') is None
 
 # Test cases to add:
 # Multiple authors


### PR DESCRIPTION
Right now BWB price API only returns things directly in BWB holdings (not third party or partners, i.e. "other sellers"). BWB prefers this because the BWB API is intended for affiliates and these "other seller" books are not good candidates for affiliate sales.

This said, the Internet Archive would like to enable as many books to be sponsored as patrons want, and so (instead of hitting the API) we provide a mechanism to say -- if the BWB price API fails, attempt to hit the live BWB website for price and quality information.

We only use this mechanism when we suspect a book may be eligible for sponsorship (i.e. it passes a bunch of other checks). This won't be displayed to the average user on the website.

**Risks**
The regex check for scraping the site is somewhat fragile. If the BWB website schema changes, the code will become stall (but should degrade gracefully). The risk is fairly low compared to the possibility of enabling thousands of additional books for sponsorship (including a specific user who is requesting a book which is for sale on the website, but not via the API)

**Example**
https://dev.openlibrary.org/books/OL3395301M/Dictionary_of_atheism_skepticism_and_humanism is sponsorable with this mechanism on dev, but not on production.