### PR TITLE
fixing addbook if not logged in via login redir

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -141,7 +141,7 @@ class addbook(delegate.page):
         """Main user interface for adding a book to Open Library."""
 
         if not self.has_permission():
-            return render_template("permission_denied", "/books/add", "Permission denied to add a book to Open Library.")
+            return web.seeother("/account/login?redirect={}".format(self.path))
 
         i = web.input(work=None, author=None)
         work = i.work and web.ctx.site.get(i.work)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #906 and follows up on the work of #2990

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged out, go to dev.openlibrary.org/addbook. You should be redirected to login with a referrer of /addbook (once logged in)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@user404d  