### PR TITLE
hotfix civi calls when civi is down

### DIFF
--- a/openlibrary/core/civicrm.py
+++ b/openlibrary/core/civicrm.py
@@ -28,7 +28,7 @@ def get_contact_id_by_username(username):
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })
-    contacts = r.status_code == 200 and r.json().get('values', None) 
+    contacts = r.status_code == 200 and r.json().get('values', None)
     return contacts and contacts[0].get('contact_id')
 
 

--- a/openlibrary/core/civicrm.py
+++ b/openlibrary/core/civicrm.py
@@ -28,7 +28,7 @@ def get_contact_id_by_username(username):
         headers={
             'Authorization': 'Basic %s' % lending.config_ia_civicrm_api.get('auth', '')
         })
-    contacts = r.json().get('values', None)
+    contacts = r.status_code == 200 and r.json().get('values', None) 
     return contacts and contacts[0].get('contact_id')
 
 


### PR DESCRIPTION
@tabshaikh and I discovered a bug where reading log pages broke when Civi went offline. This deals with failed civi responses gracefully

![2020-05-30-223755_1600x900_scrot](https://user-images.githubusercontent.com/978325/83345294-50bcdb80-a2c6-11ea-8dd1-bbf13c511919.png)
