### PR TITLE
Standardizing CTA Button metrics

### DIFF
--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -34,7 +34,7 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
 
   $elif (availability_status == 'borrow_unavailable'):
     $if waiting_loan:
-        <span data-ol-link-track="leave_waitlist">
+        <span data-ol-link-track="CTAClick|LeaveWaitlist">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="leave-waitlist waitinglist-form">
             <input type="hidden" name="action" value="leave-waitinglist"/>
             <input type="submit" class="cta-btn cta-btn--missing" id="unwaitlist_ebook" value="Leave Waitlist"/>
@@ -49,7 +49,7 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
         </div>
 
     $else:
-        <span class="borrow_unavailable" data-ol-link-track="borrow_unavailable">
+        <span class="borrow_unavailable" data-ol-link-track="CTAClick|JoinWaitlist">
           <form method="POST" action="$(read_link)?action=join-waitinglist" class="join-waitlist waitinglist-form">
             <input type="hidden" name="action" value="join-waitinglist"/>
             <button type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook">

--- a/openlibrary/macros/AvailabilityButton.html
+++ b/openlibrary/macros/AvailabilityButton.html
@@ -65,7 +65,8 @@ $if availability_status in ['open', 'borrow_available', 'borrow_unavailable']:
           </div>
 
 $else:
-  <a href="$page.key" class="cta-btn--missing cta-btn">$_('Not in Library')</a>
+  <a href="$page.key" class="cta-btn--missing cta-btn"
+     data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
   $if page.ia:
     $ daisy_url = "/ia/%s/daisy" % page.ia[0]
     $:macros.daisy(page, url=daisy_url, protected=True, msg=_("Print-disabled access available"))

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -20,7 +20,8 @@ $if render_floater:
         </div>
         <p class="learn-more">
           <a href="https://archive.org/details/$ocaid"
-             data-key="book_preview_learn_more">
+             data-key="book_preview_learn_more"
+             data-ol-link-track="book_preview_learn_more">
             $_("See more about this book on Archive.org")
           </a>
         </p>

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -10,7 +10,7 @@ $if render_floater:
       <div class="book-preview">
         <div class="floaterHead">
           <h2>$_('Preview Book')</h2>
-          <a class="dialog--close" data-key="book_preview" data-ol-link-track="book_preview"
+          <a class="dialog--close" data-key="book_preview" data-ol-link-track="CTAClick|Preview"
              title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div class="iframe-container">
@@ -20,8 +20,7 @@ $if render_floater:
         </div>
         <p class="learn-more">
           <a href="https://archive.org/details/$ocaid"
-             data-key="book_preview_learn_more"
-             data-ol-link-track="book_preview_learn_more">
+             data-key="book_preview_learn_more">
             $_("See more about this book on Archive.org")
           </a>
         </p>

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -2,7 +2,8 @@ $def with (ocaid, render_floater=True)
 $# :param str ocaid:
 $# :param bool render_floater: whether to render the floater's HTML
 
-<a class="cta-btn cta-btn--shell cta-btn--preview" href="#bookPreview">$_('Preview')</a>
+<a class="cta-btn cta-btn--shell cta-btn--preview"
+   data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview')</a>
 
 $if render_floater:
   <div class="hidden">
@@ -10,7 +11,7 @@ $if render_floater:
       <div class="book-preview">
         <div class="floaterHead">
           <h2>$_('Preview Book')</h2>
-          <a class="dialog--close" data-key="book_preview" data-ol-link-track="CTAClick|Preview"
+          <a class="dialog--close" data-key="book_preview"
              title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div class="iframe-container">

--- a/openlibrary/macros/BookSearchInside.html
+++ b/openlibrary/macros/BookSearchInside.html
@@ -1,6 +1,6 @@
 $def with(ocaid, q="")
   <form action="/borrow/ia/$(ocaid)">
     <input class="cta-btn cta-btn--shell" type="text" name="q"
-           data-ol-link-track="CTALink|ReadSearchInside"
+           data-ol-link-track="CTAClick|ReadSearchInside"
            placeholder="$_('Search Inside')">
   </form>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -84,7 +84,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
       <a href="/sponsorship" target="_blank">Learn More</a>
     </p>
   $else:
-    <a href="$work.key" class="cta-btn cta-btn--missing">$_('Not in Library')</a>
+    <a href="$work.key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
 
 $if ocaid and page.is_access_restricted() and editions_page:
   $:macros.BookPreview(ocaid, render_preview_floater)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -77,7 +77,7 @@ $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
     $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"
