### PR TITLE
search: Use absolute imports

### DIFF
--- a/openlibrary/plugins/search/code.py
+++ b/openlibrary/plugins/search/code.py
@@ -19,7 +19,8 @@ from collections import defaultdict
 
 import six
 
-from openlibrary.plugins.search import solr_client, stopword
+from openlibrary.plugins.search import facet_hash, solr_client
+from openlibrary.plugins.search.collapse import collapse_groups
 
 render = template.render
 
@@ -69,7 +70,7 @@ def lookup_ocaid(ocaid):
     w = web.ctx.site.get(ocat[0]) if ocat else None
     return w
 
-from collapse import collapse_groups
+
 class fullsearch(delegate.page):
     def POST(self):
         errortext = None
@@ -134,7 +135,6 @@ class fullsearch(delegate.page):
 
     GET = POST
 
-import facet_hash
 facet_token = view.public(facet_hash.facet_token)
 
 class Timestamp(object):

--- a/openlibrary/plugins/search/solr_client.py
+++ b/openlibrary/plugins/search/solr_client.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import cgi
 import web
 import simplejson
-from facet_hash import facet_token
+from openlibrary.plugins.search.facet_hash import facet_token
 import pdb
 
 import six

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -803,10 +803,10 @@ class search_json(delegate.page):
         return delegate.RawText(json.dumps(response, indent=True))
 
 def setup():
-    import searchapi
+    from openlibrary.plugins.worksearch import searchapi
     searchapi.setup()
 
-    from . import subjects
+    from openlibrary.plugins.worksearch import subjects
 
     # subjects module needs read_author_facet and solr_select_url.
     # Importing this module to access them will result in circular import.
@@ -817,7 +817,7 @@ def setup():
 
     subjects.setup()
 
-    from . import publishers, languages
+    from openlibrary.plugins.worksearch import languages, publishers
     publishers.setup()
     languages.setup()
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Use absolute imports in the plugin search for compatibility with both Python 2 and Python 3.

These changes close 5 out of our current 9 open pytest errors on Python 3.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->