### PR TITLE
Remove unused pmap() function

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -129,18 +129,6 @@ def sort_dump(dump_file=None, tmpdir="/tmp/", buffer_size="1G"):
         if status != 0:
             raise Exception("sort failed with status %d" % status)
 
-def pmap(f, tasks):
-    """Run tasks parallelly."""
-    try:
-        from subprocess import Pool
-
-        from multiprocessing import Pool
-        r = pool.map_async(f, tasks, callback=results.append)
-        r.wait() # Wait on the results
-
-    except ImportError:
-        Pool = None
-
 def generate_dump(cdump_file=None):
     """Generate dump from cdump.
 


### PR DESCRIPTION
1. There is no mention of this function anywhere in this repo:
    * https://github.com/internetarchive/openlibrary/search?q=pmap
2. This code overwrites the unused `Pool` (title case)
    * `subprocess` has `no Pool.map_async()` but `multiprocessing` does https://docs.python.org/2/library/multiprocessing.html#multiprocessing.pool.multiprocessing.Pool.map_async
3. Line 138 contains two _undefined names_ `pool` (lowercase) and `results`.
```
./openlibrary/data/dump.py:138:13: F821 undefined name 'pool'
        r = pool.map_async(f, tasks, callback=results.append)
            ^
./openlibrary/data/dump.py:138:47: F821 undefined name 'results'
        r = pool.map_async(f, tasks, callback=results.append)
                                              ^
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->