### PR TITLE
Disable autocomplete requests for search inside

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -75,6 +75,9 @@ export default function init(){
 
     renderInstantSearchResults = function(q) {
         var facet_value = searchFacets[localStorage.getItem('facet')];
+        // Not implemented; also, this call is _expensive_ and should not be done!
+        if (facet_value === 'inside') return;
+
         var url, facet;
         if (q === '') {
             return;

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -74,11 +74,10 @@ export default function init(){
     }
 
     renderInstantSearchResults = function(q) {
-        var facet_value = searchFacets[localStorage.getItem('facet')];
+        const facet_value = searchFacets[localStorage.getItem('facet')];
         // Not implemented; also, this call is _expensive_ and should not be done!
         if (facet_value === 'inside') return;
 
-        var url, facet;
         if (q === '') {
             return;
         }
@@ -86,9 +85,8 @@ export default function init(){
             q = marshalBookSearchQuery(q);
         }
 
-        url = composeSearchUrl(q, true, 10);
-
-        facet = facet_value === 'all'? 'books' : facet_value;
+        const url = composeSearchUrl(q, true, 10);
+        const facet = facet_value === 'all'? 'books' : facet_value;
         $searchResults.css('opacity', 0.5);
         $.getJSON(url, function(data) {
             var d;


### PR DESCRIPTION
Closes #3285. Although /search/inside.json isn't defined, it hits the regular /search/inside endpoint! So each character typed while "Text" was selected would trigger a _very_ expensive call to IA's FTS.

### Technical
Nothing to note.

### Testing
- ✅ Typing in search box with "Title" selected shows autocomplete
- ✅ Typing in search box with "Text" selected makes no network requests

### Evidence
No ui changes.

### Stakeholders
@mekarpeles @gdamdam 