### PR TITLE
re-patching homepage carousels missing info for availability check

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -77,7 +77,7 @@ const Carousel = {
             open: {cls: 'cta-btn--available', cta: 'Read'},
             borrow_available: {cls: 'cta-btn--available', cta: 'Borrow'},
             borrow_unavailable: {cls: 'cta-btn--unavailable', cta: 'Join Waitlist'},
-            error: {cls: 'cta-btn--missing', cta: 'No eBook'}
+            error: {cls: 'cta-btn--missing', cta: 'Not In Library'}
         };
 
         addWork = function(work) {

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -7,7 +7,7 @@ $if slick_font not in ctx.links:
 
 $def render_carousel_cover(book, lazy):
   $ availability = book.get('availability', {})
-  $ ocaid = book.get('ocaid') or availability.get('identifier') or book.get('ia')
+  $ ocaid = book.get('ocaid') or availability.get('identifier')
   $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
@@ -38,16 +38,18 @@ $def render_carousel_cover(book, lazy):
     $ cta_url = book['eligibility']['sponsor_url']
     $ cta = _('Sponsor')
     $ cta_cls = 'sponsor'
-  $elif ocaid:
-    $if book.get('public_scan') or availability.get('status') == 'open':
-      $ cta_cls = 'available'
-      $ cta_url = "//archive.org/stream/%s?ref=ol"%book.get('ia')
-      $ cta = _('Read')
-    $elif book.get('lending_edition') or availability.get('status') == 'borrow_available':
-      $ cta_cls = 'available'
+  $if book.get('ia') or book.get('ocaid'):
+    $ cta_cls = 'available'
+    $if book.get('ocaid') or availability.get('status') == 'borrow_available' or book.get('lending_edition'):
       $ modifier = 'borrow-link'
       $ cta = _('Borrow')
-      $ cta_url = '/borrow/ia/%s' % ocaid
+      $if ocaid:
+        $ cta_url = '/borrow/ia/%s' % book.get('ocaid')
+      $else:
+        $ cta_url = "/books/%s/x/borrow" % book.get('lending_edition')
+    $else:
+      $ cta_url = "//archive.org/stream/%s?ref=ol" % book.get('ia')[0]
+      $ cta = _('Read')
 
   $if lazy:
     $ img_attr = 'data-lazy'

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -39,6 +39,7 @@ $def render_carousel_cover(book, lazy):
     $ cta = _('Sponsor')
     $ cta_cls = 'sponsor'
   $if book.get('ia') or book.get('ocaid'):
+    $# See PR #3349 -- Hacky availability heuristic until #3180 lands  
     $ cta_cls = 'available'
     $if book.get('ocaid') or availability.get('status') == 'borrow_available' or book.get('lending_edition'):
       $ modifier = 'borrow-link'


### PR DESCRIPTION
It turns out the IA carousels (pre #3180) don't have enough information to definitively tell availability (so we use a heuristic to check). When we merged #3339, code was introduced to fix availability for these new query carousels, however this regressed the homepage hack.

This heuristic (re-introduced in this branch) is necessary (until #3180 lands) so `related` and `homepage` carousels approximately show correct availability.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Hotfix merging as this followup needs to make it in prior to Tues deploy. 

### Testing & Evidence
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Tested both old-style and new style carousels on editions page, homepage (without cache) and on https://dev.openlibrary.org/Marley-Dias-1000BlackGirlBooks-Library (new-style) carousels.

### Stakeholders
<!-- @ tag stakeholders of this bug -->