-       data-ol-link-track="book-sponsorship">Sponsor eBook</a>
+       data-ol-link-track="CTAClick|Sponsor">Sponsor eBook</a>
     <p>
       We don’t have this book yet. You can add it to our Lending
       Library with a $sponsorship['price']['total_price_display'] tax deductible donation.

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -23,7 +23,7 @@ $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
   $if listen:
     <a href="$(stream_url)&_autoReadAloud=show"
        title="$title using Read Aloud"
-       data-ol-link-track="CTALink|$(action.capitalize())Listen"
+       data-ol-link-track="CTAClick|$(action.capitalize())Listen"
        class="cta-btn cta-btn--available">
       <span class="btn-icon read-aloud"></span>
       <span class="btn-label">$_('Listen')</span>

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -16,9 +16,9 @@ $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
      $if loan:
        data-userid="$(loan['userid'])"
      $elif borrow:
-       data-ol-link-track="borrow"
+       data-ol-link-track="CTAClick|Borrow"
      $else:
-       data-ol-link-track="read_unrestricted"
+       data-ol-link-track="CTAClick|Read"
      class="cta-btn cta-btn--available">$label</a>
   $if listen:
     <a href="$(stream_url)&_autoReadAloud=show"

--- a/openlibrary/macros/databarHistory.html
+++ b/openlibrary/macros/databarHistory.html
@@ -9,7 +9,8 @@ $else:
     $if not page.is_fake_record():
         <div id="editButton">
             <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
-            <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')" accesskey="e">$_("Edit")</a>
+            <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
+               data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
         </div>
     <div id="editInfo">
         $ author = get_recent_author(page)

--- a/openlibrary/macros/databarTemplate.html
+++ b/openlibrary/macros/databarTemplate.html
@@ -5,6 +5,7 @@ $def with (page)
       <a class="linkButton larger" href="$changequery(m='history')" title="View this template's edit history" accesskey="h">$_("History")</a>
     </div>
     <div id="editButton">
-        <a class="linkButton larger" href="$changequery(m='edit')" title="Edit this template" accesskey="e">$_("Edit")</a>
+        <a class="linkButton larger" href="$changequery(m='edit')" title="Edit this template"
+           data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
     </div>
 </div>

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -9,7 +9,8 @@ $else:
     $if not page.is_fake_record():
         <div id="editButton">
           <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
