### PR TITLE
replacing html valign with css vertical-align

### DIFF
--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -41,11 +41,11 @@ $var title: $name
                     <td class="number">$v.revision</td>
                     <td class="history"><a href="$page.get_url(v=v.revision)" title="$_('View revision %s', v.revision)">$datestr(v.created)</a></td>
                     $if v.author:
-                        <td class="displayname" valign="top"><div class="truncatedisplayname"><a href="$homepath()$v.author.key" class="truncate" title="$v.author.displayname">$v.author.displayname</a></div></td>
+                        <td class="displayname" style="vertical-align: top;"><div class="truncatedisplayname"><a href="$homepath()$v.author.key" class="truncate" title="$v.author.displayname">$v.author.displayname</a></div></td>
                     $elif v.ip and v.ip != '127.0.0.1':
-                        <td class="history" valign="top"><a href="/recentchanges?ip=$v.ip">$v.ip</a></td>
+                        <td class="history" style="vertical-align: top;"><a href="/recentchanges?ip=$v.ip">$v.ip</a></td>
                     $else:
-                        <td class="history" valign="top">$v.ip</td>
+                        <td class="history" style="vertical-align: top;">$v.ip</td>
                     <td class="comment">$:render_template("history/comment", v)</td>
                     <td class="compare" style="text-align:center;">
                         <input type="radio" id="a$v.revision" name="a" title="Compare this version..." value="$v.revision"/>


### PR DESCRIPTION
Issue solved #2798

Fixes HTML validation issues in
openlibrary/templates/history.html

Proposed:

Replace HTML valign with CSS vertical-align
Stakeholder
@koderjoker