### PR TITLE
Use MARC 264 to get publisher info if 260 not present

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -33,7 +33,7 @@ want = [
     '130', '240', # work title
     '245',  # title
     '250',  # edition
-    '260',  # publisher
+    '260', '264',  # publisher
     '300',  # pagination
     '440', '490', '830'  # series
     ] + [str(i) for i in range(500, 588)] + [  # notes + toc + description
@@ -256,7 +256,7 @@ def read_pub_date(rec):
     return remove_trailing_number_dot(found[0]) if found else None
 
 def read_publisher(rec):
-    fields = rec.get_fields('260')
+    fields = rec.get_fields('260') or rec.get_fields('264')
     if not fields:
         return
     publisher = []

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -256,7 +256,7 @@ def read_pub_date(rec):
     return remove_trailing_number_dot(found[0]) if found else None
 
 def read_publisher(rec):
-    fields = rec.get_fields('260') or rec.get_fields('264')
+    fields = rec.get_fields('260') or rec.get_fields('264')[:1]
     if not fields:
         return
     publisher = []


### PR DESCRIPTION
Some LOC (2016) records only have publisher data in 264
e.g. https://openlibrary.org/show-records/marc_loc_2016/BooksAll.2016.part42.utf8:1486691:1912

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

260 and 260 share $a and $b sub-field meanings for  place and name, which are extracted in the current code.

https://www.loc.gov/marc/bibliographic/bd260.html
https://www.loc.gov/marc/bibliographic/bd264.html

264 should be a drop in substitute for 260, if it doesn't exist.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