-          <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')" accesskey="e">$_("Edit")</a>
+          <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
+             data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
         </div>
     <div id="editInfo">
         $if "superfast" in ctx.features:

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -231,7 +231,7 @@ function initAvailability() {
                                 if (work.status === 'open' || work.status === 'borrow_available') {
                                     $(cta).append(`<a href="/books/${work.openlibrary_edition}/x/borrow" ` +
                                                   'class="cta-btn cta-btn--available" ' +
-                                                  `data-ol-link-track="CTAClick|Borrow">${
+                                                  `data-ol-link-track="CTAClick|${work.status === 'open' ? 'Read' : ' Borrow'}">${
                                                       work.status === 'open' ? 'Read' : ' Borrow'
                                                   }</a>`);
                                 } else if (work.status === 'borrow_unavailable') {

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -239,7 +239,7 @@ function initAvailability() {
                                                   'action="/books/'}${work.openlibrary_edition}/x/borrow?action=join-waitinglist" ` +
                                                   'class="join-waitlist waitinglist-form">' +
                                                   '<input type="hidden" name="action" value="join-waitinglist">' +
-                                                  `<button type="submit" class="cta-btn cta-btn--unavailable" data-ol-link-track="CTAClick|JoinWaitlist">` +
+                                                  '<button type="submit" class="cta-btn cta-btn--unavailable" data-ol-link-track="CTAClick|JoinWaitlist">' +
                                                   `Join Waitlist${
                                                       work.num_waitlist !== '0' ? ` <span class="cta-btn__badge">${work.num_waitlist}</span>` : ''
                                                   }</button></form>${

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -231,8 +231,8 @@ function initAvailability() {
                                 if (work.status === 'open' || work.status === 'borrow_available') {
                                     $(cta).append(`<a href="/books/${work.openlibrary_edition}/x/borrow" ` +
                                                   'class="cta-btn cta-btn--available" ' +
-                                                  `data-ol-link-track="CTAClick|${work.status === 'open' ? 'Read' : ' Borrow'}">${
-                                                      work.status === 'open' ? 'Read' : ' Borrow'
+                                                  `data-ol-link-track="CTAClick|${work.status === 'open' ? 'Read' : 'Borrow'}">${
+                                                      work.status === 'open' ? 'Read' : 'Borrow'
                                                   }</a>`);
                                 } else if (work.status === 'borrow_unavailable') {
                                     $(cta).append(`${'<form method="POST" ' +

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -231,7 +231,7 @@ function initAvailability() {
                                 if (work.status === 'open' || work.status === 'borrow_available') {
                                     $(cta).append(`<a href="/books/${work.openlibrary_edition}/x/borrow" ` +
                                                   'class="cta-btn cta-btn--available" ' +
-                                                  `data-ol-link-track="${work.status}">${
+                                                  `data-ol-link-track="CTAClick|Borrow">${
                                                       work.status === 'open' ? 'Read' : ' Borrow'
                                                   }</a>`);
                                 } else if (work.status === 'borrow_unavailable') {
@@ -239,7 +239,7 @@ function initAvailability() {
                                                   'action="/books/'}${work.openlibrary_edition}/x/borrow?action=join-waitinglist" ` +
                                                   'class="join-waitlist waitinglist-form">' +
                                                   '<input type="hidden" name="action" value="join-waitinglist">' +
-                                                  `<button type="submit" class="cta-btn cta-btn--unavailable" data-ol-link-track="${work.status}">` +
+                                                  `<button type="submit" class="cta-btn cta-btn--unavailable" data-ol-link-track="CTAClick|JoinWaitlist">` +
                                                   `Join Waitlist${
                                                       work.num_waitlist !== '0' ? ` <span class="cta-btn__badge">${work.num_waitlist}</span>` : ''
                                                   }</button></form>${

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -85,7 +85,8 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           </ul>
         $else:
           <form>
-            <input type="submit" class="cta-btn cta-btn--missing" disabled value="$_('Not in Library')">
+            <input type="submit" class="cta-btn cta-btn--missing" 
+                   data-ol-link-track="CTAClick|NotInLibrary" disabled value="$_('Not in Library')">
           </form>
           $if book.ocaid:
             $:macros.daisy(book, protected=True)

--- a/openlibrary/templates/widget.html
+++ b/openlibrary/templates/widget.html
@@ -26,22 +26,22 @@ $ book_title = item.get('title', '')
       $if book_status == "open" :
         $ public_url = canonical_url("/books/" + item["availability"]["openlibrary_edition"] + "/x/borrow")
         <div class="cta open" type="submit">
-          <a data-ol-link-track="embed|read"  target="_blank" href="$public_url" title="Read &quot;$book_title&quot;">Read</a>
+          <a data-ol-link-track="Embed|Read"  target="_blank" href="$public_url" title="Read &quot;$book_title&quot;">Read</a>
 	</div>
       $elif book_status == "borrow_available" :
         $ borrow_url = canonical_url("/borrow/ia/" + item["availability"]["identifier"])
         <div class="cta available" type="submit">
-          <a data-ol-link-track="embed|borrow" target="_blank" href="$borrow_url" title="Borrow &quot;$book_title&quot;">Borrow</a>
+          <a data-ol-link-track="Embed|Borrow" target="_blank" href="$borrow_url" title="Borrow &quot;$book_title&quot;">Borrow</a>
 	</div>
       $elif book_status == "borrow_unavailable":
         $ waitlist_url = canonical_url("/borrow/ia/" + item["availability"]["identifier"] + "?action=join-waitinglist")
         <form class="cta waitlist" method="POST" action="$waitlist_url" target="_blank">
           <input type="hidden" name="action" value="join-waitinglist">
-          <button data-ol-link-track="embed|waitlist" type="submit" title="Join waitlist for &quot;$book_title&quot;">Join Waitlist</button>
+          <button data-ol-link-track="Embed|JoinWaitlist" type="submit" title="Join waitlist for &quot;$book_title&quot;">Join Waitlist</button>
         </form>
       $else:
         <div class="cta open">
-          <a data-ol-link-track="embed|learn" target="_blank" href="$(canonical_url(item['key']))" title="Learn more about &quot;$book_title&quot; at OpenLibrary">Learn More</a>
+          <a data-ol-link-track="Embed|Learn" target="_blank" href="$(canonical_url(item['key']))" title="Learn more about &quot;$book_title&quot; at OpenLibrary">Learn More</a>
 	</div>
       <p class="service">on <a target="_blank" href="$(canonical_url('/'))">openlibrary.org</a></p>
     </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2795 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Normalizes how we track analytics across Open Library for cta (call-to-action) buttons. (e.g. read, borrow, etc)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Verify on dev.openlibrary.org that on the following pages use the right `CTAClick` syntax:
- search results pages
- works / editions pages
- authors pages
- list pages

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 