### PR TITLE
Remove undefined name: solr_src_host

### DIFF
--- a/openlibrary/solr/inside/index_gevent.py
+++ b/openlibrary/solr/inside/index_gevent.py
@@ -256,7 +256,7 @@ def run_find_item():
 
         body = None
         if False:
-            url = 'http://' + solr_src_host + '/solr/inside/select?wt=json&rows=10&q=ia:' + ia
+            url = 'http://' + solr_host + '/solr/inside/select?wt=json&rows=10&q=ia:' + ia
             response = json.load(urllib.request.urlopen(url))['response']
             if response['numFound']:
                 doc = response['docs'][0]


### PR DESCRIPTION
`solr_src_host` is defined on line 36 and commented out so use `solr_host` defined with the same value on line 37.

This code is under `if False:` so can safely be ignored.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->