### PR TITLE
Add utils for normalizing classifications

### DIFF
--- a/openlibrary/utils/ddc.py
+++ b/openlibrary/utils/ddc.py
@@ -36,6 +36,10 @@ def collapse_multiple_space(s):
 
 
 def normalize_ddc(ddc):
+    """
+    :param str ddc:
+    :rtype: list of str
+    """
     ddc = collapse_multiple_space(ddc.strip()).replace('/', '').replace("'", '')
 
     results = []

--- a/openlibrary/utils/ddc.py
+++ b/openlibrary/utils/ddc.py
@@ -1,0 +1,100 @@
+"""
+Dewey Decimal Numbers
+
+Known issues
+
+## Further Reading
+https://www.oclc.org/bibformats/en/0xx/082.html
+"""
+import re
+
+MULTIPLE_SPACES_RE = re.compile(r'\s+')
+DDC_RE = re.compile(r'''
+    (
+        # Prefix
+        (?P<prestar>\*)?  # Should be suffix
+        (?P<neg>-)?  # Old standard; no longer used
+        (?P<j>j)?  # Juvenile prefix
+        C?  # Canadian CIP
+
+        # The number
+        (?P<number>\d{1,3}(\.\d+)?)
+
+        # Suffix
+        (?P<poststar>\*?)
+        (?P<s>\s?s)?  # Series suffix
+        (?P<B>\s?\[?B\]?)?  # Biographical
+        (?P<ninetwo>\s920?)?  # No clue; shouldn't be its own DDC though
+    )
+    |
+    (\[?(?P<fic>Fic|E)\.?\]?)
+''', re.IGNORECASE | re.X)
+
+
+def collapse_multiple_space(s):
+    return MULTIPLE_SPACES_RE.sub(' ', s)
+
+
+def normalize_ddc(ddc):
+    ddc = collapse_multiple_space(ddc.strip()).replace('/', '').replace("'", '')
+
+    results = []
+    for match in DDC_RE.finditer(ddc):
+        parts = match.groupdict()
+        prefix = ''
+        suffix = ''
+
+        # DDCs should start at word boundaries
+        start = match.start()
+        if start > 0 and re.search(r'\b', ddc[start - 1]):
+            continue
+        # And end at them
+        end = match.end()
+        if end < (len(ddc) - 1) and re.search(r'\b', ddc[end]):
+            continue
+
+        # Some old standard which isn't used anymore; might need to filter these
+        # out, but they should sort OK so let's keep them.
+        if parts['neg']:
+            prefix += '-'
+        # Juvenile prefix
+        if parts['j']:
+            prefix += 'j'
+
+        # Star should be at end
+        if parts['prestar'] or parts['poststar']:
+            suffix = '*'
+        # Series suffix
+        if parts['s']:
+            suffix += ' s'
+        # Biographical
+        if parts['B']:
+            suffix += ' B'
+        # Not at all sure
+        if parts['ninetwo']:
+            suffix += parts['ninetwo']
+
+        # And now the actual number!
+        if parts['number']:
+            # Numbers in parenthesis are "series" numbers
+            end = match.end('number')
+            if end < len(ddc) and ddc[end] == ')':
+                suffix += ' s'
+
+            # pad the integer part of the number
+            number_parts = parts['number'].split('.')
+            integer = number_parts[0]
+
+            # Copy decimal without losing precision
+            decimal = '.' + number_parts[1] if len(number_parts) > 1 else ''
+
+            number = '%03d%s' % (int(integer), decimal)
+        # Handle [Fic] or [E]
+        elif parts['fic']:
+            number = '[%s]' % parts['fic'].title()
+        else:
+            continue
+
+        results.append(prefix + number + suffix)
+
+    return results

