### PR TITLE
Fixed Markdown help button does not do anything #2624

### DIFF
--- a/static/css/components/wmd-button-bar.less
+++ b/static/css/components/wmd-button-bar.less
@@ -15,6 +15,12 @@
   li:last-child {
     display: inline-block;
   }
+
+  li:last-child a {
+    position: absolute;
+      width: inherit;
+      height: inherit;
+  }
 }
 
 @media all and ( min-width: @width-breakpoint-desktop ) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2624 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix for Help button not going to the external link when clicked

### Technical
<!-- What should be noted about the implementation? -->
There is a library called wmd used with <textarea> tag to give it extra functionalities, Help button has tag which has height and width of 0 X 0 so when we click the help button then anchor tag is not getting clicked. CSS is used to make sure that anchor tag occupies 20 X 20.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Clicking on the help button will now take you to the new page link.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2020-03-17 23-53-53](https://user-images.githubusercontent.com/32262801/76888861-a6c6d900-68aa-11ea-8ff7-0bcfee690b6d.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mightysood