### PR TITLE
Undefined name: search(self) --> self.search()

### DIFF
--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -204,7 +204,7 @@ class Solr_client(object):
     def isearch(self, query, loc=0):
         # iterator interface to search
         while True:
-            s = search(self, query, start=loc)
+            s = self.search(query, start=loc)
             if len(s) == 0: return
             loc += len(s)
             for y in s:

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -201,16 +201,6 @@ class Solr_client(object):
                         return (k,v)
         return None
 
-    def isearch(self, query, loc=0):
-        # iterator interface to search
-        while True:
-            s = self.search(query, start=loc)
-            if len(s) == 0: return
-            loc += len(s)
-            for y in s:
-                if not y.startswith('OCA/'):
-                    yield y
-
     def search(self, query, **params):
         # advanced search: directly post a Solr search which uses fieldnames etc.
         # return list of document id's


### PR DESCRIPTION
`search()` is an undefined name in this context but `self.search()` is defined 7 lines below.
```
./openlibrary/plugins/search/solr_client.py:207:17: F821 undefined name 'search'
            s = search(self, query, start=loc)
                ^
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->