### PR TITLE
Temporarily disable donation banner on prod

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -689,9 +689,16 @@ def get_donation_include(include):
         opener.addheaders.append(('Cookie', urllib.urlencode({'donation': donation_param})))
 
     html = ''
-    if include == 'true':
+    if include == 'true' and "dev" in web.ctx.features:
         try:
-            html = opener.open(url_banner_source + param, timeout=3).read()
+            html += opener.open(url_banner_source + param, timeout=3).read()
+            # Donation banner is temporarily (Jan 2020) disabled on prod, but available on dev (so that it can be used
+            # for testing). To avoid it appearing like it's working, display a warning if it loads correctly that it's
+            # disabled on prod.
+            if '<div' in html or '<iframe' in html:
+                html = """
+                <center>WARNING: Donation banner disabled on prod; see <a href="https://github.com/internetarchive/openlibrary/issues/2853">GitHub #2853</a></center>
+                """ + html
         except urllib2.URLError:
             logging.getLogger("openlibrary").error('Could not load donation banner')
             return ''


### PR DESCRIPTION
Closes #2839 

hotfix: Disabled donation banner until fix is finished on IA's side.

### Technical
- To be re-enabled once bug on IA's side is fixed in https://github.com/internetarchive/openlibrary/issues/2839
- Leave enabled on dev so that they can still continue testing

### Testing
- ✅ Check http://localhost:8080/?ymd=2019-12-06 displays banner locally
- ✅ http://localhost:8080/?ymd=2020-01-06 does not display banner

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 