### PR TITLE
from openlibrary.mocks.mock_infobase import mock_site, MockConnection

### DIFF
--- a/openlibrary/mocks/mock_ol.py
+++ b/openlibrary/mocks/mock_ol.py
@@ -6,9 +6,9 @@ from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate
 
+from openlibrary.mocks.mock_infobase import mock_site, MockConnection
 from openlibrary.plugins import ol_infobase
 
-from mock_infobase import mock_site, MockConnection
 
 @pytest.fixture
 def ol(request):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #
```
ImportError while loading conftest '/home/travis/build/internetarchive/openlibrary/openlibrary/conftest.py'.
openlibrary/conftest.py:18: in <module>
    from openlibrary.mocks.mock_ol import ol
openlibrary/mocks/mock_ol.py:11: in <module>
    from mock_infobase import mock_site, MockConnection
E   ModuleNotFoundError: No module named 'mock_infobase'
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->