### PR TITLE
Travis CI: Drop the test on Ubuntu Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ jobs:
   include:
     - name: “Python 2.7 on xenial”
       python: "2.7"
-      dist: xenial
     - name: “Python 3.8 make lint only”
       python: "3.8"
       install: pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 os: linux
-dist: bionic
+dist: xenial
 language: python
 jobs:
   include:
     - name: “Python 2.7 on xenial”
       python: "2.7"
       dist: xenial
-    - name: “Python 2.7 on bionic”
-      python: "2.7"
     - name: “Python 3.8 make lint only”
       python: "3.8"
       install: pip install flake8
       script:
-        - make lint
         # On pull requests, run all flake8 tests on modified code
-        # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
-            git diff origin/master -U0 | flake8 --diff --max-line-length=88;
-          fi
-    - name: “Python 3.8 on bionic”
+        - make lint-diff
+        - make lint
+    - name: “Python 3.8 on xenial”
       python: "3.8"
   allow_failures:
-    - name: “Python 3.8 on bionic”
+    - name: “Python 3.8 on xenial”
 install:
   - pip install flake8
   - make lint


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Reduce our Travis CI build runs by one to save CPU/energy because our current Xenial and Bionic builds never disagree with each other.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
Currently on Travis CI, we run Python 2.7 on Xenial and Python 2.7 on Bionic which seems to be a waste of CPU because we have never seen the two runs disagree with each other.

Our prod envs are running Trusty (yes, it is EOL...) and our local dev env is running Xenial so for now we might as well drop testing on Bionic.  We can always add it again once it matters.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->