### PR TITLE
906/fix/ux for anonymous user adding book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ htmlcov
 node_modules/
 .idea/
 venv/
+__pycache__
+.pytest_cache/

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -107,6 +107,9 @@ class MockSite:
         query.update(kw)
         self.save(query)
         return self.get(key)
+    
+    def can_write(self, key):
+        pass
 
     def _make_changeset(self, timestamp, kind, comment, data, changes, author=None):
         id = len(self.changesets)

--- a/openlibrary/plugins/openlibrary/dev_instance.py
+++ b/openlibrary/plugins/openlibrary/dev_instance.py
@@ -251,7 +251,7 @@ def add_missing_metadata():
     """
 
     logger.debug("Adding missing permissions")
-    for missing_permission in ["/permission", "/permission/loggedinusers"]:
+    for missing_permission in ("/permission", "/permission/loggedinusers"):
         missing_permission_thing = permission(missing_permission, 
                                               "/usergroup/everyone",
                                               "/usergroup/admin",
@@ -262,7 +262,7 @@ def add_missing_metadata():
         raise ValueError("permission not created")
 
     logger.debug("Adding missing root pages")
-    for root in ["/books", "/works", "/authors"]:
+    for root in ("/books", "/works", "/authors"):
         web.ctx.site.save(root_page(root))
 
 

--- a/openlibrary/plugins/openlibrary/dev_instance.py
+++ b/openlibrary/plugins/openlibrary/dev_instance.py
@@ -180,7 +180,9 @@ def load_sample_data():
 
 
 def start_debugger():
-    """ Attach debugger and immediately break into debugger """
+    """
+    Attach debugger and immediately break into debugger
+    """
 
     logger.debug("------------> ATTEMPTING TO ENABLE DEBUGGING <--------------")
     try:
@@ -195,8 +197,16 @@ def start_debugger():
     logger.debug("-----------------> DEBUGGING ENABLED <----------------------")
 
 
-def permission(key, readers, writers, admins):
-    """ Query for permission type \"thing\"s """
+def permission(key, reader, writer, admin):
+    """
+    Query for Thing with permission type
+    
+    :param str key: key for new Thing
+    :param str reader: key for usergroup capable of reading 
+    :param str writer: key for usergroup capable of writing 
+    :param str admin: key for admin usergroup
+    :returns: new Thing with type as permission
+    """
 
     def make_key(value):
         return {'key': value}
@@ -206,14 +216,20 @@ def permission(key, readers, writers, admins):
         'type': {
             'key': '/type/permission'
         },
-        'readers': [make_key(readers)],
-        'writers': [make_key(writers)],
-        'admins': [make_key(admins)]
+        'readers': [make_key(reader)],
+        'writers': [make_key(writer)],
+        'admins': [make_key(admin)]
     }
 
 
 def root_page(key):
