### PR TITLE
Canonical books: redirect works w/ ocaid to edition

### DIFF
--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -73,41 +73,46 @@ def _get_object(site, key):
     find object with the same OLID. OL database makes sures that OLIDs are
     unique.
     """
+    i = web.input(edition=None)
+    if web.re_compile('/works/OL[0-9]+W').match(key) and i.edition:
+        raise web.seeother('/books/%s' % i.edition)
+
     obj = site.get(key)
 
-    if obj is None and key.startswith("/a/"):
-        key = "/authors/" + key[len("/a/"):]
-        obj = key and site.get(key)
+    if not obj:
+        if key.startswith("/a/"):
+            key = "/authors/" + key[len("/a/"):]
+            obj = key and site.get(key)
 
-    if obj is None and key.startswith("/b/"):
-        key = "/books/" + key[len("/b/"):]
-        obj = key and site.get(key)
+        if key.startswith("/b/"):
+            key = "/books/" + key[len("/b/"):]
+            obj = key and site.get(key)
 
-    if obj is None and key.startswith("/user/"):
-        key = "/people/" + key[len("/user/"):]
-        obj = key and site.get(key)
+        if key.startswith("/user/"):
+            key = "/people/" + key[len("/user/"):]
+            obj = key and site.get(key)
 
-    basename = key.split("/")[-1]
+        basename = key.split("/")[-1]
 
-    # redirect all /.*/ia:foo to /books/ia:foo
-    if obj is None and basename.startswith("ia:"):
-        key = "/books/" + basename
-        obj = site.get(key)
+        # redirect all /.*/ia:foo to /books/ia:foo
+        if basename.startswith("ia:"):
+            key = "/books/" + basename
+            obj = site.get(key)
 
-    # redirect all /.*/OL123W to /works/OL123W
-    if obj is None and basename.startswith("OL") and basename.endswith("W"):
-        key = "/works/" + basename
-        obj = site.get(key)
+        # redirect all /.*/OL123W to /works/OL123W
+        if basename.startswith("OL") and basename.endswith("W"):
+            key = "/works/" + basename
+            obj = site.get(key)
 
-    # redirect all /.*/OL123M to /books/OL123M
-    if obj is None and basename.startswith("OL") and basename.endswith("M"):
-        key = "/books/" + basename
-        obj = site.get(key)
+        # redirect all /.*/OL123M to /books/OL123M
+        if basename.startswith("OL") and basename.endswith("M"):
+            key = "/books/" + basename
+            obj = site.get(key)
 
-    # redirect all /.*/OL123A to /authors/OL123A
-    if obj is None and basename.startswith("OL") and basename.endswith("A"):
-        key = "/authors/" + basename
-        obj = site.get(key)
+        # redirect all /.*/OL123A to /authors/OL123A
+        if basename.startswith("OL") and basename.endswith("A"):
+            key = "/authors/" + basename
+            obj = site.get(key)
 
     # Disabled temporarily as the index is not ready the db
 

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,8 +1,13 @@
 $def with (doc, decorations=None, cta=True, availability=None, user=None, extra=None)
 
+$ availability = availability or doc.get('availability')
 $ is_work = doc.get('type', {}).get('key') == '/type/work'
-$ book_url = doc.url() if is_work else doc.key
+$ work_url = doc.url() if is_work else doc.key
+$ book_url = work_url
 $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
+$if availability and availability.get('openlibrary_edition') and not is_bot():
+  $ book_url += '?edition=%s' % availability.get('openlibrary_edition')
+
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book">
   <span class="bookcover">
     $if doc.get('cover_i') or cover_ids:
@@ -33,13 +38,16 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
           $for a in doc.authors:
             <a itemprop="author" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
       </span>
-      <span class="resultPublisher">
-        $if doc.edition_count:
-          $ungettext('1 edition', '%(count)d editions', doc.edition_count, count=doc.edition_count)
-          $if doc.first_publish_year:
-              $_('- first published in %(year)s', year=doc.first_publish_year)
+      $if doc.edition_count or doc.first_publish_year:
+        <span class="resultPublisher">
+            $if doc.edition_count:
+              <a href="$work_url">
+                $ungettext('1 edition', '%(count)d editions', doc.edition_count, count=doc.edition_count)</a>
+            $if doc.first_publish_year:
+              - $_('first published in %(year)s', year=doc.first_publish_year)
       </span>
 
+      $# Used for e.g. reading log class, "Want to Read" btn, etc
       $if extra:
         <div class="serp-extras">
           $:extra
@@ -62,8 +70,8 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
         </div>
       $if cta:
         <div class="searchResultItemCTA-lending">
-          $if availability or doc.get('availability'):
-            $:macros.AvailabilityButton(doc, doc.get('availability') or availability, user)
+          $if availability:
+            $:macros.AvailabilityButton(doc, availability, user)
         </div>
   </div>
 </li>


### PR DESCRIPTION
Related to #684.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

On search results, if a result has a borrow / read button (i.e. has an ocaid) then clicking the title brings the patron to the corresponding edition page.

Clicking on `X editions first published in YYYY` goes to the works page (so Librarians still have a way).

If no ocaid can be determined, it could be that our availability is screwed up. So maybe we want to continue to bring them to the work page for now? At least that's how it's designed in this PR.

The net victory of this PR is that people who are searching for a readable edition will get to it faster, and librarians will still have the ability to go to the works page by clicking the new # editions link from the same UI.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Do a search for something readable --> should go to correct edition
- Do a search for something borrowable --> should go to correct edition
- Do a search for something print disabled  --> should go to correct edition
- Do a search for something not in library --> should go to work
- The `# editions published in YYYY` should work for these links
- Worth also checking Reading Log and Lists which I believe use the same SearchResultsWork.html template

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

on dev. tested

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini  @seabelis @tfmorris 