### PR TITLE
Update to Node 12

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -30,7 +30,7 @@ RUN apt-get -qq update && apt-get install -y \
 RUN pip install --upgrade --disable-pip-version-check pip==19.3.1
 
 # Install LTS version of node.js
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y nodejs
 
 # enable users to bind to port 80

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -51,7 +51,7 @@ RUN pip install --disable-pip-version-check --default-timeout=100 -r requirement
 
 USER openlibrary
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY --chown=openlibrary:openlibrary . /openlibrary
 

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -24,7 +24,7 @@ COPY requirements*.txt ./
 RUN pip install --disable-pip-version-check -r requirements_test.txt
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 # Expose Open Library, Infobase, and Coverstore
 EXPOSE 80 7000 8081 3000


### PR DESCRIPTION
Closes #2081. This updates the Docker dev environment from Node 8, which is end-of-life, to Node 12 LTS. 

### Technical

It is based on and includes #2911 (since the build doesn't work with the old version of pip).

It also includes an `npm audit fix` for all our modules to resolve the hundreds of vulnerabilities which are flagged (but there are still a couple of critical ones, e.g. jQuery, which need manual updates)

It switches from `npm install` to `npm ci` for better reproducibility of versions.

### Testing

All automated tests pass and cursory testing on a local dev build looks ok, but it should be more thoroughly tested.

## Stakeholders

@jdlrobson 