--- a/openlibrary/utils/lcc.py
+++ b/openlibrary/utils/lcc.py
@@ -1,0 +1,143 @@
+"""
+Crash course Library of Congress Classification (LCC)
+
+Examples:
+ - HB1951 .R64 1995
+ - DP402.C8 O46 1995
+ - CS879 .R3 1995
+ - NC248.S22 A4 1992
+ - TJ563 .P66 1998
+ - PQ3919.2.M2866 C83 1994
+ - NA2500 .H64 1995
+ - DT423.E26 9th.ed. 2012
+ - PZ73.S758345255 2011
+ - PZ8.3.G276Lo 1971
+
+Has 3 parts:
+ 1. The class number: e.g. PQ3919.2 ; should match `[A-Z]{1,3}(\\d{1,4}(\\.\\d+)?)?`
+ 2. Cutter number(s): e.g. .M2866 C83
+ 3. Specification: Basically everything else, e.g. 2012, 9th.ed. 2012
+
+### 1. The Class Number
+The class number is what's used to determine the Library of Congress Subject. It has
+a pretty well-defined structure, and should match `[A-Z]{1,3}(\\d{1,4}(\\.\\d+)?)?`
+
+For example:
+ - QH -> Biology
+ - QH426-470 -> Genetics
+
+_Note_: According to [1] (page 36), the first cutter is sometimes considered a part of
+the class number. But this isn't discussed in [2], so it seems like it might not be
+entirely well-defined.
+
+### 2. Cutter Numbers
+Cutter numbers are a somewhat phonetic hashing of a piece of "extra" information like
+author last name, city, or whatever. Each character maps to a letter range, so for
+example:
+  - Idaho -> I33 -> I[d][a-d]
+  - Campbell -> C36 -> C[a][m-o]
+
+For the full mapping of character to letter ranges, see [1] Appendix B1 (page 355).
+
+Because the number part of a cutter number maps to letters, even the numeral is sorted
+lexicographically, so for example this is the correct sorting:
+    [I2, I23, I3], **not** [I2, I3, I23]
+
+In essence they are sort of sorted as if they were decimal numbers.
+
+### 3. Specification
+
+These aren't very well defined and could be just about anything. They usually include at
+least the publication year of the edition, but might include edition numbers.
+
+## Sorting
+
+To get _fully_ sortable LCCs, you likely need to use a multipart scheme (as described in
+[2]). That's not really feasible for our Solr instance (especially since we store info
+at the work level, which likely has multiple LCCs). The added complexity of that
+approach is also not immediately worth it right now (but might be in the future).
+
+As a compromise, we make the class number and the first cutter sortable by making the
+class number fixed-width. For example:
+ - PZ73.S758345255 2011 -> PZ-0073.00000000.S758345255 2011
+ - PZ8.3.G276Lo 1971    -> PZ-0008.30000000.G276Lo 1971
+
+This allows for range queries that could include the first cutter. It sorts incorrectly
+if:
+  - The decimal of the class number is longer than 8 digits (few such cases in OL db)
+  - The sort is determined by information that appears after the first cutter
+  - The first cutter is a "double cutter", e.g. B945.D4B65 199
+
+But it works for subject-related range queries, so we consider it sufficient.
+
+## Further Reading
+
+- Wagner, Scott etal. "A Comprehensive Approach to Algorithmic Machine Sorting of
+    Library of Congress Call Numbers" (2019) [1]
+- LCTS/CCS-PCC Task Force on  Library of Congress Classification Training. "Fundamentals
+    of Library of Congress Classification" (????) [2]
+- LCC subjects as PDFs https://www.loc.gov/catdir/cpso/lcco/
+- LCC subjects "walkable" tree http://id.loc.gov/authorities/classification.html
+
+## References
+
+[1]: https://www.terkko.helsinki.fi/files/9666/classify_trnee_manual.pdf
+[2]: https://ejournals.bc.edu/index.php/ital/article/download/11585/9839/
+"""
+import re
+
+LCC_PARTS_RE = re.compile(
+    r'^'
+    r'(?P<letters>[A-Z]{1,3}-*)'  # trailing dash only valid in sortable LCCs; not real
+    r'\s*?'
+    r'(?P<number>\d{1,4}(\.\d+)?)?'
+    r'\s*?'
+    r'\.?(?P<cutter1>[^\d\s]+\S+)?'
+    r'(?P<rest>.*)?'
+    r'$', re.IGNORECASE)
+
+
+def short_lcc_to_sortable_lcc(lcc):
+    """
+    See Sorting section of doc above
+    :param str lcc: unformatted lcc
+    :rtype: basestring|None
+    """
+    m = LCC_PARTS_RE.match(clean_raw_lcc(lcc))
+    if not m:
+        return None
+
+    parts = m.groupdict()
+    parts['letters'] = parts['letters'].upper().ljust(3, '-')
+    parts['number'] = float(parts['number'] or 0)
+    parts['cutter1'] = '.' + parts['cutter1'] if parts['cutter1'] else ''
+
+    return '%(letters)s%(number)013.8f%(cutter1)s%(rest)s' % parts
+
+
+def sortable_lcc_to_short_lcc(lcc):
+    """
+    As close to the inverse of make_sortable_lcc as possible
+    :param basestring lcc:
+    :rtype: basestring
+    """
+    m = LCC_PARTS_RE.match(lcc)
+    parts = m.groupdict()
+    parts['letters'] = parts['letters'].strip('-')
+    parts['number'] = parts['number'].strip('0').strip('.')  # Need to do in order!
+    parts['cutter1'] = '.' + parts['cutter1'] if parts['cutter1'] else ''
+
+    return '%(letters)s%(number)s%(cutter1)s%(rest)s' % parts
+
+
+def clean_raw_lcc(raw_lcc):
+    """
+    Remove noise in lcc before matching to LCC_PARTS_RE
+    :param basestring raw_lcc:
+    :rtype: basestring
+    """
+    lcc = raw_lcc.strip(' ').replace('\\', '')
+    if ((lcc.startswith('[') and lcc.endswith(']')) or
+            (lcc.startswith('(') and lcc.endswith(')'))):
+        lcc = lcc[1:-1]
+    return lcc

