### PR TITLE
Python 3: sixer --write urllib .

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -9,8 +9,6 @@ import random
 import string
 import simplejson
 import uuid
-import urllib
-import urllib2
 import logging
 
 import lepl.apps.rfc3696
@@ -21,6 +19,9 @@ from infogami.utils.view import render_template, public
 from infogami.infobase.client import ClientException
 
 from openlibrary.core import stats, helpers
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("openlibrary.account.model")
 
@@ -550,12 +551,12 @@ class InternetArchiveAccount(web.storage):
         if test:
             url += "&developer=%s" % test
         try:
-            req = urllib2.Request(url, payload, {
+            req = urllib.request.Request(url, payload, {
                 'Content-Type': 'application/json'})
-            f = urllib2.urlopen(req)
+            f = urllib.request.urlopen(req)
             response = f.read()
             f.close()
-        except urllib2.HTTPError as e:
+        except urllib.error.HTTPError as e:
             try:
                 response = e.read()
             except simplejson.decoder.JSONDecodeError:
@@ -568,14 +569,14 @@ class InternetArchiveAccount(web.storage):
         from openlibrary.core import lending
         url = lending.config_ia_s3_auth_url
         try:
-            req = urllib2.Request(url, headers={
+            req = urllib.request.Request(url, headers={
                 'Content-Type': 'application/json',
                 'authorization': 'LOW %s:%s' % (access_key, secret_key)
             })
-            f = urllib2.urlopen(req)
+            f = urllib.request.urlopen(req)
             response = f.read()
             f.close()
-        except urllib2.HTTPError as e:
+        except urllib.error.HTTPError as e:
             try:
                 response = e.read()
             except simplejson.decoder.JSONDecodeError:

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -18,14 +18,15 @@ Functions with names other than the these will not be called from the
 main harness. They can be utility functions.
 
 """
-import os
-import time
-import urllib
-import logging
-import tempfile
-import datetime
 import calendar
+import datetime
 import functools
+import logging
+import os
+import tempfile
+import time
+
+from six.moves import urllib
 
 import web
 
@@ -134,7 +135,7 @@ def admin_range__visitors(**kargs):
         sqlitefile = tempfile.mktemp(prefix="sqlite-")
         url = "http://www.archive.org/download/stats/numUniqueIPsOL.sqlite"
         logging.debug("  Downloading '%s'", url)
-        sqlite_contents = urllib.urlopen(url).read()
+        sqlite_contents = urllib.request.urlopen(url).read()
         f = open(sqlitefile, "w")
         f.write(sqlite_contents)
         f.close()

--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -19,14 +19,13 @@ __author__ = "Anand Chitipothu <anandology@gmail.com>"
 import os
 import re
 import datetime
-from ConfigParser import ConfigParser
-import urllib
-import urllib2
 import simplejson
 import web
 import logging
 
 import six
+from six.moves import urllib
+from six.moves.configparser import ConfigParser
 
 logger = logging.getLogger("openlibrary.api")
 
@@ -51,10 +50,10 @@ class OpenLibrary:
             headers['Cookie'] = self.cookie
 
         try:
-            req = urllib2.Request(url, data, headers)
+            req = urllib.request.Request(url, data, headers)
             req.get_method = lambda: method
-            return urllib2.urlopen(req)
-        except urllib2.HTTPError as e:
+            return urllib.request.urlopen(req)
+        except urllib.error.HTTPError as e:
             raise OLError(e)
 
     def autologin(self, section=None):
@@ -98,7 +97,7 @@ class OpenLibrary:
         try:
             data = simplejson.dumps(dict(username=username, password=password))
             response = self._request('/account/login', method='POST', data=data, headers=headers)
-        except urllib2.HTTPError as e:
+        except urllib.error.HTTPError as e:
             response = e
 
         if 'Set-Cookie' in response.headers:
@@ -122,7 +121,7 @@ class OpenLibrary:
             return self._get_many(keys)
 
     def _get_many(self, keys):
-        response = self._request("/api/get_many?" + urllib.urlencode({"keys": simplejson.dumps(keys)}))
+        response = self._request("/api/get_many?" + urllib.parse.urlencode({"keys": simplejson.dumps(keys)}))
         return simplejson.loads(response.read())['result']
 
     def save(self, key, data, comment=None):
@@ -194,12 +193,12 @@ class OpenLibrary:
             return unlimited_query(q)
         else:
             q = simplejson.dumps(q)
-            response = self._request("/query.json?" + urllib.urlencode(dict(query=q)))
+            response = self._request("/query.json?" + urllib.parse.urlencode(dict(query=q)))
             return unmarshal(simplejson.loads(response.read()))
 
     def import_ocaid(self, ocaid, require_marc=True):
         data = {'identifier': ocaid, 'require_marc': 'true' if require_marc else 'false'}
-        return self._request('/api/import/ia', method='POST', data=urllib.urlencode(data)).read()
+        return self._request('/api/import/ia', method='POST', data=urllib.parse.urlencode(data)).read()
 
 
 def marshal(data):

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -25,8 +25,8 @@ A record is loaded by calling the load function.
 import json
 import re
 import six
+from six.moves import urllib
 import unicodedata
-import urllib
 import web
 
 from collections import defaultdict
@@ -230,7 +230,7 @@ def add_cover(cover_url, ekey, account=None):
     reply = None
     for attempt in range(10):
         try:
-            res = urllib.urlopen(upload_url, urllib.urlencode(params))
+            res = urllib.request.urlopen(upload_url, urllib.parse.urlencode(params))
         except IOError:
             sleep(2)
             continue

--- a/openlibrary/catalog/add_book/test_add_book.py
+++ b/openlibrary/catalog/add_book/test_add_book.py
@@ -4,7 +4,6 @@ import os
 import pytest
 
 from copy import deepcopy
-from urllib import urlopen
 from collections import defaultdict
 
 from infogami.infobase.core import Text
@@ -17,6 +16,9 @@ from openlibrary.catalog.add_book.merge import try_merge
 from openlibrary.catalog.merge.merge_marc import build_marc
 from openlibrary.catalog.marc.parse import read_edition
 from openlibrary.catalog.marc.marc_binary import MarcBinary, BadLength, BadMARC
+
+
+from six.moves.urllib.request import urlopen
 
 
 def open_test_data(filename):

--- a/openlibrary/catalog/amazon/add_covers.py
+++ b/openlibrary/catalog/amazon/add_covers.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
-from urllib2 import urlopen
 import simplejson
+
+from six.moves.urllib.request import urlopen
+
 
 base = 'http://ia331526.us.archive.org:7001/openlibrary.org/log/'
 

--- a/openlibrary/catalog/amazon/crawl.py
+++ b/openlibrary/catalog/amazon/crawl.py
@@ -4,12 +4,14 @@ import re
 import sys
 import os
 import socket
-from urllib import unquote
-from urllib2 import urlopen
 from time import sleep
 from os.path import exists
 from datetime import date, timedelta, datetime
 import codecs
+
+from six.moves.urllib.parse import unquote
+from six.moves.urllib.request import urlopen
+
 
 # scrap Amazon for book and author data
 

--- a/openlibrary/catalog/amazon/get_other_editions.py
+++ b/openlibrary/catalog/amazon/get_other_editions.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 from catalog.read_rc import read_rc
 import web
-import urllib2
 import sys
 import os.path
 from time import time
+
+from six.moves import urllib
+
 
 rc = read_rc()
 web.config.db_parameters = dict(dbn='postgres', db=rc['db'], user=rc['user'], pw=rc['pw'], host=rc['host'])
@@ -24,8 +26,8 @@ for i, row in enumerate(isbn_iter):
         continue
     url = 'http://www.amazon.com/dp/other-editions/' + isbn
     try:
-        page = urllib2.urlopen(url).read()
-    except urllib2.HTTPError as error:
+        page = urllib.request.urlopen(url).read()
+    except urllib.error.HTTPError as error:
         if error.code != 404:
             raise
         page = ''

--- a/openlibrary/catalog/amazon/import.py
+++ b/openlibrary/catalog/amazon/import.py
@@ -10,9 +10,9 @@ import catalog.merge.amazon as amazon_merge
 from catalog.get_ia import get_from_local, get_ia
 from catalog.merge.merge_marc import build_marc
 import catalog.marc.fast_parse as fast_parse
-import urllib2
 
 import six
+from six.moves import urllib
 
 
 re_amazon = re.compile('^([A-Z0-9]{10}),(\d+):(.*)$', re.S)
@@ -83,7 +83,7 @@ def follow_redirects(key):
 def ia_match(a, ia):
     try:
         loc, rec = get_ia(ia)
-    except urllib2.HTTPError:
+    except urllib.error.HTTPError:
         return False
     if rec is None or 'full_title' not in rec:
         return False

--- a/openlibrary/catalog/amazon/load_merge.py
+++ b/openlibrary/catalog/amazon/load_merge.py
@@ -2,7 +2,9 @@ from __future__ import print_function
 from time import time
 from catalog.marc.MARC21 import MARC21Record
 from catalog.marc.parse import pick_first_date
-import urllib2
+
+from six.moves import urllib
+
 
 entity_fields = ('name', 'birth_date', 'death_date', 'date')
 
@@ -33,8 +35,8 @@ def get_from_archive(locator):
 
     assert 0 < length < 100000
 
-    ureq = urllib2.Request(url, None, {'Range':'bytes=%d-%d'% (r0, r1)},)
-    result = urllib2.urlopen(ureq).read(100000)
+    ureq = urllib.request.Request(url, None, {'Range':'bytes=%d-%d'% (r0, r1)},)
+    result = urllib.request.urlopen(ureq).read(100000)
     rec = MARC21Record(result)
     return rec
 

--- a/openlibrary/catalog/amazon/other_editions.py
+++ b/openlibrary/catalog/amazon/other_editions.py
@@ -1,7 +1,9 @@
 import re
 import os.path
-import urllib2
 from bs4 import BeautifulSoup
+
+from six.moves import urllib
+
 
 # http://amazon.com/other-editions/dp/0312153325 has:
 # http://www.amazon.com/gp/product/0312247869
@@ -45,8 +47,8 @@ def parse_html(html):
 def get_from_amazon(isbn):
     url = 'http://www.amazon.com/dp/other-editions/' + isbn
     try:
-        return urllib2.urlopen(url).read()
-    except urllib2.HTTPError as error:
+        return urllib.request.urlopen(url).read()
+    except urllib.error.HTTPError as error:
         if error.code != 404:
             raise
         return ''

--- a/openlibrary/catalog/author/merge.py
+++ b/openlibrary/catalog/author/merge.py
@@ -8,9 +8,9 @@ import web
 import re
 import sys
 import codecs
-import urllib
 
 import six
+from six.moves import urllib
 
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, unmarshal, Reference
@@ -18,7 +18,7 @@ from openlibrary.catalog.utils.edit import fix_edition
 from openlibrary.catalog.utils.query import query_iter
 
 def urlread(url):
-    return urllib.urlopen(url).read()
+    return urllib.request.urlopen(url).read()
 
 def norm(s):
     return normalize('NFC', s)

--- a/openlibrary/catalog/author/web_merge2.py
+++ b/openlibrary/catalog/author/web_merge2.py
@@ -1,10 +1,12 @@
 import web
 import re
-from urllib2 import urlopen
 import simplejson as json
 from pprint import pformat
 
 from catalog.utils.query import query_iter
+
+from six.moves.urllib.request import urlopen
+
 
 urls = (
     '/', 'index'

--- a/openlibrary/catalog/crawl/catalogue.nla.gov.au/crawl.py
+++ b/openlibrary/catalog/crawl/catalogue.nla.gov.au/crawl.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 import re
-from urllib2 import urlopen
 from os.path import exists
+
+from six.moves.urllib.request import urlopen
+
 
 # crawl catalogue.nla.gov.au
 

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -5,12 +5,14 @@ from openlibrary.catalog.marc import fast_parse, parse
 from infogami import config
 from lxml import etree
 import xml.parsers.expat
-import urllib2
 import os.path
 import socket
 from time import sleep
 import traceback
 from openlibrary.core import ia
+
+from six.moves import urllib
+
 
 IA_BASE_URL = config.get('ia_base_url')
 IA_DOWNLOAD_URL = '%s/download/' % IA_BASE_URL
@@ -23,12 +25,12 @@ class NoMARCXML(IOError):
 def urlopen_keep_trying(url):
     for i in range(3):
         try:
-            f = urllib2.urlopen(url)
+            f = urllib.request.urlopen(url)
             return f
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             if error.code in (403, 404, 416):
                 raise
-        except urllib2.URLError:
+        except urllib.error.URLError:
             pass
         sleep(2)
 
@@ -143,7 +145,7 @@ def get_from_archive_bulk(locator):
 
     assert 0 < length < MAX_MARC_LENGTH
 
-    ureq = urllib2.Request(url, None, {'Range': 'bytes=%d-%d' % (r0, r1)})
+    ureq = urllib.request.Request(url, None, {'Range': 'bytes=%d-%d' % (r0, r1)})
     f = urlopen_keep_trying(ureq)
     data = None
     if f:

--- a/openlibrary/catalog/ia/scan_img.py
+++ b/openlibrary/catalog/ia/scan_img.py
@@ -3,10 +3,12 @@ import httplib
 import xml.etree.ElementTree as et
 import xml.parsers.expat
 import socket # for exceptions
-import urllib
 import re
 from openlibrary.catalog.get_ia import urlopen_keep_trying
 from openlibrary.utils.ia import find_item
+
+from six.moves import urllib
+
 
 re_remove_xmlns = re.compile(' xmlns="[^"]+"')
 

--- a/openlibrary/catalog/importer/db_read.py
+++ b/openlibrary/catalog/importer/db_read.py
@@ -1,9 +1,12 @@
 from __future__ import print_function
 import web
 import simplejson as json
-from urllib import urlopen, urlencode
 from time import sleep
 from openlibrary.catalog.read_rc import read_rc
+
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import urlopen
+
 
 staging = False
 

--- a/openlibrary/catalog/importer/from_scribe.py
+++ b/openlibrary/catalog/importer/from_scribe.py
@@ -13,7 +13,9 @@ from catalog.get_ia import get_ia, urlopen_keep_trying
 from catalog.merge.merge_marc import build_marc
 import pool
 import sys
-import urllib2
+
+from six.moves import urllib
+
 
 archive_url = "http://archive.org/download/"
 
@@ -86,7 +88,7 @@ def load():
             loc, rec = get_ia(ia)
         except (KeyboardInterrupt, NameError):
             raise
-        except urllib2.HTTPError:
+        except urllib.error.HTTPError:
             continue
         if loc is None:
             continue

--- a/openlibrary/catalog/importer/import_marc.py
+++ b/openlibrary/catalog/importer/import_marc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python2.5
 from __future__ import print_function
+from six.moves import urllib
 from time import time, sleep
 import openlibrary.catalog.marc.fast_parse as fast_parse
 from openlibrary.catalog.marc.marc_binary import MarcBinary
@@ -7,7 +8,6 @@ import web
 import sys
 import codecs
 import re
-import urllib2
 import httplib
 from openlibrary.catalog.importer import pool
 import simplejson as json
@@ -52,7 +52,7 @@ def get_with_retry(key):
     for i in range(3):
         try:
             return ol.get(key)
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             if error.code != 500:
                 raise
         print('retry save')
@@ -63,13 +63,13 @@ def save_with_retry(key, data, comment):
     for i in range(3):
         try:
             return ol.save(key, data, comment)
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             if error.code != 500:
                 raise
         print('retry save')
         sleep(10)
 
-# urllib2.HTTPError: HTTP Error 500: Internal Server Error
+# urllib.error.HTTPError: HTTP Error 500: Internal Server Error
 
 def percent(a, b):
     return float(a * 100.0) / b
@@ -142,7 +142,7 @@ def undelete_author(a):
     key = a['key']
     assert a['type'] == '/type/delete'
     url = 'http://openlibrary.org' + key + '.json?v=' + str(a['revision'] - 1)
-    prev = unmarshal(json.load(urllib2.urlopen(url)))
+    prev = unmarshal(json.load(urllib.request.urlopen(url)))
     assert prev['type'] == '/type/author'
     save_with_retry(key, prev, 'undelete author')
 

--- a/openlibrary/catalog/importer/import_server.py
+++ b/openlibrary/catalog/importer/import_server.py
@@ -7,7 +7,10 @@ import simplejson as json
 from openlibrary.catalog.load import add_keys
 from copy import deepcopy
 from openlibrary.catalog.merge.index import *
-from urllib import urlopen, urlencode
+
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import urlopen
+
 
 path = '/1/edward/marc_index/'
 #dbm_fields = ('lccn', 'oclc', 'isbn', 'title')

--- a/openlibrary/catalog/importer/load_cornell.py
+++ b/openlibrary/catalog/importer/load_cornell.py
@@ -3,7 +3,6 @@ import web
 import re
 import httplib
 import sys
-import urllib2
 import simplejson as json
 import openlibrary.catalog.importer.pool as pool
 from openlibrary.catalog.merge.merge_marc import build_marc
@@ -20,6 +19,7 @@ from time import time, sleep
 import openlibrary.catalog.marc.fast_parse as fast_parse
 sys.path.append('/home/edward/src/olapi')
 from olapi import OpenLibrary, unmarshal
+from six.moves import urllib
 
 import six
 
@@ -138,7 +138,7 @@ for row in iter:
     except NoMARCXML:
         write_log(ia, when, "no MARCXML")
         continue
-    except urllib2.HTTPError as error:
+    except urllib.error.HTTPError as error:
         write_log(ia, when, "error: HTTPError: " + str(error))
         continue
     if loc is None:

--- a/openlibrary/catalog/importer/load_scribe.py
+++ b/openlibrary/catalog/importer/load_scribe.py
@@ -4,7 +4,6 @@ import web
 import re
 import httplib
 import sys
-import urllib2
 import threading
 import simplejson as json
 from lxml import etree
@@ -32,6 +31,7 @@ from subprocess import Popen, PIPE
 import argparse
 
 import six
+from six.moves import urllib
 
 
 parser = argparse.ArgumentParser(description='scribe loader')
@@ -365,7 +365,7 @@ if __name__ == '__main__':
 
             try:
                 formats = marc_formats(ia, host, path)
-            except urllib2.HTTPError as error:
+            except urllib.error.HTTPError as error:
                 write_log(ia, when, "error: HTTPError: " + str(error))
                 continue
             use_binary = False
@@ -377,7 +377,7 @@ if __name__ == '__main__':
                 use_binary = True
                 try:
                     marc_data = get_marc_ia_data(ia, host, path)
-                except urllib2.HTTPError as error:
+                except urllib.error.HTTPError as error:
                     if error.code == 403:
                         error_marc_403(ia)
                         continue
@@ -424,7 +424,7 @@ if __name__ == '__main__':
                 except NoMARCXML:
                     write_log(ia, when, "no MARCXML")
                     continue
-                except urllib2.HTTPError as error:
+                except urllib.error.HTTPError as error:
                     write_log(ia, when, "error: HTTPError: " + str(error))
                     continue
             if not use_binary and not formats['xml']:

--- a/openlibrary/catalog/importer/pool.py
+++ b/openlibrary/catalog/importer/pool.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from urllib2 import urlopen, Request
 import simplejson as json
 import web
 from openlibrary.catalog.merge.merge_index import add_to_indexes
@@ -9,6 +8,10 @@ from openlibrary.catalog.merge.merge_index import add_to_indexes
 
 import psycopg2
 from openlibrary.catalog.read_rc import read_rc
+
+from six.moves.urllib.request import urlopen, Request
+
+
 conn = psycopg2.connect(database='marc_index', host='ol-db')
 cur = conn.cursor()
 

--- a/openlibrary/catalog/importer/scribe.py
+++ b/openlibrary/catalog/importer/scribe.py
@@ -10,12 +10,14 @@ from time import sleep, time
 
 import MySQLdb
 import re
-import urllib2
 import httplib
 import json
 import codecs
 import socket
 import sys
+
+from six.moves import urllib
+
 
 ol = OpenLibrary('http://openlibrary.org/')
 
@@ -164,7 +166,7 @@ def load_book(ia, collections, boxid, scanned=True):
     bad_binary = None
     try:
         formats = marc_formats(ia, host, path)
-    except urllib2.HTTPError as error:
+    except urllib.error.HTTPError as error:
         return
 
     if formats['bin']: # binary MARC
@@ -179,7 +181,7 @@ def load_book(ia, collections, boxid, scanned=True):
         contenttype = 'application/marc'
     elif formats['xml']: # MARC XML
         return # waiting for Raj to fox MARC XML loader
-        marc_data = urllib2.urlopen('http://' + host + path + '/' + ia + '_meta.xml').read()
+        marc_data = urllib.request.urlopen('http://' + host + path + '/' + ia + '_meta.xml').read()
         contenttype = 'text/xml'
     else:
         return

--- a/openlibrary/catalog/importer/status.py
+++ b/openlibrary/catalog/importer/status.py
@@ -1,9 +1,11 @@
 import web
-import urllib2
 import simplejson as json
 from pprint import pformat
 from time import time
 from catalog.read_rc import read_rc
+
+from six.moves import urllib
+
 
 urls = (
     '/', 'index'
@@ -28,7 +30,7 @@ def read_book_count():
 files = eval(open('files').read())
 
 def server_read(path):
-    return json.load(urllib2.urlopen(base_url + path))
+    return json.load(urllib.request.urlopen(base_url + path))
 
 def progress(archive, part, pos):
     total = 0

--- a/openlibrary/catalog/importer/update.py
+++ b/openlibrary/catalog/importer/update.py
@@ -3,7 +3,6 @@ import re
 import web
 import sys
 import simplejson as json
-from urllib2 import urlopen, URLError
 from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.importer.db_read import get_mc
 from time import sleep
@@ -11,6 +10,8 @@ from openlibrary.catalog.title_page_img.load import add_cover_image
 from openlibrary.api import OpenLibrary, unmarshal, marshal
 
 import six
+from six.moves.urllib.error import URLError
+from six.moves.urllib.request import urlopen
 
 rc = read_rc()
 ol = OpenLibrary("http://openlibrary.org")

--- a/openlibrary/catalog/lc_updates/update.py
+++ b/openlibrary/catalog/lc_updates/update.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from urllib2 import urlopen
 from lxml.html import parse
 from openlibrary.catalog.read_rc import read_rc
 import os
@@ -7,6 +6,9 @@ import sys
 import httplib
 import subprocess
 from time import sleep
+
+from six.moves.urllib.request import urlopen
+
 
 # httplib.HTTPConnection.debuglevel = 1
 

--- a/openlibrary/catalog/marc/download.py
+++ b/openlibrary/catalog/marc/download.py
@@ -3,7 +3,9 @@
 from __future__ import print_function
 import web
 import web.form as form
-import urllib2
+
+from six.moves import urllib
+
 
 urls = (
     '/', 'index',
@@ -72,7 +74,7 @@ myform = form.Form(
         form.Validator('Must be less than 50000', lambda x:int(x)>50000)))
 
 def start_and_len(file, start, count):
-    f = urllib2.urlopen("http://archive.org/download/bpl_marc/" + file)
+    f = urllib.request.urlopen("http://archive.org/download/bpl_marc/" + file)
     pos = 0
     num = 0
     start_pos = None
@@ -113,8 +115,8 @@ class get:
         web.header("Content-Type","application/octet-stream")
         r0, r1 = offset, offset+length-1
         url = "http://archive.org/download/bpl_marc/" + file
-        ureq = urllib2.Request(url, None, {'Range':'bytes=%d-%d'% (r0, r1)},)
-        f = urllib2.urlopen(ureq)
+        ureq = urllib.request.Request(url, None, {'Range':'bytes=%d-%d'% (r0, r1)},)
+        f = urllib.request.urlopen(ureq)
         while True:
             buf = f.read(1024)
             if not buf:

--- a/openlibrary/catalog/marc/read_from_archive.py
+++ b/openlibrary/catalog/marc/read_from_archive.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
-import urllib2
 import xml.etree.ElementTree as et
 from MARC21 import MARC21Record
 from MARC21Exn import MARC21Exn
 from time import sleep
+
+from six.moves import urllib
+
 
 archive_url = "http://archive.org/download/"
 
@@ -11,8 +13,8 @@ def urlopen_keep_trying(url):
     while True:
         print(url)
         try:
-            return urllib2.urlopen(url)
-        except urllib2.URLError:
+            return urllib.request.urlopen(url)
+        except urllib.error.URLError:
             pass
         sleep(5)
 
@@ -121,9 +123,9 @@ def check():
 #    pos = 303085246
     part = 'marc_records_scriblio_net/part10.dat'
     pos = 99557594
-#    ureq = urllib2.Request(archive_url + part, None, {'Range':'bytes=%d-%d'% (pos, pos+1000000000)} )
-#    f = urllib2.urlopen(ureq)
-    f = urllib2.urlopen(archive_url + part)
+#    ureq = urllib.request.Request(archive_url + part, None, {'Range':'bytes=%d-%d'% (pos, pos+1000000000)} )
+#    f = urllib.request.urlopen(ureq)
+    f = urllib.request.urlopen(archive_url + part)
 
     i = 0
     total = 0

--- a/openlibrary/catalog/marc/show-marc.py
+++ b/openlibrary/catalog/marc/show-marc.py
@@ -2,11 +2,13 @@
 
 from __future__ import print_function
 import web
-import urllib2
 from time import time
 import re
 
 from MARC21 import MARC21Record, MARC21HtmlPrint, MARC21Exn
+
+from six.moves import urllib
+
 
 class show_marc:
     def GET(self, record, offset, length):
@@ -24,13 +26,13 @@ class show_marc:
         assert 0 < length < 100000
 
         t0 = time()
-        ureq = urllib2.Request(url,
+        ureq = urllib.request.Request(url,
                                None,
                                {'Range':'bytes=%d-%d'% (r0, r1)},
                                )
 
 
-        result = urllib2.urlopen(ureq).read(100000)
+        result = urllib.request.urlopen(ureq).read(100000)
         # print 'urllib2 got %d bytes (%.3f sec):<p/>'% (len(result), time()-t0)
 
         rec = None

--- a/openlibrary/catalog/onix/sax_utils.py
+++ b/openlibrary/catalog/onix/sax_utils.py
@@ -1,10 +1,12 @@
 import os
 from types import *
-import urlparse
 from urlcache import URLCache
 import xml.sax
 from xml.sax.handler import *
 import sys
+
+from six.moves import urllib
+
 
 class CachingEntityResolver (EntityResolver):
 	def __init__ (self, parser, dir):
@@ -25,7 +27,7 @@ class CachingEntityResolver (EntityResolver):
 		return src
 
 	def resolveURL (self, sysid, base = ""):
-		url = urlparse.urljoin (base, sysid)
+		url = urllib.parse.urljoin (base, sysid)
 		source = xml.sax.xmlreader.InputSource (url)
 		f = self.cache.get (url)
 		source.setByteStream (f)

--- a/openlibrary/catalog/onix/urlcache.py
+++ b/openlibrary/catalog/onix/urlcache.py
@@ -2,9 +2,11 @@ import sys
 import os
 import time
 import shutil
-import urllib
 import traceback
 from fcntl import *
+
+from six.moves import urllib
+
 
 class URLCache:
 	def __init__ (self, dir):
@@ -42,7 +44,7 @@ class URLCache:
 			# having released the lock on the index, suck data
 			# into the temporary file
 			sys.stderr.write ("URLCache: fetching %s\n" % url)
-			net_data = urllib.urlopen (url)
+			net_data = urllib.request.urlopen (url)
 			shutil.copyfileobj (net_data, tmp_data)
 			tmp_data.flush ()
 			os.link (tmp_data_file, data_file)  # the fetch is good: attach it

--- a/openlibrary/catalog/solr/solr.py
+++ b/openlibrary/catalog/solr/solr.py
@@ -2,21 +2,23 @@
 
 from __future__ import print_function
 from time import sleep, time
-import urllib
 import web
 import subprocess
 import sys
 from catalog.read_rc import read_rc
+
+from six.moves import urllib
+
 
 rc = read_rc()
 
 def solr_query(q, start=0, rows=None, sort_by="publicdate desc"):
     q += " AND NOT collection:test_collection AND NOT collection:opensource AND NOT collection:microfilm"
 #    q += " AND NOT collection:test_collection AND collection:gutenberg"
-    url = rc['solr_url'] + "?q=%s;%s&wt=json&start=%d" % (urllib.quote(q), urllib.quote_plus(sort_by), start)
+    url = rc['solr_url'] + "?q=%s;%s&wt=json&start=%d" % (urllib.parse.quote(q), urllib.parse.quote_plus(sort_by), start)
     if rows:
         url += "&rows=%d" % rows
-    ret = eval(urllib.urlopen(url).read())
+    ret = eval(urllib.request.urlopen(url).read())
     return ret['response']
 
 def get_books(**args):

--- a/openlibrary/catalog/title_page_img/load.py
+++ b/openlibrary/catalog/title_page_img/load.py
@@ -1,7 +1,9 @@
 from openlibrary.catalog.read_rc import read_rc
-import urllib
 import httplib
 import json
+
+from six.moves import urllib
+
 
 rc = read_rc()
 
@@ -19,7 +21,7 @@ def add_cover_image(ekey, ia):
     cookie =  ';'.join([c.split(';')[0] for c in cookies])
 
     cover_url = 'http://www.archive.org/download/' + ia + '/page/' + ia + '_preview.jpg'
-    body = urllib.urlencode({"url": cover_url})
+    body = urllib.parse.urlencode({"url": cover_url})
     assert ekey.startswith('/books/')
     add_cover_url = 'http://openlibrary.org' + ekey + '/add-cover.json'
     headers = {'Content-type': 'application/x-www-form-urlencoded', 'Cookie': cookie}

--- a/openlibrary/catalog/title_page_img/replace_cover_with_title.py
+++ b/openlibrary/catalog/title_page_img/replace_cover_with_title.py
@@ -5,13 +5,15 @@ from openlibrary.catalog.utils.query import query, withKey, has_cover
 from subprocess import Popen, PIPE
 import web
 import re
-import urllib
 import sys
 import xml.etree.ElementTree as et
 import xml.parsers.expat
 import socket  # for exceptions
 import httplib
 from time import sleep
+
+from six.moves import urllib
+
 
 re_single_cover = re.compile('^\[(\d+)\]$')
 re_remove_xmlns = re.compile(' xmlns="[^"]+"')
@@ -45,7 +47,7 @@ def parse_scandata_xml(f):
     return (cover, title)
 
 def find_title_leaf_et(ia_host, ia_path, url):
-    f = urllib.urlopen(url)
+    f = urllib.request.urlopen(url)
     try:
         return parse_scandata_xml(f)
     except xml.parsers.expat.ExpatError:
@@ -100,10 +102,10 @@ def scandata_zip_test(ia_host, ia_path):
 
 
 def urlread(url):
-    return urllib.urlopen(url).read()
+    return urllib.request.urlopen(url).read()
 
 def post_cover(ol, source_url):
-    param = urllib.urlencode({'olid': ol[3:], 'source_url': source_url})
+    param = urllib.parse.urlencode({'olid': ol[3:], 'source_url': source_url})
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     conn = httplib.HTTPConnection("covers.openlibrary.org", timeout=20)
     conn.request("POST", "/b/upload", param, headers)

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -2,12 +2,12 @@ from __future__ import print_function
 import re
 import web
 import json
-import urllib2
 from openlibrary.catalog.importer.db_read import get_mc
 from openlibrary.api import unmarshal
 from time import sleep
 
 import six
+from six.moves import urllib
 
 re_meta_mrc = re.compile('([^/]+)_(meta|marc).(mrc|xml)')
 re_skip = re.compile('\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
@@ -58,7 +58,7 @@ def undelete_author(a, ol):
     key = a['key']
     assert a['type'] == '/type/delete'
     url = 'http://openlibrary.org' + key + '.json?v=' + str(a['revision'] - 1)
-    prev = unmarshal(json.load(urllib2.urlopen(url)))
+    prev = unmarshal(json.load(urllib.request.urlopen(url)))
     assert prev['type'] == '/type/author'
     ol.save(key, prev, 'undelete author')
 

--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
-import urllib
-import urllib2
 import web
 import simplejson as json
 from time import sleep
 import sys
+
+from six.moves import urllib
+
 
 query_host = 'openlibrary.org'
 
@@ -14,8 +15,8 @@ def urlopen(url, data=None):
     headers = {
         'User-Agent': user_agent
     }
-    req = urllib2.Request(url, data, headers)
-    return urllib2.urlopen(req)
+    req = urllib.request.Request(url, data, headers)
+    return urllib.request.urlopen(req)
 
 def jsonload(url):
     return json.load(urlopen(url))
@@ -64,7 +65,7 @@ def get_all_ia():
         q['offset'] += limit
 
 def query(q):
-    url = query_url() + urllib.quote(json.dumps(q))
+    url = query_url() + urllib.parse.quote(json.dumps(q))
     ret = None
     for i in range(20):
         try:

--- a/openlibrary/catalog/works/add_fields_to_works.py
+++ b/openlibrary/catalog/works/add_fields_to_works.py
@@ -1,7 +1,6 @@
 #!/usr/local/bin/python2.5
 from __future__ import print_function
 import sys
-import urllib
 import re
 import codecs
 sys.path.append('/home/edward/src/olapi')
@@ -11,6 +10,7 @@ from collections import defaultdict
 from catalog.read_rc import read_rc
 from catalog.utils.query import query, query_iter, set_staging, base_url
 from catalog.utils import mk_norm, get_title
+from six.moves import urllib
 
 import six
 

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -12,9 +12,9 @@ from openlibrary.catalog.read_rc import read_rc
 from collections import defaultdict
 
 from catalog.utils.edit import fix_edition
-import urllib
 from olapi import OpenLibrary, Reference
 import olapi
+from six.moves import urllib
 
 import six
 
@@ -36,7 +36,7 @@ set_staging(True)
 
 def withKey(key):
     url = base_url + key + ".json"
-    return urllib.urlopen(url).read()
+    return urllib.request.urlopen(url).read()
 
 def find_new_work_key():
     global work_num

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import re
 import sys
 import web
-import urllib2
 from openlibrary.solr.update_work import update_work, solr_update, update_author
 from openlibrary.catalog.get_ia import get_from_archive, get_data
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary
@@ -17,7 +16,6 @@ from collections import defaultdict
 from pprint import pformat
 from openlibrary.catalog.utils.edit import fix_edition
 from openlibrary.catalog.importer.db_read import get_mc
-from urllib import urlopen
 from openlibrary.api import OpenLibrary
 from lxml import etree
 from time import sleep, time, strftime
@@ -25,6 +23,8 @@ from openlibrary.catalog.marc.marc_subject import get_work_subjects, four_types
 import simplejson as json
 
 import six
+from six.moves import urllib
+from six.moves.urllib.request import urlopen
 
 
 ol = OpenLibrary("http://openlibrary.org")
@@ -137,7 +137,7 @@ def get_work_title(e, mc):
             print('bad record source:', src)
             print('http://openlibrary.org' + e['key'])
             continue
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             print('HTTP error:', error.code, error.msg)
             print(e['key'])
         if not data:

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -16,12 +16,12 @@ from collections import defaultdict
 from pprint import pformat
 from openlibrary.catalog.utils.edit import fix_edition
 from openlibrary.catalog.importer.db_read import get_mc
-import urllib2
 from openlibrary.api import OpenLibrary, Reference
 from lxml import etree
 from time import sleep, time
 
 import six
+from six.moves import urllib
 
 
 rc = read_rc()
@@ -122,7 +122,7 @@ def get_marc_src(e):
 def get_ia_work_title(ia):
     url = 'http://www.archive.org/download/' + ia + '/' + ia + '_marc.xml'
     try:
-        root = etree.parse(urllib2.urlopen(url)).getroot()
+        root = etree.parse(urllib.request.urlopen(url)).getroot()
     except KeyboardInterrupt:
         raise
     except:
@@ -155,7 +155,7 @@ def get_work_title(e):
             print('bad record source:', src)
             print('http://openlibrary.org' + e['key'])
             continue
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             print('HTTP error:', error.code, error.msg)
             print(e['key'])
         if not data:

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -1,6 +1,4 @@
 
-import urllib
-import urllib2
 import simplejson
 import logging
 
@@ -9,14 +7,17 @@ from infogami import config
 from openlibrary.core.lending import get_availability_of_ocaids
 
 
+from six.moves import urllib
+
+
 def fulltext_search_api(params):
     if not hasattr(config, 'plugin_inside'):
         return {'error': 'Unable to prepare search engine'}
     search_endpoint = config.plugin_inside['search_endpoint']
-    search_select = search_endpoint + '?' + urllib.urlencode(params, 'utf-8')
+    search_select = search_endpoint + '?' + urllib.parse.urlencode(params, 'utf-8')
 
     try:
-        json_data = urllib2.urlopen(search_select, timeout=30).read()
+        json_data = urllib.request.urlopen(search_select, timeout=30).read()
         logger = logging.getLogger("openlibrary.inside")
         logger.debug('URL: ' + search_select)
     except:

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -8,8 +8,6 @@ import time
 import logging
 import uuid
 import hmac
-import urllib
-import urllib2
 from amazon.api import AmazonAPI
 
 from infogami.utils.view import public
@@ -18,6 +16,7 @@ from openlibrary.core import cache
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.plugins.upstream import acs4
 from openlibrary.utils import dateutil
+from six.moves import urllib
 
 from . import ia
 from . import msgbroker
@@ -202,7 +201,7 @@ def get_random_available_ia_edition():
              "+AND+loans__status__status:AVAILABLE"\
              "&fl=identifier,openlibrary_edition,loans__status__status"\
              "&output=json&rows=1&sort[]=random" % (config_bookreader_host))
-        content = urllib2.urlopen(url=url, timeout=config_http_request_timeout).read()
+        content = urllib.request.urlopen(url=url, timeout=config_http_request_timeout).read()
         items = simplejson.loads(content).get('response', {}).get('docs', [])
         return items[0]["openlibrary_edition"]
     except Exception as e:
@@ -222,7 +221,7 @@ def get_available(limit=None, page=1, subject=None, query=None,
         limit=limit, page=page, subject=subject, query=query,
         work_id=work_id, _type=_type, sorts=sorts)
     try:
-        request = urllib2.Request(url=url)
+        request = urllib.request.Request(url=url)
 
         # Internet Archive Elastic Search (which powers some of our
         # carousel queries) needs Open Library to forward user IPs so
@@ -230,7 +229,7 @@ def get_available(limit=None, page=1, subject=None, query=None,
         client_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR', 'ol-internal')
         request.add_header('x-client-id', client_ip)
 
-        content = urllib2.urlopen(request, timeout=config_http_request_timeout).read()
+        content = urllib.request.urlopen(request, timeout=config_http_request_timeout).read()
         items = simplejson.loads(content).get('response', {}).get('docs', [])
         results = {}
         for item in items:
@@ -250,7 +249,7 @@ def get_availability(key, ids):
     """
     url = '%s?%s=%s' % (config_ia_availability_api_v2_url, key, ','.join(ids))
     try:
-        content = urllib2.urlopen(url=url, timeout=config_http_request_timeout).read()
+        content = urllib.request.urlopen(url=url, timeout=config_http_request_timeout).read()
         return simplejson.loads(content).get('responses', {})
     except Exception as e:
         return {'error': 'request_timeout', 'details': str(e)}
@@ -274,7 +273,7 @@ def get_realtime_availability_of_ocaid(ocaid):
         'error': 'error'
     }
     try:
-        content = urllib2.urlopen(url=url, timeout=config_http_request_timeout).read()
+        content = urllib.request.urlopen(url=url, timeout=config_http_request_timeout).read()
         metadata = simplejson.loads(content).get('metadata', {})
         statuses = {'available': 'borrow_available', 'unavailable': 'borrow_unavailable', 'error': 'error'}
         status = metadata.get('loans__status__status', 'error').lower()
@@ -351,7 +350,7 @@ def is_loaned_out_on_ia(identifier):
     """
     url = "https://archive.org/services/borrow/%s?action=status" % identifier
     try:
-        response = simplejson.loads(urllib2.urlopen(url).read())
+        response = simplejson.loads(urllib.request.urlopen(url).read())
         return response and response.get('checkedout')
     except:
         return None
@@ -724,7 +723,7 @@ class ACS4Item(object):
     def get_data(self):
         url = '%s/item/%s' % (config_loanstatus_url, self.identifier)
         try:
-            return simplejson.loads(urllib2.urlopen(url).read())
+            return simplejson.loads(urllib.request.urlopen(url).read())
         except IOError:
             logger.error("unable to conact BSS server", exc_info=True)
 
@@ -808,10 +807,10 @@ class IA_Lending_API:
         if config_ia_loan_api_developer_key:
             params['developer'] = config_ia_loan_api_developer_key
         params['token'] = config_ia_ol_shared_key
-        payload = urllib.urlencode(params)
+        payload = urllib.parse.urlencode(params)
 
         try:
-            jsontext = urllib2.urlopen(config_ia_loan_api_url, payload,
+            jsontext = urllib.request.urlopen(config_ia_loan_api_url, payload,
                                        timeout=config_http_request_timeout).read()
             logger.info("POST response: %s", jsontext)
             return simplejson.loads(jsontext)

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -4,8 +4,6 @@ from collections import defaultdict
 import datetime
 import re
 import time
-import urllib
-import urllib2
 
 import simplejson
 import web
@@ -21,6 +19,7 @@ from openlibrary.core import cache
 from openlibrary.plugins.worksearch.search import get_solr
 
 import six
+from six.moves import urllib
 
 
 logger = logging.getLogger("openlibrary.lists.model")

--- a/openlibrary/core/loanstats.py
+++ b/openlibrary/core/loanstats.py
@@ -5,13 +5,15 @@ Unlike other parts of openlibrary, this modules talks to the database directly.
 import re
 import time
 import datetime
-import urllib
 import logging
 import simplejson
 import web
 from infogami import config
 from . import inlibrary
 from .. import i18n
+
+from six.moves import urllib
+
 
 logger = logging.getLogger(__name__)
 
@@ -66,10 +68,10 @@ class LoanStats:
 
         logger.info("SOLR query %s", params)
 
-        q = urllib.urlencode(params, doseq=True)
+        q = urllib.parse.urlencode(params, doseq=True)
         url = self.base_url + "/select?" + q
         logger.info("urlopen %s", url)
-        response = urllib.urlopen(url).read()
+        response = urllib.request.urlopen(url).read()
         return simplejson.loads(response)
 
     def solrescape(self, text):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -1,7 +1,5 @@
 """Models of various OL objects.
 """
-import urllib
-import urllib2
 import simplejson
 import web
 import re
@@ -25,6 +23,9 @@ from openlibrary.core.vendors import create_edition_from_amazon_metadata
 from lists.model import ListMixin, Seed
 from . import db, cache, iprange, inlibrary, loanstats, waitinglist, lending
 
+from six.moves import urllib
+
+
 def _get_ol_base_url():
     # Anand Oct 2013
     # Looks like the default value when called from script
@@ -44,7 +45,7 @@ class Image:
         if url.startswith("//"):
             url = "http:" + url
         try:
-            d = simplejson.loads(urllib2.urlopen(url).read())
+            d = simplejson.loads(urllib.request.urlopen(url).read())
             d['created'] = h.parse_datetime(d['created'])
             if d['author'] == 'None':
                 d['author'] = None
@@ -136,7 +137,7 @@ class Thing(client.Thing):
         else:
             u = self.key + suffix
         if params:
-            u += '?' + urllib.urlencode(params)
+            u += '?' + urllib.parse.urlencode(params)
         if not relative:
             u = _get_ol_base_url() + u
         return u
@@ -914,7 +915,7 @@ class Subject(web.storage):
     def url(self, suffix="", relative=True, **params):
         u = self.key + suffix
         if params:
-            u += '?' + urllib.urlencode(params)
+            u += '?' + urllib.parse.urlencode(params)
         if not relative:
             u = _get_ol_base_url() + u
         return u

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -1,11 +1,13 @@
 """Various web.py application processors used in OL.
 """
 import os
-import urllib
 import web
 
 from infogami.utils.view import render
 from openlibrary.core import helpers as h
+
+from six.moves import urllib
+
 
 try:
     from booklending_utils.openlibrary import is_exclusion
@@ -44,7 +46,7 @@ class ReadableUrlProcessor:
         #@@ using builtin-server or lighttpd. Thats probably a bug in web.py.
         #@@ take care of that case here till that is fixed.
         # @@ Also, the redirection must be done only for GET requests.
-        if readable_path != web.ctx.path and readable_path != urllib.quote(web.utf8(web.ctx.path)) and web.ctx.method == "GET":
+        if readable_path != web.ctx.path and readable_path != urllib.parse.quote(web.utf8(web.ctx.path)) and web.ctx.method == "GET":
             raise web.redirect(web.safeunicode(readable_path) + web.safeunicode(web.ctx.query))
 
         web.ctx.readable_path = readable_path

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -14,8 +14,6 @@ Each waiting instance is represented as a document in the store as follows:
 """
 import datetime
 import logging
-import urllib
-import urllib2
 import json
 import web
 from infogami import config
@@ -24,6 +22,9 @@ from . import helpers as h
 from .sendmail import sendmail_with_template
 from . import db
 from . import lending
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("openlibrary.waitinglist")
 

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import web
 import simplejson
-import urllib
 import os
 import datetime
 import time
@@ -16,6 +15,9 @@ from utils import safeint, rm_f, random_string, ol_things, ol_get, changequery, 
 from coverlib import save_image, read_image, read_file
 
 import ratelimit
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("coverstore")
 
@@ -165,7 +167,7 @@ def _locate_item(item):
     """Locates the archive.org item in the cluster and returns the server and directory.
     """
     print(time.asctime(), "_locate_item", item, file=web.debug)
-    text = urllib.urlopen("https://archive.org/metadata/" + item).read()
+    text = urllib.request.urlopen("https://archive.org/metadata/" + item).read()
     d = simplejson.loads(text)
     return d['server'], d['dir']
 
@@ -283,7 +285,7 @@ class cover:
     def get_ia_cover_url(self, identifier, size="M"):
         url = "https://archive.org/metadata/%s/metadata" % identifier
         try:
-            jsontext = urllib.urlopen(url).read()
+            jsontext = urllib.request.urlopen(url).read()
             d = simplejson.loads(jsontext).get("result", {})
         except (IOError, ValueError):
             return

--- a/openlibrary/coverstore/tests/test_webapp.py
+++ b/openlibrary/coverstore/tests/test_webapp.py
@@ -1,11 +1,13 @@
 import pytest
 import web
 import simplejson
-import urllib
 
 from os import system
 from os.path import abspath, join, dirname, pardir
 from openlibrary.coverstore import config, schema, code, coverlib, utils, archive
+
+from six.moves import urllib
+
 
 static_dir = abspath(join(dirname(__file__), pardir, pardir, pardir, 'static'))
 
@@ -67,7 +69,7 @@ class WebTestCase:
         params = {'id': id}
         if redirect_url:
             params['redirect_url'] = redirect_url
-        b.open('/b/delete', urllib.urlencode(params))
+        b.open('/b/delete', urllib.parse.urlencode(params))
         return b.data
 
     def static_path(self, path):
@@ -104,7 +106,7 @@ class TestWebappWithDB(WebTestCase):
         assert id1 < id2
         assert b.open('/b/olid/OL1M.jpg').read() == open(static_dir + '/logos/logo-it.png').read()
 
-        b.open('/b/touch', urllib.urlencode({'id': id1}))
+        b.open('/b/touch', urllib.parse.urlencode({'id': id1}))
         assert b.open('/b/olid/OL1M.jpg').read() == open(static_dir + '/logos/logo-en.png').read()
 
     def test_delete(self, setup_db):

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -5,8 +5,6 @@ import sys
 import web
 import subprocess
 import datetime
-import urllib
-import urllib2
 import traceback
 import logging
 import simplejson
@@ -109,7 +107,7 @@ class reload:
             s = web.rstrips(s, "/") + "/_reload"
             yield "<h3>" + s + "</h3>"
             try:
-                response = urllib.urlopen(s).read()
+                response = urllib.request.urlopen(s).read()
                 yield "<p><pre>" + response[:100] + "</pre></p>"
             except:
                 yield "<p><pre>%s</pre></p>" % traceback.format_exc()
@@ -385,7 +383,7 @@ class stats:
 class ipstats:
     def GET(self):
         web.header('Content-Type', 'application/json')
-        json = urllib.urlopen("http://www.archive.org/download/stats/numUniqueIPsOL.json").read()
+        json = urllib.request.urlopen("http://www.archive.org/download/stats/numUniqueIPsOL.json").read()
         return delegate.RawText(json)
 
 class block:
@@ -483,6 +481,10 @@ def get_admin_stats():
     return storify(xstats)
 
 from openlibrary.plugins.upstream import borrow
+
+from six.moves import urllib
+
+
 class loans_admin:
 
     def GET(self):

--- a/openlibrary/plugins/admin/graphs.py
+++ b/openlibrary/plugins/admin/graphs.py
@@ -1,8 +1,10 @@
 """Utilities for rendering Graphite graphs.
 """
-import urllib
 import web
 from infogami import config
+
+from six.moves import urllib
+
 
 def get_graphite_base_url():
     return config.get("graphite_base_url", "")
@@ -43,7 +45,7 @@ class GraphiteGraph:
 
             $:g.render(yLimit=100, width=300, height=400)
         """
-        return '<img src="%s/render/?%s"/>' % (get_graphite_base_url(), urllib.urlencode(self.get_queryparams(**options), doseq=True))
+        return '<img src="%s/render/?%s"/>' % (get_graphite_base_url(), urllib.parse.urlencode(self.get_queryparams(**options), doseq=True))
 
 class Series:
     """One series in the GraphiteGraph.

--- a/openlibrary/plugins/admin/services.py
+++ b/openlibrary/plugins/admin/services.py
@@ -5,15 +5,17 @@ for the admin panel
 from __future__ import print_function
 
 import re
-import urllib
 from collections import defaultdict
 
 from bs4 import BeautifulSoup
 
+from six.moves import urllib
+
+
 class Nagios(object):
     def __init__(self, url):
         try:
-            self.data = BeautifulSoup(urllib.urlopen(url).read(), "lxml")
+            self.data = BeautifulSoup(urllib.request.urlopen(url).read(), "lxml")
         except Exception as m:
             print(m)
             self.data = None

--- a/openlibrary/plugins/akismet/akismet.py
+++ b/openlibrary/plugins/akismet/akismet.py
@@ -39,10 +39,13 @@ Whatever you pass in, will replace the *Python Interface by Fuzzyman* part.
 from __future__ import print_function
 import os
 import sys
-import urllib2
-from urllib import urlencode
 
+from six.moves.urllib.parse import urlencode
 import socket
+
+from six.moves import urllib
+
+
 if hasattr(socket, 'setdefaulttimeout'):
     # Set the default timeout on sockets to 5 seconds
     socket.setdefaulttimeout(5)
@@ -96,10 +99,10 @@ class Akismet(object):
     def _safeRequest(self, url, data, headers):
         print("_safeRequest", url)
         try:
-            req = urllib2.Request(url, data, headers)
-            h = urllib2.urlopen(req)
+            req = urllib.request.Request(url, data, headers)
+            h = urllib.request.urlopen(req)
             resp = h.read()
-        except (urllib2.HTTPError, urllib2.URLError, IOError) as e:
+        except (urllib.error.HTTPError, urllib.error.URLError, IOError) as e:
             raise AkismetError(str(e))
         return resp
 

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -4,9 +4,8 @@
 import dynlinks
 import readlinks
 
-import urlparse
 import re
-import urllib2
+from six.moves import urllib
 import web
 
 from infogami.infobase import _json as simplejson
@@ -55,10 +54,10 @@ class read_multiget(delegate.page):
         # see https://github.com/benoitc/gunicorn/issues/215
         raw_uri = web.ctx.env.get("RAW_URI")
         if raw_uri:
-            raw_path = urlparse.urlsplit(raw_uri).path
+            raw_path = urllib.parse.urlsplit(raw_uri).path
 
             # handle e.g. '%7C' for '|'
-            decoded_path = urllib2.unquote(raw_path)
+            decoded_path = urllib.parse.unquote(raw_path)
 
             m = self.path_re.match(decoded_path)
             if not len(m.groups()) == 2:

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -4,9 +4,9 @@ editions of the same work that might be available.
 """
 from __future__ import print_function
 import sys
-import urllib
 import re
 
+from six.moves import urllib
 import web
 from openlibrary.core import inlibrary
 from openlibrary.core import ia
@@ -46,7 +46,7 @@ def get_work_iaids(wkey):
     q = 'key:' + wkey
     stats.begin('solr', url=wkey)
     solr_select = solr_select_url + "?version=2.2&q.op=AND&q=%s&rows=10&fl=%s&qt=standard&wt=json&fq=type:work" % (q, filter)
-    json_data = urllib.urlopen(solr_select).read()
+    json_data = urllib.request.urlopen(solr_select).read()
     stats.end()
     print(json_data)
     reply = simplejson.loads(json_data)
@@ -61,7 +61,7 @@ def get_works_iaids(wkeys):
     filter = 'ia'
     q = '+OR+'.join(['key:' + wkey for wkey in wkeys])
     solr_select = solr_select_url + "?version=2.2&q.op=AND&q=%s&rows=10&fl=%s&qt=standard&wt=json&fq=type:work" % (q, filter)
-    json_data = urllib.urlopen(solr_select).read()
+    json_data = urllib.request.urlopen(solr_select).read()
     reply = simplejson.loads(json_data)
     if reply['response']['numFound'] == 0:
         return []
@@ -75,7 +75,7 @@ def get_eids_for_wids(wids):
     filter = 'edition_key'
     q = '+OR+'.join(wids)
     solr_select = solr_select_url + "?version=2.2&q.op=AND&q=%s&rows=10&fl=key,%s&qt=standard&wt=json&fq=type:work" % (q, filter)
-    json_data = urllib.urlopen(solr_select).read()
+    json_data = urllib.request.urlopen(solr_select).read()
     reply = simplejson.loads(json_data)
     if reply['response']['numFound'] == 0:
         return []
@@ -89,7 +89,7 @@ def get_solr_edition_records(iaids):
     filter = 'title'
     q = '+OR+'.join('ia:' + id for id in iaids)
     solr_select = solr_select_url + "?version=2.2&q.op=AND&q=%s&rows=10&fl=key,%s&qt=standard&wt=json" % (q, filter)
-    json_data = urllib.urlopen(solr_select).read()
+    json_data = urllib.request.urlopen(solr_select).read()
     reply = simplejson.loads(json_data)
     if reply['response']['numFound'] == 0:
         return []

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -17,13 +17,15 @@ import web
 import base64
 import json
 import re
-import urllib
 
 import import_opds
 import import_rdf
 import import_edition_builder
 from lxml import etree
 import logging
+
+from six.moves import urllib
+
 
 MARC_LENGTH_POS = 5
 logger = logging.getLogger('openlibrary.importapi')
@@ -552,9 +554,9 @@ class ils_cover_upload:
 
     def build_url(self, url, **params):
         if '?' in url:
-            return url + "&" + urllib.urlencode(params)
+            return url + "&" + urllib.parse.urlencode(params)
         else:
-            return url + "?" + urllib.urlencode(params)
+            return url + "?" + urllib.parse.urlencode(params)
 
     def login(self, authstring):
         if not authstring:

--- a/openlibrary/plugins/inside/code.py
+++ b/openlibrary/plugins/inside/code.py
@@ -2,7 +2,6 @@
 from time import time
 import re
 import simplejson
-import urllib2
 import httplib
 import logging
 
@@ -10,6 +9,9 @@ import web
 from infogami.utils import delegate
 from infogami.utils.view import render_template
 from openlibrary.core.fulltext import fulltext_search
+
+
+from six.moves import urllib
 
 
 RESULTS_PER_PAGE = 20

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 import os
 import datetime
-import urllib
 import simplejson
 import logging
 import logging.config
@@ -14,6 +13,7 @@ import re
 import unicodedata
 
 import six
+from six.moves import urllib
 import web
 from infogami.infobase import config, common, server, cache, dbstore
 
@@ -292,7 +292,7 @@ def http_notify(site, old, new):
 
     for url in config.http_listeners:
         try:
-            response = urllib.urlopen(url, json).read()
+            response = urllib.request.urlopen(url, json).read()
             print('http_notify', repr(url), repr(key), repr(response), file=web.debug)
         except:
             print('failed to send http_notify', repr(url), repr(key), file=web.debug)

--- a/openlibrary/plugins/oltemplates/olmanage.py
+++ b/openlibrary/plugins/oltemplates/olmanage.py
@@ -2,13 +2,15 @@
 
 from __future__ import print_function
 import os
-import urllib
 import simplejson
 import glob
 import ConfigParser
 
 import olapi
 import subcommand
+
+from six.moves import urllib
+
 
 def to_local_path(path):
     """Convert path on server to local path.
@@ -41,7 +43,7 @@ def to_server_path(path):
         raise ValueError("Unrecognised path: {}".format(path))
 
 def jsonget(url):
-    return simplejson.loads(urllib.urlopen(url).read())
+    return simplejson.loads(urllib.request.urlopen(url).read())
 
 def thing2data(d):
     if d['type']['key'] == '/type/template':

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -8,7 +8,6 @@ import web
 import simplejson
 import os
 import sys
-import urllib
 import socket
 import random
 import datetime
@@ -666,13 +665,17 @@ def changequery(query=None, **kw):
     query = dict((k, (map(web.safestr, v) if isinstance(v, list) else web.safestr(v))) for k, v in query.items())
     out = web.ctx.get('readable_path', web.ctx.path)
     if query:
-        out += '?' + urllib.urlencode(query, doseq=True)
+        out += '?' + urllib.parse.urlencode(query, doseq=True)
     return out
 
 # Hack to limit recent changes offset.
 # Large offsets are blowing up the database.
 
 from infogami.core.db import get_recent_changes as _get_recentchanges
+
+from six.moves import urllib
+
+
 @public
 def get_recent_changes(*a, **kw):
     if 'offset' in kw and kw['offset'] > 5000:
@@ -693,7 +696,7 @@ def most_recent_change():
 
 def wget(url):
     try:
-        return urllib.urlopen(url).read()
+        return urllib.request.urlopen(url).read()
     except:
         return ""
 

--- a/openlibrary/plugins/openlibrary/tests/test_listapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_listapi.py
@@ -3,9 +3,10 @@ from py.test import config
 import web
 import simplejson
 
-import urllib
-import urllib2
 import cookielib
+
+from six.moves import urllib
+
 
 def pytest_funcarg__config(request):
     return request.config
@@ -18,9 +19,9 @@ class ListAPI:
 
         self.cookiejar = cookielib.CookieJar()
 
-        self.opener = urllib2.build_opener()
+        self.opener = urllib.request.build_opener()
         self.opener.add_handler(
-            urllib2.HTTPCookieProcessor(self.cookiejar))
+            urllib.request.HTTPCookieProcessor(self.cookiejar))
 
     def urlopen(self, path, data=None, method=None, headers={}):
         """url open with cookie support."""
@@ -30,13 +31,13 @@ class ListAPI:
             else:
                 method = "GET"
 
-        req = urllib2.Request(self.server + path, data=data, headers=headers)
+        req = urllib.request.Request(self.server + path, data=data, headers=headers)
         req.get_method = lambda: method
         return self.opener.open(req)
 
     def login(self):
         data = dict(username=self.username, password=self.password)
-        self.urlopen("/account/login", data=urllib.urlencode(data), method="POST")
+        self.urlopen("/account/login", data=urllib.parse.urlencode(data), method="POST")
         print(self.cookiejar)
 
     def create_list(self, data):

--- a/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
@@ -2,9 +2,8 @@ from py.test import config
 import web
 import simplejson
 
-import urllib
-import urllib2
 import cookielib
+from six.moves import urllib
 
 from openlibrary.plugins.openlibrary.api import ratings
 from openlibrary import accounts
@@ -23,9 +22,9 @@ class RatingsAPI:
 
         self.cookiejar = cookielib.CookieJar()
 
-        self.opener = urllib2.build_opener()
+        self.opener = urllib.request.build_opener()
         self.opener.add_handler(
-            urllib2.HTTPCookieProcessor(self.cookiejar))
+            urllib.request.HTTPCookieProcessor(self.cookiejar))
 
     def urlopen(self, path, data=None, method=None, headers={}):
         """url open with cookie support."""
@@ -35,13 +34,13 @@ class RatingsAPI:
             else:
                 method = "GET"
 
-        req = urllib2.Request(self.server + path, data=data, headers=headers)
+        req = urllib.request.Request(self.server + path, data=data, headers=headers)
         req.get_method = lambda: method
         return self.opener.open(req)
 
     def login(self):
         data = dict(username=self.username, password=self.password)
-        self.urlopen("/account/login", data=urllib.urlencode(data), method="POST")
+        self.urlopen("/account/login", data=urllib.parse.urlencode(data), method="POST")
 
     def rate_book(self, work_key, data):
         url = '%s/ratings.json' % (work_key)

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-from urllib import quote_plus, urlopen
 from xml.etree.cElementTree import ElementTree
 from cStringIO import StringIO
 import os
@@ -12,6 +11,8 @@ from facet_hash import facet_token
 import pdb
 
 import six
+from six.moves.urllib.parse import quote_plus
+from six.moves.urllib.request import urlopen
 
 php_location = "/petabox/setup.inc"
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -2,7 +2,6 @@ import web
 import hmac
 import logging
 import random
-import urllib
 import uuid
 import datetime
 import time
@@ -34,6 +33,7 @@ import borrow
 
 
 from six.moves import range
+from six.moves import urllib
 
 
 logger = logging.getLogger("openlibrary.account")

--- a/openlibrary/plugins/upstream/adapter.py
+++ b/openlibrary/plugins/upstream/adapter.py
@@ -8,12 +8,11 @@ Upstream requires:
 
 This adapter module is a filter that sits above an Infobase server and fakes the new URL structure.
 """
-import urllib
-import urllib2
 import simplejson
 import web
 
 import six
+from six.moves import urllib
 
 
 urls = (
@@ -65,10 +64,10 @@ class proxy:
         self.before_request()
         try:
             server = web.config.infobase_server
-            req = urllib2.Request(server + self.path + '?' + urllib.urlencode(self.input), self.data, headers=headers)
+            req = urllib.request.Request(server + self.path + '?' + urllib.parse.urlencode(self.input), self.data, headers=headers)
             req.get_method = lambda: web.ctx.method
-            response = urllib2.urlopen(req)
-        except urllib2.HTTPError as e:
+            response = urllib.request.urlopen(req)
+        except urllib.error.HTTPError as e:
             response = e
         self.status_code = response.code
         self.status_msg = response.msg
@@ -233,7 +232,7 @@ class save_many(proxy):
             q = simplejson.loads(i['query'])
             q = convert_dict(q)
             i['query'] = simplejson.dumps(q)
-            self.data = urllib.urlencode(i)
+            self.data = urllib.parse.urlencode(i)
 
 class reindex(proxy):
     def before_request(self):
@@ -241,7 +240,7 @@ class reindex(proxy):
         if 'keys' in i:
             keys = [convert_key(k) for k in simplejson.loads(i['keys'])]
             i['keys'] = simplejson.dumps(keys)
-            self.data = urllib.urlencode(i)
+            self.data = urllib.parse.urlencode(i)
 
 class account(proxy):
     def before_request(self):

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1,8 +1,6 @@
 """Handlers for adding and editing books."""
 
 import web
-import urllib
-import urllib2
 import simplejson
 from collections import defaultdict
 from StringIO import StringIO
@@ -31,6 +29,7 @@ from openlibrary.plugins.recaptcha import recaptcha
 from . import spamcheck
 
 import six
+from six.moves import urllib
 
 
 logger = logging.getLogger("openlibrary.book")

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -6,8 +6,6 @@ import time
 import hmac
 import re
 import simplejson
-import urllib
-import urllib2
 import logging
 
 import web
@@ -31,6 +29,9 @@ from openlibrary.utils import dateutil
 from lxml import etree
 
 import acs4
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("openlibrary.borrow")
 
@@ -86,7 +87,7 @@ class checkout_with_ocaid(delegate.page):
         then redirects user to the canonical OL borrow page.
         """
         i = web.input()
-        params = urllib.urlencode(i)
+        params = urllib.parse.urlencode(i)
         ia_edition = web.ctx.site.get('/books/ia:%s' % ocaid)
         edition = web.ctx.site.get(ia_edition.location)
         url = '%s/x/borrow' % (edition.key)
@@ -130,7 +131,7 @@ class borrow(delegate.page):
             archive_url += '&_autoReadAloud=show'
 
         if i.q:
-            _q = urllib.quote(i.q, safe='')
+            _q = urllib.parse.quote(i.q, safe='')
             archive_url += "#page/-/mode/2up/search/%s" % _q
 
         if availability and availability['status'] == 'open':
@@ -652,7 +653,7 @@ def get_loan_status(resource_id):
 
     url = '%s/is_loaned_out/%s' % (loanstatus_url, resource_id)
     try:
-        response = simplejson.loads(urllib2.urlopen(url).read())
+        response = simplejson.loads(urllib.request.urlopen(url).read())
         if len(response) == 0:
             # No outstanding loans
             return None
@@ -679,7 +680,7 @@ def get_all_loaned_out():
 
     url = '%s/is_loaned_out/' % loanstatus_url
     try:
-        response = simplejson.loads(urllib2.urlopen(url).read())
+        response = simplejson.loads(urllib.request.urlopen(url).read())
         return response
     except IOError:
         raise Exception('Loan status server not available')
@@ -996,7 +997,7 @@ def make_bookreader_auth_link(loan_key, item_id, book_path, ol_host, ia_userid=N
         'iaUserId': ia_userid,
         'iaAuthToken': make_ia_token(ia_userid, READER_AUTH_SECONDS)
     }
-    return auth_link + urllib.urlencode(params)
+    return auth_link + urllib.parse.urlencode(params)
 
 def on_loan_update(loan):
     # update the waiting list and ebook document.

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -1,7 +1,5 @@
 """Handle book cover/author photo upload.
 """
-import urllib
-import urllib2
 import web
 import simplejson
 
@@ -10,6 +8,9 @@ from infogami.utils.view import safeint
 from utils import get_coverstore_url, render_template
 from models import Image
 from openlibrary import accounts
+
+from six.moves import urllib
+
 
 def setup():
     pass
@@ -70,9 +71,9 @@ class add_cover(delegate.page):
             upload_url = "http:" + upload_url
 
         try:
-            response = urllib2.urlopen(upload_url, urllib.urlencode(params))
+            response = urllib.request.urlopen(upload_url, urllib.parse.urlencode(params))
             out = response.read()
-        except urllib2.HTTPError as e:
+        except urllib.error.HTTPError as e:
             out = {'error': e.read()}
 
         return web.storage(simplejson.loads(out))

--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -6,14 +6,15 @@ from infogami.utils import delegate
 from infogami.utils.view import public
 
 import simplejson
-import urllib2
+
+from six.moves import urllib
 
 
 IA_BASE_URL = config.get('ia_base_url')
 
 
 def wget(url):
-    return urllib2.urlopen(url).read()
+    return urllib.request.urlopen(url).read()
 
 
 def get_ol_dumps():

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import web
-import urllib2
 import simplejson
 import re
 from collections import defaultdict
@@ -27,6 +26,7 @@ import borrow
 import logging
 
 import six
+from six.moves import urllib
 
 
 def follow_redirect(doc):
@@ -709,7 +709,7 @@ class Subject(client.Thing):
 
         try:
             url = '%s/b/query?cmd=ids&olid=%s' % (get_coverstore_url(), ",".join(olids))
-            data = urllib2.urlopen(url).read()
+            data = urllib.request.urlopen(url).read()
             cover_ids = simplejson.loads(data)
         except IOError as e:
             print('ERROR in getting cover_ids', str(e), file=web.debug)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -7,8 +7,6 @@ from UserDict import DictMixin
 from collections import defaultdict
 import re
 import random
-import urllib
-import urllib2
 import xml.etree.ElementTree as etree
 import datetime
 import gzip
@@ -17,6 +15,7 @@ import logging
 from HTMLParser import HTMLParser
 
 import six
+from six.moves import urllib
 
 from infogami import config
 from infogami.utils import view, delegate, stats
@@ -396,7 +395,7 @@ def add_metatag(tag="meta", **attrs):
 def url_quote(text):
     if isinstance(text, six.text_type):
         text = text.encode('utf8')
-    return urllib.quote_plus(text)
+    return urllib.parse.quote_plus(text)
 
 @public
 def entity_decode(text):
@@ -649,7 +648,7 @@ def _get_blog_feeds():
     url = "http://blog.openlibrary.org/feed/"
     try:
         stats.begin("get_blog_feeds", url=url)
-        tree = etree.parse(urllib.urlopen(url))
+        tree = etree.parse(urllib.request.urlopen(url))
     except Exception:
         # Handle error gracefully.
         logging.getLogger("openlibrary").error("Failed to fetch blog feeds", exc_info=True)
@@ -682,11 +681,11 @@ def get_donation_include(include):
         param += '&ymd=' + web_input.ymd
 
     # Look for presence of cookie indicating banner has been closed
-    opener = urllib2.build_opener()
+    opener = urllib.request.build_opener()
     donation_param = web.cookies().get('donation')
     if donation_param:
         # Append a tuple with the cookie pair (*not* extraneous parentheses!)
-        opener.addheaders.append(('Cookie', urllib.urlencode({'donation': donation_param})))
+        opener.addheaders.append(('Cookie', urllib.parse.urlencode({'donation': donation_param})))
 
     html = ''
     if include == 'true' and "dev" in web.ctx.features:
@@ -699,7 +698,7 @@ def get_donation_include(include):
                 html = """
                 <center>WARNING: Donation banner disabled on prod; see <a href="https://github.com/internetarchive/openlibrary/issues/2853">GitHub #2853</a></center>
                 """ + html
-        except urllib2.URLError:
+        except urllib.error.URLError:
             logging.getLogger("openlibrary").error('Could not load donation banner')
             return ''
     return html

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1,7 +1,5 @@
 import web
 import re
-import urllib
-import urllib2
 from lxml.etree import XML, XMLSyntaxError
 from infogami.utils import delegate, stats
 from infogami import config
@@ -14,6 +12,9 @@ from openlibrary.utils import url_quote, escape_bracket
 from openlibrary.utils.isbn import normalize_isbn, opposite_isbn
 from unicodedata import normalize
 import logging
+
+from six.moves import urllib
+
 
 ftoken_db = None
 
@@ -172,7 +173,7 @@ def parse_json_from_solr_query(url):
 def execute_solr_query(url):
     stats.begin("solr", url=url)
     try:
-        solr_result = urllib2.urlopen(url, timeout=3)
+        solr_result = urllib.request.urlopen(url, timeout=3)
     except Exception as e:
         logger.exception("Failed solr query")
         return None
@@ -461,7 +462,7 @@ class search(delegate.page):
 
         # Send to full-text Search Inside if checkbox checked
         if i.get('search-fulltext'):
-            raise web.seeother('/search/inside?' + urllib.urlencode({'q': i.get('q', '')}))
+            raise web.seeother('/search/inside?' + urllib.parse.urlencode({'q': i.get('q', '')}))
 
         if i.get('ftokens') and ',' not in i.ftokens:
             token = i.ftokens
@@ -696,7 +697,7 @@ class subject_search(delegate.page):
             "sort": "work_count desc"
         }
 
