### PR TITLE
HOTFIX: temporaily re-add URL 

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -315,7 +315,7 @@ class ia_importapi(importapi):
         """
         edition['ocaid'] = identifier
         edition['source_records'] = "ia:" + identifier
-        edition['cover'] = "{0}/download/{1}/{1}/page/title.jpg".format(IA_BASE_URL, identifier)
+        edition['cover'] = "{0}/download/{1}/{1}/page/title.jpg".format('https://archive.org', identifier)
         return edition
 
     def get_marc_record(self, identifier):


### PR DESCRIPTION
that will be fully replaced by #2909
short term fixes #2915

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Addresses a missing constant that got dropped in the revert of a change which caused a memory leak but refactored away the requirement for an archive.org URL in this file. This adds the URL back so the code can temporarily function. #2909 will resolve the problem also, but this change allows us to revert #2909 if there are still memory leaks if we really need to, and still have working imports.

@cdrini if you can review and merge this, I will re-base #2909