### PR TITLE
cmp parameter was removed from sorted() in Python 3

### DIFF
--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -1,16 +1,15 @@
 from __future__ import print_function
 # lookup MARC records and show details on the web
-from catalog.read_rc import read_rc
-from catalog.get_ia import get_data
-from catalog.marc.build_record import build_record
-from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
-from openlibrary.catalog.utils import cmp
+from openlibrary.catalog.read_rc import read_rc
+from openlibrary.catalog.get_ia import get_data
+from openlibrary.catalog.marc.build_record import build_record
+from openlibrary.catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
 import re
 import sys
 import os.path
 import web
-from catalog.amazon.other_editions import find_others
-from catalog.utils import strip_count
+from openlibrary.catalog.amazon.other_editions import find_others
+from openlibrary.catalog.utils import strip_count
 
 import six
 
@@ -64,7 +63,7 @@ def counts_html(v):
     sep = '<br>' if lens and max(lens) > 20 else ' '
     for i, loc in v:
         count.setdefault(i, []).append(loc)
-    s = sorted(count.iteritems(), cmp=lambda x,y: cmp(len(y[1]), len(x[1]) ))
+    s = sorted(count.items(), key=lambda x: len(x[1]), reverse=True)
     s = strip_count(s)
     return sep.join('<b>%d</b>: <span title="%s">%s</span>' % (len(loc), repr(loc), value if value else '<em>empty</em>') for value, loc in s)
 
@@ -106,7 +105,7 @@ def show_locs(locs, isbn):
     for loc, rec in recs:
         s = loc[:loc.find('/')]
         ret += '<li><a href="http://openlibrary.org/show-marc/%s">%s</a>' % (loc, s)
-        keys.update([k for k in rec.keys()])
+        keys.update([k for k in rec])
         for f in 'uri':
             if f in rec:
                 del rec[f]

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -167,7 +167,7 @@ def match_with_bad_chars(a, b):
     if a == b:
         return True
     def drop(s):
-        return re_drop.sub('', s)
+        return re_drop.sub('', six.ensure_text(s))
     return drop(a) == drop(b)
 
 def accent_count(s):
@@ -221,13 +221,13 @@ def strip_count(counts):
     for i, j in counts:
         foo.setdefault(i.rstrip('.').lower() if isinstance(i, six.string_types) else i, []).append((i, j))
     ret = {}
-    for k, v in foo.iteritems():
+    for k, v in foo.items():
         m = max(v, key=lambda x: len(x[1]))[0]
         bar = []
         for i, j in v:
             bar.extend(j)
         ret[m] = bar
-    return sorted(ret.iteritems(), cmp=lambda x,y: cmp(len(y[1]), len(x[1]) ))
+    return sorted(ret.items(), key=lambda x: len(x[1]), reverse=True)
 
 def fmt_author(a):
     if 'birth_date' in a or 'death_date' in a:


### PR DESCRIPTION
Use a sorting syntax that is easier to understand and is compatible with both Python 2 and 3.
https://docs.python.org/3/howto/sorting.html
https://portingguide.readthedocs.io/en/latest/comparisons.html#the-cmp-argument

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->