-        solr_select = solr_select_url + "?" + urllib.urlencode(params, 'utf-8')
+        solr_select = solr_select_url + "?" + urllib.parse.urlencode(params, 'utf-8')
         results = run_solr_search(solr_select)
         response = results['response']
 

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -6,10 +6,12 @@ from infogami.utils.view import render_template, safeint
 import web
 import simplejson
 import logging
-import urllib
 
 from . import subjects
 from . import search
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("openlibrary.worksearch")
 

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -5,10 +5,12 @@ from infogami.utils.view import render_template, safeint
 import web
 import simplejson
 import logging
-import urllib
 
 from . import subjects
 from . import search
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("openlibrary.worksearch")
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -6,13 +6,13 @@ import re
 import simplejson as json
 import logging
 from collections import defaultdict
-import urllib
 import datetime
 
 from infogami import config
 from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate, stats
 from infogami.utils.view import render, render_template, safeint
+from six.moves import urllib
 
 from openlibrary.core.models import Subject
 from openlibrary.core.lending import add_availability
@@ -408,7 +408,7 @@ def execute_ebook_count_query(q):
     solr_url = root_url % (rows, start, q)
 
     stats.begin("solr", url=solr_url)
-    response = json.load(urllib.urlopen(solr_url))['response']
+    response = json.load(urllib.request.urlopen(solr_url))['response']
     stats.end()
 
     num_found = response['numFound']
