### PR TITLE
Make get_cached_groundtruth_availability actually cache

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -207,8 +207,9 @@ def get_random_available_ia_edition():
         logger.exception("get_random_available_ia_edition(%s)" % url)
         return None
 
-@cache.memoize(engine="memcache", expires=5*dateutil.MINUTE_SECS)
+
 @public
+@cache.memoize(engine="memcache", key="gt-availability", expires=5*dateutil.MINUTE_SECS)
 def get_cached_groundtruth_availability(ocaid):
     return get_groundtruth_availability(ocaid)
 


### PR DESCRIPTION
Fix

### Technical
- Turns out these operate in binding order, but public will still be able to get the correct `__name__` since the memoize method uses `functools.wrap`.
- Turns out key is mandatory, not optional. But don't worry it appends the args to the specified `key`

### Testing
- Tested https://dev.openlibrary.org/books/OL23260146M/Matilda?debug=true takes <1s as opposed to https://openlibrary.org/books/OL23260146M/Matilda?debug=true , which takes ~20s
- Checked https://dev.openlibrary.org/books/OL26440726M/On_tyranny?debug=true shows as checked out

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
