### PR TITLE
Macro carousel powered by arbitrary openlibrary search query

### DIFF
--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -17,9 +17,9 @@ $if search:
     <input type="submit"/>
   </form>
 
-$ url = '/search?q=%s&has_fulltext=true' % query
+$ url = '/search?q=%s&has_fulltext=true' % urlquote(query)
 $ results = work_search({'has_fulltext': 'true', 'q': query}, sort=sort, limit=limit)
 $ books = [storage(b) for b in (results.get('docs', []))]
-$ load_more = {"url": "/search.json?q=%s&has_fulltext=true" % query, "limit": limit}
+$ load_more = {"url": "/search.json?q=%s&has_fulltext=true" % urlquote(query), "limit": limit}
 
 $:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more)

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,0 +1,25 @@
+$def with(query, title=None, sort='new', key='', limit=20, search=False)
+
+$# Takes following parameters
+$# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
+$# * title (str) -- A title to show above the carousel (links to /search?q=query)
+$# * sort (str) -- optional sort param defined within work_search.py `work_search`
+$# * key (str) -- unique name of the carousel in analytics
+$# * limit (int) -- initial number of books to pull
+$# * search (bool) -- whether to include search within collection
+
+$# Enable search within this query
+$if search:
+  <form action="/search" class="olform pagesearchbox">
+    <input type="hidden" name="q" value="$query"/>
+    <input type="hidden" name="has_fulltext" value="true"/>
+    <input type="text" placeholder="Search collection" name="q2"/>
+    <input type="submit"/>
+  </form>
+
+$ url = '/search?q=%s&has_fulltext=true' % query
+$ results = work_search({'has_fulltext': 'true', 'q': query}, sort=sort, limit=limit)
+$ books = [storage(b) for b in (results.get('docs', []))]
+$ load_more = {"url": "/search.json?q=%s&has_fulltext=true" % query, "limit": limit}
+
+$:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more)

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -842,6 +842,7 @@ def setup_template_globals():
         'sorted': sorted,
         'zip': zip,
         'tuple': tuple,
+        'urlquote': web.urlquote,
         'isbn_13_to_isbn_10': isbn_13_to_isbn_10,
         'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
         'NEWLINE': '\n',

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -87,17 +87,17 @@ const Carousel = {
                 type: 'id',
                 id: work.covers? work.covers[0] : work.cover_id || work.cover_i
             };
-            if (!cover.id && ocaid) {
-              cover.type = 'ia';
-              cover.id = ocaid;
-            }
-
             var cls = availabilityStatuses[availability].cls;
             var url = (cls == 'cta-btn--available') ?
                 (`/borrow/ia/${ocaid}`) : (cls == 'cta-btn--unavailable') ?
                     (`/books/${work.availability.openlibrary_edition}`) : work.key;
             var cta = availabilityStatuses[availability].cta;
             var isClickable = availability == 'error' ? 'disabled' : '';
+
+            if (!cover.id && ocaid) {
+                cover.type = 'ia';
+                cover.id = ocaid;
+            }
 
             return `${'<div class="book carousel__item slick-slide slick-active" ' +
                 '"aria-hidden="false" role="option">' +
@@ -161,14 +161,10 @@ const Carousel = {
                         url: url,
                         type: 'GET',
                         success: function(subject_results) {
-                            console.log(subject_results);
-                            console.log('here');
                             var works = subject_results.works;
-                            if(!works) {
-                              works = subject_results.docs;
+                            if (!works) {
+                                works = subject_results.docs;
                             }
-                            console.log('works');
-                            console.log(subject_results);
                             $.each(works, function(work_idx) {
                                 var work = works[work_idx];
                                 var lastSlidePos = $(`${selector}.slick-slider`)

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -82,8 +82,16 @@ const Carousel = {
 
         addWork = function(work) {
             var availability = work.availability.status;
-            var cover_id = work.covers? work.covers[0] : work.cover_id;
             var ocaid = work.availability.identifier;
+            var cover = {
+                type: 'id',
+                id: work.covers? work.covers[0] : work.cover_id || work.cover_i
+            };
+            if (!cover.id && ocaid) {
+              cover.type = 'ia';
+              cover.id = ocaid;
+            }
+
             var cls = availabilityStatuses[availability].cls;
             var url = (cls == 'cta-btn--available') ?
                 (`/borrow/ia/${ocaid}`) : (cls == 'cta-btn--unavailable') ?
@@ -97,7 +105,7 @@ const Carousel = {
                   '<a href="'}${work.key}" ${isClickable}>` +
                     `<img class="bookcover" width="130" height="200" title="${
                         work.title}" ` +
-                      `src="//covers.openlibrary.org/b/id/${cover_id}-M.jpg">` +
+                      `src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg">` +
                   '</a>' +
                 '</div>' +
                 '<div class="book-cta">' +
