### PR TITLE
Fixing edition count ungettext formatter %d -> %s

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -3,7 +3,7 @@ $def with (edition_count=1)
 <ul class="work-menu sticky">
   <li class="selected">
     <a href="#editions-list">
-      $ungettext('View 1 Edition', 'View %(count)d Editions', edition_count, count=edition_count)
+      $ungettext('View %(count)s Edition', 'View %(count)s Editions', edition_count, count=edition_count)
     </a>
   </li>
   <li>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
`ungettext` string formatting breaking with `%d` on prod.
https://openlibrary.org/books/OL13350845M/The_Best_American_Short_Stories_1958?v=1&debug=true


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
tested on dev

https://dev.openlibrary.org/books/OL13350845M/The_Best_American_Short_Stories_1958?v=1&debug=true

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![2020-07-08-012249_1600x900_scrot](https://user-images.githubusercontent.com/978325/86895596-8faa3200-c0b9-11ea-98fd-a0a09c3e1ae9.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tabshaikh @seabelis 