### PR TITLE
Fixed XSS in work/edition title

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -761,7 +761,8 @@ def setup():
         'request': Request(),
         'logger': logging.getLogger("openlibrary.template"),
         'sum': sum,
-        'get_donation_include': get_donation_include
+        'get_donation_include': get_donation_include,
+        'websafe': web.websafe,
     })
 
     from openlibrary.core import helpers as h

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -370,7 +370,7 @@ $if ctx.user:
     <script type="text/javascript">
     var seed = $:json_encode(seed);
     var seed_type = $:json_encode(seed_type);
-    var title = $:json_encode(title);
+    var title = $:json_encode(websafe(title));
 
     var user_lists = $:json_encode(user_lists);
     var page_lists = $:json_encode(page_lists);

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -2,8 +2,10 @@ $def with (page, show_other_editions=False)
 
 $ work = page.works and page.works[0] or None
 $ ocaid = page.get('ocaid')
+$ bad_chars = ["'", "^", "\\", "\"", "<", ">"]
 $ book_title = page.get('title', '') if page.title else (work.title if work else '')
 $ work_title = work.title if work else page.get('title', '')
+$ work_title = ''.join(i for i in work_title if not i in bad_chars)
 $ book_subtitle = page.subtitle if page.get('subtitle') else (work.subtitle if work and work.get('subtitle') else '')
 $ title_suffix = cond(page.publish_date, u"({0} edition)".format(page.publish_date), "(edition)")
 $ title = book_title + " " + title_suffix
@@ -141,6 +143,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
     <div class="navEdition sansserif">
         $ edition_count = work.edition_count if work and work.edition_count else 1
         $ url = work.url() if work else ''
+        $ url = ''.join(i for i in url if not i in bad_chars)
         $:ungettext('<a href="%(url)s"><strong>1 edition</strong></a> of <strong class="booktitle">%(title)s</strong> found in the catalog.','<a href="%(url)s"><strong>%(count)d editions</strong></a> of <strong class="booktitle">%(title)s</strong> found in the catalog.', edition_count, url=url,count=edition_count, title=truncate(work_title, 60))
         $if work:
             <span><a href="/books/add?work=$work.key" title="$_('Add another edition of') $book_title">$_("Add another edition")</a>?</span>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -2,10 +2,8 @@ $def with (page, show_other_editions=False)
 
 $ work = page.works and page.works[0] or None
 $ ocaid = page.get('ocaid')
-$ bad_chars = ["'", "^", "\\", "\"", "<", ">"]
 $ book_title = page.get('title', '') if page.title else (work.title if work else '')
 $ work_title = work.title if work else page.get('title', '')
-$ work_title = ''.join(i for i in work_title if not i in bad_chars)
 $ book_subtitle = page.subtitle if page.get('subtitle') else (work.subtitle if work and work.get('subtitle') else '')
 $ title_suffix = cond(page.publish_date, u"({0} edition)".format(page.publish_date), "(edition)")
 $ title = book_title + " " + title_suffix
@@ -143,8 +141,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
     <div class="navEdition sansserif">
         $ edition_count = work.edition_count if work and work.edition_count else 1
         $ url = work.url() if work else ''
-        $ url = ''.join(i for i in url if not i in bad_chars)
-        $:ungettext('<a href="%(url)s"><strong>1 edition</strong></a> of <strong class="booktitle">%(title)s</strong> found in the catalog.','<a href="%(url)s"><strong>%(count)d editions</strong></a> of <strong class="booktitle">%(title)s</strong> found in the catalog.', edition_count, url=url,count=edition_count, title=truncate(work_title, 60))
+        $:ungettext('<a href="%(url)s"><strong>1 edition</strong></a> of <strong class="booktitle">%(title)s</strong> found in the catalog.','<a href="%(url)s"><strong>%(count)d editions</strong></a> of <strong class="booktitle">%(title)s</strong> found in the catalog.', edition_count, url=url,count=edition_count, title=websafe(truncate(work_title, 60)))
         $if work:
             <span><a href="/books/add?work=$work.key" title="$_('Add another edition of') $book_title">$_("Add another edition")</a>?</span>
     </div>


### PR DESCRIPTION
**Why is this change necessary:** 
This change fix the severe bug XSS in page add-blog of OpenLibrary"

**How does this commit address the issue:** 
The issue was that the URL in anchor was formatted as string in ungettext which was causing the problem, so removing the ungettext causes the template broken error and disturb the blog title, so alternatively the URL is filtered to remove the bad character from the user input

**What effects does this change have:** 
This change solve the XSS vulnerability and encode the URL and title safely

_My first commit in OpenLibrary, really enjoyed to contribute and looking further for more contribution_

<!-- What issue does this PR close? -->
Closes #3080 

### Testing
1.Click  Add Book
2. In Title --->  "'><script>alert(/Ultra Security/)</script>
3. Create and load the page