### PR TITLE
Fix markdown editor JS being loaded indiscriminately + error

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -9,8 +9,6 @@ import '../../../../vendor/js/colorbox/1.5.14.js';
 import '../../../../vendor/js/jquery-form/jquery.form.js';
 // jquery-autocomplete#1.1 with modified
 import '../../../../vendor/js/jquery-autocomplete/jquery.autocomplete-modified.js';
-// unversioned.
-import '../../../../vendor/js/wmd/jquery.wmd.js'
 import autocompleteInit from './autocomplete';
 // Used only by the openlibrary/templates/books/edit/addfield.html template
 import addNewFieldInit from './add_new_field';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     },
     {
       "path": "static/build/markdown-editor.*.js",
-      "maxSize": "10.5KB"
+      "maxSize": "11KB"
     },
     {
       "path": "static/build/carousel.*.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "146.3KB"
+      "maxSize": "136KB"
     },
     {
       "path": "static/build/page-admin.css",


### PR DESCRIPTION
Fix. Markdown editor JS being loaded indiscriminately + error in .wmd file.

| ✅ ~Merge https://github.com/internetarchive/wmd/pull/5  first; then will update to not point to my fork.~ |
| -- |

### Technical
- It looks like the WMD editor was pulled out into `markdown-editor/index.js`, but the initial import never removed. Removed it.
- While working on #3408 , noticed some JS errors along the lines of "assignment to undefined reference WMDEditor". Adding `var WMDEditor = ...` fixed it.
- Updated the submodule

### Testing
- Check markdown previews load with no JS errors on:
  - [x] Author edit
  - [x] Work edit
  - [x] Edition edit
  - [x] docs page

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jdlrobson 
