### PR TITLE
ctx.user has key (not user)

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -45,7 +45,7 @@ $ current_loans = current_and_available_loans[0] if current_and_available_loans 
 
 $if user:
     $for current_loan in current_loans:
-        $if current_loan['user'] == user.key:
+        $if current_loan['user'] == ctx.user.key:
             $ user_loan = current_loan
             $ break
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
trivial fix, we were using `user` variable (which didn't seem to have a key)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 