### PR TITLE
Hotfix/readinglog pages

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -53,10 +53,11 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
         <div class="decorations">
           $:decorations
         </div>
-      $if cta:
-        <div class="searchResultItemCTA-lending">
+
+      <div class="searchResultItemCTA-lending">
+        $if cta:
           $ doc['availability'] = doc.get('availability', {})
           $:macros.LoanStatus(doc, user, editions_page=False, work_key=doc.key)
-        </div>
+      </div>
   </div>
 </li>

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -99,16 +99,16 @@ $if og_title:
               $if key == 'loans':
                 $ edition = get_document(item['book'])
                 $ work = get_document(edition.works[0]) if (edition.get('type', {}).get('key') == '/type/work' and edition.works and edition.works[0]) else None
-                $ decorations = macros.ManageLoansButtons(item, edition) if urlbase.startswith('/account') else ''
+                $ decorations = owners_page and macros.ManageLoansButtons(item, edition) or ''
                 $:macros.SearchResultsWork(work or edition, decorations=decorations, cta=False)
               $elif key == 'waitlists':
                 $ edition = item
-                $ decorations = macros.ManageWaitlistButton(edition) if urlbase.startswith('/account') else ''
+                $ decorations = owners_page and macros.ManageWaitlistButton(edition) or ''
                 $:macros.SearchResultsWork(edition, decorations=decorations, cta=False)
               $else:
                 $ work = item
-                $ decorations = macros.ReadingLogButton(work, read_status=bookshelf_id) if bookshelf_id and urlbase.startswith('/account') else None
-                $:macros.SearchResultsWork(work, decorations=decorations)
+                $ decorations = (bookshelf_id and owners_page) and macros.ReadingLogButton(work, read_status=bookshelf_id)
+                $:macros.SearchResultsWork(work, decorations=decorations, cta=False)
           $else:
             <li>$_('No books are on this shelf')</li>
         </ul>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup of #3500 (s3 & session loans) and #3465 (public reading logs)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1. adds "Reading Log" dropdown selector back to page
2. Fixes SearchWorkResult, avoids double CTA links for availability.js to inject availability

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

tested on dev

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
