### PR TITLE
from six.moves.urllib.parse import urlsplit

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -2,9 +2,10 @@
 """
 import web
 import simplejson
-import urlparse
 import string
 import re
+
+from six.moves.urllib.parse import urlsplit
 
 import babel
 import babel.core
@@ -66,7 +67,7 @@ def sanitize(html, encoding='utf8'):
 
         if href:
             # add rel=nofollow to all absolute links
-            _, host, _, _, _ = urlparse.urlsplit(href)
+            _, host, _, _, _ = urlsplit(href)
             if host:
                 return 'nofollow'
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2840 

Required because of https://travis-ci.org/internetarchive/openlibrary/jobs/635160585#L890

https://six.readthedocs.io

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->