### PR TITLE
2879 requests cleanup

### DIFF
--- a/openlibrary/core/civicrm.py
+++ b/openlibrary/core/civicrm.py
@@ -1,6 +1,5 @@
 import json
 import requests
-import urllib
 
 from infogami import config
 from openlibrary.core import lending 
@@ -25,7 +24,7 @@ def get_contact_id_by_username(username):
     data['json'] = json.dumps(data['json'])  # flatten the json field as a string
     r = requests.get(
         lending.config_ia_civicrm_api.get('url', ''),
-        params=urllib.urlencode(data),
+        params=data,
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })
@@ -50,7 +49,7 @@ def get_sponsorships_by_contact_id(contact_id, isbn=None):
     data['json'] = json.dumps(data['json'])  # flatten the json field as a string
     r = requests.get(
         lending.config_ia_civicrm_api.get('url', ''),
-        params=urllib.urlencode(data),
+        params=data,
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -1,12 +1,12 @@
-import urllib
 import requests
 import logging
 import web
 
+from six.moves.urllib.parse import urlencode
+
 from collections import OrderedDict
 from infogami.utils.view import public
 from openlibrary.core import lending
-from openlibrary.core import models, cache
 from openlibrary.core.vendors import (
     get_betterworldbooks_metadata,
     get_amazon_metadata)
@@ -14,7 +14,6 @@ from openlibrary.accounts.model import get_internet_archive_id
 from openlibrary.core.civicrm import (
     get_contact_id_by_username,
     get_sponsorships_by_contact_id)
-from openlibrary.utils.isbn import to_isbn_13
 
 try:
     from booklending_utils.sponsorship import eligibility_check
@@ -80,8 +79,8 @@ def do_we_want_it(isbn, work_id):
         'include_promises': 'true',  # include promises and sponsored books
         'search_id': isbn
     }
-    url = '%s/book/marc/ol_dedupe.php?%s' % (lending.config_ia_domain,  urllib.urlencode(params))
-    r = requests.get(url)
+    url = '%s/book/marc/ol_dedupe.php' % lending.config_ia_domain
+    r = requests.get(url, params=params)
     try:
         data = r.json()
         dwwi = data.get('response', 0)
@@ -168,7 +167,7 @@ def qualifies_for_sponsorship(edition):
     })
     resp.update({
         'edition': edition_data,
-        'sponsor_url': lending.config_ia_domain + '/donate?' + urllib.urlencode({
+        'sponsor_url': lending.config_ia_domain + '/donate?' + urlencode({
             'campaign': 'pilot',
             'type': 'sponsorship',
             'context': 'ol',

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -1,11 +1,8 @@
 import re
-import web
-import urllib2
 import simplejson
 import requests
 from decimal import Decimal
 from amazon.api import SearchException
-from infogami import config
 from infogami.utils.view import public
 from . import lending, cache, helpers as h
 from openlibrary.utils import dateutil
@@ -314,33 +311,29 @@ def _get_betterworldbooks_metadata(isbn):
     """
 
     url = BETTERWORLDBOOKS_API_URL + isbn
-    try:
-        response = requests.get(url).content
-        new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", response)
-        new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", response)
-        used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", response)
-        used_qty = re.findall("<TotalUsed>([0-9]+)</TotalUsed>", response)
+    response = requests.get(url)
+    if response.status_code != requests.codes.ok:
+        return {'error': response.text, 'code': response.status_code}
+    response = response.content
+    new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", response)
+    new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", response)
+    used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", response)
+    used_qty = re.findall("<TotalUsed>([0-9]+)</TotalUsed>", response)
 
-        price = qlt = None
+    price = qlt = None
 
-        if used_qty and used_qty[0] and used_qty[0] != '0':
-            price = used_price[0] if used_price else ''
-            qlt = 'used'
+    if used_qty and used_qty[0] and used_qty[0] != '0':
+        price = used_price[0] if used_price else ''
+        qlt = 'used'
 
-        if new_qty and new_qty[0] and new_qty[0] != '0':
-            _price = new_price[0] if new_price else None
-            if _price and (not price or float(_price) < float(price)):
-                price = _price
-                qlt = 'new'
+    if new_qty and new_qty[0] and new_qty[0] != '0':
+        _price = new_price[0] if new_price else None
+        if _price and (not price or float(_price) < float(price)):
+            price = _price
+            qlt = 'new'
 
-        return betterworldbooks_fmt(isbn, qlt, price)
+    return betterworldbooks_fmt(isbn, qlt, price)
 
-    except urllib2.HTTPError as e:
-        try:
-            response = e.read()
-        except simplejson.decoder.JSONDecodeError:
-            return {'error': e.read(), 'code': e.code}
-        return simplejson.loads(response)
 
 def betterworldbooks_fmt(isbn, qlt=None, price=None):
     """Defines a standard interface for returning bwb price info

--- a/openlibrary/tests/core/test_sponsors.py
+++ b/openlibrary/tests/core/test_sponsors.py
@@ -44,7 +44,7 @@ class TestSponsorship:
         # Simulating exception / API call failure ...
         monkeypatch.setattr(sponsorships.lending, 'get_work_availability',
                             lambda work_id: mock_availability__need)
-        monkeypatch.setattr(sponsorships.requests, 'get', lambda url: {'invalid': 'json'})
+        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, params: {'invalid': 'json'})
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == False
         assert matches == []
@@ -52,14 +52,14 @@ class TestSponsorship:
         # Check archive.org promise items, previous sponsorships ...
         monkeypatch.setattr(sponsorships.lending, 'get_work_availability',
                             lambda work_id: mock_availability__need)
-        monkeypatch.setattr(sponsorships.requests, 'get', lambda url: None)
+        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, params: None)
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == False
         assert matches == []
 
         # We need a copy ...
         r = storage({'json': lambda: {"response": 1}})
-        monkeypatch.setattr(sponsorships.requests, 'get', lambda url: r)
+        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, params: r)
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == True
         assert matches == []

--- a/openlibrary/tests/core/test_sponsors.py
+++ b/openlibrary/tests/core/test_sponsors.py
@@ -44,7 +44,7 @@ class TestSponsorship:
         # Simulating exception / API call failure ...
         monkeypatch.setattr(sponsorships.lending, 'get_work_availability',
                             lambda work_id: mock_availability__need)
-        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, params: {'invalid': 'json'})
+        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, **kwargs: {'invalid': 'json'})
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == False
         assert matches == []
@@ -52,14 +52,14 @@ class TestSponsorship:
         # Check archive.org promise items, previous sponsorships ...
         monkeypatch.setattr(sponsorships.lending, 'get_work_availability',
                             lambda work_id: mock_availability__need)
-        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, params: None)
+        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, **kwargs: None)
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == False
         assert matches == []
 
         # We need a copy ...
         r = storage({'json': lambda: {"response": 1}})
-        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, params: r)
+        monkeypatch.setattr(sponsorships.requests, 'get', lambda url, **kwargs: r)
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == True
         assert matches == []


### PR DESCRIPTION
Closes #2879

Removes unnecessary `urlencode()` calls and fixes up the import for the remaining one that's needed.

### Stakeholders

@cdrini for `vendors.py` @tabshaikh for the others - as mentioned in the issue, I think this is your code, so please review. 
@mekarpeles 