### PR TITLE
Fix test merge authors.py

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -74,7 +74,7 @@ class BasicMergeEngine:
     def merge_docs(self, master, dup, ignore=[]):
         """Merge duplicate doc into master doc.
         """
-        keys = set(master.keys() + dup.keys())
+        keys = set(list(master) + list(dup))
         return dict((k, self.merge_property(master.get(k), dup.get(k))) for k in keys)
 
     def merge_property(self, a, b):

--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -56,7 +56,7 @@ class MockSite(client.Site):
 
 def test_MockSite():
     site = MockSite()
-    assert site.docs.keys() == []
+    assert list(site.docs) == []
 
     site.add([{
             "key": "a",
@@ -66,7 +66,7 @@ def test_MockSite():
             "type": {"key": "/type/object"}
         }
     ])
-    assert site.docs.keys() == ["a", "b"]
+    assert list(site.docs) == ["a", "b"]
 
 testdata = web.storage({
     "a": {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
A subset of #3134 created to simplify the review process.

Closes pytests on Python 3

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
$ `python3`
```
# keys = set(master.keys() + dup.keys())
>>> {}.keys() + {}.keys()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
>>> list({}) + list({}) == []
True

# assert site.docs.keys() == []
>>> {}.keys() == []
False
>>> list({}) == []
True

# assert site.docs.keys() == ["a", "b"]
>>> {"a": 0, "b": 1}.keys() == ["a", "b"]
False
>>> list({"a": 0, "b": 1}) == ["a", "b"]
True
```

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->