### PR TITLE
Remove `state:backlogged` label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "Type: Bug, State: Backlogged, Needs: Triage"
+labels: "Type: Bug, Needs: Triage"
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: "Type: Feature, State: Backlogged, Needs: Triage"
+labels: "Type: Feature, Needs: Triage"
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -2,7 +2,7 @@
 name: Question
 about: Propose an answerable question
 title: ''
-labels: "Type: Question, State: Backlogged, Needs: Triage"
+labels: "Type: Question, Needs: Triage"
 assignees: ''
 ---
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part of #3161 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes `State:Backlogged` from issue templates

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->