### PR TITLE
Make mock_ol.py compatible with old and new web.py

### DIFF
--- a/openlibrary/mocks/mock_ol.py
+++ b/openlibrary/mocks/mock_ol.py
@@ -5,6 +5,10 @@ import web
 from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate
+try:  # newer versions of web.py
+    from web.browser import AppBrowser
+except ImportError:  # older versions of web.py
+    from web import AppBrowser
 
 from openlibrary.mocks.mock_infobase import mock_site, MockConnection
 from openlibrary.plugins import ol_infobase
@@ -34,11 +38,11 @@ class EMail(web.storage):
         """Extracts link from the email message."""
         return re.findall(r"http://[^\s]*", self.message)
 
-class OLBrowser(web.AppBrowser):
+class OLBrowser(AppBrowser):
     def get_text(self, e=None, name=None, **kw):
         if name or kw:
             e = self.get_soup().find(name=name, **kw)
-        return web.AppBrowser.get_text(self, e)
+        return AppBrowser.get_text(self, e)
 
 class OL:
     """Mock OL object for all tests.


### PR DESCRIPTION
Compatible with both web.py 0.3.9 and 0.4.0 as discussed at https://github.com/internetarchive/openlibrary/pull/2416#issuecomment-536190367

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->