### PR TITLE
Use cover.jpg if title.jpg does not exist, and never send empty covers to infobase

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -542,6 +542,7 @@ def load_data(rec, account=None):
     cover_id = None
     if cover_url:
         cover_id = add_cover(cover_url, ekey, account=account)
+    if cover_id:
         edition['covers'] = [cover_id]
 
     edits = []  # Things (Edition, Work, Authors) to be saved

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -79,11 +79,11 @@ def process_metadata_dict(metadata):
     non-list cases. This function makes sure the known multi-valued fields are
     always lists.
     """
-    mutlivalued = set(['collection', 'external-identifier', 'isbn', 'subject', 'oclc-id'])
+    multivalued = set(['collection', 'external-identifier', 'isbn', 'subject', 'oclc-id'])
     def process_item(k, v):
-        if k in mutlivalued and not isinstance(v, list):
+        if k in multivalued and not isinstance(v, list):
             v = [v]
-        elif k not in mutlivalued and isinstance(v, list):
+        elif k not in multivalued and isinstance(v, list):
             v = v[0]
         return (k, v)
     return dict(process_item(k, v) for k, v in metadata.items() if v)

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -3,7 +3,6 @@
 import os
 import urllib2
 import datetime
-from xml.dom import minidom
 import simplejson
 import web
 import logging
@@ -74,35 +73,6 @@ def process_metadata_dict(metadata):
 def get_meta_xml(itemid):
     # use metadata API instead of parsing meta xml manually
     return get_metadata(itemid)
-
-
-def xml2dict(xml, **defaults):
-    """Converts xml to python dictionary assuming that the xml is not nested.
-
-    To get some tag as a list/set, pass a keyword argument with list/set as value.
-
-        >>> xml2dict('<doc><x>1</x><x>2</x></doc>')
-        {'x': 2}
-        >>> xml2dict('<doc><x>1</x><x>2</x></doc>', x=[])
-        {'x': [1, 2]}
-    """
-    d = defaults
-    dom = minidom.parseString(xml)
-
-    for node in dom.documentElement.childNodes:
-        if node.nodeType == node.TEXT_NODE or len(node.childNodes) == 0:
-            continue
-        else:
-            key = node.tagName
-            value = node.childNodes[0].data
-
-            if key in d and isinstance(d[key], list):
-                d[key].append(value)
-            elif key in d and isinstance(d[key], set):
-                d[key].add(value)
-            else:
-                d[key] = value
-    return d
 
 
 def _get_metadata(itemid):

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -1,14 +1,17 @@
 """Library for interacting with archive.org.
 """
-import os
-import urllib2
-import datetime
-import simplejson
-import web
+
+import cache
 import logging
+import os
+import simplejson
+import urllib2
+import warnings
+import web
+
 from infogami import config
 from infogami.utils import stats
-import cache
+
 from openlibrary.utils.dateutil import date_n_days_ago
 
 import six
@@ -57,6 +60,7 @@ _get_metadata = web.memoize(_get_metadata, expires=60)
 
 def get_meta_xml(itemid):
     # use metadata API instead of parsing meta xml manually
+    warnings.warn('Deprecated, use ia.get_metadata(itemid) instead.', DeprecationWarning)
     return get_metadata(itemid)
 
 

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -100,7 +100,11 @@ def edition_from_item_metadata(itemid, metadata):
 def get_cover_url(item_id):
     """Gets the URL of the archive.org item's title (or cover) page.
     """
-    return '{0}/download/{1}/page/title.jpg'.format(IA_BASE_URL, item_id)
+    base_url = '{0}/download/{1}/page/'.format(IA_BASE_URL, item_id)
+    title_response = requests.head(base_url + 'title.jpg', allow_redirects=True)
+    if title_response.status_code == 404:
+        return base_url + 'cover.jpg'
+    return base_url + 'title.jpg'
 
 
 def get_item_manifest(item_id, item_server, item_path):

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -71,33 +71,6 @@ def process_metadata_dict(metadata):
     return dict(process_item(k, v) for k, v in metadata.items() if v)
 
 
-def _old_get_meta_xml(itemid):
-    """Returns the contents of meta_xml as JSON.
-    """
-    itemid = web.safestr(itemid.strip())
-    url = 'http://www.archive.org/download/%s/%s_meta.xml' % (itemid, itemid)
-    try:
-        stats.begin('archive.org', url=url)
-        metaxml = urllib2.urlopen(url).read()
-        stats.end()
-    except IOError:
-        logger.error("Failed to download _meta.xml for %s", itemid, exc_info=True)
-        stats.end()
-        return web.storage()
-
-    # archive.org returns html on internal errors.
-    # Checking for valid xml before trying to parse it.
-    if not metaxml.strip().startswith("<?xml"):
-        return web.storage()
-
-    try:
-        defaults = {"collection": [], "external-identifier": []}
-        return web.storage(xml2dict(metaxml, **defaults))
-    except Exception as e:
-        logger.error("Failed to parse metaxml for %s", itemid, exc_info=True)
-        return web.storage()
-
-
 def get_meta_xml(itemid):
     # use metadata API instead of parsing meta xml manually
     return get_metadata(itemid)

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -1,4 +1,4 @@
-"""Library for interacting wih archive.org.
+"""Library for interacting with archive.org.
 """
 import os
 import urllib2