-    """ Query for root page type \"thing\" """
+    """
+    Query for Thing with page type and permissions required of root pages
+
+    :param key: key for new Thing
+    :returns: Thing with page type and permissions required of root pages
+    """
+
     return {
         'key': key,
         'type': {
@@ -230,7 +246,9 @@ def root_page(key):
 
 @infogami.install_hook
 def add_missing_metadata():
-    """ Add missing /permission types and root pages """
+    """
+    Add missing /permission types and root pages
+    """
 
     logger.debug("Adding missing permissions")
     for missing_permission in ["/permission", "/permission/loggedinusers"]:
@@ -250,6 +268,8 @@ def add_missing_metadata():
 
 @infogami.install_hook
 def add_ol_unpriviliged_user():
-    """ Add unprivileged user for manual testing/debugging """
+    """
+    Add unprivileged user for manual testing/debugging
+    """
 
     pass

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -22,11 +22,11 @@ from openlibrary import accounts
 import logging
 
 import utils
-from .utils import render_template, fuzzy_find
+from openlibrary.plugins.upstream.utils import render_template, fuzzy_find
 
 from account import as_admin
 from openlibrary.plugins.recaptcha import recaptcha
-from . import spamcheck
+from openlibrary.plugins.upstream import spamcheck
 
 import six
 from six.moves import urllib

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -22,7 +22,7 @@ from openlibrary import accounts
 import logging
 
 import utils
-from utils import render_template, fuzzy_find
+from .utils import render_template, fuzzy_find
 
 from account import as_admin
 from openlibrary.plugins.recaptcha import recaptcha
@@ -144,6 +144,10 @@ class addbook(delegate.page):
         """Main user interface for adding a book to Open Library."""
 
         if not self.has_permission():
+            if not web.ctx.site.get_user():
+                #TODO: investigate adding flash message
+                # add_flash_message("error", "You must be logged in to add a book.")
+                return web.seeother("/account/login?redirect={}".format(self.path))
             return render_template("permission_denied", "/books/add", "Permission denied to add a book to Open Library.")
 
         i = web.input(work=None, author=None)
@@ -418,7 +422,8 @@ delegate.pages.pop('/addbook', None)
 delegate.pages.pop('/addauthor', None)
 
 
-class addbook(delegate.page):
+class addbook_redirect(delegate.page):
+    path = "/addbook"
     def GET(self):
         raise web.redirect("/books/add")
 

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -1,8 +1,11 @@
 """py.test tests for addbook"""
 import web
-from .. import addbook
+from collections import namedtuple
+
 from openlibrary import accounts
 from openlibrary.mocks.mock_infobase import MockSite
+from openlibrary.plugins.upstream import addbook, utils
+
 
 def strip_nones(d):
     return dict((k, v) for k, v in d.items() if v is not None)
@@ -348,3 +351,98 @@ class TestSaveBookHelper:
         assert new_work.title == "Original Edition Title"
         # Should ignore edits to work data
         assert web.ctx.site.get("/works/OL100W").title == "Original Work Title"
+
+
+class TestAddBook:
+    def setup_method(self, method):
+        web.ctx.site = MockSite()
+
+    def test_unpermitted_logged_in_user_cannot_add_book(self, monkeypatch):
+        nonlocal = {'render_template_permission_denied': False}
+
+        def mock_user():
+            return True
+
+        def mock_render_template(*args):
+            if len(args) > 0:
+                denied = (args[0] == "permission_denied")
+                nonlocal['render_template_permission_denied'] = denied
+
+        def mock_seeother(*args):
+            assert False
+
+        def mock_can_write(key):
+            return False
+
+        monkeypatch.setattr(web.ctx.site, "can_write", mock_can_write)
+        monkeypatch.setattr(web.ctx.site, "get_user", mock_user)
+        monkeypatch.setattr(addbook, "render_template", mock_render_template)
+        monkeypatch.setattr(web, "seeother", mock_seeother)
+
+        s = addbook.addbook()
+        s.GET()
+
+        assert nonlocal['render_template_permission_denied']
+
+    def test_unpermitted_anonymous_user_cannot_add_book(self, monkeypatch):
+        nonlocal = {'seeother_redirect_login_called_correctly': False}
+
+        def mock_anonymous_user():
+            return None
+
+        def mock_render_template(*args):
+            assert False, "should be unreachable given test setup"
+
+        def mock_seeother(*args):
+            if len(args) > 0:
+                path = addbook.addbook.path
+                denied = (args[0] == "/account/login?redirect={}".format(path))
+                nonlocal['seeother_redirect_login_called_correctly'] = denied
+
+        def mock_can_write(key):
+            return False
+
+        monkeypatch.setattr(web.ctx.site, "can_write", mock_can_write)
+        monkeypatch.setattr(web.ctx.site, "get_user", mock_anonymous_user)
+        monkeypatch.setattr(addbook, "render_template", mock_render_template)
+        monkeypatch.setattr(web, "seeother", mock_seeother)
+
+        s = addbook.addbook()
+        s.GET()
+
+        assert nonlocal['seeother_redirect_login_called_correctly']
+
+    def test_permitted_user_may_add_books(self, monkeypatch):
+        nonlocal = {'render_template_permission_granted': False}
+
+        def mock_anonymous_user():
+            assert False, "should be unreachable given test setup"
+
+        def mock_can_write(key):
+            return True
+
+        def mock_input(**kwargs):
+            return namedtuple("input", kwargs.keys())
+
+        def mock_recaptcha():
+            assert True, "called when rendering page"
+
+        def mock_render_template(path_arg, **kwargs):
+            #FIXME: this seems silly
+            path = addbook.addbook.path[1:]
+            nonlocal['render_template_permission_granted'] = (path == path_arg)
+
+        def mock_seeother(*args):
+            assert False, "should be unreachable given test setup"
+        
+        monkeypatch.setattr(web.ctx.site, "can_write", mock_can_write)
+        monkeypatch.setattr(web.ctx.site, "get_user", mock_anonymous_user)
+        monkeypatch.setattr(addbook, "render_template", mock_render_template)
+        monkeypatch.setattr(addbook, "get_recaptcha", mock_recaptcha)
+        monkeypatch.setattr(web, "input", mock_input)
+        monkeypatch.setattr(web, "seeother", mock_seeother)
+
+        s = addbook.addbook()
+        s.GET()
+
+        assert nonlocal['render_template_permission_granted']

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -358,7 +358,7 @@ class TestAddBook:
         web.ctx.site = MockSite()
 
     def test_unpermitted_logged_in_user_cannot_add_book(self, monkeypatch):
-        nonlocal = {'render_template_permission_denied': False}
+        _nonlocal = {'render_template_permission_denied': False}
 
         def mock_user():
             return True
@@ -366,7 +366,7 @@ class TestAddBook:
         def mock_render_template(*args):
             if len(args) > 0:
                 denied = (args[0] == "permission_denied")
-                nonlocal['render_template_permission_denied'] = denied
+                _nonlocal['render_template_permission_denied'] = denied
 
         def mock_seeother(*args):
             assert False
@@ -382,10 +382,10 @@ class TestAddBook:
         s = addbook.addbook()
         s.GET()
 
-        assert nonlocal['render_template_permission_denied']
+        assert _nonlocal['render_template_permission_denied']
 
     def test_unpermitted_anonymous_user_cannot_add_book(self, monkeypatch):
-        nonlocal = {'seeother_redirect_login_called_correctly': False}
+        _nonlocal = {'seeother_redirect_login_called_correctly': False}
 
         def mock_anonymous_user():
             return None
@@ -397,7 +397,7 @@ class TestAddBook:
             if len(args) > 0:
                 path = addbook.addbook.path
                 denied = (args[0] == "/account/login?redirect={}".format(path))
-                nonlocal['seeother_redirect_login_called_correctly'] = denied
+                _nonlocal['seeother_redirect_login_called_correctly'] = denied
 
         def mock_can_write(key):
             return False
@@ -410,10 +410,10 @@ class TestAddBook:
         s = addbook.addbook()
         s.GET()
 
-        assert nonlocal['seeother_redirect_login_called_correctly']
+        assert _nonlocal['seeother_redirect_login_called_correctly']
 
     def test_permitted_user_may_add_books(self, monkeypatch):
-        nonlocal = {'render_template_permission_granted': False}
+        _nonlocal = {'render_template_permission_granted': False}
 
         def mock_anonymous_user():
             assert False, "should be unreachable given test setup"
@@ -430,7 +430,7 @@ class TestAddBook:
         def mock_render_template(path_arg, **kwargs):
             #FIXME: this seems silly
             path = addbook.addbook.path[1:]
-            nonlocal['render_template_permission_granted'] = (path == path_arg)
+            _nonlocal['render_template_permission_granted'] = (path == path_arg)
 
         def mock_seeother(*args):
             assert False, "should be unreachable given test setup"
@@ -445,4 +445,4 @@ class TestAddBook:
         s = addbook.addbook()
         s.GET()
 
-        assert nonlocal['render_template_permission_granted']
+        assert _nonlocal['render_template_permission_granted']

--- a/openlibrary/templates/permission_denied.html
+++ b/openlibrary/templates/permission_denied.html
@@ -14,12 +14,12 @@ $var title: Permission Denied
 $if not ctx.user:
     $if path == "/books/add":
         <p>
-            Only logged users are allowed to add records on Open Library.
+            Only logged in users are allowed to add records on Open Library.
             Please <a href="/account/login?redirect=$path">log in</a> to add a book.
         </p>
     $elif path.startswith("/books/") or path.startswith("/works/") or path.startswith("/authors/"):
         <p>
-            Only logged users are allowed to modify records on Open Library.
+            Only logged in users are allowed to modify records on Open Library.
             Please <a href="/account/login?redirect=$path">log in</a> to edit this page.
         </p>
     $else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #906, though I think there may be a few more things to try and test. I would like to ideally set up an integration test for the flows through `/books/add` and `/addbook` just to be thorough.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix for UX when attempting to add a book as an anonymous user.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
It may be necessary to enable the `dev_instance` flag in `openlibrary.yml` in order to 
add missing permissions and root pages for editing those permissions to match the
environment in production. Please see the changes in `openlibrary/plugins/openlibrary/dev_isntance.py`. These were necessary to complete this fix.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Anonymous user navigating to `/addbook`:
![anonymous user at home page](https://user-images.githubusercontent.com/6620882/74013570-693d6a80-4952-11ea-96bb-f870759c4691.png)

Anonymous user redirected to `/account/login` with redirect path:
![anonymous user add book attempt](https://user-images.githubusercontent.com/6620882/74013574-6b072e00-4952-11ea-93c4-520403c30685.png)

Anonymous user post log in at `/books/add`:
![post log in user add book](https://user-images.githubusercontent.com/6620882/74013580-6cd0f180-4952-11ea-9068-ed11180a3f5d.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->