### PR TITLE
Remove unused imports from code.py & conftest.py

### DIFF
--- a/openlibrary/code.py
+++ b/openlibrary/code.py
@@ -32,9 +32,6 @@ def setup():
 
     load_views()
 
-    # load actions
-    from . import actions
-
     logger.info("loading complete.")
 
 def setup_logging():
@@ -51,7 +48,5 @@ def setup_logging():
 def load_views():
     """Registers all views by loading all view modules.
     """
-    from .views import showmarc
-    from .views import loanstats
 
 setup()

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -11,6 +11,8 @@ from infogami.utils.view import render_template as infobase_render_template
 from openlibrary.i18n import gettext
 from openlibrary.core import helpers
 
+from openlibrary.mocks.mock_infobase import mock_site  # noqa: F401
+from openlibrary.mocks.mock_memcache import mock_memcache  # noqa: F401
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -1,6 +1,5 @@
 """pytest configutation for openlibrary
 """
-import glob
 import pytest
 import web
 
@@ -12,10 +11,6 @@ from infogami.utils.view import render_template as infobase_render_template
 from openlibrary.i18n import gettext
 from openlibrary.core import helpers
 
-from openlibrary.mocks.mock_infobase import mock_site
-from openlibrary.mocks.mock_ia import mock_ia
-from openlibrary.mocks.mock_memcache import mock_memcache
-from openlibrary.mocks.mock_ol import ol
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -12,6 +12,7 @@ from openlibrary.i18n import gettext
 from openlibrary.core import helpers
 
 from openlibrary.mocks.mock_infobase import mock_site  # noqa: F401
+from openlibrary.mocks.mock_ia import mock_ia # noqa: F401
 from openlibrary.mocks.mock_memcache import mock_memcache  # noqa: F401
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the unused import from `openlibrary/code.py` & `openlibrary/conftest.py`

- [X]  openlibrary/mocks
- [X]  openlibrary/accounts and openlibrary/admin
- [x]  openlibrary/code.py and openlibrary/conftest.py
- [ ]  openlibrary/coverstore
- [ ]  openlibrary/data
- [ ]  openlibrary/records
- [ ]  openlibrary/solr
- [x]  openlibrary/utils
- [ ] openlibrary/views

 Save for the end:

- [ ]  openlibrary/core
- [ ]  openlibrary/catalog (perhaps multiple PRs)
- [ ]  openlibrary/plugins (perhaps multiple PRs)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss @mekarpeles 