### PR TITLE
Adds missing 's', fixes authors ebooks only mode

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -145,7 +145,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
                 <p>
                   $if input(mode="everything").mode == "everything":
-                    $:_('Showing all works by author. Would you like to see <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebook'))
+                    $:_('Showing all works by author. Would you like to see <a href="%(url)s">only ebooks</a>?', url=changequery(mode='ebooks'))
                   $else:
                     $:_('Showing ebooks only. Would you like to see <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))
                 </p>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Trivial change `?mode=ebook` should be `?mode=ebooks`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Go to authors page and click ebooks only on dev:
https://dev.openlibrary.org/authors/OL6951711A/Tom_Clancy?mode=ebooks

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
