### PR TITLE
Fix some typos discovered via codespell

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -315,7 +315,7 @@ class OpenLibraryAccount(Account):
                                  Usernames must be unique
             email (unicode) - the login and email of the account
             password (unicode)
-            displayname (unicode) - human readable, changable screenname
+            displayname (unicode) - human readable, changeable screenname
             retries (int) - If the username is unavailable, how many
                             subsequent attempts should be made to find
                             an available username.
@@ -483,7 +483,7 @@ class InternetArchiveAccount(web.storage):
                verified=False, test=None):
         """
         Args:
-            screenname (unicode) - changable human readable archive.org username.
+            screenname (unicode) - changeable human readable archive.org username.
                                    The slug / itemname is generated automatically
                                    from this value.
             email (unicode)

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -228,7 +228,7 @@ def _query_count(db, table, type, property, distinct=False):
 
 def admin_total__ebooks(**kargs):
     # Anand - Dec 2014
-    # The following implementaiton is too slow. Disabling for now.
+    # The following implementation is too slow. Disabling for now.
     return 0
 
     db = kargs['thingdb']

--- a/openlibrary/app.py
+++ b/openlibrary/app.py
@@ -6,7 +6,7 @@ from infogami.utils.macro import macro
 
 class view(_app.page):
     """A view is a class that defines how a page or a set of pages
-    identified by a regualar expression are rendered.
+    identified by a regular expression are rendered.
 
     Here is a sample view::
 
@@ -38,7 +38,7 @@ class subview(_app.view):
     For example, the in the subview with URL "/works/OL123W/foo/identifiers",
     "identifiers" is the action and "/works/OL123W" is the key of the document.
     The middle part "foo" is added by a middleware to make the URLs readable
-    and not that is transparant to this.
+    and not that is transparent to this.
 
     Here is a sample subview:
 

--- a/openlibrary/config.py
+++ b/openlibrary/config.py
@@ -14,7 +14,7 @@ def load(config_file):
     The loaded config will be available via runtime_config var in this module.
     This doesn't affect the global config.
 
-    WARNING: This function is depricated, please use load_config instead.
+    WARNING: This function is deprecated, please use load_config instead.
     """
     # for historic reasons
     global runtime_config

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -89,7 +89,7 @@ class memcache_memoize:
     def __call__(self, *args, **kw):
         """Memoized function call.
 
-        Returns the cached value when avaiable. Computes and adds the result
+        Returns the cached value when available. Computes and adds the result
         to memcache when not available. Updates asynchronously after timeout.
         """
         _cache = kw.pop("_cache", None)
@@ -515,7 +515,7 @@ class PrefixKeyFunc:
             return a
 
     def json_encode(self, value):
-        """simplejson.dumps without extra spaces and consistant ordering of dictionary keys.
+        """simplejson.dumps without extra spaces and consistent ordering of dictionary keys.
 
         memcache doesn't like spaces in the key.
         """

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -28,7 +28,7 @@ def _proxy(method_name):
         stats.end()
         return result
     f.__name__ = method_name
