### PR TITLE
Cache the home page by language

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -2,7 +2,6 @@
 """
 import random
 import web
-import simplejson
 import logging
 
 from infogami.utils import delegate
@@ -10,15 +9,12 @@ from infogami.utils.view import render_template, public
 from infogami.infobase.client import storify
 from infogami import config
 
-from openlibrary import accounts
-from openlibrary.core import admin, cache, ia, inlibrary, lending, \
+from openlibrary.core import admin, cache, ia, lending, \
     helpers as h
 from openlibrary.core.sponsorships import get_sponsorable_editions
 from openlibrary.utils import dateutil
-from openlibrary.plugins.upstream import borrow
 from openlibrary.plugins.upstream.utils import get_blog_feeds
 from openlibrary.plugins.worksearch import search, subjects
-from openlibrary.plugins.openlibrary import lists
 
 
 import six

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -51,8 +51,9 @@ def get_homepage():
 
 def get_cached_homepage():
     five_minutes = 5 * dateutil.MINUTE_SECS
+    lang = web.ctx.get("lang", "en")
     return cache.memcache_memoize(
-        get_homepage, "home.homepage", timeout=five_minutes)()
+        get_homepage, "home.homepage." + lang, timeout=five_minutes)()
 
 class home(delegate.page):
     path = "/"


### PR DESCRIPTION
Closes #2707

This changes the key for the cached home page from 'home.homepage' to 'home.homepage.{lang}'
