### PR TITLE
Remove acs4 dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,3 @@
 [submodule "vendor/js/wmd"]
 	path = vendor/js/wmd
 	url = git://github.com/internetarchive/wmd.git
-[submodule "vendor/acs4_py"]
-	path = vendor/acs4_py
-	url = http://github.com/internetarchive/acs4_py.git

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -14,7 +14,6 @@ from infogami.utils.view import public
 from infogami.utils import delegate
 from openlibrary.core import cache
 from openlibrary.accounts.model import OpenLibraryAccount
-from openlibrary.plugins.upstream import acs4
 from openlibrary.plugins.upstream.utils import urlencode
 from openlibrary.utils import dateutil
 from six.moves import urllib

--- a/openlibrary/plugins/upstream/acs4.py
+++ b/openlibrary/plugins/upstream/acs4.py
@@ -1,1 +1,0 @@
-../../../vendor/acs4_py/acs4.py

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -409,14 +409,9 @@ class borrow_receive_notification(delegate.page):
         data = web.data()
         try:
             notify_xml = etree.fromstring(data)
-
-            # XXX verify signature?  Should be acs4 function...
-            # notify_obj is not used?
-            # notify_obj = acs4.el_to_o(notify_xml)
-
-            output = simplejson.dumps({'success':True})
+            output = simplejson.dumps({'success': True})
         except Exception as e:
-            output = simplejson.dumps({'success':False, 'error': str(e)})
+            output = simplejson.dumps({'success': False, 'error': str(e)})
         return delegate.RawText(output, content_type='application/json')
 
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -23,7 +23,6 @@ from openlibrary.core import waitinglist
 from openlibrary.core import ab
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary import accounts
-from openlibrary.plugins.upstream import acs4
 from openlibrary.utils import dateutil
 
 from lxml import etree
@@ -412,7 +411,8 @@ class borrow_receive_notification(delegate.page):
             notify_xml = etree.fromstring(data)
 
             # XXX verify signature?  Should be acs4 function...
-            notify_obj = acs4.el_to_o(notify_xml)
+            # notify_obj is not used?
+            # notify_obj = acs4.el_to_o(notify_xml)
 
             output = simplejson.dumps({'success':True})
         except Exception as e:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3055 
Closes #3119 assuming the correct answer is 'No, OL does not have a real dependency on acs4'


### What does this PR achieve? 
* Allows local dev linting to pass by avoiding the external vendor acs4.py code from outside this repo
* Removes a symlink (symlinks have caused problems on different OSs with Docker in the past)
* Removes a seemingly unused dependency from /vendors

### Technical
<!-- What should be noted about the implementation? -->
A call was made to a single method 

https://github.com/internetarchive/acs4_py/blob/66780231ed8b32214d880b900ff275bb8379fbee/acs4.py#L561-L580

and the result was not used anywhere.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- [ ] Needs to be tested somehow, apparently last time this was attempted there were problems?

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->