### PR TITLE
style and whitespace changes before fixing endpoint logic

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -44,12 +44,12 @@ except:
     api = None
 
 # http header extension for OL API
-infogami.config.http_ext_header_uri = "http://openlibrary.org/dev/docs/api"
+infogami.config.http_ext_header_uri = 'http://openlibrary.org/dev/docs/api'
 
 # setup special connection with caching support
 from openlibrary.plugins.openlibrary import connection
 client._connection_types['ol'] = connection.OLConnection
-infogami.config.infobase_parameters = dict(type="ol")
+infogami.config.infobase_parameters = dict(type='ol')
 
 # set up infobase schema. required when running in standalone mode.
 from openlibrary.core import schema
@@ -60,22 +60,23 @@ models.register_models()
 models.register_types()
 
 # Remove movefiles install hook. openlibrary manages its own files.
-infogami._install_hooks = [h for h in infogami._install_hooks if h.__name__ != "movefiles"]
+infogami._install_hooks = [h for h in infogami._install_hooks if h.__name__ != 'movefiles']
 
 from openlibrary.plugins.openlibrary import lists
 lists.setup()
 
-logger = logging.getLogger("openlibrary")
+logger = logging.getLogger('openlibrary')
+
 
 class hooks(client.hook):
     def before_new_version(self, page):
         user = web.ctx.site.get_user()
         account = user and user.get_account()
         if account and account.is_blocked():
-            raise ValidationException("Your account has been suspended. You are not allowed to make any edits.")
+            raise ValidationException('Your account has been suspended. You are not allowed to make any edits.')
 
         if page.type.key == '/type/library':
-            bad = list(page.find_bad_ip_ranges(page.ip_ranges or ""))
+            bad = list(page.find_bad_ip_ranges(page.ip_ranges or ''))
             if bad:
                 raise ValidationException('Bad IPs: ' + '; '.join(bad))
 
@@ -83,12 +84,13 @@ class hooks(client.hook):
             if page.type.key == '/type/author':
                 return
 
-            books = web.ctx.site.things({"type": "/type/edition", "authors": page.key})
-            books = books or web.ctx.site.things({"type": "/type/work", "authors": {"author": {"key": page.key}}})
+            books = web.ctx.site.things({'type': '/type/edition', 'authors': page.key})
+            books = books or web.ctx.site.things({'type': '/type/work', 'authors': {'author': {'key': page.key}}})
             if page.type.key == '/type/delete' and books:
-                raise ValidationException("This Author page cannot be deleted as %d record(s) still reference this id. Please remove or reassign before trying again. Referenced by: %s" % (len(books), books))
+                raise ValidationException('This Author page cannot be deleted as %d record(s) still reference this id. Please remove or reassign before trying again. Referenced by: %s' % (len(books), books))
             elif page.type.key != '/type/author' and books:
-                raise ValidationException("Changing type of author pages is not allowed.")
+                raise ValidationException('Changing type of author pages is not allowed.')
+
 
 @infogami.action
 def sampledump():
@@ -162,8 +164,9 @@ def sampledump():
     for k in keys:
         visit(k)
 
+
 @infogami.action
-def sampleload(filename="sampledump.txt.gz"):
+def sampleload(filename='sampledump.txt.gz'):
     if filename.endswith('.gz'):
         import gzip
         f = gzip.open(filename)
@@ -175,13 +178,13 @@ def sampleload(filename="sampledump.txt.gz"):
 
 
 class routes(delegate.page):
-    path = "/developers/routes"
+    path = '/developers/routes'
 
     def GET(self):
         class ModulesToStr(simplejson.JSONEncoder):
             def default(self, obj):
                 if isinstance(obj, metapage):
-                    return obj.__module__ + "." + obj.__name__
+                    return obj.__module__ + '.' + obj.__name__
                 return super(ModulesToStr, self).default(obj)
 
         from openlibrary import code
@@ -189,8 +192,9 @@ class routes(delegate.page):
             code.delegate.pages, sort_keys=True, cls=ModulesToStr,
             indent=4, separators=(',', ': '))
 
+
 class addbook(delegate.page):
-    path = "/addbook"
+    path = '/addbook'
 
     def GET(self):
         d = {'type': web.ctx.site.get('/type/edition')}
