### PR TITLE
Redirect to the correct stats page

### DIFF
--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -35,7 +35,7 @@ $if stats:
         </div>
 
         <div class="statschart">
-          <div class="chartShow" onClick="window.location.href='/borrow';" title="$_('We\'re a library, so we lend books, too')">
+          <div class="chartShow" onClick="window.location.href='/stats';" title="$_('We\'re a library, so we lend books, too')">
             <div id="ebooks-graph" style="width:150px;height:60px;"></div>
             <a href="/borrow" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
           </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3232

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Redirects to the correct stats page

### Results
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Before: It was getting redirected to an irrelevant page.
After: Now when "Ebooks Borrowed" is clicked, it redirects to the correct stats page. 

### Stakeholders
<!-- @ tag stakeholders of this bug -->