### PR TITLE
3359/hotfix/carousel fixes

### DIFF
--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='new', key='', limit=20, search=False)
+$def with(query, title=None, sort='', key='', limit=20, search=False)
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='', key='', limit=20, search=False)
+$def with(query, title=None, sort='new', key='', limit=20, search=False)
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -45,9 +45,9 @@ $def render_carousel_cover(book, lazy):
       $ modifier = 'borrow-link'
       $ cta = _('Borrow')
       $if ocaid:
-        $ cta_url = '/borrow/ia/%s' % book.get('ocaid')
+        $ cta_url = '/borrow/ia/%s?ref=ol' % ocaid
       $else:
-        $ cta_url = "/books/%s/x/borrow" % book.get('lending_edition')
+        $ cta_url = "/books/%s/x/borrow?ref=ol" % book.get('lending_edition')
     $else:
       $ cta_url = "//archive.org/stream/%s?ref=ol" % book.get('ia')[0]
       $ cta = _('Read')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3359 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
There was a case where we were using `book.get('ocaid')` instead of the already aggregated `ocaid` value. For any book which **did** have an `ocaid`, this would have appeared to work.

### Technical
<!-- What should be noted about the implementation? -->

### Testing & Evidence
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

test dev.openlibrary.org/k-12 -- hover over borrow btn, check read + borrow buttons on homepage.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 