### PR TITLE
hotfix disable price lookup due to traffic increase, help bwb

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,6 +1,6 @@
 $def with (page, opts)
 
-$ prices = opts.get('prices') and False
+$ prices = opts.get('prices')
 $ isbn = opts.get('isbn', '')
 $ asin = opts.get('asin', '')
 

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,6 +1,6 @@
 $def with (page, opts)
 
-$ prices = opts.get('prices')
+$ prices = opts.get('prices') and False
 $ isbn = opts.get('isbn', '')
 $ asin = opts.get('asin', '')
 

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -8,7 +8,10 @@ $else:
     $ edit_url = page.key + "?m=edit"
 
 $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
-$ prices = page.key.startswith('/books/')
+
+$# Disable price temporarily: NEL causing too much traffic to BWB!
+$# Was: page.key.startswith('/books/')
+$ prices = False
 
 $ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
 $ isbn_13 = page.get_isbn13()


### PR DESCRIPTION
Hotfix -- our increase of traffic is causing 13% increase in affiliate price lookups against BWB and affecting their service availability.

They've adjusted on their side. Suggesting we merge this PR, out-of-cycle deploy, and re-visit next-steps for next Tues release.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Disables price-lookup on editions page (via affiliate macro) should not affect sponsorship.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Clear cache on dev via `/etc/init.d/restart mecache` and then visit https://dev.openlibrary.org/books/OL18141225M/Snow_crash (load time should be reasonable, price should not appear, link to BWB **should**).

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

tested on dev


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bfalling @cdrini 