@@ -417,7 +417,7 @@ def execute_ebook_count_query(q):
         if start:
             solr_url = root_url % (rows, start, q)
             stats.begin("solr", url=solr_url)
-            response = json.load(urllib.urlopen(solr_url))['response']
+            response = json.load(urllib.request.urlopen(solr_url))['response']
             stats.end()
         for doc in response['docs']:
             for k in doc['edition_key']:

--- a/openlibrary/solr/find_modified_works.py
+++ b/openlibrary/solr/find_modified_works.py
@@ -8,7 +8,9 @@ import json
 import os
 import sys
 import time
-import urllib2
+
+from six.moves import urllib
+
 
 BASE_URL = "https://openlibrary.org/recentchanges/"
 # BASE_URL = "http://0.0.0.0:8080/recentchanges/"
@@ -45,7 +47,7 @@ def get_modified_works(frm, to):
     while frm < to:
         url = frm.strftime(BASE_URL+"%Y/%m/%d.json")
         logging.debug("Fetching changes from %s", url)
-        ret.append(extract_works(json.load(urllib2.urlopen(url))))
+        ret.append(extract_works(json.load(urllib.request.urlopen(url))))
         frm += one_day
     return itertools.chain(*ret)
 
@@ -66,7 +68,7 @@ def poll_for_changes(start_time_file, max_chunk_size, delay):
     while True:
         url = date.strftime(BASE_URL+"%Y/%m/%d.json")
         logging.debug("-- Fetching changes from %s", url)
