### PR TITLE
fixes srcset attribute errors

### DIFF
--- a/openlibrary/templates/books/show.html
+++ b/openlibrary/templates/books/show.html
@@ -3,7 +3,7 @@ $def with (book)
 <span itemscope itemtype="https://schema.org/Book">
   <span class="bookcover">
     $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
-    $ urlB= book.get_cover_url("M") or "/images/icons/avatar_book-lg.png"
+    $ urlB = book.get_cover_url("M") or "/images/icons/avatar_book-lg.png"
     <a href="$book.key"><img itemprop="image" src="$url" srcset= "$urlB 2x" height="60"/></a>
   </span>
   <span class="details">

--- a/openlibrary/templates/books/show.html
+++ b/openlibrary/templates/books/show.html
@@ -3,7 +3,8 @@ $def with (book)
 <span itemscope itemtype="https://schema.org/Book">
   <span class="bookcover">
     $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
-    <a href="$book.key"><img itemprop="image" src="$url" height="60"/></a>
+    $ urlB= book.get_cover_url("M") or "/images/icons/avatar_book-lg.png"
+    <a href="$book.key"><img itemprop="image" src="$url" srcset= "$urlB 2x" height="60"/></a>
   </span>
   <span class="details">
     <span class="resultTitle">

--- a/openlibrary/templates/books/works-show.html
+++ b/openlibrary/templates/books/works-show.html
@@ -3,7 +3,8 @@ $def with (book)
 <span itemscope itemtype="https://schema.org/Book">
   <span class="bookcover">
     $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
-    <a href="$book.key"><img itemprop="image" src="$url" height="60"/></a>
+    $ urlB= book.get_cover_url("M") or "/images/icons/avatar_book-lg.png"
+    <a href="$book.key"><img itemprop="image" src="$url" srcset= "$urlB 2x" height="60"/></a>
   </span>
   <span class="resultTitle">
     <span class="details">

--- a/openlibrary/templates/books/works-show.html
+++ b/openlibrary/templates/books/works-show.html
@@ -3,7 +3,7 @@ $def with (book)
 <span itemscope itemtype="https://schema.org/Book">
   <span class="bookcover">
     $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
-    $ urlB= book.get_cover_url("M") or "/images/icons/avatar_book-lg.png"
+    $ urlB = book.get_cover_url("M") or "/images/icons/avatar_book-lg.png"
     <a href="$book.key"><img itemprop="image" src="$url" srcset= "$urlB 2x" height="60"/></a>
   </span>
   <span class="resultTitle">


### PR DESCRIPTION
Closes #2144

Fixes issue of Book covers appearing fuzzy on high-resolution displays

Technical
Added srcset attribute alongside src for templates/books/show.html &
templates/books/works-show.html

Testing
Tested on locally run docker container and chrome dev console using toggle device toolbar

Stakeholders
@jdlrobson