### PR TITLE
Undefined names: html_subfields() and html_line()

### DIFF
--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -51,33 +51,6 @@ class html_record():
             s = esc_sp(line[0:2]) + ' ' + self.html_subfields(line)
         return u'<large>' + tag + u'</large> <code>' + s + u'</code>'
 
-def test_html_subfields():
-    """
-    >>> test_html_subfields()
-    """
-    samples = [
-        ('  \x1fa0123456789\x1e', '<b>$a</b>0123456789'),
-        ('  end of wrapped\x1e', 'end of wrapped'),
-        ('  \x1fa<whatever>\x1e', '<b>$a</b>&lt;whatever&gt;'),
-    ]
-    hr = html_record("00053This is the leader.Now we are beyond the leader.")
-    for input, output in samples:
-        assert hr.html_subfields(input) == output
-
-def test_html_line():
-    """
-    >>> test_html_line()
-    """
-    samples = [
-        ('020', '  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),
-        ('520', '  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
-        ('245', '10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k :\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1fcKarma-pa Mi-bskyod-rdo-rje.\x1e', u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Karma-pa Mi-bskyod-rdo-rje.'),
-    ]
-    hr = html_record("00053This is the leader.Now we are beyond the leader.")
-    for tag, input, output in samples:
-        expect = '<large>%s</large> <code>%s</code>' % (tag, output)
-        assert hr.html_line(tag, input) == expect
-
 
 if __name__ == '__main__':
     import doctest

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -22,7 +22,7 @@ class html_record():
         >>> hr = html_record("00054This is the leader.Now we are beyond the leader.")
         Traceback (most recent call last):
         ...
-        AssertionError:
+        AssertionError
         >>> # Change " " to "a"...
         >>> hr = html_record("00053Thisais the leader.Now we are beyond the leader.")
         >>> hr.is_marc8
@@ -77,3 +77,9 @@ def test_html_line():
     for tag, input, output in samples:
         expect = '<large>%s</large> <code>%s</code>' % (tag, output)
         assert hr.html_line(tag, input) == expect
+
+
+if __name__ == '__main__':
+    import doctest
+
+    doctest.testmod()

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -12,10 +12,25 @@ def esc_sp(s):
 
 class html_record():
     def __init__(self, data):
+        """
+        >>> hr = html_record("00053This is the leader.Now we are beyond the leader.")
+        >>> hr.leader
+        '00053This is the leader.'
+        >>> hr.is_marc8
+        True
+        >>> hr = html_record("00053Thisais the leader.Now we are beyond the leader.")  # "a"
+        >>> hr.is_marc8
+        False
+        >>> hr = html_record("00054This is the leader.Now we are beyond the leader.")  # 53 -> 54
+        Traceback (most recent call last):
+        ...
+        AssertionError:
+        """
         assert len(data) == int(data[:5])
         self.data = data
         self.leader = data[:24]
         self.is_marc8 = data[9] != 'a'
+
     def html(self):
         return '<br>\n'.join(self.html_line(t, l) for t, l in get_all_tag_lines(self.data))
 
@@ -35,21 +50,28 @@ class html_record():
         return u'<large>' + tag + u'</large> <code>' + s + u'</code>'
 
 def test_html_subfields():
+    """
+    >>> test_html_subfields()
+    """
     samples = [
         ('  \x1fa0123456789\x1e', '<b>$a</b>0123456789'),
         ('  end of wrapped\x1e', 'end of wrapped'),
         ('  \x1fa<whatever>\x1e', '<b>$a</b>&lt;whatever&gt;'),
     ]
+    hr = html_record("00053This is the leader.Now we are beyond the leader.")
     for input, output in samples:
-        assert html_subfields(input) == output
+        assert hr.html_subfields(input) == output
 
 def test_html_line():
+    """
+    >>> test_html_line()
+    """
     samples = [
         ('020', '  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),
         ('520', '  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
         ('245', '10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k :\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1fcKarma-pa Mi-bskyod-rdo-rje.\x1e', u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Karma-pa Mi-bskyod-rdo-rje.'),
     ]
-
+    hr = html_record("00053This is the leader.Now we are beyond the leader.")
     for tag, input, output in samples:
         expect = '<large>%s</large> <code>%s</code>' % (tag, output)
-        assert html_line(tag, input) == expect
+        assert hr.html_line(tag, input) == expect

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -18,13 +18,15 @@ class html_record():
         '00053This is the leader.'
         >>> hr.is_marc8
         True
-        >>> hr = html_record("00053Thisais the leader.Now we are beyond the leader.")  # "a"
-        >>> hr.is_marc8
-        False
-        >>> hr = html_record("00054This is the leader.Now we are beyond the leader.")  # 53 -> 54
+        >>> # Change "00053" to "00054"...
+        >>> hr = html_record("00054This is the leader.Now we are beyond the leader.")
         Traceback (most recent call last):
         ...
         AssertionError:
+        >>> # Change " " to "a"...
+        >>> hr = html_record("00053Thisais the leader.Now we are beyond the leader.")
+        >>> hr.is_marc8
+        False
         """
         assert len(data) == int(data[:5])
         self.data = data

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -23,9 +23,9 @@ def test_html_line():
         ('245', ('10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k '
                  ':\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1f'
                  'cKarma-pa Mi-bskyod-rdo-rje.\x1e'),
-                 (u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>'
-                  u'$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Ka'
-                  u'rma-pa Mi-bskyod-rdo-rje.')),
+                (u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>'
+                 u'$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Ka'
+                 u'rma-pa Mi-bskyod-rdo-rje.')),
     ]
     hr = html_record("00053This is the leader.Now we are beyond the leader.")
     for tag, input, output in samples:

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -22,9 +22,10 @@ def test_html_line():
         ('520', '  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
         ('245', ('10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k '
                  ':\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1f'
-                 'cKarma-pa Mi-bskyod-rdo-rje.\x1e', u'10 <b>$a</b>Dbu ma la \u02be'
-                 'jug pa\u02bei kar \u1e6d\u012bk :<b>$b</b>Dwags-brgyud grub pa\u0'
-                 '2bei \u015bi\u1e45 rta /<b>$c</b>Karma-pa Mi-bskyod-rdo-rje.')),
+                 'cKarma-pa Mi-bskyod-rdo-rje.\x1e'),
+                 (u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>'
+                  u'$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Ka'
+                  u'rma-pa Mi-bskyod-rdo-rje.')),
     ]
     hr = html_record("00053This is the leader.Now we are beyond the leader.")
     for tag, input, output in samples:

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -1,0 +1,24 @@
+from openlibrary.catalog.marc.html import html_record
+
+
+def test_html_subfields():
+    samples = [
+        ('  \x1fa0123456789\x1e', '<b>$a</b>0123456789'),
+        ('  end of wrapped\x1e', 'end of wrapped'),
+        ('  \x1fa<whatever>\x1e', '<b>$a</b>&lt;whatever&gt;'),
+    ]
+    hr = html_record("00053This is the leader.Now we are beyond the leader.")
+    for input, output in samples:
+        assert hr.html_subfields(input) == output
+
+
+def test_html_line():
+    samples = [
+        ('020', '  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),
+        ('520', '  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
+        ('245', '10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k :\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1fcKarma-pa Mi-bskyod-rdo-rje.\x1e', u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Karma-pa Mi-bskyod-rdo-rje.'),
+    ]
+    hr = html_record("00053This is the leader.Now we are beyond the leader.")
+    for tag, input, output in samples:
+        expect = '<large>%s</large> <code>%s</code>' % (tag, output)
+        assert hr.html_line(tag, input) == expect

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -1,3 +1,5 @@
+import pytest
+
 from openlibrary.catalog.marc.html import html_record
 
 

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -20,7 +20,11 @@ def test_html_line():
     samples = [
         ('020', '  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),
         ('520', '  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
-        ('245', '10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k :\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1fcKarma-pa Mi-bskyod-rdo-rje.\x1e', u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>$b</b>Dwags-brgyud grub pa\u02bei \u015bi\u1e45 rta /<b>$c</b>Karma-pa Mi-bskyod-rdo-rje.'),
+        ('245', ('10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k '
+                 ':\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1f'
+                 'cKarma-pa Mi-bskyod-rdo-rje.\x1e', u'10 <b>$a</b>Dbu ma la \u02be'
+                 'jug pa\u02bei kar \u1e6d\u012bk :<b>$b</b>Dwags-brgyud grub pa\u0'
+                 '2bei \u015bi\u1e45 rta /<b>$c</b>Karma-pa Mi-bskyod-rdo-rje.')),
     ]
     hr = html_record("00053This is the leader.Now we are beyond the leader.")
     for tag, input, output in samples:

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -12,6 +12,8 @@ def test_html_subfields():
         assert hr.html_subfields(input) == output
 
 
+@pytest.mark.xfail(reason='As discussed in #3071, the encoding (marc8 or utf8) is '
+                          'not defined for a single field.  To be fixed by #3057.')
 def test_html_line():
     samples = [
         ('020', '  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),


### PR DESCRIPTION
Fixes #3064 and adds doctests.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->