### PR TITLE
Add more graphite state (specifically for errors)

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -782,12 +782,19 @@ def save_error():
     print('error saved to', path, file=web.debug)
     return name
 
-
+# TODO: move this stats stuff to plugins\openlibrary\stats.py
 def internalerror():
     i = web.input(_method='GET', debug='false')
     name = save_error()
 
-    openlibrary.core.stats.increment('ol.internal-errors', 1)
+    # Can't have sub-metrics, so can't add more info
+    openlibrary.core.stats.increment('ol.internal-errors')
+
+    # Mirrors code in plugins\openlibrary\stats.py that runs on pageload
+    response_code = 'not_specified'
+    if web.ctx and hasattr(web.ctx, 'status'):
+        response_code = web.ctx.status.split(' ')[0]
+    openlibrary.core.stats.increment('ol.response-codes.' + response_code)
 
     if i.debug.lower() == 'true':
         raise web.debugerror()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -32,7 +32,7 @@ from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.core.lending import get_work_availability, get_edition_availability
 import openlibrary.core.stats
 from openlibrary.plugins.openlibrary.home import format_work_data
-
+from openlibrary.plugins.openlibrary.stats import increment_error_count
 from openlibrary.plugins.openlibrary import processors
 
 delegate.app.add_processor(processors.ReadableUrlProcessor())
@@ -782,19 +782,14 @@ def save_error():
     print('error saved to', path, file=web.debug)
     return name
 
-# TODO: move this stats stuff to plugins\openlibrary\stats.py
 def internalerror():
     i = web.input(_method='GET', debug='false')
     name = save_error()
 
+    # TODO: move this stats stuff to plugins\openlibrary\stats.py
     # Can't have sub-metrics, so can't add more info
     openlibrary.core.stats.increment('ol.internal-errors')
-
-    # Mirrors code in plugins\openlibrary\stats.py that runs on pageload
-    response_code = 'not_specified'
-    if web.ctx and hasattr(web.ctx, 'status'):
-        response_code = web.ctx.status.split(' ')[0]
-    openlibrary.core.stats.increment('ol.response-codes.' + response_code)
+    increment_error_count('ol.internal-errors-segmented')
 
     if i.debug.lower() == 'true':
         raise web.debugerror()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -32,7 +32,7 @@ from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.core.lending import get_work_availability, get_edition_availability
 import openlibrary.core.stats
 from openlibrary.plugins.openlibrary.home import format_work_data
-from openlibrary.plugins.openlibrary.stats import increment_error_count
+from openlibrary.plugins.openlibrary.stats import increment_error_count  # noqa: E402
 from openlibrary.plugins.openlibrary import processors
 
 delegate.app.add_processor(processors.ReadableUrlProcessor())

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -154,7 +154,7 @@ def _get_path_page_name(path):
         pageClass, _ = find_mode()
 
     result = pageClass.__name__
-    if hasattr(pageClass, 'encoding'):
+    if hasattr(pageClass, 'encoding') and not result.endswith(pageClass.encoding):
         result += '_' + pageClass.encoding
 
     return result

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -65,7 +65,17 @@ def stats_hook():
         # don't let errors in stats collection break the app.
         print(str(e), file=web.debug)
 
+    # This name is misleading. It gets incremented for more than just pages.
+    # E.g. *.json requests (even ajax), image requests. Although I can't
+    # see any *.js requests? So not sure exactly when we're called here.
+    # FURTHERMORE: pages that get e.g. 500 status codes don't get here
+    # either; that needs to be in an internalerrors hook
     openlibrary.core.stats.increment('ol.pageviews')
+
+    response_code = 'not_specified'
+    if web.ctx and hasattr(web.ctx, 'status'):
+        response_code = web.ctx.status.split(' ')[0]
+    openlibrary.core.stats.increment('ol.response-codes.' + response_code)
 
     memcache_hits = 0
     memcache_misses = 0

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -76,8 +76,6 @@ def stats_hook():
     # This name is misleading. It gets incremented for more than just pages.
     # E.g. *.json requests (even ajax), image requests. Although I can't
     # see any *.js requests? So not sure exactly when we're called here.
-    # FURTHERMORE: pages that get e.g. 500 status codes don't get here
-    # either; that needs to be in an internalerrors hook
     graphite_stats.increment('ol.pageviews')
 
     memcache_hits = 0
