### PR TITLE
from six import StringIO for Python 2 and 3

### DIFF
--- a/openlibrary/catalog/amazon/arc_view.py
+++ b/openlibrary/catalog/amazon/arc_view.py
@@ -1,6 +1,6 @@
 import web
 import os
-from StringIO import StringIO
+from six import StringIO
 
 arc_dir = '/2/edward/amazon/arc'
 urls = (

--- a/openlibrary/catalog/lang.py
+++ b/openlibrary/catalog/lang.py
@@ -1,5 +1,5 @@
 import sys
-from StringIO import StringIO
+from six import StringIO
 import time
 import re
 

--- a/openlibrary/catalog/oca/parse.py
+++ b/openlibrary/catalog/oca/parse.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from cStringIO import StringIO
+from six.moves.cStringIO import StringIO
 from xml.parsers.expat import error as xml_error
 from elementtree import ElementTree
 from types import *

--- a/openlibrary/catalog/oca/parse.py
+++ b/openlibrary/catalog/oca/parse.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from six.moves.cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 from xml.parsers.expat import error as xml_error
 from elementtree import ElementTree
 from types import *

--- a/openlibrary/catalog/onix/xmltramp.py
+++ b/openlibrary/catalog/onix/xmltramp.py
@@ -267,7 +267,7 @@ def seed(fileobj):
     return seeder.result
 
 def parse(text):
-    from StringIO import StringIO
+    from six import StringIO
     return seed(StringIO(text))
 
 def load(url):

--- a/openlibrary/core/middleware.py
+++ b/openlibrary/core/middleware.py
@@ -1,7 +1,7 @@
 """WSGI middleware used in Open Library.
 """
 import web
-import StringIO
+from six import StringIO
 import gzip
 
 class GZipMiddleware:
@@ -23,7 +23,7 @@ class GZipMiddleware:
             return default
 
         def compress(text, level=9):
-            f = StringIO.StringIO()
+            f = StringIO()
             gz = gzip.GzipFile(None, 'wb', level, fileobj=f)
             gz.write(text)
             gz.close()

--- a/openlibrary/coverstore/tests/test_code.py
+++ b/openlibrary/coverstore/tests/test_code.py
@@ -1,5 +1,5 @@
 from .. import code
-from six.moves.cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 import web
 import datetime
 

--- a/openlibrary/coverstore/tests/test_code.py
+++ b/openlibrary/coverstore/tests/test_code.py
@@ -1,5 +1,5 @@
 from .. import code
-from cStringIO import StringIO
+from six.moves.cStringIO import StringIO
 import web
 import datetime
 

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -14,8 +14,8 @@ CRLF = "\r\n"
 class WARCReader:
     """Reader to read records from a warc file.
 
-    >>> import StringIO
-    >>> f = StringIO.StringIO()
+    >>> from six import StringIO
+    >>> f = StringIO()
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo")
     >>> r2 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "bar")
     >>> w = WARCWriter(f)
@@ -219,9 +219,9 @@ class WARCRecord:
 class LazyWARCRecord(WARCRecord):
     """Class to create WARCRecord lazily.
 
-    >>> import StringIO
+    >>> from six import StringIO
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo bar", creation_date="20080808080808", record_id="record_42")
-    >>> f = StringIO.StringIO(str(r1))
+    >>> f = StringIO(str(r1))
     >>> offset = len(str(r1.get_header()))
     >>> r2 = LazyWARCRecord(f, offset, r1.get_header())
     >>> r1 == r2
@@ -247,8 +247,9 @@ class LazyWARCRecord(WARCRecord):
 class WARCWriter:
     r"""Writes to write warc records to file.
 
-    >>> import re, StringIO
-    >>> f = StringIO.StringIO()
+    >>> import re
+    >>> from six import StringIO
+    >>> f = StringIO()
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo", creation_date="20080808080808", record_id="record_42")
     >>> r2 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "bar", creation_date="20080808090909", record_id="record_43")
     >>> w = WARCWriter(f)

--- a/openlibrary/plugins/openlibrary/libraries.py
+++ b/openlibrary/plugins/openlibrary/libraries.py
@@ -5,7 +5,7 @@ import time
 import logging
 import datetime
 import itertools
-from six.moves.cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 import csv
 import simplejson
 

--- a/openlibrary/plugins/openlibrary/libraries.py
+++ b/openlibrary/plugins/openlibrary/libraries.py
@@ -5,7 +5,7 @@ import time
 import logging
 import datetime
 import itertools
-from cStringIO import StringIO
+from six.moves.cStringIO import StringIO
 import csv
 import simplejson
 

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 from xml.etree.cElementTree import ElementTree
-from cStringIO import StringIO
+from six.moves.cStringIO import StringIO
 import os
 import re
 from collections import defaultdict

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 from xml.etree.cElementTree import ElementTree
-from six.moves.cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 import os
 import re
 from collections import defaultdict

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -3,7 +3,7 @@
 import web
 import simplejson
 from collections import defaultdict
-from StringIO import StringIO
+from six import StringIO
 import csv
 import datetime
 

--- a/openlibrary/tests/core/mocklib.py
+++ b/openlibrary/tests/core/mocklib.py
@@ -1,6 +1,6 @@
 """Simple mock utility.
 """
-from StringIO import StringIO
+from six import StringIO
 
 from six.moves import urllib
 

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -1,7 +1,7 @@
 from openlibrary.solr import update_work
 from openlibrary.solr.data_provider import DataProvider
 from openlibrary.solr.update_work import build_data
-from StringIO import StringIO
+from six import StringIO
 
 author_counter = 0
 edition_counter = 0

--- a/scripts/jsondump.py
+++ b/scripts/jsondump.py
@@ -270,9 +270,9 @@ def log(*a):
     print(time.asctime(), " ".join(map(str, a)), file=sys.stderr)
 
 def capture_stdout(f):
-    import StringIO
+    from six import StringIO
     def g(*a):
-        stdout, sys.stdout = sys.stdout, StringIO.StringIO()
+        stdout, sys.stdout = sys.stdout, StringIO()
         f(*a)
         out, sys.stdout = sys.stdout.getvalue(), stdout
         return out


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Run the following commands to find `StringIO.StringIO` issues:
1. `grep -r StringIO.StringIO .`
2. `grep -r "from StringIO" .`

Then change to import to `from six import StringIO` in alignment with https://six.readthedocs.io/#six.StringIO

---

Run `grep -r cStringIO .` to find `cStringIO.StringIO` issues and then change to import to
`from six.moves import cStringIO as StringIO` in alignment with https://six.readthedocs.io/#module-six.moves

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->