### PR TITLE
Fix coverstore doctests for WARCRecords on Python 3

### DIFF
--- a/scripts/test-py3.sh
+++ b/scripts/test-py3.sh
@@ -5,14 +5,12 @@ pytest openlibrary/catalog openlibrary/coverstore openlibrary/mocks openlibrary/
        --ignore=openlibrary/catalog/marc/tests/test_get_subjects.py \
        --ignore=openlibrary/catalog/marc/tests/test_parse.py \
        --ignore=openlibrary/tests/catalog/test_get_ia.py \
-       --ignore=openlibrary/coverstore/tests/test_doctests.py \
        --ignore=openlibrary/plugins/openlibrary/tests/test_home.py
 RETURN_CODE=$?
        
 pytest openlibrary/catalog/marc/tests/test_get_subjects.py || true
 pytest openlibrary/catalog/marc/tests/test_parse.py || true
 pytest openlibrary/tests/catalog/test_get_ia.py || true
-pytest --show-capture=all openlibrary/coverstore/tests/test_doctests.py || true
 pytest --show-capture=all openlibrary/plugins/openlibrary/tests/test_home.py || true
 flake8 --exit-zero --count --select=E722 --show-source
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes `python3 -m pytest openlibrary/coverstore/tests/test_doctests.py`

This test is now obligatory on both Python 2 and Python 3.  Once this PR lands, we are down to just four failing pytest files.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

On Python 3: [`OSError: Can't do nonzero cur-relative seeks`](https://stackoverflow.com/questions/21533391/seeking-from-end-of-file-throwing-unsupported-exception)
```
# self._file.seek(int(header.data_length), 1)  # old --> new...
self._file.seek(self._file.tell() + int(header.data_length), 0)
```
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
