### PR TITLE
Use sorting to fix solr update_work

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -641,7 +641,7 @@ class SolrProcessor:
         if has_fulltext:
             add('public_scan_b', public_scan)
         if all_collection:
-            add('ia_collection_s', ';'.join(sorted(all_collection)))
+            add('ia_collection_s', ';'.join(all_collection))
         if lending_edition:
             add('lending_edition_s', lending_edition)
             add('lending_identifier_s', lending_ia_identifier)

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -509,7 +509,7 @@ class SolrProcessor:
                            for v in e[db_key])
             add_list(solr_key, values)
 
-        add_list("isbn", sorted(self.get_isbns(editions)))
+        add_list("isbn", self.get_isbns(editions))
         add("last_modified_i", self.get_last_modified(w, editions))
 
         self.add_ebook_info(d, editions)
@@ -637,7 +637,7 @@ class SolrProcessor:
 
         has_fulltext = any(e.get('ocaid', None) for e in editions)
 
-        add_list('ia', sorted(ia_list))
+        add_list('ia', ia_list)
         if has_fulltext:
             add('public_scan_b', public_scan)
         if all_collection:

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -8,7 +8,6 @@ edition_counter = 0
 work_counter = 0
 
 
-
 def sorted_split_semicolon(s):
     """
     >>> sort_split_semi("z;c;x;a;y;b")
@@ -236,7 +235,7 @@ class Test_build_data:
         assert 'printdisabled_s' not in d
         assert d['lending_edition_s'] == 'OL1M'
         assert d['ia'] == ['foo00bar']
-        assert sss(d['ia_collection_s']) == "americana;lendinglibrary"
+        assert sss(d['ia_collection_s']) == sss("americana;lendinglibrary")
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
@@ -254,7 +253,7 @@ class Test_build_data:
         assert d['public_scan_b'] is False
         assert 'printdisabled_s' not in d
         assert d['lending_edition_s'] == 'OL1M'
-        assert d['ia'] == ['foo01bar', 'foo02bar']
+        assert sorted(d['ia']) == ['foo01bar', 'foo02bar']
         assert sss(d['ia_collection_s']) == sss(
             "lendinglibrary;americana;internetarchivebooks"
         )
@@ -309,7 +308,7 @@ class Test_build_data:
         assert d['public_scan_b'] is True
         assert d['printdisabled_s'] == 'OL4M'
         assert d['lending_edition_s'] == 'OL3M'
-        assert d['ia'] == ['foo00bar', 'foo01bar', 'foo02bar']
+        assert sorted(d['ia']) == ['foo00bar', 'foo01bar', 'foo02bar']
         assert sss(d['ia_collection_s']) == sss(
             "americana;inlibrary;lendinglibrary;printdisabled"
         )
@@ -367,9 +366,7 @@ class Test_update_items():
         requests = update_work.update_author('/authors/OL23A')
         assert isinstance(requests, list)
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == (
-            b'<delete><query>key:/authors/OL23A</query></delete>'
-        )
+        assert requests[0].toxml() == '<delete><query>key:/authors/OL23A</query></delete>'
 
     def test_redirect_author(self):
         update_work.data_provider = FakeDataProvider([
@@ -378,9 +375,7 @@ class Test_update_items():
         requests = update_work.update_author('/authors/OL24A')
         assert isinstance(requests, list)
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == (
-            b'<delete><query>key:/authors/OL24A</query></delete>'
-        )
+        assert requests[0].toxml() == '<delete><query>key:/authors/OL24A</query></delete>'
 
     def test_update_author(self, monkeypatch):
         update_work.data_provider = FakeDataProvider([
@@ -401,7 +396,7 @@ class Test_update_items():
         assert isinstance(requests, list)
         assert isinstance(requests[0], update_work.UpdateRequest)
         assert requests[0].toxml().startswith('<add>')
-        assert b'<field name="key">/authors/OL25A</field>' in requests[0].toxml()
+        assert '<field name="key">/authors/OL25A</field>' in requests[0].toxml()
 
     def test_delete_edition(self):
         editions = update_work.update_edition({'key': '/books/OL23M', 'type': {'key': '/type/delete'}})
@@ -415,7 +410,7 @@ class Test_update_items():
         olids = ['/works/OL1W', '/works/OL2W', '/works/OL3W']
         del_req = update_work.DeleteRequest(olids)
         assert isinstance(del_req, update_work.DeleteRequest)
-        assert del_req.toxml().startswith(b"<delete>")
+        assert del_req.toxml().startswith("<delete>")
         for olid in olids:
             assert "<query>key:%s</query>" % olid in del_req.toxml()
 
@@ -429,22 +424,16 @@ class TestUpdateWork:
         requests = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/delete'}})
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == (
-            b'<delete><query>key:/works/OL23W</query></delete>'
-        )
+        assert requests[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'
 
     def test_delete_editions(self):
         requests = update_work.update_work({'key': '/works/OL23M', 'type': {'key': '/type/delete'}})
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == (
-            b'<delete><query>key:/works/OL23M</query></delete>'
-        )
+        assert requests[0].toxml() == '<delete><query>key:/works/OL23M</query></delete>'
 
     def test_redirects(self):
         requests = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/redirect'}})
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == (
-            b'<delete><query>key:/works/OL23W</query></delete>'
-        )
+        assert requests[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -92,7 +92,7 @@ class Test_build_data:
         d = build_data(work)
         assert d["key"] == "/works/OL1M"
         assert d["title"] == "Foo"
-        assert d["has_fulltext"] == False
+        assert d["has_fulltext"] is False
         assert d["edition_count"] == 0
 
     def test_edition_count_when_editions_on_work(self):
@@ -218,12 +218,12 @@ class Test_build_data:
                          _ia_meta={"collection": ['lendinglibrary', 'americana']})
         ])
         d = build_data(w)
-        assert d['has_fulltext'] == True
-        assert d['public_scan_b'] == False
+        assert d['has_fulltext'] is True
+        assert d['public_scan_b'] is False
         assert 'printdisabled_s' not in d
         assert d['lending_edition_s'] == 'OL1M'
         assert d['ia'] == ['foo00bar']
-        assert d['ia_collection_s'] == "lendinglibrary;americana"
+        assert d['ia_collection_s'] == "americana;lendinglibrary"
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
@@ -237,12 +237,12 @@ class Test_build_data:
                          _ia_meta={"collection": ['lendinglibrary', 'internetarchivebooks']})
         ])
         d = build_data(w)
-        assert d['has_fulltext'] == True
-        assert d['public_scan_b'] == False
+        assert d['has_fulltext'] is True
+        assert d['public_scan_b'] is False
         assert 'printdisabled_s' not in d
         assert d['lending_edition_s'] == 'OL1M'
         assert d['ia'] == ['foo01bar', 'foo02bar']
-        assert d['ia_collection_s'] == "lendinglibrary;americana;internetarchivebooks"
+        assert d['ia_collection_s'] == "americana;internetarchivebooks;lendinglibrary"
         assert d['edition_count'] == 2
         assert d['ebook_count_i'] == 2
 
@@ -254,12 +254,12 @@ class Test_build_data:
                          _ia_meta={"collection": ['printdisabled', 'inlibrary']})
         ])
         d = build_data(w)
-        assert d['has_fulltext'] == True
-        assert d['public_scan_b'] == False
+        assert d['has_fulltext'] is True
+        assert d['public_scan_b'] is False
         assert d['printdisabled_s'] == 'OL1M'
         assert d['lending_edition_s'] == 'OL1M'
         assert d['ia'] == ['foo00bar']
-        assert d['ia_collection_s'] == "printdisabled;inlibrary"
+        assert d['ia_collection_s'] == "inlibrary;printdisabled"
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
@@ -271,12 +271,12 @@ class Test_build_data:
                          _ia_meta={"collection": ['printdisabled', 'americana']})
         ])
         d = build_data(w)
-        assert d['has_fulltext'] == True
-        assert d['public_scan_b'] == False
+        assert d['has_fulltext'] is True
+        assert d['public_scan_b'] is False
         assert d['printdisabled_s'] == 'OL1M'
         assert 'lending_edition_s' not in d
         assert d['ia'] == ['foo00bar']
-        assert d['ia_collection_s'] == "printdisabled;americana"
+        assert d['ia_collection_s'] == "americana;printdisabled"
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
@@ -290,12 +290,13 @@ class Test_build_data:
             make_edition(w, key="/books/OL4M", ocaid='foo02bar', _ia_meta={"collection": ['printdisabled', 'inlibrary']})
         ])
         d = build_data(w)
-        assert d['has_fulltext'] == True
-        assert d['public_scan_b'] == True
+        assert d['has_fulltext'] is True
+        assert d['public_scan_b'] is True
         assert d['printdisabled_s'] == 'OL4M'
         assert d['lending_edition_s'] == 'OL3M'
         assert d['ia'] == ['foo00bar', 'foo01bar', 'foo02bar']
-        assert sorted(d['ia_collection_s'].split(";")) == ["americana", "inlibrary", "lendinglibrary", "printdisabled"]
+        assert d['ia_collection_s'] == ("americana;inlibrary;lendinglibrary;"
+                                        "printdisabled")
 
         assert d['edition_count'] == 4
         assert d['ebook_count_i'] == 3

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -10,7 +10,7 @@ work_counter = 0
 
 def sorted_split_semicolon(s):
     """
