### PR TITLE
Temporarily disable falling back to full-text search results

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -202,18 +202,13 @@ $ )
     $if param and not docs:
         $ query = query_param('q')
         $ page = int(query_param('page') or 1)
-        $ results = fulltext_search(query, page)
-        <div class="serp-ctx">
-          <div><span class="red">$_("No results found.")</span></div>
-
-          $if results:
-            <div class="show-similar">$_("Showing books with similar text to:") <strong>$(query)</strong></div>
-        </div>
-
-        $if results:
-          $if 'error' in results:
-            <div class="searchResultsError">$results['error']</div>
-          $:macros.FulltextResults(query, results, page=page)
+        $# Temporarily (2020-03-26) disable automatically showing full-text
+        $# results because of performance issues due to increased load. See
+        $# this commit to revert.
+        <center>
+            <span class="red">$_("No results found.")</span>
+            <a href="/search/inside?$urlencode(dict(q=query))">$_('Search for books containing "%s"?' % query)</a>
+        </center>
 
     $elif param and not error and len(docs):
         <div class="shift">$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -207,7 +207,7 @@ $ )
         $# this commit to revert.
         <center>
             <span class="red">$_("No results found.")</span>
-            <a href="/search/inside?$urlencode(dict(q=query))">$_('Search for books containing "%s"?' % query)</a>
+            <a href="/search/inside?$urlencode(dict(q=query))">$_('Search for books containing the phrase "%s"?' % query)</a>
         </center>
 
     $elif param and not error and len(docs):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # TODO . Don't auto full-text search on failed search; instead show text directly to fts.

### Technical
This was causing performance issues on FTS servers because of high load on OL during global lockdown.

### Testing
- Tested locally:
  - ✅ a search with results shows results https://dev.openlibrary.org/search?q=tacos
  - ✅ a search without results shows text + link to search inside https://dev.openlibrary.org/search?q=gobbly+gook
  - ✅ link to search inside takes you to/performs search inside https://dev.openlibrary.org/search/inside?q=title%3A+%22gobbly+gook%22
  - ✅ searching directly for "Text" goes to search inside. https://dev.openlibrary.org/search/inside?q=gooky&mode=printdisabled&m=edit&m=edit&has_fulltext=true&subject_facet=Protected+DAISY

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/6251786/77704592-cdb09980-6f93-11ea-9989-61ba601aca4e.png)



### Stakeholders
@mekarpeles 