### PR TITLE
don't redirect back to archive.org after activate + login

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -310,6 +310,9 @@ class account_login(delegate.page):
 
     def GET(self):
         referer = web.ctx.env.get('HTTP_REFERER', '/')
+        # Don't set referer on user activation
+        if '//archive.org/account/verify.php' in referer:
+            referer = None
         i = web.input(redirect=referer)
         f = forms.Login()
         f['redirect'].value = i.redirect


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2985 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When a patron registers for an OpenLibrary.org account, activates, and then logs in, successful login should **not** redirect the patron back to `referrer` (if referrer was archive.org/account/verify.php). This PR resolves this edge case. (some times upon login we may want to send to a remote referrer)

### Technical
<!-- What should be noted about the implementation? -->
N/A

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Registered an account on dev.openlibrary.org, activated via archive.org, was presented with a link to login via openlibrary.org (edited this url in the page source to point to **dev.openlibrary.org**, clicked this link, logged in, and was presented with openlibrary.org (as expected) -- not redirected back to archive.org.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 