@@ -209,8 +213,9 @@ class addbook(delegate.page):
         web.ctx.path = key
         return edit().POST(key)
 
+
 class widget(delegate.page):
-    path = r"/(works|books)/(OL\d+[W|M])/widget"
+    path = r'/(works|books)/(OL\d+[W|M])/widget'
 
     def GET(self, _type, olid=None):
         if olid:
@@ -220,50 +225,52 @@ class widget(delegate.page):
             item['availability'] = getter(olid).get(item['olid'])
             item['authors'] = [web.storage(key=a.key, name=a.name or None) for a in item.get_authors()]
             return delegate.RawText(
-                render_template("widget", item if _type == 'books' else format_work_data(item)),
-                content_type="text/html")
-        raise web.seeother("/")
+                render_template('widget', item if _type == 'books' else format_work_data(item)),
+                content_type='text/html')
+        raise web.seeother('/')
+
 
 class addauthor(delegate.page):
     path = '/addauthor'
 
     def POST(self):
-        i = web.input("name")
+        i = web.input('name')
         if len(i.name) < 2:
             return web.badrequest()
         key = web.ctx.site.new_key('/type/author')
         web.ctx.path = key
         web.ctx.site.save({'key': key, 'name': i.name, 'type': dict(key='/type/author')}, comment='New Author')
-        raise web.HTTPError("200 OK", {}, key)
+        raise web.HTTPError('200 OK', {}, key)
+
 
 class clonebook(delegate.page):
     def GET(self):
         from infogami.core.code import edit
-        i = web.input("key")
+        i = web.input('key')
         page = web.ctx.site.get(i.key)
         if page is None:
             raise web.seeother(i.key)
         else:
             d =page._getdata()
-            for k in ['isbn_10', 'isbn_13', 'lccn', "oclc"]:
+            for k in ['isbn_10', 'isbn_13', 'lccn', 'oclc']:
                  d.pop(k, None)
             return render.edit(page, '/addbook', 'Clone Book')
 
+
 class search(delegate.page):
-    path = "/suggest/search"
+    path = '/suggest/search'
 
     def GET(self):
-        i = web.input(prefix="")
+        i = web.input(prefix='')
         if len(i.prefix) > 2:
             q = {'type': '/type/author', 'name~': i.prefix + '*', 'sort': 'name', 'limit': 5}
             things = web.ctx.site.things(q)
             things = [web.ctx.site.get(key) for key in things]
-
             result = [dict(type=[{'id': t.key, 'name': t.key}], name=web.utf8(t.name), guid=t.key, id=t.key, article=dict(id=t.key)) for t in things]
         else:
             result = []
         callback = i.pop('callback', None)
-        d = dict(status="200 OK", query=dict(i, escape='html'), code='/api/status/ok', result=result)
+        d = dict(status='200 OK', query=dict(i, escape='html'), code='/api/status/ok', result=result)
 
         if callback:
             data = '%s(%s)' % (callback, simplejson.dumps(d))
@@ -271,24 +278,25 @@ class search(delegate.page):
             data = simplejson.dumps(d)
         raise web.HTTPError('200 OK', {}, data)
 
+
 class blurb(delegate.page):
-    path = "/suggest/blurb/(.*)"
+    path = '/suggest/blurb/(.*)'
     def GET(self, path):
         i = web.input()
         callback = i.pop('callback', None)
         author = web.ctx.site.get('/' +path)
         body = ''
         if author.birth_date or author.death_date:
-            body = "%s - %s" % (author.birth_date, author.death_date)
+            body = '%s - %s' % (author.birth_date, author.death_date)
         else:
-            body = "%s" % author.date
+            body = '%s' % author.date
 
-        body += "<br/>"
+        body += '<br/>'
         if author.bio:
             body += web.utf8(author.bio)
 
-        result = dict(body=body, media_type="text/html", text_encoding="utf-8")
-        d = dict(status="200 OK", code="/api/status/ok", result=result)
+        result = dict(body=body, media_type='text/html', text_encoding='utf-8')
+        d = dict(status='200 OK', code='/api/status/ok', result=result)
         if callback:
             data = '%s(%s)' % (callback, simplejson.dumps(d))
         else:
@@ -296,15 +304,18 @@ class blurb(delegate.page):
 
         raise web.HTTPError('200 OK', {}, data)
 
