### PR TITLE
Add meta description and keywords on the landing page of OL

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -5,6 +5,8 @@ $def with (page)
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />
+    <meta name="description" content="Open Library is an open, editable library catalog, building towards a web page for every book ever published.">
+    <meta name = "keywords" content = "free books, books to read, free ebooks,audio books,read books for free, read books online, online library">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="OpenLibrary.org" />
     <meta name="creator" content="OpenLibrary.org" />


### PR DESCRIPTION
<!-- What issue does this PR close? -->
fixes #3234 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added the meta description and keywords for the home page
### Technical
<!-- What should be noted about the implementation? -->
The keywords I have used have relatively higher search volume and are relatively less competitive. 
![Screenshot_20200402_101139](https://user-images.githubusercontent.com/45262592/78213832-62a21e00-74d1-11ea-80df-12e9de3ddfa9.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->