### PR TITLE
Add lcc: and ddc: to search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -175,6 +175,8 @@ def lcc_transform(raw):
             normed[0] or lcc_range[0],
             normed[1] or lcc_range[1])
     elif '*' in raw and not raw.startswith('*'):
+        # Marshals human repr into solr repr
+        # lcc:A720* should become A--0720*
         parts = raw.split('*', 1)
         lcc_prefix = normalize_lcc_prefix(parts[0])
         return (lcc_prefix or parts[0]) + '*' + parts[1]

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -195,9 +195,12 @@ def parse_query_fields(q):
             elif '*' in v and not v.startswith('*'):
                 parts = v.split('*', 1)
                 lcc_prefix = normalize_lcc_prefix(parts[0])
-                v = (lcc_prefix or parts[0]) + '*'.join(parts[1:])
+                v = (lcc_prefix or parts[0]) + '*' + parts[1]
             else:
-                v = short_lcc_to_sortable_lcc(v) or v
+                normed = short_lcc_to_sortable_lcc(v.strip('"'))
+                if normed:
+                    use_quotes = ' ' in normed or v.startswith('"')
+                    v = ('"%s"' if use_quotes else '%s*') % normed
         if field_name == 'ddc':
             m = re_range.match(v)
             if m:
@@ -209,7 +212,7 @@ def parse_query_fields(q):
             elif v.endswith('*'):
                 v = normalize_ddc_prefix(v[:-1]) + '*'
             else:
-                normed = normalize_ddc(v)
+                normed = normalize_ddc(v.strip('"'))
                 if normed:
                     v = normed[0]
 

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -83,7 +83,38 @@ QUERY_PARSER_TESTS = {
         {'field': 'author_name', 'value': 'Kim Harrison'},
         {'op': 'OR'},
         {'field': 'author_name', 'value': 'Lynsay Sands'},
-    ])
+    ]),
+
+    # LCCs
+    'LCC: quotes added if space present': ('lcc:NC760 .B2813 2004', [
+        {'field': 'lcc', 'value': '"NC-0760.00000000.B2813 2004"'},
+    ]),
+    'LCC: star added if no space': ('lcc:NC760 .B2813', [
+        {'field': 'lcc', 'value': 'NC-0760.00000000.B2813*'},
+    ]),
+    'LCC: Noise left as is': ('lcc:good evening', [
+        {'field': 'lcc', 'value': 'good evening'},
+    ]),
+    'LCC: range': ('lcc:[NC1 TO NC1000]', [
+        {'field': 'lcc', 'value': '[NC-0001.00000000 TO NC-1000.00000000]'},
+    ]),
+    'LCC: prefix': ('lcc:NC76.B2813*', [
+        {'field': 'lcc', 'value': 'NC-0076.00000000.B2813*'},
+    ]),
+    'LCC: suffix': ('lcc:*B2813', [
+        {'field': 'lcc', 'value': '*B2813'},
+    ]),
+    'LCC: multi-star without prefix': ('lcc:*B2813*', [
+        {'field': 'lcc', 'value': '*B2813*'},
+    ]),
+    'LCC: multi-star with prefix': ('lcc:NC76*B2813*', [
+        {'field': 'lcc', 'value': 'NC-0076*B2813*'},
+    ]),
+    'LCC: quotes preserved': ('lcc:"NC760 .B2813"', [
+        {'field': 'lcc', 'value': '"NC-0760.00000000.B2813"'},
+    ]),
+
+    # TODO Add tests for DDC
 }
 
 

--- a/openlibrary/utils/ddc.py
+++ b/openlibrary/utils/ddc.py
@@ -102,3 +102,51 @@ def normalize_ddc(ddc):
         results.append(prefix + number + suffix)
 
     return results