-        changes = list(json.load(urllib2.urlopen(url)))
+        changes = list(json.load(urllib.request.urlopen(url)))
         unseen_changes = list(x for x in changes if x['id'] not in seen)
         logging.debug("%d changes fetched", len(changes))
         logging.debug(" of which %d are unseen", len(unseen_changes))

--- a/openlibrary/solr/inside/index_all.py
+++ b/openlibrary/solr/inside/index_all.py
@@ -6,12 +6,12 @@ import re
 import httplib
 from collections import defaultdict
 from socket import socket, AF_INET, SOCK_DGRAM, SOL_UDP, SO_BROADCAST, timeout
-from urllib import urlopen
 from time import sleep, time
 from lxml.etree import Element, tostring
 from unicodedata import normalize
 
 import six
+from six.moves.urllib.request import urlopen
 
 def add_field(doc, name, value):
     field = Element("field", name=name)

--- a/openlibrary/solr/inside/index_gevent.py
+++ b/openlibrary/solr/inside/index_gevent.py
@@ -6,6 +6,7 @@ monkey.patch_socket()
 import re
 import httplib
 import json
+from six.moves import urllib
 import sys
 import os
 import codecs
@@ -13,7 +14,6 @@ from openlibrary.utils.ia import find_item
 from time import time
 from collections import defaultdict
 from lxml.etree import Element, tostring, parse, fromstring
