### PR TITLE
remove unsused get_library() reference errors

### DIFF
--- a/openlibrary/templates/borrow_admin.html
+++ b/openlibrary/templates/borrow_admin.html
@@ -212,17 +212,6 @@ ul.inner {
         <h3>You</h3>
         <ul>
             <li>You are <a href="$ctx.user.key" title="$ctx.user.key">$ctx.user.displayname</a></li>
-            <li>Your IP is <span class="small">$user_ip</li>
-            <li>
-                $if "inlibrary" in ctx.features:
-                    $ lib = get_library()
-                    $if lib:
-                        In Library: <a href="$lib.key">$lib.name</a>
-                    $else:
-                        <i>You are not in a Library</i>
-                $else:
-                    <i>You are not in a Library</i>
-            </li>
         </ul>
     </div>
 

--- a/openlibrary/templates/borrow_admin_no_update.html
+++ b/openlibrary/templates/borrow_admin_no_update.html
@@ -27,22 +27,6 @@ $ available_loans = page.get_available_loans()
         </p>
 
         <p>
-          IP address: $user_ip
-        </p>
-
-        <p>
-          you are in library? (inlibrary flag set):
-          $if "inlibrary" in ctx.features:
-             yes
-          $else:
-             no
-        </p>
-
-        <p>
-          which library: $get_library()
-        </p>
-
-        <p>
           work subjects: $page.works[0].get_subjects()
         </p>
 

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -56,8 +56,6 @@ $if books and books.works:
 $ description = _("Author of %(book_titles)s", book_titles=book_list_excerpt)
 $putctx("description", description)
 
-$ library = (get_library() if 'inlibrary' in ctx.features else None)
-
 $add_metatag(property="og:title", content=title_with_site)
 $add_metatag(property="og:type", content="books.author")
 $add_metatag(property="og:image", content=meta_photo_url)


### PR DESCRIPTION
relates to #2955

<!-- What issue does this PR close? -->

https://dev.openlibrary.org/authors/OL18524A/G._K._Chesterton

gives an error with the code from #2955 
```
/opt/openlibrary/deploys/openlibrary/openlibrary/openlibrary/templates/type/author/view.html: error in processing template: NameError: global name 'get_library' is not defined (falling back to default template
```
Easy fix is to remove the `library` variable which is not used anywhere on that page.
This PR does that.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