@@ -18,6 +18,7 @@ logger = logging.getLogger('openlibrary.ia')
 
 VALID_READY_REPUB_STATES = ['4', '19', '20', '22']
 
+
 def get_item_json(itemid):
     itemid = web.safestr(itemid.strip())
     url = 'http://archive.org/metadata/%s' % itemid
@@ -29,6 +30,7 @@ def get_item_json(itemid):
     except IOError:
         stats.end()
         return {}
+
 
 def extract_item_metadata(item_json):
     metadata = process_metadata_dict(item_json.get('metadata', {}))
@@ -42,11 +44,13 @@ def extract_item_metadata(item_json):
         metadata['_filenames'] = [f['name'] for f in files]
     return metadata
 
+
 def get_metadata(itemid):
     item_json = get_item_json(itemid)
     return extract_item_metadata(item_json)
 
 get_metadata = cache.memcache_memoize(get_metadata, key_prefix='ia.get_metadata', timeout=5*60)
+
 
 def process_metadata_dict(metadata):
     """Process metadata dict to make sure multi-valued fields like
@@ -65,6 +69,7 @@ def process_metadata_dict(metadata):
             v = v[0]
         return (k, v)
     return dict(process_item(k, v) for k, v in metadata.items() if v)
+
 
 def _old_get_meta_xml(itemid):
     """Returns the contents of meta_xml as JSON.
@@ -92,9 +97,11 @@ def _old_get_meta_xml(itemid):
         logger.error("Failed to parse metaxml for %s", itemid, exc_info=True)
         return web.storage()
 
+
 def get_meta_xml(itemid):
     # use metadata API instead of parsing meta xml manually
     return get_metadata(itemid)
+
 
 def xml2dict(xml, **defaults):
     """Converts xml to python dictionary assuming that the xml is not nested.
@@ -122,8 +129,8 @@ def xml2dict(xml, **defaults):
                 d[key].add(value)
             else:
                 d[key] = value
-
     return d
+
 
 def _get_metadata(itemid):
     """Returns metadata by querying the archive.org metadata API.
@@ -140,11 +147,13 @@ def _get_metadata(itemid):
 # cache the results in memcache for a minute
 _get_metadata = web.memoize(_get_metadata, expires=60)
 
+
 def locate_item(itemid):
     """Returns (hostname, path) for the item.
     """
     d = _get_metadata(itemid)
     return d.get('server'), d.get('dir')
+
 
 def edition_from_item_metadata(itemid, metadata):
     """Converts the item metadata into a form suitable to be used as edition
@@ -158,6 +167,7 @@ def edition_from_item_metadata(itemid, metadata):
         e.add_metadata(metadata)
         return e
 
+
 def get_item_manifest(item_id, item_server, item_path):
     url = 'https://%s/BookReader/BookReaderJSON.php' % item_server
     url += "?itemPath=%s&itemId=%s&server=%s" % (item_path, item_id, item_server)
@@ -170,11 +180,13 @@ def get_item_manifest(item_id, item_server, item_path):
         stats.end()
         return {}
 
+
 def get_item_status(itemid, metadata, **server):
     item_server = server.pop('item_server', None)
     item_path = server.pop('item_path', None)
     return ItemEdition.get_item_status(itemid, metadata, item_server=item_server,
                                        item_path=item_path)
+
 
 class ItemEdition(dict):
     """Class to convert item metadata into edition dict.
