### PR TITLE
Travis CI: Fail PRs that modify files with undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       install: pip install flake8
       script:
         - make lint
-        # On pull requests, run all flake8 tests on the lines of modified code
+        # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       install: pip install flake8
       script:
         - make lint
-        - make i18n
+        - pip install -r requirements_test.txt
         - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests
         # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
         # On pull requests, run all flake8 tests on modified code
         # Also test the entire files for syntax errors, undefined names, etc.
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]
+        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" || true ]
           then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88
             echo "If the following test fails, please see PR-3040 for suggested fixes."

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ jobs:
         # On pull requests, run all flake8 tests on the lines of modified code
         # Also, test the entire modified files for undefined names
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - python undefined_names_in_modified_files.py
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             python scripts/undefined_names_in_modified_files.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ jobs:
       script:
         - make lint
         - pip install -r requirements_test.txt
+        - pushd vendor/infogami && git pull origin master && popd
         - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests
         # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
+            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',') ;
             echo "FILENAMES: $FILENAMES";
             flake8 --select=F821 --show-source --statistics --filename=${FILENAMES};
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ jobs:
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
             sleep 1;
-            flake8 --select=F821 --show-source --statistics $(git diff origin/master --name-only | grep '.py' | tr '\n' ' ');
+            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ' ')
+            if [ "$FILENAMES" != "" ]; then
+              flake8 --select=F821 --show-source --statistics "$FILENAMES";
+            fi
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            git diff origin/master --name-only | grep '.py' | tr '\n' ' '
+            sleep 1;
             flake8 --select=F821 --show-source --statistics $(git diff origin/master --name-only | grep '.py' | tr '\n' ' ');
           fi
     - name: “Python 3.8 on bionic”

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ jobs:
       script:
         - make lint
         # On pull requests, run all flake8 tests on modified code
+        # Also test the entire files for syntax errors, undefined names, etc.
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
+            echo "If the following test fails, please see PR #3040 for suggested fixes."
+            git diff origin/master --name-only | flake8 --select=F821 --show-source --statistics;
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
+            set -e;
             flake8 --select=F821 --show-source --statistics $(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
           fi
     - name: “Python 3.8 on bionic”

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - python undefined_names_in_modified_files.py
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
-            python scripts/undefined_names_in_modified_files.py
+            python scripts/undefined_names_in_modified_files.py;
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,11 @@ jobs:
         # On pull requests, run all flake8 tests on modified code
         # Also test the entire files for syntax errors, undefined names, etc.
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" || true ]
-          then
-            git diff origin/master -U0 | flake8 --diff --max-line-length=88
-            echo "If the following test fails, please see PR-3040 for suggested fixes."
-            FILENAMES=$(git diff origin/master --name-only)
-            echo "aFILENAMES: $FILENAMES"
-            FILENAMES=$(git diff origin/master --name-only | grep '.py')
-            echo "bFILENAMES: $FILENAMES"
-            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',')
-            echo "FILENAMES: $FILENAMES"
-            flake8 --select=F821 --show-source --statistics --filename=${FILENAMES}
+        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
+            git diff origin/master -U0 | flake8 --diff --max-line-length=88;
+            echo "If the following test fails, please see PR-3040 for suggested fixes.";
+            flake8 --select=F821 --show-source --statistics \
+                   --filename=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
       install: pip install flake8
       script:
         - make lint
+        - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests
         # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,17 @@ jobs:
         # On pull requests, run all flake8 tests on modified code
         # Also test the entire files for syntax errors, undefined names, etc.
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
-            git diff origin/master -U0 | flake8 --diff --max-line-length=88;
-            echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',') ;
-            echo "FILENAMES: $FILENAMES";
-            flake8 --select=F821 --show-source --statistics --filename=${FILENAMES};
+        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]
+          then
+            git diff origin/master -U0 | flake8 --diff --max-line-length=88
+            echo "If the following test fails, please see PR-3040 for suggested fixes."
+            FILENAMES=$(git diff origin/master --name-only)
+            echo "aFILENAMES: $FILENAMES"
+            FILENAMES=$(git diff origin/master --name-only | grep '.py')
+            echo "bFILENAMES: $FILENAMES"
+            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',')
+            echo "FILENAMES: $FILENAMES"
+            flake8 --select=F821 --show-source --statistics --filename=${FILENAMES}
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,13 @@ jobs:
       install: pip install flake8
       script:
         - make lint
