### PR TITLE
Enabling public reading log at account creation

### DIFF
--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -48,13 +48,6 @@ def get_current_user():
     return web.ctx.site.get_user()
 
 
-def username_available(cls, username):
-    """Returns True if an OL username is available, or False otherwise"""
-    return bool(
-        accounts.find(username=username) or
-        accounts.find(lusername=username))
-
-
 def find(username=None, lusername=None, email=None):
     """Finds an account by username, email or lowercase username.
     """

--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -1,13 +1,16 @@
-from .model import * #XXX: Fix this. Import only specific names
-
 import web
+
+# FIXME: several modules import things from accounts.model
+# directly through openlibrary.accounts
+from .model import *
+
 
 ## Unconfirmed functions (I'm not sure that these should be here)
 def get_group(name):
     """
     Returns the group named 'name'.
     """
-    return web.ctx.site.get("/usergroup/%s"%name)
+    return web.ctx.site.get("/usergroup/%s" % name)
 
 
 class RunAs(object):

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -699,6 +699,7 @@ def audit_accounts(email, password, require_link=False,
                     ia_account.itemname, email, password,
                     displayname=ia_account.screenname,
                     verified=True, retries=5, test=test)
+                ol_account.save_preferences({'public_readlog':'yes'})
             except ValueError as e:
                 return {'error': 'max_retries_exceeded'}
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -137,8 +137,7 @@ class Account(web.storage):
 
     @property
     def displayname(self):
-        key = "/people/" + self.username
-        doc = web.ctx.site.get(key)
+        doc = self.get_user()
         if doc:
             return doc.displayname or self.username
         elif "data" in self:
@@ -235,9 +234,15 @@ class Account(web.storage):
         return t and helpers.parse_datetime(t)
 
     def get_user(self):
+        """A user is where preferences are attached to an account. An
+        "Account" is outside of infogami in a separate table and is
+        used to store private user information.
+
+        :rtype: User
+        :returns: Not an Account obj, but a /people/xxx User
+        """
         key = "/people/" + self.username
-        doc = web.ctx.site.get(key)
-        return doc
+        return web.ctx.site.get(key)
 
     def get_creation_info(self):
         key = "/people/" + self.username
@@ -369,6 +374,10 @@ class OpenLibraryAccount(Account):
             web.ctx.site.activate_account(username=username)
 
         ol_account = cls.get(email=email)
+
+        # Update user preferences; reading log public by default
+        ol_account.get_user().save_preferences({'public_readlog':'yes'})
+
         return ol_account
 
     @classmethod

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -376,7 +376,9 @@ class OpenLibraryAccount(Account):
         ol_account = cls.get(email=email)
 
         # Update user preferences; reading log public by default
-        ol_account.get_user().save_preferences({'public_readlog':'yes'})
+        from openlibrary.accounts import RunAs
+        with RunAs(username):
+            ol_account.get_user().save_preferences({'public_readlog':'yes'})
 
         return ol_account
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -710,7 +710,6 @@ def audit_accounts(email, password, require_link=False,
                     ia_account.itemname, email, password,
                     displayname=ia_account.screenname,
                     verified=True, retries=5, test=test)
-                ol_account.save_preferences({'public_readlog':'yes'})
             except ValueError as e:
                 return {'error': 'max_retries_exceeded'}
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -603,6 +603,11 @@ class User(Thing):
     DEFAULT_PREFERENCES = {
         'updates': 'no',
         'public_readlog': 'no'
+        # New users are now public by default for new patrons
+        # As of 2020-05, OpenLibraryAccount.create will
+        # explicitly set public_readlog: 'yes'.
+        # Legacy acconts w/ no public_readlog key
+        # will continue to default to 'no'
     }
 
     def get_status(self):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -244,8 +244,6 @@ class account_create(delegate.page):
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,
                     notifications=notifications, verified=False, retries=USERNAME_RETRIES)
-                user = OpenLibraryAccount.get(email=f.email.value)
-                user.save_preferences({'public_readlog':'yes'})
                 page = render['account/verify'](username=f.username.value, email=f.email.value)
                 page.v2 = True
                 return page

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -244,6 +244,8 @@ class account_create(delegate.page):
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,
                     notifications=notifications, verified=False, retries=USERNAME_RETRIES)
+                user = OpenLibraryAccount.get(email=f.email.value)
+                user.save_preferences({'public_readlog':'yes'})
                 page = render['account/verify'](username=f.username.value, email=f.email.value)
                 page.v2 = True
                 return page
@@ -579,7 +581,9 @@ class account_privacy(delegate.page):
     @require_login
     def POST(self):
         user = accounts.get_current_user()
-        user.save_preferences(web.input())
+        inst = web.input()
+        logger.log(inst)
+        user.save_preferences(inst)
         add_flash_message('note', _("Notification preferences have been updated successfully."))
         web.seeother("/account")
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -581,9 +581,7 @@ class account_privacy(delegate.page):
     @require_login
     def POST(self):
         user = accounts.get_current_user()
-        inst = web.input()
-        logger.log(inst)
-        user.save_preferences(inst)
+        user.save_preferences(web.input())
         add_flash_message('note', _("Notification preferences have been updated successfully."))
         web.seeother("/account")
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2058

[feature]

### Technical
<!-- What should be noted about the implementation? -->

1. There are two types of records for users, one is for their /people/xxx public `user`, the other is for their private `account` (e.g. encrypted password, email). Preferences and public settings, such as public_readinglog are stored on the `user` record.

2. An OpenLibraryAccount `account` record is not created for a user (nor their `user` record) until they have created + activated an InternetArchiveAccount and successfully logged in for their first time. At this point, the code we're adding will fetch the patron's **user** account and update their settings so their reading log is public by default.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested on dev (@mekarpeles + @tabshaikh)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
