### PR TITLE
Temporary patch to fix empty borrows graph via graphite data

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -3,6 +3,8 @@
 
 import calendar
 import datetime
+
+import requests
 import web
 from infogami import config
 from infogami.utils import stats
@@ -57,6 +59,40 @@ class Stats:
         """
         return sum(x[1] for x in self.get_counts(ndays))
 
+
+class LoanStats(Stats):
+    """
+    Temporary (2020-03-19) override of Stats for loans, due to bug
+    which caused 1mo of loans stats to be missing from regular
+    stats db. This implementation uses graphite, but only on prod,
+    so that we don't forget.
+    """
+
+    @cache.method_memoize
+    def _get_graphite_data(self, ndays):
+        try:
+            r = requests.get('http://graphite.us.archive.org/render', params={
+                'target': 'hitcount(stats.ol.loans.bookreader, "1d")',
+                'from': '-%ddays' % ndays,
+                'tz': 'UTC',
+                'format': 'json',
+            })
+            return r.json()[0]['datapoints']
+        except (requests.exceptions.RequestException, ValueError, AttributeError):
+            return None
+
+    def get_counts(self, ndays=28, times=False):
+        # Let dev.openlibrary.org show the true state of things
+        if 'dev' in config.features:
+            return Stats.get_counts(self, ndays, times)
+
+        graphite_data = self._get_graphite_data(ndays)
+        if graphite_data:
+            return [[timestamp * 1000, count] for [count, timestamp] in graphite_data]
+        else:
+            return Stats.get_counts(self, ndays, times)
+
+
 @cache.memoize(engine="memcache", key="admin._get_count_docs", expires=5*60)
 def _get_count_docs(ndays):
     """Returns the count docs from admin stats database.
@@ -75,16 +111,17 @@ def _get_count_docs(ndays):
 def get_stats(ndays = 30):
     """Returns the stats for the past `ndays`"""
     docs = _get_count_docs(ndays)
-    retval = dict(human_edits = Stats(docs, "human_edits", "human_edits"),
-                  bot_edits   = Stats(docs, "bot_edits", "bot_edits"),
-                  lists       = Stats(docs, "lists", "total_lists"),
-                  visitors    = Stats(docs, "visitors", "visitors"),
-                  loans       = Stats(docs, "loans", "loans"),
-                  members     = Stats(docs, "members", "total_members"),
-                  works       = Stats(docs, "works", "total_works"),
-                  editions    = Stats(docs, "editions", "total_editions"),
-                  ebooks      = Stats(docs, "ebooks", "total_ebooks"),
-                  covers      = Stats(docs, "covers", "total_covers"),
-                  authors     = Stats(docs, "authors", "total_authors"),
-                  subjects    = Stats(docs, "subjects", "total_subjects"))
-    return retval
+    return {
+        'human_edits': Stats(docs, "human_edits", "human_edits"),
+        'bot_edits': Stats(docs, "bot_edits", "bot_edits"),
+        'lists': Stats(docs, "lists", "total_lists"),
+        'visitors': Stats(docs, "visitors", "visitors"),
+        'loans': LoanStats(docs, "loans", "loans"),
+        'members': Stats(docs, "members", "total_members"),
+        'works': Stats(docs, "works", "total_works"),
+        'editions': Stats(docs, "editions", "total_editions"),
+        'ebooks': Stats(docs, "ebooks", "total_ebooks"),
+        'covers': Stats(docs, "covers", "total_covers"),
+        'authors': Stats(docs, "authors", "total_authors"),
+        'subjects': Stats(docs, "subjects", "total_subjects"),
+    }

--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -88,6 +88,7 @@ class LoanStats(Stats):
 
         graphite_data = self._get_graphite_data(ndays)
         if graphite_data:
+            # convert timestamp seconds to ms (as required by API)
             return [[timestamp * 1000, count] for [count, timestamp] in graphite_data]
         else:
             return Stats.get_counts(self, ndays, times)

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -525,17 +525,22 @@ class PrefixKeyFunc:
         """
         return simplejson.dumps(value, separators=(",", ":"), sort_keys=True)
 
+
 def method_memoize(f):
-    """object-local memoize.
-
-    Works only for functions without any arguments.
-
-    TODO: support arguments.
+    """
+    object-local memoize.
+    Works only for functions with simple arguments; i.e. JSON serializeable
     """
     @functools.wraps(f)
-    def g(self):
+    def g(self, *args, **kwargs):
         cache = self.__dict__.setdefault('_memoize_cache', {})
-        if f.__name__ not in cache:
-            cache[f.__name__] = f(self)
-        return cache[f.__name__]
+        key = simplejson.dumps({
+            'function': f.__name__,
+            'args': args,
+            'kwargs': kwargs,
+        }, sort_keys=True)
+
+        if key not in cache:
+            cache[key] = f(self, *args, **kwargs)
+        return cache[key]
     return g

--- a/openlibrary/tests/core/test_cache.py
+++ b/openlibrary/tests/core/test_cache.py
@@ -127,3 +127,38 @@ class Test_memoize:
         assert self.get("3") == {"square": 9}
         assert double(3) == 6
         assert self.get("3") == {"square": 9, "double": 6}
+
+
+class Test_method_memoize:
+    def test_handles_no_args(self):
+        class A:
+            def __init__(self):
+                self.result = 0
+
+            @cache.method_memoize
+            def foo(self):
+                self.result += 1
+                return self.result
+
+        a = A()
+        assert a.foo() == 1
+        assert a.foo() == 1
+        assert a.result == 1
+
+    def test_handles_args(self):
+        class A:
+            def __init__(self):
+                self.result = 1
+
+            @cache.method_memoize
+            def foo(self, multiplier):
+                self.result *= multiplier
+                return self.result
+
+        a = A()
+        assert a.foo(2) == 2
+        assert a.foo(2) == 2
+        assert a.result == 2
+        assert a.foo(3) == 6
+        assert a.foo(2) == 2
+        assert a.result == 6


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Temporary fix to #3194 until logs catch up again in ~1mo. Mek has a PR in progress to fix that. Hits graphite for data instead of data base if not on dev (so dev should show the "broken" graphs, but prod should show the functioning graphs).

### Technical
- Caches graphite request in memory

### Testing
- On dev, change `"dev" in config.feature` → `"dev" not in config.feature`, then reload homepage without memcache

### Evidence
![image](https://user-images.githubusercontent.com/6251786/77124999-e14f8380-6a1a-11ea-957f-cc1e85c51793.png)

### Stakeholders
@mekarpeles 