### PR TITLE
Regex wants raw strings

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -256,7 +256,7 @@ def parse_datetime(value):
     if isinstance(value, datetime.datetime):
         return value
     else:
-        tokens = re.split('-|T|:|\.| ', value)
+        tokens = re.split(r'-|T|:|\.| ', value)
         return datetime.datetime(*map(int, tokens))
 
 

--- a/openlibrary/catalog/marc/__init__.py
+++ b/openlibrary/catalog/marc/__init__.py
@@ -1,8 +1,8 @@
 """marc"""
 import re
 
-re_leader = re.compile('^\d{5}.{19}$')
-re_control = re.compile('\d{3} ')
+re_leader = re.compile(r'^\d{5}.{19}$')
+re_control = re.compile(r'\d{3} ')
 re_data = re.compile(r'\d{3} (..) \$')
 
 def is_display_marc(data):

--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -25,15 +25,15 @@ def translate(bytes_in, leader_says_marc8=False):
         data = bytes_in.decode('utf-8')
     return normalize('NFC', data)
 
-re_question = re.compile('^\?+$')
-re_lccn = re.compile('(...\d+).*')
+re_question = re.compile(r'^\?+$')
+re_lccn = re.compile(r'(...\d+).*')
 re_letters_and_bad = re.compile('[A-Za-z\x80-\xff]')
-re_int = re.compile ('\d{2,}')
-re_isbn = re.compile('([^ ()]+[\dX])(?: \((?:v\. (\d+)(?: : )?)?(.*)\))?')
-re_oclc = re.compile ('^\(OCoLC\).*?0*(\d+)')
+re_int = re.compile (r'\d{2,}')
+re_isbn = re.compile(r'([^ ()]+[\dX])(?: \((?:v\. (\d+)(?: : )?)?(.*)\))?')
+re_oclc = re.compile (r'^\(OCoLC\).*?0*(\d+)')
 
-re_normalize = re.compile('[^\w ]')
-re_whitespace = re.compile('\s+')
+re_normalize = re.compile(r'[^\w ]')
+re_whitespace = re.compile(r'\s+')
 
 @deprecated
 def normalize_str(s):

--- a/openlibrary/catalog/marc/get_subjects.py
+++ b/openlibrary/catalog/marc/get_subjects.py
@@ -5,7 +5,7 @@ from openlibrary.catalog.utils import remove_trailing_dot, flip_name
 re_flip_name = re.compile('^(.+), ([A-Z].+)$')
 
 # 'Rhodes, Dan (Fictitious character)'
-re_fictitious_character = re.compile('^(.+), (.+)( \(.* character\))$')
+re_fictitious_character = re.compile(r'^(.+), (.+)( \(.* character\))$')
 re_etc = re.compile('^(.+?)[, .]+etc[, .]?$', re.I)
 re_comma = re.compile('^([A-Z])([A-Za-z ]+?) *, ([A-Z][A-Z a-z]+)$')
 

--- a/openlibrary/catalog/marc/marc_base.py
+++ b/openlibrary/catalog/marc/marc_base.py
@@ -1,8 +1,8 @@
 import re
 
-re_isbn = re.compile('([^ ()]+[\dX])(?: \((?:v\. (\d+)(?: : )?)?(.*)\))?')
+re_isbn = re.compile(r'([^ ()]+[\dX])(?: \((?:v\. (\d+)(?: : )?)?(.*)\))?')
 # handle ISBN like: 1402563884c$26.95
-re_isbn_and_price = re.compile('^([-\d]+X?)c\$[\d.]+$')
+re_isbn_and_price = re.compile(r'^([-\d]+X?)c\$[\d.]+$')
 
 class MarcException(Exception):
     # Base MARC exception class

--- a/openlibrary/catalog/marc/marc_subject.py
+++ b/openlibrary/catalog/marc/marc_subject.py
@@ -14,7 +14,7 @@ subject_fields = set(['600', '610', '611', '630', '648', '650', '651', '662'])
 re_flip_name = re.compile('^(.+), ([A-Z].+)$')
 
 # 'Rhodes, Dan (Fictitious character)'
-re_fictitious_character = re.compile('^(.+), (.+)( \(.* character\))$')
+re_fictitious_character = re.compile(r'^(.+), (.+)( \(.* character\))$')
 re_etc = re.compile('^(.+?)[, .]+etc[, .]?$', re.I)
 re_comma = re.compile('^([A-Z])([A-Za-z ]+?) *, ([A-Z][A-Z a-z]+)$')
 
