### PR TITLE
Switch from pystatsd to statsd

### DIFF
--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -1,20 +1,11 @@
 """
 StatsD client to be used in the application to log various metrics
 
-Based on the code in http://www.monkinetic.com/2011/02/statsd.html (pystatsd client)
-
 """
 
-# statsd.py
-
-# Steve Ivy <steveivy@gmail.com>
-# http://monkinetic.com
-
 import logging
-import socket
-import random
 
-from pystatsd import Client
+from statsd import StatsClient
 
 from infogami import config
 
@@ -28,7 +19,7 @@ def create_stats_client(cfg = config):
         stats_server = cfg.get("admin", {}).get("statsd_server",None)
         if stats_server:
             host, port = stats_server.rsplit(":", 1)
-            return Client(host, port)
+            return StatsClient(host, port)
         else:
             logger.critical("Couldn't find statsd_server section in config")
             return False
@@ -49,7 +40,7 @@ def increment(key, n=1):
     if client:
         l.debug("Incrementing %s"% key)
         for i in range(n):
-            client.increment(key)
+            client.incr(key)
 
 
 client = create_stats_client()

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -13,7 +13,7 @@ python-memcached==1.59
 simplejson==3.16.0
 web.py==0.39; python_version < '3.0'
 web.py==0.40; python_version >= '3.0'
-pystatsd==0.1.6
+statsd==3.3.0
 PyYAML==4.2b4
 eventer==0.1.1
 lepl==5.1.3


### PR DESCRIPTION
Closes #1486

Switches to a Python 3 compatible statsd client library.