### PR TITLE
Index LCC/DDC into solr

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -51,6 +51,9 @@ plugin_worksearch:
         db: openlibrary_ebook_count
         host: localhost
 
+    # Temporary (2020-04-09) field to use until classifications are in production solr
+    has_classifications: false
+
 http_request_timeout: 10
 
 stats_solr: solr:8080

--- a/conf/solr/conf/schema.xml
+++ b/conf/solr/conf/schema.xml
@@ -472,6 +472,13 @@
     <field name="ia_count" type="int"/>
     <field name="oclc" type="text" multiValued="true"/>
     <field name="isbn" type="string" multiValued="true"/>
+
+    <!-- Classifications -->
+    <field name="lcc" type="string" multiValued="true" />
+    <field name="lcc_sort" type="string" stored="false" /> <!-- Need non-multiValued for sorting -->
+    <field name="ddc" type="string" multiValued="true" />
+    <field name="ddc_sort" type="string" stored="false" /> <!-- Need non-multiValued for sorting -->
+
     <field name="contributor" type="textgen" multiValued="true"/>
     <field name="publish_place" type="text" multiValued="true"/>
     <field name="publisher" type="text" multiValued="true"/>

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -21,7 +21,9 @@ from openlibrary.catalog.utils.query import set_query_host, base_url as get_ol_b
 from openlibrary.core import helpers as h
 from openlibrary.core import ia
 from openlibrary.solr.data_provider import get_data_provider, DataProvider
+from openlibrary.utils.ddc import normalize_ddc
 from openlibrary.utils.isbn import opposite_isbn
+from openlibrary.utils.lcc import short_lcc_to_sortable_lcc
 
 logger = logging.getLogger("openlibrary.solr")
 
@@ -509,6 +511,32 @@ class SolrProcessor:
                            if db_key in e
                            for v in e[db_key])
             add_list(solr_key, values)
+
+        # Need this to enable in pytest, which have config.runtime_config = {}
+        conf = config.runtime_config or {
+            'plugin_worksearch': {
+                'has_classifications': True
+            }}
+        if conf.get('plugin_worksearch', {}).get('has_classifications', False):
+            raw_lccs = set(lcc
+                           for ed in editions
+                           for lcc in ed.get('lc_classifications', []))
+            lccs = set(lcc for lcc in map(short_lcc_to_sortable_lcc, raw_lccs) if lcc)
+            if lccs:
+                add_list("lcc", lccs)
+                # Choose the... idk, longest for sorting?
+                add("lcc_sort", sorted(lccs, key=len, reverse=True)[0])
+
+            raw_ddcs = set(ddc
+                           for ed in editions
+                           for ddc in ed.get('dewey_decimal_class', []))
+            ddcs = set(ddc
+                       for raw_ddc in raw_ddcs
+                       for ddc in normalize_ddc(raw_ddc))
+            if ddcs:
+                add_list("ddc", ddcs)
+                # Choose longest, since has most precision?
+                add("ddc_sort", sorted(ddcs, key=len, reverse=True)[0])
 
         add_list("isbn", self.get_isbns(editions))
         add("last_modified_i", self.get_last_modified(w, editions))

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -356,6 +356,7 @@ class Test_build_data:
         assert d['author_facet'] == ['OL1A Author One', 'OL2A Author Two']
         assert d['author_alternative_name'] == ["Author 1"]
 
+    # {'Test name': (doc_lccs, solr_lccs, sort_lcc_index)}
     LCC_TESTS = {
         'Remove dupes': (['A', 'A'], ['A--0000.00000000'], 0),
         'Ignores garbage': (['$9.99'], None, None),


### PR DESCRIPTION
Part 3 of #3290 . Updates indexing code to include LCC/DDC

| ~Based on #3302 ; that must be merged first! This is the diff you seek: https://github.com/internetarchive/openlibrary/pull/3338/commits/64d3e3ef848699636ebf03bce70d94d9d90293bf~ |
| -- |

### Technical
- Adds 4 new fields to solr
- Since the new fields haven't been deployed yet, add them behind a config flag (we can't deploy those fields until we have solr-updater running with this new code, (unless we want to do 2 full reindexes (no thank you)).

### Testing
- I tested by adding print statements to the code in question, and confirming that: (1) when flag set to false, the code is not run, (2) when set to true, it is run.
- Tested by running a _full_ solr reindex, and analysing result here: here: https://docs.google.com/spreadsheets/d/1QuZyA6B9nq5mgOc5pmfDLVyLsgX86A_YP75VqYf5mVM
- Try it yourself sample facet query: http://server.openjournal.foundation:8984/solr/select/?q=type:work&version=2.2&start=0&indent=on&rows=0&facet=true&facet.query=lcc:A*&facet.query=lcc:B*&facet.query=lcc:C*&facet.query=lcc:D*&facet.query=lcc:E*&facet.query=lcc:F*&facet.query=lcc:G*&facet.query=lcc:H*&facet.query=lcc:J*&facet.query=lcc:K*&facet.query=lcc:L*&facet.query=lcc:M*&facet.query=lcc:N*&facet.query=lcc:P*&facet.query=lcc:Q*&facet.query=lcc:R*&facet.query=lcc:S*&facet.query=lcc:T*&facet.query=lcc:U*&facet.query=lcc:V*&facet.query=lcc:W*&facet.query=lcc:Z*

### Evidence
No ui changes.

### Stakeholders
@cclauss @mekarpeles @tfmorris 