@@ -264,15 +276,12 @@ class ItemEdition(dict):
 
     def add_metadata(self, metadata):
         self.metadata = metadata
-
         self.add('title')
         self.add('description', 'description')
         self.add_list('publisher', 'publishers')
-        self.add_list("creator", "author_names")
+        self.add_list('creator', 'author_names')
         self.add('date', 'publish_date')
-
         self.add_isbns()
-        self.add_subjects()
 
     def add(self, key, key2=None):
         metadata = self.metadata
@@ -298,7 +307,7 @@ class ItemEdition(dict):
         metadata = self.metadata
 
         key2 = key2 or key
-        # sometimes the empty values are represneted as {} in metadata API. Avoid them.
+        # sometimes the empty values are represented as {} in metadata API. Avoid them.
         if key in metadata and metadata[key] != {}:
             value = metadata[key]
             if not isinstance(value, list):
@@ -321,15 +330,6 @@ class ItemEdition(dict):
         if isbn_13:
             self["isbn_13"] = isbn_13
 
-    def add_subjects(self):
-        collections = self.metadata.get("collection", [])
-        mapping = {
-            "inlibrary": "In library",
-            "lendinglibrary": "Lending library"
-        }
-        subjects = [subject for c, subject in mapping.items() if c in collections]
-        if subjects:
-            self['subjects'] = subjects
 
 _ia_db = None
 def get_ia_db(configfile=None):

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -6,7 +6,6 @@ import logging
 import os
 import simplejson
 import urllib2
-import warnings
 import web
 
 from infogami import config
@@ -56,12 +55,6 @@ def _get_metadata(itemid):
 
 # cache the results in memcache for a minute
 _get_metadata = web.memoize(_get_metadata, expires=60)
-
-
-def get_meta_xml(itemid):
-    # use metadata API instead of parsing meta xml manually
-    warnings.warn('Deprecated, use ia.get_metadata(itemid) instead.', DeprecationWarning)
-    return get_metadata(itemid)
 
 
 def extract_item_metadata(item_json):

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -4,8 +4,7 @@
 import cache
 import logging
 import os
-import simplejson
-import urllib2
+import requests
 import web
 
 from infogami import config
@@ -28,9 +27,9 @@ def _get_metadata(itemid):
     url = '%s/metadata/%s' % (IA_BASE_URL, itemid)
     try:
         stats.begin('archive.org', url=url)
-        metadata_json = urllib2.urlopen(url).read()
+        metadata = requests.get(url)
         stats.end()
-        return simplejson.loads(metadata_json)
+        return metadata.json()
     except IOError:
         stats.end()
         return {}
@@ -106,12 +105,12 @@ def get_cover_url(item_id):
 
 def get_item_manifest(item_id, item_server, item_path):
     url = 'https://%s/BookReader/BookReaderJSON.php' % item_server
-    url += "?itemPath=%s&itemId=%s&server=%s" % (item_path, item_id, item_server)
+    url += '?itemPath=%s&itemId=%s&server=%s' % (item_path, item_id, item_server)
     try:
-        stats.begin("archive.org", url=url)
-        manifest_json = urllib2.urlopen(url).read()
+        stats.begin('archive.org', url=url)
+        manifest = requests.get(url)
         stats.end()
-        return simplejson.loads(manifest_json)
+        return manifest.json()
     except IOError:
         stats.end()
         return {}
@@ -197,7 +196,6 @@ class ItemEdition(dict):
         # items with metadata no_ol_import=true will be not imported
         if metadata.get("no_ol_import", '').lower() == 'true':
             return "no-ol-import"
-
         return "ok"
 
     @classmethod

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -98,6 +98,12 @@ def edition_from_item_metadata(itemid, metadata):
         return e
 
 
+def get_cover_url(item_id):
+    """Gets the URL of the archive.org item's title (or cover) page.
+    """
+    return '{0}/download/{1}/page/title.jpg'.format(IA_BASE_URL, item_id)
+
+
 def get_item_manifest(item_id, item_server, item_path):
     url = 'https://%s/BookReader/BookReaderJSON.php' % item_server
     url += "?itemPath=%s&itemId=%s&server=%s" % (item_path, item_id, item_server)

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -1,7 +1,6 @@
 """Library for interacting with archive.org.
 """
 
-import cache
 import logging
 import os
 import requests
@@ -10,6 +9,7 @@ import web
 from infogami import config
 from infogami.utils import stats
 
