### PR TITLE
Use pymemcache MockMemcacheClient instead of mockcache on Python 3

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -67,8 +67,12 @@ class memcache_memoize:
                 self._memcache = memcache.Client(servers)
             else:
                 web.debug("Could not find memcache_servers in the configuration. Used dummy memcache.")
-                import mockcache
-                self._memcache = mockcache.Client()
+                try:
+                    import mockcache  # Only supports legacy Python
+                    self._memcache = mockcache.Client()
+                except ImportError:  # Python 3
+                    from pymemcache.test.utils import MockMemcacheClient
+                    self._memcache = MockMemcacheClient()
 
         return self._memcache
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,6 +5,7 @@
 -r requirements_common.txt
 flake8==3.7.9
 mockcache==1.0.3; python_version < '3.0'
+pymemcache==3.0.0; python_version >= '3.0'
 ptvsd==4.3.2
-pytest==4.6.6; python_version < '3.0'
-pytest==5.2.2; python_version >= '3.0'
+pytest==4.6.9; python_version < '3.0'
+pytest==5.4.1; python_version >= '3.0'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,5 +7,5 @@ flake8==3.7.9
 mockcache==1.0.3; python_version < '3.0'
 pymemcache==3.0.0; python_version >= '3.0'
 ptvsd==4.3.2
-pytest==4.6.9; python_version < '3.0'
-pytest==5.4.1; python_version >= '3.0'
+pytest==4.6.6; python_version < '3.0'
+pytest==5.2.2; python_version >= '3.0'

--- a/scripts/test-py3.sh
+++ b/scripts/test-py3.sh
@@ -18,6 +18,7 @@ pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests \
     openlibrary/tests/core/test_cache.py \
     openlibrary/tests/core/test_connections.py \
     openlibrary/tests/core/test_helpers.py \
+    openlibrary/tests/core/test_ia.py \
     openlibrary/tests/core/test_i18n.py \
     openlibrary/tests/core/test_init.py \
     openlibrary/tests/core/test_lending.py \
@@ -63,5 +64,4 @@ pytest openlibrary/plugins/books/tests/test_dynlinks.py \
 
 # openlibrary/tests: All failing tests run in allow failures (|| true) mode
 pytest openlibrary/tests/accounts/test_models.py \
-    openlibrary/tests/core/test_ia.py \
     openlibrary/tests/solr/test_update_work.py || true


### PR DESCRIPTION
This PR leaves Python2 unmodified but changes Python 3 to pass pytests.

Use [`from pymemcache.test.utils import MockMemcacheClient`](https://pymemcache.readthedocs.io/en/latest/apidoc/pymemcache.test.utils.html) on Python 3 because `mockcache` only supports legacy Python.

<!-- What issue does this PR close? -->
Closes #3183

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->