### PR TITLE
Make lists widget standalone

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -340,11 +340,11 @@ export function initReadingListFeature() {
 
     // Close any open dropdown list if the user clicks outside...
     $(document).on('click', function() {
-        closeDropdown($('#widget-add'));
+        closeDropdown($('.widget-add'));
     });
 
     // ... but don't let that happen if user is clicking inside dropdown
-    $(document).on('click', '#widget-add', function(e) {
+    $(document).on('click', '.widget-add', function(e) {
         e.stopPropagation();
     });
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -7,9 +7,10 @@ $ edition_key = edition.key if edition else None
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ users_work_read_status = read_status or work.get_users_read_status(username) if work and username else None
 $ users_work_rating = rating or work.get_users_rating(username) if work and username else None
-$ uid = 'widget-lists-wrapper-%s' % str(random.random())
+$ uid = str(random.randint(1000, 9999))
+$ container_id = 'widget-lists-wrapper-%s' % str(uid)
 
-<div id="$uid">
+<div id="$container_id">
 $if "lists" not in ctx.features:
     $return
 
@@ -72,7 +73,7 @@ $ page_url = page.url()
 
 $var page_lists = page_lists
 
-$jsdef show_list(list):
+$jsdef show_list(list, user_key, get_user_list_index):
     $ remove = (list.owner.key == user_key)
     <li>
         <span class="image">
@@ -84,7 +85,7 @@ $jsdef show_list(list):
                 <a href="$list.key" title="$_('See this list')">$list.name</a>
                 $if remove:
                     $ index = get_user_list_index(list)
-                    <a href="$list.key" class="remove-from-list red smaller arial plain" id="list_$index" title="$_('Remove from your list?')">[X]</a>
+                    <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-index="$index" title="$_('Remove from your list?')">[X]</a>
             </span>
             $if remove:
                 <span class="owner">from <a href="$list.owner.key">$_('You')</a></span>
@@ -176,7 +177,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                   <div class="my-lists">
                     $for i, list in enumerate(lists):
                       $if not list.active:
-                        <p class="list"><a href="$list.key" class="add-to-list" id="list_$i">$list.name</a></p>
+                        <p class="list"><a href="$list.key" class="add-to-list" data-list-index="$i">$list.name</a></p>
                   </div>
                   <p class="create"><a href="javascript:;" id="create-new-list">$_('Create a new list')</a>
                     <a aria-controls="addList"
@@ -195,7 +196,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                      <div class="my-lists">
                       $for i, list in enumerate(lists):
                         $if not list.active:
-                          <p class="list"><a href="$list.key" class="add-to-list" id="list_$i">$list.name</a></p>
+                          <p class="list"><a href="$list.key" class="add-to-list" data-list-index="$i">$list.name</a></p>
                     </div>
                     <p class="create"><a href="javascript:;" id="create-new-list">$_('Create a new list')</a>
                     </p>
@@ -210,12 +211,12 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
       </div>
     </div>
 
-$jsdef render_widget_display(lists, limit):
+$jsdef render_widget_display(lists, limit, user_key, get_user_list_index):
     $for i, list in enumerate(lists):
         $if i < limit:
-            $:show_list(list)
+            $:show_list(list, user_key, get_user_list_index)
 
-$jsdef render_head(seed_type, page_lists):
+$jsdef render_head(seed_type, page_lists, page_url):
     $if seed_type == "subject":
         <div class="head">
           <h3>Lists</h3>
@@ -267,12 +268,13 @@ $if include_widget:
 
 $if include_showcase:
   <ul class="listLists" id="widget-lists">
-    $:render_widget_display(page_lists, 3)
+    $:render_widget_display(page_lists, 3, user_key, get_user_list_index)
   </ul>
 
-<div id="remove-dialog" class="hidden" title="$_('Remove')">$_('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title)</div>
+$if render_once('lists/widget.remove-dialog'):
+    <div id="remove-dialog" class="hidden" title="$_('Remove')"></div>
 
-$if ctx.user:
+$if ctx.user and render_once('lists/widget.addList'):
     <div class="hidden">
         <div class="floaterAdd" id="addList">
             <div class="floaterHead">
@@ -308,244 +310,232 @@ $if ctx.user:
         </div>
     </div>
 
+$if render_once('lists-api-js'):
     <script type="text/javascript">
-    window.q.push(function() {
-        var Lists = {
-            wantToRead: function(success) {
-                this.ajax({
-                    url: "$(work_key)/bookshelves.json",
-                    data: {
-                        action: \$('input[name=action]').val(),
-                        edition_id: \$('input[name=edition_id]').val()
-                    }
-                });
-            },
-            create: function(user, data, success, complete) {
-                this.ajax({
-                    url: user + "/lists.json",
-                    data: data,
-                    success: success,
-                    complete: complete
-                });
-            },
-            add: function(list_key, seed, success, complete) {
-                this.ajax({
-                    url: list_key + "/seeds.json",
-                    data: {
-                        'add': [seed]
-                    },
-                    success: success,
-                    complete: complete
-                });
-            },
-            remove: function(list_key, seed, success, complete) {
-                this.ajax({
-                    url: list_key + "/seeds.json",
-                    data: {
-                        'remove': [seed]
-                    },
-                    success: success,
-                    complete: complete
-                });
-            },
-
-            ajax: function(d) {
-                \$.ajax({
-                    type: "POST",
-                    url: d.url,
-                    contentType: "application/json",
-                    data: JSON.stringify(d.data),
-                    dataType: "json",
-
-                    beforeSend: function(xhr) {
-                        xhr.setRequestHeader("Content-Type", "application/json");
-                        xhr.setRequestHeader("Accept", "application/json");
-                    },
-                    success: d.success,
-                    complete: d.complete
-                });
-            }
-        }
-
-        var \$container = \$($:json_encode(uid));
-        var seed = $:json_encode(seed);
-        var seed_type = $:json_encode(seed_type);
-        var title = $:json_encode(websafe(title));
-
-        var user_lists = $:json_encode(user_lists);
-        var page_lists = $:json_encode(page_lists);
-
-        var user_key = $:json_encode(user_key);
-        var page_url = $:(json_encode(page_url));
-
-        var users_work_read_status = $(users_work_read_status or 'null');
-        var work_key = '$(work_key)';
-        var edition_key = '$(edition_key)';
-        var username = '$(username or "")';
-
-        function reload_widget() {
-            \$container.find("#widget-head").html(render_head(seed_type, page_lists));
-            \$container.find("#widget-add").html(render_widget_add(user_lists, work_key, edition_key, users_work_read_status, username, page_url));
-
-            \$container.find("#widget-lists").html(render_widget_display(page_lists, 3));
-            setup_events();
-
-            // We've added new .dropclick element. Need to setup listeners again.
-            \$container.find('.dropclick').click(function(){
-                \$(this).closest('.dropdown').slideToggle();
-                \$(this).closest('.arrow').toggleClass("up");
+    window.Lists = {
+        user_lists: $:json_encode(user_lists),
+        create: function(user_key, data, success, complete) {
+            this.ajax({
+                url: user_key + "/lists.json",
+                data: data,
+                success: success,
+                complete: complete
             });
-
-            // Trigger an event to allow adding listeners
-            \$(window).trigger("ol.lists");
-        }
-
-        function get_user_list_index(list) {
-            for (var i=0; i< user_lists.length; i++) {
-                if (list.key == user_lists[i].key) {
-                    return i;
-                }
-            }
-        }
-
-        function get_list(id) {
-            // strip "list_" from id.
-            id = id.substr(5);
-            return user_lists[parseInt(id)];
-        }
-
-        function add_page_list(list) {
-            page_lists.splice(0, 0, list);
-        }
-
-        function remove_page_list(list) {
-            for (var i=0; i<page_lists.length; i++) {
-                var pagelist = page_lists[i];
-                if (page_lists[i].key == list.key) {
-                    page_lists.splice(i, 1);
-                    break;
-                }
-            }
-        }
-
-        function setup_submit_event() {
-            // This form in created only at the beginning.
-            // Unlike other elements, event for this form should be setup only once.
-            \$container.find("#new-list").ol_validate({
-                submitHandler: function(form) {
-                    // disable form while waiting for response
-                    \$container.find("#new-list button").attr("disabled", true);
-
-                    var data = {
-                        name: \$container.find("#list_label").val(),
-                        description: \$container.find("#list_desc").val(),
-                        seeds: [seed]
-                    };
-
-                    Lists.create("$ctx.user.key", data, function(d) {
-                        \$.fn.colorbox.close();
-                        var list = {
-                          key: d.key,
-                          name: data.name,
-                          active: true,
-                          owner: {key: user_key},
-                          cover_url: "/images/icons/avatar_book-sm.png",
-
-                          edition_count: 1,
-                          description: websafe(data.description)
-                        };
-                        user_lists[user_lists.length] = list;
-                        add_page_list(list);
-
-                        reload_widget();
-                    }, function(){
-                        // re-enable form now that the request is finished
-                        reload_widget();
-                        \$container.find("#new-list button").attr("disabled", false);
-                    });
-                    return false;
-                }
+        },
+        add: function(list_key, seed, success, complete) {
+            this.ajax({
+                url: list_key + "/seeds.json",
+                data: { add: [seed] },
+                success: success,
+                complete: complete
             });
-        }
-
-        function setup_events() {
-            \$container.find("#create-new-list").click(function() {
-               close_popup();
-               \$.colorbox({inline: true, opacity: "0.5", href: "#addList"});
+        },
+        remove: function(list_key, seed, success, complete) {
+            this.ajax({
+                url: list_key + "/seeds.json",
+                data: { remove: [seed] },
+                success: success,
+                complete: complete
             });
+        },
+        ajax: function(d) {
+            \$.ajax({
+                type: "POST",
+                url: d.url,
+                contentType: "application/json",
+                data: JSON.stringify(d.data),
+                dataType: "json",
 
-            \$container.find("a.add-to-list").click(function(event) {
-                event.preventDefault();
-                close_popup();
-
-                \$(this).unbind("click");   // ignore clicks while waiting for response
-
-                var id = \$(this).attr("id");
-                var list = get_list(id);
-
-                Lists.add(list.key, seed, function() {
-                    list.active = true;
-                    add_page_list(list);
-                }, function(data){
-                    reload_widget();    // reload widget regardless of success or failure
-                });
-                return false;
+                beforeSend: function(xhr) {
+                    xhr.setRequestHeader("Content-Type", "application/json");
+                    xhr.setRequestHeader("Accept", "application/json");
+                },
+                success: d.success,
+                complete: d.complete
             });
+        },
+    };
+    </script>
 
-            \$container.find("a.remove-from-list").click(function(event) {
-                event.preventDefault();
-                var id = \$(this).attr("id");
-                setup_dialog();
+<script type="text/javascript">
+window.q.push(function() {
+    window.listWidgets = window.listWidgets || [];
 
-                \$container.find("#remove-dialog")
-                    .data("list-id", id)
-                    .dialog("open");
-                return false;
-            });
-        }
+    var \$container = \$("#$container_id");
+    var seed = $:json_encode(seed);
+    var seed_type = $:json_encode(seed_type);
+    var title = $:json_encode(websafe(title));
 
-        function close_popup() {
-            \$(this).next('.dropdown').slideToggle();
-            \$(this).parent().find('.arrow').toggleClass("down");
-        }
+    var page_lists = $:json_encode(page_lists);
+    var user_key = $:json_encode(user_key);
+    var page_url = $:json_encode(page_url);
 
-        function setup_dialog() {
-            \$container.find("#remove-dialog").ol_confirm_dialog(function() {
-                var id = \$(this).data("list-id");
-                var list = get_list(id);
-                var _this = this;
+    var users_work_read_status = $(users_work_read_status or 'null');
+    var work_key = '$(work_key)';
+    var edition_key = '$(edition_key)';
+    var username = '$(username or "")';
+    var listWidgetIndex = window.listWidgets.length;
 
-                Lists.remove(list.key, seed, function() {
-                    list.active = false;
-                    remove_page_list(list);
-                    reload_widget();
-                    \$(_this).dialog("close");
-                });
-            });
+    var remove_dialog_html = $:json_encode(_('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title))
 
-        }
+    function reload_widget() {
+        \$container.find("#widget-head").html(render_head(seed_type, page_lists));
+        \$container.find("#widget-add").html(render_widget_add(Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url));
 
-        setup_submit_event();
+        \$container.find("#widget-lists").html(render_widget_display(page_lists, 3, user_key, get_user_list_index));
         setup_events();
 
-        var mylist = \$container.find('.dropdown');
-        var listitems = mylist.children('p.list').get();
-        var listcreate = \$container.find('.dropdown p.create');
-        var a = a;
-        var b = b;
-        listitems.sort(function(a, b) {
-           var compA = \$(a).text().toUpperCase();
-           var compB = \$(b).text().toUpperCase();
-           return (compA < compB) ? -1 : (compA > compB) ? 1 : 0;
-        })
-        \$.each(listitems, function(idx, itm) { mylist.append(itm); });
-        \$container.find('.dropdown').append(listcreate);
-
-        \$(document).on( 'click', '.book-progress-btn, .nostyle-btn', function(e) {
-           \$('.book-progress-btn').text("$_('saving...')");
+        // We've added new .dropclick element. Need to setup listeners again.
+        \$container.find('.dropclick').click(function(){
+            \$(this).closest('.dropdown').slideToggle();
+            \$(this).closest('.arrow').toggleClass("up");
         });
+    }
+
+    function get_user_list_index(list) {
+        for (var i=0; i< Lists.user_lists.length; i++) {
+            if (list.key == Lists.user_lists[i].key) {
+                return i;
+            }
+        }
+    }
+
+    function add_page_list(list) {
+        page_lists.splice(0, 0, list);
+    }
+
+    function remove_page_list(list) {
+        for (var i=0; i<page_lists.length; i++) {
+            var pagelist = page_lists[i];
+            if (page_lists[i].key == list.key) {
+                page_lists.splice(i, 1);
+                break;
+            }
+        }
+    }
+
+    function create_new_list_submit_handler(form) {
+        // disable form while waiting for response
+        \$("#addList").find("#new-list button").attr("disabled", true);
+
+        var data = {
+            name: \$("#addList").find("#list_label").val(),
+            description: \$("#addList").find("#list_desc").val(),
+            seeds: [seed]
+        };
+
+        Lists.create("$ctx.user.key", data, function(d) {
+            \$.fn.colorbox.close();
+            var list = {
+              key: d.key,
+              name: data.name,
+              active: true,
+              owner: {key: user_key},
+              cover_url: "/images/icons/avatar_book-sm.png",
+
+              edition_count: 1,
+              description: websafe(data.description)
+            };
+            Lists.user_lists[Lists.user_lists.length] = list;
+            add_page_list(list);
+
+            reload_widget();
+        }, function(){
+            // re-enable form now that the request is finished
+            reload_widget();
+            \$("#addList").find("#new-list button").attr("disabled", false);
+        });
+        return false;
+    }
+
+    function setup_events() {
+        \$container.find("#create-new-list").click(function() {
+           window.activeListWidgetIndex = listWidgetIndex;
+           close_popup();
+           \$.colorbox({
+             inline: true,
+             opacity: "0.5",
+             href: "#addList",
+             onOpen: function() {
+                \$('#addList').find("#new-list").ol_validate({
+                    // list widget index of the "active"
+                    submitHandler: function(form) {
+                        window.listWidgets[window.activeListWidgetIndex].create_new_list_submit_handler(form);
+                    }
+                });
+            }
+           });
+        });
+
+        \$container.find("a.add-to-list").click(function(event) {
+            event.preventDefault();
+            close_popup();
+
+            \$(this).unbind("click");   // ignore clicks while waiting for response
+
+            var list = Lists.user_lists[\$(this).data('list-index')];
+
+            Lists.add(list.key, seed, function() {
+                list.active = true;
+                add_page_list(list);
+            }, function(data){
+                reload_widget();    // reload widget regardless of success or failure
+            });
+            return false;
+        });
+
+        \$container.find("a.remove-from-list").click(function(event) {
+            event.preventDefault();
+            setup_dialog();
+
+            \$("#remove-dialog")
+                .html(remove_dialog_html)
+                .data("list-index", \$(this).data("list-index"))
+                .dialog("open");
+            return false;
+        });
+    }
+
+    function close_popup() {
+        \$(this).next('.dropdown').slideToggle();
+        \$(this).parent().find('.arrow').toggleClass("down");
+    }
+
+    function setup_dialog() {
+        \$("#remove-dialog").ol_confirm_dialog(function() {
+            var list = Lists.user_lists[\$(this).data("list-index")];
+            var _this = this;
+
+            Lists.remove(list.key, seed, function() {
+                list.active = false;
+                remove_page_list(list);
+                reload_widget();
+                \$(_this).dialog("close");
+            });
+        });
+    }
+
+    window.listWidgets.push({
+        create_new_list_submit_handler: create_new_list_submit_handler
     });
+    setup_events();
 
+    var mylist = \$container.find('.dropdown');
+    var listitems = mylist.children('p.list').get();
+    var listcreate = \$container.find('.dropdown p.create');
+    var a = a;
+    var b = b;
+    listitems.sort(function(a, b) {
+       var compA = \$(a).text().toUpperCase();
+       var compB = \$(b).text().toUpperCase();
+       return (compA < compB) ? -1 : (compA > compB) ? 1 : 0;
+    })
+    \$.each(listitems, function(idx, itm) { mylist.append(itm); });
+    \$container.find('.dropdown').append(listcreate);
 
-    </script>
+    \$(document).on( 'click', '.book-progress-btn, .nostyle-btn', function(e) {
+       \$('.book-progress-btn').text("$_('saving...')");
+    });
+});
+</script>
 </div>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -7,7 +7,9 @@ $ edition_key = edition.key if edition else None
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ users_work_read_status = read_status or work.get_users_read_status(username) if work and username else None
 $ users_work_rating = rating or work.get_users_rating(username) if work and username else None
+$ uid = 'widget-lists-wrapper-%s' % str(random.random())
 
+<div id="$uid">
 $if "lists" not in ctx.features:
     $return
 
@@ -213,7 +215,7 @@ $jsdef render_widget_display(lists, limit):
         $if i < limit:
             $:show_list(list)
 
-$jsdef render_head():
+$jsdef render_head(seed_type, page_lists):
     $if seed_type == "subject":
         <div class="head">
           <h3>Lists</h3>
@@ -233,7 +235,7 @@ $jsdef render_head():
 
 $if include_header:
   <div id="widget-head">
-    $:render_head()
+    $:render_head(seed_type, page_lists)
   </div>
 
 $if include_widget:
@@ -261,6 +263,7 @@ $if include_widget:
             </div>
         </div>
     </div>
+
 
 $if include_showcase:
   <ul class="listLists" id="widget-lists">
@@ -306,232 +309,228 @@ $if ctx.user:
     </div>
 
     <script type="text/javascript">
-    // Lists API
+    window.q.push(function() {
+        var Lists = {
+            wantToRead: function(success) {
+                this.ajax({
+                    url: "$(work_key)/bookshelves.json",
+                    data: {
+                        action: \$('input[name=action]').val(),
+                        edition_id: \$('input[name=edition_id]').val()
+                    }
+                });
+            },
+            create: function(user, data, success, complete) {
+                this.ajax({
+                    url: user + "/lists.json",
+                    data: data,
+                    success: success,
+                    complete: complete
+                });
+            },
+            add: function(list_key, seed, success, complete) {
+                this.ajax({
+                    url: list_key + "/seeds.json",
+                    data: {
+                        'add': [seed]
+                    },
+                    success: success,
+                    complete: complete
+                });
+            },
+            remove: function(list_key, seed, success, complete) {
+                this.ajax({
+                    url: list_key + "/seeds.json",
+                    data: {
+                        'remove': [seed]
+                    },
+                    success: success,
+                    complete: complete
+                });
+            },
 
-    Lists = {
-        wantToRead: function(success) {
-            this.ajax({
-                url: "$(work_key)/bookshelves.json",
-                data: {
-                    action: \$('input[name=action]').val(),
-                    edition_id: \$('input[name=edition_id]').val()
+            ajax: function(d) {
+                \$.ajax({
+                    type: "POST",
+                    url: d.url,
+                    contentType: "application/json",
+                    data: JSON.stringify(d.data),
+                    dataType: "json",
+
+                    beforeSend: function(xhr) {
+                        xhr.setRequestHeader("Content-Type", "application/json");
+                        xhr.setRequestHeader("Accept", "application/json");
+                    },
+                    success: d.success,
+                    complete: d.complete
+                });
+            }
+        }
+
+        var \$container = \$($:json_encode(uid));
+        var seed = $:json_encode(seed);
+        var seed_type = $:json_encode(seed_type);
+        var title = $:json_encode(websafe(title));
+
+        var user_lists = $:json_encode(user_lists);
+        var page_lists = $:json_encode(page_lists);
+
+        var user_key = $:json_encode(user_key);
+        var page_url = $:(json_encode(page_url));
+
+        var users_work_read_status = $(users_work_read_status or 'null');
+        var work_key = '$(work_key)';
+        var edition_key = '$(edition_key)';
+        var username = '$(username or "")';
+
+        function reload_widget() {
+            \$container.find("#widget-head").html(render_head(seed_type, page_lists));
+            \$container.find("#widget-add").html(render_widget_add(user_lists, work_key, edition_key, users_work_read_status, username, page_url));
+
+            \$container.find("#widget-lists").html(render_widget_display(page_lists, 3));
+            setup_events();
+
+            // We've added new .dropclick element. Need to setup listeners again.
+            \$container.find('.dropclick').click(function(){
+                \$(this).closest('.dropdown').slideToggle();
+                \$(this).closest('.arrow').toggleClass("up");
+            });
+
+            // Trigger an event to allow adding listeners
+            \$(window).trigger("ol.lists");
+        }
+
+        function get_user_list_index(list) {
+            for (var i=0; i< user_lists.length; i++) {
+                if (list.key == user_lists[i].key) {
+                    return i;
+                }
+            }
+        }
+
+        function get_list(id) {
+            // strip "list_" from id.
+            id = id.substr(5);
+            return user_lists[parseInt(id)];
+        }
+
+        function add_page_list(list) {
+            page_lists.splice(0, 0, list);
+        }
+
+        function remove_page_list(list) {
+            for (var i=0; i<page_lists.length; i++) {
+                var pagelist = page_lists[i];
+                if (page_lists[i].key == list.key) {
+                    page_lists.splice(i, 1);
+                    break;
+                }
+            }
+        }
+
+        function setup_submit_event() {
+            // This form in created only at the beginning.
+            // Unlike other elements, event for this form should be setup only once.
+            \$container.find("#new-list").ol_validate({
+                submitHandler: function(form) {
+                    // disable form while waiting for response
+                    \$container.find("#new-list button").attr("disabled", true);
+
+                    var data = {
+                        name: \$container.find("#list_label").val(),
+                        description: \$container.find("#list_desc").val(),
+                        seeds: [seed]
+                    };
+
+                    Lists.create("$ctx.user.key", data, function(d) {
+                        \$.fn.colorbox.close();
+                        var list = {
+                          key: d.key,
+                          name: data.name,
+                          active: true,
+                          owner: {key: user_key},
+                          cover_url: "/images/icons/avatar_book-sm.png",
+
+                          edition_count: 1,
+                          description: websafe(data.description)
+                        };
+                        user_lists[user_lists.length] = list;
+                        add_page_list(list);
+
+                        reload_widget();
+                    }, function(){
+                        // re-enable form now that the request is finished
+                        reload_widget();
+                        \$container.find("#new-list button").attr("disabled", false);
+                    });
+                    return false;
                 }
             });
-        },
-        create: function(user, data, success, complete) {
-            this.ajax({
-                url: user + "/lists.json",
-                data: data,
-                success: success,
-                complete: complete
-            });
-        },
-        add: function(list_key, seed, success, complete) {
-            this.ajax({
-                url: list_key + "/seeds.json",
-                data: {
-                    'add': [seed]
-                },
-                success: success,
-                complete: complete
-            });
-        },
-        remove: function(list_key, seed, success, complete) {
-            this.ajax({
-                url: list_key + "/seeds.json",
-                data: {
-                    'remove': [seed]
-                },
-                success: success,
-                complete: complete
-            });
-        },
-
-        ajax: function(d) {
-            \$.ajax({
-                type: "POST",
-                url: d.url,
-                contentType: "application/json",
-                data: JSON.stringify(d.data),
-                dataType: "json",
-
-                beforeSend: function(xhr) {
-                    xhr.setRequestHeader("Content-Type", "application/json");
-                    xhr.setRequestHeader("Accept", "application/json");
-                },
-                success: d.success,
-                complete: d.complete
-            });
         }
-    }
 
-    </script>
+        function setup_events() {
+            \$container.find("#create-new-list").click(function() {
+               close_popup();
+               \$.colorbox({inline: true, opacity: "0.5", href: "#addList"});
+            });
 
-    <script type="text/javascript">
-    var seed = $:json_encode(seed);
-    var seed_type = $:json_encode(seed_type);
-    var title = $:json_encode(websafe(title));
+            \$container.find("a.add-to-list").click(function(event) {
+                event.preventDefault();
+                close_popup();
 
-    var user_lists = $:json_encode(user_lists);
-    var page_lists = $:json_encode(page_lists);
+                \$(this).unbind("click");   // ignore clicks while waiting for response
 
-    var user_key = $:json_encode(user_key);
-    var page_url = $:(json_encode(page_url));
+                var id = \$(this).attr("id");
+                var list = get_list(id);
 
-    var users_work_read_status = $(users_work_read_status or 'null');
-    var work_key = '$(work_key)';
-    var edition_key = '$(edition_key)';
-    var username = '$(username or "")';
-
-    function reload_widget() {
-        \$("#widget-head").html(render_head());
-        \$("#widget-add").html(render_widget_add(user_lists, work_key, edition_key, users_work_read_status, username, page_url));
-
-        \$("#widget-lists").html(render_widget_display(page_lists, 3));
-        setup_events();
-
-        // We've added new .dropclick element. Need to setup listeners again.
-        \$('.dropclick').click(function(){
-            \$(this).closest('.dropdown').slideToggle();
-            \$(this).closest('.arrow').toggleClass("up");
-        });
-
-        // Trigger an event to allow adding listeners
-        \$(window).trigger("ol.lists");
-    }
-
-    function get_user_list_index(list) {
-        for (var i=0; i< user_lists.length; i++) {
-            if (list.key == user_lists[i].key) {
-                return i;
-            }
-        }
-    }
-
-    function get_list(id) {
-        // strip "list_" from id.
-        id = id.substr(5);
-        return user_lists[parseInt(id)];
-    }
-
-    function add_page_list(list) {
-        page_lists.splice(0, 0, list);
-    }
-
-    function remove_page_list(list) {
-        for (var i=0; i<page_lists.length; i++) {
-            var pagelist = page_lists[i];
-            if (page_lists[i].key == list.key) {
-                page_lists.splice(i, 1);
-                break;
-            }
-        }
-    }
-
-    function setup_submit_event() {
-        // This form in created only at the beginning.
-        // Unlike other elements, event for this form should be setup only once.
-        \$("#new-list").ol_validate({
-            submitHandler: function(form) {
-                // disable form while waiting for response
-                \$("#new-list button").attr("disabled", true);
-
-                var data = {
-                    name: \$("#list_label").val(),
-                    description: \$("#list_desc").val(),
-                    seeds: [seed]
-                };
-
-                Lists.create("$ctx.user.key", data, function(d) {
-                    \$.fn.colorbox.close();
-                    var list = {
-                      key: d.key,
-                      name: data.name,
-                      active: true,
-                      owner: {key: user_key},
-                      cover_url: "/images/icons/avatar_book-sm.png",
-
-                      edition_count: 1,
-                      description: websafe(data.description)
-                    };
-                    user_lists[user_lists.length] = list;
+                Lists.add(list.key, seed, function() {
+                    list.active = true;
                     add_page_list(list);
-
-                    reload_widget();
-                }, function(){
-                    // re-enable form now that the request is finished
-                    reload_widget();
-                    \$("#new-list button").attr("disabled", false);
+                }, function(data){
+                    reload_widget();    // reload widget regardless of success or failure
                 });
                 return false;
-            }
-        });
-    }
-
-    function setup_events() {
-        \$("#create-new-list").click(function() {
-           close_popup();
-           \$.colorbox({inline: true, opacity: "0.5", href: "#addList"});
-        });
-
-        \$("a.add-to-list").click(function(event) {
-            event.preventDefault();
-            close_popup();
-
-            \$(this).unbind("click");   // ignore clicks while waiting for response
-
-            var id = \$(this).attr("id");
-            var list = get_list(id);
-
-            Lists.add(list.key, seed, function() {
-                list.active = true;
-                add_page_list(list);
-            }, function(data){
-                reload_widget();    // reload widget regardless of success or failure
             });
-            return false;
-        });
 
-        \$("a.remove-from-list").click(function(event) {
-            event.preventDefault();
-            var id = \$(this).attr("id");
-            setup_dialog();
+            \$container.find("a.remove-from-list").click(function(event) {
+                event.preventDefault();
+                var id = \$(this).attr("id");
+                setup_dialog();
 
-            \$("#remove-dialog")
-                .data("list-id", id)
-                .dialog("open");
-            return false;
-        });
-    }
-
-    function close_popup() {
-        \$(this).next('.dropdown').slideToggle();
-        \$(this).parent().find('.arrow').toggleClass("down");
-    }
-
-    function setup_dialog() {
-        \$("#remove-dialog").ol_confirm_dialog(function() {
-            var id = \$(this).data("list-id");
-            var list = get_list(id);
-            var _this = this;
-
-            Lists.remove(list.key, seed, function() {
-                list.active = false;
-                remove_page_list(list);
-                reload_widget();
-                \$(_this).dialog("close");
+                \$container.find("#remove-dialog")
+                    .data("list-id", id)
+                    .dialog("open");
+                return false;
             });
-        });
+        }
 
-    }
+        function close_popup() {
+            \$(this).next('.dropdown').slideToggle();
+            \$(this).parent().find('.arrow').toggleClass("down");
+        }
 
-    window.q.push(function(){
+        function setup_dialog() {
+            \$container.find("#remove-dialog").ol_confirm_dialog(function() {
+                var id = \$(this).data("list-id");
+                var list = get_list(id);
+                var _this = this;
+
+                Lists.remove(list.key, seed, function() {
+                    list.active = false;
+                    remove_page_list(list);
+                    reload_widget();
+                    \$(_this).dialog("close");
+                });
+            });
+
+        }
+
         setup_submit_event();
         setup_events();
 
-        var mylist = \$('.dropdown');
+        var mylist = \$container.find('.dropdown');
         var listitems = mylist.children('p.list').get();
-        var listcreate = \$('.dropdown p.create');
+        var listcreate = \$container.find('.dropdown p.create');
         var a = a;
         var b = b;
         listitems.sort(function(a, b) {
@@ -540,12 +539,13 @@ $if ctx.user:
            return (compA < compB) ? -1 : (compA > compB) ? 1 : 0;
         })
         \$.each(listitems, function(idx, itm) { mylist.append(itm); });
-        \$('.dropdown').append(listcreate);
+        \$container.find('.dropdown').append(listcreate);
 
         \$(document).on( 'click', '.book-progress-btn, .nostyle-btn', function(e) {
            \$('.book-progress-btn').text("$_('saving...')");
         });
-
     });
 
+
     </script>
+</div>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -372,14 +372,13 @@ $if render_once('lists-api-js'):
     </script>
 
 $code:
-    def build_contains_dict(user_list, work_key, edition_key):
+    def build_contains_dict(user_list, work_key, edition_key, seed_key):
         result = {}
         for list in user_list:
             result[list.key] = {}
-            if work_key and list.has_seed({"key": work_key}):
-                result[list.key][work_key] = True;
-            if edition_key and list.has_seed({"key": edition_key}):
-                result[list.key][edition_key] = True;
+            for key in [work_key, edition_key, seed_key]:
+                if key and list.has_seed({"key": key}):
+                    result[list.key][work_key] = True;
         return result
 
 <script type="text/javascript">
@@ -400,7 +399,7 @@ window.q.push(function() {
     var edition_key = '$(edition_key)';
     var username = '$(username or "")';
     var listWidgetIndex = window.listWidgets.length;
-    var list_contained_keys = $:json_encode(build_contains_dict(_user_lists, work_key, edition_key));
+    var list_contained_keys = $:json_encode(build_contains_dict(_user_lists, work_key, edition_key, seed['key']));
 
     var remove_dialog_html = $:json_encode(_('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title))
 
@@ -417,10 +416,6 @@ window.q.push(function() {
             \$(this).closest('.dropdown').slideToggle();
             \$(this).closest('.arrow').toggleClass("up");
         });
-    }
-
-    function add_page_list(list) {
-        page_lists.splice(0, 0, list);
     }
 
     function remove_page_list(list) {
@@ -443,7 +438,7 @@ window.q.push(function() {
             seeds: [seed]
         };
 
-        Lists.create("$ctx.user.key", data, function(d) {
+        Lists.create("$user_key", data, function(d) {
             \$.fn.colorbox.close();
             var list = {
               key: d.key,
@@ -457,7 +452,7 @@ window.q.push(function() {
             };
             Lists.user_lists[Lists.user_lists.length] = list;
             Lists.user_lists_by_key[list.key] = list;
-            add_page_list(list);
+            page_lists.unshift(list);
 
             reload_widget();
         }, function(){
@@ -501,7 +496,7 @@ window.q.push(function() {
                 list.active = true;
                 list_contained_keys[list.key] = list_contained_keys[list.key] || {};
                 list_contained_keys[list.key][seed.key] = true;
-                add_page_list(list);
+                page_lists.unshift(list);
             }, function(data){
                 reload_widget();    // reload widget regardless of success or failure
             });

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -389,7 +389,7 @@ $code:
                     result[list.key][key] = True;
         return result
 
-$ default_seed_key = seed_info['seed'].get('key', seed_info['seed']);
+$ default_seed_key = seed_info['seed'].key if hasattr(seed_info['seed'], 'key') else seed_info['seed']
 
 <script type="text/javascript">
 window.q.push(function() {

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -10,7 +10,7 @@ $ users_work_rating = rating or work.get_users_rating(username) if work and user
 $ uid = str(random.randint(1000, 9999))
 $ container_id = 'widget-lists-wrapper-%s' % str(uid)
 
-<div id="$container_id">
+<div id="$container_id" class="lists-widget-container">
 $if "lists" not in ctx.features:
     $return
 
@@ -252,7 +252,7 @@ $if include_widget:
   $if include_rating:
     $:macros.StarRatings(work_key, edition_key=edition_key, rating=users_work_rating)
   $if ctx.user or not work_key:
-    <div id="widget-add" $:(not work_key and 'class="old-style-lists"')>
+    <div class="widget-add $:(not work_key and 'old-style-lists')">
       $:render_widget_add(user_lists, work_key, edition_key, users_work_read_status, ctx.user, page.url(), readinglog_only, False)
     </div>
   $else:
@@ -405,7 +405,7 @@ window.q.push(function() {
 
     function reload_widget() {
         \$container.find("#widget-head").html(render_head(seed_type, page_lists));
-        \$container.find("#widget-add").html(render_widget_add(
+        \$container.find(".widget-add").html(render_widget_add(
             Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url, \$container.find(".work-checkbox")[0].checked));
 
         \$container.find("#widget-lists").html(render_widget_display(page_lists, 3, user_key));

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -251,7 +251,7 @@ $jsdef render_head(seed_type, page_lists, page_url):
 
 $if include_header:
   <div id="widget-head">
-    $:render_head(seed_info['type'], page_lists)
+    $:render_head(seed_info['type'], page_lists, page_url)
   </div>
 
 $if include_widget:
@@ -421,7 +421,7 @@ window.q.push(function() {
 
     function reload_widget() {
         var seed_info = get_active_seed_info();
-        \$container.find("#widget-head").html(render_head(seed_info.type, seed_info.lists));
+        \$container.find("#widget-head").html(render_head(seed_info.type, seed_info.lists, page_url));
         \$container.find(".widget-add").html(render_widget_add(
             Lists.user_lists,
             work_key,

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -1,4 +1,4 @@
-$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, user_lists_only=False, readinglog_only=False, read_status=None, rating=None)
+$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, user_lists_only=False, readinglog_only=False, read_status=None, rating=None, _user_lists=None)
 
 $ edition = page if page.key.startswith("/books/") else None
 $ work = (page.works and page.works[0]) if page.key.startswith("/books/") else page if page.key.startswith("/works/") else None
@@ -15,9 +15,10 @@ $if "lists" not in ctx.features:
     $return
 
 $code:
-    _user_lists = ctx.user and ctx.user.get_lists(sort=True) or []
+    _user_lists = _user_lists or (ctx.user and ctx.user.get_lists(sort=True) or [])
 
     def get_seed_info(page):
+        """Takes a thing, determines what type it is, and returns a seed summary"""
         if page.key.startswith("/subjects/"):
             seed = page.key.split("/")[-1]
             if seed.split(":")[0] not in ["place", "person", "time"]:
@@ -43,8 +44,6 @@ $code:
             "remove_dialog_html": _('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title)
         }
 
-    seed_info = get_seed_info(page)
-
     def get_list_data(list, seed, include_cover_url=True):
         d = storage({
             "name": list.name or "",
@@ -60,18 +59,20 @@ $code:
         d['owner'] = storage(displayname=owner.displayname or "", key=owner.key)
         return d
 
-    def get_user_lists():
+    def get_user_lists(seed_info):
         return [get_list_data(list, seed_info['seed'], include_cover_url=True) for list in _user_lists]
 
-    def get_page_lists(page):
+    def get_page_lists(page, seed_info):
         user_key = ctx.user and ctx.user.key
         return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
 
-$ user_lists = get_user_lists()
+$ seed_info = get_seed_info(page)
+$ work_seed_info= edition and work and get_seed_info(work)
+$ user_lists = get_user_lists(seed_info)
 $if user_lists_only:
     $ page_lists = [list for list in user_lists if list.active]
 $else:
-    $ page_lists = get_page_lists(page)
+    $ page_lists = get_page_lists(page, seed_info)
 $ user_key = ctx.user and ctx.user.key
 $ page_url = page.url()
 
@@ -369,7 +370,7 @@ $if render_once('lists-api-js'):
                 complete: d.complete
             });
         },
-        seed_lists: {},
+        seed_lists: {}, // seed key -> containing list key
         widgets: [],
     };
     Lists.user_lists_by_key = {};
@@ -392,6 +393,17 @@ $code:
 $ default_seed_key = seed_info['seed'].key if hasattr(seed_info['seed'], 'key') else seed_info['seed']
 
 <script type="text/javascript">
+
+/**
+activeSeed: what thing are we considering / is selected?
+user_lists - all of my lists
+mylists - set of eligible user_lists which don't contain activeSeed
+
+reload_widget - currently renders widget + showcase
+
+*/
+
+
 window.q.push(function() {
     var \$container = \$("#$container_id");
 
@@ -399,9 +411,10 @@ window.q.push(function() {
     var default_seed_info = $:json_encode(seed_info);
     default_seed_info.lists = Lists.seed_lists[$:json_encode(default_seed_key)];
     var work_seed_info = null;
-    $if work and edition:
-        Lists.seed_lists[$:json_encode(work.key)] = $:json_encode(get_page_lists(work));
-        work_seed_info = $:json_encode(get_seed_info(work));
+
+    $if work_seed_info:
+        Lists.seed_lists[$:json_encode(work.key)] = $:json_encode(get_page_lists(work, work_seed_info));
+        work_seed_info = $:json_encode(work_seed_info);
         work_seed_info.lists = Lists.seed_lists[$:json_encode(work.key)];
 
     var user_key = $:json_encode(user_key);
@@ -414,6 +427,7 @@ window.q.push(function() {
     var listWidgetIndex = Lists.widgets.length;
     var list_contained_keys = $:json_encode(build_contains_dict(_user_lists, default_seed_key, work_key));
 
+    /** Whether to use the default thing or work (if work v. edition) */
     function get_active_seed_info() {
         var checkbox = \$container.find(".work-checkbox")[0];
         return checkbox && checkbox.checked && work_seed_info ? work_seed_info : default_seed_info;
@@ -432,7 +446,7 @@ window.q.push(function() {
             false,
             work_seed_info && seed_info.type == 'work' ));
 
-        \$container.find("#widget-lists").html(render_widget_display(seed_info.lists, 3, user_key));
+        update_my_lists();
         setup_events();
 
         // We've added new .dropclick element. Need to setup listeners again.
@@ -442,6 +456,7 @@ window.q.push(function() {
         });
     }
 
+    // the active lists of this seed
     function remove_page_list(lists, list) {
         for (var i=0; i<lists.length; i++) {
             var pagelist = lists[i];
@@ -477,7 +492,6 @@ window.q.push(function() {
             };
             Lists.user_lists[Lists.user_lists.length] = list;
             Lists.user_lists_by_key[list.key] = list;
-            seed_info.lists.unshift(list);
 
             reload_widget();
         }, function(){
@@ -488,6 +502,7 @@ window.q.push(function() {
         return false;
     }
 
+    /** Prunes lists off my_lists if seed is on list */
     function update_my_lists() {
         var listsThatDontContainIt = [];
         var listsThatContainIt = [];
@@ -501,8 +516,7 @@ window.q.push(function() {
             }
         }
         \$container.find(".my-lists").html(render_my_lists(listsThatDontContainIt, 'key'));
-        // FIXME: Will remove all non-user lists
-        \$container.find("#widget-lists").html(render_widget_display(listsThatContainIt, 3, user_key));
+        \$container.find("#widget-lists").html(render_widget_display(listsThatContainIt.concat(seed_info.lists), 3, user_key));
         setup_widget_display_events();
     }
 
@@ -520,7 +534,6 @@ window.q.push(function() {
                 list.active = true;
                 list_contained_keys[list.key] = list_contained_keys[list.key] || {};
                 list_contained_keys[list.key][seed_info.seed.key || seed_info.seed] = true;
-                seed_info.lists.unshift(list);
             }, function(data){
                 reload_widget();    // reload widget regardless of success or failure
             });
@@ -596,11 +609,12 @@ window.q.push(function() {
         users_work_read_status,
         edition_key,
         username,
+        update_my_lists,
         listWidgetIndex,
     });
 
     setup_events();
-    update_my_lists();
+    update_my_lists(); // update set of eligible lists for this seed
 
     var mylist = \$container.find('.dropdown');
     var listitems = mylist.children('p.list').get();

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -403,10 +403,16 @@ window.q.push(function() {
 
     var remove_dialog_html = $:json_encode(_('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title))
 
+    function get_main_key() {
+        var checkbox = \$container.find(".work-checkbox")[0];
+        if (!checkbox) return seed.key;
+        else return checkbox.checked ? work_key : edition_key;
+    }
+
     function reload_widget() {
         \$container.find("#widget-head").html(render_head(seed_type, page_lists));
         \$container.find(".widget-add").html(render_widget_add(
-            Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url, \$container.find(".work-checkbox")[0].checked));
+            Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url, get_main_key()));
 
         \$container.find("#widget-lists").html(render_widget_display(page_lists, 3, user_key));
         setup_events();
@@ -465,12 +471,11 @@ window.q.push(function() {
 
     function update_my_lists() {
         if (!edition_key) return;
-        var workMode = \$container.find(".work-checkbox")[0].checked;
         var listsThatDontContainIt = [];
         var listsThatContainIt = [];
+        var key = get_main_key();
         for (var i = 0; i < Lists.user_lists.length; i++) {
             var list = Lists.user_lists[i];
-            var key = workMode ? work_key : edition_key;
             if (list_contained_keys[list.key][key]) {
                 listsThatContainIt.push(list);
             } else {

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -394,14 +394,6 @@ $ default_seed_key = seed_info['seed'].key if hasattr(seed_info['seed'], 'key') 
 
 <script type="text/javascript">
 
-/**
-activeSeed: what thing are we considering / is selected?
-user_lists - all of my lists
-mylists - set of eligible user_lists which don't contain activeSeed
-
-reload_widget - currently renders widget + showcase
-
-*/
 
 
 window.q.push(function() {

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -592,17 +592,17 @@ window.q.push(function() {
     Lists.widgets.push({
         create_new_list_submit_handler: create_new_list_submit_handler,
         reload_widget: reload_widget,
-        list_contained_keys,
-        \$container,
-        default_seed_info,
-        work_seed_info,
-        user_key,
-        page_url,
-        users_work_read_status,
-        edition_key,
-        username,
-        update_my_lists,
-        listWidgetIndex,
+        list_contained_keys: list_contained_keys,
+        \$container: \$container,
+        default_seed_info: default_seed_info,
+        work_seed_info: work_seed_info,
+        user_key: user_key,
+        page_url: page_url,
+        users_work_read_status: users_work_read_status,
+        edition_key: edition_key,
+        username: username,
+        update_my_lists: update_my_lists,
+        listWidgetIndex: listWidgetIndex
     });
 
     setup_events();

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -17,7 +17,7 @@ $if "lists" not in ctx.features:
 $code:
     _user_lists = ctx.user and ctx.user.get_lists(sort=True) or []
 
-    def get_seed_info():
+    def get_seed_info(page):
         if page.key.startswith("/subjects/"):
             seed = page.key.split("/")[-1]
             if seed.split(":")[0] not in ["place", "person", "time"]:
@@ -36,9 +36,16 @@ $code:
             else:
                 seed_type = "edition"
                 title = page.get("title", "untitled")
-        return seed, seed_type, title
+        return {
+            "seed": seed,
+            "type": seed_type,
+            "title": title,
+            "remove_dialog_html": _('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title)
+        }
 
-    def get_list_data(list, include_cover_url=True):
+    seed_info = get_seed_info(page)
+
+    def get_list_data(list, seed, include_cover_url=True):
         d = storage({
             "name": list.name or "",
             "key": list.key,
@@ -54,18 +61,17 @@ $code:
         return d
 
     def get_user_lists():
-        return [get_list_data(list, include_cover_url=True) for list in _user_lists]
+        return [get_list_data(list, seed_info['seed'], include_cover_url=True) for list in _user_lists]
 
-    def get_page_lists():
+    def get_page_lists(page):
         user_key = ctx.user and ctx.user.key
-        return [get_list_data(list) for list in page.get_lists(sort=False)]
+        return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
 
-$ seed, seed_type, title = get_seed_info()
 $ user_lists = get_user_lists()
 $if user_lists_only:
     $ page_lists = [list for list in user_lists if list.active]
 $else:
-    $ page_lists = get_page_lists()
+    $ page_lists = get_page_lists(page)
 $ user_key = ctx.user and ctx.user.key
 $ page_url = page.url()
 
@@ -98,7 +104,7 @@ $jsdef render_my_lists(lists, property='active'):
                 <a href="$list.key" class="add-to-list" data-list-key="$list.key">$list.name</a>
             </p>
 
-$jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly, work_mode):
+$jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly, use_work):
     <div class="dropit">
           $if edition_key and not work_key:
             <div class="dropper on edition-page-lists-dropdown">
@@ -185,7 +191,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                       <p class="create checkboxes">
                         <label>
                            <input type="checkbox" class="work-checkbox"
-                              $if work_mode:
+                              $if use_work:
                                 checked
                            /> <span>$_('Use this Work')</span>
                         </label>
@@ -245,7 +251,7 @@ $jsdef render_head(seed_type, page_lists, page_url):
 
 $if include_header:
   <div id="widget-head">
-    $:render_head(seed_type, page_lists)
+    $:render_head(seed_info['type'], page_lists)
   </div>
 
 $if include_widget:
@@ -363,6 +369,8 @@ $if render_once('lists-api-js'):
                 complete: d.complete
             });
         },
+        seed_lists: {},
+        widgets: [],
     };
     Lists.user_lists_by_key = {};
     for (var i = 0; i < Lists.user_lists.length; i++) {
@@ -372,25 +380,30 @@ $if render_once('lists-api-js'):
     </script>
 
 $code:
-    def build_contains_dict(user_list, work_key, edition_key, seed_key):
+    def build_contains_dict(user_list, seed_key, work_key):
         result = {}
         for list in user_list:
             result[list.key] = {}
-            for key in [work_key, edition_key, seed_key]:
+            for key in [seed_key, work_key]:
                 if key and list.has_seed({"key": key}):
-                    result[list.key][work_key] = True;
+                    result[list.key][key] = True;
         return result
+
+$ default_seed_key = seed_info['seed'].get('key', seed_info['seed']);
 
 <script type="text/javascript">
 window.q.push(function() {
-    window.listWidgets = window.listWidgets || [];
-
     var \$container = \$("#$container_id");
-    var seed = $:json_encode(seed);
-    var seed_type = $:json_encode(seed_type);
-    var title = $:json_encode(websafe(title));
 
-    var page_lists = $:json_encode(page_lists);
+    Lists.seed_lists[$:json_encode(default_seed_key)] = $:json_encode(page_lists);
+    var default_seed_info = $:json_encode(seed_info);
+    default_seed_info.lists = Lists.seed_lists[$:json_encode(default_seed_key)];
+    var work_seed_info = null;
+    $if work and edition:
+        Lists.seed_lists[$:json_encode(work.key)] = $:json_encode(get_page_lists(work));
+        work_seed_info = $:json_encode(get_seed_info(work));
+        work_seed_info.lists = Lists.seed_lists[$:json_encode(work.key)];
+
     var user_key = $:json_encode(user_key);
     var page_url = $:json_encode(page_url);
 
@@ -398,23 +411,28 @@ window.q.push(function() {
     var work_key = '$(work_key)';
     var edition_key = '$(edition_key)';
     var username = '$(username or "")';
-    var listWidgetIndex = window.listWidgets.length;
-    var list_contained_keys = $:json_encode(build_contains_dict(_user_lists, work_key, edition_key, seed['key']));
+    var listWidgetIndex = Lists.widgets.length;
+    var list_contained_keys = $:json_encode(build_contains_dict(_user_lists, default_seed_key, work_key));
 
-    var remove_dialog_html = $:json_encode(_('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title))
-
-    function get_main_key() {
+    function get_active_seed_info() {
         var checkbox = \$container.find(".work-checkbox")[0];
-        if (!checkbox) return seed.key;
-        else return checkbox.checked ? work_key : edition_key;
+        return checkbox && checkbox.checked && work_seed_info ? work_seed_info : default_seed_info;
     }
 
     function reload_widget() {
-        \$container.find("#widget-head").html(render_head(seed_type, page_lists));
+        var seed_info = get_active_seed_info();
+        \$container.find("#widget-head").html(render_head(seed_info.type, seed_info.lists));
         \$container.find(".widget-add").html(render_widget_add(
-            Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url, get_main_key()));
+            Lists.user_lists,
+            work_key,
+            edition_key,
+            users_work_read_status,
+            username,
+            page_url,
+            false,
+            work_seed_info && seed_info.type == 'work' ));
 
-        \$container.find("#widget-lists").html(render_widget_display(page_lists, 3, user_key));
+        \$container.find("#widget-lists").html(render_widget_display(seed_info.lists, 3, user_key));
         setup_events();
 
         // We've added new .dropclick element. Need to setup listeners again.
@@ -424,11 +442,11 @@ window.q.push(function() {
         });
     }
 
-    function remove_page_list(list) {
-        for (var i=0; i<page_lists.length; i++) {
-            var pagelist = page_lists[i];
-            if (page_lists[i].key == list.key) {
-                page_lists.splice(i, 1);
+    function remove_page_list(lists, list) {
+        for (var i=0; i<lists.length; i++) {
+            var pagelist = lists[i];
+            if (lists[i].key == list.key) {
+                lists.splice(i, 1);
                 break;
             }
         }
@@ -438,13 +456,14 @@ window.q.push(function() {
         // disable form while waiting for response
         \$("#addList").find("#new-list button").attr("disabled", true);
 
+        var seed_info = get_active_seed_info();
         var data = {
             name: \$("#addList").find("#list_label").val(),
             description: \$("#addList").find("#list_desc").val(),
-            seeds: [seed]
+            seeds: [seed_info.seed]
         };
 
-        Lists.create("$user_key", data, function(d) {
+        Lists.create(user_key, data, function(d) {
             \$.fn.colorbox.close();
             var list = {
               key: d.key,
@@ -458,7 +477,7 @@ window.q.push(function() {
             };
             Lists.user_lists[Lists.user_lists.length] = list;
             Lists.user_lists_by_key[list.key] = list;
-            page_lists.unshift(list);
+            seed_info.lists.unshift(list);
 
             reload_widget();
         }, function(){
@@ -470,13 +489,12 @@ window.q.push(function() {
     }
 
     function update_my_lists() {
-        if (!edition_key) return;
         var listsThatDontContainIt = [];
         var listsThatContainIt = [];
-        var key = get_main_key();
+        var seed_info = get_active_seed_info();
         for (var i = 0; i < Lists.user_lists.length; i++) {
             var list = Lists.user_lists[i];
-            if (list_contained_keys[list.key][key]) {
+            if (list_contained_keys[list.key][seed_info.seed.key || seed_info.seed]) {
                 listsThatContainIt.push(list);
             } else {
                 listsThatDontContainIt.push(list);
@@ -497,11 +515,12 @@ window.q.push(function() {
 
             var list = Lists.user_lists_by_key[\$(this).data('list-key')];
 
-            Lists.add(list.key, seed, function() {
+            var seed_info = get_active_seed_info();
+            Lists.add(list.key, seed_info.seed, function() {
                 list.active = true;
                 list_contained_keys[list.key] = list_contained_keys[list.key] || {};
-                list_contained_keys[list.key][seed.key] = true;
-                page_lists.unshift(list);
+                list_contained_keys[list.key][seed_info.seed.key || seed_info.seed] = true;
+                seed_info.lists.unshift(list);
             }, function(data){
                 reload_widget();    // reload widget regardless of success or failure
             });
@@ -513,7 +532,7 @@ window.q.push(function() {
             setup_dialog();
 
             \$("#remove-dialog")
-                .html(remove_dialog_html)
+                .html(get_active_seed_info().remove_dialog_html)
                 .data("list-key", \$(this).data("list-key"))
                 .dialog("open");
             return false;
@@ -533,7 +552,7 @@ window.q.push(function() {
                 \$('#addList').find("#new-list").ol_validate({
                     // list widget index of the "active"
                     submitHandler: function(form) {
-                        window.listWidgets[window.activeListWidgetIndex].create_new_list_submit_handler(form);
+                        Lists.widgets[window.activeListWidgetIndex].create_new_list_submit_handler(form);
                     }
                 });
             }
@@ -553,28 +572,28 @@ window.q.push(function() {
             var list = Lists.user_lists_by_key[\$(this).data("list-key")];
             var _this = this;
 
-            Lists.remove(list.key, seed, function() {
+            var seed_info = get_active_seed_info();
+            Lists.remove(list.key, seed_info.seed, function() {
                 list.active = false;
-                delete list_contained_keys[list.key][seed.key];
+                delete list_contained_keys[list.key][seed_info.seed.key || seed_info.seed];
                 delete Lists.user_lists_by_key[list.key];
-                remove_page_list(list);
+                remove_page_list(seed_info.lists, list);
                 reload_widget();
                 \$(_this).dialog("close");
             });
         });
     }
 
-    window.listWidgets.push({
+    Lists.widgets.push({
         create_new_list_submit_handler: create_new_list_submit_handler,
+        reload_widget: reload_widget,
+        list_contained_keys,
         \$container,
-        seed,
-        seed_type,
-        title,
-        page_lists,
+        default_seed_info,
+        work_seed_info,
         user_key,
         page_url,
         users_work_read_status,
-        work_key,
         edition_key,
         username,
         listWidgetIndex,

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -15,6 +15,8 @@ $if "lists" not in ctx.features:
     $return
 
 $code:
+    _user_lists = ctx.user and ctx.user.get_lists(sort=True) or []
+
     def get_seed_info():
         if page.key.startswith("/subjects/"):
             seed = page.key.split("/")[-1]
@@ -45,22 +47,18 @@ $code:
         if include_cover_url:
             cover = list.get_cover() or list.get_default_cover()
             d['cover_url'] = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
+            if 'None' in d['cover_url']:
+                d['cover_url'] = "/images/icons/avatar_book-sm.png"
         owner = list.get_owner()
         d['owner'] = storage(displayname=owner.displayname or "", key=owner.key)
         return d
 
     def get_user_lists():
-        lists = ctx.user and ctx.user.get_lists(sort=True) or []
-        return [get_list_data(list, include_cover_url=True) for list in lists]
+        return [get_list_data(list, include_cover_url=True) for list in _user_lists]
 
     def get_page_lists():
         user_key = ctx.user and ctx.user.key
         return [get_list_data(list) for list in page.get_lists(sort=False)]
-
-    def get_user_list_index(list):
-        for i, ulist in enumerate(user_lists):
-            if ulist.key == list.key:
-                return i
 
 $ seed, seed_type, title = get_seed_info()
 $ user_lists = get_user_lists()
@@ -73,7 +71,7 @@ $ page_url = page.url()
 
 $var page_lists = page_lists
 
-$jsdef show_list(list, user_key, get_user_list_index):
+$jsdef show_list(list, user_key):
     $ remove = (list.owner.key == user_key)
     <li>
         <span class="image">
@@ -84,8 +82,7 @@ $jsdef show_list(list, user_key, get_user_list_index):
             <span class="label">
                 <a href="$list.key" title="$_('See this list')">$list.name</a>
                 $if remove:
-                    $ index = get_user_list_index(list)
-                    <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-index="$index" title="$_('Remove from your list?')">[X]</a>
+                    <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-key="$list.key" title="$_('Remove from your list?')">[X]</a>
             </span>
             $if remove:
                 <span class="owner">from <a href="$list.owner.key">$_('You')</a></span>
@@ -94,7 +91,14 @@ $jsdef show_list(list, user_key, get_user_list_index):
         </span>
     </li>
 
-$jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly):
+$jsdef render_my_lists(lists, property='active'):
+    $for list in lists:
+        $if list[property]:
+            <p class="list">
+                <a href="$list.key" class="add-to-list" data-list-key="$list.key">$list.name</a>
+            </p>
+
+$jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly, work_mode):
     <div class="dropit">
           $if edition_key and not work_key:
             <div class="dropper on edition-page-lists-dropdown">
@@ -175,10 +179,17 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 <div class="reading-lists">
                   <p class="reading-list-title">$_('My Reading Lists:')</p>
                   <div class="my-lists">
-                    $for i, list in enumerate(lists):
-                      $if not list.active:
-                        <p class="list"><a href="$list.key" class="add-to-list" data-list-index="$i">$list.name</a></p>
+                    $:render_my_lists(lists)
                   </div>
+                  $if edition_key:
+                      <p class="create checkboxes">
+                        <label>
+                           <input type="checkbox" class="work-checkbox"
+                              $if work_mode:
+                                checked
+                           /> <span>$_('Use this Work')</span>
+                        </label>
+                      </p>
                   <p class="create"><a href="javascript:;" id="create-new-list">$_('Create a new list')</a>
                     <a aria-controls="addList"
                       class="hidden listClick dialog--open"></a>
@@ -193,10 +204,8 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                     <div class="arrow arrow-activated"></div>
                   </a>
                   <div class="dropdown">
-                     <div class="my-lists">
-                      $for i, list in enumerate(lists):
-                        $if not list.active:
-                          <p class="list"><a href="$list.key" class="add-to-list" data-list-index="$i">$list.name</a></p>
+                    <div class="my-lists">
+                        $:render_my_lists(lists, 'active')
                     </div>
                     <p class="create"><a href="javascript:;" id="create-new-list">$_('Create a new list')</a>
                     </p>
@@ -211,10 +220,10 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
       </div>
     </div>
 
-$jsdef render_widget_display(lists, limit, user_key, get_user_list_index):
+$jsdef render_widget_display(lists, limit, user_key):
     $for i, list in enumerate(lists):
         $if i < limit:
-            $:show_list(list, user_key, get_user_list_index)
+            $:show_list(list, user_key)
 
 $jsdef render_head(seed_type, page_lists, page_url):
     $if seed_type == "subject":
@@ -244,7 +253,7 @@ $if include_widget:
     $:macros.StarRatings(work_key, edition_key=edition_key, rating=users_work_rating)
   $if ctx.user or not work_key:
     <div id="widget-add" $:(not work_key and 'class="old-style-lists"')>
-      $:render_widget_add(user_lists, work_key, edition_key, users_work_read_status, ctx.user, page.url(), readinglog_only)
+      $:render_widget_add(user_lists, work_key, edition_key, users_work_read_status, ctx.user, page.url(), readinglog_only, False)
     </div>
   $else:
     <div class="dropit">
@@ -268,7 +277,7 @@ $if include_widget:
 
 $if include_showcase:
   <ul class="listLists" id="widget-lists">
-    $:render_widget_display(page_lists, 3, user_key, get_user_list_index)
+    $:render_widget_display(page_lists, 3, user_key)
   </ul>
 
 $if render_once('lists/widget.remove-dialog'):
@@ -355,7 +364,23 @@ $if render_once('lists-api-js'):
             });
         },
     };
+    Lists.user_lists_by_key = {};
+    for (var i = 0; i < Lists.user_lists.length; i++) {
+        var list = Lists.user_lists[i];
+        Lists.user_lists_by_key[list.key] = list;
+    }
     </script>
+
+$code:
+    def build_contains_dict(user_list, work_key, edition_key):
+        result = {}
+        for list in user_list:
+            result[list.key] = {}
+            if work_key and list.has_seed({"key": work_key}):
+                result[list.key][work_key] = True;
+            if edition_key and list.has_seed({"key": edition_key}):
+                result[list.key][edition_key] = True;
+        return result
 
 <script type="text/javascript">
 window.q.push(function() {
@@ -375,14 +400,16 @@ window.q.push(function() {
     var edition_key = '$(edition_key)';
     var username = '$(username or "")';
     var listWidgetIndex = window.listWidgets.length;
+    var list_contained_keys = $:json_encode(build_contains_dict(_user_lists, work_key, edition_key));
 
     var remove_dialog_html = $:json_encode(_('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title))
 
     function reload_widget() {
         \$container.find("#widget-head").html(render_head(seed_type, page_lists));
-        \$container.find("#widget-add").html(render_widget_add(Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url));
+        \$container.find("#widget-add").html(render_widget_add(
+            Lists.user_lists, work_key, edition_key, users_work_read_status, username, page_url, \$container.find(".work-checkbox")[0].checked));
 
-        \$container.find("#widget-lists").html(render_widget_display(page_lists, 3, user_key, get_user_list_index));
+        \$container.find("#widget-lists").html(render_widget_display(page_lists, 3, user_key));
         setup_events();
 
         // We've added new .dropclick element. Need to setup listeners again.
@@ -390,14 +417,6 @@ window.q.push(function() {
             \$(this).closest('.dropdown').slideToggle();
             \$(this).closest('.arrow').toggleClass("up");
         });
-    }
-
-    function get_user_list_index(list) {
-        for (var i=0; i< Lists.user_lists.length; i++) {
-            if (list.key == Lists.user_lists[i].key) {
-                return i;
-            }
-        }
     }
 
     function add_page_list(list) {
@@ -437,6 +456,7 @@ window.q.push(function() {
               description: websafe(data.description)
             };
             Lists.user_lists[Lists.user_lists.length] = list;
+            Lists.user_lists_by_key[list.key] = list;
             add_page_list(list);
 
             reload_widget();
@@ -448,7 +468,60 @@ window.q.push(function() {
         return false;
     }
 
+    function update_my_lists() {
+        if (!edition_key) return;
+        var workMode = \$container.find(".work-checkbox")[0].checked;
+        var listsThatDontContainIt = [];
+        var listsThatContainIt = [];
+        for (var i = 0; i < Lists.user_lists.length; i++) {
+            var list = Lists.user_lists[i];
+            var key = workMode ? work_key : edition_key;
+            if (list_contained_keys[list.key][key]) {
+                listsThatContainIt.push(list);
+            } else {
+                listsThatDontContainIt.push(list);
+            }
+        }
+        \$container.find(".my-lists").html(render_my_lists(listsThatDontContainIt, 'key'));
+        // FIXME: Will remove all non-user lists
+        \$container.find("#widget-lists").html(render_widget_display(listsThatContainIt, 3, user_key));
+        setup_widget_display_events();
+    }
+
+    function setup_widget_display_events() {
+        \$container.find("a.add-to-list").click(function(event) {
+            event.preventDefault();
+            close_popup();
+
+            \$(this).unbind("click");   // ignore clicks while waiting for response
+
+            var list = Lists.user_lists_by_key[\$(this).data('list-key')];
+
+            Lists.add(list.key, seed, function() {
+                list.active = true;
+                list_contained_keys[list.key] = list_contained_keys[list.key] || {};
+                list_contained_keys[list.key][seed.key] = true;
+                add_page_list(list);
+            }, function(data){
+                reload_widget();    // reload widget regardless of success or failure
+            });
+            return false;
+        });
+
+        \$container.find("a.remove-from-list").click(function(event) {
+            event.preventDefault();
+            setup_dialog();
+
+            \$("#remove-dialog")
+                .html(remove_dialog_html)
+                .data("list-key", \$(this).data("list-key"))
+                .dialog("open");
+            return false;
+        });
+    }
+
     function setup_events() {
+        \$container.find(".work-checkbox").click(update_my_lists);
         \$container.find("#create-new-list").click(function() {
            window.activeListWidgetIndex = listWidgetIndex;
            close_popup();
@@ -467,33 +540,7 @@ window.q.push(function() {
            });
         });
 
-        \$container.find("a.add-to-list").click(function(event) {
-            event.preventDefault();
-            close_popup();
-
-            \$(this).unbind("click");   // ignore clicks while waiting for response
-
-            var list = Lists.user_lists[\$(this).data('list-index')];
-
-            Lists.add(list.key, seed, function() {
-                list.active = true;
-                add_page_list(list);
-            }, function(data){
-                reload_widget();    // reload widget regardless of success or failure
-            });
-            return false;
-        });
-
-        \$container.find("a.remove-from-list").click(function(event) {
-            event.preventDefault();
-            setup_dialog();
-
-            \$("#remove-dialog")
-                .html(remove_dialog_html)
-                .data("list-index", \$(this).data("list-index"))
-                .dialog("open");
-            return false;
-        });
+        setup_widget_display_events();
     }
 
     function close_popup() {
@@ -503,11 +550,13 @@ window.q.push(function() {
 
     function setup_dialog() {
         \$("#remove-dialog").ol_confirm_dialog(function() {
-            var list = Lists.user_lists[\$(this).data("list-index")];
+            var list = Lists.user_lists_by_key[\$(this).data("list-key")];
             var _this = this;
 
             Lists.remove(list.key, seed, function() {
                 list.active = false;
+                delete list_contained_keys[list.key][seed.key];
+                delete Lists.user_lists_by_key[list.key];
                 remove_page_list(list);
                 reload_widget();
                 \$(_this).dialog("close");
@@ -516,9 +565,23 @@ window.q.push(function() {
     }
 
     window.listWidgets.push({
-        create_new_list_submit_handler: create_new_list_submit_handler
+        create_new_list_submit_handler: create_new_list_submit_handler,
+        \$container,
+        seed,
+        seed_type,
+        title,
+        page_lists,
+        user_key,
+        page_url,
+        users_work_read_status,
+        work_key,
+        edition_key,
+        username,
+        listWidgetIndex,
     });
+
     setup_events();
+    update_my_lists();
 
     var mylist = \$container.find('.dropdown');
     var listitems = mylist.children('p.list').get();

--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -123,7 +123,7 @@ div#subjectLists {
   }
 }
 
-#widget-add {
+.widget-add {
   div.dropper {
     div.dropdown p.create {
       border-top: 1px solid @lightest-grey;
@@ -192,7 +192,7 @@ div.Tools {
   // Where is widget-add.old-style-lists used?
   // It's used on authors pages!
   // And Orphaned Editions (no work)
-  #widget-add.old-style-lists {
+  .widget-add.old-style-lists {
     .dropclick {
       padding: 10px;
       text-decoration: none;

--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -57,7 +57,7 @@
     .my-lists {
       background: @white;
       max-height: 250px;
-      overflow-y: scroll;
+      overflow-y: auto;
       padding: 10px 15px;
 
       // stylelint-disable-next-line max-nesting-depth

--- a/static/css/legacy-tools.less
+++ b/static/css/legacy-tools.less
@@ -279,7 +279,7 @@
   #readBooks p {
     font-size: .75em !important;
   }
-  #widget-add.old-style-lists {
+  .widget-add.old-style-lists {
     div.edition-page-lists-dropdown {
       margin: 0;
       left: 0;

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -65,7 +65,7 @@ export const editionIdentifiersSample = `<fieldset id="identifiers">
 </table>
 </div>`;
 
-/** Part/Simplification of the #widget-add element */
+/** Part/Simplification of the .widget-add element */
 export const bookDropdownSample = `
     <a href="javascript:;" class="dropclick dropclick-unactivated">
         <div class="arrow arrow-unactivated"></div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested locally:
- [x] Adding 2 identical items, one bound to a work, one bound to an edition, renders
- [x] deleting works
- [x] checking/unchecking "use this work" changes the lists displayed in the drop down and the showcase
- [x] List "showcase" displayed for logged out users
- [x] both dropdowns close when clicking outside dropdown.
- [x] Adding authors to lists works
- [x] deleting authors to lists works
- [x] Adding subjects to lists works
- [x] Deleting subjects to lists works

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
