### PR TITLE
Add load balancing to new solr to fix new solr getting overwhelmed by prod traffic

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -45,7 +45,7 @@ plugin_modules:
     - infogami.plugins.api
 
 plugin_worksearch:
-    solr: solr:8080
+    solr: solr:8983
     spellcheck_count: 3
     ebook_count_db_parameters:
         db: openlibrary_ebook_count
@@ -56,7 +56,7 @@ plugin_worksearch:
 
 http_request_timeout: 10
 
-stats_solr: solr:8080
+stats_solr: solr:8983
 
 features:
     cache_most_recent: enabled

--- a/conf/solr/haproxy.cfg
+++ b/conf/solr/haproxy.cfg
@@ -1,5 +1,3 @@
-# this config needs haproxy-1.1.28 or haproxy-1.2.1
-
 global
 	log 127.0.0.1	daemon info
 	#log loghost	local0 info
@@ -20,9 +18,9 @@ defaults
 	retries	3
 	option redispatch
 	maxconn	2000
-	contimeout	9000
-	clitimeout	7200000
-	srvtimeout	7200000
+	timeout connect	9000ms
+	timeout client	7200000ms
+	timeout server	7200000ms
     stats uri     /admin?stats
     stats refresh 5s
     # these are added so the client ip comes through
@@ -31,9 +29,10 @@ defaults
     option forceclose
 
 
-listen	solr 0.0.0.0:8983
+listen solr
+	bind	*:8983
 	mode	http
 	balance	roundrobin
     #option httpchk GET /solr/
     option httpchk GET /solr/select?rows=0&q=*:*
-    server  localhost-8984 127.0.0.1:8984 maxconn 10 check inter 500 rise 2 fall 2
+    server  localhost-8080 127.0.0.1:8080 maxconn 10 check inter 500 rise 2 fall 2

--- a/conf/solr/haproxy.cfg
+++ b/conf/solr/haproxy.cfg
@@ -1,0 +1,39 @@
+# this config needs haproxy-1.1.28 or haproxy-1.2.1
+
+global
+	log 127.0.0.1	daemon info
+	#log loghost	local0 info
+	maxconn 4096
+	#chroot /usr/share/haproxy
+	user haproxy
+	group haproxy
+	daemon
+    #nbproc 6
+	#debug
+	#quiet
+
+defaults
+	log	global
+	mode	http
+	option	httplog
+	option	dontlognull
+	retries	3
+	option redispatch
+	maxconn	2000
+	contimeout	9000
+	clitimeout	7200000
+	srvtimeout	7200000
+    stats uri     /admin?stats
+    stats refresh 5s
+    # these are added so the client ip comes through
+    option httpclose
+    option forwardfor
+    option forceclose
+
+
+listen	solr 0.0.0.0:8983
+	mode	http
+	balance	roundrobin
+    #option httpchk GET /solr/
+    option httpchk GET /solr/select?rows=0&q=*:*
+    server  localhost-8984 127.0.0.1:8984 maxconn 10 check inter 500 rise 2 fall 2

--- a/conf/solr/start.sh
+++ b/conf/solr/start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Default to dev env
+ENV=${ENV:-dev}
+
+ln -sf /etc/solr/conf/solrconfig-$ENV.xml /etc/solr/conf/solrconfig.xml
+
+# On dev, don't use haproxy; make tomcat serve directly to 8983
+if [ "$ENV" = "dev" ] ; then
+    sed -i 's/8080/8983/g' /var/lib/tomcat7/conf/server.xml;
+fi
+
+if [ "$ENV" = "prod" ] ; then
+    # Use more memory
+    echo 'export JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true -Xmx10g -Xms10g -XX:+UseConcMarkSweepGC"' > /usr/share/tomcat7/bin/setenv.sh
+    # Load balance with haproxy
+    service haproxy start
+fi
+
+/usr/share/tomcat7/bin/catalina.sh run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.olsolr
+    environment:
+      - ENV=${ENV:-dev}
     ports:
-      - 8983:8080
+      - 8983:8983
     volumes:
       - solr-data:/var/lib/solr/data
     networks:

--- a/docker/Dockerfile.olsolr
+++ b/docker/Dockerfile.olsolr
@@ -1,18 +1,13 @@
 FROM ubuntu:xenial
 
 RUN apt-get -qq update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y solr-tomcat && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y solr-tomcat haproxy && \
     ln -s /var/log/tomcat7/ /usr/share/tomcat7/logs && \
     ln -s /etc/tomcat7/ /usr/share/tomcat7/conf
 
