### PR TITLE
Fix IA availability requests having un-urlencoded params

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -177,10 +177,10 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
 
     if not advanced:
         _sort = sorts[0] if sorts else ''
-        if '+desc' in _sort:
-            _sort = '-' + _sort.split('+desc')[0]
-        elif '+asc' in _sort:
-            _sort = _sort.split('+asc')[0]
+        if ' desc' in _sort:
+            _sort = '-' + _sort.split(' desc')[0]
+        elif ' asc' in _sort:
+            _sort = _sort.split(' asc')[0]
         params = {'query': q}
         if _sort:
             params['sort'] = _sort

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -7,6 +7,29 @@ def test_url_quote():
     assert utils.url_quote('Kabitā') == 'Kabit%C4%81'
     assert utils.url_quote(u'Kabit\u0101') == 'Kabit%C4%81'
 
+
+def test_urlencode():
+    f = utils.urlencode
+    assert f({}) == '', 'empty dict'
+    assert f([]) == '', 'empty list'
+    assert f({'q': 'hello'}) == 'q=hello', 'basic dict'
+    assert f({'q': ''}) == 'q=', 'empty param value'
+    assert f({'q': None}) == 'q=None', 'None param value'
+    assert f([('q', 'hello')]) == 'q=hello', 'basic list'
+    assert f([('x', '3'), ('x', '5')]) == 'x=3&x=5', 'list with multi keys'
+    assert f({'q': 'a b c'}) == 'q=a+b+c', 'handles spaces'
+    assert f({'q': 'a$$'}) == 'q=a%24%24', 'handles special ascii chars'
+    assert f({'q': u'héé'}) == 'q=h%C3%A9%C3%A9'
+    assert f({'q': 'héé'}) == 'q=h%C3%A9%C3%A9', 'handles unicode without the u?'
+    assert f({'q': 1}) == 'q=1', 'numbers'
+    assert f({'q': ['test']}) == 'q=%5B%27test%27%5D', 'list'
+    assert f({'q': 'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'unicode without the u'
+    # Can't run this since it's a SyntaxError in python3... But it passes in Python 2
+    # assert f({'q': b'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'byte-string unicode?'
+    assert f({'q': u'αβγ'.encode('utf8')}) == 'q=%CE%B1%CE%B2%CE%B3', 'uf8 encoded unicode'
+    assert f({'q': u'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'unicode'
+
+
 def test_entity_decode():
     assert utils.entity_decode('&gt;foo') == '>foo'
     assert utils.entity_decode('<h1>') == '<h1>'

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -403,6 +403,26 @@ def url_quote(text):
         text = text.encode('utf8')
     return urllib.parse.quote_plus(text)
 
+
+@public
+def urlencode(dict_or_list_of_tuples):
+    """
+    You probably want to use this, if you're looking to urlencode parameters. This will
+    encode things to utf8 that would otherwise cause urlencode to error.
+    :param dict or list dict_or_list_of_tuples:
+    :rtype: basestring
+    """
+    from six.moves.urllib.parse import urlencode as og_urlencode
+    tuples = dict_or_list_of_tuples
+    if isinstance(dict_or_list_of_tuples, dict):
+        tuples = dict_or_list_of_tuples.items()
+    params = [
+        (k, v.encode('utf-8') if isinstance(v, six.text_type) else v)
+        for (k, v) in tuples
+    ]
+    return og_urlencode(params)
+
+
 @public
 def entity_decode(text):
     return HTMLParser().unescape(text)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1,6 +1,3 @@
-import six
-from six.moves.urllib.parse import urlencode
-
 import web
 import re
 from lxml.etree import XML, XMLSyntaxError
@@ -12,6 +9,7 @@ from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.core.lending import get_availability_of_ocaids, add_availability
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.inside.code import fulltext_search
+from openlibrary.plugins.upstream.utils import urlencode
 from openlibrary.utils import escape_bracket
 from openlibrary.utils.ddc import (
     normalize_ddc,
@@ -383,8 +381,6 @@ def run_solr_query(param = {}, rows=100, page=1, sort=None, spellcheck_count=Non
         params.append(('sort', sort))
 
     params.append(('wt', param.get('wt', 'standard')))
-    params = [(k, v.encode('utf-8') if isinstance(v, six.string_types) else v)
-              for (k, v) in params]
     url = solr_select_url + '?' + urlencode(params)
     solr_result = execute_solr_query(url)
     if solr_result is None:

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -22,17 +22,17 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["loans__status__last_loan_date desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Recently Returned'), key="recently_returned", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Recently Returned'), key="recently_returned", sorts=["loans__status__last_loan_date desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Romance'), key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Romance'), key="romance", query="subject:(romance)", sorts=["loans__status__last_loan_date desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Kids'), key="children", query="subject:(Juvenile Fiction)", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Kids'), key="children", query="subject:(Juvenile Fiction)", sorts=["loans__status__last_loan_date desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Thrillers'), key="thrillers", query="preset:thrillers", sorts=["downloads+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Thrillers'), key="thrillers", query="preset:thrillers", sorts=["downloads desc"], limit=18, test=test)
 
-  $:render_template("home/custom_ia_carousel", title=_('Textbooks'), key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date+desc"], limit=18, test=test)
+  $:render_template("home/custom_ia_carousel", title=_('Textbooks'), key="textbooks", subject="textbooks", sorts=["loans__status__last_loan_date desc"], limit=18, test=test)
 
   $:render_template("home/custom_ia_carousel", title="Authors Alliance & MIT Press", key="authorsalliance_mit_press", query="preset:authorsalliance_mitpress", limit=18, test=test)
 


### PR DESCRIPTION
- Also fixes url encoding bug when trying to search inside with non-ascii characters

<!-- What issue does this PR close? -->
Closes #3467, Closes #3491

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
- Uses suggested algorithm from https://github.com/internetarchive/openlibrary/pull/3117/files#r390016993 (and its tests)

### Testing
- [x] https://dev.openlibrary.org/search?q=M%C3%A9thodes+de+la+th%C3%A9orie+des+fonctions+d%27une+variable+complexe&mode=ebooks&has_fulltext=true
- [x] https://openlibrary.org/search?q=%D0%A7%D0%B5%D1%81%D1%82%D0%BD%D1%8B%D0%B9+%D0%B2%D0%BE%D1%80&mode=everything
- [x] availability checks now encoded in logs
- [x] No url encoding errors being spit out from docker env
- [x] Sorted availability checks still work

### Screenshot

![image](https://user-images.githubusercontent.com/6251786/86498107-50df4980-bd52-11ea-9d8d-4282330b799f.png)


### Stakeholders
@hornc 
