### PR TITLE
Fix AttributeError when trying to fetch doc with broken key

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -176,8 +176,11 @@ def setup_jquery_urls():
 
 @public
 def get_document(key, limit_redirs=5):
+    doc = None
     for i in range(limit_redirs):
         doc = web.ctx.site.get(key)
+        if doc is None:
+            return None
         if doc.type.key == "/type/redirect":
             key = doc.location
         else:


### PR DESCRIPTION
Fix. This was causing some issues in the local dev env (for some reason).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] nothing imploded locall
- [x] on dev?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
