### PR TITLE
Anmelden (Login) / Registrieren (Signup)

### DIFF
--- a/openlibrary/i18n/de/messages.po
+++ b/openlibrary/i18n/de/messages.po
@@ -405,7 +405,7 @@ msgstr ""
 
 #: create.html:6 create.html:92 nav_head.html:106 search_head.html:74
 msgid "Sign Up"
-msgstr "Anmelden"
+msgstr "Registrieren"
 
 #: create.html:8
 msgid "Complete the form below to create a new Internet Archive account."
@@ -2324,4 +2324,3 @@ msgid ""
 "target=\"_blank\" title=\"This link to Creative Commons will open in a "
 "new window\">CC0</a>. Yippee!"
 msgstr ""
-


### PR DESCRIPTION
On the German front page, there are two buttons named Anmelden. One for login, the other for registration. I changed the one to Registireren (register) which would be the better translation and is also used anywhere else.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
