### PR TITLE
Define internal_error and no_bucket_error

### DIFF
--- a/openlibrary/catalog/lc_updates/update.py
+++ b/openlibrary/catalog/lc_updates/update.py
@@ -17,6 +17,9 @@ from six.moves.urllib.request import urlopen
 rc = read_rc()
 accesskey = rc['s3_accesskey']
 secret = rc['s3_secret']
+no_bucket_error = '<Code>NoSuchBucket</Code>'
+internal_error = '<Code>InternalError</Code>'
+
 
 def put_file(con, ia, filename):
     print('uploading %s' % filename)

--- a/scripts/lc_marc_update.py
+++ b/scripts/lc_marc_update.py
@@ -22,6 +22,9 @@ config.load(config_file)
 c = config.runtime_config['lc_marc_update']
 base_url = 'http://openlibrary.org'
 import_api_url = base_url + '/api/import'
+internal_error = '<Code>InternalError</Code>'
+no_bucket_error = '<Code>NoSuchBucket</Code>'
+
 
 def put_file(con, ia, filename, data):
     print('uploading %s' % filename)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
As discussed to https://github.com/internetarchive/openlibrary/pull/3040/files#r379621016, `internal_error` and `no_bucket_error` are defined with identical values in [upload_arc.py](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/catalog/amazon/upload_arc.py#L15-L16) and in [upload.py](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/catalog/amazon/upload.py#L33-L34) but they are both ___undefined names___ in the files on this PR.  Here we copy the existing definitions to resolve the _undefined names_.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->