### PR TITLE
WIP: GitHub Action pytest_on_python3 to track burndown

### DIFF
--- a/.github/workflows/pytest_on_python3.yml
+++ b/.github/workflows/pytest_on_python3.yml
@@ -59,7 +59,7 @@ jobs:
         #        openlibrary/tests/catalog/test_get_ia.py \
         #        openlibrary/tests/catalog/test_utils.py || true
         # coverstore: All failing tests run in allow failures (|| true) mode
-        - |
+      - run: |
             pytest openlibrary/coverstore/tests/test_coverstore.py \
                 openlibrary/coverstore/tests/test_doctests.py || true
         # plugins: All failing tests run in allow failures (|| true) mode

--- a/.github/workflows/pytest_on_python3.yml
+++ b/.github/workflows/pytest_on_python3.yml
@@ -1,0 +1,78 @@
+name: pytest_on_python3
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  pytest_on_python3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+      - pip install -r requirements_test.txt
+      - pushd vendor/infogami && git pull origin master && popd
+      - run: |
+            pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests \
+                openlibrary/coverstore/tests/test_code.py \
+                openlibrary/coverstore/tests/test_webapp.py \
+                openlibrary/plugins/admin/tests/test_services.py \
+                openlibrary/plugins/importapi/tests/test_code_ils.py \
+                openlibrary/plugins/importapi/tests/test_import_edition_builder.py \
+                openlibrary/plugins/openlibrary/tests/test_borrow_home.py \
+                openlibrary/plugins/openlibrary/tests/test_lists.py \
+                openlibrary/plugins/upstream/tests/test_account.py \
+                openlibrary/plugins/upstream/tests/test_addbook.py \
+                openlibrary/plugins/upstream/tests/test_forms.py \
+                openlibrary/plugins/upstream/tests/test_utils.py \
+                openlibrary/plugins/worksearch/tests/test_worksearch.py \
+                openlibrary/tests/core/test_cache.py \
+                openlibrary/tests/core/test_helpers.py \
+                openlibrary/tests/core/test_i18n.py \
+                openlibrary/tests/core/test_init.py \
+                openlibrary/tests/core/test_lending.py \
+                openlibrary/tests/core/test_lists_engine.py \
+                openlibrary/tests/core/test_models.py \
+                openlibrary/tests/core/test_olmarkdown.py \
+                openlibrary/tests/core/test_processors.py \
+                openlibrary/tests/core/test_processors_invalidation.py \
+                openlibrary/tests/core/test_ratings.py \
+                openlibrary/tests/core/test_sponsors.py \
+                openlibrary/tests/core/test_vendors.py \
+                openlibrary/tests/core/test_waitinglist.py
+                # Remove catalog tests as discussed in #3150
+                # openlibrary/catalog/marc/tests/test_marc_binary.py \
+                # openlibrary/catalog/marc/tests/test_marc_html.py \
+                # openlibrary/catalog/merge/test_amazon.py \
+                # openlibrary/catalog/merge/test_merge.py \
+                # openlibrary/catalog/merge/test_merge_marc.py \
+                # openlibrary/catalog/merge/test_names.py \
+                # openlibrary/catalog/merge/test_normalize.py \
+        # The following sections allow us to quickly spot tests that are fixed
+        # catalog: All failing tests run in allow failures (|| true) mode
+        # Remove catalog tests as discussed in #3150
+        #- |
+        #    pytest openlibrary/catalog/add_book/test_add_book.py \
+        #        openlibrary/catalog/add_book/test_load_book.py \
+        #        openlibrary/catalog/add_book/test_merge.py \
+        #        openlibrary/catalog/marc/tests/test_marc.py \
+        #        openlibrary/catalog/marc/tests/test_parse.py \
+        #        openlibrary/tests/catalog/test_get_ia.py \
+        #        openlibrary/tests/catalog/test_utils.py || true
+        # coverstore: All failing tests run in allow failures (|| true) mode
+        - |
+            pytest openlibrary/coverstore/tests/test_coverstore.py \
+                openlibrary/coverstore/tests/test_doctests.py || true
+        # plugins: All failing tests run in allow failures (|| true) mode
+      - run: |
+            pytest openlibrary/plugins/books/tests/test_doctests.py \
+                openlibrary/plugins/books/tests/test_dynlinks.py \
+                openlibrary/plugins/openlibrary/tests/test_home.py \
+                openlibrary/plugins/openlibrary/tests/test_stats.py \
+                openlibrary/plugins/upstream/tests/test_merge_authors.py \
+                openlibrary/plugins/upstream/tests/test_related_carousels.py || true
+        # openlibrary/tests: All failing tests run in allow failures (|| true) mode
+      - run: |
+            pytest openlibrary/tests/accounts/test_models.py \
+                openlibrary/tests/core/test_connections.py \
+                openlibrary/tests/core/test_ia.py \
+                openlibrary/tests/solr/test_update_work.py || true