+from openlibrary.core import cache
 from openlibrary.utils.dateutil import date_n_days_ago
 
 import six

--- a/openlibrary/mocks/mock_ia.py
+++ b/openlibrary/mocks/mock_ia.py
@@ -10,21 +10,21 @@ def mock_ia(request, monkeypatch):
         from openlibrary.core import ia
 
         def test_ia(mock_ia):
-            assert ia.get_meta_xml("foo") == {}
+            assert ia.get_metadata("foo") == {}
 
-            mock_ia.set_meta_xml("foo", {"collection": ["a", "b"]})
-            assert ia.get_meta_xml("foo") == {"collection": ["a", "b"]}
+            mock_ia.set_metadata("foo", {"collection": ["a", "b"]})
+            assert ia.get_metadata("foo") == {"collection": ["a", "b"]}
     """
-    metaxml = {}
+    metadata = {}
 
     class IA:
-        def set_meta_xml(self, itemid, meta):
-            metaxml[itemid] = meta
+        def set_metadata(self, itemid, meta):
+            metadata[itemid] = meta
 
-        def get_meta_xml(self, itemid):
-            return metaxml.get(itemid, {})
+        def get_metadata(self, itemid):
+            return metadata.get(itemid, {})
 
     mock_ia = IA()
-    monkeypatch.setattr(ia, "get_meta_xml", ia.get_meta_xml)
+    monkeypatch.setattr(ia, 'get_metadata', ia.get_metadata)
 
     return mock_ia

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -364,7 +364,7 @@ def process_result_for_viewapi(result):
 
 
 def get_ia_availability(itemid):
-    collections = ia.get_meta_xml(itemid).get("collection", [])
+    collections = ia.get_metadata(itemid).get('collection', [])
 
     if 'lendinglibrary' in collections or 'inlibrary' in collections:
         return 'borrow'

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -331,7 +331,7 @@ class ReadProcessor:
         self.wkey_to_iaids = dict((wkey, get_work_iaids(wkey)[:iaid_limit])
                                   for wkey in self.works)
         iaids = sum(self.wkey_to_iaids.values(), [])
-        self.iaid_to_meta = dict((iaid, ia.get_meta_xml(iaid)) for iaid in iaids)
+        self.iaid_to_meta = dict((iaid, ia.get_metadata(iaid)) for iaid in iaids)
 
         def lookup_iaids(iaids):
             step = 10

--- a/openlibrary/plugins/books/tests/test_dynlinks.py
+++ b/openlibrary/plugins/books/tests/test_dynlinks.py
@@ -236,7 +236,7 @@ def monkeypatch_ol(monkeypatch):
     mock.default = []
     monkeypatch.setattr(dynlinks, "ol_get_many", mock)
 
-    monkeypatch.setattr(ia, "get_meta_xml", lambda itemid: web.storage())
+    monkeypatch.setattr(ia, "get_metadata", lambda itemid: web.storage())
 
 def test_query_keys(monkeypatch):
     monkeypatch_ol(monkeypatch)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -118,12 +118,13 @@ class importapi:
 
         try:
             reply = add_book.load(edition)
+            # TODO: If any records have been created, return a 201, otherwise 200
+            return json.dumps(reply)
         except add_book.RequiredField as e:
             return self.error('missing-required-field', str(e))
-        return json.dumps(reply)
 
     def reject_non_book_marc(self, marc_record, **kwargs):
-        details = "Item rejected"
+        details = 'Item rejected'
         # Is the item a serial instead of a book?
         marc_leaders = marc_record.leader()
         if marc_leaders[7] == 's':

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -206,31 +206,24 @@ class ia_importapi(importapi):
             return json.dumps(result)
 
         # Case 1 - Is this a valid Archive.org item?
-        try:
-            item_json = ia.get_item_json(identifier)
-            item_server = item_json['server']
-            item_path = item_json['dir']
-        except KeyError:
-            return self.error("invalid-ia-identifier", "%s not found" % identifier)
-        metadata = ia.extract_item_metadata(item_json)
+        metadata = ia.get_metadata(identifier)
         if not metadata:
-            return self.error("invalid-ia-identifier")
+            return self.error('invalid-ia-identifier', '%s not found' % identifier)
 
         # Case 2 - Does the item have an openlibrary field specified?
         # The scan operators search OL before loading the book and add the
         # OL key if a match is found. We can trust them and attach the item
         # to that edition.
-        if metadata.get("mediatype") == "texts" and metadata.get("openlibrary"):
+        if metadata.get('mediatype') == 'texts' and metadata.get('openlibrary'):
             edition_data = self.get_ia_record(metadata)
-            edition_data["openlibrary"] = metadata["openlibrary"]
+            edition_data['openlibrary'] = metadata['openlibrary']
             edition_data = self.populate_edition_data(edition_data, identifier)
             return self.load_book(edition_data)
 
         # Case 3 - Can the item be loaded into Open Library?
-        status = ia.get_item_status(identifier, metadata,
-                                    item_server=item_server, item_path=item_path)
+        status = ia.get_item_status(identifier, metadata)
         if status != 'ok':
-            return self.error(status, "Prohibited Item")
+            return self.error(status, 'Prohibited Item %s' % identifier)
 
         # Case 4 - Does this item have a marc record?
         marc_record = self.get_marc_record(identifier)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -313,8 +313,8 @@ class ia_importapi(importapi):
         :return: Edition record
         """
         edition['ocaid'] = identifier
