### PR TITLE
Log URL generation failures in lending.py

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -220,12 +220,10 @@ def get_available(limit=None, page=1, subject=None, query=None,
     )
     if not url:
         fmt = (
-            "get_available(limit={}, page={}, subject={}, "
-            "query={}, work_id={}, _type={}, sorts={}, url={}"
+            "get_available(limit={}, page={}, subject={}, query={}, "
+            "work_id={}, _type={}, sorts={}"
         )
-        logger.error(
-            fmt.format(limit, page, subject, query, work_id, _type, sorts, url)
-        )
+        logger.error(fmt.format(limit, page, subject, query, work_id, _type, sorts))
     try:
         request = urllib.request.Request(url=url)
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -122,7 +122,7 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
     archive.org to see more books)
     """
     from openlibrary.plugins.openlibrary.home import CAROUSELS_PRESETS
-    query = CAROUSELS_PRESETS[query] if query in CAROUSELS_PRESETS else query
+    query = CAROUSELS_PRESETS.get(query, query)
     q = 'openlibrary_work:(*)'
 
     # If we don't provide an openlibrary_subject and no collection is
@@ -157,11 +157,11 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
                         authors.append(author_name)
                         authors.append(','.join(author_name.split(' ', 1)[::-1]))
                     if authors:
-                        _q = ' OR '.join(['creator:"%s"' % author for author in authors])
+                        _q = ' OR '.join('creator:"%s"' % author for author in authors)
                 elif _type == "subjects":
                     subjects = works_authors_and_subjects.get('subjects', [])
                     if subjects:
-                        _q = ' OR '.join(['subject:"%s"' % subject for subject in subjects])
+                        _q = ' OR '.join('subject:"%s"' % subject for subject in subjects)
             if not _q:
                 logger.error('compose_ia_url(limit={}, page={}, subject={}, query={}, '
                     'work_id={}, _type={}, sorts={}, advanced={}) failed!'.format(

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -218,11 +218,14 @@ def get_available(limit=None, page=1, subject=None, query=None,
         limit=limit, page=page, subject=subject, query=query,
         work_id=work_id, _type=_type, sorts=sorts
     )
-    assert url, (
-        'get_available(limit={}, page={}, subject={}, query={}, work_id={}, _type={}, '
-        'sorts={}, url={})').format(limit, page, subject, query, work_id, _type, sorts,
-                                    url
-    )
+    if not url:
+        fmt = (
+            "get_available(limit={}, page={}, subject={}, "
+            "query={}, work_id={}, _type={}, sorts={}, url={}"
+        )
+        logger.error(
+            fmt.format(limit, page, subject, query, work_id, _type, sorts, url)
+        )
     try:
         request = urllib.request.Request(url=url)
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -220,7 +220,8 @@ def get_available(limit=None, page=1, subject=None, query=None,
     )
     assert url, (
         'get_available(limit={}, page={}, subject={}, query={}, work_id={}, _type={}, '
-        'sorts={}, url={})').format(limit, page, subject, query, work_id, _type, sorts
+        'sorts={}, url={})').format(limit, page, subject, query, work_id, _type, sorts,
+                                    url
     )
     try:
         request = urllib.request.Request(url=url)

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -163,7 +163,12 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
                     if subjects:
                         _q = ' OR '.join(['subject:"%s"' % subject for subject in subjects])
             if not _q:
-                return []
+                logger.error('compose_ia_url(limit={}, page={}, subject={}, query={}, '
+                    'work_id={}, _type={}, sorts={}, advanced={}) failed!'.format(
+                        limit, page, subject, query, work_id, _type, sorts, advanced
+                    )
+                )
+                return ''  # TODO: Should we just raise an excpetion instead?
             q += ' AND (%s) AND !openlibrary_work:(%s)' % (_q, work_id.split('/')[-1])
 
     if not advanced:
@@ -211,7 +216,12 @@ def get_available(limit=None, page=1, subject=None, query=None,
     """
     url = url or compose_ia_url(
         limit=limit, page=page, subject=subject, query=query,
-        work_id=work_id, _type=_type, sorts=sorts)
+        work_id=work_id, _type=_type, sorts=sorts
+    )
+    assert url, (
+        'get_available(limit={}, page={}, subject={}, query={}, work_id={}, _type={}, '
+        'sorts={}, url={})').format(limit, page, subject, query, work_id, _type, sorts
+    )
     try:
         request = urllib.request.Request(url=url)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Try to add more logging around https://github.com/internetarchive/openlibrary/pull/3350#issuecomment-615279522

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
A bare exception is hiding the fact that `compose_ia_url()` is returning an empty list for a URL which should be a `str`.  Adding logging so that we can see what input parameters are causing `compose_ia_url()` to fail.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Evidence
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->