### PR TITLE
Fix addbook endpoint ignoring author

### DIFF
--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -28,12 +28,7 @@ $var title: $_("Add a book")
         </div>
         <div class="formElement">
             <div class="label"><label for="author">$_("Author")</label> <span class="smaller lighter">$_('Like, "Agatha Christie" or "Jean-Paul Sartre." We\'ll also do a live check to see if we already know the author.')</span></div>
-            <div class="input">
-                $if author:
-                    $:render_template("books/author-autocomplete", [ author ])
-                $else:
-                    $:render_template("books/author-autocomplete", [])
-            </div>
+            $:render_template("books/author-autocomplete", cond(author, [author], []), "author_names", "authors")
         </div>
 
         <div class="formElement">

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -1,4 +1,8 @@
-$def with (authors)
+$def with (authors, name_path, dict_path)
+$# :param list[dict] authors: e.g. {name: str, key: str}
+$# :param str name_path: form path for the user-visible author name
+$# :param str dict_path: form path for the author dict
+
 $jsdef render_author_autocomplete_item(item):
     $if item.key == "__new__":
         <div class="ac_author ac_addnew" title="Add a new author">
@@ -27,26 +31,23 @@ $jsdef render_author_autocomplete_item(item):
                 <span class="subject">Subjects: ${', '.join(item.subjects)}</span>
         </div>
 
-$jsdef render_author(i, author):
+$jsdef render_author(name_path, dict_path, i, author):
     <div class="input">
-        <input name="authors--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name"/>
-        <input name="work--authors--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
-        <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[x]</a>&nbsp;
+        <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name"/>
+        <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
+        <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
         <a href="javascript:;" class="add">$_("Add another author?")</a>
     </div>
 
 <div id="authors">
-    $if authors:
-        $for i, author in enumerate(authors):
-            $:render_author(i, author)
-    $else:
-        $:render_author(0, storage(name="", key=""))
+    $for author in (authors or [storage(name="", key="")]):
+        $:render_author(name_path, dict_path, loop.index0, author)
 </div>
 <script type="text/javascript">
 window.q.push( function () {
     \$("#authors").setup_multi_input_autocomplete(
         "input.author-autocomplete",
-        render_author,
+        render_author.bind(null, "$name_path", "$dict_path"),
         {
             endpoint: "/authors/_autocomplete",
             // Don't render "Create new author" if searching by key

--- a/openlibrary/templates/books/check.html
+++ b/openlibrary/templates/books/check.html
@@ -1,11 +1,14 @@
 $def with (d, matches)
 
+$# :param web.Storage d: form data
+$# :param list matches:
+
 $var title: $_("Add a book")
 
 <div id="contentHead">
     <h1>$_("Add a Book")</h1>
     <p class="instruct">
-        $:_("One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>.", title=d.title, author=d.author_name)
+        $:_("One moment... It looks like we already have <em>some potential matches</em> for <b>%(title)s</b> by <b>%(author)s</b>.", title=d.title, author=d.author_names[0])
         <br/><br/>
         $_("Rather than creating a duplicate record, please click through the result you think best matches your book.")
     </p>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -95,7 +95,7 @@ window.q.push( function(){
                 <span class="tip">$:_('You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href="/authors/OL23919A" target="_blank"><em>OL23919A</em></a>).')</span>
             </div>
             $ authors = work.authors and [a.author for a in work.authors]
-            $:render_template("books/author-autocomplete", authors)
+            $:render_template("books/author-autocomplete", authors, "authors", "work--authors")
         </div>
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #1716 ; Fixes bug where adding a book would ignore the entered author.

### Technical
- make author-autocomplete.html more configurable: In order for the author-autocomplete template to be used on both the add page and the edit page, one needs to be able to specify the paths of the form fields.
- Change the /book/add POST form to accept `authors` and `author_names` in the same format as edit page
- Since that means `authors` is now an array of objects, unflattens the input
- Updated anywhere this input item was passed to handle the new fields
- Previously was using the type-prefixed OLID for matching records in solr, which doesn't work
- Consolidate the author creation logic inside /books/add and edit page
- DRY up anywhere a new record is created to use same helper

### Testing
- ✅ Creating new author from work
- ✅ Removing authors from work
- ✅ Adding existing authors to work
- ✅ Creating a new work with existing author
- ✅ Creating a new work with new author
- ✅ Creating a new work with multiple authors
- ✅ Creating a new work from author page
- ✅* Creating a new edition from work page
    - oddly lets you set the author for some reason, but that can be dealt with in a future PR
- ✅ Creating a new work that matches

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@seabelis 