### PR TITLE
i18n and style cleanup

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -51,7 +51,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
               $_('in') <a class="hoverlink" title="$(', '.join(doc.languages))">$(len(doc.languages)) $_('languages')</a>
             </span>
           $if doc.get('ia'):
-            &mdash; $_('%s previewable' % len(doc.get('ia')))
+            &mdash; $_('%s previewable', len(doc.get('ia')))
             $if len(doc.get('ia')) > 1:
               <div class="preview-covers">
                 $for x, i in enumerate(doc.get('ia')[1:10]):

--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -3,7 +3,7 @@ $def with(work, tags=[])
 $def render_subjects(label, subjects, prefix=""):
   $if subjects:
     <div class="section link-box">
-      <h6>$_(label)</h6>
+      <h6>$label</h6>
       <span>
         $for subject in subjects:
           <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',',''))">$subject</a>$cond(not loop.last,",","")
@@ -13,10 +13,10 @@ $def render_subjects(label, subjects, prefix=""):
 $if work:
   $for tag in tags:
     $if tag=="Subjects":
-      $:render_subjects("Subjects", work.get_subjects())
+      $:render_subjects(_("Subjects"), work.get_subjects())
     $elif tag=="People":
-      $:render_subjects("People", work.subject_people, prefix="person:")
+      $:render_subjects(_("People"), work.subject_people, prefix="person:")
     $elif tag=="Places":
-      $:render_subjects("Places", work.subject_places, prefix="place:")
+      $:render_subjects(_("Places"), work.subject_places, prefix="place:")
     $elif tag=="Times":
-      $:render_subjects("Times", work.subject_times, prefix="time:")
+      $:render_subjects(_("Times"), work.subject_times, prefix="time:")

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -2,7 +2,7 @@
 
 .workDetails {
   padding: 20px 0;
-  .section {
+  .book-description {
     text-align: justify;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Followup to #3553 which closed #684   

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes i18n (% and variable)
Removes `text-align: justify`, other than the main book page description
 
### Technical
<!-- What should be noted about the implementation? -->
N/a

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
tested on dev

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 