### PR TITLE
2648/edit form improve title fields text

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -239,7 +239,7 @@ window.q.push(function() {
         <div class="formElement">
             <div class="label">
                 <label for="edition-title_other">$_("Is it known by any other titles?")</label>
-                <span class="tip">$_("Perhaps in another language?")</span>
+                <span class="tip">$_("Do different titles appear on the cover, spine, or title page? The individual titles of collections or anthologies may be entered here as well as.")</span>
             </div>
             <div class="input">
                 <input type="text" name="edition--other_titles--0" id="edition-title_other" value="$(book.other_titles and book.other_titles[0])"/>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -201,7 +201,7 @@ window.q.push(function() {
         <div class="formElement">
             <div class="label">
                 <label for="edition-title">Title</label>
-                <span class="tip">$_("There are occasionally title variants amongst editions.")</span>
+                <span class="tip">$_("Enter the title of this specific edition.")</span>
             </div>
             <div class="input">
                 <input type="text" name="edition--title" id="edition-title" value="$book.title"/>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -239,11 +239,11 @@ window.q.push(function() {
         <div class="formElement">
             <div class="label">
                 <label for="edition-title_other">$_("Is it known by any other titles?")</label>
-                <span class="tip">$_("Do different titles appear on the cover, spine, or title page? The individual titles of collections or anthologies may be entered here as well as.")</span>
+                <span class="tip">$_("Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here.")</span>
             </div>
             <div class="input">
                 <input type="text" name="edition--other_titles--0" id="edition-title_other" value="$(book.other_titles and book.other_titles[0])"/>
-                <div class="tip">$_("For example:") <i>Der Zauberberg</i> $_("is an alternate title for") <i>The Magic Mountain</i>.</div>
+                <div class="tip">$_("For example:") <i>Eaters of the Dead</i> $_("is an alternate title for") <i><a href='/books/OL24923038M'>The 13th Warrior</i></a>.</div>
             </div>
             $if book.other_titles and len(book.other_titles) > 1:
                 $for i, t in enumerate(book.other_titles):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2648 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes confusing and outdated text for title and variant title fields on edition edit form.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Edit an edition: http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain/edit
### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="312" alt="Screenshot 2020-01-08 at 12 08 38" src="https://user-images.githubusercontent.com/17739465/71976890-bcb77e00-3217-11ea-9a10-86a1ce808b4d.png">
<img width="709" alt="Screenshot 2020-01-08 at 12 08 55" src="https://user-images.githubusercontent.com/17739465/71976896-bfb26e80-3217-11ea-8978-70ccbb2ae6a8.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->