### PR TITLE
Hotfix to some i18n bugs

### DIFF
--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -214,7 +214,7 @@ $else:
                             $if delta_hours == 0:
                                 $_("You have less than an hour to borrow it.")
                             $else:
-                                $unggettext("You have one more hour to borrow it.", "You have %(hours)d more hours to borrow it.", delta_hours, hours=delta_hours)
+                                $ungettext("You have one more hour to borrow it.", "You have %(hours)d more hours to borrow it.", delta_hours, hours=delta_hours)
                         </div>
                 </td>
                 <td class="actions">

--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -145,7 +145,8 @@ $var title: $page.title
                                 $if excerpt.pages:
                                     $_("Page") $excerpt.pages,
                                 $if excerpt.author:
-                                    $:_("added by %s", '<a href="$excerpt.author.key">$excerpt.author.displayname</a>.')
+                                    $def excerpt_author_link(): <a href="$excerpt.author.key">$excerpt.author.displayname</a>
+                                    $:(_("added by %s.") % str(excerpt_author_link()).strip())
                                 $else:
                                     $_("added anonymously").
                                 $if excerpt.comment:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2925 . Hotfix to 2 issues:
- Loans page referencing undefined function (commit pulled from @tfmorris ' PR #2926)
- Excerpts showing uninterpolated markup

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ Adding excerpts works/they get displayed correctly
- ✅ Excerpts by multiple people display correctly
- ✅ Excerpts display on https://dev.openlibrary.org/works/OL81613W/It
- ✅ Test https://dev.openlibrary.org/account/loans renders

### Evidence

![image](https://user-images.githubusercontent.com/6251786/73370548-64a5f180-4282-11ea-866f-5245c5fc832e.png)


### Stakeholders
@tfmorris 