### PR TITLE
Resolve 32 undefined names from `make lint`

### DIFF
--- a/openlibrary/catalog/marc/build_record.py
+++ b/openlibrary/catalog/marc/build_record.py
@@ -2,6 +2,9 @@
     openlibrary.catalog.marc.parse is the preferred module
 """
 
+# Tell the flake8 linter to ignore this deprecated file.
+# flake8: noqa
+
 import re
 from deprecated import deprecated
 from warnings import warn


### PR DESCRIPTION
Tell the flake8 linter to ignore this deprecated file.  Adding this flake8 directive removes 32 of the _undefined names_ that `make lint` discovers so that we can focus on resolving those that remain.  See #1684

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
https://travis-ci.org/internetarchive/openlibrary/jobs/643480952#L342-L437

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->