### PR TITLE
Refactor LoanStatus.html

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -460,6 +460,8 @@ def _get_ia_loan(identifier, userid):
     ia_loan = ia_lending_api.get_loan(identifier, userid)
     return ia_loan and Loan.from_ia_loan(ia_loan)
 
+
+@cache.memoize(engine="memory", key="get_loans_of_user")
 def get_loans_of_user(user_key):
     """TODO: Remove inclusion of local data; should only come from IA"""
     account = OpenLibraryAccount.get(username=user_key.split('/')[-1])

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -772,8 +772,12 @@ class User(Thing):
             if book.key == loan['book'] or book.ocaid == loan['ocaid']:
                 return loan
 
-    def get_waiting_loan_for(self, book):
-        return waitinglist.get_waiting_loan_object(self.key, book.key)
+    def get_waiting_loan_for(self, ocaid):
+        """
+        :param str ocaid:
+        :rtype: dict (e.g. {position: number})
+        """
+        return waitinglist.get_waiting_loan_object(self.key, ocaid)
 
     def __repr__(self):
         return "<User: %s>" % repr(self.key)

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -24,6 +24,7 @@ from . import cache, waitinglist
 from six.moves import urllib
 
 from .ia import get_metadata_direct
+from .waitinglist import WaitingLoan
 from ..accounts import OpenLibraryAccount
 
 
@@ -347,9 +348,6 @@ class Edition(Thing):
         """
         return waitinglist.get_waitinglist_size(self.key)
 
-    def get_waitinglist_position(self, user):
-        """Returns the position of this user in the waiting list."""
-        return waitinglist.get_waitinglist_position(user.key, self.key)
 
     def get_scanning_contributor(self):
         return self.get_ia_meta_fields().get("contributor")
@@ -774,10 +772,10 @@ class User(Thing):
 
     def get_waiting_loan_for(self, ocaid):
         """
-        :param str ocaid:
+        :param str or None ocaid:
         :rtype: dict (e.g. {position: number})
         """
-        return waitinglist.get_waiting_loan_object(self.key, ocaid)
+        return ocaid and WaitingLoan.find(self.key, ocaid)
 
     def __repr__(self):
         return "<User: %s>" % repr(self.key)

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -349,9 +349,6 @@ class Edition(Thing):
         return waitinglist.get_waitinglist_size(self.key)
 
 
-    def get_scanning_contributor(self):
-        return self.get_ia_meta_fields().get("contributor")
-
     def get_loans(self):
         from ..plugins.upstream import borrow
         return borrow.get_edition_loans(self)
@@ -756,18 +753,18 @@ class User(Thing):
     def has_borrowed(self, book):
         """Returns True if this user has borrowed given book.
         """
-        loan = self.get_loan_for(book)
+        loan = self.get_loan_for(book.ocaid)
         return loan is not None
 
-    def get_loan_for(self, book):
-        """Returns the loan object for given book.
+    def get_loan_for(self, ocaid):
+        """Returns the loan object for given ocaid.
 
         Returns None if this user hasn't borrowed the given book.
         """
         from ..plugins.upstream import borrow
         loans = borrow.get_loans(self)
         for loan in loans:
-            if book.key == loan['book'] or book.ocaid == loan['ocaid']:
+            if ocaid == loan['ocaid']:
                 return loan
 
     def get_waiting_loan_for(self, ocaid):

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -214,10 +214,9 @@ def is_user_waiting_for(user_key, book_key):
     if book and book.ocaid:
         return WaitingLoan.find(user_key, book.ocaid) is not None
 
-def get_waiting_loan_object(user_key, book_key):
-    book = web.ctx.site.get(book_key)
-    if book and book.ocaid:
-        return WaitingLoan.find(user_key, book.ocaid)
+def get_waiting_loan_object(user_key, ocaid):
+    if ocaid:
+        return WaitingLoan.find(user_key, ocaid)
 
 def get_waitinglist_position(user_key, book_key):
     book = web.ctx.site.get(book_key)

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -214,17 +214,6 @@ def is_user_waiting_for(user_key, book_key):
     if book and book.ocaid:
         return WaitingLoan.find(user_key, book.ocaid) is not None
 