-        # On pull requests, run all flake8 tests on modified code
-        # Also test the entire files for syntax errors, undefined names, etc.
+        # On pull requests, run all flake8 tests on the lines of modified code
+        # Also, test the entire modified files for undefined names
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - set -e
+        - python undefined_names_in_modified_files.py
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
-            echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            sleep 1;
-            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ' ')
-            if [ "$FILENAMES" != "" ]; then
-              flake8 --select=F821 --show-source --statistics "$FILENAMES";
-            fi
+            python scripts/undefined_names_in_modified_files.py
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ jobs:
       install: pip install flake8
       script:
         - make lint
-        - pip install -r requirements_test.txt
-        - pushd vendor/infogami && git pull origin master && popd
-        - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils
         # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            FILENAMES=$(git diff origin/master --name-only | grep '.py\n' | tr '\n' ',');
+            FILENAMES=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
             echo "FILENAMES: $FILENAMES";
             flake8 --select=F821 --show-source --statistics --filename=${FILENAMES};
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
       install: pip install flake8
       script:
         - make lint
+        - make i18n
         - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests
         # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
-            echo "If the following test fails, please see PR #3040 for suggested fixes."
+            echo "If the following test fails, please see PR #3040 for suggested fixes.";
             git diff origin/master --name-only | flake8 --select=F821 --show-source --statistics;
           fi
     - name: “Python 3.8 on bionic”

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ jobs:
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
             FILENAMES=$(git diff origin/master --name-only | grep ".py\n" | tr "\n" ",");