@@ -133,7 +133,7 @@ Bad source record: %s
     server.sendmail(msg_from, [msg_to], msg)
     server.quit()
 
-re_ia_marc = re.compile('^(?:.*/)?([^/]+)_(marc\.xml|meta\.mrc)(:0:\d+)?$')
+re_ia_marc = re.compile(r'^(?:.*/)?([^/]+)_(marc\.xml|meta\.mrc)(:0:\d+)?$')
 def get_work_subjects(w, do_get_mc=True):
     found = set()
     for e in w['editions']:

--- a/openlibrary/catalog/marc/mnemonics.py
+++ b/openlibrary/catalog/marc/mnemonics.py
@@ -3,7 +3,7 @@
 
 import re
 
-re_brace = re.compile('(\{.+?\})', re.U)
+re_brace = re.compile(r'(\{.+?\})', re.U)
 
 mapping = {
  '{00}': '\x00',

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -4,14 +4,14 @@ from openlibrary.catalog.marc.get_subjects import subjects_for_work
 from openlibrary.catalog.marc.marc_base import BadMARC, NoTitle, MarcException
 from openlibrary.catalog.utils import pick_first_date, tidy_isbn, flip_name, remove_trailing_dot, remove_trailing_number_dot
 
-re_question = re.compile('^\?+$')
-re_lccn = re.compile('([ \dA-Za-z\-]{3}[\d/-]+).*')
-re_oclc = re.compile('^\(OCoLC\).*?0*(\d+)')
+re_question = re.compile(r'^\?+$')
+re_lccn = re.compile(r'([ \dA-Za-z\-]{3}[\d/-]+).*')
+re_oclc = re.compile(r'^\(OCoLC\).*?0*(\d+)')
 re_ocolc = re.compile('^ocolc *$', re.I)
-re_ocn_or_ocm = re.compile('^oc[nm]0*(\d+) *$')
-re_int = re.compile ('\d{2,}')
-re_number_dot = re.compile('\d{3,}\.$')
-re_bracket_field = re.compile('^\s*(\[.*\])\.?\s*$')
+re_ocn_or_ocm = re.compile(r'^oc[nm]0*(\d+) *$')
+re_int = re.compile(r'\d{2,}')
+re_number_dot = re.compile(r'\d{3,}\.$')
+re_bracket_field = re.compile(r'^\s*(\[.*\])\.?\s*$')
 foc = '[from old catalog]'
 
 def strip_foc(s):

--- a/openlibrary/catalog/merge/amazon.py
+++ b/openlibrary/catalog/merge/amazon.py
@@ -5,8 +5,8 @@ import warnings
 from openlibrary.catalog.merge.names import match_name
 from openlibrary.catalog.merge.normalize import normalize
 
-re_year = re.compile('(\d{4})$')
-re_amazon_title_paren = re.compile('^(.*) \([^)]+?\)$')
+re_year = re.compile(r'(\d{4})$')
+re_amazon_title_paren = re.compile(r'^(.*) \([^)]+?\)$')
 re_and_of_space = re.compile(' and | of | ')
 
 isbn_match = 85

--- a/openlibrary/catalog/merge/merge.py
+++ b/openlibrary/catalog/merge/merge.py
@@ -5,7 +5,7 @@ from openlibrary.catalog.merge.names import match_name
 from openlibrary.catalog.merge.normalize import normalize
 
 
-re_amazon_title_paren = re.compile('^(.*) \([^)]+?\)$')
+re_amazon_title_paren = re.compile(r'^(.*) \([^)]+?\)$')
 re_and_of_space = re.compile(' and | of | ')
 
 isbn_match = 85

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -8,7 +8,7 @@ from openlibrary.catalog.merge.normalize import normalize
 # fields needed for merge process:
 # title_prefix, title, subtitle, isbn, publish_country, lccn, publishers, publish_date, number_of_pages, authors
 
-re_amazon_title_paren = re.compile('^(.*) \([^)]+?\)$')
+re_amazon_title_paren = re.compile(r'^(.*) \([^)]+?\)$')
 
 isbn_match = 85
 

--- a/openlibrary/catalog/merge/normalize.py
+++ b/openlibrary/catalog/merge/normalize.py
@@ -5,7 +5,7 @@ import six
 
 #re_brace = re.compile('{[^{}]+?}')
 re_normalize = re.compile('[^[:alpha:] ]', re.I)
-re_whitespace_and_punct = re.compile('[-\s,;:.]+')
+re_whitespace_and_punct = re.compile(r'[-\s,;:.]+')
 
 def normalize(s):
     """

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -14,22 +14,22 @@ except NameError:
 
 
 re_date = map (re.compile, [
-    '(?P<birth_date>\d+\??)-(?P<death_date>\d+\??)',
-    '(?P<birth_date>\d+\??)-',
-    'b\.? (?P<birth_date>(?:ca\. )?\d+\??)',
-    'd\.? (?P<death_date>(?:ca\. )?\d+\??)',
-    '(?P<birth_date>.*\d+.*)-(?P<death_date>.*\d+.*)',
-    '^(?P<birth_date>[^-]*\d+[^-]+ cent\.[^-]*)$'])
+    r'(?P<birth_date>\d+\??)-(?P<death_date>\d+\??)',
+    r'(?P<birth_date>\d+\??)-',
+    r'b\.? (?P<birth_date>(?:ca\. )?\d+\??)',
+    r'd\.? (?P<death_date>(?:ca\. )?\d+\??)',
+    r'(?P<birth_date>.*\d+.*)-(?P<death_date>.*\d+.*)',
+    r'^(?P<birth_date>[^-]*\d+[^-]+ cent\.[^-]*)$'])
 
 re_ad_bc = re.compile(r'\b(B\.C\.?|A\.D\.?)')
 re_date_fl = re.compile('^fl[., ]')
-re_number_dot = re.compile('\d{2,}[- ]*(\.+)$')
-re_l_in_date = re.compile('(l\d|\dl)')
-re_end_dot = re.compile('[^ .][^ .]\.$', re.UNICODE)
+re_number_dot = re.compile(r'\d{2,}[- ]*(\.+)$')
+re_l_in_date = re.compile(r'(l\d|\dl)')
+re_end_dot = re.compile(r'[^ .][^ .]\.$', re.UNICODE)
 re_marc_name = re.compile('^(.*?),+ (.*)$')
 re_year = re.compile(r'\b(\d{4})\b')
 
-re_brackets = re.compile('^(.+)\[.*?\]$')
+re_brackets = re.compile(r'^(.+)\[.*?\]$')
 
 
 def key_int(rec):

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -10,7 +10,7 @@ import six
 from six.moves import urllib
 
 re_meta_mrc = re.compile('([^/]+)_(meta|marc).(mrc|xml)')
-re_skip = re.compile('\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
+re_skip = re.compile(r'\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
 
 db_amazon = web.database(dbn='postgres', db='amazon')
 db_amazon.printing = False

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -30,11 +30,11 @@ from six.moves.urllib.request import urlopen
 ol = OpenLibrary("http://openlibrary.org")
 
 re_skip = re.compile(r'\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon|etc)\.$')
-re_work_key = re.compile('^/works/OL(\d+)W$')
+re_work_key = re.compile(r'^/works/OL(\d+)W$')
 re_lang_key = re.compile('^/(?:l|languages)/([a-z]{3})$')
-re_author_key = re.compile('^/(?:a|authors)/(OL\d+A)$')
+re_author_key = re.compile(r'^/(?:a|authors)/(OL\d+A)$')
 
-re_ia_marc = re.compile('^(?:.*/)?([^/]+)_(marc\.xml|meta\.mrc)(:0:\d+)?$')
+re_ia_marc = re.compile(r'^(?:.*/)?([^/]+)_(marc\.xml|meta\.mrc)(:0:\d+)?$')
 
 ns = '{http://www.loc.gov/MARC21/slim}'
 ns_leader = ns + 'leader'
@@ -56,7 +56,7 @@ def get_with_retry(k):
 #set_staging(True)
 
 # sample title: The Dollar Hen (Illustrated Edition) (Dodo Press)
-re_parens = re.compile('^(.*?)(?: \(.+ (?:Edition|Press|Print|Plays|Collection|Publication|Novels|Mysteries|Book Series|Classics Library|Classics|Books)\))+$', re.I)
+re_parens = re.compile(r'^(.*?)(?: \(.+ (?:Edition|Press|Print|Plays|Collection|Publication|Novels|Mysteries|Book Series|Classics Library|Classics|Books)\))+$', re.I)
 
 def top_rev_wt(d):
     d_sorted = sorted(d.keys(), cmp=lambda i, j: cmp(d[j], d[i]) or cmp(len(j), len(i)))

--- a/openlibrary/core/iprange.py
+++ b/openlibrary/core/iprange.py
@@ -11,7 +11,7 @@ re_range_star = re.compile(r'^(\d+\.\d+)\.(\d+)\s*-\s*(\d+)\.\*$')
 re_three = re.compile(r'^(\d+\.\d+\.\d+)\.$')
 re_four = re.compile(r'^' + four_octet + r'(/\d+)?$')
 re_range_in_last = re.compile(r'^(\d+\.\d+\.\d+)\.(\d+)\s*-\s*(\d+)$')
-re_four_to_four = re.compile('^%s\s*-\s*%s$' % (four_octet, four_octet))
+re_four_to_four = re.compile(r'^%s\s*-\s*%s$' % (four_octet, four_octet))
 
 patterns = (re_four_to_four, re_four, re_range_star, re_three, re_range_in_last)
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -214,7 +214,7 @@ class Edition(Thing):
 
     def get_publish_year(self):
         if self.publish_date:
-            m = web.re_compile("(\d\d\d\d)").search(self.publish_date)
+            m = web.re_compile(r"(\d\d\d\d)").search(self.publish_date)
             return m and int(m.group(1))
 
     def get_lists(self, limit=50, offset=0, sort=True):

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -17,7 +17,7 @@ from openlibrary import accounts
 BETTERWORLDBOOKS_BASE_URL = 'https://betterworldbooks.com'
 BETTERWORLDBOOKS_API_URL = 'https://products.betterworldbooks.com/service.aspx?ItemId='
 BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(h.affiliate_id('betterworldbooks'))
-AMAZON_FULL_DATE_RE = re.compile('\d{4}-\d\d-\d\d')
+AMAZON_FULL_DATE_RE = re.compile(r'\d{4}-\d\d-\d\d')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 
 @public
@@ -177,7 +177,7 @@ def split_amazon_title(full_title):
 
     # strip parenthetical blocks wherever they occur
     # can handle 1 level of nesting
-    re_parens_strip = re.compile('\(([^\)\(]*|[^\(]*\([^\)]*\)[^\)]*)\)')
+    re_parens_strip = re.compile(r'\(([^\)\(]*|[^\(]*\([^\)]*\)[^\)]*)\)')
     full_title = re.sub(re_parens_strip, '', full_title)
 
     titles = full_title.split(':')
@@ -317,8 +317,8 @@ def _get_betterworldbooks_metadata(isbn):
     try:
         response = requests.get(url).content
         new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", response)
-        new_price = re.findall("<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", response)
-        used_price = re.findall("<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", response)
+        new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", response)
+        used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", response)
         used_qty = re.findall("<TotalUsed>([0-9]+)</TotalUsed>", response)
 
         price = qlt = None

--- a/openlibrary/olbase/events.py
+++ b/openlibrary/olbase/events.py
@@ -84,7 +84,7 @@ class MemcacheInvalidater:
         seed are invalidated.
         """
         docs = changeset['docs'] + changeset['old_docs']
-        rx = web.re_compile("(/people/[^/]*)/lists/OL\d+L")
+        rx = web.re_compile(r"(/people/[^/]*)/lists/OL\d+L")
         for doc in docs:
             match = doc and rx.match(doc['key'])
             if match:

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -51,7 +51,7 @@ def split_key(bib_key):
         value = bib_key
 
     # treat OLxxxM as OLID
-    re_olid = web.re_compile('OL\d+M(@\d+)?')
+    re_olid = web.re_compile(r'OL\d+M(@\d+)?')
     if key is None and re_olid.match(bib_key.upper()):
         key = 'olid'
         value = bib_key.upper()

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -38,7 +38,7 @@ def parse_meta_headers(edition_builder):
     # we don't yet support augmenting complex fields like author or language
     # string_keys = ['title', 'title_prefix', 'description']
 
-    re_meta = re.compile('HTTP_X_ARCHIVE_META(?:\d{2})?_(.*)')
+    re_meta = re.compile(r'HTTP_X_ARCHIVE_META(?:\d{2})?_(.*)')
     for k, v in web.ctx.env.items():
         m = re_meta.match(k)
         if m:
@@ -170,7 +170,7 @@ class ia_importapi(importapi):
         # First check whether this is a non-book, bulk-marc item
         if bulk_marc:
             # Get binary MARC by identifier = ocaid/filename:offset:length
-            re_bulk_identifier = re.compile("([^/]*)/([^:]*):(\d*):(\d*)")
+            re_bulk_identifier = re.compile(r"([^/]*)/([^:]*):(\d*):(\d*)")
             try:
                 ocaid, filename, offset, length = re_bulk_identifier.match(identifier).groups()
                 data, next_offset, next_length = get_from_archive_bulk(identifier)

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -83,7 +83,7 @@ class browse(delegate.page):
 
 
 class ratings(delegate.page):
-    path = "/works/OL(\d+)W/ratings"
+    path = r"/works/OL(\d+)W/ratings"
     encoding = "json"
 
     def POST(self, work_id):
@@ -128,7 +128,7 @@ class ratings(delegate.page):
 # not a value tied to this logged in user. This is being used as debugging.
 
 class work_bookshelves(delegate.page):
-    path = "/works/OL(\d+)W/bookshelves"
+    path = r"/works/OL(\d+)W/bookshelves"
     encoding = "json"
 
     def POST(self, work_id):
@@ -172,7 +172,7 @@ class work_bookshelves(delegate.page):
 
 
 class work_editions(delegate.page):
-    path = "(/works/OL\d+W)/editions"
+    path = r"(/works/OL\d+W)/editions"
     encoding = "json"
 
     def GET(self, key):
@@ -214,7 +214,7 @@ class work_editions(delegate.page):
 
 
 class author_works(delegate.page):
-    path = "(/authors/OL\d+A)/works"
+    path = r"(/authors/OL\d+A)/works"
     encoding = "json"
 
     def GET(self, key):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -210,7 +210,7 @@ class addbook(delegate.page):
         return edit().POST(key)
 
 class widget(delegate.page):
-    path = "/(works|books)/(OL\d+[W|M])/widget"
+    path = r"/(works|books)/(OL\d+[W|M])/widget"
 
     def GET(self, _type, olid=None):
         if olid:
@@ -770,7 +770,7 @@ class memory(delegate.page):
 
 
 def is_bot():
-    """Generated on ol-www1 within /var/log/nginx with:
+    r"""Generated on ol-www1 within /var/log/nginx with:
 
     cat access.log | grep -oh "; \w*[bB]ot" | sort --unique | awk '{print tolower($2)}'
     cat access.log | grep -oh "; \w*[sS]pider" | sort --unique | awk '{print tolower($2)}'

--- a/openlibrary/plugins/openlibrary/libraries.py
+++ b/openlibrary/plugins/openlibrary/libraries.py
@@ -178,7 +178,7 @@ class libraries_dashboard(delegate.page):
         return web.ctx.site.new(key, doc)
 
 class pending_libraries(delegate.page):
-    path = "/(libraries/pending-\d+)"
+    path = r"/(libraries/pending-\d+)"
 
     def GET(self, key):
         doc = web.ctx.site.store.get(key)

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -54,7 +54,7 @@ class lists(delegate.page):
         return render_template("lists/lists.html", doc, lists)
 
 class lists_delete(delegate.page):
-    path = "(/people/\w+/lists/OL\d+L)/delete"
+    path = r"(/people/\w+/lists/OL\d+L)/delete"
     encoding = "json"
 
     def POST(self, key):
@@ -205,7 +205,7 @@ class lists_yaml(lists_json):
     content_type = "text/yaml"
 
 class list_view_json(delegate.page):
-    path = "(/people/[^/]+/lists/OL\d+L)"
+    path = r"(/people/[^/]+/lists/OL\d+L)"
     encoding = "json"
     content_type = "application/json"
 
@@ -250,7 +250,7 @@ class list_view_yaml(list_view_json):
     content_type = "text/yaml"
 
 class list_seeds(delegate.page):
-    path = "(/people/\w+/lists/OL\d+L)/seeds"
+    path = r"(/people/\w+/lists/OL\d+L)/seeds"
     encoding = "json"
 
     content_type = "application/json"
@@ -324,7 +324,7 @@ class list_seed_yaml(list_seeds):
 class list_editions(delegate.page):
     """Controller for displaying lists of a seed or lists of a person.
     """
-    path = "(/people/\w+/lists/OL\d+L)/editions"
+    path = r"(/people/\w+/lists/OL\d+L)/editions"
 
     def is_enabled(self):
         return "lists" in web.ctx.features
@@ -347,7 +347,7 @@ class list_editions(delegate.page):
         return render_template("type/list/editions.html", lst, editions)
 
 class list_editions_json(delegate.page):
-    path = "(/people/\w+/lists/OL\d+L)/editions"
+    path = r"(/people/\w+/lists/OL\d+L)/editions"
     encoding = "json"
 
     content_type = "application/json"
@@ -400,7 +400,7 @@ def make_collection(size, entries, limit, offset):
     return d
 
 class list_subjects_json(delegate.page):
-    path = "(/people/\w+/lists/OL\d+L)/subjects"
+    path = r"(/people/\w+/lists/OL\d+L)/subjects"
     encoding = "json"
     content_type = "application/json"
 
@@ -444,7 +444,7 @@ class list_editions_yaml(list_subjects_json):
     content_type = 'text/yaml; charset="utf-8"'
 
 class lists_embed(delegate.page):
-    path = "(/people/\w+/lists/OL\d+L)/embed"
+    path = r"(/people/\w+/lists/OL\d+L)/embed"
 
     def GET(self, key):
         doc = web.ctx.site.get(key)
@@ -453,7 +453,7 @@ class lists_embed(delegate.page):
         return render_template("type/list/embed", doc)
 
 class export(delegate.page):
-    path = "(/people/\w+/lists/OL\d+L)/export"
+    path = r"(/people/\w+/lists/OL\d+L)/export"
 
     def GET(self, key):
         lst = web.ctx.site.get(key)
@@ -493,7 +493,7 @@ class export(delegate.page):
         return doc
 
 class feeds(delegate.page):
-    path = "(/people/[^/]+/lists/OL\d+L)/feeds/(updates).(atom)"
+    path = r"(/people/[^/]+/lists/OL\d+L)/feeds/(updates).(atom)"
 
     def GET(self, key, name, fmt):
         lst = web.ctx.site.get(key)

--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -294,7 +294,7 @@ class search_api:
         def format(val, prettyprint=False, callback=None):
             if callback is not None:
                 if (not isinstance(callback, str) or
-                        not re.match('[a-z][a-z0-9\.]*$', callback, re.I)):
+                        not re.match(r'[a-z][a-z0-9\.]*$', callback, re.I)):
                     val = self.error_val
                     callback = None
 

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -278,7 +278,7 @@ class Solr_client(object):
             which this function extracts asa a locator and
             a leaf number ('adventsuburbanit00butlrich', 65). """
 
-            g = re.search('(.*)_(\d{4})\.djvu$', page_id)
+            g = re.search(r'(.*)_(\d{4})\.djvu$', page_id)
             a,b = g.group(1,2)
             return a, int(b)
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -747,7 +747,7 @@ class SaveBookHelper:
 
 
 class book_edit(delegate.page):
-    path = "(/books/OL\d+M)/edit"
+    path = r"(/books/OL\d+M)/edit"
 
     def GET(self, key):
         i = web.input(v=None)
@@ -819,7 +819,7 @@ class book_edit(delegate.page):
 
 
 class work_edit(delegate.page):
-    path = "(/works/OL\d+W)/edit"
+    path = r"(/works/OL\d+W)/edit"
 
     def GET(self, key):
         i = web.input(v=None, _method="GET")
@@ -866,7 +866,7 @@ class work_edit(delegate.page):
 
 
 class author_edit(delegate.page):
-    path = "(/authors/OL\d+A)/edit"
+    path = r"(/authors/OL\d+A)/edit"
 
     def GET(self, key):
         if not web.ctx.site.can_write(key):

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -174,7 +174,7 @@ class AuthorMergeEngine(BasicMergeEngine):
         work_keys_2 = web.ctx.site.things(q)
         return edition_keys + work_keys_1 + work_keys_2
 
-re_whitespace = re.compile('\s+')
+re_whitespace = re.compile(r'\s+')
 def space_squash_and_strip(s):
     return re_whitespace.sub(' ', s).strip()
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -189,7 +189,7 @@ def fuzzy_find(value, options, stopwords=[]):
     if not options:
         return value
 
-    rx = web.re_compile("[-_\.&, ]+")
+    rx = web.re_compile(r"[-_\.&, ]+")
 
     # build word frequency
     d = defaultdict(list)
@@ -448,7 +448,7 @@ def parse_toc_row(line):
         >>> f("1.1 | Apple")
         (0, '1.1', 'Apple', '')
     """
