### PR TITLE
Fix cmp argument

### DIFF
--- a/openlibrary/catalog/edition_merge/merge_works.py
+++ b/openlibrary/catalog/edition_merge/merge_works.py
@@ -3,7 +3,6 @@ import MySQLdb
 import datetime
 import re
 import sys
-from openlibrary.catalog.utils import cmp
 sys.path.append('/1/src/openlibrary')
 from openlibrary.api import OpenLibrary, Reference
 
@@ -140,7 +139,9 @@ for ia, ekeys, done, unmerge_count in cur.fetchall():
     print('  works:', wkeys)
     def work_key_int(wkey):
         return int(re_work_key.match(wkey).group(1))
-    works = sorted(works, cmp=lambda a,b:-cmp(a['number_of_editions'],b['number_of_editions']) or cmp(work_key_int(a['key']), work_key_int(b['key'])))
+    works = sorted(
+        sorted(works, key=lambda x: work_key_int(x["key"])),
+        key=lambda x: x["number_of_editions"], reverse=True)
     print('  titles:', [(w['title'], w['number_of_editions']) for w in works])
     print(author0)
     #print [w['authors'][0]['author'] for w in works]

--- a/openlibrary/catalog/works/by_author.py
+++ b/openlibrary/catalog/works/by_author.py
@@ -7,7 +7,7 @@ import web
 from openlibrary.catalog.get_ia import get_from_archive
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields
 from openlibrary.catalog.utils.query import query_iter, set_staging, query
-from openlibrary.catalog.utils import cmp, mk_norm
+from openlibrary.catalog.utils import mk_norm
 from openlibrary.catalog.read_rc import read_rc
 from collections import defaultdict
 
@@ -62,7 +62,7 @@ def next_work_key():
 re_parens = re.compile('^(.*?)(?: \(.+ (?:Edition|Press)\))+$')
 
 def top_rev_wt(d):
-    d_sorted = sorted(d.keys(), cmp=lambda i, j: cmp(d[j], d[i]) or cmp(len(j), len(i)))
+    d_sorted = sorted(sorted(d, key=len, reverse=True), key=lambda i: d[i], reverse=True)
     return d_sorted[0]
 
 def books_query(akey): # live version

--- a/openlibrary/catalog/works/find_works.py
+++ b/openlibrary/catalog/works/find_works.py
@@ -17,7 +17,7 @@ from openlibrary.catalog.importer.db_read import get_mc
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary
 from openlibrary.catalog.marc.marc_subject import get_work_subjects, four_types
 from openlibrary.catalog.read_rc import read_rc
-from openlibrary.catalog.utils import cmp, mk_norm
+from openlibrary.catalog.utils import mk_norm
 from openlibrary.catalog.utils.edit import fix_edition
 from openlibrary.catalog.utils.query import query_iter, withKey
 from openlibrary.solr.update_work import update_work, solr_update, update_author
@@ -59,7 +59,7 @@ def get_with_retry(k):
 re_parens = re.compile(r'^(.*?)(?: \(.+ (?:Edition|Press|Print|Plays|Collection|Publication|Novels|Mysteries|Book Series|Classics Library|Classics|Books)\))+$', re.I)
 
 def top_rev_wt(d):
-    d_sorted = sorted(d.keys(), cmp=lambda i, j: cmp(d[j], d[i]) or cmp(len(j), len(i)))
+    d_sorted = sorted(sorted(d, key=len, reverse=True), key=lambda i: d[i], reverse=True)
     return d_sorted[0]
 
 def books_query(akey): # live version

--- a/openlibrary/catalog/works/live.py
+++ b/openlibrary/catalog/works/live.py
@@ -10,7 +10,7 @@ import web
 from openlibrary.catalog.get_ia import get_from_archive, get_data
 from openlibrary.catalog.marc.fast_parse import get_subfield_values, get_first_tag, get_tag_lines, get_subfields, BadDictionary
 from openlibrary.catalog.utils.query import query_iter, set_staging, query
-from openlibrary.catalog.utils import cmp, mk_norm
+from openlibrary.catalog.utils import mk_norm
 from openlibrary.catalog.read_rc import read_rc
 from collections import defaultdict
 from pprint import pformat
@@ -74,7 +74,7 @@ def update_work_edition(ekey, wkey, use):
     print(ol.save(e['key'], e, 'remove duplicate work page'))
 
 def top_rev_wt(d):
-    d_sorted = sorted(d.keys(), cmp=lambda i, j: cmp(d[j], d[i]) or cmp(len(j), len(i)))
+    d_sorted = sorted(sorted(d, key=len, reverse=True), key=lambda i: d[i], reverse=True)
     return d_sorted[0]
 
 def books_query(akey): # live version


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3038 

Fixes compound sorting as discussed in #3038 because the `cmp()` builtin and the `cmp=` parameter to `sorted()` were both removed in Python 3.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
```python
#!/usr/bin/env python2

from pprint import pprint

data = {
    "aaa": "test data",
    "aaaa": "more test data",
    "bbbb": "test date",
    "cc": "some more test data",
}

d = data
print(sorted(d.keys(), cmp=lambda i, j: cmp(d[j], d[i]) or cmp(len(j), len(i))))

d = data
print(sorted(sorted(d, key=len, reverse=True), key=lambda i: d[i], reverse=True))

works_data = [
    {"number_of_editions": 0, "key": "a"},
    {"number_of_editions": 0, "key": "b"},
    {"number_of_editions": 0, "key": "c"},
    {"number_of_editions": 3, "key": "a"},
    {"number_of_editions": 2, "key": "b"},
    {"number_of_editions": 1, "key": "c"},
    {"number_of_editions": 4, "key": "a"},
    {"number_of_editions": 4, "key": "b"},
    {"number_of_editions": 4, "key": "c"},
]

works = works_data
pprint(
    sorted(
        works,
        cmp=lambda a, b: -cmp(a["number_of_editions"], b["number_of_editions"])
        or cmp(a["key"], b["key"]),
    )
)

works = works_data
pprint(
    sorted(
        sorted(works, key=lambda x: x["key"]),
        key=lambda x: x["number_of_editions"],
        reverse=True,
    )
)
```

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->