### PR TITLE
Fix solr-updater crashing trying to encode "edition_key:ia\:foo"

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -20,6 +20,7 @@ from openlibrary import config
 from openlibrary.catalog.utils.query import set_query_host, base_url as get_ol_base_url
 from openlibrary.core import helpers as h
 from openlibrary.core import ia
+from openlibrary.plugins.upstream.utils import url_quote
 from openlibrary.solr.data_provider import get_data_provider, DataProvider
 from openlibrary.utils.ddc import normalize_ddc
 from openlibrary.utils.isbn import opposite_isbn
@@ -1318,7 +1319,10 @@ def solr_select_work(edition_key):
 
     edition_key = solr_escape(edition_key)
 
-    url = 'http://' + get_solr() + '/solr/select?wt=json&q=edition_key:%s&rows=1&fl=key' % edition_key
+    url = 'http://%s/solr/select?wt=json&q=edition_key:%s&rows=1&fl=key' % (
+        get_solr(),
+        url_quote(edition_key)
+    )
     reply = json.load(urlopen(url))
     docs = reply['response'].get('docs', [])
     if docs:


### PR DESCRIPTION
Hotfix: Unbreak solr-updater crashing trying to encode '\'

Note this was _not_ affecting ol-home's solrupdater (for some reason). Only the ol-solr0 dev solrupdater

### Technical
- We should use requests (automatic encoding!) but didn't want to do such a large refactor right now

### Testing
✅ Ran solrupdater on dev and it stopped erroring! :)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