-    RE_LEVEL = web.re_compile("(\**)(.*)")
+    RE_LEVEL = web.re_compile(r"(\**)(.*)")
     level, text = RE_LEVEL.match(line.strip()).groups()
 
     if "|" in text:
@@ -576,7 +576,7 @@ def _get_recent_changes():
             return False
 
     # ignore reverts
-    re_revert = web.re_compile("reverted to revision \d+")
+    re_revert = web.re_compile(r"reverted to revision \d+")
     def is_revert(r):
         return re_revert.match(r.comment or "")
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -29,7 +29,7 @@ if hasattr(config, 'plugin_worksearch'):
 
     default_spellcheck_count = config.plugin_worksearch.get('spellcheck_count', 10)
 
-re_author_facet = re.compile('^(OL\d+A) (.*)$')
+re_author_facet = re.compile(r'^(OL\d+A) (.*)$')
 def read_author_facet(af):
     # example input: "OL26783A Leo Tolstoy"
     return re_author_facet.match(af).groups()
@@ -81,7 +81,7 @@ def read_facets(root):
     return facets
 
 
-re_isbn_field = re.compile('^\s*(?:isbn[:\s]*)?([-0-9X]{9,})\s*$', re.I)
+re_isbn_field = re.compile(r'^\s*(?:isbn[:\s]*)?([-0-9X]{9,})\s*$', re.I)
 
 re_author_key = re.compile(r'(OL\d+A)')
 
