### PR TITLE
Reading log stats modified internetarchive#3219:v1

### DIFF
--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -11,7 +11,7 @@
     list-style-type: none;
     display: inline;
     &.reading-log-stat {
-      color: @light-grey;
+      color: @black;
     }
     &:not(:last-child):after {
       content:'·';

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -10,9 +10,6 @@
   li {
     list-style-type: none;
     display: inline;
-    &.reading-log-stat {
-      color: @black;
-    }
     &:not(:last-child):after {
       content:'·';
       margin: 0 5px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3219

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The color of the Reading log stats modified to black.
### Technical
<!-- What should be noted about the implementation? -->
&.reading-log-stat {
      color: @black;
}


### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/23471306/77139033-5f9f3a80-6a9a-11ea-8d21-02519a0bb452.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->