### PR TITLE
Fix undefined name mock_site

### DIFF
--- a/openlibrary/tests/core/test_sponsors.py
+++ b/openlibrary/tests/core/test_sponsors.py
@@ -66,4 +66,5 @@ class TestSponsorship:
 
     def qualifies_for_sponsorship(self, monkeypatch):
         # XXX TODO
+        from openlibrary.mocks.mock_infobase import mock_site
         work = mock_site.quicksave("/works/OL1W", "/type/work", title="Foo")

--- a/openlibrary/tests/core/test_sponsors.py
+++ b/openlibrary/tests/core/test_sponsors.py
@@ -63,8 +63,3 @@ class TestSponsorship:
         dwwi, matches = do_we_want_it(isbn, work_id)
         assert dwwi == True
         assert matches == []
-
-    def qualifies_for_sponsorship(self, monkeypatch):
-        # XXX TODO
-        from openlibrary.mocks.mock_infobase import mock_site
-        work = mock_site.quicksave("/works/OL1W", "/type/work", title="Foo")


### PR DESCRIPTION
```
./openlibrary/tests/core/test_sponsors.py:69:16: F821 undefined name 'mock_site'
        work = mock_site.quicksave("/works/OL1W", "/type/work", title="Foo")
               ^
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->