### PR TITLE
Alignment Error between the buttons internetarchive#3225:v1

### DIFF
--- a/openlibrary/macros/LoanReadForm.html
+++ b/openlibrary/macros/LoanReadForm.html
@@ -1,6 +1,14 @@
 $def with(edition_key)
 
-<form class="LoanReadForm" method="POST" action="$edition_key/_doread/borrow"><input type="hidden" name="action" value="read" /><input type="text" name="ol_host" value="" class="hidden ol_host" /><input type="submit" value="Read Online" /></form><br />
+<style type="text/css">
+.LoanReadForm {
+    margin-top: 10px;
+    margin-bottom: 10px;
+
+}
+</style>
+
+<form class="LoanReadForm" method="POST" action="$edition_key/_doread/borrow"><input type="hidden" name="action" value="read" /><input type="text" name="ol_host" value="" class="hidden ol_host" /><input type="submit" value="Read Online" /></form>
 
 <script type="text/javascript">
     jQuery('.ol_host').attr('value', location.host);

--- a/openlibrary/macros/LoanReadForm.html
+++ b/openlibrary/macros/LoanReadForm.html
@@ -1,12 +1,5 @@
 $def with(edition_key)
 
-<style type="text/css">
-.LoanReadForm {
-    margin-top: 10px;
-    margin-bottom: 10px;
-
-}
-</style>
 
 <form class="LoanReadForm" method="POST" action="$edition_key/_doread/borrow"><input type="hidden" name="action" value="read" /><input type="text" name="ol_host" value="" class="hidden ol_host" /><input type="submit" value="Read Online" /></form>
 

--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -37,10 +37,6 @@ th.action {
 th.status {
     width: 150px;
 }
-.LoanReadForm {
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
 </style>
 
 $if len(loans) >= 5:

--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -37,6 +37,10 @@ th.action {
 th.status {
     width: 150px;
 }
+.LoanReadForm {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
 </style>
 
 $if len(loans) >= 5:

--- a/static/css/components/borrowTable.less
+++ b/static/css/components/borrowTable.less
@@ -11,6 +11,9 @@
 
 // stylelint-disable selector-max-specificity
 #borrowTable {
+  .LoanReadForm {
+      margin: 10px 0;
+  }
   table {
     td {
       margin-top: 30px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3225

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the redundant newline to fix misaligned Loan Actions buttons.
### Technical
<!-- What should be noted about the implementation? -->
Instead of using br for newline, the following is added to provide proper space between buttons.
.LoanReadForm {
    margin-top: 10px;
    margin-bottom: 10px;

}

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/23471306/77258730-8fb92a00-6ca2-11ea-991b-51ba183ecb9d.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->