### PR TITLE
fixed unresponsive [x] using css

### DIFF
--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -35,7 +35,7 @@ $jsdef render_author(name_path, dict_path, i, author):
     <div class="input">
         <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name"/>
         <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
-        <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
+        <a href="javascript:;" class="remove red plain" style="visibility: hidden;" title="$_('Remove this author')">[&times;]</a>&nbsp;
         <a href="javascript:;" class="add">$_("Add another author?")</a>
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
With JS disabled delete icons show but are not clickable #1920

### Technical
css inline rule `visibility: hidden;` for the unresponsive [x] <a> tag 

### Evidence
![Screenshot at 2020-04-02 22-46-29](https://user-images.githubusercontent.com/55073596/78278603-e987e280-7533-11ea-845c-f10e08ee0825.png)

### Stakeholders
@jdlrobson 