### PR TITLE
WIP: Re-fix test_merge_authors.py

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -344,7 +344,13 @@ class TestAuthorMergeEngine:
 def test_dicthash():
     assert dicthash({}) == dicthash({})
     assert dicthash({"a": 1}) == dicthash({"a": 1})
-    assert dicthash({"a": 1, "b": 2}) == dicthash({"b": 2, "a": 1})
+    a_b = {"a": 1, "b": 2}
+    b_a = {"b": 2, "a": 1}
+    if a_b == b_a:  # Python 2 same items in the same order
+        assert dicthash(a_b) == dicthash(b_a)
+    else:  # Python 3 same items but not necessarily the same order
+        assert len(dicthash(a_b)) == len(dicthash(b_a))
+        assert all(item in dicthash(a_b) for item in dicthash(b_a))
     assert dicthash({}) != dicthash({"a": 1})
     assert dicthash({"b": 1}) != dicthash({"a": 1})
 

--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -346,9 +346,10 @@ def test_dicthash():
     assert dicthash({"a": 1}) == dicthash({"a": 1})
     a_b = {"a": 1, "b": 2}
     b_a = {"b": 2, "a": 1}
-    if a_b == b_a:  # Python 2 dicts have same items in the same order
+    # a_b and b_a will have the same dicthash() in Python 2 but NOT in Python 3
+    if list(a_b.items()) == list(b_a.items()):  # Py2 dicts w/ same items in same order
         assert dicthash(a_b) == dicthash(b_a)
-    else:  # Python 3 same items but not necessarily the same order
+    else:  # Py3 dicts have the same items but not necessarily in the same order
         assert len(dicthash(a_b)) == len(dicthash(b_a))
         assert all(item in dicthash(a_b) for item in dicthash(b_a))
     assert dicthash({}) != dicthash({"a": 1})

--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -346,7 +346,7 @@ def test_dicthash():
     assert dicthash({"a": 1}) == dicthash({"a": 1})
     a_b = {"a": 1, "b": 2}
     b_a = {"b": 2, "a": 1}
-    if a_b == b_a:  # Python 2 same items in the same order
+    if a_b == b_a:  # Python 2 dicts have same items in the same order
         assert dicthash(a_b) == dicthash(b_a)
     else:  # Python 3 same items but not necessarily the same order
         assert len(dicthash(a_b)) == len(dicthash(b_a))

--- a/openlibrary/plugins/upstream/tests/test_merge_authors.py
+++ b/openlibrary/plugins/upstream/tests/test_merge_authors.py
@@ -346,10 +346,10 @@ def test_dicthash():
     assert dicthash({"a": 1}) == dicthash({"a": 1})
     a_b = {"a": 1, "b": 2}
     b_a = {"b": 2, "a": 1}
-    # a_b and b_a will have the same dicthash() in Python 2 but NOT in Python 3
-    if list(a_b.items()) == list(b_a.items()):  # Py2 dicts w/ same items in same order
+    # NOTE: In Python 2, a_b and b_a will have the same dicthash() but NOT in Python 3
+    if list(a_b) == list(b_a):  # Python 2 dicts keys are in the same order
         assert dicthash(a_b) == dicthash(b_a)
-    else:  # Py3 dicts have the same items but not necessarily in the same order
+    else:  # Python 3 dict keys are kept in insertion order
         assert len(dicthash(a_b)) == len(dicthash(b_a))
         assert all(item in dicthash(a_b) for item in dicthash(b_a))
     assert dicthash({}) != dicthash({"a": 1})

--- a/scripts/test-py3.sh
+++ b/scripts/test-py3.sh
@@ -7,7 +7,7 @@ pytest openlibrary/catalog openlibrary/coverstore openlibrary/mocks openlibrary/
        --ignore=openlibrary/catalog/marc/tests/test_parse.py \
        --ignore=openlibrary/tests/catalog/test_get_ia.py \
        --ignore=openlibrary/coverstore/tests/test_doctests.py \
-       --ignore=openlibrary/plugins/openlibrary/tests/test_home.py \
+       --ignore=openlibrary/plugins/openlibrary/tests/test_home.py
 RETURN_CODE=$?
        
 pytest openlibrary/catalog/marc/tests/test_get_subjects.py || true

--- a/scripts/test-py3.sh
+++ b/scripts/test-py3.sh
@@ -8,7 +8,6 @@ pytest openlibrary/catalog openlibrary/coverstore openlibrary/mocks openlibrary/
        --ignore=openlibrary/tests/catalog/test_get_ia.py \
        --ignore=openlibrary/coverstore/tests/test_doctests.py \
        --ignore=openlibrary/plugins/openlibrary/tests/test_home.py \
-       --ignore=openlibrary/plugins/upstream/tests/test_merge_authors.py
 RETURN_CODE=$?
        
 pytest openlibrary/catalog/marc/tests/test_get_subjects.py || true
@@ -17,6 +16,5 @@ pytest openlibrary/catalog/marc/tests/test_parse.py || true
 pytest openlibrary/tests/catalog/test_get_ia.py || true
 pytest openlibrary/coverstore/tests/test_doctests.py || true
 pytest openlibrary/plugins/openlibrary/tests/test_home.py || true
-pytest openlibrary/plugins/upstream/tests/test_merge_authors.py || true
 
 exit ${RETURN_CODE}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
__DO NOT MERGE__: I believe that #3348 is a better solution.

Fixes the test_merge_authors.py pytest so it passes on both Python 2 and Python 3.  Dicts in Python 3 are order preserving so the items of the `dicthash()` will not be in the same order but it must contain exactly the same elements.

@cdrini Is it OK that the `dicthash()` might not be the same??  If the dicthash must be the same then I would recommend #3348

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->