### PR TITLE
Prevent uploading an invalid file internetarchive#3208:v1

### DIFF
--- a/openlibrary/plugins/openlibrary/js/FileValidation.js
+++ b/openlibrary/plugins/openlibrary/js/FileValidation.js
@@ -1,0 +1,29 @@
+export default function Filevalidation (){
+ var fi = document.getElementById('coverFile'); 
+ if (fi.files.length > 0) {
+  for (var i = 0; i <= fi.files.length - 1; i++) {
+       var fsize = fi.files.item(i).size; 
+       var filname=fi.files.item(i).type;
+       var filtyp=filname.split('/')[0];
+       var file = (fsize / 1024); 
+       // The type of the file. 
+       if(!filtyp.startsWith('image')){
+         document.getElementById('imageUploadSize').innerHTML = 
+         '<b>Max Size Upload: 30MB.</b>';
+         document.getElementById("coverFile").value = "";
+         alert("Please provide a valid image.");
+       }
+       // The size of the file. 
+       else if (file > 30720) { 
+         document.getElementById("coverFile").value = "";
+         document.getElementById('imageUploadSize').innerHTML = 
+         '<b>Max Size Upload: 30MB.</b>'; 
+         alert("Please provide a file less than 30mb."); 
+       } 
+       else { 
+         document.getElementById('imageUploadSize').innerHTML = '<b>'
+           + file.toFixed(2) + 'KB</b>'; 
+       } 
+    } 
+  } 
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -34,7 +34,7 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
-
+import Filevalidation from './FileValidation.js';
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
 // closePopup used in openlibrary/templates/covers/saved.html
@@ -76,6 +76,7 @@ jQuery(function () {
     // expose ol_confirm_dialog method
     $.fn.ol_confirm_dialog = confirmDialog;
     initTabs($('#tabsAddbook,#tabsAddauthor,.tabs:not(.ui-tabs)'));
+    $("#coverFile").change(Filevalidation);
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -25,6 +25,35 @@ $if status:
 </div>
 
 <script type="text/javascript">
+  Filevalidation = () =>{
+      var fi = document.getElementById('coverFile'); 
+      if (fi.files.length > 0) { 
+          for (var i = 0; i <= fi.files.length - 1; i++) { 
+              var fsize = fi.files.item(i).size; 
+              var filname=fi.files.item(i).type;
+              var filtyp=filname.split('/')[0];
+              var file = (fsize / 1024); 
+              // The type of the file. 
+              if(!filtyp.startsWith('image')){
+                document.getElementById('imageUploadSize').innerHTML = 
+                '<b>Max Size Upload: 30MB.</b>';
+                document.getElementById("coverFile").value = "";
+                alert("Please provide a valid image.");
+              }
+              // The size of the file. 
+              else if (file > 30720) { 
+                document.getElementById("coverFile").value = "";
+                document.getElementById('imageUploadSize').innerHTML = 
+                '<b>Max Size Upload: 30MB.</b>'; 
+                alert("Please provide a file less than 30mb."); 
+              } 
+              else { 
+                document.getElementById('imageUploadSize').innerHTML = '<b>'
+                  + file.toFixed(2) + 'KB</b>'; 
+              } 
+          } 
+      } 
+  };
 <!--
 window.q.push(function(){
     // page may not be loaded via iframe
@@ -110,10 +139,9 @@ window.q.push(function(){
                     <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer,")</label>
                 </div>
                 <div class="input">
-                    <input type="file" name="file" id="coverFile" value=""/>
+                    <input type="file" name="file" id="coverFile" value="" onchange="Filevalidation()"/>
                 </div>
             </div>
-
             <div class="formElement">
                 <div class="label">
                     <label id="imageWeb" for="imageUrl"><span class="highlight">$:_("<u>Or</u></span>, paste in the image URL if it's on the web.")</label>
@@ -122,12 +150,11 @@ window.q.push(function(){
                     <input type="text" name="url" id="imageUrl" value="$data.get('url', 'http://')" onClick="if(!this._haschanged && this.value == 'http://'){this.value=''};this._haschanged=true;"/>
                 </div>
             </div>
-
+            <p id="imageUploadSize"><b>Max Size Upload: 30MB.</b></p>
             <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == "/type/work" else '50px 0px 0px 30px;')">
                 <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest">$_("Submit")</button>
                 <a class="dialog--close-parent red" href="javascript:;">$_("Cancel")</a>
             </div>
-
         </div>
     </div>
 </form>

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -25,35 +25,6 @@ $if status:
 </div>
 
 <script type="text/javascript">
-  Filevalidation = () =>{
-      var fi = document.getElementById('coverFile'); 
-      if (fi.files.length > 0) { 
-          for (var i = 0; i <= fi.files.length - 1; i++) { 
-              var fsize = fi.files.item(i).size; 
-              var filname=fi.files.item(i).type;
-              var filtyp=filname.split('/')[0];
-              var file = (fsize / 1024); 
-              // The type of the file. 
-              if(!filtyp.startsWith('image')){
-                document.getElementById('imageUploadSize').innerHTML = 
-                '<b>Max Size Upload: 30MB.</b>';
-                document.getElementById("coverFile").value = "";
-                alert("Please provide a valid image.");
-              }
-              // The size of the file. 
-              else if (file > 30720) { 
-                document.getElementById("coverFile").value = "";
-                document.getElementById('imageUploadSize').innerHTML = 
-                '<b>Max Size Upload: 30MB.</b>'; 
-                alert("Please provide a file less than 30mb."); 
-              } 
-              else { 
-                document.getElementById('imageUploadSize').innerHTML = '<b>'
-                  + file.toFixed(2) + 'KB</b>'; 
-              } 
-          } 
-      } 
-  };
 <!--
 window.q.push(function(){
     // page may not be loaded via iframe
@@ -139,7 +110,8 @@ window.q.push(function(){
                     <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer,")</label>
                 </div>
                 <div class="input">
-                    <input type="file" name="file" id="coverFile" value="" onchange="Filevalidation()"/>
+
+                    <input type="file" name="file" id="coverFile" value=""/>
                 </div>
             </div>
             <div class="formElement">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3208 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents a user from uploading an invalid file as "Cover Image" by accident or intentionally.

### Technical
<!-- What should be noted about the implementation? -->
Create an alert before the user can submit an invalid file. Check the size and image type of the file being uploaded and take action accordingly.
Display the Maximum acceptable Size of the image in advance.


### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/23471306/76924035-267c9400-68fb-11ea-991a-ca0f3411b568.png)




### Stakeholders
<!-- @ tag stakeholders of this bug -->