-    >>> sort_split_semi("z;c;x;a;y;b")
+    >>> sorted_split_semicolon("z;c;x;a;y;b")
     ['a', 'b', 'c', 'x', 'y', 'z']
     """
     return sorted(s.split(';'))

--- a/scripts/test-py3.sh
+++ b/scripts/test-py3.sh
@@ -41,7 +41,8 @@ pytest openlibrary/mocks openlibrary/olbase openlibrary/utils scripts/tests \
     openlibrary/tests/core/test_ratings.py \
     openlibrary/tests/core/test_sponsors.py \
     openlibrary/tests/core/test_vendors.py \
-    openlibrary/tests/core/test_waitinglist.py
+    openlibrary/tests/core/test_waitinglist.py \
+    openlibrary/tests/solr/test_update_work.py 
 
 # The following sections allow us to quickly spot tests that are fixed
 
@@ -62,5 +63,4 @@ pytest openlibrary/plugins/books/tests/test_dynlinks.py \
     openlibrary/plugins/upstream/tests/test_merge_authors.py || true
 
 # openlibrary/tests: All failing tests run in allow failures (|| true) mode
-pytest openlibrary/tests/accounts/test_models.py \
-    openlibrary/tests/solr/test_update_work.py || true
+pytest openlibrary/tests/accounts/test_models.py || true


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes failing pytests on Python 3

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Python 2 and Python 3 do not agree on the order of elements in a set or keys in a dict.
```
% python2 -c "print(list(set('abcdefg')))"
['a', 'c', 'b', 'e', 'd', 'g', 'f']
% python3 -c "print(list(set('abcdefg')))"
['d', 'a', 'b', 'c', 'g', 'f', 'e']
% python2 -c "print(list({key: value for value, key in enumerate('abcdefg')}))"
['a', 'c', 'b', 'e', 'd', 'g', 'f']
% python3 -c "print(list({key: value for value, key in enumerate('abcdefg')}))"
['a', 'b', 'c', 'd', 'e', 'f', 'g']
```
However, our tests are currently hardcoded to the Python 2 order.  To make these tests pass on both Python 2 and Python 3, we need to sort the output ~either in the code file or~ in the test file. 

 __Which should we do?__
    Modify the tests, not the code.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->