### PR TITLE
Sorts reading lists by most recently modified

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -47,7 +47,7 @@ $code:
         return d
 
     def get_user_lists():
-        lists = ctx.user and ctx.user.get_lists(sort=False) or []
+        lists = ctx.user and ctx.user.get_lists(sort=True) or []
         return [get_list_data(list, include_cover_url=True) for list in lists]
 
     def get_page_lists():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2943

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sorts the user reading lists by most recently modified in the add book dropdown.

### Testing
1. Create 2 reading lists (at least).
2. Go to a book page (e.g. [Book Example](https://openlibrary.org/books/OL22450756M/The_Principles_of_Exercise_Therapy)
3. Click the arrow next to `Want To Read` and instead add to one of the two Reading Lists.
4. Go to a different book page (e.g. [Book Example 2](https://openlibrary.org/books/OL1175816M/Never_mind)
5. Click the arrow again, and verify that the list you added a book to is on top.
6. Add the book to another reading list than you did in step 3.
7. Navigate to a different book (e.g. [Book](https://openlibrary.org/books/OL9298653M/Ergonomics)
8. Repeat step 5 and verify that the list you most recently added a book to is now on top.

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->