### PR TITLE
Use integer division for Python 3

### DIFF
--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -126,7 +126,7 @@ class MarcBinary(MarcBase):
             directory = data[:self.directory_end].decode('utf-8')[24:]
             if len(directory) % 12 != 0:
                 raise BadMARC("MARC directory invalid length")
-        iter_dir = (directory[i*12:(i+1)*12] for i in range(len(directory) / 12))
+        iter_dir = (directory[i*12:(i+1)*12] for i in range(int(len(directory) // 12)))
         return iter_dir
 
     def leader(self):

--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -126,7 +126,7 @@ class MarcBinary(MarcBase):
             directory = data[:self.directory_end].decode('utf-8')[24:]
             if len(directory) % 12 != 0:
                 raise BadMARC("MARC directory invalid length")
-        iter_dir = (directory[i*12:(i+1)*12] for i in range(int(len(directory) // 12)))
+        iter_dir = (directory[i*12:(i+1)*12] for i in range(len(directory) // 12))
         return iter_dir
 
     def leader(self):


### PR DESCRIPTION
This PR fixes 63 failing pytests on Python 3.

$ python3
```
>>> range(15 / 3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'float' object cannot be interpreted as an integer
>>> range(15 // 3)
range(0, 5)
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->