### PR TITLE
Importing render_template is used for its side effects

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -10,7 +10,7 @@ import simplejson
 
 from infogami import config
 from infogami.utils import delegate
-from infogami.utils.view import render_template
+from infogami.utils.view import render_template  # noqa: F401 used for its side effects
 from infogami.plugins.api.code import jsonapi
 from infogami.utils.view import add_flash_message
 from openlibrary import accounts

--- a/openlibrary/plugins/openlibrary/borrow_home.py
+++ b/openlibrary/plugins/openlibrary/borrow_home.py
@@ -8,7 +8,7 @@ import datetime
 
 from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate
-from infogami.utils.view import render_template
+from infogami.utils.view import render_template  # noqa: F401 used for its side effects
 
 from openlibrary.core import helpers as h
 from openlibrary.core import statsdb

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -12,7 +12,7 @@ from infogami.utils import delegate, app, types
 from infogami.utils.view import public, safeint, render
 from infogami.utils.context import context
 
-# from utils import render_template  # TODO: unused import?
+from utils import render_template  # noqa: F401  render_template used for side effects
 
 from openlibrary import accounts
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The flake8 linter will raise F401 errors for `module imported but unused` but sometimes modules like `render_template` are imported for their runtime side effects.  This PR marks those imports with the linter directive `noqa: F401` to silence the linter and help future readers of the code.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