-def get_waiting_loan_object(user_key, ocaid):
-    if ocaid:
-        return WaitingLoan.find(user_key, ocaid)
-
-def get_waitinglist_position(user_key, book_key):
-    book = web.ctx.site.get(book_key)
-    if book and book.ocaid:
-        w = WaitingLoan.find(user_key, book.ocaid)
-        if w:
-            return w['position']
-    return -1
 
 def join_waitinglist(user_key, book_key, itemname=None):
     """Adds a user to the waiting list of given book.

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,11 +1,10 @@
-$def with (ocaid, render_floater=True)
+$def with (ocaid)
 $# :param str ocaid:
-$# :param bool render_floater: whether to render the floater's HTML
 
 <a class="cta-btn cta-btn--shell cta-btn--preview"
    data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview')</a>
 
-$if render_floater:
+$if render_once('book-preview-floater'):
   <div class="hidden">
     <div class="floater" id="bookPreview">
       <div class="book-preview">

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -2,6 +2,8 @@ $def with (ocaid)
 $# :param str ocaid:
 
 <a class="cta-btn cta-btn--shell cta-btn--preview"
+   data-iframe-src="https://archive.org/stream/$ocaid?wrapper=false"
+   data-iframe-link="https://archive.org/details/$ocaid"
    data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview')</a>
 
 $if render_once('book-preview-floater'):
@@ -14,13 +16,10 @@ $if render_once('book-preview-floater'):
              title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div class="iframe-container">
-          <iframe width="100%" height="515"
-                  data-src="https://archive.org/stream/$ocaid?wrapper=false">
-          </iframe>
+          <iframe width="100%" height="515"></iframe>
         </div>
         <p class="learn-more">
-          <a href="https://archive.org/details/$ocaid"
-             data-key="book_preview_learn_more"
+          <a data-key="book_preview_learn_more"
              data-ol-link-track="book_preview_learn_more">
             $_("See more about this book on Archive.org")
           </a>

--- a/openlibrary/macros/FulltextResults.html
+++ b/openlibrary/macros/FulltextResults.html
@@ -1,10 +1,6 @@
 $def with(query, results, page=1)
 
 $if results and results.get('hits'):
-  $ loans = ctx.user.get_loans() if ctx.user else []
-  $ waiting_loans = ctx.user.get_waitinglist() if ctx.user else []
-  $ user = {'loans': loans, 'waitlists': waiting_loans}
-
   $ hits = results['hits'].get('hits', [])
   $ num_found = results['hits'].get('total', 0)
   <div id="searchResults">
@@ -12,7 +8,7 @@ $if results and results.get('hits'):
       $for doc in hits:                
         $if doc.get('edition'):
           $ snippet = macros.FulltextSnippet(query, doc=doc)
-          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], user=user, extra=snippet)
+          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=snippet)
     </ul>
     $:macros.Pager(page, num_found)
   </div>          

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False)
+$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * user
@@ -9,6 +9,8 @@ $# * listen whether to display listen button
 $# * daisy whether to display daisy print-disabled link
 $# * allow_expensive_availability_check whether to check the groundtruth availability if can't get availability from specified fields
 $# * secondary_action whether to display the preview/search inside button
+$# * check_sponsorship whether to check if the book is eligible for sponsorship
+$# * sponsorship_help whether to show the sponsorship help text
 
 $ loanstatus_start_time = time()
 
@@ -111,13 +113,13 @@ $elif ocaid and is_lendable:
          data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
     </div>
 
-$elif doc.key.startswith('/book') and not ocaid or (editions_page or 'eligibility' in doc) and not is_lendable:
+$elif doc.key.startswith('/book') and not ocaid or (check_sponsorship or 'eligibility' in doc) and not is_lendable:
   $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc)
   $if sponsorship.get('is_eligible'):
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"
        data-ol-link-track="CTAClick|Sponsor">$_('Sponsor')</a>
-    $if editions_page:
+    $if sponsorship_help:
       <p>
         $_("We don't have this book yet. You can add it to our Lending Library with a %(price)s tax deductible donation.", price=sponsorship['price']['total_price_display'])
         <a href="/sponsorship" target="_blank">$_('Learn More')</a>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
+$def with (doc, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False, check_loan_status=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * listen whether to display listen button
@@ -7,6 +7,7 @@ $# * allow_expensive_availability_check whether to check the groundtruth availab
 $# * secondary_action whether to display the preview/search inside button
 $# * check_sponsorship whether to check if the book is eligible for sponsorship
 $# * sponsorship_help whether to show the sponsorship help text
+$# * check_loan_status whether to check the user's loan status to determine read button
 
 $ loanstatus_start_time = time()
 
@@ -14,7 +15,7 @@ $ availability = doc.availability if hasattr(doc, 'availability') else {}
 $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0].key)
 
-$ waiting_loan = ocaid and ctx.user and ctx.user.get_waiting_loan_for(ocaid)
+$ waiting_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_waiting_loan_for(ocaid)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 
 $ availability_st = availability.get('status')
@@ -31,8 +32,8 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = availability.get('is_restricted', False)
 $ is_readable = availability.get('is_readable', False)
 
-$ user_loan = ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
-$if doc.key.startswith('/book') and user_loan:
+$ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
+$if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,6 +1,6 @@
-$def with (page, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True)
+$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True)
 $# Takes following parameters:
-$# * page
+$# * doc - Can be a Work, Edition, or solr dict.
 $# * user
 $# * editions_page renders additional data if you're seeing LoanStatus rendered in the sidebar of an edition page v. in the work's table.
 $# * block_name is a BEM block name
@@ -10,11 +10,11 @@ $# * daisy whether to display daisy print-disabled link
 
 $ loanstatus_start_time = time()
 
-$ availability = page.availability if hasattr(page, 'availability') else {}
-$ ocaid = page.get('ocaid') or availability.get('identifier')
-$ work_key = work_key or (page.get('works') and page.works[0].key)
+$ availability = doc.availability if hasattr(doc, 'availability') else {}
+$ ocaid = doc.get('ocaid') or availability.get('identifier')
+$ work_key = work_key or (doc.get('works') and doc.works[0].key)
 $ user_loan = None
-$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(page)
+$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(doc)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 $ current_and_available_loans = []
 
@@ -32,8 +32,8 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = availability.get('is_restricted', False)
 $ is_readable = availability.get('is_readable', False)
 
-$if user and ocaid and page.key.startswith('/book'):
-  $ current_and_available_loans = page.get_current_and_available_loans()
+$if user and ocaid and doc.key.startswith('/book'):
+  $ current_and_available_loans = doc.get_current_and_available_loans()
   $ user_loan = None
   $if ctx.user:
     $for current_loan in current_and_available_loans[0]:
@@ -49,9 +49,9 @@ $if user:
             $ user_loan = current_loan
             $ break
 
-$if page.key.startswith('/book') and user_loan:
+$if doc.key.startswith('/book') and user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
-  $ return_url = page.url().rsplit('/', 1)[0] + '/do_return/borrow'
+  $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
   <form action="$return_url" method="post" class="waitinglist-form return-book">
     <input type="hidden" name="action" value="return" />
     <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--available" id="return_ebook"/>
@@ -74,7 +74,7 @@ $elif ocaid and is_lendable:
     $ wlsize = lending_st.get('users_on_waitlist') or availability.get('num_waitlist')
     $if waiting_loan:
       <p class="waitinglist-message">
-        $ spot = ctx.user.get_waiting_loan_for(page)['position']
+        $ spot = ctx.user.get_waiting_loan_for(doc)['position']
         $if spot == 1:
           $:_('You are <strong>next</strong> on the waiting list')
         $else:
@@ -109,8 +109,8 @@ $elif ocaid and is_lendable:
          data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
     </div>
 
-$elif page.key.startswith('/book') and not ocaid or (editions_page or 'eligibility' in page) and not is_lendable:
-  $ sponsorship = page.get('eligibility') if 'eligibility' in page else qualifies_for_sponsorship(page)
+$elif doc.key.startswith('/book') and not ocaid or (editions_page or 'eligibility' in doc) and not is_lendable:
+  $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc)
   $if sponsorship.get('is_eligible'):
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor"
@@ -133,7 +133,7 @@ $elif not ocaid or (is_restricted and not is_lendable):
 $if ocaid and daisy:
   $if editions_page and is_printdisabled:
     $:macros.BookPreview(ocaid, render_preview_floater)
-  $:macros.daisy(page, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled, block_name=block_name)
+  $:macros.daisy(doc, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled, block_name=block_name)
 
 $if query_param('debug'):
   $ loanstatus_end_time = time() - loanstatus_start_time

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -32,14 +32,13 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = availability.get('is_restricted', False)
 $ is_readable = availability.get('is_readable', False)
 
-$if ctx.user and ocaid and doc.key.startswith('/book'):
+$if ctx.user and ocaid and hasattr(doc, 'get_current_and_available_loans'):
   $ current_and_available_loans = doc.get_current_and_available_loans()
   $ user_loan = None
-  $if ctx.user:
-    $for current_loan in current_and_available_loans[0]:
-      $if current_loan['user'] == ctx.user.key:
-        $ user_loan = current_loan
-        $ break
+  $for current_loan in current_and_available_loans[0]:
+    $if current_loan['user'] == ctx.user.key:
+      $ user_loan = current_loan
+      $ break
 
 $ current_loans = current_and_available_loans[0] if current_and_available_loans else []
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False)
+$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * user
@@ -8,6 +8,7 @@ $# * render_preview_floater whether to render the HTML for the preview floater
 $# * listen whether to display listen button
 $# * daisy whether to display daisy print-disabled link
 $# * allow_expensive_availability_check whether to check the groundtruth availability if can't get availability from specified fields
+$# * secondary_action whether to display the preview/search inside button
 
 $ loanstatus_start_time = time()
 
@@ -60,7 +61,7 @@ $if doc.key.startswith('/book') and user_loan:
 
 $elif ocaid and is_readable:
   $:macros.ReadButton(ocaid, listen=listen)
-  $if editions_page:
+  $if secondary_action:
     $:macros.BookSearchInside(ocaid)
 
 $elif ocaid and is_lendable:
@@ -132,7 +133,7 @@ $elif not ocaid or (is_restricted and not is_lendable):
 
 
 $if ocaid and daisy:
-  $if editions_page and is_printdisabled:
+  $if secondary_action and is_printdisabled:
     $:macros.BookPreview(ocaid, render_preview_floater)
   $:macros.daisy(doc, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled, block_name=block_name)
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -135,7 +135,7 @@ $elif not ocaid or (is_restricted and not is_lendable):
 $if ocaid and daisy:
   $if secondary_action and is_printdisabled:
     $:macros.BookPreview(ocaid, render_preview_floater)
-  $:macros.daisy(doc, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled)
+  $:macros.daisy('/ia/%s/daisy' % ocaid, protected=is_printdisabled)
 
 $if query_param('debug'):
   $ loanstatus_end_time = time() - loanstatus_start_time

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -13,10 +13,9 @@ $ loanstatus_start_time = time()
 $ availability = doc.availability if hasattr(doc, 'availability') else {}
 $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0].key)
-$ user_loan = None
-$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(ocaid)
+
+$ waiting_loan = ocaid and ctx.user and ctx.user.get_waiting_loan_for(ocaid)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
-$ current_and_available_loans = []
 
 $ availability_st = availability.get('status')
 
@@ -32,21 +31,7 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = availability.get('is_restricted', False)
 $ is_readable = availability.get('is_readable', False)
 
-$if ctx.user and ocaid and hasattr(doc, 'get_current_and_available_loans'):
-  $ current_and_available_loans = doc.get_current_and_available_loans()
-  $ user_loan = None
-  $for current_loan in current_and_available_loans[0]:
-    $if current_loan['user'] == ctx.user.key:
-      $ user_loan = current_loan
-      $ break
-
-$ current_loans = current_and_available_loans[0] if current_and_available_loans else []
-
-$for current_loan in current_loans:
-    $if current_loan['user'] == ctx.user.key:
-        $ user_loan = current_loan
-        $ break
-
+$ user_loan = ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
 $if doc.key.startswith('/book') and user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,8 +1,7 @@
-$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
+$def with (doc, user=None, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * user
-$# * editions_page renders additional data if you're seeing LoanStatus rendered in the sidebar of an edition page v. in the work's table.
 $# * block_name is a BEM block name
 $# * render_preview_floater whether to render the HTML for the preview floater
 $# * listen whether to display listen button

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,8 +1,7 @@
-$def with (doc, user=None, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
+$def with (doc, user=None, render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * user
-$# * block_name is a BEM block name
 $# * render_preview_floater whether to render the HTML for the preview floater
 $# * listen whether to display listen button
 $# * daisy whether to display daisy print-disabled link
@@ -136,7 +135,7 @@ $elif not ocaid or (is_restricted and not is_lendable):
 $if ocaid and daisy:
   $if secondary_action and is_printdisabled:
     $:macros.BookPreview(ocaid, render_preview_floater)
-  $:macros.daisy(doc, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled, block_name=block_name)
+  $:macros.daisy(doc, url='/ia/%s/daisy' % ocaid, protected=is_printdisabled)
 
 $if query_param('debug'):
   $ loanstatus_end_time = time() - loanstatus_start_time

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -14,7 +14,7 @@ $ availability = doc.availability if hasattr(doc, 'availability') else {}
 $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0].key)
 $ user_loan = None
-$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(doc)
+$ waiting_loan = ctx.user and ctx.user.get_waiting_loan_for(ocaid)
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 $ current_and_available_loans = []
 
@@ -83,7 +83,7 @@ $elif ocaid and is_lendable:
     $ wlsize = lending_st.get('users_on_waitlist') or availability.get('num_waitlist')
     $if waiting_loan:
       <p class="waitinglist-message">
-        $ spot = ctx.user.get_waiting_loan_for(doc)['position']
+        $ spot = waiting_loan['position']
         $if spot == 1:
           $:_('You are <strong>next</strong> on the waiting list')
         $else:

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -55,6 +55,17 @@ $if doc.key.startswith('/book') and user_loan:
     <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--available" id="return_ebook"/>
   </form>
 
+  $if render_once('LoanStatus:return-book-js'):
+    <script type="text/javascript">
+      window.q.push(function() {
+        \$('.return-book').submit(function(event) {
+          if (!confirm("$_('Really return this book?')")) {
+            event.preventDefault();
+          }
+        });
+      });
+    </script>
+
 $elif ocaid and is_readable:
   $:macros.ReadButton(ocaid, listen=listen)
   $if secondary_action:

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,7 +1,6 @@
-$def with (doc, user=None, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
+$def with (doc, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
-$# * user
 $# * listen whether to display listen button
 $# * daisy whether to display daisy print-disabled link
 $# * allow_expensive_availability_check whether to check the groundtruth availability if can't get availability from specified fields
@@ -33,7 +32,7 @@ $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('avail
 $ is_restricted = availability.get('is_restricted', False)
 $ is_readable = availability.get('is_readable', False)
 
-$if user and ocaid and doc.key.startswith('/book'):
+$if ctx.user and ocaid and doc.key.startswith('/book'):
   $ current_and_available_loans = doc.get_current_and_available_loans()
   $ user_loan = None
   $if ctx.user:
@@ -44,11 +43,10 @@ $if user and ocaid and doc.key.startswith('/book'):
 
 $ current_loans = current_and_available_loans[0] if current_and_available_loans else []
 
-$if user:
-    $for current_loan in current_loans:
-        $if current_loan['user'] == ctx.user.key:
-            $ user_loan = current_loan
-            $ break
+$for current_loan in current_loans:
+    $if current_loan['user'] == ctx.user.key:
+        $ user_loan = current_loan
+        $ break
 
 $if doc.key.startswith('/book') and user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -30,7 +30,7 @@ $# ^ This will be resolved when Jude adds 'access-restricted-item' check
 $ is_printdisabled = lending_st.get('is_printdisabled', False) or availability.get('is_printdisabled', False)
 $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('available_to_browse') or availability_st == 'borrow_available' or my_turn_to_borrow
 $ is_restricted = availability.get('is_restricted', False)
-$ is_readable = availability.get('is_readable', False)
+$ is_readable = ocaid and availability.get('is_readable', False)
 $ borrow_link = '/borrow/ia/%s' % ocaid
 
 $ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,8 +1,7 @@
-$def with (doc, user=None, render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
+$def with (doc, user=None, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * user
-$# * render_preview_floater whether to render the HTML for the preview floater
 $# * listen whether to display listen button
 $# * daisy whether to display daisy print-disabled link
 $# * allow_expensive_availability_check whether to check the groundtruth availability if can't get availability from specified fields
@@ -134,7 +133,7 @@ $elif not ocaid or (is_restricted and not is_lendable):
 
 $if ocaid and daisy:
   $if secondary_action and is_printdisabled:
-    $:macros.BookPreview(ocaid, render_preview_floater)
+    $:macros.BookPreview(ocaid)
   $:macros.daisy('/ia/%s/daisy' % ocaid, protected=is_printdisabled)
 
 $if query_param('debug'):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True)
+$def with (doc, user=None, editions_page=False, block_name='', render_preview_floater=True, work_key=None, listen=True, daisy=True, allow_expensive_availability_check=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * user
@@ -7,6 +7,7 @@ $# * block_name is a BEM block name
 $# * render_preview_floater whether to render the HTML for the preview floater
 $# * listen whether to display listen button
 $# * daisy whether to display daisy print-disabled link
+$# * allow_expensive_availability_check whether to check the groundtruth availability if can't get availability from specified fields
 
 $ loanstatus_start_time = time()
 
@@ -21,7 +22,7 @@ $ current_and_available_loans = []
 $ availability_st = availability.get('status')
 
 $ lending_st = {}
-$if editions_page and (availability.get('is_browseable', False) or availability_st == 'borrow_unavailable'):
+$if allow_expensive_availability_check and (availability.get('is_browseable', False) or availability_st == 'borrow_unavailable'):
   $ lending_st = get_cached_groundtruth_availability(ocaid)
 
 $ is_lendable = lending_st.get('is_lendable', False) or availability.get('is_lendable', False)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -31,6 +31,7 @@ $ is_printdisabled = lending_st.get('is_printdisabled', False) or availability.g
 $ is_borrowable = lending_st.get('available_to_borrow') or lending_st.get('available_to_browse') or availability_st == 'borrow_available' or my_turn_to_borrow
 $ is_restricted = availability.get('is_restricted', False)
 $ is_readable = availability.get('is_readable', False)
+$ borrow_link = '/borrow/ia/%s' % ocaid
 
 $ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
 $if user_loan:
@@ -52,59 +53,60 @@ $if user_loan:
       });
     </script>
 
-$elif ocaid and is_readable:
+$elif is_readable:
   $:macros.ReadButton(ocaid, listen=listen)
   $if secondary_action:
     $:macros.BookSearchInside(ocaid)
 
-$elif ocaid and is_lendable:
-  $ borrow_link = '/borrow/ia/%s' % ocaid
-  $if is_borrowable:
-    $ label = None
-    $if availability_st == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
+$elif is_lendable and is_borrowable:
+  $ label = None
+  $if availability_st == 'borrow_unavailable' or lending_st and not lending_st.get('available_to_borrow'):
       $ label = _('1 Hour Borrow')
-    $:macros.ReadButton(ocaid, borrow=True, listen=listen, label=label)
-  $elif lending_st.get('available_to_waitlist', False):
-    $# lending_st is the only API which accurately tells us if a book is waitlistable
-    $ wlsize = lending_st.get('users_on_waitlist') or availability.get('num_waitlist')
-    $if waiting_loan:
-      <p class="waitinglist-message">
-        $ spot = waiting_loan['position']
-        $if spot == 1:
-          $:_('You are <strong>next</strong> on the waiting list')
-        $else:
-          $:_('You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list.', spot=spot, wlsize=wlsize)
-      </p>
-      <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
-        <input type="hidden" name="action" value="leave-waitinglist"/>
-        <input type="submit" class="cta-btn" id="unwaitlist_ebook"
-               value="$_('Leave waiting list')"/>
-      </form>
-    $else:
-      $# "JOIN-WAITLIST" button
-      <p class="waitinglist-message">
-        $if wlsize:
-          $_("Readers waiting for this title: %(count)d", count=wlsize)
-        $else:
-          $_("You'll be next in line.")
-      </p>
-      <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
-        <input type="hidden" name="action" value="join-waitinglist"/>
-        <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
-      </form>
-  $elif availability_st == 'borrow_unavailable' and not lending_st:
-    $# This _used_ to mean that the book was waitlistable, but no longer! Now show this little cop-out button
-    <div class="cta-button-group">
-      <a href="/ia/$(ocaid)" class="cta-btn cta-btn--available" title="$_('We were unable to determine the availability of this book! Click to check on Internet Archive.')"
-         data-ol-link-track="CTAClick|CheckAvailability">$_('Check Availability')</a>
-    </div>
-  $else:
-    <div class="cta-button-group">
-      <a href="$work_key" class="cta-btn cta-btn--missing" title="$_('This book is currently checked out, please check back later.')"
-         data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
-    </div>
+  $:macros.ReadButton(ocaid, borrow=True, listen=listen, label=label)
 
-$elif doc.key.startswith('/book') and not ocaid or (check_sponsorship or 'eligibility' in doc) and not is_lendable:
+$elif is_lendable and lending_st.get('available_to_waitlist', False):
+  $# lending_st is the only API which accurately tells us if a book is waitlistable
+  $ wlsize = lending_st.get('users_on_waitlist') or availability.get('num_waitlist')
+  $if waiting_loan:
+    <p class="waitinglist-message">
+      $ spot = waiting_loan['position']
+      $if spot == 1:
+        $:_('You are <strong>next</strong> on the waiting list')
+      $else:
+        $:_('You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list.', spot=spot, wlsize=wlsize)
+    </p>
+    <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
+      <input type="hidden" name="action" value="leave-waitinglist"/>
+      <input type="submit" class="cta-btn" id="unwaitlist_ebook"
+             value="$_('Leave waiting list')"/>
+    </form>
+  $else:
+    $# "JOIN-WAITLIST" button
+    <p class="waitinglist-message">
+      $if wlsize:
+        $_("Readers waiting for this title: %(count)d", count=wlsize)
+      $else:
+        $_("You'll be next in line.")
+    </p>
+    <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
+      <input type="hidden" name="action" value="join-waitinglist"/>
+      <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
+    </form>
+
+$elif is_lendable and availability_st == 'borrow_unavailable' and not lending_st:
+  $# This _used_ to mean that the book was waitlistable, but no longer! Now show this little cop-out button
+  <div class="cta-button-group">
+    <a href="/ia/$ocaid" class="cta-btn cta-btn--available" title="$_('We were unable to determine the availability of this book! Click to check on Internet Archive.')"
+       data-ol-link-track="CTAClick|CheckAvailability">$_('Check Availability')</a>
+  </div>
+
+$elif is_lendable:
+  <div class="cta-button-group">
+    <a href="$work_key" class="cta-btn cta-btn--missing" title="$_('This book is currently checked out, please check back later.')"
+       data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
+  </div>
+
+$elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not is_lendable):
   $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc)
   $if sponsorship.get('is_eligible'):
     <a href="$(sponsorship['sponsor_url'])"
@@ -124,10 +126,10 @@ $elif not ocaid or (is_restricted and not is_lendable):
        data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
   </div>
 
+$if ocaid and secondary_action and is_printdisabled:
+  $:macros.BookPreview(ocaid)
 
 $if ocaid and daisy:
-  $if secondary_action and is_printdisabled:
-    $:macros.BookPreview(ocaid)
   $:macros.daisy('/ia/%s/daisy' % ocaid, protected=is_printdisabled)
 
 $if query_param('debug'):

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, user=None, extra=None)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None)
 
 $ is_work = doc.get('type', {}).get('key') == '/type/work'
 $ book_url = doc.url() if is_work else doc.key
@@ -57,7 +57,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
       <div class="searchResultItemCTA-lending">
         $if cta:
           $ doc['availability'] = doc.get('availability', {})
-          $:macros.LoanStatus(doc, user, work_key=doc.key)
+          $:macros.LoanStatus(doc, work_key=doc.key)
       </div>
   </div>
 </li>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -57,7 +57,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
       <div class="searchResultItemCTA-lending">
         $if cta:
           $ doc['availability'] = doc.get('availability', {})
-          $:macros.LoanStatus(doc, user, editions_page=False, work_key=doc.key)
+          $:macros.LoanStatus(doc, user, work_key=doc.key)
       </div>
   </div>
 </li>

--- a/openlibrary/macros/daisy.html
+++ b/openlibrary/macros/daisy.html
@@ -1,17 +1,11 @@
-$def with(page, url='', msg='', protected=False, block_name=None)
+$def with(page, url='', msg='', protected=False)
 $# Takes following parameters:
 $# * page
 $# * url (in case page doesn't have one)
 $# * msg (in case default doesn't match context)
 $# * protected (is daisy encrypted or not)
-$# * block_name is a BEM block name
 
 $ msg = msg or _("Download for print-disabled")
-
-$if block_name:
-  $ prefix = block_name + '__'
-$else:
-  $ prefix = ''
 
 <div class="cta-section print-disabled-download">
   <a href="$(url or page.url('/daisy'))" title="Encrypted daisy download for authorized print-disabled patrons">

--- a/openlibrary/macros/daisy.html
+++ b/openlibrary/macros/daisy.html
@@ -1,17 +1,13 @@
-$def with(page, url='', msg='', protected=False)
-$# Takes following parameters:
-$# * page
-$# * url (in case page doesn't have one)
+$def with(url, msg='', protected=False)
+$# * url (daisy link)
 $# * msg (in case default doesn't match context)
 $# * protected (is daisy encrypted or not)
 
-$ msg = msg or _("Download for print-disabled")
-
 <div class="cta-section print-disabled-download">
-  <a href="$(url or page.url('/daisy'))" title="Encrypted daisy download for authorized print-disabled patrons">
+  <a href="$(url or page.url('/daisy'))" title="$_('Encrypted daisy download for authorized print-disabled patrons')">
     $if protected:
-      <img src="/images/icons/icon-encrypto-sm.png" class="daisy-lock" width="8" height="12" alt="Encrypted daisy lock"/>
+      <img src="/images/icons/icon-encrypto-sm.png" class="daisy-lock" width="8" height="12" alt="$_('Encrypted daisy lock')"/>
     <meta itemprop="bookFormat" content="EBook/DAISY3"/>
-    $msg
+    $(msg or _("Download for print-disabled"))
   </a>
 </div>

--- a/openlibrary/macros/daisy.html
+++ b/openlibrary/macros/daisy.html
@@ -1,6 +1,5 @@
-$def with(url, msg='', protected=False)
+$def with(url, protected=False)
 $# * url (daisy link)
-$# * msg (in case default doesn't match context)
 $# * protected (is daisy encrypted or not)
 
 <div class="cta-section print-disabled-download">
@@ -8,6 +7,6 @@ $# * protected (is daisy encrypted or not)
     $if protected:
       <img src="/images/icons/icon-encrypto-sm.png" class="daisy-lock" width="8" height="12" alt="$_('Encrypted daisy lock')"/>
     <meta itemprop="bookFormat" content="EBook/DAISY3"/>
-    $(msg or _("Download for print-disabled"))
+    $_("Download for print-disabled")
   </a>
 </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -39,18 +39,6 @@ $if isbn_10 and not asin:
       <div class="btn-notice read-options" id="read-options">
         $:macros.LoanStatus(page, allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
 
-        $# Added here instead of LoanStatus to avoid the js being bound to every item
-        $# in a work's edition listing
-        <script type="text/javascript">
-          window.q.push(function() {
-            \$('.return-book').submit(function(event) {
-              if (!confirm("$_('Really return this book?')")) {
-                event.preventDefault();
-              }
-            });
-          });
-        </script>
-
         $if page.get('ocaid') and not page.is_access_restricted() and page.ia_metadata:
             $:macros.DownloadOptions(page)
 

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel")
+        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel", allow_expensive_availability_check=editions_page)
 
         $# Added here instead of LoanStatus to avoid the js being bound to every item
         $# in a work's edition listing

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, ctx.user, block_name="read-options-panel", allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
+        $:macros.LoanStatus(page, ctx.user, allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
 
         $# Added here instead of LoanStatus to avoid the js being bound to every item
         $# in a work's edition listing

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, ctx.user, allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
+        $:macros.LoanStatus(page, allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
 
         $# Added here instead of LoanStatus to avoid the js being bound to every item
         $# in a work's edition listing

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
+        $:macros.LoanStatus(page, allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page)
 
         $if page.get('ocaid') and not page.is_access_restricted() and page.ia_metadata:
             $:macros.DownloadOptions(page)

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel", allow_expensive_availability_check=editions_page)
+        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel", allow_expensive_availability_check=editions_page, secondary_action=editions_page)
 
         $# Added here instead of LoanStatus to avoid the js being bound to every item
         $# in a work's edition listing

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel", allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
+        $:macros.LoanStatus(page, ctx.user, block_name="read-options-panel", allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
 
         $# Added here instead of LoanStatus to avoid the js being bound to every item
         $# in a work's edition listing

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -37,7 +37,7 @@ $if isbn_10 and not asin:
 
     <div class="panel">
       <div class="btn-notice read-options" id="read-options">
-        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel", allow_expensive_availability_check=editions_page, secondary_action=editions_page)
+        $:macros.LoanStatus(page, ctx.user, editions_page=editions_page, block_name="read-options-panel", allow_expensive_availability_check=editions_page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page)
 
         $# Added here instead of LoanStatus to avoid the js being bound to every item
         $# in a work's edition listing

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -72,9 +72,4 @@ export function initEditionsTable() {
             bAutoWidth: false
         });
     }
-    $('.return-book').submit(function(event) {
-        if (!confirm('Really return this book?')) {
-            event.preventDefault();
-        }
-    });
 }

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -392,18 +392,25 @@ export function initBorrowAndReadLinks() {
 
 export function initPreviewButton() {
     // Colorbox modal + iframe for Book Preview Button
-    $('.cta-btn--preview').colorbox({
-        width: '100%',
-        maxWidth: '640px',
-        inline: true,
-        opacity: '0.5',
-        href: '#bookPreview',
-        onOpen() {
-            const $iframe = $('#bookPreview iframe');
-            $iframe.prop('src', $iframe.data('src'));
-        },
-        onCleanup() {
-            $('#bookPreview iframe').prop('src', '');
-        },
+    const $buttons = $('.cta-btn--preview');
+    $buttons.each((i, button) => {
+        const $button = $(button);
+        $button.colorbox({
+            width: '100%',
+            maxWidth: '640px',
+            inline: true,
+            opacity: '0.5',
+            href: '#bookPreview',
+            onOpen() {
+                const $iframe = $('#bookPreview iframe');
+                $iframe.prop('src', $button.data('iframe-src'));
+
+                const $link = $('#bookPreview .learn-more a');
+                $link[0].href = $button.data('iframe-link');
+            },
+            onCleanup() {
+                $('#bookPreview iframe').prop('src', '');
+            },
+        });
     });
 }

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -748,7 +748,7 @@ def is_users_turn_to_borrow(user, edition):
     """If this user is waiting on this edition, it can only borrowed if
     user is the user is the first in the waiting list.
     """
-    waiting_loan = user.get_waiting_loan_for(edition)
+    waiting_loan = user.get_waiting_loan_for(edition.ocaid)
     return (waiting_loan and waiting_loan['status'] == 'available'
             and waiting_loan['position'] == 1)
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -744,6 +744,16 @@ class Request:
         return ("https://" + url) if url else ''
 
 
+@public
+def render_once(key):
+    rendered = web.ctx.setdefault('render_once', {})
+    if key in rendered:
+        return False
+    else:
+        rendered[key] = True
+        return True
+
+
 def setup():
     """Do required initialization"""
     # monkey-patch get_markdown to use OL Flavored Markdown

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -53,7 +53,7 @@ $def render_carousel_cover(book, lazy):
       </a>
     </div>
     <div class="book-cta">
-      $:macros.LoanStatus(book, editions_page=False, work_key=work_key, listen=False, daisy=False)
+      $:macros.LoanStatus(book, work_key=work_key, listen=False, daisy=False)
     </div>
   </div>
 

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -74,18 +74,15 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
       <div class="links">
         $if active:
           <ul class="read">
-            $if availability.get('status') == 'open':
-              <li class="read-option">$:macros.ReadButton(book.ocaid, listen=True)</li>
-
-            $elif availability.get('status') in ['borrow_available', 'borrow_unavailable']:
-              <li class="read-option">$:macros.LoanStatus(book)</li>
+            $if availability.get('status') in ['open', 'borrow_available', 'borrow_unavailable']:
+              <li class="read-option">$:macros.LoanStatus(book, check_loan_status=True)</li>
 
             $if availability.get('status') == 'open':
               $:macros.DownloadOptions(book)
           </ul>
         $else:
           <form>
-            <input type="submit" class="cta-btn cta-btn--missing" 
+            <input type="submit" class="cta-btn cta-btn--missing"
                    data-ol-link-track="CTAClick|NotInLibrary" disabled value="$_('Not in Library')">
           </form>
           $if book.ocaid:

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -78,7 +78,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
               <li class="read-option">$:macros.ReadButton(book.ocaid, listen=True)</li>
 
             $elif availability.get('status') in ['borrow_available', 'borrow_unavailable']:
-              <li class="read-option">$:macros.LoanStatus(book, ctx.user)</li>
+              <li class="read-option">$:macros.LoanStatus(book)</li>
 
             $if availability.get('status') == 'open':
               $:macros.DownloadOptions(book)

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -89,7 +89,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
                    data-ol-link-track="CTAClick|NotInLibrary" disabled value="$_('Not in Library')">
           </form>
           $if book.ocaid:
-            $:macros.daisy(book, protected=True)
+            $:macros.daisy(book.url('/daisy'), protected=True)
       </div>
     </td>
 

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -72,21 +72,12 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
     <td class="icon read $('inact' if not active else '')">
       <div class="$(availability_class)"></div>
       <div class="links">
-        $if active:
-          <ul class="read">
-            $if availability.get('status') in ['open', 'borrow_available', 'borrow_unavailable']:
-              <li class="read-option">$:macros.LoanStatus(book, check_loan_status=True)</li>
+        <ul class="read">
+          <li class="read-option">$:macros.LoanStatus(book, check_loan_status=True)</li>
 
-            $if availability.get('status') == 'open':
-              $:macros.DownloadOptions(book)
-          </ul>
-        $else:
-          <form>
-            <input type="submit" class="cta-btn cta-btn--missing"
-                   data-ol-link-track="CTAClick|NotInLibrary" disabled value="$_('Not in Library')">
-          </form>
-          $if book.ocaid:
-            $:macros.daisy(book.url('/daisy'), protected=True)
+          $if availability.get('status') == 'open':
+            $:macros.DownloadOptions(book)
+        </ul>
       </div>
     </td>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False)
+              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False, allow_expensive_availability_check=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False, allow_expensive_availability_check=True)
+              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False, allow_expensive_availability_check=True, secondary_action=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False, allow_expensive_availability_check=True, secondary_action=True)
+              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
+              $:macros.LoanStatus(page, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, render_preview_floater=False, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
+              $:macros.LoanStatus(page, ctx.user, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
+              $:macros.LoanStatus(page, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True, check_loan_status=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                     $:render_template('covers/change', page, ".edition-cover .bookCover img")
             </div>
             <div class="mobile-borrow-cta">
-              $:macros.LoanStatus(page, ctx.user, editions_page=True, render_preview_floater=False, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
+              $:macros.LoanStatus(page, ctx.user, render_preview_floater=False, allow_expensive_availability_check=True, secondary_action=True, check_sponsorship=True, sponsorship_help=True)
             </div>
             $# pages like /books/ia:foo00bar are fake records created from metadata API.
             $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -33,9 +33,6 @@ $ book_keys = []
     </tbody>
 </table>
 
-$# Added here instead of LoanStatus to avoid the js being bound to every item
-$# in a work's edition listing
-
 <!-- Admin only text doesn't need to be translated -->
 $if ctx.user and ctx.user.is_admin():
     <div class="clearfix"></div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -215,17 +215,13 @@ $ )
           <ul class="list-books" id="siteSearch">
             $ works = add_availability([get_doc(d) for d in docs])
 
-            $ loans = ctx.user.get_loans() if ctx.user else []
-            $ waiting_loans = ctx.user.get_waitinglist() if ctx.user else []
-            $ user = {'loans': loans, 'waitlists': waiting_loans}
-
             $for work in works:
                 $ ocaid = work.ia[0] if work.ia else None
                 $ availability = work.get('availability', {}).get('status')
                 $# if we're explicitly showing *everything*...
                 $# or if we're showing only things with ocaids which are available...
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):
-                    $:macros.SearchResultsWork(work, user=user)
+                    $:macros.SearchResultsWork(work)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>


### PR DESCRIPTION
Refactor. Make the template dumber (i.e. take simpler parameters, make fewer deductions).

### Technical
- Replace `editions_page` parameter with a few booleans for specifically what they enabled/disabled
- Removed `user` parameter entirely; it wasn't really used? Testing needed.

### Testing
- ✅ Tested enabling `secondary_action` on search page, all preview buttons work correctly
- [x] Dev: Tested books show Read/Return when borrowed from editions page
- [x] Dev: Tested books show Read/Return when borrowed from works page
- [x] Dev: Tested books show Read/Return when borrowed from loans page
- [x] Dev: Tested books show Read when borrowed from search inside page

### Screenshot
No UI changes

### Stakeholders
@mekarpeles 
