### PR TITLE
Lending changes, ubiquitous LoanStatus usage, sponsor btns, redirect fix

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -270,7 +270,7 @@ def get_available(limit=None, page=1, subject=None, query=None,
         for item in items:
             if item.get('openlibrary_work'):
                 results[item['openlibrary_work']] = item['openlibrary_edition']
-        books = web.ctx.site.get_many(['/books/%s' % result for result in results.values()])
+        books = add_availability(web.ctx.site.get_many(['/books/%s' % result for result in results.values()]))
         return books
     except Exception:  # TODO: Narrow exception scope
         logger.exception("get_available(%s)" % url)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (page, user, editions_page=False, block_name='', render_preview_floater=True, work_key=None)
+$def with (page, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True)
 $# Takes following parameters:
 $# * page
 $# * user
@@ -9,7 +9,7 @@ $# * render_preview_floater whether to render the HTML for the preview floater
 $ loanstatus_start_time = time()
 
 $ ocaid = page.get('ocaid') or page.availability.get('identifier')
-$ work_key = work_key or (page.works and page.works[0].key)
+$ work_key = work_key or ''
 $ user_loan = None
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
@@ -29,7 +29,7 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = page.availability.get('is_restricted', False)
 $ is_readable = page.availability.get('is_readable', False)
 
-$if ocaid and page.key.startswith('/book'):
+$if user and ocaid and page.key.startswith('/book'):
   $ current_and_available_loans = page.get_current_and_available_loans()
   $ user_loan = None
   $if ctx.user:
@@ -47,22 +47,15 @@ $if user:
             $ break
 
 $if page.key.startswith('/book') and user_loan:
-  $:macros.ReadButton(ocaid, loan=user_loan, listen=True)
+  $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">
     <input type="hidden" name="action" value="return" />
     <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--available" id="return_ebook"/>
   </form>
 
-$elif not ocaid or (is_restricted and not is_lendable):
-  <div class="cta-button-group">
-    <a href="$work_key" class="cta-btn cta-btn--missing"
-       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
-  </div>
-
-
 $elif ocaid and is_readable:
-  $:macros.ReadButton(ocaid, listen=True)
+  $:macros.ReadButton(ocaid, listen=listen)
   $if editions_page:
     $:macros.BookSearchInside(ocaid)
 
@@ -72,7 +65,7 @@ $elif ocaid and is_lendable:
     $ label = None
     $if availability == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
       $ label = _('1 Hour Borrow')
-    $:macros.ReadButton(ocaid, borrow=True, listen=True, label=label)
+    $:macros.ReadButton(ocaid, borrow=True, listen=listen, label=label)
   $elif lending_st.get('available_to_waitlist', False):
     $# lending_st is the only API which accurately tells us if a book is waitlistable
     $ wlsize = lending_st.get('users_on_waitlist') or page.get('availability', {}).get('num_waitlist')
@@ -113,21 +106,28 @@ $elif ocaid and is_lendable:
          data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
     </div>
 
-$elif page.key.startswith('/book') and not ocaid or editions_page and not is_lendable:
-  $ sponsorship = qualifies_for_sponsorship(page)
+$elif page.key.startswith('/book') and not ocaid or (editions_page or 'elibibility' in page) and not is_lendable:
+  $ sponsorship = page.get('eligibility') if 'eligibility' in page else qualifies_for_sponsorship(page)
   $if sponsorship.get('is_eligible'):
-    $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"
-       data-ol-link-track="CTAClick|Sponsor">$_('Sponsor eBook')</a>
-    <p>
-      $_("We don't have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation.", price=sponsorship['price']['total_price_display'])
-      <a href="/sponsorship" target="_blank">$_('Learn More')</a>
-    </p>
+       data-ol-link-track="CTAClick|Sponsor">$_('Sponsor')</a>
+    $if editions_page:
+      <p>
+        $_("We don't have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation.", price=sponsorship['price']['total_price_display'])
+        <a href="/sponsorship" target="_blank">$_('Learn More')</a>
+      </p>
   $else:
     <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
 
-$if ocaid:
+$elif not ocaid or (is_restricted and not is_lendable):
+  <div class="cta-button-group">
+    <a href="$work_key" class="cta-btn cta-btn--missing"
+       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+  </div>
+
+
+$if ocaid and daisy:
   $if editions_page and is_printdisabled:
     $:macros.BookPreview(ocaid, render_preview_floater)
   $:macros.daisy(page, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled, block_name=block_name)

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -50,6 +50,7 @@ def get_homepage():
     return dict(page)
 
 def get_cached_homepage():
+    return get_homepage()
     five_minutes = 5 * dateutil.MINUTE_SECS
     lang = web.ctx.get("lang", "en")
     return cache.memcache_memoize(
@@ -145,8 +146,8 @@ def readonline_carousel():
     """
     try:
         data = random_ebooks()
-        if len(data) > 60:
-            data = random.sample(data, 60)
+        if len(data) > 30:
+            data = lending.add_availability(random.sample(data, 30))
         return storify(data)
 
     except Exception:
@@ -231,12 +232,13 @@ def format_book_data(book):
     d.title = book.title or None
     d.ocaid = book.get("ocaid")
     d.eligibility = book.get("eligibility", {})
-
+    d.availability = book.get('availability', {})
     def get_authors(doc):
         return [web.storage(key=a.key, name=a.name or None) for a in doc.get_authors()]
 
     work = book.works and book.works[0]
     d.authors = get_authors(work if work else book)
+    d.work_key = book.key if book.key.startswith('/work') else work.key
     cover = work.get_cover() if work and work.get_cover() else book.get_cover()
 
     if cover:

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -175,8 +175,15 @@ def setup_jquery_urls():
     web.template.Template.globals['use_google_cdn'] = config.get('use_google_cdn', True)
 
 @public
-def get_document(key):
-    return web.ctx.site.get(key)
+def get_document(key, limit_redirs=5):
+    for i in range(limit_redirs):
+        doc = web.ctx.site.get(key)
+        if doc.type.key == "/type/redirect":
+            key = doc.location
+        else:
+            return doc
+    return doc
+
 
 class revert(delegate.mode):
     def GET(self, key):

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -7,8 +7,6 @@ $if slick_font not in ctx.links:
   $ ctx.links.append(slick_font)
 
 $def render_carousel_cover(book, lazy):
-  $ availability = book.get('availability', {})
-  $ ocaid = book.get('ocaid') or availability.get('identifier')
   $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
@@ -32,26 +30,7 @@ $def render_carousel_cover(book, lazy):
     $ author_names = ''
   $ modifier = ''
 
-  $ cta = ('Not In Library')
-  $ cta_cls = 'missing'
-  $ cta_url = url
-  $if book.get('eligibility', {}).get('is_eligible'):
-    $ cta_url = book['eligibility']['sponsor_url']
-    $ cta = _('Sponsor')
-    $ cta_cls = 'sponsor'
-  $if book.get('ia') or book.get('ocaid'):
-    $# See PR #3349 -- Hacky availability heuristic until #3180 lands  
-    $ cta_cls = 'available'
-    $if book.get('ocaid') or availability.get('status') == 'borrow_available' or book.get('lending_edition'):
-      $ modifier = 'borrow-link'
-      $ cta = _('Borrow')
-      $if ocaid:
-        $ cta_url = '/borrow/ia/%s?ref=ol' % ocaid
-      $else:
-        $ cta_url = "/books/%s/x/borrow?ref=ol" % book.get('lending_edition')
-    $else:
-      $ cta_url = "//archive.org/stream/%s?ref=ol" % book.get('ia')[0]
-      $ cta = _('Read')
+  $ work_key = book.key if book.key.startswith('/work') else book.work_key
 
   $if lazy:
     $ img_attr = 'data-lazy'
@@ -74,12 +53,12 @@ $def render_carousel_cover(book, lazy):
           </div>
       </a>
     </div>
-    $if cta:
-      <div class="book-cta"><a class="cta-btn cta-btn--$(cta_cls) $modifier" href="$cta_url" data-ol-link-track="$key" title="$cta $book.title"
-        data-key="$(key)" data-ocaid="$(book.get('ia'))">$cta</a></div>
+    <div class="book-cta">
+      $:macros.LoanStatus(book, editions_page=False, work_key=work_key, listen=False, daisy=False)
+    </div>
   </div>
 
-$if test or (books and len(books) >= min_books):
+$if test or (books and len(books) >= min_books):      
       <div class="carousel-section">
       $if title and url:
         <div class="carousel-section-header">


### PR DESCRIPTION
1. Re-orders and consolidates lending to use s3 API for everything
2. ~Carousels now use correct LoanStatus UI (js load-more is incomplete)~ #3518
3. ~Fixes sponsorship buttons by re-ordering LoanStatus (needs more testing)~ #3518
4. ~Recursively fetching the doc if a doc is a redirect (check if this fixes lists)~ #3517 (It did not fix reading log; didn't check lists)

<!-- What issue does this PR close? -->
Closes #3514 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
