### PR TITLE
only use check availability btn if no ground truth available

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -98,7 +98,7 @@ $elif ocaid and is_lendable:
         <input type="hidden" name="action" value="join-waitinglist"/>
         <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
       </form>
-  $elif availability == 'borrow_unavailable':
+  $elif availability == 'borrow_unavailable' and not lending_st:
     $# This _used_ to mean that the book was waitlistable, but no longer! Now show this little cop-out button
     <div class="cta-button-group">
       <a href="/ia/$(ocaid)" class="cta-btn cta-btn--available" title="$_('We were unable to determine the availability of this book! Click to check on Internet Archive.')"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to #3500 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

https://openlibrary.org/books/OL26440726M/On_tyranny?debug=true (hotfixed) was showing "Check Availability" on the **books** editions page. -- this happens when a book is only browsable but is checked out.

We're only checking if borrow_unavailable from availability without checking whether we have a more accurate answer from lending_st. This hotfix is patched on prod.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Add ?debug=true to the url and it will show more borrow stats to ensure it's working correctly
