### PR TITLE
Handle and show full Infogami error messages

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -2,6 +2,7 @@
 """
 
 from infogami.plugins.api.code import add_hook
+from infogami.infobase.client import ClientException
 
 from openlibrary.plugins.openlibrary.code import can_write
 from openlibrary.catalog.marc.marc_binary import MarcBinary, MarcException
@@ -125,6 +126,8 @@ class importapi:
             return json.dumps(reply)
         except add_book.RequiredField as e:
             return self.error('missing-required-field', str(e))
+        except ClientException as e:
+            return self.error('bad-request', **json.loads(e.json))
 
     def reject_non_book_marc(self, marc_record, **kwargs):
         details = 'Item rejected'
@@ -405,6 +408,7 @@ class ils_search:
         # step 4: format the result
         d = self.format_result(matches, auth_header, keys)
         return json.dumps(d)
+
 
     def error(self, reason):
         d = json.dumps({ "status" : "error", "reason" : reason})


### PR DESCRIPTION
Example now:
```
<Response [400]>
{"at": {"property": "lc_classifications", "key": "/books/OL31M"}, "success": false, "error": "bad_data", 
"message": "expected list, found atom", "error_code": "bad-request", "value": "PN1995.9.A26N37 1990"}
```
Prior to this PR this error was a unhandled server error, with HTML only
debug mode if ?debug=true was used. Useless html page otherwise.

Part of investigation relating to #2966 

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->