### PR TITLE
Prepare coverstore/warc.py for Python 3

### DIFF
--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -88,8 +88,12 @@ def resize_image(image, size):
     """Resizes image to specified size while making sure that aspect ratio is maintained."""
     # from PIL
     x, y = image.size
-    if x > size[0]: y = max(y * size[0] // x, 1); x = size[0]
-    if y > size[1]: x = max(x * size[1] // y, 1); y = size[1]
+    if x > size[0]:
+        y = max(y * size[0] // x, 1)
+        x = size[0]
+    if y > size[1]:
+        x = max(x * size[1] // y, 1)
+        y = size[1]
     size = x, y
 
     return image.resize(size, Image.ANTIALIAS)

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -61,9 +61,8 @@ def write_image(data, prefix):
         os.makedirs(dirname)
     try:
         # save original image
-        f = open(path_prefix + '.jpg', 'w')
-        f.write(data)
-        f.close()
+        with open(path_prefix + '.jpg', 'wb') as f:
+            f.write(data)
 
         img = Image.open(StringIO(data))
         if img.mode != 'RGB':

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -88,8 +88,8 @@ def resize_image(image, size):
     """Resizes image to specified size while making sure that aspect ratio is maintained."""
     # from PIL
     x, y = image.size
-    if x > size[0]: y = max(y * size[0] / x, 1); x = size[0]
-    if y > size[1]: x = max(x * size[1] / y, 1); y = size[1]
+    if x > size[0]: y = max(y * size[0] // x, 1); x = size[0]
+    if y > size[1]: x = max(x * size[1] // y, 1); y = size[1]
     size = x, y
 
     return image.resize(size, Image.ANTIALIAS)

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -106,17 +106,12 @@ def find_image_path(filename):
 def read_file(path):
     if ':' in path:
         path, offset, size = path.rsplit(':', 2)
-        offset = int(offset)
-        size = int(size)
-        f = open(path)
-        f.seek(offset)
-        data = f.read(size)
-        f.close()
-    else:
-        f = open(path)
-        data = f.read()
-        f.close()
-    return data
+        with open(path, 'rb') as f:
+            f.seek(int(offset))
+            return f.read(int(size))
+    with open(path, 'rb') as f:
+        return f.read()
+
 
 def read_image(d, size):
     if size:

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -3,12 +3,12 @@ from __future__ import print_function
 
 import datetime
 import os
+from io import BytesIO
 
 try:
     from PIL import Image
 except ImportError:
     import Image
-from six import StringIO
 import web
 
 from openlibrary.coverstore import config, db
@@ -64,7 +64,7 @@ def write_image(data, prefix):
         with open(path_prefix + '.jpg', 'wb') as f:
             f.write(data)
 
-        img = Image.open(StringIO(data))
+        img = Image.open(BytesIO(data))
         if img.mode != 'RGB':
             img = img.convert('RGB')
 

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -37,14 +37,14 @@ def test_write_image(prefix, path, image_dir):
     assert _exists(prefix + '-M.jpg')
     assert _exists(prefix + '-L.jpg')
 
-    assert open(coverlib.find_image_path(prefix + '.jpg')).read() == data
+    assert open(coverlib.find_image_path(prefix + '.jpg') 'rb').read() == data
 
 def test_bad_image(image_dir):
     prefix = config.data_root + '/bad'
-    assert coverlib.write_image('', prefix) == None
+    assert coverlib.write_image(b'', prefix) is None
 
     prefix = config.data_root + '/bad'
-    assert coverlib.write_image('not an image', prefix) == None
+    assert coverlib.write_image(b'not an image', prefix) is None
 
 def test_resize_image_aspect_ratio():
     """make sure the aspect-ratio is maintained"""

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -37,7 +37,7 @@ def test_write_image(prefix, path, image_dir):
     assert _exists(prefix + '-M.jpg')
     assert _exists(prefix + '-L.jpg')
 
-    assert open(coverlib.find_image_path(prefix + '.jpg') 'rb').read() == data
+    assert open(coverlib.find_image_path(prefix + '.jpg'), 'rb').read() == data
 
 def test_bad_image(image_dir):
     prefix = config.data_root + '/bad'

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -66,46 +66,45 @@ def test_resize_image_aspect_ratio():
 def test_serve_file(image_dir):
     path = static_dir + "/logos/logo-en.png"
 
-    assert coverlib.read_file('/dev/null') == ''
-    assert coverlib.read_file(path) == open(path).read()
+    assert coverlib.read_file('/dev/null') == b''
+    assert coverlib.read_file(path) == open(path, "rb").read()
 
-    assert coverlib.read_file(path + ":10:20") == open(path).read()[10:10+20]
+    assert coverlib.read_file(path + ":10:20") == open(path, "rb").read()[10:10+20]
 
 def test_server_image(image_dir):
     def write(filename, data):
-        f = open(join(config.data_root, filename), 'w')
-        f.write(data)
-        f.close()
+        with open(join(config.data_root, filename), 'wb') as f:
+            f.write(data)
 
     def do_test(d):
         def serve_image(d, size):
-            return "".join(coverlib.read_image(d, size))
+            return b"".join(coverlib.read_image(d, size))
 
-        assert serve_image(d, '') == 'main image'
-        assert serve_image(d, None) == 'main image'
+        assert serve_image(d, '') == b'main image'
+        assert serve_image(d, None) == b'main image'
 
-        assert serve_image(d, 'S') == 'S image'
-        assert serve_image(d, 'M') == 'M image'
-        assert serve_image(d, 'L') == 'L image'
+        assert serve_image(d, 'S') == b'S image'
+        assert serve_image(d, 'M') == b'M image'
+        assert serve_image(d, 'L') == b'L image'
 
-        assert serve_image(d, 's') == 'S image'
-        assert serve_image(d, 'm') == 'M image'
-        assert serve_image(d, 'l') == 'L image'
+        assert serve_image(d, 's') == b'S image'
+        assert serve_image(d, 'm') == b'M image'
+        assert serve_image(d, 'l') == b'L image'
 
     # test with regular images
-    write('localdisk/a.jpg', 'main image')
-    write('localdisk/a-S.jpg', 'S image')
-    write('localdisk/a-M.jpg', 'M image')
-    write('localdisk/a-L.jpg', 'L image')
+    write('localdisk/a.jpg', b'main image')
+    write('localdisk/a-S.jpg', b'S image')
+    write('localdisk/a-M.jpg', b'M image')
+    write('localdisk/a-L.jpg', b'L image')
 
     d = web.storage(id=1, filename='a.jpg', filename_s='a-S.jpg', filename_m='a-M.jpg', filename_l='a-L.jpg')
     do_test(d)
 
     # test with offsets
-    write('items/covers_0000/covers_0000_00.tar', 'xxmain imagexx')
-    write('items/s_covers_0000/s_covers_0000_00.tar', 'xxS imagexx')
-    write('items/m_covers_0000/m_covers_0000_00.tar', 'xxM imagexx')
-    write('items/l_covers_0000/l_covers_0000_00.tar', 'xxL imagexx')
+    write('items/covers_0000/covers_0000_00.tar', b'xxmain imagexx')
+    write('items/s_covers_0000/s_covers_0000_00.tar', b'xxS imagexx')
+    write('items/m_covers_0000/m_covers_0000_00.tar', b'xxM imagexx')
+    write('items/l_covers_0000/l_covers_0000_00.tar', b'xxL imagexx')
 
     d = web.storage(
         id=1,

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -78,7 +78,7 @@ def test_server_image(image_dir):
 
     def do_test(d):
         def serve_image(d, size):
-            return "".join(str(x) for x in coverlib.read_image(d, size))
+            return "".join(coverlib.read_image(d, size).decode('utf-8'))
 
         assert serve_image(d, '') == 'main image'
         assert serve_image(d, None) == 'main image'

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -78,18 +78,18 @@ def test_server_image(image_dir):
 
     def do_test(d):
         def serve_image(d, size):
-            return b"".join(coverlib.read_image(d, size))
+            return "".join(str(x) for x in coverlib.read_image(d, size))
 
-        assert serve_image(d, '') == b'main image'
-        assert serve_image(d, None) == b'main image'
+        assert serve_image(d, '') == 'main image'
+        assert serve_image(d, None) == 'main image'
 
-        assert serve_image(d, 'S') == b'S image'
-        assert serve_image(d, 'M') == b'M image'
-        assert serve_image(d, 'L') == b'L image'
+        assert serve_image(d, 'S') == 'S image'
+        assert serve_image(d, 'M') == 'M image'
+        assert serve_image(d, 'L') == 'L image'
 
-        assert serve_image(d, 's') == b'S image'
-        assert serve_image(d, 'm') == b'M image'
-        assert serve_image(d, 'l') == b'L image'
+        assert serve_image(d, 's') == 'S image'
+        assert serve_image(d, 'm') == 'M image'
+        assert serve_image(d, 'l') == 'L image'
 
     # test with regular images
     write('localdisk/a.jpg', b'main image')

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -26,7 +26,7 @@ def image_dir(tmpdir):
 @pytest.mark.parametrize('prefix, path', image_formats)
 def test_write_image(prefix, path, image_dir):
     """Test writing jpg, gif and png images"""
-    data = open(join(static_dir, path)).read()
+    data = open(join(static_dir, path), 'rb').read()
     assert coverlib.write_image(data, prefix) is not None
 
     def _exists(filename):

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -112,17 +112,15 @@ def read_file(path, offset, size, chunk=50*1024):
         >>> len("".join(read_file('/dev/urandom', 100, 10000)))
         10000
     """
-    f = open(path)
-    f.seek(offset)
-    while size:
-        data = f.read(min(chunk, size))
-        size -= len(data)
-        if data:
-            yield data
-        else:
-            f.close()
-            raise IOError("file truncated")
-    f.close()
+    with open(path, "rb") as f:
+        f.seek(offset)
+        while size:
+            data = f.read(min(chunk, size))
+            size -= len(data)
+            if data:
+                yield data
+            else:
+                raise IOError("file truncated")
 
 
 def rm_f(filename):

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -109,7 +109,7 @@ def changequery(url, **kw):
 def read_file(path, offset, size, chunk=50*1024):
     """Returns an iterator over file data at specified offset and size.
 
-        >>> len("".join(read_file('/dev/urandom', 100, 10000)))
+        >>> len(b"".join(read_file('/dev/urandom', 100, 10000)))
         10000
     """
     with open(path, "rb") as f:

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -284,7 +284,7 @@ class WARCWriter:
         """Writes a record into the WARC file.
         Assumes that data_length and other attributes are correctly set in record.header.
         """
-        self.file.write(record.get_header().encode('utf-8'))
+        self.file.write(str(record.get_header()).encode('utf-8'))
         offset = self.file.tell()
         self.file.write(record.get_data().encode('utf-8'))
         self.file.write(CRLF.encode('utf-8') + CRLF.encode('utf-8'))

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -41,7 +41,7 @@ class WARCReader:
             if header is None:
                 break
             yield LazyWARCRecord(self._file, self._file.tell(), header)
-            self._file.seek(int(header.data_length), 1)
+            self._file.seek(int(header.data_length.decode('utf-8')), 1)
             consume_crlf()
             consume_crlf()
 
@@ -49,7 +49,7 @@ class WARCReader:
         """Reads the header of a record from the WARC file."""
         def consume_crlf():
             line = self._file.readline()
-            assert line == CRLF
+            assert line == CRLF.encode('utf-8')
 
         line = self._file.readline()
         if not line:

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -20,6 +20,8 @@ class WARCReader:
     >>> f = BytesIO()
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo")
     >>> r2 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "bar")
+    >>> str(r2)
+    'WARCRecord()'
     >>> w = WARCWriter(f)
     >>> _ = w.write(r1)
     >>> _ = w.write(r2)
@@ -59,7 +61,7 @@ class WARCReader:
         tokens = line.strip().split()
         warc_id, data_length, record_type, subject_uri, creation_date, record_id, content_type = tokens
         header = WARCHeader(warc_id,
-            int(data_length), record_type, subject_uri,
+            data_length, record_type, subject_uri,
             creation_date, record_id, content_type, {})
 
         while True:

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -10,7 +10,7 @@ from six.moves.http_client import HTTPConnection
 from six.moves.urllib.parse import urlparse
 
 WARC_VERSION = "0.10"
-CRLF = "\r\n"
+CRLF = b"\r\n"
 
 class WARCReader:
     """Reader to read records from a warc file.
@@ -284,7 +284,7 @@ class WARCWriter:
         """Writes a record into the WARC file.
         Assumes that data_length and other attributes are correctly set in record.header.
         """
-        self.file.write(str(record.get_header()))
+        self.file.write(record.get_header())
         offset = self.file.tell()
         self.file.write(record.get_data())
         self.file.write(CRLF + CRLF)

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -62,7 +62,7 @@ class WARCReader:
             creation_date, record_id, content_type, {})
 
         while True:
-            line = self._file.readline()
+            line = self._file.readline().decode('utf-8')
             if line == CRLF:
                 break
             k, v = line.strip().split(':', 1)

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -10,7 +10,7 @@ from six.moves.http_client import HTTPConnection
 from six.moves.urllib.parse import urlparse
 
 WARC_VERSION = "0.10"
-CRLF = b"\r\n"
+CRLF = "\r\n"
 
 class WARCReader:
     """Reader to read records from a warc file.

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -42,7 +42,7 @@ class WARCReader:
             if header is None:
                 break
             yield LazyWARCRecord(self._file, self._file.tell(), header)
-            self._file.seek(int(bytes(header.data_length).decode('utf-8')), 1)
+            self._file.seek(int(bytes(header.data_length, 'utf-8').decode('utf-8')), 1)
             consume_crlf()
             consume_crlf()
 

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -21,7 +21,7 @@ class WARCReader:
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo")
     >>> r2 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "bar")
     >>> str(r2)
-    'WARCRecord()'
+    'WARC/0.10 3 resource subject_uri ... image/jpeg\r\nhello: world\r\n\r\nbar'
     >>> w = WARCWriter(f)
     >>> _ = w.write(r1)
     >>> _ = w.write(r2)

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -42,7 +42,7 @@ class WARCReader:
             if header is None:
                 break
             yield LazyWARCRecord(self._file, self._file.tell(), header)
-            self._file.seek(int(ensure_text(header.data_length)), 1)
+            self._file.seek(int(bytes(header.data_length).decode('utf-8')), 1)
             consume_crlf()
             consume_crlf()
 

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -6,6 +6,7 @@ http://archive-access.sourceforge.net/warc/warc_file_format-0.10.html
 
 import datetime
 
+from six import ensure_text
 from six.moves.http_client import HTTPConnection
 from six.moves.urllib.parse import urlparse
 
@@ -41,7 +42,7 @@ class WARCReader:
             if header is None:
                 break
             yield LazyWARCRecord(self._file, self._file.tell(), header)
-            self._file.seek(int(header.data_length.decode('utf-8')), 1)
+            self._file.seek(int(ensure_text(header.data_length)), 1)
             consume_crlf()
             consume_crlf()
 

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -284,10 +284,10 @@ class WARCWriter:
         """Writes a record into the WARC file.
         Assumes that data_length and other attributes are correctly set in record.header.
         """
-        self.file.write(record.get_header())
+        self.file.write(record.get_header().encode('utf-8'))
         offset = self.file.tell()
-        self.file.write(record.get_data())
-        self.file.write(CRLF + CRLF)
+        self.file.write(record.get_data().encode('utf-8'))
+        self.file.write(CRLF.encode('utf-8') + CRLF.encode('utf-8'))
         self.file.flush()
         return offset
 

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -22,7 +22,7 @@ class WARCReader:
     >>> w = WARCWriter(f)
     >>> _ = w.write(r1)
     >>> _ = w.write(r2)
-    >>> f.seek(0)
+    >>> _ = f.seek(0)
     >>> reader = WARCReader(f)
     >>> records = list(reader.read())
     >>> records == [r1, r2]

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -4,9 +4,10 @@ Reader and writer for WARC file format version 0.10.
 http://archive-access.sourceforge.net/warc/warc_file_format-0.10.html
 """
 
-import urllib
-import httplib
 import datetime
+
+from six.moves.http_client import HTTPConnection
+from six.moves.urllib.parse import urlparse
 
 WARC_VERSION = "0.10"
 CRLF = "\r\n"
@@ -111,7 +112,7 @@ class HTTPFile:
 
     def read(self, size):
         protocol, host, port, path = self.urlsplit(self.url)
-        conn = httplib.HTTPConnection(host, port)
+        conn = HTTPConnection(host, port)
         headers = {'Range': 'bytes=%d-%d' % (self.offset, self.offset + size - 1)}
         conn.request('GET', path, None, headers)
         response = conn.getresponse()
@@ -123,13 +124,16 @@ class HTTPFile:
         """Splits url into protocol, host, port and path.
 
             >>> f = HTTPFile('')
+            >>> f.urlsplit("http://www.google.com")
+            ('http', 'www.google.com', None, '')
             >>> f.urlsplit("http://www.google.com/search?q=hello")
             ('http', 'www.google.com', None, '/search?q=hello')
+            >>> f.urlsplit("http://www.google.com:80/search?q=hello")
+            ('http', 'www.google.com', 80, '/search?q=hello')
         """
-        protocol, rest = urllib.splittype(url)
-        hostport, path = urllib.splithost(rest)
-        host, port = urllib.splitport(hostport)
-        return protocol, host, port, path
+        p = urlparse(url)
+        fullpath = "?".join((p.path, p.query)) if (p.path or p.query) else ""
+        return p.scheme, p.hostname, p.port, fullpath
 
 class WARCHeader:
     r"""WARCHeader class represents the header in the WARC file format.

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -15,8 +15,8 @@ CRLF = "\r\n"
 class WARCReader:
     """Reader to read records from a warc file.
 
-    >>> from six import StringIO
-    >>> f = StringIO()
+    >>> from io import BytesIO
+    >>> f = BytesIO()
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo")
     >>> r2 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "bar")
     >>> w = WARCWriter(f)

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -20,7 +20,7 @@ class WARCReader:
     >>> f = BytesIO()
     >>> r1 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "foo")
     >>> r2 = WARCRecord("resource", "subject_uri", "image/jpeg", {"hello": "world"}, "bar")
-    >>> str(r2)
+    >>> str(r2)  # doctest: +NORMALIZE_WHITESPACE
     'WARC/0.10 3 resource subject_uri ... image/jpeg\r\nhello: world\r\n\r\nbar'
     >>> w = WARCWriter(f)
     >>> _ = w.write(r1)

--- a/openlibrary/coverstore/warc.py
+++ b/openlibrary/coverstore/warc.py
@@ -42,7 +42,7 @@ class WARCReader:
             if header is None:
                 break
             yield LazyWARCRecord(self._file, self._file.tell(), header)
-            self._file.seek(int(bytes(header.data_length, 'utf-8').decode('utf-8')), 1)
+            self._file.seek(int(header.data_length), 1)
             consume_crlf()
             consume_crlf()
 
@@ -59,7 +59,7 @@ class WARCReader:
         tokens = line.strip().split()
         warc_id, data_length, record_type, subject_uri, creation_date, record_id, content_type = tokens
         header = WARCHeader(warc_id,
-            data_length, record_type, subject_uri,
+            int(data_length), record_type, subject_uri,
             creation_date, record_id, content_type, {})
 
         while True:


### PR DESCRIPTION
Some utility functions were removed from urllib in Python 3.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->