+
 class thumbnail(delegate.page):
-    path = "/suggest/thumbnail"
+    path = '/suggest/thumbnail'
+
 
 @public
 def get_property_type(type, name):
     for p in type.properties:
         if p.name == name:
             return p.expected_type
-    return web.ctx.site.get("/type/string")
+    return web.ctx.site.get('/type/string')
+
 
 def save(filename, text):
     root = os.path.dirname(__file__)
@@ -316,58 +327,63 @@ def save(filename, text):
     f.write(text)
     f.close()
 
+
 def change_ext(filename, ext):
     filename, _ = os.path.splitext(filename)
     if ext:
         filename = filename + ext
     return filename
 
+
 def get_pages(type, processor):
     pages = web.ctx.site.things(dict(type=type))
     for p in pages:
         processor(web.ctx.site.get(p))
 
+
 class robotstxt(delegate.page):
-    path = "/robots.txt"
+    path = '/robots.txt'
     def GET(self):
         web.header('Content-Type', 'text/plain')
         try:
             robots_file = 'norobots.txt' if 'dev' in infogami.config.features else 'robots.txt'
             data = open('static/' + robots_file).read()
-            raise web.HTTPError("200 OK", {}, data)
+            raise web.HTTPError('200 OK', {}, data)
         except IOError:
             raise web.notfound()
 
+
 class health(delegate.page):
-    path = "/health"
+    path = '/health'
     def GET(self):
         web.header('Content-Type', 'text/plain')
-        raise web.HTTPError("200 OK", {}, 'OK')
+        raise web.HTTPError('200 OK', {}, 'OK')
+
 
 class bookpage(delegate.page):
-    path = r"/(isbn|oclc|lccn|ia|ISBN|OCLC|LCCN|IA)/([^/]*)(/.*)?"
+    path = r'/(isbn|oclc|lccn|ia|ISBN|OCLC|LCCN|IA)/([^/]*)(/.*)?'
 
     def GET(self, key, value, suffix):
         key = key.lower()
-        suffix = suffix or ""
+        suffix = suffix or ''
 
-        if key == "isbn":
+        if key == 'isbn':
             if len(value) == 13:
-                key = "isbn_13"
+                key = 'isbn_13'
             else:
-                key = "isbn_10"
-        elif key == "oclc":
-            key = "oclc_numbers"
-        elif key == "ia":
-            key = "ocaid"
+                key = 'isbn_10'
+        elif key == 'oclc':
+            key = 'oclc_numbers'
+        elif key == 'ia':
+            key = 'ocaid'
 
-        if key != 'ocaid': # example: MN41558ucmf_6
+        if key != 'ocaid':  # example: MN41558ucmf_6
             value = value.replace('_', ' ')
 
-        if web.ctx.encoding and web.ctx.path.endswith("." + web.ctx.encoding):
-            ext = "." + web.ctx.encoding
+        if web.ctx.encoding and web.ctx.path.endswith('.' + web.ctx.encoding):
+            ext = '.' + web.ctx.encoding
         else:
-            ext = ""
+            ext = ''
 
         if web.ctx.env.get('QUERY_STRING'):
             ext += '?' + web.ctx.env['QUERY_STRING']
@@ -379,27 +395,27 @@ class bookpage(delegate.page):
                 book = web.ctx.site.get(key)
                 return web.found(book.url(suffix))
 
-        q = {"type": "/type/edition", key: value}
+        q = {'type': '/type/edition', key: value}
         try:
             result = web.ctx.site.things(q)
             if result:
                 raise redirect(result[0], ext, suffix)
             elif key =='ocaid':
-                q = {"type": "/type/edition", 'source_records': 'ia:' + value}
+                q = {'type': '/type/edition', 'source_records': 'ia:' + value}
                 result = web.ctx.site.things(q)
                 if result:
                     raise redirect(result[0], ext, suffix)
-                q = {"type": "/type/volume", 'ia_id': value}
+                q = {'type': '/type/volume', 'ia_id': value}
                 result = web.ctx.site.things(q)
                 if result:
                     raise redirect(result[0], ext, suffix)
                 else:
