### PR TITLE
Deterministic dicthash() regardless of key order

### DIFF
--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -44,10 +44,11 @@ def uniq(values, key=None):
     return result
 
 def dicthash(d):
-    """Dictionaries are not hashable. This function converts dictionary into nested tuples, so that it can hashed.
+    """Dictionaries are not hashable. This function converts dictionary into nested
+    tuples, so that it can hashed.
     """
     if isinstance(d, dict):
-        return tuple((k, dicthash(v)) for k, v in d.items())
+        return tuple((k, dicthash(d[k])) for k in sorted(d))
     elif isinstance(d, list):
         return tuple(dicthash(v) for v in d)
     else:

--- a/scripts/test-py3.sh
+++ b/scripts/test-py3.sh
@@ -7,8 +7,7 @@ pytest openlibrary/catalog openlibrary/coverstore openlibrary/mocks openlibrary/
        --ignore=openlibrary/catalog/marc/tests/test_parse.py \
        --ignore=openlibrary/tests/catalog/test_get_ia.py \
        --ignore=openlibrary/coverstore/tests/test_doctests.py \
-       --ignore=openlibrary/plugins/openlibrary/tests/test_home.py \
-       --ignore=openlibrary/plugins/upstream/tests/test_merge_authors.py
+       --ignore=openlibrary/plugins/openlibrary/tests/test_home.py
 RETURN_CODE=$?
        
 pytest openlibrary/catalog/marc/tests/test_get_subjects.py || true
@@ -17,6 +16,5 @@ pytest openlibrary/catalog/marc/tests/test_parse.py || true
 pytest openlibrary/tests/catalog/test_get_ia.py || true
 pytest openlibrary/coverstore/tests/test_doctests.py || true
 pytest openlibrary/plugins/openlibrary/tests/test_home.py || true
-pytest openlibrary/plugins/upstream/tests/test_merge_authors.py || true
 
 exit ${RETURN_CODE}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3347  This is a better solution as it fixes the problem, not the test.  This approach generates the same dicthash for both `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` on both Python 2 and Python 3.  It sorts the keys to circumvent Python 3's order preserving dicts.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->