### PR TITLE
Less erroneous availability for works

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -268,15 +268,18 @@ def add_availability(items):
             'lending_identifier',  # In solr works records + worksearch get_doc
         ]
         # SOLR WORK RECORDS ONLY:
-        # If public domain, prioritize ia over lending_identifier (i.e. prefer freely
-        # readable over borrowable)
-        # HACK: Obviously this isn't a good test for public domain, but none of the
-        # fields we store in solr can accurately tell us if a work is public domain.
-        # Long term solution is a full reindex, but this will work in the vast majority
-        # of cases for now
+        # Open Library only has access to a list of archive.org IDs
+        # and solr isn't currently equipped with the information
+        # necessary to determine which editions may be openly
+        # available. Using public domain date as a heuristic
+        # Long term solution is a full reindex, but this hack will work in the
+        # vast majority of cases for now.
+        # NOTE: there is still a risk pre-1923 books will get a print-diabled-only
+        # or lendable edition.
         # Note: guaranteed to be int-able if none None
+        US_PD_YEAR = 1923
         if ('first_publish_year' in item
-                and float(item['first_publish_year'] or '-inf') > 1923):
+                and float(item['first_publish_year'] or '-inf') > US_PD_YEAR):
             possible_fields.remove('ia')
             possible_fields.append('ia')
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -278,8 +278,8 @@ def add_availability(items):
         # or lendable edition.
         # Note: guaranteed to be int-able if none None
         US_PD_YEAR = 1923
-        if ('first_publish_year' in item
-                and float(item['first_publish_year'] or '-inf') > US_PD_YEAR):
+        if float(item.get('first_publish_year') or '-inf') > US_PD_YEAR:
+            # Prefer `lending_identifier` over `ia` (push `ia` to bottom)
             possible_fields.remove('ia')
             possible_fields.append('ia')
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -209,7 +209,8 @@ def run_solr_query(param = {}, rows=100, page=1, sort=None, spellcheck_count=Non
         ('fl', ','.join(fields or [
             'key', 'author_name', 'author_key', 'title', 'subtitle', 'edition_count',
             'ia', 'has_fulltext', 'first_publish_year', 'cover_i', 'cover_edition_key',
-            'public_scan_b', 'lending_edition_s', 'ia_collection_s'])),
+            'public_scan_b', 'lending_edition_s', 'lending_identifier_s',
+            'ia_collection_s'])),
         ('fq', 'type:work'),
         ('q.op', 'AND'),
         ('start', offset),
@@ -361,7 +362,8 @@ def get_doc(doc): # called from work_search template
         has_fulltext = (doc.find("bool[@name='has_fulltext']").text == 'true'),
         public_scan = ((e_public_scan.text == 'true') if e_public_scan is not None else (e_ia is not None)),
         lending_edition = (e_lending_edition.text if e_lending_edition is not None else None),
-        lending_identifier = (e_lending_identifier and e_lending_identifier.text),
+        lending_identifier=(
+            e_lending_identifier.text if e_lending_identifier is not None else None),
         collections = collections,
         authors = authors,
         first_publish_year = first_pub,


### PR DESCRIPTION
Closes #2141 ; Fix: Choose a better ia id when displaying work availability instead of random.

### Technical
- Solr records store an ia id in "lending_identifier" which is less likely to be print-disabled-only; prefer that when getting availability to choosing the first ia id (which is ~random).
- HOWEVER, that field does not include freely available books, so it would show a "Borrow" button even when a work is PD. Unfortunately there is no accurate way to determine if a work is PD via solr info, so using a hack for now. The only long term solution to this would likely involve a full re-index of solr, with more information stored therein.
- The other possible solution would involve making multiple requests to IA for availability data, or ~doubling the number of OCAIDs sent to IA for availability checking. I assumed these were non-options.

### Testing
- ✅ Previously failing PD works now readable on search page:
  - Before: https://openlibrary.org/search?q=wind+in+the+willows&mode=everything
  - After: https://dev.openlibrary.org/search?q=wind+in+the+willows&mode=everything
- ✅ regular results work as before https://openlibrary.org/search?q=1984&mode=everything
- ✅ Previously failing borrowable works now borrowable
  - Before: https://openlibrary.org/search?q=author%3Aorwell&mode=everything
  - After: https://dev.openlibrary.org/search?q=author%3Aorwell&mode=everything
- ✅ Author pages
  - Before: https://openlibrary.org/authors/OL118077A/George_Orwell
  - After: https://dev.openlibrary.org/authors/OL118077A/George_Orwell

### Evidence
Before/After:
George Orwell: https://dev.openlibrary.org/authors/OL118077A/George_Orwell
![image](https://user-images.githubusercontent.com/6251786/76459263-3dc6f900-63b2-11ea-9a93-e3aed8b6e207.png)
J. K. Rowling: https://dev.openlibrary.org/authors/OL23919A/J._K._Rowling
![image](https://user-images.githubusercontent.com/6251786/76460852-2f2e1100-63b5-11ea-8abc-3626b6179f49.png)

### Stakeholders
@mekarpeles 