### PR TITLE
Reverting get_metadata code, caused memory leak on prod

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -542,7 +542,6 @@ def load_data(rec, account=None):
     cover_id = None
     if cover_url:
         cover_id = add_cover(cover_url, ekey, account=account)
-    if cover_id:
         edition['covers'] = [cover_id]
 
     edits = []  # Things (Edition, Work, Authors) to be saved

--- a/openlibrary/mocks/mock_ia.py
+++ b/openlibrary/mocks/mock_ia.py
@@ -10,21 +10,21 @@ def mock_ia(request, monkeypatch):
         from openlibrary.core import ia
 
         def test_ia(mock_ia):
-            assert ia.get_metadata("foo") == {}
+            assert ia.get_meta_xml("foo") == {}
 
-            mock_ia.set_metadata("foo", {"collection": ["a", "b"]})
-            assert ia.get_metadata("foo") == {"collection": ["a", "b"]}
+            mock_ia.set_meta_xml("foo", {"collection": ["a", "b"]})
+            assert ia.get_meta_xml("foo") == {"collection": ["a", "b"]}
     """
-    metadata = {}
+    metaxml = {}
 
     class IA:
-        def set_metadata(self, itemid, meta):
-            metadata[itemid] = meta
+        def set_meta_xml(self, itemid, meta):
+            metaxml[itemid] = meta
 
-        def get_metadata(self, itemid):
-            return metadata.get(itemid, {})
+        def get_meta_xml(self, itemid):
+            return metaxml.get(itemid, {})
 
     mock_ia = IA()
-    monkeypatch.setattr(ia, 'get_metadata', ia.get_metadata)
+    monkeypatch.setattr(ia, "get_meta_xml", ia.get_meta_xml)
 
     return mock_ia

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -364,7 +364,7 @@ def process_result_for_viewapi(result):
 
 
 def get_ia_availability(itemid):
-    collections = ia.get_metadata(itemid).get('collection', [])
+    collections = ia.get_meta_xml(itemid).get("collection", [])
 
     if 'lendinglibrary' in collections or 'inlibrary' in collections:
         return 'borrow'

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -331,7 +331,7 @@ class ReadProcessor:
         self.wkey_to_iaids = dict((wkey, get_work_iaids(wkey)[:iaid_limit])
                                   for wkey in self.works)
         iaids = sum(self.wkey_to_iaids.values(), [])
-        self.iaid_to_meta = dict((iaid, ia.get_metadata(iaid)) for iaid in iaids)
+        self.iaid_to_meta = dict((iaid, ia.get_meta_xml(iaid)) for iaid in iaids)
 
         def lookup_iaids(iaids):
             step = 10

--- a/openlibrary/plugins/books/tests/test_dynlinks.py
+++ b/openlibrary/plugins/books/tests/test_dynlinks.py
@@ -236,7 +236,7 @@ def monkeypatch_ol(monkeypatch):
     mock.default = []
     monkeypatch.setattr(dynlinks, "ol_get_many", mock)
 
-    monkeypatch.setattr(ia, "get_metadata", lambda itemid: web.storage())
+    monkeypatch.setattr(ia, "get_meta_xml", lambda itemid: web.storage())
 
 def test_query_keys(monkeypatch):
     monkeypatch_ol(monkeypatch)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -2,14 +2,15 @@
 """
 
 from infogami.plugins.api.code import add_hook
-
+from infogami import config
 from openlibrary.plugins.openlibrary.code import can_write
 from openlibrary.catalog.marc.marc_binary import MarcBinary, MarcException
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.parse import read_edition
 from openlibrary.catalog import add_book
 from openlibrary.catalog.get_ia import get_marc_record_from_ia, get_from_archive_bulk
-from openlibrary import accounts, records
+from openlibrary import accounts
+from openlibrary import records
 from openlibrary.core import ia
 
 import web
@@ -120,13 +121,12 @@ class importapi:
 
         try:
             reply = add_book.load(edition)