--- a/openlibrary/utils/lcc.py
+++ b/openlibrary/utils/lcc.py
@@ -92,7 +92,7 @@ LCC_PARTS_RE = re.compile(r'''
     ^
     # trailing dash only valid in "sortable" LCCs
     # Include W, even though technically part of NLM system
-    (?P<letters>[A-HJ-NP-VWZ]{1,3}-{0,2})
+    (?P<letters>[A-HJ-NP-VWZ][A-Z-]{0,2})
     \s?
     (?P<number>\d{1,4}(\.\d+)?)?
     (?P<cutter1>[\s.][^\d\s\[]{1,3}\d+\S*)?

--- a/openlibrary/utils/tests/test_ddc.py
+++ b/openlibrary/utils/tests/test_ddc.py
@@ -1,0 +1,53 @@
+import pytest
+
+from openlibrary.utils.ddc import normalize_ddc
+
+# Src: https://www.oclc.org/bibformats/en/0xx/082.html
+TESTS_FROM_OCLC = [
+    ("370.19'342", ['370.19342'], "Segmentation (prime) marks"),
+    ("370.19/342", ['370.19342'], "Segmentation (prime) marks"),
+    ("j574", ['j574'], "Juvenile works."),
+    ("[E]", ['[E]'], "Juvenile works with [E]"),
+    ("[Fic]", ['[Fic]'], "Juvenile works with [Fic]."),
+    ("658.404 92", ['658.404 92'], "Dewey numbers followed by 92 or 920."),
+    ("658.404 920", ['658.404 920'], "Dewey numbers followed by 92 or 920."),
+    ("942.082 [B]", ['942.082 B'], "Uppercase B in post-1971 numbers."),
+    ("*657.6", ['657.6*'],
+     "LC assigned Dewey numbers according to both the 14th and the 15th editions of "
+     "the Dewey schedules."),
+    ("*735.29 735.42", ['735.29*', '735.42'],
+     "LC assigned Dewey numbers according to both the 14th and the 15th editions of "
+     "the Dewey schedules."),
+    ("081s", ['081 s'], "Series numbers."),
+    ("081 s", ['081 s'], "Series numbers."),
+    ("(015.73)", ['015.73 s'],
+     "Parentheses indicating Dewey numbers assigned to a series."),
+    ("015.73 s", ['015.73 s'],
+     "Parentheses indicating Dewey numbers assigned to a series."),
+    ("(015.73) 015.791", ['015.73 s', '015.791'],
+     "Two Dewey numbers: one in parentheses, one not."),
+    ("-222.14", ['-222.14'], "Dewey numbers with minus signs."),
+    ("-222.14 (927.5)", ['-222.14', '927.5 s'], "Dewey numbers with minus signs."),
+    ("[320.9777]", ['320.9777'], "Dewey numbers in brackets."),
+    ("[016.3584] 012", ['016.3584', '012'], "Dewey numbers in brackets."),
+    ("081s [370.19'342]", ['081 s', '370.19342'],
+     "Dewey number followed by lowercase s and a second number in brackets."),
+    ("C364/.971", ['364.971'], "Canadian CIP"),
+]
+TESTS = [
+    ('123', ['123'], 'whole number'),
+    ('1', ['001'], 'whole number padding'),
+    ('hello world!', [], 'junk'),
+    ('978123412341', [], 'junk'),
+]
+
+
+@pytest.mark.parametrize("raw_ddc,expected,name", TESTS, ids=[t[2] for t in TESTS])
+def test_noramlize_ddc(raw_ddc, expected, name):
+    assert normalize_ddc(raw_ddc) == expected
+
+
+@pytest.mark.parametrize("raw_ddc,expected,name", TESTS_FROM_OCLC,
+                         ids=[t[2] for t in TESTS_FROM_OCLC])
+def test_normalize_ddc_with_oclc_spec(raw_ddc, expected, name):
+    assert normalize_ddc(raw_ddc) == expected

--- a/openlibrary/utils/tests/test_lcc.py
+++ b/openlibrary/utils/tests/test_lcc.py
@@ -4,22 +4,49 @@ from openlibrary.utils.lcc import short_lcc_to_sortable_lcc, sortable_lcc_to_sho
 
 
 TESTS = [
-    ('PZ-0073.00000000', 'pz73', 'lower case'),
-    ('PZ-0000.00000000', 'PZ', 'just class'),
-    ('PZ-0123.00000000 [P]', 'PZ123 [P]', 'keeps brackets at end'),
+    ('PZ-0073.00000000', 'pz73', 'PZ73', 'lower case'),
+    ('PZ-0000.00000000', 'PZ', 'PZ', 'just class'),
+    ('PZ-0123.00000000 [P]', 'PZ123 [P]', 'PZ123 [P]', 'keeps brackets at end'),
+    ('BP-0166.94000000.S277 1999', '\\BP\\166.94\\.S277\\1999', 'BP166.94.S277 1999',
+     'backslashes instead of spaces'),
+    ('LC-6252.00000000.T4 T4 vol. 33, no. 10', '[LC6252.T4 T4 vol. 33, no. 10]',
+     'LC6252.T4 T4 vol. 33, no. 10', 'brackets')
 ]
 
 
-@pytest.mark.parametrize("sortable_lcc,short_lcc,name", TESTS,
-                         ids=[t[2] for t in TESTS])
-def test_to_sortable(sortable_lcc, short_lcc, name):
-    assert short_lcc_to_sortable_lcc(short_lcc) == sortable_lcc
+@pytest.mark.parametrize("sortable_lcc,raw_lcc,short_lcc,name", TESTS,
+                         ids=[t[-1] for t in TESTS])
+def test_to_sortable(sortable_lcc, raw_lcc, short_lcc, name):
+    assert short_lcc_to_sortable_lcc(raw_lcc) == sortable_lcc
 
 
-@pytest.mark.parametrize("sortable_lcc,short_lcc,name", TESTS,
-                         ids=[t[2] for t in TESTS])
-def test_to_short_lcc(sortable_lcc, short_lcc, name):
-    assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc.strip(' ').upper()
+@pytest.mark.parametrize("sortable_lcc,raw_lcc,short_lcc,name", TESTS,
+                         ids=[t[-1] for t in TESTS])
+def test_to_short_lcc(sortable_lcc, raw_lcc, short_lcc, name):
+    assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc
+
+
+INVALID_TESTS = [
+    ('6113 .136', 'dewey decimal'),
+    ('9608 BOOK NOT YET IN LC', 'noise'),
+    ('#M8184', 'hash prefixed'),
+    ('', 'empty'),
+    ('MLCS 92/14990', 'too much class'),
+    ('PZ123.234.234', 'too much decimal'),
+    # The following are "real world" data from open library
+    ('IN PROCESS', 'noise'),
+    ('African Section Pamphlet Coll', 'real ol data'),
+    ('Microfilm 99/20', 'real ol data'),
+    ('Microfilm 61948 E', 'real ol data'),
+    ('Microfiche 92/80965 (G)', 'real ol data'),
+    ('MLCSN+', 'real ol data'),
+    ('UNCLASSIFIED 809 (S)', 'real ol data'),
+]
+
+
+@pytest.mark.parametrize("text,name", INVALID_TESTS, ids=[t[-1] for t in INVALID_TESTS])
+def test_invalid_lccs(text, name):
+    assert short_lcc_to_sortable_lcc(text) is None
 
 
 # Note: we don't handle all of these _entirely_ correctly as the paper says they should
@@ -40,12 +67,12 @@ WAGNER_2019_EXAMPLES = [
 
 
 @pytest.mark.parametrize("sortable_lcc,short_lcc,name", WAGNER_2019_EXAMPLES,
-                         ids=[t[2] for t in WAGNER_2019_EXAMPLES])
+                         ids=[t[-1] for t in WAGNER_2019_EXAMPLES])
 def test_wagner_2019_to_sortable(sortable_lcc, short_lcc, name):
     assert short_lcc_to_sortable_lcc(short_lcc) == sortable_lcc
 
 
 @pytest.mark.parametrize("sortable_lcc,short_lcc,name", WAGNER_2019_EXAMPLES,
-                         ids=[t[2] for t in WAGNER_2019_EXAMPLES])
+                         ids=[t[-1] for t in WAGNER_2019_EXAMPLES])
 def test_wagner_2019_to_short_lcc(sortable_lcc, short_lcc, name):
     assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc.strip()

--- a/openlibrary/utils/tests/test_lcc.py
+++ b/openlibrary/utils/tests/test_lcc.py
@@ -1,0 +1,51 @@
+import pytest
+
+from openlibrary.utils.lcc import short_lcc_to_sortable_lcc, sortable_lcc_to_short_lcc
+
+
+TESTS = [
+    ('PZ-0073.00000000', 'pz73', 'lower case'),
+    ('PZ-0000.00000000', 'PZ', 'just class'),
+    ('PZ-0123.00000000 [P]', 'PZ123 [P]', 'keeps brackets at end'),
+]
+
+
+@pytest.mark.parametrize("sortable_lcc,short_lcc,name", TESTS,
+                         ids=[t[2] for t in TESTS])
+def test_to_sortable(sortable_lcc, short_lcc, name):
+    assert short_lcc_to_sortable_lcc(short_lcc) == sortable_lcc
+
+
+@pytest.mark.parametrize("sortable_lcc,short_lcc,name", TESTS,
+                         ids=[t[2] for t in TESTS])
+def test_to_short_lcc(sortable_lcc, short_lcc, name):
+    assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc.strip(' ').upper()
+
+
+# Note: we don't handle all of these _entirely_ correctly as the paper says they should
+# be, but we handle enough (See lcc.py)
+# Src: https://ejournals.bc.edu/index.php/ital/article/download/11585/9839/
+WAGNER_2019_EXAMPLES = [
+    ('B--1190.00000000 1951', 'B1190 1951', 'no Cutter string'),
+    ('DT-0423.00000000.E26 9th.ed. 2012', 'DT423.E26 9th.ed. 2012', 'compound spec'),
+    ('E--0505.50000000 102nd.F57 1999', 'E505.5 102nd.F57 1999', 'ordinal in classif.'),
+    ('HB-3717.00000000 1929.E37 2015', 'HB3717 1929.E37 2015 ', 'date in classif.'),
+    ('KBD0000.00000000.G189s', 'KBD.G189s ', 'no caption number, no specification'),
+    ('N--8354.00000000.B67 2000x', 'N8354.B67 2000x', 'date with suffix '),
+    ('PS-0634.00000000.B4 1958-63', 'PS634.B4 1958-63', 'hyphenated range of dates'),
+    ('PS-3557.00000000.A28R4 1955', 'PS3557.A28R4 1955', '"double Cutter"'),
+    ('PZ-0008.30000000.G276Lo 1971', 'PZ8.3.G276Lo 1971 ', 'Cutter with "work mark"'),
+    ('PZ-0073.00000000.S758345255 2011', 'PZ73.S758345255 2011', 'long Cutter decimal'),
+]
+
+
+@pytest.mark.parametrize("sortable_lcc,short_lcc,name", WAGNER_2019_EXAMPLES,
+                         ids=[t[2] for t in WAGNER_2019_EXAMPLES])
+def test_wagner_2019_to_sortable(sortable_lcc, short_lcc, name):
+    assert short_lcc_to_sortable_lcc(short_lcc) == sortable_lcc
+
+
+@pytest.mark.parametrize("sortable_lcc,short_lcc,name", WAGNER_2019_EXAMPLES,
+                         ids=[t[2] for t in WAGNER_2019_EXAMPLES])
+def test_wagner_2019_to_short_lcc(sortable_lcc, short_lcc, name):
+    assert sortable_lcc_to_short_lcc(sortable_lcc) == short_lcc.strip()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Part 1 of #3290

Adds utils for normalizing LCCs and DDCs to standard format that allows for sorting (this is essential for being able to do queries like `lcc:[PR1 TO PR10]`.

### Technical
- This normalization is needed for sorting because solr does lexicographical sorting. Without normalization, `lcc:[PR1 TO PR10]` would _not_ match `PR2`, since lexicographically, `PR2` comes after `PR10` (similar to how in a dictionary, `B` comes after `Aa` and `Ab`). We resolve this by making LCCs fixed-length, so `PR10` → `PR-0010.00000000`. For fixed length strings, lexicographic sorting is equivalent to integer sorting. (Side note: Integers grow/sort right-to-left, whereas text/decimals grow/sort left-to-right. I wonder if this has something to do with the fact that we use Arabic numerals? 🤷‍♂ ).

### Testing
- ✅ imported 1000 books with LCCs and 1000 books with DDCs into local solr to test, logging (1) all lcc mapping and all ddc transformations, (2) any errors in the transformation code. https://docs.google.com/spreadsheets/d/1F21Io93Zudm-Jh4D-Pa8FVPdbBzVD-PUNOHZA5m9PFU/edit
  - Here's a nifty one-liner I used to import a bunch of books:
```sh
apt-get install pv
curl -s -L https://openlibrary.org/data/ol_dump_editions_latest.txt.gz | zcat | grep -e 'lc_classifications\|dewey_decimal_class' | cut -f2 | pv -L 40 | xargs -n 10 ./scripts/copydocs.py -r
```
- In progress: Spin up a  full solr-reindex over the weekend to include everything.

### Evidence
No UI changes

### Stakeholders
@seabelis @cclauss @finnless @tfmorris