### PR TITLE
Fix /ia/xxx import api throwing error instead of serving dummy wrapper page

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -429,13 +429,15 @@ class bookpage(delegate.page):
                     return web.found(result[0] + ext)
 
             # Perform import, if possible
-            from openlibrary.plugins.importapi.code import ia_importapi
+            from openlibrary.plugins.importapi.code import ia_importapi, BookImportError
             from openlibrary import accounts
             with accounts.RunAs('ImportBot'):
-                # May want to catch importapi.code.BookImportError
-                ia_importapi.ia_import(value, require_marc=True)
+                try:
+                    ia_importapi.ia_import(value, require_marc=True)
+                except BookImportError:
+                    logger.exception('Unable to import ia record')
 
-            # If nothing matched, try this as a last resort:
+            # Go the the record created, or to the dummy ia-wrapper record
             return web.found('/books/ia:' + value + ext)
 
         web.ctx.status = '404 Not Found'


### PR DESCRIPTION
Hotfix. Apparently this is endpoint is being used by some book scanning code. This was causing errors in our last deploy as result of the /ia/xxx changes #3346 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Doesn't error for non-marc IA record: combatingdrugtra1094555588
- Import does work for valid IA record: https://dev.openlibrary.org/ia/youcantscaremegu0000unse ( from https://archive.org/search.php?query=publisher%3ATicktock%20AND%20%21openlibrary_work%3A%2A )
- Test imported book matches: https://dev.openlibrary.org/ia/youcantscaremegu0000unse

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