-import urllib2
 from unicodedata import normalize
 
 import six
@@ -73,8 +73,8 @@ def use_primary(host):
 def urlread_keep_trying(url):
     for i in range(3):
         try:
-            return urllib2.urlopen(url).read()
-        except urllib2.HTTPError as error:
+            return urllib.request.urlopen(url).read()
+        except urllib.error.HTTPError as error:
             if error.code in (403, 404):
                 #print "404 for '%s'" % url
                 raise
@@ -85,7 +85,7 @@ def urlread_keep_trying(url):
             print('bad status line')
         except httplib.IncompleteRead:
             print('incomplete read')
-        except urllib2.URLError:
+        except urllib.error.URLError:
             pass
         print(url, "failed")
         sleep(2)
@@ -119,7 +119,7 @@ def read_text_from_node(host):
         url = 'http://%s/%s' % (host, path)
         try:
             dir_html = urlread_keep_trying('http://%s/%s' % (host, path))
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             if error.code == 403:
                 print('403 on directory listing for:', ia)
                 dir_html = None
@@ -137,7 +137,7 @@ def read_text_from_node(host):
         url = 'http://%s/~edward/abbyy_to_text.php?ia=%s&path=%s&file=%s' % (host, ia, path, filename)
         try:
             reply = urlread_keep_trying(url)
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             if error.code != 403:
                 raise
             url = 'http://%s/~edward/abbyy_to_text_p.php?ia=%s&path=%s&file=%s' % (host, ia, path, filename)
