### PR TITLE
Travis CI: Run make lint on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
+os: linux
 dist: bionic
 language: python
-matrix:
+jobs:
   include:
     - name: “Python 2.7 on xenial”
       python: "2.7"
       dist: xenial
     - name: “Python 2.7 on bionic”
       python: "2.7"
+    - name: “Python 3.8 make lint only”
+      install:
+        - pip install flake8
+        - make lint
+      script: true
     - name: “Python 3.8 on bionic”
       python: "3.8"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
     - name: “Python 3.8 on bionic”
       python: "3.8"
   allow_failures:
-    - python: "3.8"
+    - name: “Python 3.8 on bionic”
 install:
   - pip install flake8
   - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ jobs:
     - name: “Python 2.7 on bionic”
       python: "2.7"
     - name: “Python 3.8 make lint only”
+      python: "3.8"
       install:
         - pip install flake8
         - make lint


### PR DESCRIPTION
This will ensure that PRs do not introduce new Python 3 errors.  Travis CI's current Python 3 run is done in __allow_failures__ mode so a PR can add a Py3-only syntax error without warning.  This PR adds a quick (< 1 minute) check to avoid such breakage.

A partial solution to #2300 and #3011

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->