### PR TITLE
Remove unused imports from openlibrary/utils

### DIFF
--- a/openlibrary/utils/ia.py
+++ b/openlibrary/utils/ia.py
@@ -1,4 +1,4 @@
-from socket import socket, AF_INET, SOCK_DGRAM, SOL_UDP, SO_BROADCAST, timeout
+from socket import socket, AF_INET, SOCK_DGRAM, SOL_UDP, SO_BROADCAST
 import re
 
 re_loc = re.compile('^(ia\d+\.us\.archive\.org):(/\d+/items/(.*))$')


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the unused import from `openlibrary/utils`

@cclauss  These are done!

- [X]  openlibrary/mocks
- [X]  openlibrary/accounts and openlibrary/admin
- [ ]  openlibrary/code.py and openlibrary/conftest.py
- [ ]  openlibrary/coverstore
- [ ]  openlibrary/data
- [ ]  openlibrary/records
- [ ]  openlibrary/solr
- [x]  openlibrary/utils
- [ ] openlibrary/views

 Save for the end:

- [ ]  openlibrary/core
- [ ]  openlibrary/catalog (perhaps multiple PRs)
- [ ]  openlibrary/plugins (perhaps multiple PRs)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 