### PR TITLE
Add solr-updater option to skip edits

### DIFF
--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -36,6 +36,7 @@ def parse_arguments():
     parser.add_argument('-c', '--config')
     parser.add_argument('--debugger', action="store_true", help="Wait for a debugger to attach before beginning.")
     parser.add_argument('--state-file', default="solr-update.state")
+    parser.add_argument('--exclude-edits', help="Don't index edits containing the string anywhere")
     parser.add_argument('--ol-url', default="http://openlibrary.org/")
     parser.add_argument('--socket-timeout', type=int, default=10)
     parser.add_argument('--load-ia-scans', dest="load_ia_scans", action="store_true", default=False)
@@ -54,9 +55,14 @@ def get_default_offset():
 
 
 class InfobaseLog:
-    def __init__(self, hostname):
+    def __init__(self, hostname, exclude=None):
+        """
+        :param str hostname:
+        :param str or None exclude: if specified, excludes records that include the string
+        """
         self.base_url = 'http://%s/openlibrary.org/log' % hostname
         self.offset = get_default_offset()
+        self.exclude = exclude
 
     def tell(self):
         return self.offset
@@ -91,6 +97,8 @@ class InfobaseLog:
                 return
 
             for record in data:
+                if self.exclude and self.exclude in json.dumps(record):
+                    continue
                 yield record
 
             self.offset = d['offset']
@@ -253,7 +261,7 @@ def main():
     state_file = args.state_file
     offset = read_state_file(state_file)
 
-    logfile = InfobaseLog(config.get('infobase_server'))
+    logfile = InfobaseLog(config.get('infobase_server'), exclude=args.exclude_edits)
     logfile.seek(offset)
 
     solr = Solr()

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -36,8 +36,7 @@ def parse_arguments():
     parser.add_argument('-c', '--config')
     parser.add_argument('--debugger', action="store_true", help="Wait for a debugger to attach before beginning.")
     parser.add_argument('--state-file', default="solr-update.state")
-    parser.add_argument('--exclude-edits',
-                        help="Don't index edits containing the string anywhere")
+    parser.add_argument('--exclude-edits-containing', help="Don't index matching edits")
     parser.add_argument('--ol-url', default="http://openlibrary.org/")
     parser.add_argument('--socket-timeout', type=int, default=10)
     parser.add_argument('--load-ia-scans', dest="load_ia_scans", action="store_true", default=False)

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -36,7 +36,8 @@ def parse_arguments():
     parser.add_argument('-c', '--config')
     parser.add_argument('--debugger', action="store_true", help="Wait for a debugger to attach before beginning.")
     parser.add_argument('--state-file', default="solr-update.state")
-    parser.add_argument('--exclude-edits', help="Don't index edits containing the string anywhere")
+    parser.add_argument('--exclude-edits',
+                        help="Don't index edits containing the string anywhere")
     parser.add_argument('--ol-url', default="http://openlibrary.org/")
     parser.add_argument('--socket-timeout', type=int, default=10)
     parser.add_argument('--load-ia-scans', dest="load_ia_scans", action="store_true", default=False)
@@ -58,7 +59,7 @@ class InfobaseLog:
     def __init__(self, hostname, exclude=None):
         """
         :param str hostname:
-        :param str or None exclude: if specified, excludes records that include the string
+        :param str|None exclude: if specified, excludes records that include the string
         """
         self.base_url = 'http://%s/openlibrary.org/log' % hostname
         self.offset = get_default_offset()


### PR DESCRIPTION
Feature. Add option for solr-updater to exclude edits: specifying e.g. `--exclude-edits "fake subjects"` excludes edits containing the text "fake subjects".

### Technical
- Bulk edits bring solr updater to a near stand still; sometimes it might be better to just ignore these edits, knowing they'll be added when a full re-index is done at some point in the near future.

### Testing
(for previous iteration, but should still work; not re-testing).
1. ✅ Add junk text to [some work](http://192.168.99.100:8080/works/OL53924W/The_complete_works_of_Mark_Twain) ; confirm shows up when searching for that junk text
2. ✅ Add junk text to [some other work](http://192.168.99.100:8080/works/OL5702375W/Three_cups_of_tea); confirm shows up when searching for that junk text
3. ✅ Add junk text to [some other work](http://192.168.99.100:8080/works/OL192489W/Practical_use_of_the_slide_rule), but specify `#solr-updater-exclude` in the edit comment; confirm it _does not_ show up when searching for that junk text

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@hornc @tfmorris 