@@ -282,7 +280,7 @@ TEMPLATE_SYNTAX_ERROR_RE = re.compile(r"File '([^']+?)'")
 
 def find_topmost_useful_file(exception, tback):
     """
-    Find the topmast path in the traceback stack that's useful to report.
+    Find the topmost path in the traceback stack that's useful to report.
 
     :param BaseException exception: error from e.g. sys.exc_inf()
     :param TracebackType tback: traceback from e.g. sys.exc_inf()

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -44,7 +44,4 @@ def setup():
 
     # Host is e.g. ol-web4.blah.archive.org ; we just want the first subdomain
     first_subdomain = host.split('.')[0] or 'unknown'
-    stats.increment('ol.server.%s.started' % first_subdomain)
-    stats.increment('ol.server.%s.version.%s' % (first_subdomain, version))
-
-
+    stats.increment('ol.servers.%s.started' % first_subdomain)

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -7,6 +7,7 @@ import subprocess
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import render_template, public
+from openlibrary.core import stats
 
 status_info = {}
 feature_flags = {}
@@ -32,9 +33,18 @@ def get_features_enabled():
 def setup():
     "Basic startup status for the server"
     global status_info, feature_flags
-    status_info = {"Software version" : get_software_version(),
-                   "Host" : socket.gethostname(),
-                   "Start time" : datetime.datetime.utcnow()
-                   }
+    version = get_software_version()
+    host = socket.gethostname()
+    status_info = {
+        "Software version": version,
+        "Host": host,
+        "Start time": datetime.datetime.utcnow(),
+    }
     feature_flags = get_features_enabled()
+
+    # Host is e.g. ol-web4.blah.archive.org ; we just want the first subdomain
+    first_subdomain = host.split('.')[0] or 'unknown'
+    stats.increment('ol.server.%s.started' % first_subdomain)
+    stats.increment('ol.server.%s.version.%s' % (first_subdomain, version))
+
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3283

Fix/feature: Add more graphite stats for pageloads, internal-errors, and exceptions. This will let us easily drill down into specific endpoint data if we see a large number of errors, as well as perf regressions.

### Technical
- The format for pageloads is:
`ol.requests.(started|completed).(GET|POST|...).(400|404|...).(logged_in|not_logged_in).[first_level_path].[page_class].(10ms|100ms|...).count`; e.g.:
  - `ol.requests.started.GET.200.not_logged_in.books.class_book_edit.unknown.count`
  - `ol.requests.completed.GET.500.not_logged_in.books.class_book_edit.5000ms.count`
- For errors and exceptions, the format is:
`ol.internal-errors-segmented.[first_level_path].[page_class].[error_file_in_ol].[error_name].count`; e.g.:
  - `ol.internal-errors-segmented.books.book_edit.class_books_edit_html.SyntaxError.count`
  - `ol_exceptions.search.class_search.worksearch_code_py.TypeError.count`
- I'm a little concerned whether these long metric names might have perf complications, but found this article https://matt.aimonetti.net/posts/2013-06-practical-guide-to-graphite-monitoring/ which did something similar (even including multiple levels of the path name!), so think it should be ok. We can always of course axe it if it isn't.
- I'm suspicious that the existing `ol.pageload` stats are incorrect; the code seems to only measure time spent other resources (like memcache, solr) when explicitly triggered using `begin()` and `end()` functions. My _guess_ would be it underestimates? Unless there's something else going on here where it's _needed_ to measure those explicitly because otherwise they aren't measure. In local testing the time metrics seemed ok for both :/
- Also log webnode restarts. This should hopefully be closesly correlated to deploys, so we can display them as Grafana annotations to easily see if a shift in metrics is closely correlated to a deploy. Note they fire for each worker, but that shouldn't be an issue.

### Testing
Spied on the increment/put sections, and did a bunch of testing locally:

#### Normal Stats

<details><summary>/books/OL2058361M/edit</summary>
<pre>
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.requests.started.GET.200.not_logged_in.books.class_book_edit.unknown.count'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put pageload.all=103.716016'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put pageload.books=103.716016'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.pageviews'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.memcache.hits'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.memcache.misses'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put ol.total=1037.160158'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put ol.memcache_get=6.448030'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put ol.infobase=10.480881'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.requests.completed.GET.200.not_logged_in.books.class_book_edit.1000ms.count'
</pre></details>

<details><summary>/books/OL2058361M</summary>
<pre>
web_1        | u'DRINI(path=/books/OL2058361M): increment ol.requests.started.GET.200.not_logged_in.books.class_view.unknown.count'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.started.POST.200.not_logged_in.internal.class_loans.unknown.count'
web_1        | u'DRINI(path=/internal/fake/loans): put pageload.all=0.359201'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.pageviews'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.memcache.misses'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.total=3.592014'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.memcache_get=0.557184'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.infobase=1.698971'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.completed.POST.200.not_logged_in.internal.class_loans.10ms.count'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.started.POST.200.not_logged_in.internal.class_loans.unknown.count'
web_1        | u'DRINI(path=/internal/fake/loans): put pageload.all=0.383592'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.pageviews'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.memcache.misses'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.total=3.835917'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.memcache_get=0.507832'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.infobase=2.558947'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.completed.POST.200.not_logged_in.internal.class_loans.10ms.count'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.started.POST.200.not_logged_in.internal.class_loans.unknown.count'
web_1        | u'DRINI(path=/internal/fake/loans): put pageload.all=0.293398'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.pageviews'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.memcache.misses'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.total=2.933979'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.memcache_get=0.298977'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.infobase=1.898050'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.completed.POST.200.not_logged_in.internal.class_loans.10ms.count'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.started.POST.200.not_logged_in.internal.class_loans.unknown.count'
web_1        | u'DRINI(path=/internal/fake/loans): put pageload.all=0.461698'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.pageviews'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.memcache.misses'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.total=4.616976'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.memcache_get=0.382185'
web_1        | u'DRINI(path=/internal/fake/loans): put ol.infobase=3.400803'
web_1        | u'DRINI(path=/internal/fake/loans): increment ol.requests.completed.POST.200.not_logged_in.internal.class_loans.10ms.count'
web_1        | u'DRINI(path=/books/OL2058361M): put pageload.all=2179.340100'
web_1        | u'DRINI(path=/books/OL2058361M): put pageload.books=2179.340100'
web_1        | u'DRINI(path=/books/OL2058361M): increment ol.pageviews'
web_1        | u'DRINI(path=/books/OL2058361M): increment ol.memcache.hits'
web_1        | u'DRINI(path=/books/OL2058361M): increment ol.memcache.misses'
web_1        | u'DRINI(path=/books/OL2058361M): put ol.infobase=18.893242'
web_1        | u'DRINI(path=/books/OL2058361M): put ol.archive_org=20033.339977'
web_1        | u'DRINI(path=/books/OL2058361M): put ol.memcache_set=1.192093'
web_1        | u'DRINI(path=/books/OL2058361M): put ol.memcache_get=20.370007'
web_1        | u'DRINI(path=/books/OL2058361M): put ol.total=21793.401003'
web_1        | u'DRINI(path=/books/OL2058361M): put ol.memcache_get_multi=0.180960'
web_1        | u'DRINI(path=/books/OL2058361M): increment ol.requests.completed.GET.200.not_logged_in.books.class_view.5000ms.count'
</pre></details>
<details><summary>/works/OL54120W</summary>
<pre>
web_1        | u'DRINI(path=/works/OL54120W): increment ol.requests.started.GET.200.not_logged_in.works.class_view.unknown.count'
web_1        | u'DRINI(path=/works/OL54120W): put pageload.all=2070.816708'
web_1        | u'DRINI(path=/works/OL54120W): increment ol.pageviews'
web_1        | u'DRINI(path=/works/OL54120W): increment ol.memcache.hits'
web_1        | u'DRINI(path=/works/OL54120W): put ol.memcache_get=12.880802'
web_1        | u'DRINI(path=/works/OL54120W): put ol.total=20708.167076'
web_1        | u'DRINI(path=/works/OL54120W): put ol.solr=5.378962'
web_1        | u'DRINI(path=/works/OL54120W): put ol.memcache_get_multi=0.738859'
web_1        | u'DRINI(path=/works/OL54120W): put ol.memcache_set=0.777960'
web_1        | u'DRINI(path=/works/OL54120W): increment ol.requests.completed.GET.200.not_logged_in.works.class_view.5000ms.count'
web_1        | u'DRINI(path=/images/icons/avatar_book-sm.png): increment ol.requests.started.GET.200.not_logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/icons/icon-encrypto-sm.png): increment ol.requests.started.GET.200.not_logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/icons/avatar_book-sm.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/icons/icon-encrypto-sm.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/icons/icon-encrypto-sm.png): increment ol.requests.completed.GET.303.not_logged_in.images.class_static.10ms.count'
web_1        | u'DRINI(path=/images/icons/avatar_book-sm.png): increment ol.requests.completed.GET.303.not_logged_in.images.class_static.10ms.count'
web_1        | u'DRINI(path=/images/icons/icon_dropit2.png): increment ol.requests.started.GET.200.not_logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/icons/icon_dropit2.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/icons/icon_dropit2.png): increment ol.requests.completed.GET.303.not_logged_in.images.class_static.10ms.count'
web_1        | u'DRINI(path=/images/sort_both.png): increment ol.requests.started.GET.200.not_logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/sort_both.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/sort_asc.png): increment ol.requests.started.GET.200.not_logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/sort_both.png): increment ol.requests.completed.GET.303.not_logged_in.images.class_static.10ms.count'
web_1        | u'DRINI(path=/images/sort_asc.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/sort_asc.png): increment ol.requests.completed.GET.303.not_logged_in.images.class_static.10ms.count'
</pre></details>
<details><summary>/subjects/accessible_book</summary>
<pre>
web_1        | u'DRINI(path=/subjects/accessible_book): increment ol.requests.started.GET.200.not_logged_in.subjects.class_subjects.unknown.count'
web_1        | u'DRINI(path=/subjects/accessible_book): put pageload.all=2038.114190'
web_1        | u'DRINI(path=/subjects/accessible_book): increment ol.pageviews'
web_1        | u'DRINI(path=/subjects/accessible_book): increment ol.memcache.misses'
web_1        | u'DRINI(path=/subjects/accessible_book): put ol.total=20381.141901'
web_1        | u'DRINI(path=/subjects/accessible_book): put ol.memcache_get=2.080917'
web_1        | u'DRINI(path=/subjects/accessible_book): put ol.infobase=26.818037'
web_1        | u'DRINI(path=/subjects/accessible_book): put ol.solr=0.000000'
web_1        | u'DRINI(path=/subjects/accessible_book): increment ol.requests.completed.GET.200.not_logged_in.subjects.class_subjects.5000ms.count'
web_1        | u'DRINI(path=/images/ajax-loader-bar.gif): increment ol.requests.started.GET.200.not_logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/ajax-loader-bar.gif): increment ol.pageviews'
web_1        | u'DRINI(path=/images/ajax-loader-bar.gif): increment ol.requests.completed.GET.303.not_logged_in.images.class_static.10ms.count'
</pre></details>
<details><summary>/search/inside</summary>
<pre>
web_1        | u'DRINI(path=/search/inside): increment ol.requests.started.GET.200.not_logged_in.search.class_search_inside.unknown.count'
web_1        | u'DRINI(path=/search/inside): increment ol.pageviews'
web_1        | u'DRINI(path=/search/inside): increment ol.requests.completed.GET.200.not_logged_in.search.class_search_inside.5000ms.count'
</pre></details>
<details><summary>/search</summary>
<pre>
web_1        | u'DRINI(path=/search): increment ol.requests.completed.GET.200.not_logged_in.search.class_search.5000ms.count'
web_1        | u'DRINI(path=/search): increment ol.requests.started.GET.200.not_logged_in.search.class_search.unknown.count'
web_1        | u'DRINI(path=/search): put pageload.all=2003.356099'
web_1        | u'DRINI(path=/search): increment ol.pageviews'
web_1        | u'DRINI(path=/search): put ol.total=20033.560991'
web_1        | u'DRINI(path=/search): put ol.solr=4.612923'
web_1        | u'DRINI(path=/search): increment ol.requests.completed.GET.200.not_logged_in.search.class_search.5000ms.count'
</pre></details>
<details><summary>/account/login</summary>
<pre>
web_1        | u'DRINI(path=/account/login): increment ol.requests.started.GET.200.not_logged_in.account.class_account_login.unknown.count'
web_1        | u'DRINI(path=/account/login): increment ol.pageviews'
web_1        | u'DRINI(path=/account/login): increment ol.requests.completed.GET.200.not_logged_in.account.class_account_login.10ms.count'
</pre></details>
<details><summary>/account/login</summary>
<pre>
web_1        | u'DRINI(path=/account/login): increment ol.requests.started.POST.200.not_logged_in.account.class_account_login.unknown.count'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.requests.started.POST.200.not_logged_in.internal.class_xauth.unknown.count'
web_1        | u'DRINI(path=/internal/fake/xauth): put pageload.all=0.451303'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.pageviews'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.memcache.misses'
web_1        | u'DRINI(path=/internal/fake/xauth): put ol.total=4.513025'
web_1        | u'DRINI(path=/internal/fake/xauth): put ol.memcache_get=0.504971'
web_1        | u'DRINI(path=/internal/fake/xauth): put ol.infobase=2.188206'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.requests.completed.POST.200.not_logged_in.internal.class_xauth.10ms.count'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.requests.started.POST.200.not_logged_in.internal.class_xauth.unknown.count'
web_1        | u'DRINI(path=/internal/fake/xauth): put pageload.all=0.366902'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.pageviews'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.memcache.misses'
web_1        | u'DRINI(path=/internal/fake/xauth): put ol.total=3.669024'
web_1        | u'DRINI(path=/internal/fake/xauth): put ol.memcache_get=0.232220'
web_1        | u'DRINI(path=/internal/fake/xauth): put ol.infobase=1.612902'
web_1        | u'DRINI(path=/internal/fake/xauth): increment ol.requests.completed.POST.200.not_logged_in.internal.class_xauth.10ms.count'
web_1        | u'DRINI(path=/account/login): put pageload.all=8.527589'
web_1        | u'DRINI(path=/account/login): increment ol.pageviews'
web_1        | u'DRINI(path=/account/login): increment ol.memcache.misses'
web_1        | u'DRINI(path=/account/login): put ol.total=85.275888'
web_1        | u'DRINI(path=/account/login): put ol.memcache_get=0.149012'
web_1        | u'DRINI(path=/account/login): put ol.infobase=17.329693'
web_1        | u'DRINI(path=/account/login): increment ol.requests.completed.POST.303.not_logged_in.account.class_account_login.10ms.count'
</pre></details>
<details><summary>/people/openlibrary</summary>
<pre>
web_1        | u'DRINI(path=/people/openlibrary): increment ol.requests.started.GET.200.logged_in.people.class_view.unknown.count'
web_1        | u'DRINI(path=/people/openlibrary): put pageload.all=17.866421'
web_1        | u'DRINI(path=/people/openlibrary): increment ol.pageviews'
web_1        | u'DRINI(path=/people/openlibrary): increment ol.memcache.hits'
web_1        | u'DRINI(path=/people/openlibrary): increment ol.memcache.misses'
web_1        | u'DRINI(path=/people/openlibrary): put ol.infobase=75.045586'
web_1        | u'DRINI(path=/people/openlibrary): put ol.memcache_set_multi=0.341892'
web_1        | u'DRINI(path=/people/openlibrary): put ol.memcache_set=0.623226'
web_1        | u'DRINI(path=/people/openlibrary): put ol.memcache_get=2.699137'
web_1        | u'DRINI(path=/people/openlibrary): put ol.total=178.664207'
web_1        | u'DRINI(path=/people/openlibrary): put ol.memcache_get_multi=0.356913'
web_1        | u'DRINI(path=/people/openlibrary): increment ol.requests.completed.GET.200.logged_in.people.class_view.100ms.count'
</pre></details>
<details><summary>/account</summary>
<pre>
web_1        | u'DRINI(path=/account): increment ol.requests.started.GET.200.logged_in.account.class_account.unknown.count'
web_1        | u'DRINI(path=/account): put pageload.all=7.971883'
web_1        | u'DRINI(path=/account): increment ol.pageviews'
web_1        | u'DRINI(path=/account): increment ol.memcache.hits'
web_1        | u'DRINI(path=/account): put ol.total=79.718828'
web_1        | u'DRINI(path=/account): put ol.memcache_get=1.020908'
web_1        | u'DRINI(path=/account): put ol.infobase=13.346672'
web_1        | u'DRINI(path=/account): increment ol.requests.completed.GET.200.logged_in.account.class_account.10ms.count'
</pre></details>
<details><summary>/random</summary>
<pre>
web_1        | u'DRINI(path=/random): increment ol.requests.started.GET.200.logged_in.random.class_random_book.unknown.count'
web_1        | u'DRINI(path=/random): put pageload.all=2008.710909'
web_1        | u'DRINI(path=/random): increment ol.pageviews'
web_1        | u'DRINI(path=/random): increment ol.memcache.hits'
web_1        | u'DRINI(path=/random): put ol.total=20087.109089'
web_1        | u'DRINI(path=/random): put ol.memcache_get=13.538837'
web_1        | u'DRINI(path=/random): put ol.infobase=7.109165'
web_1        | u'DRINI(path=/random): increment ol.requests.completed.GET.303.logged_in.random.class_random_book.5000ms.count'
web_1        | u'DRINI(path=/): increment ol.requests.started.GET.200.logged_in.home.class_home.unknown.count'
web_1        | u'DRINI(path=/): put pageload.all=2.826500'
web_1        | u'DRINI(path=/): put pageload.home=2.826500'
web_1        | u'DRINI(path=/): increment ol.pageviews'
web_1        | u'DRINI(path=/): increment ol.memcache.hits'
web_1        | u'DRINI(path=/): put ol.total=28.264999'
web_1        | u'DRINI(path=/): put ol.memcache_get=4.353046'
web_1        | u'DRINI(path=/): put ol.infobase=6.971121'
web_1        | u'DRINI(path=/): increment ol.requests.completed.GET.200.logged_in.home.class_home.10ms.count'
</pre></details>
<details><summary>/fooo</summary>
<pre>
web_1        | u'DRINI(path=/fooo): increment ol.requests.started.GET.200.logged_in.fooo.class_edit.unknown.count'
web_1        | u'DRINI(path=/fooo): put pageload.all=28.718710'
web_1        | u'DRINI(path=/fooo): increment ol.pageviews'
web_1        | u'DRINI(path=/fooo): increment ol.memcache.hits'
web_1        | u'DRINI(path=/fooo): increment ol.memcache.misses'
web_1        | u'DRINI(path=/fooo): put ol.total=287.187099'
web_1        | u'DRINI(path=/fooo): put ol.memcache_get=1.785278'
web_1        | u'DRINI(path=/fooo): put ol.infobase=50.604582'
web_1        | u'DRINI(path=/fooo): put ol.memcache_get_multi=0.919104'
web_1        | u'DRINI(path=/fooo): increment ol.requests.completed.GET.200.logged_in.fooo.class_edit.100ms.count'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): increment ol.requests.started.GET.200.logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): put pageload.all=6.734109'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): increment ol.memcache.hits'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): put ol.total=67.341089'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): put ol.memcache_get=12.959003'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): put ol.infobase=9.891033'
web_1        | u'DRINI(path=/images/logo_OL-sm.png): increment ol.requests.completed.GET.303.logged_in.images.class_static.10ms.count'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): increment ol.requests.started.GET.200.logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): put pageload.all=13.963485'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): increment ol.memcache.hits'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): put ol.total=139.634848'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): put ol.memcache_get=2.352238'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): put ol.infobase=27.346849'
web_1        | u'DRINI(path=/images/logo_CC0-20px.png): increment ol.requests.completed.GET.303.logged_in.images.class_static.100ms.count'
web_1        | u'DRINI(path=/images/wmd-buttons.png): increment ol.requests.started.GET.200.logged_in.images.class_static.unknown.count'
web_1        | u'DRINI(path=/images/wmd-buttons.png): put pageload.all=12.631702'
web_1        | u'DRINI(path=/images/wmd-buttons.png): increment ol.pageviews'
web_1        | u'DRINI(path=/images/wmd-buttons.png): increment ol.memcache.hits'
web_1        | u'DRINI(path=/images/wmd-buttons.png): put ol.total=126.317024'
web_1        | u'DRINI(path=/images/wmd-buttons.png): put ol.memcache_get=25.449991'
web_1        | u'DRINI(path=/images/wmd-buttons.png): put ol.infobase=22.435904'
web_1        | u'DRINI(path=/images/wmd-buttons.png): increment ol.requests.completed.GET.303.logged_in.images.class_static.10ms.count'
</pre></details>
<details><summary>/fooo</summary>
<pre>
web_1        | u'DRINI(path=/fooo): increment ol.requests.started.POST.200.logged_in.fooo.class_edit.unknown.count'
web_1        | u'DRINI(path=/fooo): put pageload.all=13.478589'
web_1        | u'DRINI(path=/fooo): increment ol.pageviews'
web_1        | u'DRINI(path=/fooo): increment ol.memcache.hits'
web_1        | u'DRINI(path=/fooo): increment ol.memcache.misses'
web_1        | u'DRINI(path=/fooo): put ol.total=134.785891'
web_1        | u'DRINI(path=/fooo): put ol.memcache_get=1.687765'
web_1        | u'DRINI(path=/fooo): put ol.infobase=114.640713'
web_1        | u'DRINI(path=/fooo): put ol.memcache_set=0.241041'
web_1        | u'DRINI(path=/fooo): increment ol.requests.completed.POST.303.logged_in.fooo.class_edit.100ms.count'
web_1        | u'DRINI(path=/fooo): increment ol.requests.started.GET.200.logged_in.fooo.class_view.unknown.count'
web_1        | u'DRINI(path=/fooo): put pageload.all=37.638998'
web_1        | u'DRINI(path=/fooo): increment ol.pageviews'
web_1        | u'DRINI(path=/fooo): increment ol.memcache.hits'
web_1        | u'DRINI(path=/fooo): increment ol.memcache.misses'
web_1        | u'DRINI(path=/fooo): put ol.total=376.389980'
web_1        | u'DRINI(path=/fooo): put ol.memcache_get=4.984140'
web_1        | u'DRINI(path=/fooo): put ol.infobase=38.226128'
web_1        | u'DRINI(path=/fooo): put ol.memcache_get_multi=0.795126'
web_1        | u'DRINI(path=/fooo): put ol.memcache_set=0.434160'
web_1        | u'DRINI(path=/fooo): increment ol.requests.completed.GET.200.logged_in.fooo.class_view.100ms.count'
</pre></details>
<details><summary>/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d</summary>
<pre>
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): increment ol.requests.started.GET.200.logged_in.hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d.class_view.unknown.count'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): put pageload.all=109.710813'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): increment ol.pageviews'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): increment ol.memcache.hits'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): increment ol.memcache.misses'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): put ol.total=1097.108126'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): put ol.memcache_get=20.395756'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): put ol.infobase=207.885981'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): put ol.memcache_get_multi=2.264023'
web_1        | u'DRINI(path=/hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d): increment ol.requests.completed.GET.404.logged_in.hack_hacks_hacks_alot_\u03b1\u03b2\u03b3_d.class_view.1000ms.count'
</pre></details>

#### Errors Stats
<details><summary>purposeful template syntax error</summary>
<pre>
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.requests.started.GET.200.not_logged_in.books.class_book_edit.unknown.count'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.internal-errors'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol_internal-errors-segmented.books.book_edit.class_books_edit_html.SyntaxError.count'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put pageload.all=2676.972604'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put pageload.books=2676.972604'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.pageviews'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.memcache.hits'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.memcache.misses'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put ol.total=26769.726038'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put ol.memcache_get=6.733894'
web_1        | u'DRINI(path=/books/OL2058361M/edit): put ol.infobase=43.655157'
web_1        | u'DRINI(path=/books/OL2058361M/edit): increment ol.requests.completed.GET.500.not_logged_in.books.class_book_edit.5000ms.count'
</pre></details>

<details><summary>Make solr purposefully return `None`</summary>
<pre>
web_1        | u'DRINI(path=/search): increment ol.requests.started.GET.200.logged_in.search.class_search.unknown.count'
web_1        | u'DRINI(path=/search): increment ol_exceptions.search.class_search.worksearch_code_py.TypeError.count'
web_1        | u'DRINI(path=/search): put pageload.all=281.889391'
web_1        | u'DRINI(path=/search): increment ol.pageviews'
web_1        | u'DRINI(path=/search): increment ol.memcache.hits'
web_1        | u'DRINI(path=/search): put ol.total=2818.893909'
web_1        | u'DRINI(path=/search): put ol.memcache_get=12.547970'
web_1        | u'DRINI(path=/search): put ol.infobase=97.142935'
web_1        | u'DRINI(path=/search): put ol.solr=33.380032'
web_1        | u'DRINI(path=/search): increment ol.requests.completed.GET.200.logged_in.search.class_search.1000ms.count'
</pre>
</details>

### Evidence
No UI changes.

### Stakeholders
@mekarpeles 