@@ -203,7 +203,7 @@ def add_to_item_queue():
         current_book = ia
         if check_for_existing:
             url = 'http://' + solr_host + '/solr/inside/select?indent=on&wt=json&rows=0&q=ia:' + ia
-            num_found = json.load(urllib2.urlopen(url))['response']['numFound']
+            num_found = json.load(urllib.request.urlopen(url))['response']['numFound']
             if num_found != 0:
                 continue
 
@@ -257,7 +257,7 @@ def run_find_item():
         body = None
         if False:
             url = 'http://' + solr_src_host + '/solr/inside/select?wt=json&rows=10&q=ia:' + ia
-            response = json.load(urllib2.urlopen(url))['response']
+            response = json.load(urllib.request.urlopen(url))['response']
             if response['numFound']:
                 doc = response['docs'][0]
                 for doc_lang in ['eng', 'fre', 'deu', 'spa', 'other']:
@@ -271,7 +271,7 @@ def run_find_item():
         if body:
             try:
                 meta_xml = urlread_keep_trying('http://%s%s/%s_meta.xml' % (host, path, ia))
-            except urllib2.HTTPError as error:
+            except urllib.error.HTTPError as error:
                 if error.code != 403:
                     raise
                 print('403 on meta XML for:', ia)

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -6,13 +6,12 @@ import os
 import re
 import sys
 import time
