### PR TITLE
Made Eligibility API to fail gracefully

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -324,6 +324,8 @@ class sponsorship_eligibility_check(delegate.page):
             else models.Edition.from_isbn(_id)
             
         )
+        if not edition:
+            return simplejson.dumps({ "status" : "error", "reason" : "Invalid ISBN 13"})
         return simplejson.dumps(qualifies_for_sponsorship(edition))
 
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -325,7 +325,7 @@ class sponsorship_eligibility_check(delegate.page):
             
         )
         if not edition:
-            return simplejson.dumps({ "status" : "error", "reason" : "Invalid ISBN 13"})
+            return simplejson.dumps({"status": "error", "reason": "Invalid ISBN 13"})
         return simplejson.dumps(qualifies_for_sponsorship(edition))
 
 


### PR DESCRIPTION
Closes #2517

Technical
Checked if not an eligible edition should throw an error

Testing
Go to https://dev.openlibrary.org/sponsorship/eligibility/97802992042042 and check if the API throws an error gracefully

Stakeholders
@cdrini here is the updated pr as I messed up the previous branch in merging from master