-            echo $FILENAMES;
-            flake8 --select=F821 --show-source --statistics --filename=$FILENAMES;
+            echo "FILENAMES: $FILENAMES";
+            flake8 --select=F821 --show-source --statistics --filename=${FILENAMES};
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
-            echo "If the following test fails, please see PR #3040 for suggested fixes.";
+            echo "If the following test fails, please see PR-3040 for suggested fixes.";
             git diff origin/master --name-only | flake8 --select=F821 --show-source --statistics;
           fi
     - name: “Python 3.8 on bionic”

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            FILENAMES=git diff origin/master --name-only | tr "\n" ",";
+            FILENAMES=$(git diff origin/master --name-only | grep ".py\n" | tr "\n" ",");
             echo $FILENAMES;
             flake8 --select=F821 --show-source --statistics --filename=$FILENAMES;
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            flake8 --select=F821 --show-source --statistics \
-                   --filename=$(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
+            flake8 --select=F821 --show-source --statistics $(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ jobs:
         # On pull requests, run all flake8 tests on modified code
         # Also test the entire files for syntax errors, undefined names, etc.
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
+        - set -e
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            set -e;
-            flake8 --select=F821 --show-source --statistics $(git diff origin/master --name-only | grep '.py' | tr '\n' ',');
+            git diff origin/master --name-only | grep '.py' | tr '\n' ' '
+            flake8 --select=F821 --show-source --statistics $(git diff origin/master --name-only | grep '.py' | tr '\n' ' ');
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            FILENAMES=$(git diff origin/master --name-only | grep ".py\n" | tr "\n" ",");
+            FILENAMES=$(git diff origin/master --name-only | grep '.py\n' | tr '\n' ',');
             echo "FILENAMES: $FILENAMES";
             flake8 --select=F821 --show-source --statistics --filename=${FILENAMES};
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - make lint
         - pip install -r requirements_test.txt
         - pushd vendor/infogami && git pull origin master && popd
-        - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests
+        - pytest openlibrary/mocks openlibrary/olbase openlibrary/utils
         # On pull requests, run all flake8 tests only on the modified lines of code
         # Also, test the entire modified files for undefined names
         # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
             git diff origin/master -U0 | flake8 --diff --max-line-length=88;
             echo "If the following test fails, please see PR-3040 for suggested fixes.";
-            git diff origin/master --name-only | flake8 --select=F821 --show-source --statistics;
+            FILENAMES=git diff origin/master --name-only | tr "\n" ",";
+            echo $FILENAMES;
+            flake8 --select=F821 --show-source --statistics --filename=$FILENAMES;
           fi
     - name: “Python 3.8 on bionic”
       python: "3.8"

--- a/junk.py
+++ b/junk.py
@@ -1,0 +1,1 @@
+print(junk)

--- a/junk.py
+++ b/junk.py
@@ -1,1 +1,0 @@
-print(junk)

--- a/scripts/undefined_names_in_modified_files.py
+++ b/scripts/undefined_names_in_modified_files.py
@@ -23,5 +23,8 @@ if __name__ == "__main__":
         returncode, results = do_run(
             "flake8 --select=F821 --show-source --statistics " + filenames
         )
+        if returncode:
+            print("For suggested fixes, please see "
+                  "https://github.com/internetarchive/openlibrary/pull/3040")
         print(results)
         sys.exit(returncode)

--- a/scripts/undefined_names_in_modified_files.py
+++ b/scripts/undefined_names_in_modified_files.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+from subprocess import PIPE, run  # Requires Python >= 3.5
+from typing import Tuple
+
+
+def do_run(command: str) -> Tuple[int, str]:
+    print("$ {}".format(command))
+    completed_process = run(command.split(), stdout=PIPE)
+    return completed_process.returncode, completed_process.stdout.decode()
+
+
+def junk():
+    bubba
+
+
+if __name__ == "__main__":
+    returncode, results = do_run("git diff origin/master --name-only")
+    filenames = " ".join(
+        line.strip() for line in results.splitlines() if line.endswith(".py")
+    )
+    if filenames:
+        returncode, results = do_run(
+            "flake8 --select=F821 --show-source --statistics " + filenames
+        )
+        print(results)
+        sys.exit(returncode)

--- a/scripts/undefined_names_in_modified_files.py
+++ b/scripts/undefined_names_in_modified_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Legacy Python sees type hints as syntax errrors.
+# Legacy Python sees type hints as syntax errors.
 # flake8: noqa
 
 import sys

--- a/scripts/undefined_names_in_modified_files.py
+++ b/scripts/undefined_names_in_modified_files.py
@@ -17,7 +17,7 @@ def do_run(command: str) -> Tuple[int, str]:
 if __name__ == "__main__":
     returncode, results = do_run("git diff origin/master --name-only")
     filenames = " ".join(
-        ("../" + line.strip()) for line in results.splitlines() if line.endswith(".py")
+        line.strip() for line in results.splitlines() if line.endswith(".py")
     )
     if filenames:
         returncode, results = do_run(

--- a/scripts/undefined_names_in_modified_files.py
+++ b/scripts/undefined_names_in_modified_files.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+# Legacy Python sees type hints as syntax errrors.
+# flake8: noqa
+
 import sys
-from subprocess import PIPE, run  # Requires Python >= 3.5
+from subprocess import PIPE, run
 from typing import Tuple
 
 
@@ -9,10 +12,6 @@ def do_run(command: str) -> Tuple[int, str]:
     print("$ {}".format(command))
     completed_process = run(command.split(), stdout=PIPE)
     return completed_process.returncode, completed_process.stdout.decode()
-
-
-def junk():
-    bubba
 
 
 if __name__ == "__main__":

--- a/scripts/undefined_names_in_modified_files.py
+++ b/scripts/undefined_names_in_modified_files.py
@@ -17,7 +17,7 @@ def do_run(command: str) -> Tuple[int, str]:
 if __name__ == "__main__":
     returncode, results = do_run("git diff origin/master --name-only")
     filenames = " ".join(
-        line.strip() for line in results.splitlines() if line.endswith(".py")
+        ("../" + line.strip()) for line in results.splitlines() if line.endswith(".py")
     )
     if filenames:
         returncode, results = do_run(


### PR DESCRIPTION
Add a flake8 run to Travis CI that only examines the modified files and fails if they contain an undefined name.  If the test fails, please see PR #3040 for suggested fixes.

Partial solution to #3011

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->