### PR TITLE
Python 3: sixer --write urllib again

### DIFF
--- a/openlibrary/core/civicrm.py
+++ b/openlibrary/core/civicrm.py
@@ -4,7 +4,7 @@ import requests
 from infogami import config
 from openlibrary.core import lending
 
-from six.moves import urllib
+from six.moves.urllib.parse import urlencode
 
 
 CIVI_ISBN = 'custom_52'
@@ -27,7 +27,7 @@ def get_contact_id_by_username(username):
     data['json'] = json.dumps(data['json'])  # flatten the json field as a string
     r = requests.get(
         lending.config_ia_civicrm_api.get('url', ''),
-        params=urllib.parse.urlencode(data),
+        params=urlencode(data),
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })
@@ -52,7 +52,7 @@ def get_sponsorships_by_contact_id(contact_id, isbn=None):
     data['json'] = json.dumps(data['json'])  # flatten the json field as a string
     r = requests.get(
         lending.config_ia_civicrm_api.get('url', ''),
-        params=urllib.parse.urlencode(data),
+        params=urlencode(data),
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })

--- a/openlibrary/core/civicrm.py
+++ b/openlibrary/core/civicrm.py
@@ -1,9 +1,11 @@
 import json
 import requests
-import urllib
 
 from infogami import config
-from openlibrary.core import lending 
+from openlibrary.core import lending
+
+from six.moves import urllib
+
 
 CIVI_ISBN = 'custom_52'
 CIVI_USERNAME = 'custom_51'
@@ -25,7 +27,7 @@ def get_contact_id_by_username(username):
     data['json'] = json.dumps(data['json'])  # flatten the json field as a string
     r = requests.get(
         lending.config_ia_civicrm_api.get('url', ''),
-        params=urllib.urlencode(data),
+        params=urllib.parse.urlencode(data),
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })
@@ -50,7 +52,7 @@ def get_sponsorships_by_contact_id(contact_id, isbn=None):
     data['json'] = json.dumps(data['json'])  # flatten the json field as a string
     r = requests.get(
         lending.config_ia_civicrm_api.get('url', ''),
-        params=urllib.urlencode(data),
+        params=urllib.parse.urlencode(data),
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -15,7 +15,7 @@ from openlibrary.core.civicrm import (
     get_sponsorships_by_contact_id)
 from openlibrary.utils.isbn import to_isbn_13
 
-from six.moves import urllib
+from six.moves.urllib.parse import urlencode
 
 
 try:
@@ -82,7 +82,7 @@ def do_we_want_it(isbn, work_id):
         'include_promises': 'true',  # include promises and sponsored books
         'search_id': isbn
     }
-    url = '%s/book/marc/ol_dedupe.php?%s' % (lending.config_ia_domain,  urllib.parse.urlencode(params))
+    url = '%s/book/marc/ol_dedupe.php?%s' % (lending.config_ia_domain,  urlencode(params))
     r = requests.get(url)
     try:
         data = r.json()
