### PR TITLE
adds preview for printdisabled books

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -86,7 +86,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $else:
     <a href="$work.key" class="cta-btn cta-btn--missing">$_('Not in Library')</a>
 
-$if ocaid and page.is_access_restricted() and availability_status.startswith('borrow') and editions_page:
+$if ocaid and page.is_access_restricted() and editions_page:
   $:macros.BookPreview(ocaid, render_preview_floater)
 
 $if ocaid and page.is_access_restricted():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2829 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
N/A

### Testing & Evidence
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Here's an example of such a printdisabled book for testing:
https://dev.openlibrary.org/books/OL22691653M/Software_engineering

Example of a sponsorable of books
https://dev.openlibrary.org/books/OL2719185M/Linear_and_nonlinear_circuits

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 