@@ -103,7 +103,7 @@ def parse_query_fields(q):
     found = [(m.start(), m.end()) for m in re_fields.finditer(q)]
     first = q[:found[0][0]].strip() if found else q.strip()
     if first:
-        yield {'field': 'text', 'value': first.replace(':', '\:')}
+        yield {'field': 'text', 'value': first.replace(':', r'\:')}
     for field_num in range(len(found)):
         op_found = None
         f = found[field_num]
@@ -122,7 +122,7 @@ def parse_query_fields(q):
             isbn = normalize_isbn(v)
             if isbn:
                 v = isbn
-        yield {'field': field_name, 'value': v.replace(':', '\:')}
+        yield {'field': field_name, 'value': v.replace(':', r'\:')}
         if op_found:
             yield {'op': op_found }
 
@@ -145,7 +145,7 @@ def build_q_list(param):
             if isbn:
                 q_list.append('isbn:(%s)' % isbn)
             else:
-                q_list.append(q_param.strip().replace(':', '\:'))
+                q_list.append(q_param.strip().replace(':', r'\:'))
                 use_dismax = True
     else:
         if 'author' in param:
@@ -378,7 +378,7 @@ subject_types = {
     'subjects': 'subject',
 }
 
-re_year_range = re.compile('^(\d{4})-(\d{4})$')
+re_year_range = re.compile(r'^(\d{4})-(\d{4})$')
 
 def work_object(w): # called by works_by_author
     ia = w.get('ia', [])
