### PR TITLE
exclude node modules from linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 BUILD=static/build
 ACCESS_LOG_FORMAT='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
 GITHUB_EDITOR_WIDTH=127
+LINTEXCLUDE=./.*,scripts/20*,vendor/*,node_modules/*
 
 define lessc
 	echo Compressing $(1).less; \
@@ -64,10 +65,10 @@ lint-diff:
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor/* --select=E9,F63,F7,F82 --show-source --statistics
+	$(PYTHON) -m flake8 . --count --exclude=$(LINTEXCLUDE) --select=E9,F63,F7,F82 --show-source --statistics
 ifndef CONTINUOUS_INTEGRATION
 	# exit-zero treats all errors as warnings, only run this in local dev while fixing issue, not CI as it will never fail.
-	$(PYTHON) -m flake8 . --count --exclude=./.*,scripts/20*,vendor*,node_modules/* --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
+	$(PYTHON) -m flake8 . --count --exclude=$(LINTEXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 BUILD=static/build
 ACCESS_LOG_FORMAT='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
 GITHUB_EDITOR_WIDTH=127
-LINTEXCLUDE=./.*,scripts/20*,vendor/*,node_modules/*
+FLAKE_EXCLUDE=./.*,scripts/20*,vendor/*,node_modules/*
 
 define lessc
 	echo Compressing $(1).less; \
@@ -65,10 +65,10 @@ lint-diff:
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	$(PYTHON) -m flake8 . --count --exclude=$(LINTEXCLUDE) --select=E9,F63,F7,F82 --show-source --statistics
+	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --select=E9,F63,F7,F82 --show-source --statistics
 ifndef CONTINUOUS_INTEGRATION
 	# exit-zero treats all errors as warnings, only run this in local dev while fixing issue, not CI as it will never fail.
-	$(PYTHON) -m flake8 . --count --exclude=$(LINTEXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
+	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif
 
 test:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This is the uncontroversial bit of #3120  I'm trying to run the linting Makefile tasks locally and node_modules + the acs4 symlink are blocking.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->