### PR TITLE
Read & Return Ebook buttons sep internetarchive#2972:v1

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -38,9 +38,12 @@ $if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=True)
   $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">
+    <p>
     <input type="hidden" name="action" value="return" />
     <input type="submit" value="Return eBook" class="cta-btn cta-btn--available" id="return_ebook"/>
+    </p>
   </form>
+
 
 $elif ocaid and not page.is_access_restricted() and editions_page:
   $:macros.ReadButton(ocaid, listen=True)
@@ -60,16 +63,21 @@ $elif (availability_status == 'borrow_unavailable'):
           $:_('You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list.', spot=spot, wlsize=wlsize)
     </p>
     <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
+      <p>
       <input type="hidden" name="action" value="leave-waitinglist"/>
       <input type="submit" class="cta-btn" id="unwaitlist_ebook" value="Leave waiting list"/>
+      </p>
     </form>
   $else:
     <p class="waitinglist-message">
       $("Readers waiting for this title: %s" % wlsize if wlsize else "You'll be next in line.")
     </p>
     <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
+      <p>
       <input type="hidden" name="action" value="join-waitinglist"/>
       <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="Join Waitlist"/>
+      </p>
+    </form>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:
   $ sponsorship = qualifies_for_sponsorship(page)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -38,10 +38,8 @@ $if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=True)
   $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">
-    <p>
     <input type="hidden" name="action" value="return" />
     <input type="submit" value="Return eBook" class="cta-btn cta-btn--available" id="return_ebook"/>
-    </p>
   </form>
 
 
@@ -63,20 +61,16 @@ $elif (availability_status == 'borrow_unavailable'):
           $:_('You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list.', spot=spot, wlsize=wlsize)
     </p>
     <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
-      <p>
       <input type="hidden" name="action" value="leave-waitinglist"/>
       <input type="submit" class="cta-btn" id="unwaitlist_ebook" value="Leave waiting list"/>
-      </p>
     </form>
   $else:
     <p class="waitinglist-message">
       $("Readers waiting for this title: %s" % wlsize if wlsize else "You'll be next in line.")
     </p>
     <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
-      <p>
       <input type="hidden" name="action" value="join-waitinglist"/>
       <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="Join Waitlist"/>
-      </p>
     </form>
 
 $elif (not page.get('ocaid') or page.is_access_restricted()) and editions_page:

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -11,6 +11,7 @@ a.cta-btn {
   display: block;
   border: 0;
   border-radius: 5px;
+  margin-top: 5px;
   box-sizing: border-box;
   cursor: pointer;
   font-family: @lucida_sans_serif-1;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2972
The issue was more general and not limited to read and return buttons.(borrow, join_waitlist)  
Also, one of the form tags was not closed. The PR adds a top-margin: 5px to all .cta-buttons to add space.

### Technical
<!-- What should be noted about the implementation? -->
```css
.cta-button-group {
....
  .cta-btn {
    margin:0;
    ...}
```
The above CSS snippets set all margins to 0 including the margin-top: 5px. I set a default margin-top: 5px for all cta-buttons, now Read and Listen are part of .cta-button-group hence their top margin will be set 0, but other buttons will have a margin of 5px at the top like Return.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
In the web version, the error only appears to exist in edition pages:/works only but in smartphones, the error exists in the edition tools panel: /books/ of a borrowed book.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://user-images.githubusercontent.com/23471306/76911117-ef47bc00-68d5-11ea-9886-4df53400ad61.png)


After:
![image](https://user-images.githubusercontent.com/23471306/76911133-fcfd4180-68d5-11ea-8e60-dbb20fc08a54.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->