### PR TITLE
fix embed sharelink using wrong url

### DIFF
--- a/openlibrary/macros/SocialShare.html
+++ b/openlibrary/macros/SocialShare.html
@@ -3,7 +3,7 @@ $# :param list[dict] share_links:
 $# :param str page_url: absolute url excluding params
 
 $def embed_iframe(page_url):
-  <iframe frameborder="0" width="165" height="400" src="$(page_url)/widget"></iframe>
+  <iframe frameborder="0" width="165" height="400" src="$(page_url)/-/widget"></iframe>
 
 <div class="shareLinks cta-section">
   <p class="cta-section-title">Share this book</p>


### PR DESCRIPTION
Hotfix: the embed share link was pointing to e.g. https://openlibrary.org/books/OL18768980M/widget instead of https://openlibrary.org/books/OL18768980M/-/widget , causing the iframe code to render the full page instead of just the widget

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ Visit https://dev.openlibrary.org/books/OL18768980M/The_one_minute_manager , and copy/paste the embed code to see if it works.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 