+
+
+def normalize_ddc_range(start, end):
+    """
+    Normalizes the pieces of a lucene (i.e. solr)-style range.
+    E.g. ('23.23', '*')
+    :param str start:
+    :param str end:
+
+    >>> normalize_ddc_range('23.23', '*')
+    ['023.23', '*']
+    """
+
+    ddc_range_norm = []
+    for ddc in start, end:
+        if ddc == '*':
+            ddc_range_norm.append('*')
+        else:
+            normed = normalize_ddc(ddc)
+            if normed:
+                ddc_range_norm.append(normed[0])
+            else:
+                ddc_range_norm.append(None)
+    return ddc_range_norm
+
+
+def normalize_ddc_prefix(prefix):
+    """
+    Normalizes a DDC prefix to be used in searching. Integer prefixes are not modified
+    :param str prefix:
+    :rtype: str
+
+    >>> normalize_ddc_prefix('1')
+    '1'
+    >>> normalize_ddc_prefix('1.1')
+    '001.1'
+    """
+    # 23.* should become 023*
+    # 23.45* should become 023.45*
+    if '.' in prefix:
+        normed = normalize_ddc(prefix)
+        if normed:
+            return normed[0]
+    # 0* should stay as is
+    # 23* should stay as is
+    # j* should stay as is
+    else:
+        return prefix

--- a/openlibrary/utils/lcc.py
+++ b/openlibrary/utils/lcc.py
@@ -160,7 +160,7 @@ def normalize_lcc_prefix(prefix):
     else:
         # A123* should be normalized to A--0123*
         # A123.* should be normalized to A--0123.*
-        # A123.C* should be normalized to A--0123.00000000C*
+        # A123.C* should be normalized to A--0123.00000000.C*
         lcc_norm = short_lcc_to_sortable_lcc(prefix.rstrip('.'))
         if lcc_norm:
             result = lcc_norm.rstrip('0')

--- a/openlibrary/utils/tests/test_ddc.py
+++ b/openlibrary/utils/tests/test_ddc.py
@@ -1,6 +1,10 @@
 import pytest
 
-from openlibrary.utils.ddc import normalize_ddc
+from openlibrary.utils.ddc import (
+    normalize_ddc,
+    normalize_ddc_prefix,
+    normalize_ddc_range,
+)
 
 # Src: https://www.oclc.org/bibformats/en/0xx/082.html
 TESTS_FROM_OCLC = [
@@ -51,3 +55,33 @@ def test_noramlize_ddc(raw_ddc, expected, name):
                          ids=[t[2] for t in TESTS_FROM_OCLC])
 def test_normalize_ddc_with_oclc_spec(raw_ddc, expected, name):
     assert normalize_ddc(raw_ddc) == expected
+
+
+PREFIX_TESTS = [
+    ('0', '0', 'Single number'),
+    ('j', 'j', 'Only juvenile'),
+    ('12', '12', 'Integer'),
+    ('12.3', '012.3', 'Decimal'),
+    ('12.300', '012.300', 'Trailing decimal zeros'),
+    ('100', '100', 'Trailing zeros'),
+    ('noise', 'noise', 'Noise')
+]
+
+
+@pytest.mark.parametrize("prefix,normed,name", PREFIX_TESTS,
+                         ids=[t[-1] for t in PREFIX_TESTS])
+def test_normalize_ddc_prefix(prefix, normed, name):
+    assert normalize_ddc_prefix(prefix) == normed
+
+
+RANGE_TESTS = [
+    (['0', '3'], ['000', '003'], 'Single numbers'),
+    (['100', '300'], ['100', '300'], 'Single numbers'),
+    (['100', '*'], ['100', '*'], 'Star'),
+]
+
+
+@pytest.mark.parametrize("raw,normed,name", RANGE_TESTS,
+                         ids=[t[-1] for t in RANGE_TESTS])
+def test_normalize_ddc_range(raw, normed, name):
+    assert normalize_ddc_range(*raw) == normed


### PR DESCRIPTION
Part 2 of #3290; Feature: adds lcc: and ddc: fields when performing a search. Depends on #3302 and #3335 

### Technical
- This will do nothing if the solr does not have lcc/ddc fields; so can be deployed
- Have to do normalization on prefix and range queries to be compatible with the way these are stored in solr (see #3302 for more details).

### Testing
Imported a bunch of records and tested searching (see #3302 for script).

### Evidence
![image](https://user-images.githubusercontent.com/6251786/78949699-59e5b500-7a9a-11ea-8319-28e17c0eafb5.png)

### Stakeholders
@cclauss @mekarpeles 