### PR TITLE
No more inappropriate content in kids carousel 

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -28,7 +28,6 @@ logger = logging.getLogger("openlibrary.home")
 
 CAROUSELS_PRESETS = {
     'preset:thrillers': '(creator:"Clancy, Tom" OR creator:"King, Stephen" OR creator:"Clive Cussler" OR creator:("Cussler, Clive") OR creator:("Dean Koontz") OR creator:("Koontz, Dean") OR creator:("Higgins, Jack")) AND !publisher:"Pleasantville, N.Y. : Reader\'s Digest Association" AND languageSorter:"English"',
-    'preset:children': '(creator:("parish, Peggy") OR creator:("avi") OR title:("goosebumps") OR creator:("Dahl, Roald") OR creator:("ahlberg, allan") OR creator:("Seuss, Dr") OR creator:("Carle, Eric") OR creator:("Pilkey, Dav"))',
     'preset:comics': '(subject:"comics" OR creator:("Gary Larson") OR creator:("Larson, Gary") OR creator:("Charles M Schulz") OR creator:("Schulz, Charles M") OR creator:("Jim Davis") OR creator:("Davis, Jim") OR creator:("Bill Watterson") OR creator:("Watterson, Bill") OR creator:("Lee, Stan"))',
     'preset:authorsalliance_mitpress': '(openlibrary_subject:(authorsalliance) OR collection:(mitpress) OR publisher:(MIT Press) OR openlibrary_subject:(mitpress)) AND (!loans__status__status:UNAVAILABLE)'
 }

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -16,7 +16,7 @@ $var title: $_("Welcome to Open Library")
 
   $:render_template("home/custom_ia_carousel", title="Romance", key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title="Kids", key="children", query="preset:children", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title="Kids", key="children", query="subject:(Juvenile Fiction)", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
   $:render_template("home/custom_ia_carousel", title="Thrillers", key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=18, test=test)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2820 

<!-- What does this PR achieve? [hotfix] -->

### Technical
<!-- What should be noted about the implementation? -->
removed `preset:children` and added `subject(Juvenile Fiction)` in query

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 