### PR TITLE
Next Py3 pytest fix: import ReadableUrlProcessor

### DIFF
--- a/openlibrary/core/processors/__init__.py
+++ b/openlibrary/core/processors/__init__.py
@@ -1,1 +1,1 @@
-from readableurls import ReadableUrlProcessor
+from openlibrary.core.processors.readableurls import ReadableUrlProcessor


### PR DESCRIPTION
Absolute import that fixes 4 pytest failures when running on Python 3:
```
__________ ERROR collecting openlibrary/tests/core/test_processors.py __________
ImportError while importing test module '/home/travis/build/internetarchive/openlibrary/openlibrary/tests/core/test_processors.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
openlibrary/tests/core/test_processors.py:2: in <module>
    from openlibrary.core.processors import readableurls as processors
openlibrary/core/processors/__init__.py:1: in <module>
    from readableurls import ReadableUrlProcessor
E   ModuleNotFoundError: No module named 'readableurls'

___ ERROR collecting openlibrary/tests/core/test_processors_invalidation.py ____
ImportError while importing test module '/home/travis/build/internetarchive/openlibrary/openlibrary/tests/core/test_processors_invalidation.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
openlibrary/tests/core/test_processors_invalidation.py:5: in <module>
    from openlibrary.core.processors import invalidation
openlibrary/core/processors/__init__.py:1: in <module>
    from readableurls import ReadableUrlProcessor
E   ModuleNotFoundError: No module named 'readableurls'

______ ERROR collecting openlibrary/plugins/books/tests/test_doctests.py _______
openlibrary/plugins/books/tests/test_doctests.py:7: in find_doctests
    mod = __import__(m, None, None, ['x'])
openlibrary/plugins/books/dynlinks.py:7: in <module>
    from openlibrary.plugins.openlibrary.processors import urlsafe
openlibrary/plugins/openlibrary/processors.py:5: in <module>
    from openlibrary.core.processors import ReadableUrlProcessor
openlibrary/core/processors/__init__.py:1: in <module>
    from readableurls import ReadableUrlProcessor
E   ModuleNotFoundError: No module named 'readableurls'

______ ERROR collecting openlibrary/plugins/books/tests/test_dynlinks.py _______
ImportError while importing test module '/home/travis/build/internetarchive/openlibrary/openlibrary/plugins/books/tests/test_dynlinks.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
openlibrary/plugins/books/tests/test_dynlinks.py:17: in <module>
    from openlibrary.plugins.books import dynlinks
openlibrary/plugins/books/dynlinks.py:7: in <module>
    from openlibrary.plugins.openlibrary.processors import urlsafe
openlibrary/plugins/openlibrary/processors.py:5: in <module>
    from openlibrary.core.processors import ReadableUrlProcessor
openlibrary/core/processors/__init__.py:1: in <module>
    from readableurls import ReadableUrlProcessor
E   ModuleNotFoundError: No module named 'readableurls'
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->