### PR TITLE
Fix search rendering failing when availability=None

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -11,7 +11,7 @@ $# * check_loan_status whether to check the user's loan status to determine read
 
 $ loanstatus_start_time = time()
 
-$ availability = doc.availability if hasattr(doc, 'availability') else {}
+$ availability = (doc.availability or {}) if hasattr(doc, 'availability') else {}
 $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0].key)
 

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,6 +1,6 @@
 $def with (doc, decorations=None, cta=True, availability=None, extra=None)
 
-$ availability = availability or doc.get('availability', {})
+$ availability = availability or doc.get('availability') or {}
 $ ocaid = availability.get('identifier')
 $ is_work = doc.get('type', {}).get('key') == '/type/work'
 $ book_url = doc.url() if is_work else doc.key

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -217,7 +217,7 @@ $ )
 
             $for work in works:
                 $ ocaid = work.ia[0] if work.ia else None
-                $ availability = work.get('availability', {}).get('status')
+                $ availability = (work.get('availability') or {}).get('status')
                 $# if we're explicitly showing *everything*...
                 $# or if we're showing only things with ocaids which are available...
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):


### PR DESCRIPTION
Hotfix search rendering failing on https://openlibrary.org/search?q=windcatcher&mode=everything due to invalid OCAID on https://openlibrary.org/books/OL25374638M/The_Wind-Catcher (ocaid since fixed).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] https://dev.openlibrary.org/search?q=windcatcher&mode=everything does not error

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