-            # TODO: If any records have been created, return a 201, otherwise 200
-            return json.dumps(reply)
         except add_book.RequiredField as e:
             return self.error('missing-required-field', str(e))
+        return json.dumps(reply)
 
     def reject_non_book_marc(self, marc_record, **kwargs):
-        details = 'Item rejected'
+        details = "Item rejected"
         # Is the item a serial instead of a book?
         marc_leaders = marc_record.leader()
         if marc_leaders[7] == 's':
@@ -207,36 +207,45 @@ class ia_importapi(importapi):
             return json.dumps(result)
 
         # Case 1 - Is this a valid Archive.org item?
-        metadata = ia.get_metadata(identifier)
+        try:
+            item_json = ia.get_item_json(identifier)
+            item_server = item_json['server']
+            item_path = item_json['dir']
+        except KeyError:
+            return self.error("invalid-ia-identifier", "%s not found" % identifier)
+        metadata = ia.extract_item_metadata(item_json)
         if not metadata:
-            return self.error('invalid-ia-identifier', '%s not found' % identifier)
+            return self.error("invalid-ia-identifier")
 
         # Case 2 - Does the item have an openlibrary field specified?
         # The scan operators search OL before loading the book and add the
         # OL key if a match is found. We can trust them and attach the item
         # to that edition.
-        if metadata.get('mediatype') == 'texts' and metadata.get('openlibrary'):
+        if metadata.get("mediatype") == "texts" and metadata.get("openlibrary"):
             edition_data = self.get_ia_record(metadata)
-            edition_data['openlibrary'] = metadata['openlibrary']
+            edition_data["openlibrary"] = metadata["openlibrary"]
             edition_data = self.populate_edition_data(edition_data, identifier)
             return self.load_book(edition_data)
 
         # Case 3 - Can the item be loaded into Open Library?
-        status = ia.get_item_status(identifier, metadata)
+        status = ia.get_item_status(identifier, metadata,
+                                    item_server=item_server, item_path=item_path)
         if status != 'ok':
-            return self.error(status, 'Prohibited Item %s' % identifier)
+            return self.error(status, "Prohibited Item")
 
         # Case 4 - Does this item have a marc record?
-        marc_record = get_marc_record_from_ia(identifier)
+        marc_record = self.get_marc_record(identifier)
         if marc_record:
             self.reject_non_book_marc(marc_record)
             try:
                 edition_data = read_edition(marc_record)
             except MarcException as e:
-                logger.error('failed to read from MARC record %s: %s', identifier, str(e))
-                return self.error('invalid-marc-record')
+                logger.error("failed to read from MARC record %s: %s", identifier, str(e))
+                return self.error("invalid-marc-record")
+
         elif require_marc:
-            return self.error('no-marc-record')
+            return self.error("no-marc-record")
+
         else:
             try:
                 edition_data = self.get_ia_record(metadata)
@@ -245,6 +254,7 @@ class ia_importapi(importapi):
 
         # Add IA specific fields: ocaid, source_records, and cover
         edition_data = self.populate_edition_data(edition_data, identifier)
+
         return self.load_book(edition_data)
 
     def get_ia_record(self, metadata):
@@ -304,9 +314,15 @@ class ia_importapi(importapi):
         :return: Edition record
         """
         edition['ocaid'] = identifier
-        edition['source_records'] = 'ia:' + identifier
-        edition['cover'] = ia.get_cover_url(identifier)
+        edition['source_records'] = "ia:" + identifier
+        edition['cover'] = "{0}/download/{1}/{1}/page/title.jpg".format(IA_BASE_URL, identifier)
         return edition
+
+    def get_marc_record(self, identifier):
+        try:
+            return get_marc_record_from_ia(identifier)
+        except IOError:
+            return None
 
     def find_edition(self, identifier):
         """

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -248,7 +248,7 @@ def format_book_data(book):
         d.cover_url = 'https://archive.org/services/img/%s' % d.ocaid
 
     if d.ocaid:
