### PR TITLE
Increase solr timeout for subject pages

### DIFF
--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -91,11 +91,11 @@ class Solr:
         if len(payload) < 500:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
-            data = urllib.request.urlopen(url, timeout=3).read()
+            data = urllib.request.urlopen(url, timeout=10).read()
         else:
             logger.info("solr request: %s ...", url)
             request = urllib.request.Request(url, payload, {"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"})
-            data = urllib.request.urlopen(request, timeout=3).read()
+            data = urllib.request.urlopen(request, timeout=10).read()
         return self._parse_solr_result(
             simplejson.loads(data),
             doc_wrapper=doc_wrapper,


### PR DESCRIPTION
Hotfix needed while testing #3489

### Technical
- Same reason we increased for worksearch; the way the timeout is handled on the python side looks like it causes performance issues for solr
- Was seeing in jump in errors from subjects pages when connected to new solr (which is a little slower). This caused the errors to go away.

### Testing
- Subjects pages still load, and don't throw `NoneType has no attribute v2`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
