### PR TITLE
Import URL title from public note if $3 does not exist

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -418,16 +418,11 @@ def read_description(rec):
 def read_url(rec):
     found = []
     for f in rec.get_fields('856'):
-        contents = f.get_contents(['3', 'u'])
-        if not contents.get('u', []):
+        contents = f.get_contents(['u', '3', 'z'])
+        if not contents.get('u'):
             continue
-        if '3' not in contents:
-            found += [{ 'url': u.strip(' ') } for u in contents['u']]
-            continue
-        assert len(contents['3']) == 1
-        title = contents['3'][0].strip(' ')
-        found += [{ 'url': u.strip(' '), 'title': title  } for u in contents['u']]
-
+        title = (contents.get('3') or contents.get('z', ['External']))[0].strip()
+        found += [{'url':  u.strip(), 'title': title} for u in contents['u']]
     return found
 
 def read_other_titles(rec):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Relates to and unblocks #1401

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Alows link titles to be imported from more MARC records to enable the URLs to be displayed on the current UI:

![image](https://user-images.githubusercontent.com/905545/87275654-b1c90780-c532-11ea-83c5-bc31f5c3ea82.png)



### Technical
<!-- What should be noted about the implementation? -->

MARC 21 ref: https://www.loc.gov/marc/bibliographic/bd856.html

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Previously the External links would not display:
![image](https://user-images.githubusercontent.com/905545/87275792-010f3800-c533-11ea-923a-63e22dbc4c7b.png)
from https://openlibrary.org/books/OL28324549M/Das_erweiterte_Museum
even though the URL is in the metadata: https://openlibrary.org/books/OL28324549M.json -- it needs a `title` to be clickable.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
