### PR TITLE
Replace deprecated UserDict.DictMixin with Mapping

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -3,7 +3,6 @@ import simplejson
 import babel
 import babel.core
 import babel.dates
-from UserDict import DictMixin
 from collections import defaultdict
 import re
 import random
@@ -16,6 +15,7 @@ from HTMLParser import HTMLParser
 
 import six
 from six.moves import urllib
+from six.moves.collections_abc import Mapping
 
 from infogami import config
 from infogami.utils import view, delegate, stats
@@ -28,7 +28,7 @@ from openlibrary.core.helpers import commify, parse_datetime
 from openlibrary.core.middleware import GZipMiddleware
 from openlibrary.core import cache, ab
 
-class MultiDict(DictMixin):
+class MultiDict(Mapping):
     """Ordered Dictionary that can store multiple values.
 
         >>> d = MultiDict()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2889

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[`UserDict.DictMixin`](https://docs.python.org/2/library/userdict.html#UserDict.DictMixin) was removed in Python 3 so use [`collections.abc.Mapping`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Mapping) instead as we did in internetarchive/infogami#45.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->