### PR TITLE
Make carousels use LoanStatus.html

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -270,7 +270,7 @@ def get_available(limit=None, page=1, subject=None, query=None,
         for item in items:
             if item.get('openlibrary_work'):
                 results[item['openlibrary_work']] = item['openlibrary_edition']
-        books = web.ctx.site.get_many(['/books/%s' % result for result in results.values()])
+        books = add_availability(web.ctx.site.get_many(['/books/%s' % result for result in results.values()]))
         return books
     except Exception:  # TODO: Narrow exception scope
         logger.exception("get_available(%s)" % url)

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -270,7 +270,8 @@ def get_available(limit=None, page=1, subject=None, query=None,
         for item in items:
             if item.get('openlibrary_work'):
                 results[item['openlibrary_work']] = item['openlibrary_edition']
-        books = add_availability(web.ctx.site.get_many(['/books/%s' % result for result in results.values()]))
+        books = web.ctx.site.get_many(['/books/%s' % olid for olid in results.values()])
+        books = add_availability(books)
         return books
     except Exception:  # TODO: Narrow exception scope
         logger.exception("get_available(%s)" % url)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -10,26 +10,27 @@ $# * daisy whether to display daisy print-disabled link
 
 $ loanstatus_start_time = time()
 
-$ ocaid = page.get('ocaid') or page.availability.get('identifier')
+$ availability = page.availability if hasattr(page, 'availability') else {}
+$ ocaid = page.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (page.works and page.works[0].key)
 $ user_loan = None
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 $ current_and_available_loans = []
 
-$ availability = page.availability.get('status')
+$ availability_st = availability.get('status')
 
 $ lending_st = {}
-$if editions_page and (page.availability.get('is_browseable', False) or availability == 'borrow_unavailable'):
+$if editions_page and (availability.get('is_browseable', False) or availability_st == 'borrow_unavailable'):
   $ lending_st = get_cached_groundtruth_availability(ocaid)
 
-$ is_lendable = lending_st.get('is_lendable', False) or page.availability.get('is_lendable', False)
+$ is_lendable = lending_st.get('is_lendable', False) or availability.get('is_lendable', False)
 $# there could be exception where ocaid insufficient because is_restricted but not printdisabled
 $# ^ This will be resolved when Jude adds 'access-restricted-item' check
-$ is_printdisabled = lending_st.get('is_printdisabled', False) or page.availability.get('is_printdisabled', False)
-$ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('available_to_browse') or availability == 'borrow_available' or my_turn_to_borrow
-$ is_restricted = page.availability.get('is_restricted', False)
-$ is_readable = page.availability.get('is_readable', False)
+$ is_printdisabled = lending_st.get('is_printdisabled', False) or availability.get('is_printdisabled', False)
+$ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('available_to_browse') or availability_st == 'borrow_available' or my_turn_to_borrow
+$ is_restricted = availability.get('is_restricted', False)
+$ is_readable = availability.get('is_readable', False)
 
 $if user and ocaid and page.key.startswith('/book'):
   $ current_and_available_loans = page.get_current_and_available_loans()
@@ -65,12 +66,12 @@ $elif ocaid and is_lendable:
   $ borrow_link = '/borrow/ia/%s' % ocaid
   $if is_borrowable:
     $ label = None
-    $if availability == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
+    $if availability_st == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
       $ label = _('1 Hour Borrow')
     $:macros.ReadButton(ocaid, borrow=True, listen=listen, label=label)
   $elif lending_st.get('available_to_waitlist', False):
     $# lending_st is the only API which accurately tells us if a book is waitlistable
-    $ wlsize = lending_st.get('users_on_waitlist') or page.get('availability', {}).get('num_waitlist')
+    $ wlsize = lending_st.get('users_on_waitlist') or availability.get('num_waitlist')
     $if waiting_loan:
       <p class="waitinglist-message">
         $ spot = ctx.user.get_waiting_loan_for(page)['position']
@@ -96,7 +97,7 @@ $elif ocaid and is_lendable:
         <input type="hidden" name="action" value="join-waitinglist"/>
         <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
       </form>
-  $elif availability == 'borrow_unavailable' and not lending_st:
+  $elif availability_st == 'borrow_unavailable' and not lending_st:
     $# This _used_ to mean that the book was waitlistable, but no longer! Now show this little cop-out button
     <div class="cta-button-group">
       <a href="/ia/$(ocaid)" class="cta-btn cta-btn--available" title="$_('We were unable to determine the availability of this book! Click to check on Internet Archive.')"
@@ -137,4 +138,4 @@ $if ocaid and daisy:
 $if query_param('debug'):
   $ loanstatus_end_time = time() - loanstatus_start_time
   <p>LoanStatus took $("%.2f" % loanstatus_end_time) seconds</p>
-  $lending_st $page.availability
+  $lending_st $availability

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,10 +1,12 @@
-$def with (page, user, editions_page=False, block_name='', render_preview_floater=True, work_key=None)
+$def with (page, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True)
 $# Takes following parameters:
 $# * page
 $# * user
 $# * editions_page renders additional data if you're seeing LoanStatus rendered in the sidebar of an edition page v. in the work's table.
 $# * block_name is a BEM block name
 $# * render_preview_floater whether to render the HTML for the preview floater
+$# * listen whether to display listen button
+$# * daisy whether to display daisy print-disabled link
 
 $ loanstatus_start_time = time()
 
@@ -29,7 +31,7 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = page.availability.get('is_restricted', False)
 $ is_readable = page.availability.get('is_readable', False)
 
-$if ocaid and page.key.startswith('/book'):
+$if user and ocaid and page.key.startswith('/book'):
   $ current_and_available_loans = page.get_current_and_available_loans()
   $ user_loan = None
   $if ctx.user:
@@ -47,22 +49,15 @@ $if user:
             $ break
 
 $if page.key.startswith('/book') and user_loan:
-  $:macros.ReadButton(ocaid, loan=user_loan, listen=True)
+  $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">
     <input type="hidden" name="action" value="return" />
     <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--available" id="return_ebook"/>
   </form>
 
-$elif not ocaid or (is_restricted and not is_lendable):
-  <div class="cta-button-group">
-    <a href="$work_key" class="cta-btn cta-btn--missing"
-       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
-  </div>
-
-
 $elif ocaid and is_readable:
-  $:macros.ReadButton(ocaid, listen=True)
+  $:macros.ReadButton(ocaid, listen=listen)
   $if editions_page:
     $:macros.BookSearchInside(ocaid)
 
@@ -72,7 +67,7 @@ $elif ocaid and is_lendable:
     $ label = None
     $if availability == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
       $ label = _('1 Hour Borrow')
-    $:macros.ReadButton(ocaid, borrow=True, listen=True, label=label)
+    $:macros.ReadButton(ocaid, borrow=True, listen=listen, label=label)
   $elif lending_st.get('available_to_waitlist', False):
     $# lending_st is the only API which accurately tells us if a book is waitlistable
     $ wlsize = lending_st.get('users_on_waitlist') or page.get('availability', {}).get('num_waitlist')
@@ -113,21 +108,28 @@ $elif ocaid and is_lendable:
          data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
     </div>
 
-$elif page.key.startswith('/book') and not ocaid or editions_page and not is_lendable:
-  $ sponsorship = qualifies_for_sponsorship(page)
+$elif page.key.startswith('/book') and not ocaid or (editions_page or 'eligibility' in page) and not is_lendable:
+  $ sponsorship = page.get('eligibility') if 'eligibility' in page else qualifies_for_sponsorship(page)
   $if sponsorship.get('is_eligible'):
-    $ isbn = (page.isbn_13 and page.isbn_13[0] or page.isbn_10 and page.isbn_10[0])
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"
-       data-ol-link-track="CTAClick|Sponsor">$_('Sponsor eBook')</a>
-    <p>
-      $_("We don't have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation.", price=sponsorship['price']['total_price_display'])
-      <a href="/sponsorship" target="_blank">$_('Learn More')</a>
-    </p>
+       data-ol-link-track="CTAClick|Sponsor">$_('Sponsor')</a>
+    $if editions_page:
+      <p>
+        $_("We don't have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation.", price=sponsorship['price']['total_price_display'])
+        <a href="/sponsorship" target="_blank">$_('Learn More')</a>
+      </p>
   $else:
     <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
 
-$if ocaid:
+$elif not ocaid or (is_restricted and not is_lendable):
+  <div class="cta-button-group">
+    <a href="$work_key" class="cta-btn cta-btn--missing"
+       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+  </div>
+
+
+$if ocaid and daisy:
   $if editions_page and is_printdisabled:
     $:macros.BookPreview(ocaid, render_preview_floater)
   $:macros.daisy(page, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled, block_name=block_name)

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -71,11 +71,7 @@ class browse(delegate.page):
             work_id=i.work_id, _type=i._type, sorts=sorts)
         result = {
             'query': url,
-            'works': [
-                work.dict() for work in lending.add_availability(
-                    lending.get_available(url=url)
-                )
-            ]
+            'works': [work.dict() for work in lending.get_available(url=url)],
         }
         return delegate.RawText(
             simplejson.dumps(result),

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -145,8 +145,9 @@ def readonline_carousel():
     """
     try:
         data = random_ebooks()
-        if len(data) > 60:
-            data = random.sample(data, 60)
+        if len(data) > 30:
+            data = lending.add_availability(random.sample(data, 30))
+            data = [d for d in data if d['availability']['is_readable']]
         return storify(data)
 
     except Exception:
@@ -231,12 +232,14 @@ def format_book_data(book):
     d.title = book.title or None
     d.ocaid = book.get("ocaid")
     d.eligibility = book.get("eligibility", {})
+    d.availability = book.get('availability', {})
 
     def get_authors(doc):
         return [web.storage(key=a.key, name=a.name or None) for a in doc.get_authors()]
 
     work = book.works and book.works[0]
     d.authors = get_authors(work if work else book)
+    d.work_key = book.key if book.key.startswith('/work') else work.key
     cover = work.get_cover() if work and work.get_cover() else book.get_cover()
 
     if cover:

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -7,8 +7,6 @@ $if slick_font not in ctx.links:
   $ ctx.links.append(slick_font)
 
 $def render_carousel_cover(book, lazy):
-  $ availability = book.get('availability', {})
-  $ ocaid = book.get('ocaid') or availability.get('identifier')
   $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
@@ -31,27 +29,7 @@ $def render_carousel_cover(book, lazy):
     $ byline = ''
     $ author_names = ''
   $ modifier = ''
-
-  $ cta = ('Not In Library')
-  $ cta_cls = 'missing'
-  $ cta_url = url
-  $if book.get('eligibility', {}).get('is_eligible'):
-    $ cta_url = book['eligibility']['sponsor_url']
-    $ cta = _('Sponsor')
-    $ cta_cls = 'sponsor'
-  $if book.get('ia') or book.get('ocaid'):
-    $# See PR #3349 -- Hacky availability heuristic until #3180 lands  
-    $ cta_cls = 'available'
-    $if book.get('ocaid') or availability.get('status') == 'borrow_available' or book.get('lending_edition'):
-      $ modifier = 'borrow-link'
-      $ cta = _('Borrow')
-      $if ocaid:
-        $ cta_url = '/borrow/ia/%s?ref=ol' % ocaid
-      $else:
-        $ cta_url = "/books/%s/x/borrow?ref=ol" % book.get('lending_edition')
-    $else:
-      $ cta_url = "//archive.org/stream/%s?ref=ol" % book.get('ia')[0]
-      $ cta = _('Read')
+  $ work_key = book.key if book.key.startswith('/work') else book.work_key
 
   $if lazy:
     $ img_attr = 'data-lazy'
@@ -74,9 +52,9 @@ $def render_carousel_cover(book, lazy):
           </div>
       </a>
     </div>
-    $if cta:
-      <div class="book-cta"><a class="cta-btn cta-btn--$(cta_cls) $modifier" href="$cta_url" data-ol-link-track="$key" title="$cta $book.title"
-        data-key="$(key)" data-ocaid="$(book.get('ia'))">$cta</a></div>
+    <div class="book-cta">
+      $:macros.LoanStatus(book, editions_page=False, work_key=work_key, listen=False, daisy=False)
+    </div>
   </div>
 
 $if test or (books and len(books) >= min_books):

--- a/static/css/components/buttonBtn.less
+++ b/static/css/components/buttonBtn.less
@@ -13,13 +13,6 @@
     color: @white !important;
     border-radius: 5px;
   }
-  &--large {
-    padding: 7px 20px;
-    display: block;
-    font-size: 14px;
-    line-height: 1.5em;
-    width: 100%;
-  }
 }
 a {
   &.btn {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -17,7 +17,7 @@ a.cta-btn {
   cursor: pointer;
   font-family: @lucida_sans_serif-1;
   text-align: center;
-  padding: 7px 20px;
+  padding: 7px;
   white-space: nowrap;
   background-color: @mid-grey;
   line-height: 1.5em;
@@ -113,7 +113,7 @@ a.cta-btn {
 
     &:first-child {
       flex: 1;
-      padding: 8px 16px;
+      padding: 8px;
       overflow: hidden;
     }
 


### PR DESCRIPTION
- Refactor: Make carousels use LoanStatus (DRY)
- Fix: Sponsorship button not working

### Technical
- Note there is a copy of some of this in the JS which has _not_ been consolidated

### Testing
- ✅ homepage (with clean memcache) displays correct availabilities
- ✅ https://dev.openlibrary.org/collections/tv-people-books (Carousels with potentially non in library books)
- ✅ https://dev.openlibrary.org/books/OL25101686M (Sponsorship button fixed)
- ✅* https://dev.openlibrary.org/collections/read-the-movie (Showing "Not in Library" incorrectly)
- ✅* https://dev.openlibrary.org/search?q=The+COlorado+Kid+king&mode=everything (Showing "Not in library" incorrectly)
- ✅** Lists https://dev.openlibrary.org/people/mrdynamite69/lists/OL149582L/Must_Reads
- ✅** Reading log

\* Problem caused by something else; was also occurring on master
\*\* Some books incorrectly display "Waiting list (null)"; likely unrelated

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
