### PR TITLE
Fix next() to be compatible with both Python 2 and Python 3

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -7,7 +7,7 @@ import web
 from infogami import config
 from infogami.utils import stats
 
-from . import cache
+from openlibrary.core import cache
 
 class Stats:
     def __init__(self, docs, key, total_key):
@@ -25,7 +25,7 @@ class Stats:
 
         try:
             # Last available total count
-            self.total = (x for x in reversed(docs) if total_key in x).next()[total_key]
+            self.total = next(x for x in reversed(docs) if total_key in x)[total_key]
         except (KeyError, StopIteration):
             self.total = ""
 

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -96,7 +96,7 @@ class TestGetIA():
             "%s: expected instanceof MarcBinary, got %s" % (item, type(result))
         field_245 = next(result.read_fields(['245']))
         title = next(field_245[1].get_all_subfields())[1].encode('utf8')
-        print("%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item, result.leader()[9], title)
+        print("%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item, result.leader()[9], title))
 
     @pytest.mark.parametrize('bad_marc', bad_marcs)
     def test_incorrect_length_marcs(self, bad_marc, monkeypatch):

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -94,9 +94,9 @@ class TestGetIA():
         result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(result, MarcBinary), \
             "%s: expected instanceof MarcBinary, got %s" % (item, type(result))
-        print("%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item,
-                                                     result.leader()[9],
-                                                     result.read_fields(['245']).next()[1].get_all_subfields().next()[1].encode('utf8')))
+        field_245 = next(result.read_fields(['245']))
+        title = next(field_245[1].get_all_subfields())[1].encode('utf8')
+        print("%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item, result.leader()[9], title)
 
     @pytest.mark.parametrize('bad_marc', bad_marcs)
     def test_incorrect_length_marcs(self, bad_marc, monkeypatch):


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/iterators.html#new-iteration-protocol-next

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->