### PR TITLE
Librarian next button to browse stored MARC records

### DIFF
--- a/openlibrary/templates/showmarc.html
+++ b/openlibrary/templates/showmarc.html
@@ -9,6 +9,7 @@ $if format == 'raw':
 $ get_source_record = render_template("history/sources").get_source_record
 $ source_record = get_source_record("%s:%s:%s" % (filename, begin, length))
 $ title = "MARC Record from " + source_record.source_name
+$ next_url = "../%s:%s:5" % (filename, begin + length)
 
 $var title: $title
 
@@ -44,4 +45,8 @@ $var title: $title
     $else:
         <p><b>LEADER:</b> <code>$record.leader</code><br/>
         $:record.html()</p>
+   $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
+       <div>
+          <a href="$next_url" class="slick-next adminOnly right">$_("Next")</a>
+       </div>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows librarians to explore / troubleshoot stored MARC records from the `/show-records/` MARC view pages by providing an easy way to navigate to the next record in a MARC collection.


### Technical
<!-- What should be noted about the implementation? -->
Data for the previous record is not readily available from the bulk binary MARC since only the offset and length of the _current_ record is available. Because the next record begins at the end of the current record, it is trivial to point to its location. I was editing the URL manually to get to the next record frequently enough that it seemed sensible to add a helpful button to do it automatically.

This feature is Librarian only to avoid user confusion since the 'Next' record likely has no direct relationship to the original item clicked through from. This feature is only useful when inspecting bulk MARC records from a particular source, which is an admin / librarian task.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested and I am using this locally to review bulk MARC records stored on archive.org

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/905545/87271058-35c8c280-c526-11ea-94e8-17f917ac40a9.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
