### PR TITLE
Closes #3479 show printdisabled books as Not In Library

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -40,17 +40,18 @@ $def render_carousel_cover(book, lazy):
     $ cta = _('Sponsor')
     $ cta_cls = 'sponsor'
   $if book.get('ia') or book.get('ocaid'):
-    $# See PR #3349 -- Hacky availability heuristic until #3180 lands  
-    $ cta_cls = 'available'
+    $# See PR #3349 -- Hacky availability heuristic until #3180 lands
     $if book.get('ocaid') or availability.get('status') == 'borrow_available' or book.get('lending_edition'):
+      $ cta_cls = 'available'
       $ modifier = 'borrow-link'
       $ cta = _('Borrow')
       $if ocaid:
         $ cta_url = '/borrow/ia/%s?ref=ol' % ocaid
       $else:
         $ cta_url = "/books/%s/x/borrow?ref=ol" % book.get('lending_edition')
-    $else:
-      $ cta_url = "//archive.org/stream/%s?ref=ol" % book.get('ia')[0]
+    $elif not availability.get('is_restricted'):
+      $ cta_cls = 'available'
+      $ cta_url = "//archive.org/stream/%s?ref=ol" % book.get('identifier')
       $ cta = _('Read')
 
   $if lazy:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3479 so carousels show the correct `Not In Library` status for printdisabled books

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

This leverages our changes to #3500 which uses collection strings in our availability to determine of items are printdisabled.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

on dev, tested

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![2020-06-17-182149_531x350_scrot](https://user-images.githubusercontent.com/978325/84966866-73713180-b0c7-11ea-9814-3e190d223a1c.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
