### PR TITLE
Meta description made more specific to a page

### DIFF
--- a/openlibrary/macros/Metatags.html
+++ b/openlibrary/macros/Metatags.html
@@ -1,6 +1,9 @@
 $def with(title, image, description)
 
 <!-- Open graph tags handle card for both twitter and facebook -->
+
+$putctx("description", description)
+
 $add_metatag(property="og:title", content=title)
 $add_metatag(property="og:type", content="books.book")
 $add_metatag(property="og:image", content=image)

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -37,6 +37,7 @@ $elif key == 'sponsorships':
   $ og_description = "{username} is sponsoring {total} books. Join {username} on OpenLibrary.org and share the books that you'll soon be reading!".format(username=userDisplayName, total=total_items)
 
 $if og_title:
+  $putctx("description", og_description)
   $add_metatag(property="og:title", content=og_title)
   $add_metatag(property="og:url", content=request.canonical_url)
   $add_metatag(property="og:site_name", content="Open Library")

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -5,7 +5,6 @@ $def with (page)
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />
-    <meta name="description" content="Open Library is an open, editable library catalog, building towards a web page for every book ever published.">
     <meta name = "keywords" content = "free books, books to read, free ebooks,audio books,read books for free, read books online, online library">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="OpenLibrary.org" />

--- a/openlibrary/templates/site/neck.html
+++ b/openlibrary/templates/site/neck.html
@@ -8,7 +8,7 @@ $putctx("sent_neck", True)
     $if ctx.get("description"):
         <meta name="description" content="$ctx.description" />
     $else:
-        <meta name="description" content="$_('Open Library is an open, editable library catalog, building towards a web page for every book ever published.')" />
+        <meta name="description" content="$_('Open Library is an open, editable library catalog, building towards a web page for every book ever published. Read, borrow, and discover more than 3M books for free.')" />
 
     <title>$:title | $_("Open Library")</title>
 
@@ -18,4 +18,3 @@ $putctx("sent_neck", True)
     $for tag in ctx.get("metatags", []):
         $:tag
 </head>
-

--- a/openlibrary/templates/site/neck.html
+++ b/openlibrary/templates/site/neck.html
@@ -8,7 +8,7 @@ $putctx("sent_neck", True)
     $if ctx.get("description"):
         <meta name="description" content="$ctx.description" />
     $else:
-        <meta name="description" content="Open Library is an open, editable library catalog, building towards a web page for every book ever published." />
+        <meta name="description" content="$_('Open Library is an open, editable library catalog, building towards a web page for every book ever published.')" />
 
     <title>$:title | $_("Open Library")</title>
 

--- a/openlibrary/templates/site/neck.html
+++ b/openlibrary/templates/site/neck.html
@@ -6,7 +6,9 @@ $putctx("sent_neck", True)
         <meta name="robots" content="$ctx.robots" />
 
     $if ctx.get("description"):
-    	<meta name="description" content="$ctx.description" />
+        <meta name="description" content="$ctx.description" />
+    $else:
+        <meta name="description" content="Open Library is an open, editable library catalog, building towards a web page for every book ever published." />
 
     <title>$:title | $_("Open Library")</title>
 

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -11,6 +11,8 @@ $if list.description:
 
 $var title: $list.name
 
+$putctx("description", meta_description)
+
 $add_metatag(property="twitter:card", content="summary")
 $add_metatag(property="twitter:site", content="@openlibrary")
 $add_metatag(property="twitter:title", content=title_with_site)

--- a/openlibrary/templates/type/work/view.html
+++ b/openlibrary/templates/type/work/view.html
@@ -38,7 +38,6 @@ $var title: $page.title
         return "; ".join(items)
 
     description = render_description()
-    putctx("description", description)
 
   $:macros.Metatags(title=title_with_site, image=meta_cover_url, description=description)
 


### PR DESCRIPTION
The head.html page of Open Library contained a generalized meta description that would be shown for all the pages. We would want the books, edition, authors, homepage to contain page-specific meta description so that we can portray our pages better on search engines. 
![Screenshot from 2020-05-17 20-14-26](https://user-images.githubusercontent.com/31198893/82151789-07f33480-987b-11ea-8979-323f10fc543c.png)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To test the pr inspect using chrome dev and check if the page contains page specific meta tag description
- [ ] Home
- [ ] Edition
- [ ] Works
- [ ] Lists
- [ ] Author

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 