### PR TITLE
hotfix admin sponsorship dash, robust if IA book metadata missing title

### DIFF
--- a/openlibrary/templates/admin/sponsorship.html
+++ b/openlibrary/templates/admin/sponsorship.html
@@ -127,7 +127,7 @@ $ sort_facet = input(sort='status').sort
             </ul>
           </td>
           <td>
-            <a href="https://archive.org/details/$book['identifier']">$book['title']</a>
+            <a href="https://archive.org/details/$book['identifier']">$book.get('title')</a>
           </td>
           <td class="status--$(summary['status_ids'][book.get('status')])">
             $book.get('status')


### PR DESCRIPTION
Fixes the sponsorship dashboard (was breaking for a record w/ no title on archive.org)

https://openlibrary.org/books/OL7599497M/Twelve_Impossible_Things_Before_Breakfast (has title on OL, not IA).