@@ -170,7 +170,7 @@ def qualifies_for_sponsorship(edition):
     })
     resp.update({
         'edition': edition_data,
-        'sponsor_url': lending.config_ia_domain + '/donate?' + urllib.parse.urlencode({
+        'sponsor_url': lending.config_ia_domain + '/donate?' + urlencode({
             'campaign': 'pilot',
             'type': 'sponsorship',
             'context': 'ol',

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -1,4 +1,3 @@
-import urllib
 import requests
 import logging
 import web
@@ -15,6 +14,9 @@ from openlibrary.core.civicrm import (
     get_contact_id_by_username,
     get_sponsorships_by_contact_id)
 from openlibrary.utils.isbn import to_isbn_13
+
+from six.moves import urllib
+
 
 try:
     from booklending_utils.sponsorship import eligibility_check
@@ -80,7 +82,7 @@ def do_we_want_it(isbn, work_id):
         'include_promises': 'true',  # include promises and sponsored books
         'search_id': isbn
     }
-    url = '%s/book/marc/ol_dedupe.php?%s' % (lending.config_ia_domain,  urllib.urlencode(params))
+    url = '%s/book/marc/ol_dedupe.php?%s' % (lending.config_ia_domain,  urllib.parse.urlencode(params))
     r = requests.get(url)
     try:
         data = r.json()
@@ -168,7 +170,7 @@ def qualifies_for_sponsorship(edition):
     })
     resp.update({
         'edition': edition_data,
-        'sponsor_url': lending.config_ia_domain + '/donate?' + urllib.urlencode({
+        'sponsor_url': lending.config_ia_domain + '/donate?' + urllib.parse.urlencode({
             'campaign': 'pilot',
             'type': 'sponsorship',
             'context': 'ol',
@@ -224,7 +226,7 @@ def summary():
     est_book_cost_cents = sum(int(i.get('est_book_price', 0)) for i in items)
     scan_cost_cents = (PAGE_COST_CENTS * total_pages_scanned) + (SETUP_COST_CENTS * len(items))
     est_scan_cost_cents = sum(int(i.get('est_scan_price', 0)) for i in items)
-    avg_scan_cost = scan_cost_cents / (len(items) - total_unscanned_books) 
+    avg_scan_cost = scan_cost_cents / (len(items) - total_unscanned_books)
 
     return {
         'books': items,

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -1,6 +1,5 @@
 import re
 import web
-import urllib2
 import simplejson
 import requests
 from decimal import Decimal
@@ -13,6 +12,9 @@ from openlibrary.utils.isbn import (
     normalize_isbn, isbn_13_to_isbn_10, isbn_10_to_isbn_13)
 from openlibrary.catalog.add_book import load
 from openlibrary import accounts
+
+from six.moves import urllib
+
 
 BETTERWORLDBOOKS_BASE_URL = 'https://betterworldbooks.com'
 BETTERWORLDBOOKS_API_URL = 'https://products.betterworldbooks.com/service.aspx?ItemId='
@@ -333,7 +335,7 @@ def _get_betterworldbooks_metadata(isbn):
 
         return betterworldbooks_fmt(isbn, qlt, price)
 
-    except urllib2.HTTPError as e:
+    except urllib.error.HTTPError as e:
         try:
             response = e.read()
         except simplejson.decoder.JSONDecodeError:
@@ -346,7 +348,7 @@ def betterworldbooks_fmt(isbn, qlt=None, price=None):
     :param str isbn:
     :param str qlt: Quality of the book, e.g. "new", "used"
     :param str price: Price of the book as a decimal str, e.g. "4.28"
-    :rtype: dict 
+    :rtype: dict
     """
     price_fmt = "$%s (%s)" % (price, qlt) if price and qlt else None
     return {

--- a/openlibrary/mocks/mock_ol.py
+++ b/openlibrary/mocks/mock_ol.py
@@ -2,6 +2,11 @@ import os
 import pytest
 import re
 import web
+try:  # newer versions of web.py
+    from web.browser import AppBrowser
+except ImportError:  # older versions of web.py
+    from web import AppBrowser
+
 from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate
@@ -34,11 +39,11 @@ class EMail(web.storage):
         """Extracts link from the email message."""
         return re.findall(r"http://[^\s]*", self.message)
 
-class OLBrowser(web.AppBrowser):
+class OLBrowser(AppBrowser):
     def get_text(self, e=None, name=None, **kw):
         if name or kw:
             e = self.get_soup().find(name=name, **kw)
-        return web.AppBrowser.get_text(self, e)
+        return AppBrowser.get_text(self, e)
 
 class OL:
     """Mock OL object for all tests.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This Python 3 compatibility change touches the same files that are mentioned in #2879 but __these changes are orthogonal__ to the changes requested in that PR.  This allows us to spot other Python 3 compatibility issues before the changes requested in #2879 are made.  This PR was created with:

```
sixer --write urllib openlibrary/core/civicrm.py \
                     openlibrary/core/sponsorships.py \
                     openlibrary/core/vendors.py
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->