@@ -413,7 +413,7 @@ def get_facet(facets, f, limit=None):
     return list(web.group(facets[f][:limit * 2] if limit else facets[f], 2))
 
 
-re_olid = re.compile('^OL\d+([AMW])$')
+re_olid = re.compile(r'^OL\d+([AMW])$')
 olid_urls = {'A': 'authors', 'M': 'books', 'W': 'works'}
 
 class search(delegate.page):
@@ -597,7 +597,7 @@ class advancedsearch(delegate.page):
         return template
 
 class merge_author_works(delegate.page):
-    path = "/authors/(OL\d+A)/merge-works"
+    path = r"/authors/(OL\d+A)/merge-works"
     def GET(self, key):
         works = works_by_author(key)
 

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -83,13 +83,13 @@ def test_query_parser_fields():
     assert list(func(q)) == expect
 
     expect = [
-        {'field': 'text', 'value': 'flatland\:a romance of many dimensions'},
+        {'field': 'text', 'value': r'flatland\:a romance of many dimensions'},
     ]
     q = 'flatland:a romance of many dimensions'
     assert list(func(q)) == expect
 
     expect = [
-        { 'field': 'title', 'value': 'flatland\:a romance of many dimensions'},
+        { 'field': 'title', 'value': r'flatland\:a romance of many dimensions'},
     ]
     q = 'title:flatland:a romance of many dimensions'
     assert list(func(q)) == expect

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -153,7 +153,7 @@ class BetterDataProvider(LegacyDataProvider):
     def preload_documents(self, keys):
         identifiers = [k.replace("/books/ia:", "") for k in keys if k.startswith("/books/ia:")]
         #self.preload_ia_items(identifiers)
