### PR TITLE
Add a pre-commit to run `make lint-diff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,7 @@ repos:
     hooks:
       - id: make-lint-diff
         name: make lint-diff
-        entry: docker-compose run --rm web make lint-diff
+        # Running git inside docker is slow for some reason, so do that outside and pipe
+        # the results into docker.
+        entry: git diff master -U0 | docker-compose run --rm web ./scripts/flake8-diff.sh
         language: script
-      # The following hook works but takes several seconds...
-      #- id: make-lint
-      #  name: make lint
-      #  entry: /usr/bin/make lint
-      #  language: script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# To enable this pre-commit hook (in this case, pre-push hook), run:
+# `python3 -m pip install pre-commit` or `brew install pre-commit`
+
+# Learn more about this config here: https://pre-commit.com/
 default_language_version:
   python: python3.8
 default_stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_language_version:
   python: python3.8
+default_stages: [push]
 repos:
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+default_language_version:
+  python: python3.8
+repos:
+  - repo: local
+    hooks:
+      - id: make-lint-diff
+        name: make lint-diff
+        entry: /usr/bin/make lint-diff
+        language: script
+      # The following hook works but takes several seconds...
+      #- id: make-lint
+      #  name: make lint
+      #  entry: /usr/bin/make lint
+      #  language: script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: make-lint-diff
         name: make lint-diff
-        entry: /usr/bin/make lint-diff
+        entry: docker-compose run --rm web make lint-diff
         language: script
       # The following hook works but takes several seconds...
       #- id: make-lint

--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,7 @@ reindex-solr:
 	su postgres -c "psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://0.0.0.0/ -c conf/openlibrary.yml --data-provider=legacy"
 
 lint-diff:
-	# https://flake8.readthedocs.io/en/latest/user/error-codes.html
-	# https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-	# E226 missing whitespace around arithmetic operator
-	# F401 '._init_path' imported but unused
-	# W504 line break after binary operator
-	git diff master -U0 | flake8 --diff --ignore=E226,F401,W504 --max-line-length=88 --statistics
+	git diff master -U0 | ./scripts/flake8-diff.sh
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names

--- a/scripts/flake8-diff.sh
+++ b/scripts/flake8-diff.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# https://flake8.readthedocs.io/en/latest/user/error-codes.html
+# https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+# E226 missing whitespace around arithmetic operator
+# F401 '._init_path' imported but unused
+# W504 line break after binary operator
+flake8 --diff --ignore=E226,F401,W504 --max-line-length=88 --statistics


### PR DESCRIPTION
This PR adds a `.pre-commit-config.yaml` file which will cause `make lint-diff` to be executed each time a `git commit` is run on your local system.  If the lint-diff test fails then the commit fails.  This prevents contributors from creating commits that will fail our Travis CI tests.  More elaborate tests could be added to the pre-commit workflow but this test was chosen because it is both fast and easy to understand.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
How to use:
1. Install https://pre-commit.com with either:
    * `brew install pre-commit` or
    * `python3 -m pip install pre-commit`
2. Make a git commit on one of your branches.
    * The first run might be slow but subsequent runs should be fast.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Yes.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->