### PR TITLE
fix requests error handling in account registration

### DIFF
--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -1,7 +1,28 @@
-from openlibrary.accounts import model
+from openlibrary.accounts import model, InternetArchiveAccount
+from requests.models import Response
+
 
 def test_verify_hash():
       secret_key = "aqXwLJVOcV"
       hash = model.generate_hash(secret_key, "foo")
       assert model.verify_hash(secret_key, "foo", hash) == True
 
+
+class TestInternetArchiveAccount:
+      def test_xauth_http_error_without_json(self, monkeypatch):
+            xauth = InternetArchiveAccount.xauth
+
+            resp = Response()
+            resp.status_code = 500
+            resp._content = b'Internal Server Error'
+            monkeypatch.setattr(model.requests, 'post', lambda url, **kwargs: resp)
+            assert xauth('create', s3_key='_', s3_secret='_') == {'code': 500, 'error': 'Internal Server Error'}
+
+      def test_xauth_http_error_with_json(self, monkeypatch):
+            xauth = InternetArchiveAccount.xauth
+
+            resp = Response()
+            resp.status_code = 400
+            resp._content = b'{"error": "Unknown Parameter Blah"}'
+            monkeypatch.setattr(model.requests, 'post', lambda url, **kwargs: resp)
+            assert xauth('create', s3_key='_', s3_secret='_') == {"error": "Unknown Parameter Blah"}


### PR DESCRIPTION
Fix: Previously was following the guidelines from https://www.peterbe.com/plog/jsondecodeerror-in-requests.get.json-python-2-and-3 , but it looks like the correct python 2/3 compatiable was is in the docs https://2.python-requests.org/en/master/api/#requests.Response.json ; i.e. except ValueError

Note that functionally this won't really make a difference, since in Python 2 it used to fallback to ValueError anyways, but this just makes it more python 3 compatible.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Added a test to ensure this is working as expected

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@hornc @tfmorris 