### PR TITLE
granting librarians solr admin access

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -728,7 +728,7 @@ def setup():
     register_admin_page('/admin/graphs', _graphs, label="")
     register_admin_page('/admin/logs', show_log, label="")
     register_admin_page('/admin/permissions', permissions, label="")
-    register_admin_page('/admin/solr', solr, label="")
+    register_admin_page('/admin/solr', solr, label="", librarians=True)
     register_admin_page('/admin/sync', sync_ol_ia, label="", librarians=True)
     register_admin_page('/admin/staffpicks', add_work_to_staff_picks, label="")
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Gives librarians access to reindex solr entries

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Passes `librarian` permissions through to admin plugin

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

As a librarian, go to https://dev.openlibrary.org/admin/solr

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Tested w/ @seabelis 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis , @cdrini 