-import urllib
-import urllib2
 from collections import defaultdict
 from unicodedata import normalize
 
 import simplejson as json
 import six
+from six.moves import urllib
 import web
 from lxml.etree import tostring, Element, SubElement
 
@@ -45,8 +44,8 @@ def urlopen(url, data=None):
     headers = {
         'User-Agent': user_agent
     }
-    req = urllib2.Request(url, data, headers)
-    return urllib2.urlopen(req)
+    req = urllib.request.Request(url, data, headers)
+    return urllib.request.urlopen(req)
 
 def get_solr():
     """
@@ -1080,7 +1079,7 @@ def get_subject(key):
         'facet.limit': 100
     }
     base_url = 'http://' + get_solr() + '/solr/select'
-    url = base_url + '?' + urllib.urlencode(params)
+    url = base_url + '?' + urllib.parse.urlencode(params)
     result = json.load(urlopen(url))
 
     work_count = result['response']['numFound']

--- a/openlibrary/solr/work_subject.py
+++ b/openlibrary/solr/work_subject.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 import re
-import urllib2
 from openlibrary.catalog.marc.fast_parse import get_tag_lines, get_all_subfields, get_subfield_values, get_subfields, BadDictionary
 from openlibrary.catalog.utils import remove_trailing_dot, remove_trailing_number_dot, flip_name
 from openlibrary.catalog.importer.db_read import get_mc
 from collections import defaultdict
+
+from six.moves import urllib
+
 
 subject_fields = set(['600', '610', '611', '630', '648', '650', '651', '662'])
 
@@ -38,7 +40,7 @@ def get_marc_subjects(w):
             print('bad record source:', src)
             print('http://openlibrary.org' + w['key'])
             continue
-        except urllib2.HTTPError as error:
+        except urllib.error.HTTPError as error:
             print('HTTP error:', error.code, error.msg)
             print('http://openlibrary.org' + w['key'])
         if not data:

--- a/openlibrary/tests/core/mocklib.py
+++ b/openlibrary/tests/core/mocklib.py
@@ -1,8 +1,9 @@
 """Simple mock utility.
 """
-import urllib
-import urllib2
 from StringIO import StringIO
+
+from six.moves import urllib
+
 
 class Mock:
     def __init__(self):
@@ -21,10 +22,10 @@ class Mock:
         self.calls.append(call)
 
 def monkeypatch_urllib(monkeypatch, url, response_string):
-    """Monkey-patches urllib.urlopen to return the given response
+    """Monkey-patches urllib.request.urlopen to return the given response
     when urlopen is called with the given url.
     """