-        edition['source_records'] = "ia:" + identifier
-        edition['cover'] = "{0}/download/{1}/{1}/page/title.jpg".format(IA_BASE_URL, identifier)
+        edition['source_records'] = 'ia:' + identifier
+        edition['cover'] = '{0}/download/{1}/page/title.jpg'.format(IA_BASE_URL, identifier)
         return edition
 
     def get_marc_record(self, identifier):

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -248,7 +248,7 @@ def format_book_data(book):
         d.cover_url = 'https://archive.org/services/img/%s' % d.ocaid
 
     if d.ocaid:
-        collections = ia.get_meta_xml(d.ocaid).get("collection", [])
+        collections = ia.get_metadata(d.ocaid).get('collection', [])
 
         if 'lendinglibrary' in collections or 'inlibrary' in collections:
             d.borrow_url = book.url("/borrow")

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -148,9 +148,9 @@ class Edition(models.Edition):
         if not self.get('ocaid', None):
             meta = {}
         else:
-            meta = ia.get_meta_xml(self.ocaid)
-            meta.setdefault("external-identifier", [])
-            meta.setdefault("collection", [])
+            meta = ia.get_metadata(self.ocaid)
+            meta.setdefault('external-identifier', [])
+            meta.setdefault('collection', [])
 
         self._ia_meta_fields = meta
         return self._ia_meta_fields

--- a/openlibrary/solr/process_stats.py
+++ b/openlibrary/solr/process_stats.py
@@ -76,7 +76,7 @@ def _get_metadata(ia_id):
         if meta:
             meta['collection'] = meta['collection'].split(";")
     else:
-        meta = ia.get_meta_xml(ia_id)
+        meta = ia.get_metadata(ia_id)
     return meta
 
 def preload(entries):

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -12,7 +12,7 @@ def test_get_metadata(monkeypatch, mock_memcache):
         }
     }
     """
-    monkeypatch.setattr(urllib2, "urlopen", lambda url: StringIO(metadata_json))
+    monkeypatch.setattr(urllib2, 'urlopen', lambda url: StringIO(metadata_json))
     assert ia.get_metadata('foo00bar') == {
         "title": "Foo",
         "identifier": "foo00bar",
@@ -22,5 +22,5 @@ def test_get_metadata(monkeypatch, mock_memcache):
     }
 
 def test_get_metadata_empty(monkeypatch, mock_memcache):
-    monkeypatch.setattr(urllib2, "urlopen", lambda url: StringIO("{}"))
+    monkeypatch.setattr(urllib2, 'urlopen', lambda url: StringIO('{}'))
     assert ia.get_metadata('foo02bar') == {}

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,12 +1,4 @@
-from __future__ import print_function
 from openlibrary.core import ia
-
-def test_xml2dict():
-    assert ia.xml2dict("<metadata><x>1</x><y>2</y></metadata>") == {"x": "1", "y": "2"}
-    assert ia.xml2dict("<metadata><x>1</x><y>2</y></metadata>", x=[]) == {"x": ["1"], "y": "2"}
-
-    assert ia.xml2dict("<metadata><x>1</x><x>2</x></metadata>") == {"x": "2"}
-    assert ia.xml2dict("<metadata><x>1</x><x>2</x></metadata>", x=[]) == {"x": ["1", "2"]}
 
 def test_get_metaxml(monkeypatch, mock_memcache):
     import StringIO
@@ -27,8 +19,6 @@ def test_get_metaxml(monkeypatch, mock_memcache):
         }
     }
     """