-    f.__doc__ = "Equivalant to get_db().%s(*args, **kwargs).""" % method_name
+    f.__doc__ = "Equivalent to get_db().%s(*args, **kwargs).""" % method_name
     return f
 
 query = _proxy("query")

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -1,4 +1,4 @@
-"""Library for interacting wih archive.org.
+"""Library for interacting with archive.org.
 """
 import os
 import urllib2
@@ -254,7 +254,7 @@ class ItemEdition(dict):
 
     @classmethod
     def is_valid_item(cls, itemid, metadata):
-        """Returns True if the item with metadata can be useable as edition
+        """Returns True if the item with metadata can be usable as edition
         in Open Library.
 
         Items that are not book scans, darked or with noindex=true etc. are
@@ -278,7 +278,7 @@ class ItemEdition(dict):
         metadata = self.metadata
 
         key2 = key2 or key
-        # sometimes the empty values are represneted as {} in metadata API. Avoid them.
+        # sometimes the empty values are represented as {} in metadata API. Avoid them.
         if key in metadata and metadata[key] != {}:
             value = metadata[key]
             if isinstance(value, list):
@@ -298,7 +298,7 @@ class ItemEdition(dict):
         metadata = self.metadata
 
         key2 = key2 or key
-        # sometimes the empty values are represneted as {} in metadata API. Avoid them.
+        # sometimes the empty values are represented as {} in metadata API. Avoid them.
         if key in metadata and metadata[key] != {}:
             value = metadata[key]
             if not isinstance(value, list):

--- a/openlibrary/core/iprange.py
+++ b/openlibrary/core/iprange.py
@@ -159,7 +159,7 @@ class IPDict:
             self.ip_ranges.setdefault(i, {})[iptools.IpRange(ip_range)] = value
 
     def add_ip_range_text(self, ip_range_text, value):
-        """Adds all ip_ranges from the givem multi-line text and associate
+        """Adds all ip_ranges from the given multi-line text and associate
         each one of them with given value.
 
         See :func:`parse_ip_ranges` for the supported formats in the text.

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -613,7 +613,7 @@ class Loan(dict):
 
         web.ctx.site.store[self['_key']] = self
 
-        # Inform listers that a loan is creted/updated
+        # Inform listers that a loan is created/updated
         msgbroker.send_message("loan-created", self)
 
     def is_expired(self):

--- a/openlibrary/core/msgbroker.py
+++ b/openlibrary/core/msgbroker.py
@@ -2,7 +2,7 @@
 
 Message Broker or the pub/sub messaging patten allows publishers and
 subscribers of messages to communite without the knowledge of each other. This
-usally leads to a loosely-coupled design.
+usually leads to a loosely-coupled design.
 
 For examaple, the borrow module can send messages about loan-created and
 loan-completed and the stats module can subscribe to these events and update

--- a/openlibrary/core/processors/invalidation.py
+++ b/openlibrary/core/processors/invalidation.py
@@ -16,13 +16,13 @@ class InvalidationProcessor:
     way to make sure those documents are kept up-to-date with the db within
     some allowed constraints.
 
-    This implements a kind of lazy consistancy, which guaranties the following:
+    This implements a kind of lazy consistency, which guaranties the following:
 
     * If a client makes an update, he will continue to see that update on
       subsequent requests.
     * If a client sees an update made by somebody else, he will continue to
       see that update on subsequent requests.
-    * A client sees older version of a doucment no longer than the specified
+    * A client sees older version of a document no longer than the specified
       timeout (in seconds) after the document is updated.
 
     It means that the following conditions will never happen:

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -18,7 +18,7 @@ except ImportError:
 
 class ReadableUrlProcessor:
     """Open Library code works with urls like /books/OL1M and
-    /books/OL1M/edit. This processor seemlessly changes the urls to
+    /books/OL1M/edit. This processor seamlessly changes the urls to
     /books/OL1M/title and /books/OL1M/title/edit.
 
     The changequery function is also customized to support this.
@@ -43,7 +43,7 @@ class ReadableUrlProcessor:
         real_path, readable_path = get_readable_path(web.ctx.site, web.ctx.path, self.patterns, encoding=web.ctx.encoding)
 
         #@@ web.ctx.path is either quoted or unquoted depends on whether the application is running
-        #@@ using builtin-server or lighttpd. Thats probably a bug in web.py.
+        #@@ using builtin-server or lighttpd. That is probably a bug in web.py.
         #@@ take care of that case here till that is fixed.
         # @@ Also, the redirection must be done only for GET requests.
         if readable_path != web.ctx.path and readable_path != urllib.parse.quote(web.utf8(web.ctx.path)) and web.ctx.method == "GET":

--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -104,7 +104,7 @@ def get_schema():
     return schema
 
 def register_schema():
-    """Register the schema definied in this module as the default schema."""
+    """Register the schema defined in this module as the default schema."""
     dbstore.default_schema = get_schema()
 
 if __name__ == "__main__":

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -306,7 +306,7 @@ def update_waitinglist(identifier):
         borrowed=str(not_available).lower(), # store as string "true" or "false"
         wl_size=len(wl))
 