-                    raise redirect("/books/ia:" + value, ext, suffix)
-            elif key.startswith("isbn"):
+                    raise redirect('/books/ia:' + value, ext, suffix)
+            elif key.startswith('isbn'):
                 ed_key = create_edition_from_amazon_metadata(value)
                 if ed_key:
                     raise web.seeother(ed_key)
-            web.ctx.status = "404 Not Found"
+            web.ctx.status = '404 Not Found'
             return render.notfound(web.ctx.path, create=False)
         except web.HTTPError:
             raise
@@ -409,9 +425,10 @@ class bookpage(delegate.page):
                 if ed_key:
                     raise web.seeother(ed_key)
 
-            logger.error("unexpected error", exc_info=True)
-            web.ctx.status = "404 Not Found"
+            logger.error('unexpected error', exc_info=True)
+            web.ctx.status = '404 Not Found'
             return render.notfound(web.ctx.path, create=False)
+
 
 delegate.media_types['application/rdf+xml'] = 'rdf'
 class rdf(delegate.mode):
@@ -421,15 +438,16 @@ class rdf(delegate.mode):
     def GET(self, key):
         page = web.ctx.site.get(key)
         if not page:
-            raise web.notfound("")
+            raise web.notfound('')
         else:
             from infogami.utils import template
             try:
                 result = template.typetemplate('rdf')(page)
             except:
-                raise web.notfound("")
+                raise web.notfound('')
             else:
-                return delegate.RawText(result, content_type="application/rdf+xml; charset=utf-8")
+                return delegate.RawText(result, content_type='application/rdf+xml; charset=utf-8')
+
 
 delegate.media_types[' application/atom+xml;profile=opds'] = 'opds'
 class opds(delegate.mode):
@@ -439,16 +457,17 @@ class opds(delegate.mode):
     def GET(self, key):
         page = web.ctx.site.get(key)
         if not page:
-            raise web.notfound("")
+            raise web.notfound('')
         else:
             from infogami.utils import template
             from openlibrary.plugins.openlibrary import opds
             try:
                 result = template.typetemplate('opds')(page, opds)
             except:
-                raise web.notfound("")
+                raise web.notfound('')
             else:
-                return delegate.RawText(result, content_type=" application/atom+xml;profile=opds")
+                return delegate.RawText(result, content_type=' application/atom+xml;profile=opds')
+
 
 delegate.media_types['application/marcxml+xml'] = 'marcxml'
 class marcxml(delegate.mode):
@@ -457,27 +476,27 @@ class marcxml(delegate.mode):
 
     def GET(self, key):
         page = web.ctx.site.get(key)
-
         if page is None or page.type.key != '/type/edition':
-            raise web.notfound("")
+            raise web.notfound('')
         else:
             from infogami.utils import template
             try:
                 result = template.typetemplate('marcxml')(page)
             except:
-                raise web.notfound("")
+                raise web.notfound('')
             else:
-                return delegate.RawText(result, content_type="application/marcxml+xml; charset=utf-8")
+                return delegate.RawText(result, content_type='application/marcxml+xml; charset=utf-8')
+
 
 delegate.media_types['text/x-yaml'] = 'yml'
 class _yaml(delegate.mode):
-    name = "view"
-    encoding = "yml"
+    name = 'view'
+    encoding = 'yml'
 
     def GET(self, key):
         d = self.get_data(key)
 
-        if web.input(text="false").text.lower() == "true":
+        if web.input(text='false').text.lower() == 'true':
             web.header('Content-Type', 'text/plain; charset=utf-8')
         else:
             web.header('Content-Type', 'text/x-yaml; charset=utf-8')
@@ -507,9 +526,10 @@ class _yaml(delegate.mode):
         import yaml
         return yaml.safe_load(data)
 
+
 class _yaml_edit(_yaml):
-    name = "edit"
-    encoding = "yml"
+    name = 'edit'
+    encoding = 'yml'
 
     def is_admin(self):
         u = delegate.context.user
@@ -523,8 +543,8 @@ class _yaml_edit(_yaml):
         try:
             d = self.get_data(key)
         except web.HTTPError as e:
-            if web.ctx.status.lower() == "404 not found":
-                d = {"key": key}
+            if web.ctx.status.lower() == '404 not found':
+                d = {'key': key}
             else:
                 raise
         return render.edit_yaml(key, self.dump(d))
