### PR TITLE
enables sorting admin/sponsorships by ?sort=publicdate

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -183,7 +183,7 @@ def get_sponsored_books():
     params = {'page': 1, 'rows': 1000, 'scope': 'all'}
     fields = ['identifier','est_book_price','est_scan_price', 'scan_price',
               'book_price', 'repub_state', 'imagecount', 'title',
-              'openlibrary_edition']
+              'openlibrary_edition', 'publicdate', 'collection']
 
     q = 'collection:openlibraryscanningteam'
 

--- a/openlibrary/templates/admin/sponsorship.html
+++ b/openlibrary/templates/admin/sponsorship.html
@@ -97,7 +97,7 @@ $ sort_facet = input(sort='status').sort
       $if sort_facet == 'status':
         $ summary['books'].sort(key=lambda b: summary['status_ids'][b['status']])
       $else:
-        $ summary['books'].sort(key=lambda b: b[sort_facet])
+        $ summary['books'].sort(key=lambda b: b.get(sort_facet, ''))
       $for book in summary['books']:
         $ isbn = book['identifier'].replace('isbn_', '')
         <tr>
@@ -107,7 +107,7 @@ $ sort_facet = input(sort='status').sort
                  src="https://archive.org/services/img/$book['identifier']">
           </td>
           <td>
-            $book['publicdate']
+            $book.get('publicdate', '')
           </td>
           <td>
             <ul>

--- a/openlibrary/templates/admin/sponsorship.html
+++ b/openlibrary/templates/admin/sponsorship.html
@@ -2,6 +2,7 @@ $def with (summary)
 
 $ _x = ctx.setdefault('bodyid', 'admin')
 $ _x = ctx.setdefault('usergroup', 'admin')
+$ sort_facet = input(sort='status').sort
 
 <div id="contentHead">
   $:render_template("admin/menu")
@@ -86,13 +87,17 @@ $ _x = ctx.setdefault('usergroup', 'admin')
       <tr>
         <th>#</th>
         <th>Cover</th>
+        <th>Sponsor Date</th>
         <th>IDs</th>
         <th>Title</th>
         <th>Status</th>
       </tr>
     </thead>
     <tbody>
-      $ summary['books'].sort(key=lambda b: summary['status_ids'][b['status']])
+      $if sort_facet == 'status':
+        $ summary['books'].sort(key=lambda b: summary['status_ids'][b['status']])
+      $else:
+        $ summary['books'].sort(key=lambda b: b[sort_facet])
       $for book in summary['books']:
         $ isbn = book['identifier'].replace('isbn_', '')
         <tr>
@@ -100,6 +105,9 @@ $ _x = ctx.setdefault('usergroup', 'admin')
           <td>
             <img width="50" height="75"
                  src="https://archive.org/services/img/$book['identifier']">
+          </td>
+          <td>
+            $book['publicdate']
           </td>
           <td>
             <ul>


### PR DESCRIPTION
Enables sorting of sponsored books by publicdate or status and adds collections into book data returned from archive.org

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested /admin/sponsorships?sort=publicdate w/ @cdrini 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 