### PR TITLE
Adding the line break for better UI on Recent Changes page #3046

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 <!-- What issue does this PR close? -->
-Closes #
-
+Closes #3046 Adding the line break for better UI on Recent Changes page
 <!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
+feature
 
 ### Technical
-<!-- What should be noted about the implementation? -->
+a <br> tag is used to create a line-break between the div id="contentHead" and  class ="subnav".
 
 ### Testing
-<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
+run the server once and we can see that index.html has a line break in between.
 
 ### Evidence
 <!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
 
 ### Stakeholders
-<!-- @ tag stakeholders of this bug -->
+@aashimgarg

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 <!-- What issue does this PR close? -->
-Closes #3046 Adding the line break for better UI on Recent Changes page
+Closes #
+
 <!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
-feature
 
 ### Technical
-a <br> tag is used to create a line-break between the div id="contentHead" and  class ="subnav".
+<!-- What should be noted about the implementation? -->
 
 ### Testing
-run the server once and we can see that index.html has a line break in between.
+<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
 
 ### Evidence
 <!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
 
 ### Stakeholders
-@aashimgarg
+<!-- @ tag stakeholders of this bug -->

--- a/openlibrary/templates/recentchanges/index.html
+++ b/openlibrary/templates/recentchanges/index.html
@@ -34,6 +34,7 @@ $def subnav():
 
 <div id="contentHead">
     <h1>$:breadcrumbs()</h1>
+    <br>
     <div class="subNav">$:subnav()</div>
 </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3046 Adding the line break for better UI on Recent Changes page

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature
### Technical
a '<br>' tag is used to create a line-break between the div id="contentHead" and class ="subnav".

### Testing
run the server once and we can see that index.html has a line break in between.

### Stakeholders
@aashimgarg 