### PR TITLE
Increase solr timeout

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -218,7 +218,7 @@ def parse_json_from_solr_query(url):
 def execute_solr_query(url):
     stats.begin("solr", url=url)
     try:
-        solr_result = urllib.request.urlopen(url, timeout=3)
+        solr_result = urllib.request.urlopen(url, timeout=10)
     except Exception as e:
         logger.exception("Failed solr query")
         return None


### PR DESCRIPTION
Hotfix. Increase solr timeout from 3s to 10.

### Technical
- This API regularly takes longer than 3 seconds, and results in an incomprehensible error.
- The new solr looks like it might also take longer for complicated requests; perhaps because of the ~4M new records. Most average queries look to take about the same though. A strict timeout here causes some weird "pipe discontinued" errors on solr, which seem to make it even slower, so increasing the timeout to prevent that as well.

### Testing
Tested queries taking longer than 3s no longer error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
