### PR TITLE
fixing bwb price when no isbn or market_price

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -421,8 +421,7 @@ def _get_betterworldbooks_metadata(isbn):
             price = _price
             qlt = 'new'
 
-    market_price = market_price and '$' + market_price[0]
-
+    market_price = ('$' + market_price[0]) if market_price else None
     return betterworldbooks_fmt(isbn, qlt, price, market_price)
 
 

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -6,15 +6,21 @@ $ asin = opts.get('asin', '')
 
 $ bwb_affiliate_url = 'https://www.anrdoezrs.net/links/%s/type/dlg/http://www.betterworldbooks.com/' % affiliate_id('betterworldbooks')
 $ amazon_affiliate_url = 'https://www.amazon.com/dp/%s/?tag=%s'
-$ bwb_metadata = {}
+
+$ bwb_metadata = None
 $ amz_price = None
 
 <ul class="buy-options-table">
   $if not is_bot():
+
     $# Fetch price data
     $if prices and isbn:
       $ bwb_metadata = get_betterworldbooks_metadata(isbn)
-      $ amz_price = bwb_metadata.get('market_price') or get_amazon_metadata(isbn, resources='prices').get('price')
+      $ bwb_price = bwb_metadata and bwb_metadata.get('price')
+      $ amz_price = bwb_metadata and bwb_metadata.get('market_price')
+      $if not amz_price:
+        $ amz_metadata = get_amazon_metadata(isbn, resources='prices')
+        $ amz_price = amz_metadata and amz_metadata.get('price')
 
     <li class="prices-betterworldbooks">
       $if isbn:
@@ -25,9 +31,9 @@ $ amz_price = None
       <a href="$bwb_affiliate_url" title="Look for this edition for sale at Better World Books"
          target="_blank">Better World Books</a>
 
-      $if bwb_metadata.get('price'):
+      $if bwb_price:
         <br>
-        <span name="price">$bwb_metadata['price'] - includes shipping</span>
+        <span name="price">$bwb_price - includes shipping</span>
 
     </li>
 

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -6,10 +6,11 @@ $ asin = opts.get('asin', '')
 
 $ bwb_affiliate_url = 'https://www.anrdoezrs.net/links/%s/type/dlg/http://www.betterworldbooks.com/' % affiliate_id('betterworldbooks')
 $ amazon_affiliate_url = 'https://www.amazon.com/dp/%s/?tag=%s'
+$ bwb_metadata = {}
+$ amz_price = {}
 
 <ul class="buy-options-table">
   $if not is_bot():
-
     $# Fetch price data
     $if prices and isbn:
       $ bwb_metadata = get_betterworldbooks_metadata(isbn)
@@ -24,7 +25,7 @@ $ amazon_affiliate_url = 'https://www.amazon.com/dp/%s/?tag=%s'
       <a href="$bwb_affiliate_url" title="Look for this edition for sale at Better World Books"
          target="_blank">Better World Books</a>
 
-      $if prices and bwb_metadata.get('price'):
+      $if bwb_metadata.get('price'):
         <br>
         <span name="price">$bwb_metadata['price'] - includes shipping</span>
 
@@ -34,7 +35,7 @@ $ amazon_affiliate_url = 'https://www.amazon.com/dp/%s/?tag=%s'
       <li class="prices-amazon">
         <a href="$(amazon_affiliate_url % (asin or isbn, affiliate_id('amazon')))"
            title="Look for this edition for sale at Amazon" target="_blank">Amazon</a>
-        $if prices and isbn and amz_price:
+        $if amz_price:
           <br>
           <span name="price">$(amz_price)</span>
       </li>

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -7,7 +7,7 @@ $ asin = opts.get('asin', '')
 $ bwb_affiliate_url = 'https://www.anrdoezrs.net/links/%s/type/dlg/http://www.betterworldbooks.com/' % affiliate_id('betterworldbooks')
 $ amazon_affiliate_url = 'https://www.amazon.com/dp/%s/?tag=%s'
 $ bwb_metadata = {}
-$ amz_price = {}
+$ amz_price = None
 
 <ul class="buy-options-table">
   $if not is_bot():

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -7,7 +7,7 @@ $ asin = opts.get('asin', '')
 $ bwb_affiliate_url = 'https://www.anrdoezrs.net/links/%s/type/dlg/http://www.betterworldbooks.com/' % affiliate_id('betterworldbooks')
 $ amazon_affiliate_url = 'https://www.amazon.com/dp/%s/?tag=%s'
 
-$ bwb_metadata = None
+$ bwb_price = None
 $ amz_price = None
 
 <ul class="buy-options-table">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

In some cases, BWB API returns empty list `[]` as `market_price` (esp. when `isbn` is `None`). 
(a) the check needs to be fixed (to return the 1st element, not the empty list, in these cases)
(b) the Affiliate macro needs to be updates so prices are always in scope when no isbn

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

https://dev.openlibrary.org/books/OL9315560M/1984?debug=true

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->