### PR TITLE
hotfix: fix incorrect arg name in new-solr-updater.py

### DIFF
--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -261,7 +261,8 @@ def main():
     state_file = args.state_file
     offset = read_state_file(state_file)
 
-    logfile = InfobaseLog(config.get('infobase_server'), exclude=args.exclude_edits)
+    logfile = InfobaseLog(config.get('infobase_server'),
+                          exclude=args.exclude_edits_containing)
     logfile.seek(offset)
 
     solr = Solr()


### PR DESCRIPTION
Hotfix: Accidentally forgot to update references to this arg after updating it argparse name -\_-

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->