### PR TITLE
Fix loans page displaying broken book due to redirect

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -175,8 +175,15 @@ def setup_jquery_urls():
     web.template.Template.globals['use_google_cdn'] = config.get('use_google_cdn', True)
 
 @public
-def get_document(key):
-    return web.ctx.site.get(key)
+def get_document(key, limit_redirs=5):
+    for i in range(limit_redirs):
+        doc = web.ctx.site.get(key)
+        if doc.type.key == "/type/redirect":
+            key = doc.location
+        else:
+            return doc
+    return doc
+
 
 class revert(delegate.mode):
     def GET(self, key):


### PR DESCRIPTION
Extracted from #3515 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Tested on dev.openlibrary.org while debugging a user's problem which was caused by such a redirect.
- Tested https://dev.openlibrary.org/account/loans still works

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
