### PR TITLE
 pub_year = -sys.maxsize: Py3 refuses to sort None

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -327,7 +327,7 @@ class SolrProcessor:
                         v = v.strip()
                         if v not in identifiers[k]:
                             identifiers[k].append(v)
-        return sorted(editions, key=lambda e: int(e.get('pub_year', -sys.maxsize)))
+        return sorted(editions, key=lambda e: int(e.get('pub_year', 0)) or -sys.maxsize)
 
     def get_author(self, a):
         """

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -327,7 +327,7 @@ class SolrProcessor:
                         v = v.strip()
                         if v not in identifiers[k]:
                             identifiers[k].append(v)
-        return sorted(editions, key=lambda e: e.get('pub_year', -sys.maxisze))
+        return sorted(editions, key=lambda e: e.get('pub_year', -sys.maxsize))
 
     def get_author(self, a):
         """

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -327,7 +327,7 @@ class SolrProcessor:
                         v = v.strip()
                         if v not in identifiers[k]:
                             identifiers[k].append(v)
-        return sorted(editions, key=lambda e: int(e.get('pub_year', 0)) or -sys.maxsize)
+        return sorted(editions, key=lambda e: int(e.get('pub_year') or -sys.maxsize))
 
     def get_author(self, a):
         """

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -327,7 +327,7 @@ class SolrProcessor:
                         v = v.strip()
                         if v not in identifiers[k]:
                             identifiers[k].append(v)
-        return sorted(editions, key=lambda e: e.get('pub_year', None))
+        return sorted(editions, key=lambda e: e.get('pub_year', -sys.maxisze))
 
     def get_author(self, a):
         """

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -327,7 +327,7 @@ class SolrProcessor:
                         v = v.strip()
                         if v not in identifiers[k]:
                             identifiers[k].append(v)
-        return sorted(editions, key=lambda e: e.get('pub_year', -sys.maxsize))
+        return sorted(editions, key=lambda e: int(e.get('pub_year', -sys.maxsize)))
 
     def get_author(self, a):
         """


### PR DESCRIPTION
The earliest possible `pub_year` should be 9223372036854775807 BC.
https://stackoverflow.com/questions/12971631/sorting-list-by-an-attribute-that-can-be-none

1. Convert all instances of `None` to the year -9223372036854775807
2. Convert all values to `int()` because some are `str` while others are `int`
    * Python2: 'a' > 1  # True
    * Python3: 'a' > 1  # TypeError: '>' not supported between instances of 'str' and 'int'

<!-- What issue does this PR close? -->
Closes ~8 failing pytests on Python 3

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->