### PR TITLE
refactored import so /ia/xxx will now import from ia

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -140,7 +140,7 @@ def raise_non_book_marc(marc_record, **kwargs):
     # Is the item a serial instead of a book?
     marc_leaders = marc_record.leader()
     if marc_leaders[7] == 's':
-        raise BookImportError(('item-is-serial', detail, kwargs))
+        raise BookImportError(('item-is-serial', details, kwargs))
 
     # insider note: follows Archive.org's approach of
     # Item::isMARCXMLforMonograph() which excludes non-books

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -198,7 +198,7 @@ class ia_importapi(importapi):
                 raise BookImportError(('invalid-marc-record',))
         else:
             try:
-                edition_data = get_ia_record(metadata)
+                edition_data = self.get_ia_record(metadata)
             except KeyError:
                 raise BookImportError(('invalid-ia-metadata',))
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -198,7 +198,7 @@ class ia_importapi(importapi):
                 raise BookImportError(('invalid-marc-record',))
         else:
             try:
-                edition_data = self.get_ia_record(metadata)
+                edition_data = cls.get_ia_record(metadata)
             except KeyError:
                 raise BookImportError(('invalid-ia-metadata',))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -418,7 +418,7 @@ class bookpage(delegate.page):
 
         if result:
             return web.found(result[0] + ext)
-        elif key =='ocaid':
+        elif key == 'ocaid':
             # Try a range of ocaid alternatives:
             ocaid_alternatives = [
                     {'type': '/type/edition', 'source_records': 'ia:' + value},
@@ -427,6 +427,12 @@ class bookpage(delegate.page):
                 result = web.ctx.site.things(q)
                 if result:
                     return web.found(result[0] + ext)
+
+            # Perform import, if possible
+            from openlibrary.plugins.importapi.code import ia_importapi
+            book = ia_importapi.ia_import(value, require_marc=True)
+            print(book)
+
             # If nothing matched, try this as a last resort:
             return web.found('/books/ia:' + value + ext)
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -432,7 +432,8 @@ class bookpage(delegate.page):
             from openlibrary.plugins.importapi.code import ia_importapi
             from openlibrary import accounts
             with accounts.RunAs('ImportBot'):
-                book = ia_importapi.ia_import(value, require_marc=True)
+                # May want to catch importapi.code.BookImportError
+                ia_importapi.ia_import(value, require_marc=True)
 
             # If nothing matched, try this as a last resort:
             return web.found('/books/ia:' + value + ext)

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -430,8 +430,9 @@ class bookpage(delegate.page):
 
             # Perform import, if possible
             from openlibrary.plugins.importapi.code import ia_importapi
-            book = ia_importapi.ia_import(value, require_marc=True)
-            print(book)
+            from openlibrary import accounts
+            with accounts.RunAs('ImportBot'):
+                book = ia_importapi.ia_import(value, require_marc=True)
 
             # If nothing matched, try this as a last resort:
             return web.found('/books/ia:' + value + ext)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Refactors importapi/code.py to move IA import logic outside of the route and into a class which can be called independently.

Hooks up /ia/xxx url endpoint so a book may be imported in the same way as /isbn/xxx.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

First, 4 pieces of context
1. :openlibrary: has a special importapi plugin endpoint which our ImportBot uses to import books from Internet Archive every day
2. We have a very annoying artifact @bfalling, @JeffKaplan, and @alexisrossi are all too familiar with, where if you go to openlibrary.org/ia/xxx you get to a strange "fake" IA book page.
3. When a user types in /isbn/xxx, we attempt to use Amazon to fetch data + add to out catalog
4. We have about 50,000 books inlibrary which are not in Open Library (for a variety of reasons @hornc has enumerated here: https://github.com/internetarchive/openlibrary/wiki/archive.org-%E2%86%94-Open-Library-synchronisation)

This PR fixes point 2 by making it work like 3 to accomplish 4.

### Technical
<!-- What should be noted about the implementation? -->

May require changes to test cases.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Try picking any book from this list and adding its archive.org ID to the end of https://dev.openlibrary.org/ia/
https://archive.org/search.php?query=publisher%3ATicktock%20AND%20%21openlibrary_work%3A%2A

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@hornc 