### PR TITLE
Fix new author fields disabled

### DIFF
--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -31,9 +31,9 @@ $jsdef render_author_autocomplete_item(item):
                 <span class="subject">Subjects: ${', '.join(item.subjects)}</span>
         </div>
 
-$jsdef render_author(name_path, dict_path, i, author):
+$jsdef render_author(name_path, dict_path, disabled, i, author):
     <div class="input">
-        <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" disabled>
+        <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" $cond(disabled, 'disabled', '')>
         <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
         <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
         <a href="javascript:;" class="add">$_("Add another author?")</a>
@@ -41,14 +41,14 @@ $jsdef render_author(name_path, dict_path, i, author):
 
 <div id="authors">
     $for author in (authors or [storage(name="", key="")]):
-        $:render_author(name_path, dict_path, loop.index0, author)
+        $:render_author(name_path, dict_path, True, loop.index0, author)
 </div>
 <script type="text/javascript">
 window.q.push( function () {
     \$('.author-autocomplete').prop('disabled', false );
     \$("#authors").setup_multi_input_autocomplete(
         "input.author-autocomplete",
-        render_author.bind(null, "$name_path", "$dict_path"),
+        render_author.bind(null, "$name_path", "$dict_path", false),
         {
             endpoint: "/authors/_autocomplete",
             // Don't render "Create new author" if searching by key


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3459 , Closes #3460 . Hotfix disabled "add new author" not working on works/edition pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested locally that clicking "Add author" creates an enabled JS input field.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jdlrobson @seabelis 
