### PR TITLE
fixing amazon call, error handling

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -232,7 +232,10 @@ def _get_amazon_metadata(id_, id_type='isbn'):
             id_ = isbn_13_to_isbn_10(id_)
 
     if amazon_api:
-        return amazon_api.get_product(id_, serialize=True)
+        try:
+            return amazon_api.get_product(id_, serialize=True)
+        except Exception:
+            return None
 
 
 def split_amazon_title(full_title):


### PR DESCRIPTION
hotfix to add error handling to last amazon #3125 which resulted in

```
ApiException: (400) Reason: Bad Request HTTP response headers: HTTPHeaderDict({'x-amzn-RequestId': 'c935a5db-2f02-4608-9586-58e759bfbfb1', 'Content-Length': '180', 'Vary': 'Accept-Encoding,X-Amzn-CDN-Cache,X-Amzn-AX-Treatment,User-Agent', 'Server': 'Server', 'x-amz-rid': 'VQ7MYA1E7CB0YN6981NE', 'Connection': 'keep-alive', 'Date': 'Fri, 06 Mar 2020 05:15:12 GMT', 'Content-Type': 'application/json'}) HTTP response body: {"__type":"com.amazon.paapi5#ValidationException","Errors":[{"Code":"InvalidParameterValue","Message":"The value [9791186701072] provided in the request for ItemIds is invalid."}]} (falling back to default template)
```