-        re_key = web.re_compile("/(books|works|authors)/OL\d+[MWA]")
+        re_key = web.re_compile(r"/(books|works|authors)/OL\d+[MWA]")
 
         keys2 = set(k for k in keys if re_key.match(k))
         #keys2.update(k for k in self.ia_redirect_cache.values() if k is not None)

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -30,7 +30,7 @@ re_author_key = re.compile(r'^/(?:a|authors)/(OL\d+A)')
 re_bad_char = re.compile('[\x01\x0b\x1a-\x1e]')
 re_edition_key = re.compile(r"/books/([^/]+)")
 re_iso_date = re.compile(r'^(\d{4})-\d\d-\d\d$')
-re_solr_field = re.compile('^[-\w]+$', re.U)
+re_solr_field = re.compile(r'^[-\w]+$', re.U)
 re_year = re.compile(r'(\d{4})$')
 
 data_provider = None
@@ -1452,7 +1452,7 @@ def solr_escape(query):
     :param str query:
     :rtype: str
     """
-    return re.sub('([\s\-+!()|&{}\[\]^\"~*?:\\\\])', r'\\\1', query)
+    return re.sub(r'([\s\-+!()|&{}\[\]^\"~*?:\\\\])', r'\\\1', query)
 
 def do_updates(keys):
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1452,7 +1452,7 @@ def solr_escape(query):
     :param str query:
     :rtype: str
     """
