### PR TITLE
Get google search console access

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -30,6 +30,8 @@ $def with (page)
     <meta name="google-site-verification" content="KrqcZD4l5BLNVyjzSi2sjZBiwgmkJ1W7n6w7ThD7A74" />
     <meta name="google-site-verification" content="vtXGm8q3UgP-f6qXTvQBo85uh3nmIYIotVqqdJDpyz4" />
     <meta name="alexaVerifyID" content="wJKlTRj1Z1OI4G-J0w9R-cWhJjw" /> <!-- Necessary for Alexa -->
+    <!-- Drini, Google Search Console -->
+    <meta name="google-site-verification" content="XYOJ9Uj0MBr6wk7kj1IkttXrqY-bbRstFMADTfEt354" />
 
     $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books']]):
         <!-- Must be loaded in Sign Up and Add new Books page -->


### PR DESCRIPTION
Feature: Google Search Console is a tool that tracks a site's SEO performance. E.g.:
- Keywords used to find openlibrary
- Page-specific SEO audits
- JS errors that occurred while google bot was indexing the site
- load time estimates of the site

NOTE: This _does not_ in any way send any data to Google. This _gives us_ access to the data Google already collects about the site when its Googlebot does its indexing. The only change is a key in the HTML which gives my archive.org account permission to view that data.

### Technical
There are three ways to enable this:
1. Edit the DNS config
2. Use GA account - Can't do this because openlibrary doesn't load the GA JavaScript to protect user privacy
3. Add the key as a meta tag

We already have a few other verification keys in the site's `head.html`, so 3 seems best. 1 would likely require involving Ops folks.

### Testing

### Evidence

### Stakeholders
@mekarpeles 