### PR TITLE
Librarian Permissions

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -74,7 +74,7 @@ class admin(delegate.page):
 
     GET = POST = delegate
 
-    def is_admin(self, librarians=False):
+    def is_admin(self):
         """Returns True if the current user is in admin usergroup."""
         return context.user and context.user.key in [m.key for m in web.ctx.site.get('/usergroup/admin').members]
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -41,10 +41,13 @@ def render_template(name, *a, **kw):
 
 admin_tasks = []
 
+
 def register_admin_page(path, cls, label=None, visible=True, librarians=False):
     label = label or cls.__name__
-    t = web.storage(path=path, cls=cls, label=label, visible=visible, librarians=librarians)
+    t = web.storage(path=path, cls=cls, label=label,
+                    visible=visible, librarians=librarians)
     admin_tasks.append(t)
+
 
 class admin(delegate.page):
     path = "/admin(?:/.*)?"
@@ -67,7 +70,8 @@ class admin(delegate.page):
         if not m:
             raise web.nomethod(cls=cls)
         else:
-            if self.is_admin() or (librarians and context.user and context.user.is_librarian()):
+            if (self.is_admin() or (librarians and context.user and
+                                    context.user.is_librarian())):
                 return m(*args)
             else:
                 return render.permission_denied(web.ctx.path, "Permission denied.")
@@ -161,9 +165,9 @@ class add_work_to_staff_picks:
             for ocaid in ocaids:
                 results[work_id][ocaid] = create_ol_subjects_for_ocaid(
                     ocaid, subjects=subjects)
-        
+
         return delegate.RawText(simplejson.dumps(results), content_type="application/json")
-                                
+
 
 class sync_ol_ia:
     def GET(self):

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -483,7 +483,8 @@ class SaveBookHelper:
         comment = formdata.pop('_comment', '')
 
         user = accounts.get_current_user()
-        delete = user and (user.is_admin() or user.is_librarian()) and formdata.pop('_delete', '')
+        delete = (user and (user.is_admin() or user.is_librarian()) and
+                  formdata.pop('_delete', ''))
 
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -483,7 +483,7 @@ class SaveBookHelper:
         comment = formdata.pop('_comment', '')
 
         user = accounts.get_current_user()
-        delete = user and user.is_admin() and formdata.pop('_delete', '')
+        delete = user and (user.is_admin() or user.is_librarian()) and formdata.pop('_delete', '')
 
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)
@@ -674,7 +674,7 @@ class SaveBookHelper:
     def _prevent_ocaid_deletion(self, edition):
         # Allow admins to modify ocaid
         user = accounts.get_current_user()
-        if user and user.is_admin():
+        if user and (user.is_admin() or user.is_librarian()):
             return
 
         # read ocaid from form data

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -7,13 +7,17 @@ from openlibrary.mocks.mock_infobase import MockSite
 def strip_nones(d):
     return dict((k, v) for k, v in d.items() if v is not None)
 
+def mock_user():
+    return type('MockUser', (object,), {
+        'is_admin': lambda slf: False,
+        'is_librarian': lambda slf: False,
+    })()
+
 class TestSaveBookHelper:
     def setup_method(self, method):
         web.ctx.site = MockSite()
 
     def test_authors(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         s = addbook.SaveBookHelper(None, None)
@@ -25,8 +29,6 @@ class TestSaveBookHelper:
         assert f({"authors": [{"type": "/type/author_role"}]}) == {}
 
     def test_editing_orphan_creates_work(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -51,8 +53,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/works/OL1W").title == "Original Edition Title"
 
     def test_never_create_an_orphan(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -83,8 +83,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL1W"
 
     def test_moving_orphan(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -109,8 +107,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL1W"
 
     def test_moving_orphan_ignores_work_edits(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -139,8 +135,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/works/OL1W").title == "Original Work Title"
 
     def test_editing_work(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -173,9 +167,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/books/OL1M").title == "Original Edition Title"
 
     def test_editing_edition(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
-
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -208,9 +199,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/books/OL1M").title == "Modified Edition Title"
 
     def test_editing_work_and_edition(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
-
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -243,8 +231,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/books/OL1M").title == "Modified Edition Title"
 
     def test_moving_edition(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -276,8 +262,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/books/OL1M").works[0].key == "/works/OL2W"
 
     def test_moving_edition_ignores_changes_to_work(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([
@@ -309,9 +293,6 @@ class TestSaveBookHelper:
         assert web.ctx.site.get("/works/OL1W").title == "Original Work Title"
 
     def test_moving_edition_to_new_work(self, monkeypatch):
-        def mock_user():
-            return type('MockUser', (object,), {'is_admin': lambda slf: False})()
-
         monkeypatch.setattr(accounts, "get_current_user", mock_user)
 
         web.ctx.site.save_many([

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -7,11 +7,13 @@ from openlibrary.mocks.mock_infobase import MockSite
 def strip_nones(d):
     return dict((k, v) for k, v in d.items() if v is not None)
 
+
 def mock_user():
     return type('MockUser', (object,), {
         'is_admin': lambda slf: False,
         'is_librarian': lambda slf: False,
     })()
+
 
 class TestSaveBookHelper:
     def setup_method(self, method):

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -141,7 +141,7 @@ window.q.push( function(){
 
         $:macros.EditButtons(comment=work.comment_)
 
-        $if ctx.user and ctx.user.is_admin():
+        $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
             <div class="adminOnly" style="position:absolute;top:20px;right:20px;"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete this book?')" id="deleteTop">$_("Delete Record")</button></div>
 
     </form>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -498,7 +498,7 @@ window.q.push(function() {
                                 <input type="hidden" name="edition--identifiers--${i}--value" value="$id.value"/>
                             </td>
                             $# Disable removing ocaid for regular users.
-                            $ admin_user = ctx.user and ctx.user.is_admin()
+                            $ admin_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
                             $if id.name == "ocaid" and not admin_user:
                                 <td></td>
                             $else:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -98,7 +98,7 @@ $def display_contributor(c):
 $:macros.Metatags(title=title_with_site, image=meta_cover_url, description=description)
 $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
-$if ctx.user and ctx.user.is_admin():
+$if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
   <!-- Don't need to translate admin only buttons (at least initially)-->
   <div class="admin-bar">
     $ work = page.works and page.works[0]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2329 - enables Librarians to perform operations like removing archive.org ID and syncing with Archive.org OLIDs.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
permissions related

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
As a librarian / non admin, try syncing an edition's `olid`s.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 