-    return re.sub(r'([\s\-+!()|&{}\[\]^\"~*?:\\\\])', r'\\\1', query)
+    return re.sub(r'([\s\-+!()|&{}\[\]^"~*?:\\])', r'\\\1', query)
 
 def do_updates(keys):
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")

--- a/openlibrary/solr/work_subject.py
+++ b/openlibrary/solr/work_subject.py
@@ -14,7 +14,7 @@ re_large_book = re.compile('large.*book', re.I)
 
 re_edition_key = re.compile(r'^/(?:b|books)/(OL\d+M)$')
 
-re_ia_marc = re.compile('^(?:.*/)?([^/]+)_(marc\.xml|meta\.mrc)(:0:\d+)?$')
+re_ia_marc = re.compile(r'^(?:.*/)?([^/]+)_(marc\.xml|meta\.mrc)(:0:\d+)?$')
 def get_marc_source(w):
     found = set()
     for e in w['editions']:
@@ -67,7 +67,7 @@ def flip_place(s):
     return m.group(2) + ' ' + m.group(1) if m else s
 
 # 'Rhodes, Dan (Fictitious character)'
-re_fictitious_character = re.compile('^(.+), (.+)( \(.* character\))$')
+re_fictitious_character = re.compile(r'^(.+), (.+)( \(.* character\))$')
 re_etc = re.compile('^(.+?)[, .]+etc[, .]?$', re.I)
 re_aspects = re.compile(' [Aa]spects$')
 re_comma = re.compile('^([A-Z])([A-Za-z ]+?) *, ([A-Z][A-Z a-z]+)$')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses a series of `invalid escape sequence` warnings that are at the end of our pytest runs on Travis CI.
```
openlibrary/api.py:259: DeprecationWarning: invalid escape sequence \.
...
openlibrary/plugins/openlibrary/api.py:86: DeprecationWarning: invalid escape sequence \d
openlibrary/plugins/openlibrary/api.py:131: DeprecationWarning: invalid escape sequence \d
openlibrary/plugins/openlibrary/api.py:175: DeprecationWarning: invalid escape sequence \d
openlibrary/plugins/openlibrary/api.py:217: DeprecationWarning: invalid escape sequence \d
...
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that we have raw strings where we need them and do not have ambiguous string literals.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->