### PR TITLE
Move autocomplete setup scripts from HTML to JS

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -1,4 +1,93 @@
+// jquery-autocomplete#1.1 with modified
+import '../../../../vendor/js/jquery-autocomplete/jquery.autocomplete-modified.js';
 // jquery plugins to provide author and language autocompletes.
+
+// Possible globals defined using jsdef inside openlibrary/templates/books/edit/edition.html
+// In future we'll move these into JS but easier said than done!
+const render_translated_from_language_field = window.render_translated_from_language_field,
+    render_work_field = window.render_work_field,
+    // These are defined using jsdef inside templates. If they are absent, then the template was not used.
+    render_language_autocomplete_item = window.render_language_autocomplete_item,
+    render_author_autocomplete_item = window.render_author_autocomplete_item,
+    render_work_autocomplete_item = window.render_work_autocomplete_item,
+    render_author = window.render_author,
+    render_language_field = window.render_language_field;
+
+/**
+ * Some options specific to certain endpoint services.
+ */
+const ENDPOINT_OPTIONS_AUTHORS = {
+    endpoint: '/authors/_autocomplete',
+    // Don't render "Create new author" if searching by key
+    addnew: function(query) { return !/^OL\d+A/i.test(query); },
+};
+
+const ENDPOINT_OPTIONS_LANGUAGES = {
+    endpoint: '/languages/_autocomplete'
+};
+
+/**
+ * Some default options for autocompletes.
+ */
+const AUTOCOMPLETE_OPTIONS = {
+    minChars: 2,
+    max: 11,
+    matchSubset: false,
+    autoFill: false
+};
+
+/**
+ * Some slightly different options for language autocompletes.
+ */
+const AUTOCOMPLETE_LANGUAGE_OPTIONS = {
+    max: 6,
+    formatItem: render_language_autocomplete_item
+};
+
+/**
+ * Initialises autocomplete elements in the page.
+ */
+function initPageElements() {
+    if (render_author_autocomplete_item && render_author) {
+        $('#authors').setup_multi_input_autocomplete(
+            'input.author-autocomplete',
+            render_author,
+            ENDPOINT_OPTIONS_AUTHORS,
+            $.extend({}, AUTOCOMPLETE_OPTIONS, {
+                formatItem: render_author_autocomplete_item
+            })
+        );
+    }
+
+    if (render_language_field) {
+        $('#languages').setup_multi_input_autocomplete(
+            'input.language-autocomplete',
+            render_language_field,
+            ENDPOINT_OPTIONS_LANGUAGES,
+            AUTOCOMPLETE_LANGUAGE_OPTIONS
+        );
+    }
+
+    if (render_translated_from_language_field) {
+        $('#translated_from_languages').setup_multi_input_autocomplete(
+            'input.language-autocomplete',
+            render_translated_from_language_field,
+            ENDPOINT_OPTIONS_LANGUAGES,
+            AUTOCOMPLETE_LANGUAGE_OPTIONS
+        );
+    }
+
+    if (render_work_field && render_work_autocomplete_item) {
+        $('#works').setup_multi_input_autocomplete(
+            'input.work-autocomplete',
+            render_work_field,
+            $('#works').data('autocomplete-endpoint-options'),
+            $.extend({}, AUTOCOMPLETE_OPTIONS, {
+                formatItem: render_work_autocomplete_item
+            })
+        );
+    }
+}
 
 export default function($) {
     /**
@@ -123,4 +212,5 @@ export default function($) {
             update_visible();
         });
     };
+    initPageElements();
 }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -7,8 +7,6 @@ import '../../../../vendor/js/jquery-ui/jquery-ui-1.12.1.min.js';
 import '../../../../vendor/js/colorbox/1.5.14.js';
 // jquery.form#2.36 not on npm, no longer getting worked on
 import '../../../../vendor/js/jquery-form/jquery.form.js';
-// jquery-autocomplete#1.1 with modified
-import '../../../../vendor/js/jquery-autocomplete/jquery.autocomplete-modified.js';
 // unversioned.
 import '../../../../vendor/js/wmd/jquery.wmd.js'
 import autocompleteInit from './autocomplete';

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -31,7 +31,7 @@ $jsdef render_author_autocomplete_item(item):
                 <span class="subject">Subjects: ${', '.join(item.subjects)}</span>
         </div>
 
-$jsdef render_author(name_path, dict_path, i, author):
+$jsdef render_author(i, author):
     <div class="input">
         <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name"/>
         <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
@@ -41,24 +41,5 @@ $jsdef render_author(name_path, dict_path, i, author):
 
 <div id="authors">
     $for author in (authors or [storage(name="", key="")]):
-        $:render_author(name_path, dict_path, loop.index0, author)
+        $:render_author(loop.index0, author)
 </div>
-<script type="text/javascript">
-window.q.push( function () {
-    \$("#authors").setup_multi_input_autocomplete(
-        "input.author-autocomplete",
-        render_author.bind(null, "$name_path", "$dict_path"),
-        {
-            endpoint: "/authors/_autocomplete",
-            // Don't render "Create new author" if searching by key
-            addnew: function(query) { return !/^OL\d+A/i.test(query); },
-        },
-        {
-            minChars: 2,
-            max: 11,
-            matchSubset: false,
-            autoFill: false,
-            formatItem: render_author_autocomplete_item
-        });
-} );
-</script>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -74,45 +74,6 @@ $jsdef render_work_autocomplete_item(item):
                 <span class="edition_count">$item.edition_count editions</span>
         </div>
 
-<script type="text/javascript">
-window.q.push(function() {
-    \$("#languages").setup_multi_input_autocomplete(
-        "input.language-autocomplete",
-        render_language_field,
-        { endpoint: "/languages/_autocomplete" },
-        {
-            max: 6,
-            formatItem: render_language_autocomplete_item
-        });
-
-    \$("#translated_from_languages").setup_multi_input_autocomplete(
-        "input.language-autocomplete",
-        render_translated_from_language_field,
-        { endpoint: "/languages/_autocomplete" },
-        {
-            max: 6,
-            formatItem: render_language_autocomplete_item
-        });
-
-    \$("#works").setup_multi_input_autocomplete(
-        "input.work-autocomplete",
-        render_work_field,
-        {
-            endpoint: "/works/_autocomplete",
-            addnew: $cond(is_privileged_user, 'true', 'false'),
-            new_name: '$_('-- Move to a new work')',
-        },
-        {
-            minChars: 2,
-            max: 11,
-            matchSubset: false,
-            autoFill: false,
-            formatItem: render_work_autocomplete_item
-        });
-});
-</script>
-
-
 <fieldset class="major">
     <legend>$_("Publishing Info")</legend>
 
@@ -187,7 +148,12 @@ window.q.push(function() {
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            <div id="works">
+            $ data_autocomplete_options = json_encode({
+            $    "endpoint": "/works/_autocomplete",
+            $    "addnew": is_privileged_user,
+            $    "new_name": _('-- Move to a new work' )
+            $ })
+            <div id="works" data-autocomplete-endpoint-options="$data_autocomplete_options">
                 $if book.works:
                     $for i, work in enumerate(book.works):
                         $:render_work_field(i, work)


### PR DESCRIPTION
This begins work on fixing #2490. Inlining JS inside HTML is not sustainable going forward.
Use data- attributes where we need to pass data between templates and JS.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
There should be no change in the JS run before or after - it will instead be shipped in JS. This is not meant to be a refactor. Refactor will come later. Focus now is getting inline JS out of HTML.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit /works/OL192489W/Practical_use_of_the_slide_rule/edit 
AND /books/OL6179353M/Slide_rule/edit - type in the works / authors inputs and check that results show and results are clickable.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->