### PR TITLE
Absolute import: from scripts import _init_path

### DIFF
--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -11,7 +11,7 @@ This script can also be used to copy books and authors from OL to dev instance.
     ./scripts/copydocs.py /authors/OL113592A
     ./scripts/copydocs.py /works/OL1098727W?v=2
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from collections import namedtuple
 

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, print_function
 
 from collections import namedtuple
 
-from . import _init_path
+from scripts import _init_path
 import sys
 import os
 import simplejson

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 
 from collections import namedtuple
 
-from scripts import _init_path
+from . import _init_path
 import sys
 import os
 import simplejson

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 
 from collections import namedtuple
 
-import _init_path
+from scripts import _init_path
 import sys
 import os
 import simplejson


### PR DESCRIPTION
Uses absolute import to resolve pytest result:
```
_______________ ERROR collecting scripts/tests/test_copydocs.py ________________
ImportError while importing test module '/home/travis/build/internetarchive/openlibrary/scripts/tests/test_copydocs.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
scripts/tests/test_copydocs.py:1: in <module>
    from ..copydocs import copy, KeyVersionPair
scripts/copydocs.py:18: in <module>
    import _init_path
E   ModuleNotFoundError: No module named '_init_path'
```
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->