### PR TITLE
Py3 has stricter scoping rules for list comprehensions

### DIFF
--- a/openlibrary/utils/bulkimport.py
+++ b/openlibrary/utils/bulkimport.py
@@ -124,15 +124,15 @@ class DocumentLoader:
         result = [{'key': doc['key'], 'revision': doc['revision'], 'id': doc['id']} for doc in documents]
 
         # insert data
-        try:
-            data = []
-            for doc in documents:
+        data = []
+        for doc in documents:
+            try:
                 data.append(dict(thing_id=doc.pop('id'),
                                  revision=doc['revision'],
                                  data=simplejson.dumps(doc)))
-        except UnicodeDecodeError:
-            print(repr(doc))
-            raise
+            except UnicodeDecodeError:
+                print(repr(doc))
+                raise
         self.db.multiple_insert('data', data, seqname=False)
         return result
 

--- a/openlibrary/utils/bulkimport.py
+++ b/openlibrary/utils/bulkimport.py
@@ -125,10 +125,11 @@ class DocumentLoader:
 
         # insert data
         try:
-            data = [dict(thing_id=doc.pop('id'),
-                         revision=doc['revision'],
-                         data=simplejson.dumps(doc))
-                    for doc in documents]
+            data = []
+            for doc in documents:
+                data.append(dict(thing_id=doc.pop('id'),
+                                 revision=doc['revision'],
+                                 data=simplejson.dumps(doc)))
         except UnicodeDecodeError:
             print(repr(doc))
             raise


### PR DESCRIPTION
In Python 3 variables created inside a comprehension are not available outside that comprehension.
This change avoids the comprehension to ensure that `doc` is available to be printed in the except clause.
```
./openlibrary/utils/bulkimport.py:133:24: F821 undefined name 'doc'
            print(repr(doc))
                       ^
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->