### PR TITLE
don't count null covers as existing on reimport

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -679,7 +679,7 @@ def load(rec, account=None):
             w['subjects'] = work_subjects
 
     # Add cover to edition
-    if 'cover' in rec and not e.covers:
+    if 'cover' in rec and not e.get_covers():
         cover_url = rec['cover']
         cover_id = add_cover(cover_url, e.key, account=account)
         if cover_id:
@@ -687,7 +687,7 @@ def load(rec, account=None):
             need_edition_save = True
 
     # Add cover to work, if needed
-    if not w.get('covers') and e.get('covers'):
+    if not w.get('covers') and e.get_covers():
         w['covers'] = [e['covers'][0]]
         need_work_save = True
 

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -97,7 +97,7 @@ class Edition(models.Edition):
         return editions[i - 1]
 
     def get_covers(self):
-        return [Image(self._site, 'b', c) for c in self.covers if c > 0]
+        return [Image(self._site, 'b', c) for c in self.covers if c and c > 0]
 
     def get_cover(self):
         covers = self.get_covers()

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -97,6 +97,10 @@ class Edition(models.Edition):
         return editions[i - 1]
 
     def get_covers(self):
+        """
+        This methods excludes covers that are -1 or None, which are in the data
+        but should not be.
+        """
         return [Image(self._site, 'b', c) for c in self.covers if c and c > 0]
 
     def get_cover(self):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2621 

This will enable re-imports of existing records from archive.org that have already been saved with `null` cover ids to populate those records with either title pages or covers using the code in #2147 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->