### PR TITLE
Allow query carousels to optionally display non in library books

### DIFF
--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='new', key='', limit=20, search=False)
+$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True)
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
@@ -12,14 +12,19 @@ $# Enable search within this query
 $if search:
   <form action="/search" class="olform pagesearchbox">
     <input type="hidden" name="q" value="$query"/>
-    <input type="hidden" name="has_fulltext" value="true"/>
+    $if has_fulltext_only:
+      <input type="hidden" name="has_fulltext" value="true"/>
     <input type="text" placeholder="Search collection" name="q2"/>
     <input type="submit"/>
   </form>
 
-$ url = '/search?q=%s&has_fulltext=true' % urlquote(query)
-$ results = work_search({'has_fulltext': 'true', 'q': query}, sort=sort, limit=limit)
-$ books = [storage(b) for b in (results.get('docs', []))]
-$ load_more = {"url": "/search.json?q=%s&has_fulltext=true" % urlquote(query), "limit": limit}
+$code:
+  params = { 'q': query }
+  if has_fulltext_only:
+    params['has_fulltext'] = 'true'
 
-$:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more)
+  results = work_search(params, sort=sort, limit=limit)
+  books = [storage(b) for b in (results.get('docs', []))]
+  load_more = {"url": "/search.json?" + urlencode(params), "limit": limit }
+
+$:render_template("books/custom_carousel", books=books, title=title, url="/search?" + urlencode(params), key=key, load_more=load_more)


### PR DESCRIPTION
Feature: `QueryCarousel` macro now support an extra option to allow display of both fulltext and not in library books.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested locally by creating a page with:

```
{{QueryCarousel(title="foo", query="key:(/works/OL73243W OR /works/OL54120W)", has_fulltext_only=False)}}
```

On dev: https://dev.openlibrary.org/collections/tv-people-books

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@seabelis 
