### PR TITLE
adds 1 hour borrow cta-btn

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -71,7 +71,7 @@ $elif ocaid and is_lendable:
   $if is_borrowable:
     $ label = None
     $if availability == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
-      $ label = '1 Hour Borrow'
+      $ label = _('1 Hour Borrow')
     $:macros.ReadButton(ocaid, borrow=True, listen=True, label=label)
   $elif lending_st.get('available_to_waitlist', False):
     $# lending_st is the only API which accurately tells us if a book is waitlistable

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -69,7 +69,10 @@ $elif ocaid and is_readable:
 $elif ocaid and is_lendable:
   $ borrow_link = '/ia/%s/borrow' % ocaid
   $if is_borrowable:
-    $:macros.ReadButton(ocaid, borrow=True, listen=True)
+    $ label = None
+    $if availability == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
+      $ label = '1 Hour Borrow'
+    $:macros.ReadButton(ocaid, borrow=True, listen=True, label=label)
   $elif lending_st.get('available_to_waitlist', False):
     $# lending_st is the only API which accurately tells us if a book is waitlistable
     $ wlsize = lending_st.get('users_on_waitlist') or page.get('availability', {}).get('num_waitlist')

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,9 +1,9 @@
-$def with(ocaid, borrow=False, listen=False, loan=None)
+$def with(ocaid, borrow=False, listen=False, loan=None, label='')
 
 $if (borrow and not loan):
   $ action = "borrow"
-  $ label = _("Borrow")
-  $ title = _("Borrow ebook from Internet Archive")
+  $ label = _(label or "Borrow")
+  $ title = _(label + " ebook from Internet Archive")
 $else:
   $ action = "read"
   $ label = _("Read")

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -2,8 +2,8 @@ $def with(ocaid, borrow=False, listen=False, loan=None, label='')
 
 $if (borrow and not loan):
   $ action = "borrow"
-  $ label = _(label or "Borrow")
-  $ title = _(label + " ebook from Internet Archive")
+  $ label = label or _("Borrow")
+  $ title = _("Borrow ebook from Internet Archive")
 $else:
   $ action = "read"
   $ label = _("Read")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to #3500

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

 if we know a borrow is available but...
1) metadata says borrow_unavailable (then we know it's a browse which is available) or
2) loandb says it's not a borrow
Then we should present the button explicitly as only available for "1 Hour Borrow"

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

staged on prod

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
