### PR TITLE
fixes isbn searching to import and work like /isbn

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -34,6 +34,7 @@ class RunAs(object):
 
         # Temporarily become user
         web.ctx.conn.set_auth_token(self.tmp_account.generate_login_code())
+        return self.tmp_account
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Return auth token to original user or no-user

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -342,10 +342,9 @@ def create_edition_from_amazon_metadata(id_, id_type='isbn'):
     md = get_amazon_metadata(id_, id_type=id_type)
 
     if md and md.get('product_group') == 'Book':
-        with accounts.RunAs('ImportBot'):
+        with accounts.RunAs('ImportBot') as account:
             reply = load(
-                clean_amazon_metadata_for_load(md),
-                account=accounts.get_current_user())
+                clean_amazon_metadata_for_load(md), account=account)
             if reply and reply.get('success'):
                 return reply['edition'].get('key')
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -8,6 +8,7 @@ from infogami.utils import delegate, stats
 from infogami import config
 from infogami.utils.view import render, render_template, safeint, public
 import simplejson as json
+from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.core.lending import get_availability_of_ocaids, add_availability
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.inside.code import fulltext_search
@@ -482,17 +483,16 @@ class search(delegate.page):
         if need_redirect:
             raise web.seeother(web.changequery(**params))
 
+
     def isbn_redirect(self, isbn_param):
         isbn = normalize_isbn(isbn_param)
         if not isbn:
             return
-        editions = []
-        for isbn_len in (10, 13):
-            qisbn = isbn if len(isbn) == isbn_len else opposite_isbn(isbn)
-            q = {'type': '/type/edition', 'isbn_%d' % isbn_len: qisbn}
-            editions += web.ctx.site.things(q)
-        if len(editions):
-            raise web.seeother(editions[0])
+
+        ed = Edition.from_isbn(isbn)
+        if ed:
+            web.seeother(ed.key)
+
 
     def GET(self):
         # Enable patrons to search for query q2 within collection q


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Searching for an isbn used to resolve to an existing edition page (if successful). Now, searching for an isbn works exactly like the /isbn endpoint where an import will be performed if necessary.

### Technical
<!-- What should be noted about the implementation? -->

The risk is behavior when amazon API times out (but the experience should fail gracefully)

This only enhanced current/existing behavior.

### Testing & Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Test a search for an isbn which does and doesn't exist (isbn10, 13 for both cases).

https://dev.openlibrary.org/books/OL27941660M/If_It_Bleeds was imported by this codepath on dev -- by searching for the keyword `1982137975`.

Searching for `1982137975` a second time navigates patron to the right page, without re-importing -- as does `9781982137977`.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@hornc @cdrini 