### PR TITLE
Separate make test to test-py and test-js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ ifndef CONTINUOUS_INTEGRATION
 	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif
 
-test:
-	npm test
+test-py:
 	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests
+
+test-js:
+	npm test
+
+test: test-py test-js


### PR DESCRIPTION
Useful for running just the python tests when testing infogami.

### Testing
Only Travis

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