@@ -552,45 +572,53 @@ class _yaml_edit(_yaml):
             add_flash_message('unknown action')
             return render.edit_yaml(key, i.body)
 
+
 def _get_user_root():
-    user_root = infogami.config.get("infobase", {}).get("user_root", "/user")
-    return web.rstrips(user_root, "/")
+    user_root = infogami.config.get('infobase', {}).get('user_root', '/user')
+    return web.rstrips(user_root, '/')
+
 
 def _get_bots():
-    bots = web.ctx.site.store.values(type="account", name="bot", value="true")
+    bots = web.ctx.site.store.values(type='account', name='bot', value='true')
     user_root = _get_user_root()
-    return [user_root + "/" + account['username'] for account in bots]
+    return [user_root + '/' + account['username'] for account in bots]
+
 
 def _get_members_of_group(group_key):
-    """Returns keys of all members of the group identifier by group_key.
-    """
+    """Returns keys of all members of the group identifier by group_key."""
     usergroup = web.ctx.site.get(group_key) or {}
-    return [m.key for m in usergroup.get("members", [])]
+    return [m.key for m in usergroup.get('members', [])]
+
 
 def can_write():
-    """Any user with bot flag set can write.
+    """
+    Any user with bot flag set can write.
     For backward-compatability, all admin users and people in api usergroup are also allowed to write.
     """
     user_key = delegate.context.user and delegate.context.user.key
-    bots = _get_members_of_group("/usergroup/api") + _get_members_of_group("/usergroup/admin") + _get_bots()
+    bots = _get_members_of_group('/usergroup/api') + _get_members_of_group('/usergroup/admin') + _get_bots()
     return user_key in bots
 
 # overwrite the implementation of can_write in the infogami API plugin with this one.
 api.can_write = can_write
 
+
 class Forbidden(web.HTTPError):
-    def __init__(self, msg=""):
-        web.HTTPError.__init__(self, "403 Forbidden", {}, msg)
+    def __init__(self, msg=''):
+        web.HTTPError.__init__(self, '403 Forbidden', {}, msg)
+
 
 class BadRequest(web.HTTPError):
-    def __init__(self, msg=""):
-        web.HTTPError.__init__(self, "400 Bad Request", {}, msg)
+    def __init__(self, msg=''):
+        web.HTTPError.__init__(self, '400 Bad Request', {}, msg)
+
 
 class new:
-    """API to create new author/edition/work/publisher/series.
-    """
+    """API to create new author/edition/work/publisher/series."""
+
     def prepare_query(self, query):
-        """Add key to query and returns the key.
+        """
+        Add key to query and returns the key.
         If query is a list multiple queries are returned.
         """
         if isinstance(query, list):
@@ -608,19 +636,19 @@ class new:
                 self.verify_types(q)
         else:
             if 'type' not in query:
-                raise BadRequest("Missing type")
+                raise BadRequest('Missing type')
             type = query['type']
             if isinstance(type, dict):
                 if 'key' not in type:
-                    raise BadRequest("Bad Type: " + simplejson.dumps(type))
+                    raise BadRequest('Bad Type: ' + simplejson.dumps(type))
                 type = type['key']
 
             if type not in ['/type/author', '/type/edition', '/type/work', '/type/series', '/type/publisher']:
-                raise BadRequest("Bad Type: " + simplejson.dumps(type))
+                raise BadRequest('Bad Type: ' + simplejson.dumps(type))
 
     def POST(self):
         if not can_write():
-            raise Forbidden("Permission Denied.")
+            raise Forbidden('Permission Denied.')
 
         try:
             query = simplejson.loads(web.data())
@@ -640,17 +668,17 @@ class new:
         except client.ClientException as e:
             raise BadRequest(str(e))
 
-        #graphite/statsd tracking of bot edits
+        # graphite/statsd tracking of bot edits
         user = delegate.context.user and delegate.context.user.key
         if user.lower().endswith('bot'):
             botname = user.replace('/people/', '', 1)
             botname = botname.replace('.', '-')
             key = 'ol.edits.bots.'+botname
             openlibrary.core.stats.increment(key)
-
         return simplejson.dumps(keys)
 
 api and api.add_hook('new', new)
+
 
 @public
 def changequery(query=None, **kw):
