### PR TITLE
fixes low quality CoverImage render

### DIFF
--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -15,7 +15,7 @@ $if size == "M":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
-                    class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" class="cover" alt="Cover of: $title | $author_names"/></a>
+                    class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" srcset="cover_lg 2x" class="cover" alt="Cover of: $title | $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">
@@ -26,7 +26,7 @@ $if size == "M":
             </div>
     </div>
 $else:
-    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" title="$title" alt="We need a book cover for: $title"/>
+    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" srcset="cover_lg 2x" height="58" title="$title" alt="We need a book cover for: $title"/>
 
 <div class="hidden">
     <div class="coverFloat" id="seeImage">
@@ -34,6 +34,6 @@ $else:
             <h2>$:macros.TruncateString(title, 70)</h2>
             <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <a class="dialog--close"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
+        <a class="dialog--close"><img src="$cover_lg" srcset="cover_lg 2x" class="cover" alt="$title $_('by') $author_names"/></a>
     </div>
 </div>

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -15,7 +15,7 @@ $if size == "M":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
-                    class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" srcset="cover_lg 2x" class="cover" alt="Cover of: $title | $author_names"/></a>
+                    class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" srcset="$cover_lg 2x" class="cover" alt="Cover of: $title | $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">
@@ -26,7 +26,7 @@ $if size == "M":
             </div>
     </div>
 $else:
-    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" srcset="cover_lg 2x" height="58" title="$title" alt="We need a book cover for: $title"/>
+    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" srcset="$cover_lg 2x" height="58" title="$title" alt="We need a book cover for: $title"/>
 
 <div class="hidden">
     <div class="coverFloat" id="seeImage">
@@ -34,6 +34,6 @@ $else:
             <h2>$:macros.TruncateString(title, 70)</h2>
             <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
         </div>
-        <a class="dialog--close"><img src="$cover_lg" srcset="cover_lg 2x" class="cover" alt="$title $_('by') $author_names"/></a>
+        <a class="dialog--close"><img src="$cover_lg" class="cover" alt="$title $_('by') $author_names"/></a>
     </div>
 </div>


### PR DESCRIPTION
Closes #2144

Fixes issue of Book covers appearing fuzzy on high-resolution displays

Technical
Added srcset attribute alongside src for templates/books/show.html &
templates/books/works-show.html

Testing
Tested on locally run docker container and chrome dev console using toggle device toolbar

Stakeholders
@jdlrobson @cdrini 