### PR TITLE
Search autocomplete should only fetch needed info

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -13,6 +13,13 @@ const FACET_TO_ENDPOINT = {
     text: '/search/inside',
 };
 const DEFAULT_FACET = 'all';
+const DEFAULT_JSON_FIELDS = [
+    'key',
+    'cover_i',
+    'title',
+    'author_name',
+    'name',
+];
 /** Functions that render autocomplete results */
 const RENDER_AUTOCOMPLETE_RESULT = {
     ['/search'](work) {
@@ -184,16 +191,15 @@ export class SearchBar {
      * @param {String} q query that's ready to get passed to the search endpoint
      * @param {Boolean} [json] whether to hit the JSON endpoint
      * @param {Number} [limit] how many items to get
+     * @param {String[]} [fields] the Solr fields to fetch (if using JSON)
      */
-    static composeSearchUrl(facetEndpoint, q, json, limit) {
+    static composeSearchUrl(facetEndpoint, q, json=false, limit=null, fields=null) {
         let url = facetEndpoint;
-        if (json) {
-            url += '.json';
-        }
+        if (json) url += '.json';
+
         url += `?q=${q}`;
-        if (limit) {
-            url += `&limit=${limit}`;
-        }
+        if (limit) url += `&limit=${limit}`;
+        if (fields) url += `&fields=${fields.map(encodeURIComponent).join(',')}`;
         url += `&mode=${SearchUtils.mode.read()}`;
         return url;
     }
@@ -246,7 +252,7 @@ export class SearchBar {
         }
 
         this.$results.css('opacity', 0.5);
-        return $.getJSON(SearchBar.composeSearchUrl(this.facetEndpoint, q, true, 10), data => {
+        return $.getJSON(SearchBar.composeSearchUrl(this.facetEndpoint, q, true, 10, DEFAULT_JSON_FIELDS), data => {
             const renderer = RENDER_AUTOCOMPLETE_RESULT[this.facetEndpoint];
             this.$results.css('opacity', 1);
             this.clearAutocompletionResults();

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -854,7 +854,7 @@ class author_search_json(author_search):
 
 
 @public
-def work_search(query, sort=None, page=1, offset=0, limit=100):
+def work_search(query, sort=None, page=1, offset=0, limit=100, fields='*'):
     """
     params:
     query: dict
@@ -874,7 +874,7 @@ def work_search(query, sort=None, page=1, offset=0, limit=100):
                                                       page=page,
                                                       sort=sorts.get(sort),
                                                       offset=offset,
-                                                      fields="*")
+                                                      fields=fields)
         response = json.loads(reply)['response'] or ''
     except (ValueError, IOError) as e:
         logger.error("Error in processing search API.")
@@ -907,7 +907,10 @@ class search_json(delegate.page):
             offset = None
             page = safeint(query.pop("page", "1"), default=1)
 
-        response = work_search(query, sort=sort, page=page, offset=offset, limit=limit)
+        fields = query.pop('fields', '*').split(',')
+
+        response = work_search(query, sort=sort, page=page, offset=offset, limit=limit,
+                               fields=fields)
 
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response, indent=True))

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -882,7 +882,8 @@ def work_search(query, sort=None, page=1, offset=0, limit=100, fields='*'):
 
     # backward compatibility
     response['num_found'] = response['numFound']
-    response['docs'] = add_availability(response['docs'])
+    if fields == '*' or 'availability' in fields:
+        response['docs'] = add_availability(response['docs'])
     return response
 
 


### PR DESCRIPTION
~Based on #2285~. Fix: Only fetch the solr fields needed to reduce response size and improve speed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] No fields param fetches everything https://dev.openlibrary.org/search.json?q=hello&limit=2
- [x] setting fiel limits results https://dev.openlibrary.org/search.json?q=hello&limit=2&fields=key,title

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