@@ -683,6 +711,7 @@ def get_recent_changes(*a, **kw):
     else:
         return _get_recentchanges(*a, **kw)
 
+
 @public
 def most_recent_change():
     if 'cache_most_recent' in infogami.config.features:
@@ -694,11 +723,14 @@ def most_recent_change():
     else:
         return get_recent_changes(limit=1)[0]
 
+
 def wget(url):
+    # TODO: get rid of this, use requests instead.
     try:
         return urllib.request.urlopen(url).read()
     except:
-        return ""
+        return ''
+
 
 @public
 def get_cover_id(key):
@@ -708,16 +740,17 @@ def get_cover_id(key):
     except (ValueError, IndexError, TypeError):
         return None
 
+
 local_ip = None
 class invalidate(delegate.page):
-    path = "/system/invalidate"
+    path = '/system/invalidate'
     def POST(self):
         global local_ip
         if local_ip is None:
             local_ip = socket.gethostbyname(socket.gethostname())
 
-        if web.ctx.ip != "127.0.0.1" and web.ctx.ip.rsplit(".", 1)[0] != local_ip.rsplit(".", 1)[0]:
-            raise Forbidden("Allowed only in the local network.")
+        if web.ctx.ip != '127.0.0.1' and web.ctx.ip.rsplit('.', 1)[0] != local_ip.rsplit('.', 1)[0]:
+            raise Forbidden('Allowed only in the local network.')
 
         data = simplejson.loads(web.data())
         if not isinstance(data, list):
@@ -725,7 +758,8 @@ class invalidate(delegate.page):
         for d in data:
             thing = client.Thing(web.ctx.site, d['key'], client.storify(d))
             client._run_hooks('on_new_version', thing)
-        return delegate.RawText("ok")
+        return delegate.RawText('ok')
+
 
 def save_error():
     t = datetime.datetime.utcnow()
@@ -742,8 +776,8 @@ def save_error():
     f.close()
 
     print('error saved to', path, file=web.debug)
-
     return name
+
 
 def internalerror():
     i = web.input(_method='GET', debug='false')
@@ -760,8 +794,9 @@ def internalerror():
 delegate.app.internalerror = internalerror
 delegate.add_exception_hook(save_error)
 
+
 class memory(delegate.page):
-    path = "/debug/memory"
+    path = '/debug/memory'
 
     def GET(self):
         import guppy
@@ -795,21 +830,22 @@ def is_bot():
     user_agent = web.ctx.env['HTTP_USER_AGENT'].lower()
     return any([bot in user_agent for bot in user_agent_bots])
 
+
 def setup_template_globals():
     web.template.Template.globals.update({
-        "sorted": sorted,
-        "zip": zip,
-        "tuple": tuple,
-        "isbn_13_to_isbn_10": isbn_13_to_isbn_10,
+        'sorted': sorted,
+        'zip': zip,
+        'tuple': tuple,
+        'isbn_13_to_isbn_10': isbn_13_to_isbn_10,
         'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
-        "NEWLINE": "\n",
-        "random": random.Random(),
+        'NEWLINE': '\n',
+        'random': random.Random(),
 
         # bad use of globals
-        "is_bot": is_bot,
-        "time": time,
-        "input": web.input,
-        "dumps": simplejson.dumps,
+        'is_bot': is_bot,
+        'time': time,
+        'input': web.input,
+        'dumps': simplejson.dumps,
     })
 
 
@@ -820,6 +856,7 @@ def setup_context_defaults():
         'user': None,
         'MAX_VISIBLE_BOOKS': 5
     })
+
 
 def setup():
     from openlibrary.plugins.openlibrary import (home, inlibrary, borrow_home, libraries,
@@ -841,7 +878,7 @@ def setup():
     from openlibrary.plugins.openlibrary import api
     delegate.app.add_processor(web.unloadhook(stats.stats_hook))
 
-    if infogami.config.get("dev_instance") is True:
+    if infogami.config.get('dev_instance') is True:
         from openlibrary.plugins.openlibrary import dev_instance
         dev_instance.setup()
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Relates to #2857

This is to get all the whitespace and quotation mark changes I'd make as part of this work out and merged in one go.

Double spaces between classes etc help me navigate the file faster, and are in PEP8 https://www.python.org/dev/peps/pep-0008/#blank-lines

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->