### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Closes #
 ### Testing
 <!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
 
-### Evidence
+### Screenshot
 <!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
 
 ### Stakeholders


### PR DESCRIPTION
On ABC call, we decided renaming evidence to screenshot would be more accessible to new contributors