### PR TITLE
Python 3: string.letters --> string.ascii_letters

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -83,7 +83,7 @@ class memcache_memoize:
         return prefix + self._random_string(10)
 
     def _random_string(self, n):
-        chars = string.letters + string.digits
+        chars = string.ascii_letters + string.digits
         return "".join(random.choice(chars) for i in range(n))
 
     def __call__(self, *args, **kw):

--- a/openlibrary/coverstore/disk.py
+++ b/openlibrary/coverstore/disk.py
@@ -3,7 +3,7 @@ import os
 import string
 import warc
 
-chars = string.letters + string.digits
+chars = string.ascii_letters + string.digits
 def random_string(n):
     return "".join([random.choice(chars) for i in range(n)])
 
@@ -14,8 +14,8 @@ class Disk:
     >>> _ = os.system("rm -rf test_disk")
     >>> disk = Disk("test_disk")
     >>> f1 = disk.write("hello, world!")
-    >>> f2 = disk.write(string.letters)
-    >>> f3 = disk.write(string.letters)
+    >>> f2 = disk.write(string.ascii_letters)
+    >>> f3 = disk.write(string.ascii_letters)
     >>> disk.read(f1)
     'hello, world!'
     >>> disk.read(f2)
@@ -60,8 +60,8 @@ class WARCDisk:
         >>> _ = os.system("rm -rf test_disk")
         >>> disk = WARCDisk("test_disk", maxsize=200)
         >>> f1 = disk.write("hello, world!")
-        >>> f2 = disk.write(string.letters)
-        >>> f3 = disk.write(string.letters)
+        >>> f2 = disk.write(string.ascii_letters)
+        >>> f3 = disk.write(string.ascii_letters)
         >>> disk.read(f1)
         'hello, world!'
         >>> disk.read(f2)


### PR DESCRIPTION
`string.letters` was removed in Python 3 in favor of `string.ascii_letters`
https://docs.python.org/2/library/string.html
https://docs.python.org/3/whatsnew/3.0.html#library-changes

<!-- What issue does this PR close? -->
Closes two failing pytests on Python 3.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->