### PR TITLE
Add GET /works/OL1W/bookshelves.json API to get bookshelf counts

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -11,6 +11,12 @@ class Bookshelves(object):
         'Already Read': 3
     }
 
+    PRESET_BOOKSHELVES_JSON = {
+        'want_to_read': 1,
+        'currently_reading': 2,
+        'already_read': 3,
+    }
+
     @classmethod
     def summary(cls):
         return {

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -131,6 +131,17 @@ class work_bookshelves(delegate.page):
     path = r"/works/OL(\d+)W/bookshelves"
     encoding = "json"
 
+    @jsonapi
+    def GET(self, work_id):
+        from openlibrary.core.models import Bookshelves
+
+        result = {'counts': {}}
+        counts = Bookshelves.get_num_users_by_bookshelf_by_work_id(work_id)
+        for (shelf_name, shelf_id) in Bookshelves.PRESET_BOOKSHELVES_JSON.items():
+            result['counts'][shelf_name] = counts.get(shelf_id, 0)
+
+        return simplejson.dumps(result)
+
     def POST(self, work_id):
         from openlibrary.core.models import Bookshelves
 


### PR DESCRIPTION
Closes #2963 

### Technical
<!-- What should be noted about the implementation? -->
- [x] Publicly accessible endpoint `/works/OL1W/-/bookshelves.json` that returns count of books
  - turns out for JSON endpoints we _don't_ need the `/-/`, so this lives at  `/works/OL1W/bookshelves.json`
- [x] Response schema: `{ "counts": { [shelf_name]: number } }`

### Testing
- ✅ Shows all 0 for book not on any reading log
- ✅ After adding a book to want to read, count=1 for that field
- ✅ After adding a book to currently reading, count=1 for that field
- ✅ After adding a book to already read, count=1 for that field

### Evidence
![image](https://user-images.githubusercontent.com/6251786/73871253-87ed1580-481b-11ea-85c5-8acfff42b193.png)


### Stakeholders
@mekarpeles @seabelis 