### PR TITLE
updating makefile, generate librejs fsf agplv3 licenses + fix utf8 css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ js:
 	mkdir -p $(BUILD)
 	rm -f $(BUILD)/*.js $(BUILD)/*.js.map
 	npm run build-assets:webpack
+	# This adds FSF licensing for AGPLv3 to our js (for librejs)
+	for js in $(BUILD)/*.js; do \
+		echo "// @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3.0" | cat - $$js > /tmp/js && mv /tmp/js $$js; \
+		echo "\n// @license-end"  >> $$js; \
+	done
 
 i18n:
 	$(PYTHON) ./scripts/i18n-messages compile

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -21,6 +21,32 @@ $def with (page)
     <link href="/static/images/openlibrary-128x128.png" rel="icon" sizes="128x128" />
     $ style = 'build/page-%s.css'%ctx.get('bodyid', 'user')
     <link href="$static_url(style)" rel="stylesheet" type="text/css" />
+
+
+ <script>
+
+/* @licstart  The following is the entire license notice for the
+ * JavaScript code in this page.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @licend  The above is the entire license notice
+ * for the JavaScript code in this page.
+ */
+
+  </script>
+
     <!-- Both v2 and v1 pages have a JavaScript execution queue that will
     be emptied at the bottom of the page -->
     <script type="text/javascript">window.q = [];</script>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bundlesize": [
     {
       "path": "static/build/editions-table.*.js",
-      "maxSize": "16.7KB"
+      "maxSize": "16.8KB"
     },
     {
       "path": "static/build/graphs.*.js",

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -167,4 +167,16 @@
   }
 }
 
+.slick {
+  // This is a fix for firefox + Librejs
+  // because the slick css passed through js
+  // and librejs is breaking on utf8 chars
+  &-next::before {
+    content: '→' !important;
+  }
+  &-prev::before {
+    content: '←' !important;
+  }
+}
+
 @import (less) "category-item.less";


### PR DESCRIPTION
co-authored w/ @cdrini: updates the Makefile w/ agplv3 license information so that openlibrary.org passes [librejs](https://www.gnu.org/software/librejs/) validation for @brewsterkahle's talk. :)

<!-- What issue does this PR close? -->
Closes #3154 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

When librejs is enabled in firefox, we are noting that some js libraries (e.g. slick) are not loading fonts correctly when the characters are utf8 (namely → and ←) so `important` tags are used in our less to ensure these are gracefully set correctly.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Install [librejs](https://ftp.gnu.org/gnu/librejs/librejs-7.20.1.xpi) xpi for firefox, make sure to "pass" (i.e. whitelist) the archive.org includes (which are only included as dev dependencies and may be safely ignored) and then hopefully note that there is a green check next to librejs extension icon.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![wtf](https://user-images.githubusercontent.com/978325/76369707-9edac800-62f1-11ea-9c95-deb8cad54ed3.png)

@cdrini tested w/ me

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bfalling 