-
-    print(ia.get_meta_xml("foo00bar"))
     assert ia.get_meta_xml("foo00bar") == {
         "title": "Foo",
         "identifier": "foo00bar",

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,16 +1,9 @@
+from StringIO import StringIO
+import urllib2
+
 from openlibrary.core import ia
 
-def test_get_metaxml(monkeypatch, mock_memcache):
-    import StringIO
-    import urllib2
-
-    metadata_json = None
-    def urlopen(url):
-        return StringIO.StringIO(metadata_json)
-
-    monkeypatch.setattr(urllib2, "urlopen", urlopen)
-
-    # test with correct xml
+def test_get_metadata(monkeypatch, mock_memcache):
     metadata_json = """{
         "metadata": {
             "title": "Foo",
@@ -19,7 +12,8 @@ def test_get_metaxml(monkeypatch, mock_memcache):
         }
     }
     """
-    assert ia.get_meta_xml("foo00bar") == {
+    monkeypatch.setattr(urllib2, "urlopen", lambda url: StringIO(metadata_json))
+    assert ia.get_metadata('foo00bar') == {
         "title": "Foo",
         "identifier": "foo00bar",
         "collection": ["printdisabled", "inlibrary"],
@@ -27,6 +21,6 @@ def test_get_metaxml(monkeypatch, mock_memcache):
         "_filenames": []
     }
 
-    # test with metadata errors
-    metadata_json = "{}"
-    assert ia.get_meta_xml("foo02bar") == {}
+def test_get_metadata_empty(monkeypatch, mock_memcache):
+    monkeypatch.setattr(urllib2, "urlopen", lambda url: StringIO("{}"))
+    assert ia.get_metadata('foo02bar') == {}

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,18 +1,15 @@
-from StringIO import StringIO
-import urllib2
-
 from openlibrary.core import ia
 
 def test_get_metadata(monkeypatch, mock_memcache):
-    metadata_json = """{
+    metadata = {
         "metadata": {
             "title": "Foo",
             "identifier": "foo00bar",
             "collection": ["printdisabled", "inlibrary"]
         }
     }
-    """
-    monkeypatch.setattr(urllib2, 'urlopen', lambda url: StringIO(metadata_json))
+
+    monkeypatch.setattr(ia, '_get_metadata', lambda _id: metadata)
     assert ia.get_metadata('foo00bar') == {
         "title": "Foo",
         "identifier": "foo00bar",
@@ -22,5 +19,5 @@ def test_get_metadata(monkeypatch, mock_memcache):
     }
 
 def test_get_metadata_empty(monkeypatch, mock_memcache):
-    monkeypatch.setattr(urllib2, 'urlopen', lambda url: StringIO('{}'))
+    monkeypatch.setattr(ia, '_get_metadata', lambda _id: {})
     assert ia.get_metadata('foo02bar') == {}

--- a/scripts/2011/09/generate_deworks.py
+++ b/scripts/2011/09/generate_deworks.py
@@ -315,7 +315,7 @@ def make_ia_db(editions_dump_file):
             print >> f, ocaid
             """
             if ocaid:
-                metaxml = ia.get_meta_xml(ocaid)
+                metaxml = ia.get_metadata(ocaid)
                 db[ocaid] = simplejson.dumps(metaxml)
             """
     f.close()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
* Closes at least part of #2621, I cannot reproduce the bulk MARC errors from the issue locally, so I may have fixed the problem. 

* This does fix the import errors failing in https://openlibrary.org/admin/imports caused by not finding a cover image on archive.org. 

* This PR also enables more covers to be found and added to coverstore, in fact I think it will put an end to some imports from archive.org having to pull covers from archive.org because they don't have coverstore covers. We could try a reimport of all items with ocaids and no cover, then remove all the code tasked with loading the previews from archive org?

* Refactor of the `ia` module and import api code so that archive.org specific code is more consolidated.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
There are very many infobase errors occurring on imports 
```
TypeError: int() argument must be a string or a number, not 'NoneType'
2020-01-09 22:16:30 [1348] [infobase.ol] [ERROR] Error
```
It's possible some of them are caused by other invalid fields, but `covers: [None]` is a common one.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->