### PR TITLE
Remove slow call to loan.sync

### DIFF
--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -263,6 +263,11 @@ def update_waitinglist(identifier):
     * When a book is checked out or returned
     * When a person joins or leaves the waiting list
     """
+    return None
+    # For books with many active loans, calls to loan.sync can be very slow / 504.
+    # It looks like, these two functions are handled on the IA side, and don't actually
+    # need to be called from Open Library. Disabling as a patch deploy for now; can
+    # likely remove remove in the near future.
     _wl_api.request("loan.sync", identifier=identifier)
     return on_waitinglist_update(identifier)
 


### PR DESCRIPTION
Fix slow borrows 504ing

<!-- What issue does this PR close? -->
Closes #3401 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
For books with many active loans, calls to loan.sync can be very slow / 504.
It looks like, these two functions are handled on the IA side, and don't actually
need to be called from Open Library. Disabling as a patch deploy for now; can
likely remove remove in the near future.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