-    _urlopen = urllib.urlopen
+    _urlopen = urllib.request.urlopen
     given_url = url
 
     def urlopen(url, *a, **kw):
@@ -36,10 +37,10 @@ def monkeypatch_urllib(monkeypatch, url, response_string):
     monkeypatch.setattr(urllib, "urlopen", urlopen)
 
 def monkeypatch_urllib2(monkeypatch, url, response_string):
-    """Monkey-patches urllib2.urlopen to return the given response
+    """Monkey-patches urllib.request.urlopen to return the given response
     when urlopen is called with the given url.
     """
-    _urlopen = urllib2.urlopen
+    _urlopen = urllib.request.urlopen
     given_url = url
 
     def urlopen(url, *a, **kw):

--- a/openlibrary/utils/compress.py
+++ b/openlibrary/utils/compress.py
@@ -35,7 +35,7 @@ some_record, and restored_record being identical to some_record.
 class Compressor(object):
     def __init__(self, seed):
         c = zlib.compressobj(9)
-        d_seed = c.compress(seed.encode())
+        d_seed = c.compress(seed)
         d_seed += c.flush(zlib.Z_SYNC_FLUSH)
         self.c_context = c.copy()
 
@@ -47,7 +47,7 @@ class Compressor(object):
 
     def compress(self, text):
         c = self.c_context.copy()
-        t = c.compress(text.encode())
+        t = c.compress(text)
         t2 = c.flush(zlib.Z_FINISH)
         return t + t2
 
@@ -56,7 +56,7 @@ class Compressor(object):
         t = d.decompress(ctext)
         while d.unconsumed_tail:
             t += d.decompress(d.unconsumed_tail)
-        return t.decode()
+        return t
 
 def test():
     c = Compressor(__doc__)
@@ -66,6 +66,6 @@ def test():
     # the above string compresses from 43 bytes to 29 bytes using the
     # current doc text as compression seed, not bad for such short input.
     dt = c.decompress(ct)
-    assert dt == test_string, (dt, test_string)
+    assert dt == test_string
 
 test()

--- a/openlibrary/utils/httpserver.py
+++ b/openlibrary/utils/httpserver.py
@@ -3,23 +3,25 @@
     >>> server = HTTPServer(port=8090)
     >>> server.request('/hello/world', method='GET').should_return('hello, world!', headers={'content-type': 'text/plain'})
 
-    >>> response = urllib.urlopen('http://0.0.0.0:8090/hello/world')
+    >>> response = urllib.request.urlopen('http://0.0.0.0:8090/hello/world')
     >>> response.read()
     'hello, world!'
     >>> response.info().getheader('Content-Type')
     'text/plain'
 
     >>> server.stop()
-    >>> urllib.urlopen('http://0.0.0.0:8090/hello/world')
+    >>> urllib.request.urlopen('http://0.0.0.0:8090/hello/world')
     Traceback (most recent call last):
     ...
     IOError: [Errno socket error] (61, 'Connection refused')
 """
 from __future__ import print_function
 from web.wsgiserver import CherryPyWSGIServer
-import urllib
 import threading
 import time
+
+from six.moves import urllib
+
 
 class HTTPServer:
     def __init__(self, port=8090):
@@ -45,7 +47,7 @@ class HTTPServer:
         response = Respose()
 
         if isinstance(query, dict):
-            query = urllib.urlencode(query)
+            query = urllib.parse.urlencode(query)
 
         self.mappings[path, method, query] = response
         return response

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -1,12 +1,12 @@
 """Python library for accessing Solr.
 """
-import urlparse
-import urllib
-import urllib2
 import re
 import web
 import simplejson
 import logging
+
+from six.moves import urllib
+
 
 logger = logging.getLogger("openlibrary.logger")
 
@@ -14,9 +14,9 @@ def urlencode(d, doseq=False):
     """There is a bug in urllib when used with unicode data.
 
         >>> d = {"q": u"\u0C05"}
-        >>> urllib.urlencode(d)
+        >>> urllib.parse.urlencode(d)
         'q=%E0%B0%85'
-        >>> urllib.urlencode(d, doseq=True)
+        >>> urllib.parse.urlencode(d, doseq=True)
         'q=%3F'
 
     This function encodes all the unicode strings in utf-8 before passing them to urllib.
@@ -29,12 +29,12 @@ def urlencode(d, doseq=False):
         else:
             return web.safestr(d)
 
-    return urllib.urlencode(utf8(d), doseq=doseq)
+    return urllib.parse.urlencode(utf8(d), doseq=doseq)
 
 class Solr:
     def __init__(self, base_url):
         self.base_url = base_url
-        self.host = urlparse.urlsplit(self.base_url)[1]
+        self.host = urllib.parse.urlsplit(self.base_url)[1]
 
     def escape(self, query):
         r"""Escape special characters in the query string
@@ -91,11 +91,11 @@ class Solr:
         if len(payload) < 500:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
-            data = urllib2.urlopen(url, timeout=3).read()
+            data = urllib.request.urlopen(url, timeout=3).read()
         else:
             logger.info("solr request: %s ...", url)
-            request = urllib2.Request(url, payload, {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"})
-            data = urllib2.urlopen(request, timeout=3).read()
+            request = urllib.request.Request(url, payload, {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"})
+            data = urllib.request.urlopen(request, timeout=3).read()
         return self._parse_solr_result(
             simplejson.loads(data),
             doc_wrapper=doc_wrapper,

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -4,10 +4,12 @@ Hook to show mark details in Open Library.
 from .. import app
 
 import web
-import urllib2
 import os.path
 import sys
 import re
+
+from six.moves import urllib
+
 
 class old_show_marc(app.view):
     path = "/show-marc/(.*)"
@@ -22,8 +24,8 @@ class show_ia(app.view):
         error_404 = False
         url = 'http://www.archive.org/download/%s/%s_meta.mrc' % (ia, ia)
         try:
-            data = urllib2.urlopen(url).read()
-        except urllib2.HTTPError as e:
+            data = urllib.request.urlopen(url).read()
+        except urllib.error.HTTPError as e:
             if e.code == 404:
                 error_404 = True
             else:
@@ -32,8 +34,8 @@ class show_ia(app.view):
         if error_404: # no MARC record
             url = 'http://www.archive.org/download/%s/%s_meta.xml' % (ia, ia)
             try:
-                data = urllib2.urlopen(url).read()
-            except urllib2.HTTPError as e:
+                data = urllib.request.urlopen(url).read()
+            except urllib.error.HTTPError as e:
                 return "ERROR:" + str(e)
             raise web.seeother('http://www.archive.org/details/' + ia)
 
@@ -106,14 +108,14 @@ class show_marc(app.view):
         r0, r1 = offset, offset+100000
         url = 'http://www.archive.org/download/%s'% filename
 
-        ureq = urllib2.Request(url,
+        ureq = urllib.request.Request(url,
                                None,
                                {'Range':'bytes=%d-%d'% (r0, r1)},
                                )
 
         try:
-            result = urllib2.urlopen(ureq).read(100000)
-        except urllib2.HTTPError as e:
+            result = urllib.request.urlopen(ureq).read(100000)
+        except urllib.error.HTTPError as e:
             return "ERROR:" + str(e)
 
         len_in_rec = int(result[:5])

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -8,11 +8,10 @@ Changes:
 """
 import _init_path
 
+from six.moves import urllib
 import yaml
 import logging
 import json
-import urllib
-import urllib2
 import argparse
 import datetime
 import time
@@ -72,8 +71,8 @@ class InfobaseLog:
             url = "%s/%s?limit=100" % (self.base_url, self.offset)
             logger.debug("Reading log from %s", url)
             try:
-                jsontext = urllib2.urlopen(url).read()
-            except urllib2.URLError as e:
+                jsontext = urllib.request.urlopen(url).read()
+            except urllib.error.URLError as e:
                 logger.error("Failed to open URL %s", url, exc_info=True)
                 if e.args and e.args[0].args == (111, 'Connection refused'):
                     logger.error('make sure infogami server is working, connection refused from %s', url)

--- a/scripts/oclc_to_marc.py
+++ b/scripts/oclc_to_marc.py
@@ -3,13 +3,15 @@
 Usage: python oclc_to_marc.py oclc_1 oclc_2
 """
 from __future__ import print_function
-import urllib
 import simplejson
+
+from six.moves import urllib
+
 
 root = "http://openlibrary.org"
 
 def wget(path):
-    return simplejson.loads(urllib.urlopen(root + path).read())
+    return simplejson.loads(urllib.request.urlopen(root + path).read())
 
 def find_marc_url(d):
     if d.get('source_records'):
@@ -24,7 +26,7 @@ def find_marc_url(d):
         return ""
 
 def main(oclc):
-    query = urllib.urlencode({'type': '/type/edition', 'oclc_numbers': oclc, '*': ''})
+    query = urllib.parse.urlencode({'type': '/type/edition', 'oclc_numbers': oclc, '*': ''})
     result = wget('/query.json?' + query)
 
     for d in result:

--- a/scripts/solr_author_merge_work_finder.py
+++ b/scripts/solr_author_merge_work_finder.py
@@ -7,11 +7,13 @@ from openlibrary import config
 import argparse
 import simplejson
 import re
+from six.moves.urllib.request import urlopen
 import sys
-from urllib import urlopen
-from urllib2 import URLError
 from time import time, sleep
 from openlibrary.catalog.works.find_works import find_title_redirects, find_works, get_books, books_query, update_works
+
+from six.moves.urllib.error import URLError
+
 
 parser = argparse.ArgumentParser(description='solr author merge')
 parser.add_argument('--config', default='openlibrary.yml')

--- a/scripts/z3950_view.py
+++ b/scripts/z3950_view.py
@@ -3,9 +3,11 @@ from PyZ3950 import zoom
 from lxml import etree
 import sys
 import re
-from urllib import urlopen
 from openlibrary.catalog.marc.html import html_record
 from openlibrary.catalog.marc import xml_to_html
+
+from six.moves.urllib.request import urlopen
+
 
 tree = etree.parse('/petabox/www/petabox/includes/ztargets.xml')
 root = tree.getroot()


### PR DESCRIPTION
Use the __six__ module to make all imports from urllib and urllib2 compatible with both Python 2 and Python 3.  This pull request was created by running the command __[sixer](https://pypi.org/project/sixer)  --write urllib .__

<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->