### PR TITLE
from openlibrary.catalog.read_rc import read_rc

### DIFF
--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -14,12 +14,14 @@ from openlibrary.catalog.marc.marc_binary import MarcBinary
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.parse import read_edition
 from openlibrary.catalog.marc.fast_parse import read_file as fast_read_file  # Deprecated import
+from openlibrary.catalog.read_rc import read_rc
 from openlibrary.core import ia
 
 
 IA_BASE_URL = config.get('ia_base_url')
 IA_DOWNLOAD_URL = '%s/download/' % IA_BASE_URL
 MAX_MARC_LENGTH = 100000
+rc = read_rc()
 
 class NoMARCXML(IOError):
     # DEPRECATED, rely on MarcXml to raise exceptions
@@ -228,20 +230,20 @@ def marc_formats(identifier, host=None, path=None):
     return has
 
 def get_from_local(locator):
-    # DEPRECATED, Broken, undefined rc, will raise exception if called
+    # DEPRECATED
     try:
         file, offset, length = locator.split(':')
     except:
         print(('locator:', repr(locator)))
         raise
-    f = open(rc['marc_path'] + '/' + file)  # noqa: F821 DEPRECATED
+    f = open(rc['marc_path'] + '/' + file)
     f.seek(int(offset))
     buf = f.read(int(length))
     f.close()
     return buf
 
 def get_data(loc):
-    # DEPRECATED, Broken, undefined rc, will return None or raise exception if called
+    # DEPRECATED
     try:
         filename, p, l = loc.split(':')
     except ValueError:
@@ -251,7 +253,7 @@ def get_data(loc):
         return None
     if not os.path.exists(marc_path + '/' + filename):
         return None
-    f = open(rc['marc_path'] + '/' + filename)  # noqa: F821 DEPRECATED
+    f = open(rc['marc_path'] + '/' + filename)
     f.seek(int(p))
     buf = f.read(int(l))
     f.close()

--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -1,17 +1,17 @@
 from __future__ import print_function
 # lookup MARC records and show details on the web
-from catalog.read_rc import read_rc
-from catalog.get_ia import get_data
-from catalog.marc.build_record import build_record
-from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
 from openlibrary.catalog.read_rc import read_rc
+from openlibrary.catalog.get_ia import get_data
+from openlibrary.catalog.marc.build_record import build_record
+from openlibrary.catalog.marc.fast_parse import (get_all_subfields, get_first_tag,
+                                                 get_subfields)
 from openlibrary.catalog.utils import cmp
 import re
 import sys
 import os.path
 import web
-from catalog.amazon.other_editions import find_others
-from catalog.utils import strip_count
+from openlibrary.catalog.amazon.other_editions import find_others
+from openlibrary.catalog.utils import strip_count
 
 import six
 

--- a/openlibrary/catalog/marc/db/web_marc_db.py
+++ b/openlibrary/catalog/marc/db/web_marc_db.py
@@ -4,6 +4,7 @@ from catalog.read_rc import read_rc
 from catalog.get_ia import get_data
 from catalog.marc.build_record import build_record
 from catalog.marc.fast_parse import get_all_subfields, get_tag_lines, get_first_tag, get_subfields
+from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.utils import cmp
 import re
 import sys
@@ -18,6 +19,7 @@ import six
 db = web.database(dbn='postgres', db='marc_lookup')
 db.printing = False
 
+rc = read_rc()
 trans = {'&':'amp','<':'lt','>':'gt'}
 re_html_replace = re.compile('([&<>])')
 

--- a/openlibrary/catalog/people/from_works.py
+++ b/openlibrary/catalog/people/from_works.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from openlibrary.catalog.utils.query import query_iter, set_staging, get_mc
 from openlibrary.catalog.get_ia import get_data
+from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.marc.fast_parse import get_tag_lines, get_all_subfields, get_subfields
 
 from pprint import pprint
@@ -10,6 +11,8 @@ import sys
 from collections import defaultdict
 
 set_staging(True)
+rc = read_rc()
+
 
 def work_and_marc():
     i = 0

--- a/openlibrary/catalog/people/from_works.py
+++ b/openlibrary/catalog/people/from_works.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 from openlibrary.catalog.utils.query import query_iter, set_staging, get_mc
 from openlibrary.catalog.get_ia import get_data
-from openlibrary.catalog.read_rc import read_rc
 from openlibrary.catalog.marc.fast_parse import get_tag_lines, get_all_subfields, get_subfields
 
 from pprint import pprint
@@ -11,7 +10,6 @@ import sys
 from collections import defaultdict
 
 set_staging(True)
-rc = read_rc()
 
 
 def work_and_marc():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes _undefined name_ `rc` in two files.

The syntax [openlibrary.catalog.read_rc import read_rc ; rc = read_rc()](https://github.com/internetarchive/openlibrary/search?q=read_rc) is used in 60+ Python files in this repo but `rc` is an _undefined name_ in the two files of this PR.  Here we propose to adopt that syntax to resolve those undefined names.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->