-        collections = ia.get_metadata(d.ocaid).get('collection', [])
+        collections = ia.get_meta_xml(d.ocaid).get("collection", [])
 
         if 'lendinglibrary' in collections or 'inlibrary' in collections:
             d.borrow_url = book.url("/borrow")

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -148,9 +148,9 @@ class Edition(models.Edition):
         if not self.get('ocaid', None):
             meta = {}
         else:
-            meta = ia.get_metadata(self.ocaid)
-            meta.setdefault('external-identifier', [])
-            meta.setdefault('collection', [])
+            meta = ia.get_meta_xml(self.ocaid)
+            meta.setdefault("external-identifier", [])
+            meta.setdefault("collection", [])
 
         self._ia_meta_fields = meta
         return self._ia_meta_fields

--- a/openlibrary/solr/process_stats.py
+++ b/openlibrary/solr/process_stats.py
@@ -76,7 +76,7 @@ def _get_metadata(ia_id):
         if meta:
             meta['collection'] = meta['collection'].split(";")
     else:
-        meta = ia.get_metadata(ia_id)
+        meta = ia.get_meta_xml(ia_id)
     return meta
 
 def preload(entries):

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,16 +1,35 @@
+from __future__ import print_function
 from openlibrary.core import ia
 
-def test_get_metadata(monkeypatch, mock_memcache):
-    metadata = {
+def test_xml2dict():
+    assert ia.xml2dict("<metadata><x>1</x><y>2</y></metadata>") == {"x": "1", "y": "2"}
+    assert ia.xml2dict("<metadata><x>1</x><y>2</y></metadata>", x=[]) == {"x": ["1"], "y": "2"}
+
+    assert ia.xml2dict("<metadata><x>1</x><x>2</x></metadata>") == {"x": "2"}
+    assert ia.xml2dict("<metadata><x>1</x><x>2</x></metadata>", x=[]) == {"x": ["1", "2"]}
+
+def test_get_metaxml(monkeypatch, mock_memcache):
+    import StringIO
+    import urllib2
+
+    metadata_json = None
+    def urlopen(url):
+        return StringIO.StringIO(metadata_json)
+
+    monkeypatch.setattr(urllib2, "urlopen", urlopen)
+
+    # test with correct xml
+    metadata_json = """{
         "metadata": {
             "title": "Foo",
             "identifier": "foo00bar",
             "collection": ["printdisabled", "inlibrary"]
         }
     }
+    """
 
-    monkeypatch.setattr(ia, '_get_metadata', lambda _id: metadata)
-    assert ia.get_metadata('foo00bar') == {
+    print(ia.get_meta_xml("foo00bar"))
+    assert ia.get_meta_xml("foo00bar") == {
         "title": "Foo",
         "identifier": "foo00bar",
         "collection": ["printdisabled", "inlibrary"],
@@ -18,6 +37,6 @@ def test_get_metadata(monkeypatch, mock_memcache):
         "_filenames": []
     }
 
-def test_get_metadata_empty(monkeypatch, mock_memcache):
-    monkeypatch.setattr(ia, '_get_metadata', lambda _id: {})
-    assert ia.get_metadata('foo02bar') == {}
+    # test with metadata errors
+    metadata_json = "{}"
+    assert ia.get_meta_xml("foo02bar") == {}

--- a/scripts/2011/09/generate_deworks.py
+++ b/scripts/2011/09/generate_deworks.py
@@ -315,7 +315,7 @@ def make_ia_db(editions_dump_file):
             print >> f, ocaid
             """
             if ocaid:
-                metaxml = ia.get_metadata(ocaid)
+                metaxml = ia.get_meta_xml(ocaid)
                 db[ocaid] = simplejson.dumps(metaxml)
             """
     f.close()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2891

We tried this on ol-web3 for 30 minutes and memory usage looked stable. This appears to resolve #2891. We may want to carefully reapply #2838 incrementally to determine where our issues may be coming from (in a later commit)
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested the works, editions, and /isbn import path.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
n/a -- memory usage lowered

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@hornc, @cdrini 