### PR TITLE
Switch to official GeoIP module

### DIFF
--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -19,7 +19,7 @@ lepl==5.1.3
 six==1.13.0
 sixpack-client==1.2.0
 psycopg2==2.8.4
-OL-GeoIP==1.2.4; python_version < '3.0'
+GeoIP==1.3.2
 Pygments==2.4.2
 python-amazon-simple-product-api==2.2.11
 isbnlib==3.9.3


### PR DESCRIPTION
Closes #1694

This updates to the most recent MaxMind GeoIP legacy API module which is Python 3 compatible and API compatible since it's a direct descendent of what we're using.

We switch from our private fork, which was apparently only to enable it to be uploaded to PyPI, to the official MaxMind version.

### Technical
This changes a Python dependency which will need to be handled on the production servers.

### Testing

Tests pass, but it should be tested with a live database on dev.

### Stakeholders
@hornc @mekarpeles 