### PR TITLE
Make editions page lazy load IA preview iframe

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -13,7 +13,7 @@ $if render_floater:
           <a class="dialog--close" data-key="book_preview" data-ol-link-track="book_preview"
              title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <div id="bookPreviewIframe" class="lazyIframe">
+        <div class="iframe-container">
           <iframe width="100%" height="515"
                   data-src="https://archive.org/stream/$ocaid?wrapper=false">
           </iframe>
@@ -22,7 +22,7 @@ $if render_floater:
           <a href="https://archive.org/details/$ocaid"
              data-key="book_preview_learn_more"
              data-ol-link-track="book_preview_learn_more">
-            $("See more about this book on Archive.org")
+            $_("See more about this book on Archive.org")
           </a>
         </p>
       </div>

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -394,21 +394,19 @@ export function initBorrowAndReadLinks() {
 }
 
 export function initPreviewButton() {
-    /**
-     * Colorbox modal + iframe for Book Preview Button
-     */
+    // Colorbox modal + iframe for Book Preview Button
     $('.cta-btn--preview').colorbox({
         width: '100%',
         maxWidth: '640px',
         inline: true,
         opacity: '0.5',
-        href: '#bookPreview'
-    })
-
-    $('.lazyIframe').show(function(){
-        // Find the iframes within our newly-visible element
-        const $iframe = $(this).find('iframe');
-        // Set their src attribute to the value of data-src
-        $iframe.prop('src', $iframe.data('src'));
+        href: '#bookPreview',
+        onOpen() {
+            const $iframe = $('#bookPreview iframe');
+            $iframe.prop('src', $iframe.data('src'));
+        },
+        onCleanup() {
+            $('#bookPreview iframe').prop('src', '');
+        },
     });
 }

--- a/static/css/components/preview.less
+++ b/static/css/components/preview.less
@@ -2,12 +2,13 @@
  * Book Preview Modal
  */
 
-// Display iframe within modal
-.lazyIframe {
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-}
+.book-preview {
+  .iframe-container {
+    border-top: 1px solid #eee;
+    border-bottom: 1px solid #eee;
+  }
 
-.learn-more {
-  text-align: center;
+  .learn-more {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
Closes #2841

Fix: Make the editions page only load the iframe when the modal is opened.

### Technical
- It's non-trivial to have a generic solution to "do something when this element becomes visible", so opted to make this solution specific to the colorbox that needs it.

### Testing
- ✅ http://192.168.99.100:8080/books/OL6179353M/Slide_rule Does not log "soundmanager" stuff (part of IA bookreader) on page load
- ✅ Clicking the preview button console.log "soundmanager" stuff (and shows preview)
- ✅ Closing the preview does not log anything
- ✅ Opening preview again does nothing logs the stuff (and shows preview)

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 