-# Environment; one of 'prod' or 'dev'
-ARG ENV=dev
 COPY conf/solr/conf/* /etc/solr/conf/
-RUN ln -sf /etc/solr/conf/solrconfig-$ENV.xml /etc/solr/conf/solrconfig.xml
-# Increase memory on prod
-RUN if [ "$ENV" = "prod" ] ; then \
-    echo 'export JAVA_OPTS="${JAVA_OPTS} -Djava.awt.headless=true -Xmx10g -Xms10g -XX:+UseConcMarkSweepGC"' > /usr/share/tomcat7/bin/setenv.sh ; \
-fi
+COPY conf/solr/haproxy.cfg /etc/haproxy/
+COPY conf/solr/start.sh /start.sh
 
-EXPOSE 8080
-CMD ["/usr/share/tomcat7/bin/catalina.sh", "run"]
+EXPOSE 8983
+CMD /start.sh

--- a/scripts/solr_builder/Jenkinsfile
+++ b/scripts/solr_builder/Jenkinsfile
@@ -298,6 +298,13 @@ pipeline {
             }
           }
         }
+        stage('Optimize indices') {
+          // This is kind of like a disk defrag, but it's ESSENTIAL after a big import. Shouldn't
+          // really be needed after that.
+          steps {
+            sh "docker-compose exec -T solr curl -s http://localhost:8080/solr/update?optimize=true"
+          }
+        }
       }
     }
   }

--- a/scripts/solr_builder/README.md
+++ b/scripts/solr_builder/README.md
@@ -93,7 +93,7 @@ Copy this dump onto ol-solr0, and there run
 ```sh
 cd /opt/openlibrary
 # Build Solr
-time sudo docker-compose build --build-arg ENV=prod solr
+time sudo docker-compose build solr
 
 # Copy file (3min; 2020-03-02 OJF)
 time scp YOU@server.openjournal.foundation:/storage/openlibrary/solr/solrbuilder-2020-03-02.tar.gz ~
@@ -103,7 +103,7 @@ time sudo docker-compose run --no-deps --rm -v $HOME:/backup solr \
     bash -c "tar xf /backup/solrbuilder-2020-03-02.tar.gz"
 
 # Start the service
-sudo docker-compose up -d --no-deps solr
+sudo ENV=prod docker-compose up -d --no-deps solr
 ```
 
 ## Resetting

--- a/scripts/solr_builder/README.md
+++ b/scripts/solr_builder/README.md
@@ -94,6 +94,9 @@ Copy this dump onto ol-solr0, and there run
 cd /opt/openlibrary
 # Build Solr
 time sudo docker-compose build solr
+# If this fails due to docker container not getting interent access (currently a problem on ol-solr0 as of 2020-06-22). 
+# Use this:
+# sudo docker build --network=host -t olsolr:latest -f docker/Dockerfile.olsolr .
 
 # Copy file (3min; 2020-03-02 OJF)
 time scp YOU@server.openjournal.foundation:/storage/openlibrary/solr/solrbuilder-2020-03-02.tar.gz ~


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3435 ; Fix

### Technical
- Copied haproxy.cfg from prod's ol-solr2

### Testing
On local dev:
1. Comment out the memory mods in solr/start.sh (ain't got that much RAM!)
2. `docker-compose build solr`
3. `ENV=prod docker-compose up --no-deps -d solr`
    - [x] http://localhost:8983/solr/admin/ loads
    - [x] http://localhost:8983/admin?stats shows haproxy stats
4. `docker-compose down`
5. `docker-compose up --no-deps -d solr`
    - [x] http://localhost:8983/solr/admin/ loads
    - [x] http://localhost:8983/admin?stats does not load (blank screen)
6. `docker-compose down; docker-compose up -d`
    - [x] Searching work on local openlibrary

On on ol-solr0:
1. ~`docker-compose build solr`~ `sudo docker build --network=host -t olsolr:latest -f docker/Dockerfile.olsolr .`
2. `ENV=prod docker-compose up --no-deps -d solr`
    - [x] http://localhost:8983/solr/admin/ loads (was a little slow, but eventually came up!)
    - [x] http://localhost:8983/admin?stats shows haproxy stats

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
