### PR TITLE
enhancement/ add a more interactive scroll-to-top button on the home page

### DIFF
--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -27,4 +27,5 @@ $var title: $_("Welcome to Open Library")
   $:render_template("home/stats", stats)
 
   $:render_template("home/about", blog_posts)
+  $:render_template("home/scroll-to-top", test = test)
  </div>

--- a/openlibrary/templates/home/scroll-to-top.html
+++ b/openlibrary/templates/home/scroll-to-top.html
@@ -23,16 +23,16 @@ $def with (test)
 <button onclick="topFunction()"id="scrollToTop" title="Go to top">Top</button>
 <script>
     //Get the button
-var sccrollButton = document.getElementById("scrollToTop");
+var scrollButton = document.getElementById("scrollToTop");
 
 // When the user scrolls down 20px from the top of the document, show the button
 window.onscroll = function() {scrollFunction()};
 
 function scrollFunction() {
   if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-    sccrollButton.style.display = "block";
+    scrollButton.style.display = "block";
   } else {
-    sccrollButton.style.display = "none";
+    scrollButton.style.display = "none";
   }
 }
 

--- a/openlibrary/templates/home/scroll-to-top.html
+++ b/openlibrary/templates/home/scroll-to-top.html
@@ -1,6 +1,6 @@
 $def with (test)
 <style>
-#myBtn {
+#scrollToTop {
   display: none;
   position: fixed;
   bottom: 20px;
@@ -16,23 +16,23 @@ $def with (test)
   border-radius: 4px;
 }
 
-#myBtn:hover {
+#scrollToTop:hover {
   background-color: #555;
 }
 </style>
-<button onclick="topFunction()"id="myBtn" title="Go to top">Top</button>
+<button onclick="topFunction()"id="scrollToTop" title="Go to top">Top</button>
 <script>
     //Get the button
-var mybutton = document.getElementById("myBtn");
+var sccrollButton = document.getElementById("scrollToTop");
 
 // When the user scrolls down 20px from the top of the document, show the button
 window.onscroll = function() {scrollFunction()};
 
 function scrollFunction() {
   if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-    mybutton.style.display = "block";
+    sccrollButton.style.display = "block";
   } else {
-    mybutton.style.display = "none";
+    sccrollButton.style.display = "none";
   }
 }
 

--- a/openlibrary/templates/home/scroll-to-top.html
+++ b/openlibrary/templates/home/scroll-to-top.html
@@ -20,7 +20,7 @@ $def with (test)
   background-color: #555;
 }
 </style>
-<button onclick="topFunction()"id="scrollToTop" title="Go to top">Top</button>
+<button onclick="topFunction()"id="scrollToTop" title="$_('Scroll to top')">$_('Top')</button>
 <script>
     //Get the button
 var scrollButton = document.getElementById("scrollToTop");

--- a/openlibrary/templates/home/scroll-to-top.html
+++ b/openlibrary/templates/home/scroll-to-top.html
@@ -1,4 +1,5 @@
 $def with (test)
+<!-- To be placed in the right css directory -->
 <style>
 #scrollToTop {
   display: none;
@@ -12,7 +13,7 @@ $def with (test)
   background-color:#3b98fc;
   color: white;
   cursor: pointer;
-  padding: 15px;
+  padding: 2px 10px 2px 10px;
   border-radius: 4px;
 }
 
@@ -20,7 +21,9 @@ $def with (test)
   background-color: #555;
 }
 </style>
-<button onclick="topFunction()"id="scrollToTop" title="$_('Scroll to top')">$_('Top')</button>
+<button onclick="topFunction()"id="scrollToTop" title="$_('Scroll to top')">🡹</button>
+
+<!-- To be placed in the right js directory -->
 <script>
     //Get the button
 var scrollButton = document.getElementById("scrollToTop");
@@ -29,7 +32,7 @@ var scrollButton = document.getElementById("scrollToTop");
 window.onscroll = function() {scrollFunction()};
 
 function scrollFunction() {
-  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+  if (document.body.scrollTop > 30 || document.documentElement.scrollTop > 30) {
     scrollButton.style.display = "block";
   } else {
     scrollButton.style.display = "none";

--- a/openlibrary/templates/home/scroll-to-top.html
+++ b/openlibrary/templates/home/scroll-to-top.html
@@ -1,0 +1,44 @@
+$def with (test)
+<style>
+#myBtn {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 30px;
+  z-index: 99;
+  font-size: 18px;
+  border: none;
+  outline: none;
+  background-color:#3b98fc;
+  color: white;
+  cursor: pointer;
+  padding: 15px;
+  border-radius: 4px;
+}
+
+#myBtn:hover {
+  background-color: #555;
+}
+</style>
+<button onclick="topFunction()"id="myBtn" title="Go to top">Top</button>
+<script>
+    //Get the button
+var mybutton = document.getElementById("myBtn");
+
+// When the user scrolls down 20px from the top of the document, show the button
+window.onscroll = function() {scrollFunction()};
+
+function scrollFunction() {
+  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+    mybutton.style.display = "block";
+  } else {
+    mybutton.style.display = "none";
+  }
+}
+
+// When the user clicks on the button, scroll to the top of the document
+function topFunction() {
+  document.body.scrollTop = 0;
+  document.documentElement.scrollTop = 0;
+}
+</script>

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -22,7 +22,6 @@ $def with (page)
           <li><a href="/search/authors" title="$_('Explore authors')">$_('Authors')</a></li>
           <li><a href="/subjects" title="$_('Explore subjects')">$_('Subjects')</a></li>
           <li><a href="/advancedsearch" title="$_('Advanced Search')">$_('Advanced Search')</a></li>
-          <li><a href="#top" title="$_('Navigate to top of this page')">$_('Return to Top')</a></li>
         </ul>
       </div>
       <div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #
it's an enhancement to a pre-existing feature
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The pre-existing "Return to Top" button is a little difficult to use since it gets overshadowed by oher links. A better feature would be to create a bigger more visible button on the bottom right part of the screen.
### Technical
<!-- What should be noted about the implementation? -->
The code works fine, but I could not link the css and js and hence I wrote the css and js code in a single file. Need help in knowing the correct directory to put the files.
### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
Navigate to the home page and scroll down. A blue button on the bottom right part of the screen will appear, clicking on it takes the user back to the top of the page.
### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot_20200327_154508](https://user-images.githubusercontent.com/45262592/77746097-6c93cf00-7042-11ea-9cf9-ec61d144b888.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->