### PR TITLE
Makefile: add make lint-diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ reindex-solr:
 	su postgres -c "psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy"
 	su postgres -c "psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy"
 
+lint-diff:
+	git diff origin/master -U0 | $(PYTHON) -m flake8 --diff --max-line-length=88
+
 lint:
 	# stop the build if there are Python syntax errors or undefined names
 	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor/*  --select=E9,F63,F7,F822,F823 --show-source --statistics


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
As discussed at https://github.com/internetarchive/openlibrary/pull/3086#issuecomment-590492399 add a `make lint-diiff` command to ease the execution flake8 only on the lines modified vs. `origin/master`

`git diff origin/master -U0 | $(PYTHON) -m flake8 --diff --max-line-length=88`

`make lint` does not call `make lint-diff` because origin/master may not be defined.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @hornc @tfmorris @mekarpeles 