### PR TITLE
hotfixing carousels where work_key undefined

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -12,7 +12,7 @@ $ loanstatus_start_time = time()
 
 $ availability = page.availability if hasattr(page, 'availability') else {}
 $ ocaid = page.get('ocaid') or availability.get('identifier')
-$ work_key = work_key or (page.works and page.works[0].key)
+$ work_key = work_key or (page.get('works') and page.works[0].key)
 $ user_loan = None
 $ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -239,7 +239,7 @@ def format_book_data(book):
 
     work = book.works and book.works[0]
     d.authors = get_authors(work if work else book)
-    d.work_key = book.key if book.key.startswith('/work') else work.key
+    d.work_key = work.key if work else book.key
     cover = work.get_cover() if work and work.get_cover() else book.get_cover()
 
     if cover:

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -29,7 +29,7 @@ $def render_carousel_cover(book, lazy):
     $ byline = ''
     $ author_names = ''
   $ modifier = ''
-  $ work_key = book.key if book.key.startswith('/work') else book.work_key
+  $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
 
   $if lazy:
     $ img_attr = 'data-lazy'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes an issue w/ #3518 where for plugins/openlibrary/home.py `format_book_data` did not define work_url due to missing `work`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
tested on dev

labeling as P1 because every IA book carousel item is showing work_url errors on the book pages; staging this change on production