### PR TITLE
Refactors IA-Powered Carousels (Supplants #2161: ia.IAEditionSearch)

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -281,8 +281,21 @@ def uniq(values, key=None):
 def affiliate_id(affiliate):
     return config.get('affiliate_ids', {}).get(affiliate, '')
 
+
+def ia_domain():
+    return config.get('ia_base_url', 'https://archive.org')
+
+
+def http_request_timeout():
+    return config.get('http_request_timeout')
+
+
 def bookreader_host():
     return config.get('bookreader_host', '')
+
+
+def default_imageurl():
+    return '/images/icons/avatar_book.png'
 
 def private_collections():
     """Collections which are lendable but should not be linked from OL

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -3,6 +3,7 @@
 
 import logging
 import requests
+import simplejson
 import six
 import os
 import web
@@ -27,45 +28,45 @@ class IAEditionSearch:
     AVAILABILITY_STATUS = 'loans__status__status'
     RESPONSE_FIELDS = 'fl[]'
     VALID_SORTS = [
-        '__random', '__sort', 'addeddate', 'avg_rating', 'call_number',
-        'createdate', 'creatorSorter', 'creatorSorterRaw', 'date',
-        'downloads', 'foldoutcount', 'headerImage', 'identifier',
-        'identifierSorter', 'imagecount', 'indexdate',
-        'item_size', 'languageSorter', 'licenseurl', 'mediatype',
-        'mediatypeSorter', 'month', 'nav_order', 'num_reviews',
-        'programSorter', 'publicdate', 'reviewdate', 'stars',
-        'titleSorter', 'titleSorterRaw', 'week',  'year',
+        '__random', '__sort', 'addeddate', 'avg_rating',
+        'call_number', 'createdate', 'creatorSorter',
+        'creatorSorterRaw', 'date', 'downloads', 'foldoutcount',
+        'headerImage', 'identifier', 'identifierSorter', 'imagecount',
+        'indexdate', 'item_size', 'languageSorter', 'licenseurl',
+        'mediatype', 'mediatypeSorter', 'month', 'nav_order',
+        'num_reviews', 'programSorter', 'publicdate', 'reviewdate',
+        'stars', 'titleSorter', 'titleSorterRaw', 'week', 'year',
         'loans__status__last_loan_date'
     ]
 
     PRESET_QUERIES = {
         'preset:thrillers': (
             'creator:('
-              '"Clancy, Tom" OR "King, Stephen" OR "Clive Cussler" OR '
-              '"Cussler, Clive" OR "Dean Koontz" OR "Koontz, Dean" OR '
-              '"Higgins, Jack"'
+            ' "Clancy, Tom" OR "King, Stephen" OR "Clive Cussler" OR '
+            ' "Cussler, Clive" OR "Dean Koontz" OR "Koontz, Dean" OR '
+            ' "Higgins, Jack"'
             ') AND '
             '!publisher:"Pleasantville, N.Y. : Reader\'s Digest Association" AND '
             'languageSorter:"English"'
         ),
         'preset:children': (
             'creator:('
-              '"parish, Peggy" OR "avi" OR "Dahl, Roald" OR "ahlberg, allan" OR '
-              '"Seuss, Dr" OR "Carle, Eric" OR "Pilkey, Dav"'
+            ' "parish, Peggy" OR "avi" OR "Dahl, Roald" OR "ahlberg, allan" OR '
+            ' "Seuss, Dr" OR "Carle, Eric" OR "Pilkey, Dav"'
             ') OR title:"goosebumps"'
         ),
         'preset:comics': (
             'subject:"comics" OR '
             'creator:('
-              '"Gary Larson" OR "Larson, Gary" OR "Charles M Schulz" OR '
-              '"Schulz, Charles M" OR "Jim Davis" OR "Davis, Jim" OR '
-              '"Bill Watterson" OR "Watterson, Bill" OR "Lee, Stan"'
+            ' "Gary Larson" OR "Larson, Gary" OR "Charles M Schulz" OR '
+            ' "Schulz, Charles M" OR "Jim Davis" OR "Davis, Jim" OR '
+            ' "Bill Watterson" OR "Watterson, Bill" OR "Lee, Stan"'
             ')'
         ),
         'preset:authorsalliance_mitpress': (
             '(!loans__status__status:UNAVAILABLE) AND ('
-              'openlibrary_subject:("authorsalliance" OR "mitpress") OR '
-              'collection:(mitpress) OR publisher:(MIT Press)'
+            ' openlibrary_subject:("authorsalliance" OR "mitpress") OR '
+            ' collection:(mitpress) OR publisher:(MIT Press)'
             ')'
         )
     }
@@ -125,8 +126,10 @@ class IAEditionSearch:
             if isinstance(sorts, list):
                 # compare against field with +asc/desc suffix rm'd
                 # e.g: date, not date+asc or date+desc
-                return [sort.replace('+', ' ') for sort in sorts
-                    if sort.split('+')[0] in cls.VALID_SORTS]
+                return [
+                    sort.replace('+', ' ') for sort in sorts
+                    if sort.split('+')[0] in cls.VALID_SORTS
+                ]
 
     @classmethod
     def _expand_api_query(cls, query):
@@ -177,7 +180,6 @@ class IAEditionSearch:
         :rtype: str
         :return: a url for humans to view this query on archive.org
         """
-        from openlibrary.core import lending
         _sort = sorts[0] if sorts else ''
         if ' desc' in _sort:
             _sort = '-' + _sort.split(' ')[0]
@@ -205,11 +207,11 @@ class IAEditionSearch:
             response = urllib2.urlopen(
                 request, timeout=h.http_request_timeout()).read()
             return simplejson.loads(response).get('response', {})
-        except Exception as e:
+        except Exception:
             return []
 
     @classmethod
-    def _add_availability_to_edition(edition, item_index):
+    def _add_availability_to_edition(cls, edition, item_index):
         """
         To avoid a 2nd network call to `lending.add_availability`
         reconstruct availability info ad-hoc from archive.org

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -198,7 +198,7 @@ class IAEditionSearch:
         """
         try:
             import urllib2  # to port to requests
-            request = urllib2.Request(url)
+            request = six.moves.urllib.request.Request(url)
             # Internet Archive Elastic Search (which powers some of our
             # carousel queries) needs Open Library to forward user IPs so
             # we can attribute requests to end-users

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -146,6 +146,11 @@ class IAEditionSearch:
         if query in cls.PRESET_QUERIES:
             query = cls.PRESET_QUERIES[query]
 
+        # Expand work_id queries (related)
+        # XXX
+        if '\[/works/OL[0-9]+W\:([a-z])\]':
+            pass
+
         q = 'mediatype:texts AND !noindex:* AND openlibrary_work:(*)'
         # Add availability if none present (e.g. borrowable only)
         if cls.AVAILABILITY_STATUS not in query:
@@ -233,13 +238,14 @@ class IAEditionSearch:
         :rtype: Edition
         :return: edition, modified to include availability
         """
-        item = item_index[edition.ocaid]
-        edition.set_availability(
-            identifier=item.get('identifier', ''),
-            status=item.get(cls.AVAILABILITY_STATUS, 'error'),
-            num_loans=int(item.get('loans__status__num_loans', 0)),
-            num_waitlist=int(item.get('loans__status__num_waitlist', 0)),
-        )
+        item = item_index.get(edition.ocaid)
+        if item:
+            edition.set_availability(
+                identifier=item.get('identifier', ''),
+                status=item.get(cls.AVAILABILITY_STATUS, 'error'),
+                num_loans=int(item.get('loans__status__num_loans', 0)),
+                num_waitlist=int(item.get('loans__status__num_waitlist', 0)),
+            )
         return edition
 
     @staticmethod

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -204,7 +204,7 @@ class IAEditionSearch:
             # we can attribute requests to end-users
             client_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR', 'ol-internal')
             request.add_header('x-client-id', client_ip)
-            response = urllib2.urlopen(
+            response = six.moves.urllib.request.urlopen(
                 request, timeout=h.http_request_timeout()).read()
             return simplejson.loads(response).get('response', {})
         except Exception:

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -120,8 +120,7 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
     (backed by archive.org search, so we don't have to send users to
     archive.org to see more books)
     """
-    from openlibrary.plugins.openlibrary.home import CAROUSELS_PRESETS
-    query = CAROUSELS_PRESETS[query] if query in CAROUSELS_PRESETS else query
+    query = ia.IAEditionSearch.PRESET_QUERIES.get(query, query)
     q = 'openlibrary_work:(*)'
 
     # If we don't provide an openlibrary_subject and no collection is

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -10,8 +10,6 @@ import uuid
 import hmac
 
 from infogami.utils.view import public
-from infogami.utils import delegate
-from openlibrary.core import cache
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.plugins.upstream import acs4
 from openlibrary.utils import dateutil
@@ -93,26 +91,9 @@ def setup(config):
     config_http_request_timeout = config.get('http_request_timeout')
 
 
-def get_work_authors_and_related_subjects(work_id):
-    if 'env' not in web.ctx:
-        delegate.fakeload()
-    work = web.ctx.site.get(work_id)
-    return {
-        'authors': work.get_author_names(blacklist=['anonymous']) if work else [],
-        'subjects': work.get_related_books_subjects() if work else []
-    }
 
 @public
-def cached_work_authors_and_subjects(work_id):
-    try:
-        return cache.memcache_memoize(
-            get_work_authors_and_related_subjects, 'works_authors_and_subjects',
-            timeout=dateutil.HALF_DAY_SECS)(work_id)
-    except AttributeError:
-        return {'authors': [], 'subject': []}
-
-@public
-def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
+def compose_ia_url(limit=None, page=1, subject=None, query=None,
                    _type=None, sorts=None, advanced=True):
     """This needs to be exposed by a generalized API endpoint within
     plugins/openlibrary/api/browse which lets lazy-load more items for
@@ -143,26 +124,6 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
         q += " AND " + query
     if subject:
         q += " AND openlibrary_subject:" + subject
-
-    if work_id:
-        if _type.lower() in ["authors", "subjects"]:
-            _q = None
-            works_authors_and_subjects = cached_work_authors_and_subjects(work_id)
-            if works_authors_and_subjects:
-                if _type == "authors":
-                    authors = []
-                    for author_name in works_authors_and_subjects.get('authors', []):
-                        authors.append(author_name)
-                        authors.append(','.join(author_name.split(' ', 1)[::-1]))
-                    if authors:
-                        _q = ' OR '.join(['creator:"%s"' % author for author in authors])
-                elif _type == "subjects":
-                    subjects = works_authors_and_subjects.get('subjects', [])
-                    if subjects:
-                        _q = ' OR '.join(['subject:"%s"' % subject for subject in subjects])
-            if not _q:
-                return []
-            q += ' AND (%s) AND !openlibrary_work:(%s)' % (_q, work_id.split('/')[-1])
 
     if not advanced:
         _sort = sorts[0] if sorts else ''

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -196,9 +196,59 @@ class Thing(client.Thing):
             "l": self._get_lists_cached(),
         }
 
+
 class Edition(Thing):
     """Class to represent /type/edition objects in OL.
     """
+
+
+    @staticmethod
+    def canonicalize(edition):
+        """
+        Ensures `ocaid` property, normalizes `authors` as array, sets cover_url
+
+        :param dict or web.storage edition:
+        :rtype: Edition
+        """
+        work = edition.works and edition.works[0]
+
+        def _get_cover_url(edition, work):
+            ol_covers = (
+                doc.get_cover().url('M') for doc in [edition, work]
+                if doc and doc.get_cover()
+            )
+            if ol_covers:
+                return next(ol_covers)
+
+            if edition.ocaid:
+                return '%s/services/img/%s' % (
+                    lending.config_ia_domain, edition.ocaid)
+
+            return h.default_imageurl()
+
+        def _get_ocaid(edition):
+            if edition.get('ocaid'):
+                return edition.ocaid
+            if edition.get('ia'):
+                if isinstance(edition.ia, list):
+                    return edition.ia[0]
+                return edition.ia
+            if edition.availability:
+                return edition.availability.identifier
+
+        # Use ocaid as canonical internet archive identifier
+        edition.ocaid = _get_ocaid(edition)
+
+        # Ensure author is set
+        edition.authors = [web.storage(key=a.key, name=a.name or None) for a in
+                           (work or edition).get_authors()]
+
+        # Get bookcover from edition, or work, IA fallback, or default
+        edition.cover_url = _get_cover_url(edition, work)
+
+        return edition
+
+
     def url(self, suffix="", **params):
         return self.get_url(suffix, **params)
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -211,12 +211,12 @@ class Edition(Thing):
         work = edition.works and edition.works[0]
 
         def _get_cover_url(edition, work):
-            ol_covers = (
+            ol_covers = [
                 doc.get_cover().url('M') for doc in [edition, work]
                 if doc and doc.get_cover()
-            )
+            ]
             if ol_covers:
-                return next(ol_covers)
+                return ol_covers[0]
 
             if edition.ocaid:
                 return '%s/services/img/%s' % (

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -205,7 +205,7 @@ class Edition(Thing):
         """
         Ensures `ocaid` property, normalizes `authors` as array, sets cover_url
 
-        :param dict or web.storage edition:
+        :param dict or web.storage or Edition edition:
         :rtype: Edition
         """
         work = edition.works and edition.works[0]

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -198,9 +198,7 @@ class Thing(client.Thing):
 
 
 class Edition(Thing):
-    """Class to represent /type/edition objects in OL.
-    """
-
+    """Class to represent /type/edition objects in OL."""
 
     @staticmethod
     def canonicalize(edition):
@@ -222,7 +220,7 @@ class Edition(Thing):
 
             if edition.ocaid:
                 return '%s/services/img/%s' % (
-                    lending.config_ia_domain, edition.ocaid)
+                    h.ia_domain(), edition.ocaid)
 
             return h.default_imageurl()
 

--- a/openlibrary/macros/RelatedWorksCarousel.html
+++ b/openlibrary/macros/RelatedWorksCarousel.html
@@ -1,9 +1,8 @@
 $def with(work)
 
 $if work and not is_bot():
-    $ work_subjects_authors = cached_work_authors_and_subjects(work.key)
-    $ authors = ', '.join([author if isinstance(author, basestring) else author.name for author in work_subjects_authors.get('authors', [])])
+    $ authors = ', '.join(work.get_author_names()) 
     <div class="related-books">
-      $:render_template("home/custom_ia_carousel", title="You might also like", key="related-subjects-carousel", work_id=work.key, _type="subjects", limit=42, min_books=1)
-      $:render_template("home/custom_ia_carousel", title="More by %s" % (authors or "this author"), key="related-authors-carousel", work_id=work.key, _type="authors", limit=42, min_books=1)
+      $:render_template("home/custom_ia_carousel", query='[%s:subjects]' % work.key, title="You might also like", key="related-subjects-carousel", limit=42, min_books=1)
+      $:render_template("home/custom_ia_carousel", query='[%s:authors]' % work.key, title="More by %s" % (authors or "this author"), key="related-authors-carousel", limit=42, min_books=1)
     </div>

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -61,14 +61,12 @@ class browse(delegate.page):
     encoding = "json"
 
     def GET(self):
-        i = web.input(q='', page=1, limit=100, subject='',
-                      work_id='', _type='', sorts='')
+        i = web.input(q='', page=1, limit=100, subject='', sorts='')
         sorts = i.sorts.split(',')
         page = int(i.page)
         limit = int(i.limit)
         url = lending.compose_ia_url(
-            query=i.q, limit=limit, page=page, subject=i.subject,
-            work_id=i.work_id, _type=i._type, sorts=sorts)
+            query=i.q, limit=limit, page=page, subject=i.subject, sorts=sorts)
         result = {
             'query': url,
             'works': [

--- a/openlibrary/plugins/openlibrary/carousels.py
+++ b/openlibrary/plugins/openlibrary/carousels.py
@@ -1,10 +1,14 @@
 """Methods for carousels"""
 
+import web
+
+from infogami.utils import delegate
 from infogami.infobase.client import storify
 from infogami.utils.view import public
 
 from openlibrary.core.ia import IAEditionSearch
 from openlibrary.core import cache
+
 
 @public
 def get_editions_by_ia_query(query='', sorts=None, page=1, limit=None,

--- a/openlibrary/plugins/openlibrary/carousels.py
+++ b/openlibrary/plugins/openlibrary/carousels.py
@@ -13,6 +13,9 @@ from openlibrary.core import cache
 @public
 def get_editions_by_ia_query(query='', sorts=None, page=1, limit=None,
                              timeout=cache.DEFAULT_CACHE_LIFETIME):
+    """
+    TODO: Currently (2020-04-10) unused; will be used in custom_carousel
+    """
     def editions_by_ia_query(query='', sorts=None, page=1, limit=None):
         # Enable method to be cacheable
         if 'env' not in web.ctx:

--- a/openlibrary/plugins/openlibrary/carousels.py
+++ b/openlibrary/plugins/openlibrary/carousels.py
@@ -27,3 +27,6 @@ def get_editions_by_ia_query(query='', sorts=None, page=1, limit=None,
         editions_by_ia_query, 'editions.search_ia', timeout=timeout)(
             query=query, sorts=sorts, page=page, limit=limit)
     return storify(results)
+
+def setup():
+    pass

--- a/openlibrary/plugins/openlibrary/carousels.py
+++ b/openlibrary/plugins/openlibrary/carousels.py
@@ -1,0 +1,22 @@
+"""Methods for carousels"""
+
+from infogami.infobase.client import storify
+from infogami.utils.view import public
+
+from openlibrary.core.ia import IAEditionSearch
+from openlibrary.core import cache
+
+@public
+def get_editions_by_ia_query(query='', sorts=None, page=1, limit=None,
+                             timeout=cache.DEFAULT_CACHE_LIFETIME):
+    def editions_by_ia_query(query='', sorts=None, page=1, limit=None):
+        # Enable method to be cacheable
+        if 'env' not in web.ctx:
+            delegate.fakeload()
+        editions = IAEditionSearch.get(query=query, sorts=sorts, page=page, limit=limit)
+        return editions
+
+    results = cache.memcache_memoize(
+        editions_by_ia_query, 'editions.search_ia', timeout=timeout)(
+            query=query, sorts=sorts, page=page, limit=limit)
+    return storify(results)

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -865,11 +865,13 @@ def setup_context_defaults():
 
 
 def setup():
-    from openlibrary.plugins.openlibrary import (home, borrow_home, stats, support,
-                                                 events, design, status, authors)
+    from openlibrary.plugins.openlibrary import (
+        home, borrow_home, stats, support,
+        events, design, status, authors, carousels)
 
     home.setup()
     design.setup()
+    carousels.setup()
     borrow_home.setup()
     stats.setup()
     support.setup()

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -213,7 +213,8 @@ def format_work_data(work):
                         zip(work['author_key'], work['author_name'])]
 
     if 'cover_edition_key' in work:
-        d['cover_url'] = get_coverstore_url() + "/b/olid/%s-M.jpg" % work['cover_edition_key']
+        d['cover_url'] = ("%s/b/olid/%s-M.jpg" % (
+            get_coverstore_url(), work['cover_edition_key']))
 
     d['read_url'] = "//archive.org/stream/" + work['ia'][0]
     return d

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -84,13 +84,13 @@ def test_query_parser_fields():
     assert list(func(q)) == expect
 
     expect = [
-        {'field': 'text', 'value': 'flatland\:a romance of many dimensions'},
+        {'field': 'text', 'value': r'flatland\:a romance of many dimensions'},
     ]
     q = 'flatland:a romance of many dimensions'
     assert list(func(q)) == expect
 
     expect = [
-        { 'field': 'title', 'value': 'flatland\:a romance of many dimensions'},
+        {'field': 'title', 'value': r'flatland\:a romance of many dimensions'},
     ]
     q = 'title:flatland:a romance of many dimensions'
     assert list(func(q)) == expect

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -1,8 +1,10 @@
-from __future__ import print_function
 import unittest
-from openlibrary.plugins.worksearch.code import read_facets, sorted_work_editions, parse_query_fields, escape_bracket, run_solr_query, get_doc, build_q_list, escape_colon, parse_search_response
+from openlibrary.plugins.worksearch.code import (
+    read_facets, sorted_work_editions, parse_query_fields,
+    escape_bracket, get_doc, build_q_list,
+    escape_colon, parse_search_response
+)
 from lxml import etree
-from infogami import config
 
 def test_escape_bracket():
     assert escape_bracket('foo') == 'foo'
@@ -50,7 +52,6 @@ def test_query_parser_fields():
 
     expect = [{'field': 'text', 'value': 'query here'}]
     q = 'query here'
-    print(q)
     assert list(func(q)) == expect
 
     expect = [
@@ -83,13 +84,13 @@ def test_query_parser_fields():
     assert list(func(q)) == expect
 
     expect = [
-        {'field': 'text', 'value': r'flatland\:a romance of many dimensions'},
+        {'field': 'text', 'value': 'flatland\:a romance of many dimensions'},
     ]
     q = 'flatland:a romance of many dimensions'
     assert list(func(q)) == expect
 
     expect = [
-        { 'field': 'title', 'value': r'flatland\:a romance of many dimensions'},
+        { 'field': 'title', 'value': 'flatland\:a romance of many dimensions'},
     ]
     q = 'title:flatland:a romance of many dimensions'
     assert list(func(q)) == expect
@@ -102,16 +103,6 @@ def test_query_parser_fields():
     q = 'authors:Kim Harrison OR authors:Lynsay Sands'
     assert list(func(q)) == expect
 
-#     def test_public_scan(lf):
-#         param = {'subject_facet': ['Lending library']}
-#         (reply, solr_select, q_list) = run_solr_query(param, rows = 10, spellcheck_count = 3)
-#         print solr_select
-#         print q_list
-#         print reply
-#         root = etree.XML(reply)
-#         docs = root.find('result')
-#         for doc in docs:
-#             assert get_doc(doc).public_scan == False
 
 def test_get_doc():
     sample_doc = etree.fromstring('''<doc>
@@ -152,4 +143,3 @@ def test_parse_search_response():
     expect = {'error': 'This is an error'}
     assert parse_search_response(test_input) == expect
     assert parse_search_response('{"aaa": "bbb"}') == {'aaa': 'bbb'}
-

--- a/openlibrary/templates/home/custom_ia_carousel.html
+++ b/openlibrary/templates/home/custom_ia_carousel.html
@@ -1,7 +1,10 @@
-$def with(title, key, query='', subject='', work_id='', _type='', sorts='', limit=None, min_books=7, test=False)
+$def with(title, key, query='', sorts='', limit=None, min_books=7, test=False)
 
-$ url = compose_ia_url(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit, advanced=False)
-$ books = generic_carousel(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit) if not test else []
+$ results = get_editions_by_ia_query(query=query, sorts=sorts)
+$ books = results.editions
+$ url = results.browse_url
 $ sorts = ','.join(sorts) if sorts else ''
-$ load_more_url = '/browse.json?q=%s&subject=%s&work_id=%s&_type=%s&sorts=%s' % (query, subject, work_id, _type, sorts)
-$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more={"url": load_more_url, "mode": "page", "limit": limit}, test=test)
+$ load_more_url = '/browse.json?q=%s&sorts=%s' % (query, sorts)
+$ load_more = {"url": load_more_url, "mode": "page", "limit": limit}
+
+$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more=load_more, test=test)

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -10,7 +10,7 @@ $var title: $_("Welcome to Open Library")
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='openlibrary_subject:openlibrary_staff_picks AND languageSorter:("English")', sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
   $:render_template("home/custom_ia_carousel", title=_('Recently Returned'), key="recently_returned", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
@@ -20,7 +20,7 @@ $var title: $_("Welcome to Open Library")
 
   $:render_template("home/custom_ia_carousel", title=_('Thrillers'), key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Textbooks'), key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Textbooks'), key="textbooks", query="openlibrary_subject:textbooks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
 
   $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
 

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,4 +1,6 @@
 from openlibrary.core import ia
+from infogami import config
+
 
 def test_get_metadata(monkeypatch, mock_memcache):
     metadata = {
@@ -18,6 +20,48 @@ def test_get_metadata(monkeypatch, mock_memcache):
         "_filenames": []
     }
 
+
 def test_get_metadata_empty(monkeypatch, mock_memcache):
     monkeypatch.setattr(ia, 'get_api_response', lambda *args: {})
     assert ia.get_metadata('foo02bar') == {}
+
+
+def test_normalize_sorts():
+    dirty_sorts = ['loans__status__last_loan_date+desc']
+    clean_sorts = ['loans__status__last_loan_date desc']
+    assert(ia.IAEditionSearch._normalize_sorts(dirty_sorts) == clean_sorts)
+
+
+def test_ia_search_queries():
+    """Make sure IA Advanced Search and Human Browsable urls are
+    constructed correctly
+    """
+    query = 'test'
+    prepared_query = (
+        'mediatype:texts AND !noindex:* AND openlibrary_work:(*) AND '
+        'loans__status__status:AVAILABLE AND test'
+    )
+    assert(ia.IAEditionSearch.MAX_LIMIT == 20)
+    advancedsearch_url = (
+        'http://archive.org/advancedsearch.php?'
+        'rows=20&q=mediatype%3Atexts+AND+%21noindex%3A%2A+AND+'
+        'openlibrary_work%3A%28%2A%29+AND+'
+        'loans__status__status%3AAVAILABLE+AND+'
+        'test&output=json&fl%5B%5D=identifier'
+        '&fl%5B%5D=loans__status__status&fl%5B%5D=openlibrary_edition'
+        '&fl%5B%5D=openlibrary_work&page=1&sort%5B%5D='
+    )
+    browse_url = (
+        'https://archive.org/search.php?'
+        'query=mediatype:texts AND '
+        '!noindex:* AND openlibrary_work:(*) AND '
+        'loans__status__status:AVAILABLE AND test&sort='
+    )
+    _expanded_query = ia.IAEditionSearch._expand_api_query(query)
+    _params = ia.IAEditionSearch._clean_params(q=_expanded_query)
+    assert(_expanded_query == prepared_query)
+    assert(ia.IAEditionSearch._clean_params(
+        q='test', limit=200).get('rows') == ia.IAEditionSearch.MAX_LIMIT)
+    composed_url = ia.IAEditionSearch._compose_advancedsearch_url(**_params)
+    assert(composed_url == advancedsearch_url)
+    assert(ia.IAEditionSearch._compose_browsable_url(prepared_query) == browse_url)

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -40,7 +40,7 @@ def test_ia_search_queries():
         'mediatype:texts AND !noindex:* AND openlibrary_work:(*) AND '
         'loans__status__status:AVAILABLE AND test'
     )
-    assert(ia.IAEditionSearch.MAX_LIMIT == 20)
+    assert(ia.IAEditionSearch.MAX_EDITIONS_LIMIT == 20)
     advancedsearch_url = (
         'http://archive.org/advancedsearch.php?'
         'rows=20&q=mediatype%3Atexts+AND+%21noindex%3A%2A+AND+'
@@ -60,7 +60,7 @@ def test_ia_search_queries():
     _params = ia.IAEditionSearch._clean_params(q=_expanded_query)
     assert(_expanded_query == prepared_query)
     assert(ia.IAEditionSearch._clean_params(
-        q='test', limit=200).get('rows') == ia.IAEditionSearch.MAX_LIMIT)
+        q='test', limit=200).get('rows') == ia.IAEditionSearch.MAX_EDITIONS_LIMIT)
     composed_url = ia.IAEditionSearch._compose_advancedsearch_url(**_params)
     assert(composed_url == advancedsearch_url)
     assert(ia.IAEditionSearch._compose_browsable_url(prepared_query) == browse_url)

--- a/openlibrary/tests/core/test_ia.py
+++ b/openlibrary/tests/core/test_ia.py
@@ -1,5 +1,4 @@
 from openlibrary.core import ia
-from infogami import config
 
 
 def test_get_metadata(monkeypatch, mock_memcache):

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -28,7 +28,7 @@ class MockSite:
             olid = data['olid']
             return web.storage(key=self.olids.get(olid))
 
-    def _get_backreferences(self):
+    def _get_backreferences(self, *args, **kwargs):
         return {}
 
 def test_MockSite():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2161 (incomplete stale refactor of IAEditionSearch)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This PR `refactor`s how Open Library queries Archive.org Elastic Search for books matching certain queries (which are then converted into a fetch of the desired Open Library editions w/ correct Archive.org availability information) 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- [x] rendering homepage carousels should work (all the carousels should be there, e.g. thrillers -- otherwise, this reflects an error in the Elastic Search queries)
- [x] clicking on the title/link of IA-powered homepage carousels on dev + production should produce an Archive.org search results page with comparable # of results 
- [x] tests for IAEditionSearch should pass
- [x] subject pages should render with correct availability information
- [x] homepage carousel infinite loading should work
- [x] IA-powered "similar books" + "more by author" should work on books page(s): e.g. https://dev.openlibrary.org/books/OL8870200M/A_Tale_of_Two_Cities

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @cclauss 