### PR TITLE
Tell psql to do it's work quetly

### DIFF
--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -7,11 +7,11 @@ USER postgres
 RUN /etc/init.d/postgresql start \
   && createuser -s openlibrary \
   && createdb openlibrary \
-  && psql openlibrary < openlibrary/core/users.sql \
-  && psql openlibrary < openlibrary/core/schema.sql \
+  && psql --quiet openlibrary < openlibrary/core/users.sql \
+  && psql --quiet openlibrary < openlibrary/core/schema.sql \
   && createdb coverstore \
-  && psql coverstore < openlibrary/coverstore/schema.sql \
-  && psql openlibrary < scripts/dev-instance/dev_db.pg_dump \
+  && psql --quiet coverstore < openlibrary/coverstore/schema.sql \
+  && psql --quiet openlibrary < scripts/dev-instance/dev_db.pg_dump \
   && pg_ctlcluster 9.5 main stop
 
 USER root


### PR DESCRIPTION
Closes #2046 

feature

### Technical

Adding `--quiet` flag to `psql` utility. What flag dies described here: https://www.postgresql.org/docs/9.5/app-psql.html.

### Testing

To verify changes you can try to build `oldev` image with `docker build -f docker/Dockerfile.oldev .` and check that build output does not contain lots of 'garbage' messages as described in issue.
 
### Evidence

See step output after change below. While it still includes a bunch of results printouts of copy operations with setval function used, it is now much cleaner.

```
 ---> Running in 43231f953f34
 * Starting PostgreSQL 9.5 database server
   ...done.
 setval
--------
    132
(1 row)

 setval
--------
      1
(1 row)

 setval
--------
     31
(1 row)

 setval
--------
    175
(1 row)

 setval
--------
    665
(1 row)

 setval
--------
     44
(1 row)

 setval
--------
      1
(1 row)

 setval
--------
      1
(1 row)

 setval
--------
      1
(1 row)

 setval
--------
      1
(1 row)

 setval
--------
    678
(1 row)

Removing intermediate container 43231f953f34
```
### Stakeholders
<!-- @ tag stakeholders of this bug -->