### PR TITLE
Fix slick font preload not working

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,7 +1,8 @@
 $def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False)
 
 $ ctx.setdefault("links", [])
-$ slick_font = '<link rel="preload" href="/static/css/fonts/slick.woff" as="font" type="font/woff">'
+$# Apparently fonts always need crossorigin for some reason
+$ slick_font = '<link rel="preload" href="/static/css/fonts/slick.woff" as="font" type="font/woff" crossorigin>'
 $if slick_font not in ctx.links:
   $ ctx.links.append(slick_font)
 


### PR DESCRIPTION
Hotfix. Apparently the slick font preload wasn't preloading! Got an error in the lighthouse

### Technical
- Getting this error from Chrome's Lighthouse:
   > Warnings: A preload <link> was found for "https://openlibrary.org/static/css/fonts/slick.woff" but was not used by the browser. Check that you are using the `crossorigin` attribute properly.
- Apparently fonts always need `crossorigin` for some reason https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content#Cross-origin_fetches

### Testing
- https://dev.openlibrary.org/collections/k-12 does not display the font loading warning in Lighthouse

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
