### PR TITLE
Add solr-updater graphite stats

### DIFF
--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -42,7 +42,7 @@ def parse_arguments():
     parser.add_argument('--ol-url', default="http://openlibrary.org/")
     parser.add_argument('--socket-timeout', type=int, default=10)
     parser.add_argument('--stats', default='unspecified',
-                        help="Log stats to graphite under ol.solr.solr-updater.THIS")
+                        help="Log stats to graphite under ol.solr-updater.THIS")
     parser.add_argument('--load-ia-scans', dest="load_ia_scans", action="store_true", default=False)
     parser.add_argument('--no-commit', dest="commit", action="store_false", default=True)
     return parser.parse_args()
@@ -279,8 +279,9 @@ def main():
     logger.info(str(args))
     logger.info("loading config from %s", args.config)
     load_config(args.config)
+    stats.client = stats.create_stats_client()  # This needs to happen after load_config
 
-    stats_prefix = 'ol.solr.solr-updater.' + args.stats.strip('.')
+    stats_prefix = 'ol.solr-updater.' + args.stats.strip('.')
     state_file = args.state_file
     offset = read_state_file(state_file)
 


### PR DESCRIPTION
Feature: Add solr-updater stats so we can have some idea if we're regressing in performance.

Added:
- .started
- .commits.started
- .commits.completed
- .commits.duration (ms)
- .commits.docs (count)
- .edit_delay (ms)

### Technical
There could be more, specifically around error handling, but this will answer a lot of the questions I have about performance (which I once monitored manually here: https://docs.google.com/spreadsheets/d/1UZv8DyDEi74GuV206hc-0hChZngisBiFEcNO-q54uHY/edit?usp=drive_web&ouid=108756185936196029585 ). Adding _proper_ error stats here would require a non-trivial refactor of this file.

### Testing
Added some spies to core / stats.py, and then listened to ensure things were getting logged. Here's some sample output:

```
solrupdater@575f205dbe4b:/openlibrary$ python scripts/new-solr-updater.py -c conf/openlibrary.yml --state-file solr-update.offset --ol-url http://web/ | grep 'ol.solr'
Couldn't find statsd_server section in config
2020-04-07 22:27:42,797 INFO BEGIN new-solr-updater
2020-04-07 22:27:42,800 INFO Namespace(commit=True, config='conf/openlibrary.yml', debugger=False, exclude_edits_containing=None, load_ia_scans=False, ol_url='http://web/', socket_timeout=10, state_file='solr-update.offset', stats='unspecified')
2020-04-07 22:27:42,800 INFO loading config from conf/openlibrary.yml
2020-04-07 22:27:43,014 INFO loading plugin openlibrary.olbase
0.0 (1): SELECT * FROM thing LIMIT 1
0.0 (1): SELECT * FROM thing WHERE key='/type/type'
0.0 (1): SELECT * FROM thing WHERE key='/type/type'
'DR2 incr ol.solr.solr-updater.unspecified.started by 1'
'DR2 incr ol.servers.575f205dbe4b.started by 1'
'DR2 put ol.solr.solr-updater.unspecified.delay at 160850.59'
0.01 (1): SELECT edition.key as edition_key, work.key as work_key FROM thing as edition, thing as work, edition_ref WHERE edition_ref.thing_id=edition.id   AND edition_ref.value=work.id   AND edition_ref.key_id=(select id from property where name='works' and type=(select id from thing where key='/type/edition'))   AND work.key in ('/works/OL53924W')
0.01 (1): SELECT thing.key, data.data from thing, data WHERE data.revision = thing.latest_revision and data.thing_id=thing.id  AND thing.key IN ('/books/OL22782947M', '/books/OL24197450M', '/books/OL7037695M', '/books/OL13569660M', '/books/OL24197475M')
0.0 (1): SELECT * FROM thing WHERE key='/type/redirect'
0.0 (1): SELECT data FROM data WHERE thing_id=17 AND revision=2
0.0 (1): SELECT * FROM thing WHERE key='/type/redirect'
0.0 (1): SELECT * FROM thing WHERE key='/type/redirect'
0.0 (1): SELECT * FROM property
0.0 (1): SELECT * FROM thing WHERE id IN (1, 41, 11, 12, 13, 14, 50, 46, 56, 57, 31)
0.0 (1): SELECT id FROM thing WHERE key='/type/redirect'
0.0 (1): SELECT * FROM property WHERE type=17 AND name='location'
'DR2 put ol.solr.solr-updater.unspecified.delay at 4787.937'
'DR2 put ol.solr.solr-updater.unspecified.delay at 613.994'
'DR2 incr ol.solr.solr-updater.unspecified.commits.started by 1'
'DR2 incr ol.solr.solr-updater.unspecified.commits.completed by 1'
'DR2 put ol.solr.solr-updater.unspecified.commits.duration at 99.818944931'
'DR2 incr ol.solr.solr-updater.unspecified.commits.docs by 5'
```

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->