### PR TITLE
code now has correct availability for missing items

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -42,6 +42,10 @@ $if user_loan:
     <input type="submit" value="Return eBook" class="cta-btn cta-btn--available" id="return_ebook"/>
   </form>
 
+$elif editions_page and ocaid and not page.ia_metadata:
+  <div class="cta-button-group">
+    <a href="$work.key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+  </div>
 
 $elif ocaid and not page.is_access_restricted() and editions_page:
   $:macros.ReadButton(ocaid, listen=True)

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -54,7 +54,7 @@ $if isbn_10 and not asin:
           });
         </script>
 
-        $if page.get('ocaid') and not page.is_access_restricted():
+        $if page.get('ocaid') and not page.is_access_restricted() and page.ia_metadata:
             $:macros.DownloadOptions(page)
 
         $:macros.WorldcatLink(isbn=isbn_13, oclc_numbers=oclc_numbers, referer=page.url(relative=False))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
We're hitting a new case where Open Library pages have a non-existent ocaid

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Implementation not ideal (semantically), DownloadOptions moved into LoanStatus because it needs the availability information which is fetched there. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

This title should not appear as "readable" `OL26483859M`

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Tested on dev

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 