### PR TITLE
Add option to subscribe to IA newsletter on signup

### DIFF
--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -3,7 +3,7 @@ from infogami.infobase.client import ClientException
 from infogami.core import forms
 
 from openlibrary.i18n import lgettext as _
-from openlibrary.utils.form import Form, Textbox, Password, Hidden, Validator, RegexpValidator
+from openlibrary.utils.form import Form, Textbox, Password, Checkbox, Hidden, Validator, RegexpValidator
 from openlibrary import accounts
 from openlibrary.accounts import InternetArchiveAccount
 from . import spamcheck
@@ -59,6 +59,7 @@ class RegisterForm(Form):
         Password('password2', description=_('Confirm password'),
             klass='required',
             validators=[vpass, EqualToValidator('password', _("Passwords didn't match."))]),
+        Checkbox('ia_newsletter', description=_("Send me general announcements from the Internet Archive, the non-for-profit that runs Open Library (approx. two per month)"))
     ]
     def __init__(self):
         Form.__init__(self, *self.INPUTS)

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -59,7 +59,7 @@ class RegisterForm(Form):
         Password('password2', description=_('Confirm password'),
             klass='required',
             validators=[vpass, EqualToValidator('password', _("Passwords didn't match."))]),
-        Checkbox('ia_newsletter', description=_("Send me general announcements from the Internet Archive, the non-for-profit that runs Open Library (approx. two per month)"))
+        Checkbox('ia_newsletter', description=_("""Send me a monthly newsletter from the <a href="https://archive.org/">Internet Archive</a>, the non-profit that runs Open Library""")),
     ]
     def __init__(self):
         Form.__init__(self, *self.INPUTS)

--- a/openlibrary/templates/account.html
+++ b/openlibrary/templates/account.html
@@ -12,6 +12,7 @@ $var title: $_("Settings")
     <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Change Password")</a></p>
     <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Update Email Address")</a></p>
     <p class="sansserif larger"><a href="/account/notifications">$_("Your Notifications")</a></p>
+    <p class="sansserif larger"><a href="//archive.org/account/index.php?settings=1">$_("Internet Archive Announcements")</a></p>
     <p class="sansserif larger"><a href="/account/privacy">$_("Your Privacy Settings")</a></p>
     <p class="sansserif larger"><a href="$user.key">$_("View")</a> $_("or") <a href="$user.key?m=edit">$_("Edit")</a> $_("Your Profile Page")</p>
     <p class="sansserif larger"><a href="/account/books">$_("View or Edit your Reading Log")</a></p>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -59,7 +59,7 @@ $else:
 
         <br/>
         <label>
-            $:form.ia_newsletter.render() $form.ia_newsletter.description
+            $:form.ia_newsletter.render() $:form.ia_newsletter.description
         </label>
 
         <hr/>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -57,6 +57,13 @@ $else:
         $:field(form.password)
         $:field(form.password2)
 
+        <br/>
+        <label>
+            $:form.ia_newsletter.render() $form.ia_newsletter.description
+        </label>
+
+        <hr/>
+
         $if form.has_recaptcha:
             <div class="formElement">
                 <div class="label smaller lighter">$_("If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA.")</div>

--- a/openlibrary/utils/form.py
+++ b/openlibrary/utils/form.py
@@ -91,8 +91,18 @@ class Password(Input):
 class Checkbox(Input):
     """Checkbox input."""
 
+    @property
+    def checked(self):
+        return self.value is not None
+
     def get_type(self):
         return "checkbox"
+
+    def render(self):
+        if self.value is not None:
+            self.attrs['checked'] = ''
+
+        return Input.render(self)
 
 class Hidden(Input):
     """Hidden input.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #858. Feature: Add option to subscribe to IA newsletter on signup

~Based on #2912 ; merge that first. This is the _real_ diff: https://github.com/internetarchive/openlibrary/pull/2822/files/c8dcaf6406a31d955ec2c388dbb3385a3bb21f06..ebd528c409e2759cbfbd4f61be6029c771c68a6b?utf8=%E2%9C%93&diff=split&w=1~

### Technical
#### Summary of requirements
- [x] The registration page should include a check mark saying "Send me general announcements from the Internet Archive, the non-for-profit that runs Open Library (approx. two per month)"†
- [x] Users who register for the emails should receive them
    - tested that the intent is recorded in the user's IA account object
- [x] Users who do not register for the emails should not receive them
    - tested that the intent is **not** recorded in the users IA account object
- ~[ ] Emails should include an "unsubscribe" link that works~
    - no clue how to test this :/
- [x] The user's settings page on OL should include an "unsubscribe" link that works
   - includes a link to IA's user settings page

### Testing
- ✅ Creating an account with "notifications" ticked results in xauth `info` calls returning `notifications: 'announce-general'` in response (! not an array?!)
- ✅ Creating an account **without** "notifications" ticked results in xauth `info` calls returning `notifications: ''` in response
### Evidence
![image](https://user-images.githubusercontent.com/6251786/71755272-d479b580-2e57-11ea-88f6-8829bac2f577.png)

### Stakeholders
@mekarpeles 