### PR TITLE
/isbn endpoint works w/ isbn10 or 13

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -15,7 +15,7 @@ from openlibrary.plugins.upstream.utils import get_history
 from openlibrary.core.helpers import private_collection_in
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.ratings import Ratings
-from openlibrary.utils.isbn import to_isbn_13, isbn_13_to_isbn_10
+from openlibrary.utils.isbn import to_isbn_13, isbn_13_to_isbn_10, canonical
 from openlibrary.core.vendors import create_edition_from_amazon_metadata
 
 from openlibrary.core.lists.model import ListMixin, Seed
@@ -414,6 +414,11 @@ class Edition(Thing):
         :rtype: edition|None
         :return: an open library work for this isbn
         """
+        isbn = canonical(isbn)
+
+        if len(isbn) not in [10, 13]:
+            return None  # consider raising ValueError
+
         isbn13 = to_isbn_13(isbn)
         isbn10 = isbn_13_to_isbn_10(isbn)
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -28,7 +28,7 @@ from infogami.core.db import ValidationException
 
 from openlibrary.core.vendors import create_edition_from_amazon_metadata
 from openlibrary.utils.isbn import isbn_13_to_isbn_10, isbn_10_to_isbn_13
-from openlibrary.core.models import Edition
+from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.core.lending import get_work_availability, get_edition_availability
 import openlibrary.core.stats
 from openlibrary.plugins.openlibrary.home import format_work_data

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -363,7 +363,7 @@ class health(delegate.page):
 
 class isbn_lookup(delegate.page):
 
-    path = r'/isbn/([0-9xX-]+)'
+    path = r'/(?:isbn|ISBN)/([0-9xX-]+)'
 
     def GET(self, isbn):
         # Preserve the url type (e.g. `.json`) and query params

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -366,8 +366,6 @@ class isbn_lookup(delegate.page):
     path = r'/isbn/([0-9xX-]+)'
 
     def GET(self, isbn):
-        from openlibrary.core.models import Edition
-
         # Preserve the url type (e.g. `.json`) and query params
         ext = ''
         if web.ctx.encoding and web.ctx.path.endswith('.' + web.ctx.encoding):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -392,7 +392,7 @@ class bookpage(delegate.page):
     otherwise, return a 404.
     """
 
-    path = r'/(oclc|lccn|ia|ISBN|OCLC|LCCN|IA)/([^/]*)(/.*)?'
+    path = r'/(oclc|lccn|ia|OCLC|LCCN|IA)/([^/]*)(/.*)?'
 
     def GET(self, key, value, suffix=''):
         key = key.lower()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -388,7 +388,6 @@ class isbn_lookup(delegate.page):
 class bookpage(delegate.page):
     """
     Load an edition bookpage by identifier: isbn, oclc, lccn, or ia (ocaid).
-    If not found, try to import it by ISBN,
     otherwise, return a 404.
     """
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Fixes /isbn to consider both isbn10 or isbn13 (currently it only searches the exact isbn you provide it)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Find a book w/ an isbn 10 on Open Library. Try /isbn endpoing with both the isbn10 and the isbn13 version of this book. Do the same for another book with isbn13.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Tested on dev.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
co-authored with @cdrini 