### PR TITLE
UpdateRequest.toxml() should return str, not bytes

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -977,7 +977,7 @@ class UpdateRequest:
         node = dict2element(self.doc)
         root = Element("add")
         root.append(node)
-        return tostring(root)
+        return six.ensure_text(tostring(root))
 
     def tojson(self):
         """

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -977,7 +977,7 @@ class UpdateRequest:
         node = dict2element(self.doc)
         root = Element("add")
         root.append(node)
-        return tostring(root).encode('utf-8')
+        return tostring(root)
 
     def tojson(self):
         """


### PR DESCRIPTION
Python 2 does not care about the distinction between bytes and str but Python 3 does.

<!-- What issue does this PR close? -->
Closes 1 pytest on Python 3.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->