### PR TITLE
Allow AST Constant in web.py templates

### DIFF
--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -37,6 +37,7 @@ def render_template(request):
     # load all globals.
     web.template.Template.globals["_"] = gettext
     web.template.Template.globals.update(helpers.helpers)
+    web.template.ALLOWED_AST_NODES.append('Constant')
 
     web.ctx.env = web.storage()
     web.ctx.headers = []


### PR DESCRIPTION
The Python 3 Abstract Syntax Tree is different than the Python 2 AST so this PR proposes that 'Constant' be enabled in alignment with https://stackoverflow.com/questions/58518448/how-to-fix-execution-of-constant-statements-is-denied-error

<!-- What issue does this PR close? -->
Closes three pytests on Python 3.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->