### PR TITLE
Add search bar

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -504,7 +504,7 @@ class Author(models.Author):
     def get_olid(self):
         return self.key.split('/')[-1]
 
-    def get_books(self):
+    def get_books(self, q=''):
         i = web.input(sort='editions', page=1, rows=20, mode="")
         try:
             # safegaurd from passing zero/negative offsets to solr
@@ -513,7 +513,7 @@ class Author(models.Author):
             page = 1
         return works_by_author(self.get_olid(), sort=i.sort,
                                page=page, rows=i.rows,
-                               has_fulltext=i.mode=="ebooks")
+                               has_fulltext=i.mode=="ebooks", query=q)
 
     def get_work_count(self):
         """Returns the number of works by this author.

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -622,7 +622,7 @@ def works_by_author(akey, sort='editions', page=1, rows=100, has_fulltext=False,
         'first_publish_year', 'public_scan_b', 'lending_edition_s', 'lending_identifier_s',
         'ia_collection_s', 'cover_i']
     fl = ','.join(fields)
-    fq = ['author_key:OL31676A', 'type:work']
+    fq = ['author_key:' + akey, 'type:work']
     if has_fulltext:
         fq.append('has_fulltext:true')
     solr_select = solr_select_url + "?fq=%s&q.op=AND&q=%s&start=%d&rows=%d&fl=%s&wt=json" % ('&fq='.join(fq), q, offset, rows, fl)

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -1,5 +1,4 @@
 $def with (page)
-
 $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
     <script type="text/javascript">
     // <!--
@@ -149,7 +148,16 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                   $else:
                     $:_('Showing ebooks only. Would you like to see <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))
                 </p>
-
+                <p> $olid</p>
+               <span>
+              <form action="/search" class="olform pagesearchbox">
+                <input type="hidden" name="q" value="$olid"/>
+                <input type="hidden" name="has_fulltext" value="true"/>
+                <input type="text" placeholder="Search  $title Books" name="q2"/>
+                <input type="submit"/>
+             </form>
+             </span>
+                
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
 
                 <div id="searchResults">

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -151,7 +151,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
                 <form method="GET" class="olform pagesearchbox">
                   <input type="hidden" name="has_fulltext" value="true"/>
-                  <input type="text" placeholder="Search $title Books" name="q" />
+                  <input type="text" placeholder="Search $title Books" name="q" value="$(query_param('q', ''))"/>
                   <input type="submit"/>
                 </form>
 

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -47,7 +47,7 @@ $var history: $page.history
 
 $ olid = page.key.split('/')[-1]
 
-$ books = page.get_books()
+$ books = page.get_books(q=query_param('q'))
 $ book_list_excerpt = ''
 $if books and books.works:
     $ book_titles_excerpt = [work.title for work in books.works[:8]]
@@ -148,14 +148,13 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                   $else:
                     $:_('Showing ebooks only. Would you like to see <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))
                 </p>
-              
-                <form action="/search" class="olform pagesearchbox">
-                <input type="hidden" name="q" value="$olid"/>
-                <input type="hidden" name="has_fulltext" value="true"/>
-                <input type="text" placeholder="Search $title Books" name="q2" style= "width: 410px;" />
-                <input type="submit"/>
-             </form>
-                
+
+                <form method="GET" class="olform pagesearchbox">
+                  <input type="hidden" name="has_fulltext" value="true"/>
+                  <input type="text" placeholder="Search $title Books" name="q" />
+                  <input type="submit"/>
+                </form>
+
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
 
                 <div id="searchResults">

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -148,15 +148,13 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                   $else:
                     $:_('Showing ebooks only. Would you like to see <a href="%(url)s">everything</a> by this author?', url=changequery(mode='everything'))
                 </p>
-                <p> $olid</p>
-               <span>
-              <form action="/search" class="olform pagesearchbox">
+              
+                <form action="/search" class="olform pagesearchbox">
                 <input type="hidden" name="q" value="$olid"/>
                 <input type="hidden" name="has_fulltext" value="true"/>
-                <input type="text" placeholder="Search  $title Books" name="q2"/>
+                <input type="text" placeholder="Search $title Books" name="q2" style= "width: 410px;" />
                 <input type="submit"/>
              </form>
-             </span>
                 
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Supplants #3534 and Closes #3446

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Extends the work by @nsachin08 to add a search box on the authors page which allows patrons to filter an authors works by solr query.

The original PR searched against the /search page (instead of the /authors page)

### Technical
<!-- What should be noted about the implementation? -->

The author-page model `author.works_by_author` has been modified to accept a query (which can be used to filter search results further than author)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- [x] visit authors page w/ no search -- e.g. https://dev.openlibrary.org/authors/OL31676A/Noam_Chomsky
- [x] type in a search  -- e.g. https://dev.openlibrary.org/authors/OL31676A/Noam_Chomsky?q=manufacturing (the search box should be populated w/ the query param, the results should appear filtered)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![2020-07-05-213249_1046x777_scrot](https://user-images.githubusercontent.com/978325/86556088-21be0900-bf07-11ea-9621-f9f39ba5266b.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@nsachin08 @tabshaikh @cdrini 