### PR TITLE
Upgrade to web.py==0.50

### DIFF
--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -2,13 +2,13 @@
 """
 import glob
 import pytest
-import web
+# import web
 
 import six
 
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
-from infogami.utils.view import render_template as infobase_render_template
+# from infogami.utils.view import render_template as infobase_render_template
 from openlibrary.i18n import gettext
 from openlibrary.core import helpers
 
@@ -16,6 +16,12 @@ from openlibrary.mocks.mock_infobase import mock_site
 from openlibrary.mocks.mock_ia import mock_ia
 from openlibrary.mocks.mock_memcache import mock_memcache
 from openlibrary.mocks.mock_ol import ol
+
+# TODO (cclauss): Undo Python 2 workaround for out-of-date web.py
+import web
+web.utf8 = web.safestr
+from infogami.utils.view import render_template as infobase_render_template  # noqa: F401
+
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -10,7 +10,7 @@ from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 # from infogami.utils.view import render_template as infobase_render_template
 from openlibrary.i18n import gettext
-from openlibrary.core import helpers
+# from openlibrary.core import helpers
 
 from openlibrary.mocks.mock_infobase import mock_site
 from openlibrary.mocks.mock_ia import mock_ia
@@ -21,6 +21,7 @@ from openlibrary.mocks.mock_ol import ol
 import web
 web.utf8 = web.safestr
 from infogami.utils.view import render_template as infobase_render_template  # noqa: F401
+from openlibrary.core import helpers  # noqa: F401
 
 
 @pytest.fixture(autouse=True)

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -15,13 +15,15 @@ from openlibrary.i18n import gettext
 from openlibrary.mocks.mock_infobase import mock_site
 from openlibrary.mocks.mock_ia import mock_ia
 from openlibrary.mocks.mock_memcache import mock_memcache
-from openlibrary.mocks.mock_ol import ol
+# from openlibrary.mocks.mock_ol import ol
 
-# TODO (cclauss): Undo Python 2 workaround for out-of-date web.py
+# TODO (cclauss): Undo Python 2 workaround for vendoring in an out-of-date infogami
 import web
 web.utf8 = web.safestr
 from infogami.utils.view import render_template as infobase_render_template  # noqa: F401
 from openlibrary.core import helpers  # noqa: F401
+from openlibrary.mocks.mock_ol import ol  # noqa: F401
+
 
 
 @pytest.fixture(autouse=True)

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -20,7 +20,8 @@ from openlibrary.mocks.mock_memcache import mock_memcache
 # TODO (cclauss): Undo Python 2 workaround for vendoring in an out-of-date infogami
 import web
 web.utf8 = web.safestr
-from infogami.utils.view import render_template as infobase_render_template  # noqa: F401
+from infogami.utils.view import (render_template as
+                                 infobase_render_template)  # noqa: F401
 from openlibrary.core import helpers  # noqa: F401
 from openlibrary.mocks.mock_ol import ol  # noqa: F401
 

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -13,14 +13,13 @@ pymarc==3.2.0; python_version < '3.6'
 pymarc==4.0.0; python_version >= '3.6'
 python-memcached==1.59
 simplejson==3.16.0
-web.py==0.39; python_version < '3.0'
-web.py==0.40; python_version >= '3.0'
+web.py==0.50
 pystatsd==0.1.6; python_version < '3.0'
 statsd==3.3.0; python_version >= '3.0'
 PyYAML==4.2b4
 eventer==0.1.1
 validate_email==1.3
-six==1.13.0
+six==1.14.0
 sixpack-client==1.2.0
 psycopg2==2.8.4
 Pygments==2.4.2


### PR DESCRIPTION
Fixes #3192  Upgrade to web.py==0.50 on both Python 2 and Python 3.  This is the last release that is planned to support legacy Python.  https://github.com/webpy/webpy/releases

Blocked by https://github.com/internetarchive/infogami/blob/master/infogami/utils/view.py#L70

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->