### PR TITLE
Absolute import: from scripts import _init_path again

### DIFF
--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -20,13 +20,13 @@ import os
 import simplejson
 import web
 
-from openlibrary.api import OpenLibrary, marshal, unmarshal
 from optparse import OptionParser
 
 import six
 
 sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
 import scripts._init_path  # noqa: E402,F401
+from openlibrary.api import OpenLibrary, marshal, unmarshal  # noqa: E402
 
 __version__ = "0.2"
 

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -26,7 +26,7 @@ import six
 
 sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
 import scripts._init_path  # noqa: E402,F401
-from openlibrary.api import OpenLibrary, marshal, unmarshal  # noqa: E402
+from openlibrary.api import OpenLibrary, marshal  # noqa: E402
 
 __version__ = "0.2"
 

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -11,11 +11,10 @@ This script can also be used to copy books and authors from OL to dev instance.
     ./scripts/copydocs.py /authors/OL113592A
     ./scripts/copydocs.py /works/OL1098727W?v=2
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from collections import namedtuple
 
-import _init_path
 import sys
 import os
 import simplejson
@@ -25,6 +24,9 @@ from openlibrary.api import OpenLibrary, marshal, unmarshal
 from optparse import OptionParser
 
 import six
+
+sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
+import scripts._init_path  # noqa: E402,F401
 
 __version__ = "0.2"
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2942
Uses absolute import to resolve pytest on Python 3 result:
```
_______________ ERROR collecting scripts/tests/test_copydocs.py ________________
ImportError while importing test module '/home/travis/build/internetarchive/openlibrary/scripts/tests/test_copydocs.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
scripts/tests/test_copydocs.py:1: in <module>
    from ..copydocs import copy, KeyVersionPair
scripts/copydocs.py:18: in <module>
    import _init_path
E   ModuleNotFoundError: No module named '_init_path'
```
We want to be able to run:
1. `scripts/copydocs.py`
2. `python2 scripts/copydocs.py`
3. `python3 scripts/copydocs.py`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->