### PR TITLE
Add barcode regex to /type/local_id

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -76,11 +76,6 @@ class hooks(client.hook):
         if account and account.is_blocked():
             raise ValidationException('Your account has been suspended. You are not allowed to make any edits.')
 
-        if page.type.key == '/type/library':
-            bad = list(page.find_bad_ip_ranges(page.ip_ranges or ''))
-            if bad:
-                raise ValidationException('Bad IPs: ' + '; '.join(bad))
-
         if page.key.startswith('/a/') or page.key.startswith('/authors/'):
             if page.type.key == '/type/author':
                 return

--- a/openlibrary/plugins/openlibrary/types/local_id.type
+++ b/openlibrary/plugins/openlibrary/types/local_id.type
@@ -1,1 +1,38 @@
-{"name": "Local ID", "key": "/type/local_id", "type": {"key": "/type/type"}, "properties": [{"index": "0", "expected_type": {"key": "/type/string"}, "unique": true, "type": {"key": "/type/property"}, "name": "source_ocaid"}, {"index": "1", "expected_type": {"key": "/type/string"}, "unique": true, "type": {"key": "/type/property"}, "name": "urn_prefix"}, {"index": "2", "expected_type": {"key": "/type/string"}, "unique": true, "type": {"key": "/type/property"}, "name": "id_location"}]}
+{
+    "name": "Local ID",
+    "key": "/type/local_id",
+    "type": {"key": "/type/type"},
+    "kind": "regular",
+    "properties": [
+        {
+            "expected_type": {"key": "/type/string"},
+            "unique": true,
+            "type": {"key": "/type/property"},
+            "name": "name"
+        },
+        {
+            "expected_type": {"key": "/type/string"},
+            "unique": true,
+            "type": {"key": "/type/property"},
+            "name": "source_ocaid"
+        },
+        {
+            "expected_type": {"key": "/type/string"},
+            "unique": true,
+            "type": {"key": "/type/property"},
+            "name": "urn_prefix"
+        },
+        {
+            "expected_type": {"key": "/type/string"},
+            "unique": true,
+            "type": {"key": "/type/property"},
+            "name": "id_location"
+        },
+        {
+            "expected_type": {"key": "/type/string"},
+            "unique": true,
+            "type": {"key": "/type/property"},
+            "name": "barcode"
+        }
+    ]
+}

--- a/openlibrary/templates/type/local_id/view.html
+++ b/openlibrary/templates/type/local_id/view.html
@@ -23,6 +23,10 @@ $var title: $page.name
        <span class="tag">$page.id_location</span>
     </div>
     <div>
+       <span class="title">Barcode regex</span>
+       <span class="tag">$page.barcode</span>
+    </div>
+    <div>
        <span class="title">URN $_("prefix")</span>
        <span class="tag">$page.urn_prefix</span>
     </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2974 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds a barcode regex for identifying local id barcode formats from Open Library MARC collections.


### Technical
<!-- What should be noted about the implementation? -->
I have already updated the type page https://openlibrary.org/type/local_id
and added two pending local_ids to https://openlibrary.org/local_ids , but the view page change needs to be deployed.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/905545/87262616-baa7e200-c50e-11ea-9467-74496dec6407.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
