### PR TITLE
Don't silence i18n errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,6 @@ ifndef CONTINUOUS_INTEGRATION
 	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor*,node_modules/* --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif
 
-test:
+test: i18n
 	npm test
 	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -20,8 +20,9 @@ def _compile_translation(po, mo):
         write_mo(f, catalog)
         f.close()
         print('compiled', po, file=web.debug)
-    except:
+    except Exception as e:
         print('failed to compile', po, file=web.debug)
+        raise e
 
 def get_locales():
     return [d for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))]


### PR DESCRIPTION
Previously, `make i18n` wouldn't provide any info about what caused an error, and would not fail the build.

Diff ignoring whitespace: https://github.com/internetarchive/openlibrary/pull/2835/files?utf8=%E2%9C%93&diff=split&w=1
### Technical

### Testing
- I added this while working on #2834 , and it caused an error to be thrown on `make i18n`
- Modify `/de/messages.po` to have an invalid date in "last modified". Running `make test` should result in a failure.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@tfmorris 