### PR TITLE
Hotfix lending not single-click borrowing

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -283,8 +283,8 @@ class Edition(Thing):
 
     def in_borrowable_collection(self):
         collections = self.get_ia_collections()
-        return ('lendinglibrary' in collections or 'inlibrary' in collections
-                    and not self.is_in_private_collection())
+        return (('lendinglibrary' in collections or 'inlibrary' in collections)
+                and not self.is_in_private_collection())
 
     def can_borrow(self):
         """This method should be deprecated in favor of in_borrowable_collection"""

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -283,8 +283,7 @@ class Edition(Thing):
 
     def in_borrowable_collection(self):
         collections = self.get_ia_collections()
-        return ('lendinglibrary' in collections
-                and not self.is_in_private_collection())
+        return 'inlibrary' in collections and not self.is_in_private_collection()
 
     def can_borrow(self):
         """This method should be deprecated in favor of in_borrowable_collection"""

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -283,7 +283,8 @@ class Edition(Thing):
 
     def in_borrowable_collection(self):
         collections = self.get_ia_collections()
-        return 'inlibrary' in collections and not self.is_in_private_collection()
+        return ('lendinglibrary' in collections or 'inlibrary' in collections
+                    and not self.is_in_private_collection())
 
     def can_borrow(self):
         """This method should be deprecated in favor of in_borrowable_collection"""


### PR DESCRIPTION
hotfixing lending

<!-- What issue does this PR close? -->
Closes #3028

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

`lendinglibrary` is a deprecated collection, `inlibrary` is what we wanted. `inlibrary` was accidentally removed because it looked related to the PR in https://github.com/internetarchive/openlibrary/pull/2955/files#diff-6b8bedf4a9d4d4148e6b17b3e2b92a9fL288-R287 but was not.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Borrowing should now succeed (go to borrowed book) not bring up a preview on archive.org, re-asking patron to borrow.

### Stakeholders
<!-- @ tag stakeholders of this bug -->

cc: @cdrini 