### PR TITLE
Fixes history link on pages without url

### DIFF
--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -19,6 +19,9 @@ $else:
             <div class="brown smaller sansserif">$_("Last edited by") <a href="$author.key" rel="nofollow">$author.displayname</a></div>
         $else:
             <div class="brown smaller sansserif">$_("Last edited anonymously")</div>
-        <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$page.url(m='history')" rel="nofollow" title="View this template's edit history">History</a></div>
+        $if page.url:
+            <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$page.url(m='history')" rel="nofollow" title="View this template's edit history">History</a></div>
+        $else:
+            <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$changequery(m='history')" rel="nofollow" title="View this template's edit history">History</a></div>
     </div>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2637

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
First PR but I think it's fairly straightforward.

### Testing
Follow the steps in the issue or navigate to any non work/author/edition page (or any page that does not have a set URL) and click history. Previously the history link would refresh the page, now it correctly navigates to the history page.