### PR TITLE
requirements_common.txt: Upgrade iptools only on Python 3

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -3,7 +3,8 @@ beautifulsoup4==4.6.3
 DBUtils==1.3
 Genshi==0.7.1
 gunicorn==19.9.0
-iptools==0.7.0
+iptools==0.6.1; python_version < '3.0'
+iptools==0.7.0; python_version >= '3.0'
 internetarchive==1.8.5
 lxml==4.4.1
 Pillow==6.2.1

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.6.3
 DBUtils==1.3
 Genshi==0.7.1
 gunicorn==19.9.0
-iptools==0.6.1; python_version < '3.0'
+iptools==0.7.0
 internetarchive==1.8.5
 lxml==4.4.1
 Pillow==6.2.1


### PR DESCRIPTION
Previous versions were not compatible with Python 3.  https://github.com/bd808/python-iptools

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->