### PR TITLE
Edit API to add Content-Type, fixes #2846

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -798,6 +798,7 @@ class search_json(delegate.page):
 
         # backward compatibility
         response['num_found'] = response['numFound']
+        web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response, indent=True))
 
 def setup():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2846 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Fix existing response header for - `/search.json?q=isbn:9780062935045&mode=everything`
- There is no `Content-Type` property

### Technical
<!-- What should be noted about the implementation? -->
- Edited `openlibrary/plugins/worksearch/code.py` to apply header

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Execute locally via docker
- Browse to `http://localhost:8080/search.json?q=isbn:9780062935045&mode=everything`
- Open Inspector and catch the call in `Networks` tab

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Screenshots**
Live version - 
![image](https://user-images.githubusercontent.com/22821480/72337844-48824c00-36e9-11ea-8c96-96f744926380.png)

PR version -
![image](https://user-images.githubusercontent.com/22821480/72337862-51731d80-36e9-11ea-98e4-55688a678739.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 