--- a/.github/workflows/pytest_on_python3.yml
+++ b/.github/workflows/pytest_on_python3.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master
-      - pip install -r requirements_test.txt
-      - pushd vendor/infogami && git pull origin master && popd
+      - run: pip install -r requirements_test.txt
+      - run: pushd vendor/infogami && git pull origin master && popd
       - run: |
             pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests \
                 openlibrary/coverstore/tests/test_code.py \

--- a/.github/workflows/pytest_on_python3.yml
+++ b/.github/workflows/pytest_on_python3.yml
@@ -7,7 +7,7 @@ jobs:
   pytest_on_python3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
       - uses: actions/setup-python@master
       - run: pip install -r requirements_test.txt
       - run: pushd vendor/infogami && git pull origin master && popd

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -1,5 +1,7 @@
 """pytest configutation for openlibrary
 """
+# flake8: noqa
+
 import glob
 import sys
 
@@ -8,19 +10,17 @@ import web
 
 import six
 
-from openlibrary.core import helpers
-from openlibrary.i18n import gettext
-from openlibrary.mocks.mock_ia import mock_ia
-from openlibrary.mocks.mock_infobase import mock_site
-from openlibrary.mocks.mock_memcache import mock_memcache
-from openlibrary.mocks.mock_ol import ol
-
-# sys.path.insert(0, "openlibrary/vendor")  # Enable openlibrary/vendor/infogami to be imported.
-sys.path.insert(0, "../vendor")  # Enable openlibrary/vendor/infogami to be imported.
-sys.path.insert(0, "./vendor")  # Enable openlibrary/vendor/infogami to be imported.
+sys.path.insert(0, "openlibrary/vendor")  # Enable import openlibrary/vendor/infogami
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 from infogami.utils.view import render_template as infobase_render_template
+
+from openlibrary.core import helpers
+from openlibrary.i18n import gettext
+from openlibrary.mocks.mock_infobase import mock_site
+from openlibrary.mocks.mock_ia import mock_ia
+from openlibrary.mocks.mock_memcache import mock_memcache
+from openlibrary.mocks.mock_ol import ol
 
 
 @pytest.fixture(autouse=True)

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -1,21 +1,25 @@
 """pytest configutation for openlibrary
 """
 import glob
+import sys
+
 import pytest
 import web
 
 import six
 
+from openlibrary.core import helpers
+from openlibrary.i18n import gettext
+from openlibrary.mocks.mock_ia import mock_ia
+from openlibrary.mocks.mock_infobase import mock_site
+from openlibrary.mocks.mock_memcache import mock_memcache
+from openlibrary.mocks.mock_ol import ol
+
+sys.path.insert(0, "openlibrary/vendor")  # Enable openlibrary/vendor/infogami to be imported.
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 from infogami.utils.view import render_template as infobase_render_template
-from openlibrary.i18n import gettext
-from openlibrary.core import helpers
 
-from openlibrary.mocks.mock_infobase import mock_site
-from openlibrary.mocks.mock_ia import mock_ia
-from openlibrary.mocks.mock_memcache import mock_memcache
-from openlibrary.mocks.mock_ol import ol
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -10,7 +10,9 @@ import web
 
 import six
 
-sys.path.insert(0, "openlibrary/vendor")  # Enable import openlibrary/vendor/infogami
+# sys.path.insert(0, "openlibrary/vendor")  # Enable import openlibrary/vendor/infogami
+sys.path.insert(0, "../vendor")  # Enable import openlibrary/vendor/infogami
+sys.path.insert(0, "./vendor")  # Enable import openlibrary/vendor/infogami
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 from infogami.utils.view import render_template as infobase_render_template

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -15,7 +15,9 @@ from openlibrary.mocks.mock_infobase import mock_site
 from openlibrary.mocks.mock_memcache import mock_memcache
 from openlibrary.mocks.mock_ol import ol
 
-sys.path.insert(0, "openlibrary/vendor")  # Enable openlibrary/vendor/infogami to be imported.
+# sys.path.insert(0, "openlibrary/vendor")  # Enable openlibrary/vendor/infogami to be imported.
+sys.path.insert(0, "../vendor")  # Enable openlibrary/vendor/infogami to be imported.
+sys.path.insert(0, "./vendor")  # Enable openlibrary/vendor/infogami to be imported.
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 from infogami.utils.view import render_template as infobase_render_template


### PR DESCRIPTION
An alternative to #3149 that allows us to temporarily track our burndown of the remaining pytests on Python 3 without backsliding.  https://github.com/internetarchive/openlibrary/actions

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->