### PR TITLE
Fix "last edited by" link broken

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -764,6 +764,18 @@ class User(Thing):
         return "<User: %s>" % repr(self.key)
     __str__ = __repr__
 
+    def render_link(self, cls=None):
+        """
+        Generate an HTML link of this user
+        :param str cls: HTML class to add to the link
+        :rtype: str
+        """
+        extra_attrs = ''
+        if cls:
+            extra_attrs += 'class="%s" ' % cls
+        # Why nofollow?
+        return '<a rel="nofollow" href="%s" %s>%s</a>' % (self.key, extra_attrs, web.net.htmlquote(self.displayname))
+
 class List(Thing, ListMixin):
     """Class to represent /type/list objects in OL.
 

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -3531,8 +3531,8 @@ msgstr "Modifier cette template"
 #: openlibrary/macros/databarHistory.html:21
 #: openlibrary/macros/databarView.html:24
 #, python-format
-msgid "Last edited by <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
-msgstr "Modifié par <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+msgid "Last edited by %(author_link)s"
+msgstr "Modifié par %(author_link)s"
 
 #: openlibrary/macros/databarHistory.html:23
 #: openlibrary/macros/databarView.html:26

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -3323,7 +3323,7 @@ msgstr ""
 #: openlibrary/macros/databarHistory.html:21
 #: openlibrary/macros/databarView.html:24
 #, python-format
-msgid "Last edited by <a href=\"$author.key\" rel=\"nofollow\">%(authorname)s</a>"
+msgid "Last edited by %(author_link)s"
 msgstr ""
 
 #: openlibrary/macros/databarHistory.html:23

--- a/openlibrary/macros/databarHistory.html
+++ b/openlibrary/macros/databarHistory.html
@@ -14,7 +14,7 @@ $else:
     <div id="editInfo">
         $ author = get_recent_author(page)
         $if author:
-            <div class="brown smaller sansserif">$:_('Last edited by <a href="$author.key" rel="nofollow">%(authorname)s</a>', authorname=author.displayname)</div>
+            <div class="brown smaller sansserif">$:_('Last edited by %(author_link)s', author_link=author.render_link())</div>
         $else:
             <div class="brown smaller sansserif">$_("Last edited anonymously")</div>
         <div class="smallest gray sansserif">

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -17,7 +17,7 @@ $else:
         $else:
             $ author = get_recent_author(page)
         $if author:
-            <div class="brown smaller sansserif">$:_('Last edited by <a href="$author.key" rel="nofollow">%(authorname)s</a>', authorname=author.displayname)</div>
+            <div class="brown smaller sansserif">$:_('Last edited by %(author_link)s', author_link=author.render_link())</div>
         $else:
             <div class="brown smaller sansserif">$_("Last edited anonymously")</div>
         $if page.url:

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -79,7 +79,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                 <td class="timestamp"><a rel="nofollow" href="$v.key?v=$v.revision" title="$_('View revision %s', v.revision)">$datestr(v.created)</a></td>
                 <td class="timestamp">
                     $if v.author:
-                        $ author_link = '<a rel="nofollow" href="%s" class="truncate" title="%s">%s</a>' % (v.author.key, v.author.displayname, v.author.displayname)
+                        $ author_link = v.author.render_link(cls="truncate")
                     $elif v.ip and v.ip != "127.0.0.1":
                         $ author_link = '<a rel="nofollow" href="/recentchanges?ip=%s" title="%s">%s</a>' % (v.ip, _('an anonymous user'), v.ip)
                     $else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2973

### Technical
- created a util method to render an html link from a user object.

### Testing
- ✅ Tested user links are correct in top left:
  - http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain?lang=fr
  - http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain
- ✅ Tested user links are correct in bottom table:
  - http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain?lang=fr
  - http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain
- ✅ Tested user links are correct in history table:
  - http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain?lang=fr&m=history
  - http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain?m=history

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@tfmorris 