@@ -153,8 +161,16 @@ const Carousel = {
                         url: url,
                         type: 'GET',
                         success: function(subject_results) {
-                            $.each(subject_results.works, function(work_idx) {
-                                var work = subject_results.works[work_idx];
+                            console.log(subject_results);
+                            console.log('here');
+                            var works = subject_results.works;
+                            if(!works) {
+                              works = subject_results.docs;
+                            }
+                            console.log('works');
+                            console.log(subject_results);
+                            $.each(works, function(work_idx) {
+                                var work = works[work_idx];
                                 var lastSlidePos = $(`${selector}.slick-slider`)
                                     .slick('getSlick').$slides.length - 1;
                                 $(selector).slick('slickAdd', addWork(work), lastSlidePos);

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -85,7 +85,7 @@ const Carousel = {
             var ocaid = work.availability.identifier;
             var cover = {
                 type: 'id',
-                id: work.covers? work.covers[0] : work.cover_id || work.cover_i
+                id: work.covers ? work.covers[0] : work.cover_id || work.cover_i
             };
             var cls = availabilityStatuses[availability].cls;
             var url = (cls == 'cta-btn--available') ?

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -795,7 +795,7 @@ def work_search(query, sort=None, page=1, offset=0, limit=100):
         (reply, solr_select, q_list) = run_solr_query(query,
                                                       rows=limit,
                                                       page=page,
-                                                      sort=sort and sorts[sort] or None,
+                                                      sort=sorts.get(sort),
                                                       offset=offset,
                                                       fields="*")
         response = json.loads(reply)['response'] or ''

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -6,7 +6,7 @@ import re
 from lxml.etree import XML, XMLSyntaxError
 from infogami.utils import delegate, stats
 from infogami import config
-from infogami.utils.view import render, render_template, safeint
+from infogami.utils.view import render, render_template, safeint, public
 import simplejson as json
 from openlibrary.core.lending import get_availability_of_ocaids, add_availability
 from openlibrary.plugins.openlibrary.processors import urlsafe
@@ -495,6 +495,14 @@ class search(delegate.page):
             raise web.seeother(editions[0])
 
     def GET(self):
+        # Enable patrons to search for query q2 within collection q
+        # q2 param gets removed and prepended to q via a redirect
+        _i = web.input(q='', q2='')
+        if _i.q.strip() and _i.q2.strip():
+            _i.q = _i.q2.strip() + ' ' + _i.q.strip()
+            _i.pop('q2')
+            raise web.seeother('/search?' + urllib.parse.urlencode(_i))
+
         i = web.input(author_key=[], language=[], first_publish_year=[], publisher_facet=[], subject_facet=[], person_facet=[], place_facet=[], time_facet=[], public_scan_b=[])
 
         # Send to full-text Search Inside if checkbox checked
@@ -767,6 +775,40 @@ class author_search_json(author_search):
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response))
 
+
+@public
+def work_search(query, sort=None, page=1, offset=0, limit=100):
+    """
+    params:
+    query: dict
+    sort: str editions|old|new|scans
+    """
+    sorts = {
+        'editions': 'edition_count desc',
+        'old': 'first_publish_year asc',
+        'new': 'first_publish_year desc',
+        'scans': 'ia_count desc'
+    }
+    query['wt'] = 'json'
+
+    try:
+        (reply, solr_select, q_list) = run_solr_query(query,
+                                                      rows=limit,
+                                                      page=page,
+                                                      sort=sort and sorts[sort] or None,
+                                                      offset=offset,
+                                                      fields="*")
+        response = json.loads(reply)['response'] or ''
+    except (ValueError, IOError) as e:
+        logger.error("Error in processing search API.")
+        response = dict(start=0, numFound=0, docs=[], error=str(e))
+
+    # backward compatibility
+    response['num_found'] = response['numFound']
+    response['docs'] = add_availability(response['docs'])
+    return response
+
+
 class search_json(delegate.page):
     path = "/search"
     encoding = "json"
@@ -778,13 +820,7 @@ class search_json(delegate.page):
         else:
             query = i
 
-        sorts = dict(
-            editions='edition_count desc',
-            old='first_publish_year asc',
-            new='first_publish_year desc',
-            scans='ia_count desc')
-        sort_name = query.get('sort', None)
-        sort_value = sort_name and sorts[sort_name] or None
+        sort = query.get('sort', None)
 
         limit = safeint(query.pop("limit", "100"), default=100)
         if "offset" in query:
@@ -794,23 +830,8 @@ class search_json(delegate.page):
             offset = None
             page = safeint(query.pop("page", "1"), default=1)
 
-        query['wt'] = 'json'
+        response = work_search(query, sort=sort, page=page, offset=offset, limit=limit)
 
-        try:
-            (reply, solr_select, q_list) = run_solr_query(query,
-                                                rows=limit,
-                                                page=page,
-                                                sort=sort_value,
-                                                offset=offset,
-                                                fields="*")
-
-            response = json.loads(reply)['response'] or ''
-        except (ValueError, IOError) as e:
-            logger.error("Error in processing search API.")
-            response = dict(start=0, numFound=0, docs=[], error=str(e))
-
-        # backward compatibility
-        response['num_found'] = response['numFound']
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response, indent=True))
 

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -39,15 +39,15 @@ $def render_carousel_cover(book, lazy):
     $ cta = _('Sponsor')
     $ cta_cls = 'sponsor'
   $elif ocaid:
-    $ cta_cls = 'available'
     $if book.get('public_scan') or availability.get('status') == 'open':
+      $ cta_cls = 'available'
       $ cta_url = "//archive.org/stream/%s?ref=ol"%book.get('ia')
       $ cta = _('Read')
     $elif book.get('lending_edition') or availability.get('status') == 'borrow_available':
+      $ cta_cls = 'available'
       $ modifier = 'borrow-link'
       $ cta = _('Borrow')
-      $if book.get('lending_edition'):
-        $ cta_url = '/borrow/ia/%s' % ocaid
+      $ cta_url = '/borrow/ia/%s' % ocaid
 
   $if lazy:
     $ img_attr = 'data-lazy'

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -6,6 +6,8 @@ $if slick_font not in ctx.links:
   $ ctx.links.append(slick_font)
 
 $def render_carousel_cover(book, lazy):
+  $ availability = book.get('availability', {})
+  $ ocaid = book.get('ocaid') or availability.get('identifier') or book.get('ia')
   $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
@@ -13,10 +15,12 @@ $def render_carousel_cover(book, lazy):
 
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
-  $elif book.get('cover_id'):
-    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id'))
+  $elif book.get('cover_id') or book.get('cover_i'):
+    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
   $elif book.get('ia'):
     $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
+  $elif book.get('cover_edition_key'):
+    $ cover_url = '%s/b/book/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
   $else:
      $ cover_url = False
   $if book.get('authors'):
@@ -26,25 +30,24 @@ $def render_carousel_cover(book, lazy):
     $ byline = ''
     $ author_names = ''
   $ modifier = ''
-  $ cta = None
-  $ cta_cls = 'available'
+
+  $ cta = ('Not In Library')
+  $ cta_cls = 'missing'
+  $ cta_url = url
   $if book.get('eligibility', {}).get('is_eligible'):
     $ cta_url = book['eligibility']['sponsor_url']
     $ cta = _('Sponsor')
     $ cta_cls = 'sponsor'
-  $elif book.get('ocaid'):
-    $ modifier = 'borrow-link'
-    $ cta_url = '/borrow/ia/%s' % book.ocaid
-    $ cta = _('Borrow')
-  $elif book.get('ia') and book.get('public_scan'):
-    $ cta_url = "//archive.org/stream/%s?ref=ol"%book.get('ia')
-    $ cta = _('Read')
-  $elif book.get('lending_edition'):
-    $ cta_url = "/books/%s/x/borrow"%book.get('lending_edition')
-    $ cta = _('Borrow')
-  $else:
-    $ cta = _('Read')
-    $ cta_url = url
+  $elif ocaid:
+    $ cta_cls = 'available'
+    $if book.get('public_scan') or availability.get('status') == 'open':
+      $ cta_url = "//archive.org/stream/%s?ref=ol"%book.get('ia')
+      $ cta = _('Read')
+    $elif book.get('lending_edition') or availability.get('status') == 'borrow_available':
+      $ modifier = 'borrow-link'
+      $ cta = _('Borrow')
+      $if book.get('lending_edition'):
+        $ cta_url = '/borrow/ia/%s' % ocaid
 
   $if lazy:
     $ img_attr = 'data-lazy'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
     {
       "path": "static/build/carousel.*.js",
-      "maxSize": "12.1KB"
+      "maxSize": "12.2KB"
     },
     {
       "path": "static/build/all.js",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Relates to #602 and #3180 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Enables any OpenLibrary infogami page to include a `{{QueryCarousel(query="some search")}}`
macro to generate book carousels from arbitrary search queries

### Technical
<!-- What should be noted about the implementation? -->

The /search.json endpoint can now be used like the /subjects.json endpoint to `load_more` and lazy load infinite carousels.

It refactors the search.json endpoint so that we can turn any arbitrary OpenLibrary search query into a carousel.

Most of the code is existing, just moved out of a route, into a separate function which can be called from a template.

### Testing & Evidence
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See the carousel on:
https://dev.openlibrary.org/Marley-Dias-1000BlackGirlBooks-Library

- [x] try searching inside this collection, like "emma"
- [x] verify the books are the same as the search query (which is subject:"1000blackgirlbooks")
- [x] ensure the borrow links work

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @seabelis