### PR TITLE
book needs_purchase only if no price AND repub_state -1

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -196,7 +196,8 @@ def get_sponsored_books():
 
 def summary():
     """
-    Provides data model (finances, state-of-process) for the /admin/sponsorship stats page.
+    Provides data model (finances, state-of-process) for the /admin/sponsorship stats
+    page.
 
     Screenshot:
     https://user-images.githubusercontent.com/978325/71494377-b975c880-27fb-11ea-9c95-c0c1bfa78bda.png

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -177,6 +177,7 @@ def qualifies_for_sponsorship(edition):
     return resp
 
 def get_sponsored_books():
+    """Performs the `ia` query to fetch sponsored books from archive.org"""
     from internetarchive import search_items
     params = {'page': 1, 'rows': 1000}
     fields = ['identifier','est_book_price','est_scan_price', 'scan_price',

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -176,6 +176,7 @@ def qualifies_for_sponsorship(edition):
     })
     return resp
 
+
 def get_sponsored_books():
     """Performs the `ia` query to fetch sponsored books from archive.org"""
     from internetarchive import search_items

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -206,6 +206,10 @@ def summary():
     STATUSES = ['Needs purchasing', 'Needs digitizing', 'Needs republishing', 'Complete']
     status_counts = OrderedDict((status, 0) for status in STATUSES)
     for book in items:
+        # Official sponsored items set repub_state -1 at item creation,
+        # bulk sponsorship (item created at time of scanning by ttscribe)
+        # will not be repub_state -1. Thus. books which have repub_state -1
+        # and no price are those we need to digitize:
         if int(book.get('repub_state', -1)) == -1 and not book.get('book_price'):
             book['status'] = STATUSES[0]
             status_counts[STATUSES[0]] += 1

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -189,7 +189,7 @@ def get_sponsored_books():
     # XXX Note: This `search_items` query requires the `ia` tool (the
     # one installed via virtualenv) to be configured with (scope:all)
     # privileged s3 keys.
-    config = dict(general=dict(secure=False))
+    config = {'general': {'secure': False}}
     return search_items(q, fields=fields, params=params, config=config)
 
 


### PR DESCRIPTION
### Technical
<!-- What should be noted about the implementation? -->
N/A -- bulk items do not have a repub_state -1 so we update our checks s.t. book which need purchasing have a -1 repub_state (set by book sponsorship flow) 

Minor refactor to make it easier to test our sponsorship query results.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

tested on dev, affects admin only

Query can be tested on `ol-dev0` via:
```
import infogami; from openlibrary.config import load_config; load_config('/opt/openlibrary/olsystem/etc/openlibrary.yml'); infogami._setup(); from openlibrary.core.sponsorships import get_sponsored_books;
```

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@cdrini 