### PR TITLE
Fix 3382/feature/add-learnawesome-identifiers

### DIFF
--- a/openlibrary/plugins/openlibrary/pages/config_edition.page
+++ b/openlibrary/plugins/openlibrary/pages/config_edition.page
@@ -530,6 +530,12 @@
             "label": "LC Control Number"
         },
         {
+            "url": "https://learnawesome.org/items/@@@",
+            "website": "https://learnawesome.org",
+            "name": "learnawesome",
+            "label": "LearnAwesome.org"
+        },
+        {
             "url": "https://www.librarything.com/work/@@@",
             "name": "librarything",
             "label": "Library Thing"


### PR DESCRIPTION
Closes #3382

Adds LearnAwesome.org to the list of identifiers. A sample target page:  https://learnawesome.org/items/5c731d15-6a53-432e-82e4-a4de9fecb2d1-the-first-20-hours