### PR TITLE
Alignment err btwbttns

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -7,7 +7,7 @@ $ edition_key = edition.key if edition else None
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ users_work_read_status = read_status or work.get_users_read_status(username) if work and username else None
 $ users_work_rating = rating or work.get_users_rating(username) if work and username else None
-$ pidentifier = page.url() if page.url().startswith("/publishers/") else None
+
 $if "lists" not in ctx.features:
     $return
 
@@ -93,15 +93,6 @@ $jsdef show_list(list):
 
 $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly):
     <div class="dropit">
-        $if pidentifier:
-          <style type="text/css">
-
-            #subjectLists
-            {
-              display: none;
-            }
-          </style>
-        $else:
           $if edition_key and not work_key:
             <div class="dropper on edition-page-lists-dropdown">
           $else:
@@ -192,10 +183,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 </div>
             </div>
           $else:
-              $if username:    
-                <script type="text/javascript">
-                  console.log("C2: ");                 
-                </script>            
+              $if username:
                 <div class="reading-lists">
                   <a href="javascript:;" class="dropclick">
                     <h3>$_('Add to List')</h3>
@@ -211,6 +199,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                     </p>
                   </div>
                 </div>
+
               $else:
                 <a href="/account/login?redir=$pageurl" class="dropclick plain">
                   <h3>$('Add to List')</h3>
@@ -225,7 +214,6 @@ $jsdef render_widget_display(lists, limit):
             $:show_list(list)
 
 $jsdef render_head():
-  $if not pidentifier:
     $if seed_type == "subject":
         <div class="head">
           <h3>Lists</h3>
@@ -394,11 +382,9 @@ $if ctx.user:
     var work_key = '$(work_key)';
     var edition_key = '$(edition_key)';
     var username = '$(username or "")';
-    console.log("Checking in 2 "+$:(json_encode(page_url)).includes("/publishers/"));
-    function reload_widget() 
-    {
-        \$("#widget-head").html(render_head());
 
+    function reload_widget() {
+        \$("#widget-head").html(render_head());
         \$("#widget-add").html(render_widget_add(user_lists, work_key, edition_key, users_work_read_status, username, page_url));
 
         \$("#widget-lists").html(render_widget_display(page_lists, 3));

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -7,7 +7,7 @@ $ edition_key = edition.key if edition else None
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ users_work_read_status = read_status or work.get_users_read_status(username) if work and username else None
 $ users_work_rating = rating or work.get_users_rating(username) if work and username else None
-
+$ pidentifier = page.url() if page.url().startswith("/publishers/") else None
 $if "lists" not in ctx.features:
     $return
 
@@ -93,6 +93,15 @@ $jsdef show_list(list):
 
 $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly):
     <div class="dropit">
+        $if pidentifier:
+          <style type="text/css">
+
+            #subjectLists
+            {
+              display: none;
+            }
+          </style>
+        $else:
           $if edition_key and not work_key:
             <div class="dropper on edition-page-lists-dropdown">
           $else:
@@ -183,7 +192,10 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 </div>
             </div>
           $else:
-              $if username:
+              $if username:    
+                <script type="text/javascript">
+                  console.log("C2: ");                 
+                </script>            
                 <div class="reading-lists">
                   <a href="javascript:;" class="dropclick">
                     <h3>$_('Add to List')</h3>
@@ -199,7 +211,6 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                     </p>
                   </div>
                 </div>
-
               $else:
                 <a href="/account/login?redir=$pageurl" class="dropclick plain">
                   <h3>$('Add to List')</h3>
@@ -214,6 +225,7 @@ $jsdef render_widget_display(lists, limit):
             $:show_list(list)
 
 $jsdef render_head():
+  $if not pidentifier:
     $if seed_type == "subject":
         <div class="head">
           <h3>Lists</h3>
@@ -382,9 +394,11 @@ $if ctx.user:
     var work_key = '$(work_key)';
     var edition_key = '$(edition_key)';
     var username = '$(username or "")';
-
-    function reload_widget() {
+    console.log("Checking in 2 "+$:(json_encode(page_url)).includes("/publishers/"));
+    function reload_widget() 
+    {
         \$("#widget-head").html(render_head());
+
         \$("#widget-add").html(render_widget_add(user_lists, work_key, edition_key, users_work_read_status, username, page_url));
 
         \$("#widget-lists").html(render_widget_display(page_lists, 3));

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -157,7 +157,7 @@ $jsdef renderPublishers(publishers):
         <span class="count">$sprintf(ungettext("%s edition", "%s editions", p.count), commify(p.count))</span>
          <br/>
 
-$if "lists" in ctx.features:
+$if "lists" not in ctx.features:
     <div class="spacer"></div>
     <div id="subjectLists" class="widget-box">
         $:render_template("lists/widget", page, include_rating=False)

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -157,12 +157,6 @@ $jsdef renderPublishers(publishers):
         <span class="count">$sprintf(ungettext("%s edition", "%s editions", p.count), commify(p.count))</span>
          <br/>
 
-$if "lists" not in ctx.features:
-    <div class="spacer"></div>
-    <div id="subjectLists" class="widget-box">
-        $:render_template("lists/widget", page, include_rating=False)
-    </div>
-
 <div class="section clearfix"></div>
 
 <form action="/search/publishers" class="olform">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # 3225

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the redundant newline to fix misaligned Loan Actions buttons.
### Technical
<!-- What should be noted about the implementation? -->
Instead of using br for newline, the following is added to provide proper space between buttons.
.LoanReadForm {
    margin-top: 10px;
    margin-bottom: 10px;

}

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/23471306/77258730-8fb92a00-6ca2-11ea-991b-51ba183ecb9d.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->