### PR TITLE
fixing borrow stat graph regression

### DIFF
--- a/openlibrary/plugins/openlibrary/borrow_home.py
+++ b/openlibrary/plugins/openlibrary/borrow_home.py
@@ -221,50 +221,6 @@ def on_loan_created_statsdb(loan):
     d['geoip_country'] = None  # we removed geoip
     statsdb.add_entry(key, d)
 
-def on_loan_completed_statsdb(loan):
-    """Marks the loan as completed in the stats database.
-    """
-    key = _get_loan_key(loan)
-    t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
-    t_end = datetime.datetime.utcfromtimestamp(loan['returned_at'])
-    d = {
-        "book": loan['book'],
-        "identifier": loan['ocaid'],
-        "resource_type": loan['resource_type'],
-        "t_start": t_start.isoformat(),
-        "t_end": t_end.isoformat(),
-        "status": "completed",
-    }
-    old = statsdb.get_entry(key)
-    if old:
-        olddata = simplejson.loads(old.json)
-        d = dict(olddata, **d)
-    statsdb.update_entry(key, d)
-
-
-def _get_loan_key(loan):
-    # The loan key is now changed from uuid to fixed key.
-    # Using _key as key for loan stats will result in overwriting previous loans.
-    # Using the unique uuid to create the loan key and falling back to _key
-    # when uuid is not available.
-    return "loans/" + loan.get("uuid") or loan["_key"]
-
-
-def on_loan_created_statsdb(loan):
-    """Adds the loan info to the stats database.
-    """
-    key = _get_loan_key(loan)
-    t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
-    d = {
-        "book": loan['book'],
-        "identifier": loan['ocaid'],
-        "resource_type": loan['resource_type'],
-        "t_start": t_start.isoformat(),
-        "status": "active"
-    }
-    d['library'] = "/libraries/internet_archive"
-    d['geoip_country'] = None  # we removed geoip
-    statsdb.add_entry(key, d)
 
 def on_loan_completed_statsdb(loan):
     """Marks the loan as completed in the stats database.
@@ -293,6 +249,8 @@ def _get_loan_key(loan):
     # Using the unique uuid to create the loan key and falling back to _key
     # when uuid is not available.
     return "loans/" + loan.get("uuid") or loan["_key"]
+
+
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/borrow_home.py
+++ b/openlibrary/plugins/openlibrary/borrow_home.py
@@ -251,8 +251,6 @@ def _get_loan_key(loan):
     return "loans/" + loan.get("uuid") or loan["_key"]
 
 
-
-
 def setup():
     from openlibrary.core import msgbroker
     msgbroker.subscribe("loan-created", on_loan_created_statsdb)

--- a/openlibrary/plugins/openlibrary/borrow_home.py
+++ b/openlibrary/plugins/openlibrary/borrow_home.py
@@ -1,5 +1,6 @@
 """Controller for /borrow page.
 """
+
 import simplejson
 import web
 import random
@@ -10,6 +11,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template
 
 from openlibrary.core import helpers as h
+from openlibrary.core import statsdb
 from openlibrary.plugins.worksearch.subjects import SubjectEngine
 
 
@@ -203,5 +205,97 @@ class CustomSubjectEngine(SubjectEngine):
         return 0
 
 
+def on_loan_created_statsdb(loan):
+    """Adds the loan info to the stats database.
+    """
+    key = _get_loan_key(loan)
+    t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
+    d = {
+        "book": loan['book'],
+        "identifier": loan['ocaid'],
+        "resource_type": loan['resource_type'],
+        "t_start": t_start.isoformat(),
+        "status": "active"
+    }
+    d['library'] = "/libraries/internet_archive"
+    d['geoip_country'] = None  # we removed geoip
+    statsdb.add_entry(key, d)
+
+def on_loan_completed_statsdb(loan):
+    """Marks the loan as completed in the stats database.
+    """
+    key = _get_loan_key(loan)
+    t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
+    t_end = datetime.datetime.utcfromtimestamp(loan['returned_at'])
+    d = {
+        "book": loan['book'],
+        "identifier": loan['ocaid'],
+        "resource_type": loan['resource_type'],
+        "t_start": t_start.isoformat(),
+        "t_end": t_end.isoformat(),
+        "status": "completed",
+    }
+    old = statsdb.get_entry(key)
+    if old:
+        olddata = simplejson.loads(old.json)
+        d = dict(olddata, **d)
+    statsdb.update_entry(key, d)
+
+
+def _get_loan_key(loan):
+    # The loan key is now changed from uuid to fixed key.
+    # Using _key as key for loan stats will result in overwriting previous loans.
+    # Using the unique uuid to create the loan key and falling back to _key
+    # when uuid is not available.
+    return "loans/" + loan.get("uuid") or loan["_key"]
+
+
+def on_loan_created_statsdb(loan):
+    """Adds the loan info to the stats database.
+    """
+    key = _get_loan_key(loan)
+    t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
+    d = {
+        "book": loan['book'],
+        "identifier": loan['ocaid'],
+        "resource_type": loan['resource_type'],
+        "t_start": t_start.isoformat(),
+        "status": "active"
+    }
+    d['library'] = "/libraries/internet_archive"
+    d['geoip_country'] = None  # we removed geoip
+    statsdb.add_entry(key, d)
+
+def on_loan_completed_statsdb(loan):
+    """Marks the loan as completed in the stats database.
+    """
+    key = _get_loan_key(loan)
+    t_start = datetime.datetime.utcfromtimestamp(loan['loaned_at'])
+    t_end = datetime.datetime.utcfromtimestamp(loan['returned_at'])
+    d = {
+        "book": loan['book'],
+        "identifier": loan['ocaid'],
+        "resource_type": loan['resource_type'],
+        "t_start": t_start.isoformat(),
+        "t_end": t_end.isoformat(),
+        "status": "completed",
+    }
+    old = statsdb.get_entry(key)
+    if old:
+        olddata = simplejson.loads(old.json)
+        d = dict(olddata, **d)
+    statsdb.update_entry(key, d)
+
+
+def _get_loan_key(loan):
+    # The loan key is now changed from uuid to fixed key.
+    # Using _key as key for loan stats will result in overwriting previous loans.
+    # Using the unique uuid to create the loan key and falling back to _key
+    # when uuid is not available.
+    return "loans/" + loan.get("uuid") or loan["_key"]
+
+
 def setup():
-    pass
+    from openlibrary.core import msgbroker
+    msgbroker.subscribe("loan-created", on_loan_created_statsdb)
+    msgbroker.subscribe("loan-completed", on_loan_completed_statsdb)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3194 ; Fixes borrow stats graph stuck at 0
Longer term fix for #3216

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
Turns out the data was no longer getting recorded in the DB! The flow here is super awkward; it looks like there's a `stats` postgres tables that stores info about loans, _and also_ a solr instance which stores this same info, indexed for efficient query. The database was updated by the event hooks in the `setup` method of `libraries.py`, which was removed in #2955 . This means that unfortunately the borrow data for 02-13 to 03-19 will be permanently missing. But we have that data in graphite, so it's ok. This fix re-instates the necessary methods from libraries.py in `borrow_home.py`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Fix is currently live on ol-web3 and ol-web4

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 