-    # Start storing ebooks/$identifier so that we can handle mutliple editions
+    # Start storing ebooks/$identifier so that we can handle multiple editions
     # with same ocaid more effectively.
     update_ebook('ebooks/' + identifier,
         borrowed=str(not_available).lower(), # store as string "true" or "false"

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -65,7 +65,7 @@ def xopen(path, mode='r'):
         return open(path, mode)
 
 def read_tsv(file, strip=True):
-    """Read a tab seperated file and return an iterator over rows."""
+    """Read a tab separated file and return an iterator over rows."""
     log("reading", file)
     if isinstance(file, six.string_types):
         file = xopen(file)

--- a/openlibrary/olbase/events.py
+++ b/openlibrary/olbase/events.py
@@ -78,7 +78,7 @@ class MemcacheInvalidater:
         return ["d" + c['key'] for c in changeset['changes']]
 
     def find_lists(self, changeset):
-        """Returns the list entires effected by this change.
+        """Returns the list entries effected by this change.
 
         When a list is modified, the data of the user and the data of each
         seed are invalidated.

--- a/openlibrary/records/functions.py
+++ b/openlibrary/records/functions.py
@@ -289,7 +289,7 @@ def create(records):
 # Creation helpers
 def edition_doc_to_things(doc):
     """
-    unpack identifers, classifiers
+    unpack identifiers, classifiers
 
     Process work and author fields if present
     """

--- a/openlibrary/solr/solrdump.py
+++ b/openlibrary/solr/solrdump.py
@@ -5,7 +5,7 @@ Glossary:
 
 xwork document:
 
-	A dictionary contains all informatation about a work. It contains the following fields.
+	A dictionary contains all information about a work. It contains the following fields.
 
 	work - The work document
 	editions - The list of edition documents belong to the work

--- a/openlibrary/templates/lib/markdown.html
+++ b/openlibrary/templates/lib/markdown.html
@@ -38,7 +38,7 @@
                 <tr>
                     <td><blockquote>Blockquote</blockquote></td>
                     <td><span class="teal">&lt;blockquote&gt; &lt;/blockquote&gt;</span></td>
-                    <td>Preceed copy with <span class="blue">&gt;</span> </td>
+                    <td>Precede copy with <span class="blue">&gt;</span> </td>
                 </tr>
                 <tr>
                     <td><h3 class="collapse">Headers</h3></td>

--- a/openlibrary/utils/bulkimport.py
+++ b/openlibrary/utils/bulkimport.py
@@ -257,7 +257,7 @@ class Reindexer:
         return documents
 
     def delete_earlier_index(self, documents, tables=None):
-        """Remove all prevous entries corresponding to the given documents"""
+        """Remove all previous entries corresponding to the given documents"""
         all_tables = tables or set(r.relname for r in self.db.query(
                 "SELECT relname FROM pg_class WHERE relkind='r'"))
 

--- a/openlibrary/utils/form.py
+++ b/openlibrary/utils/form.py
@@ -9,7 +9,7 @@ import re
 from infogami.utils.view import render
 
 class AttributeList(dict):
-    """List of atributes of input.
+    """List of attributes of input.
 
     >>> a = AttributeList(type='text', name='x', value=20)
     >>> a

--- a/openlibrary/utils/processors.py
+++ b/openlibrary/utils/processors.py
@@ -14,7 +14,7 @@ class RateLimitProcessor:
         """Creates a rate-limit processor to limit the number of
         requests/ip in the time frame.
 
-        :param limit: the maxinum number of requests allowed in the given time window.
+        :param limit: the maximum number of requests allowed in the given time window.
         :param window_size: the time frame in seconds during which the requests are measured.
         :param path_regex: regular expression to specify which urls are rate-limited.
         """
@@ -23,9 +23,9 @@ class RateLimitProcessor:
         self.window_size = window_size
         self.reset(None)
 
-    def reset(self, timestmap):
+    def reset(self, timestamp):
         self.window = {}
-        self.window_timestamp = timestmap
+        self.window_timestamp = timestamp
 
     def get_window(self):
         t = int(time.time() / self.window_size)

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -54,7 +54,7 @@ class Solr:
         """Execute a solr query.
 
         query can be a string or a dicitonary. If query is a dictionary, query
-        is constucted by concatinating all the key-value pairs with AND condition.
+        is constructed by concatinating all the key-value pairs with AND condition.
         """
         params = {'wt': 'json'}
 
@@ -85,7 +85,7 @@ class Solr:
                 params['facet.field'].append(name)
 
         # switch to POST request when the payload is too big.
-        # XXX: would it be a good idea to swithc to POST always?
+        # XXX: would it be a good idea to switch to POST always?
         payload = urlencode(params, doseq=True)
         url = self.base_url + "/select"
         if len(payload) < 500:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix some typos discovered via [codespell](https://github.com/codespell-project/codespell).
```
python3 -m pip install codespell
SKIP=./openlibrary/catalog/*,./openlibrary/i18n/*,./openlibrary/macros/*,./openlibrary/plugins/*
codespell . -L ba,referer,te --skip=./.*,${SKIP},./.scripts/20*,*.gif,*.js,*.pg_dump,*.png,*.xsd
```
This PR only addresses some of the typos discovered so more work could be done in separate PRs.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->