### PR TITLE
Network requests are blocked in tests; make error message clearer

### DIFF
--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -19,7 +19,9 @@ from openlibrary.mocks.mock_ol import ol
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):
-    monkeypatch.delattr("requests.sessions.Session.request")
+    def mock_request(*args, **kwargs):
+        raise Warning('Network requests are blocked in the testing environment')
+    monkeypatch.setattr("requests.sessions.Session.request", mock_request)
 
 @pytest.fixture
 def wildcard():


### PR DESCRIPTION
fix: Got stuck on this for a good while while working on the #2791 ; so to help the next folk, make the error message clearer :)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Tested the message appears if `requests.get` is called

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/6251786/72134364-e07edf00-3351-11ea-988e-1d15e6cc8ec4.png)


### Stakeholders
@hornc 