### PR TITLE
Replace lepl with validate_email

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -12,7 +12,7 @@ import uuid
 import logging
 import requests
 
-import lepl.apps.rfc3696
+from validate_email import validate_email
 import web
 
 from infogami import config
@@ -29,7 +29,7 @@ def append_random_suffix(text, limit=9999):
     return '%s%s' % (text, random.randint(0, limit))
 
 def valid_email(email):
-    return lepl.apps.rfc3696.Email()(email)
+    return validate_email(email)
 
 def sendmail(to, msg, cc=None):
     cc = cc or []

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -16,7 +16,7 @@ web.py==0.40; python_version >= '3.0'
 pystatsd==0.1.6
 PyYAML==4.2b4
 eventer==0.1.1
-lepl==5.1.3
+validate_email==1.3
 six==1.13.0
 sixpack-client==1.2.0
 psycopg2==2.8.4


### PR DESCRIPTION
Closes #2945

Replaces obsolete and unmaintained `lepl` parser module (which was way overkill) with the `validate_email` module.

This also cuts down on a huge number of deprecation warnings in our Python 3.8 CI tests.

@hornc Note that this requires a dependency update.