### PR TITLE
Fix absolute import and bytes for Python 3

### DIFF
--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -70,7 +70,7 @@ def query(q):
     for i in range(20):
         try:
             ret = urlread(url)
-            while ret.startswith('canceling statement due to statement timeout'):
+            while ret.startswith(b'canceling statement due to statement timeout'):
                 ret = urlread(url)
             if not ret:
                 print('ret == None')

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -16,7 +16,7 @@ import six
 
 logger = logging.getLogger('openlibrary.ia')
 
-IA_BASE_URL = config.get('ia_base_url')
+IA_BASE_URL = config.get('ia_base_url', 'https://archive.org')
 VALID_READY_REPUB_STATES = ['4', '19', '20', '22']
 
 

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -16,6 +16,8 @@ import six
 
 logger = logging.getLogger('openlibrary.ia')
 
+# FIXME: We can't reference `config` in module scope like this; it will always be undefined!
+# See lending.py for an example of how to do it correctly.
 IA_BASE_URL = config.get('ia_base_url', 'https://archive.org')
 VALID_READY_REPUB_STATES = ['4', '19', '20', '22']
 

--- a/openlibrary/core/middleware.py
+++ b/openlibrary/core/middleware.py
@@ -1,7 +1,7 @@
 """WSGI middleware used in Open Library.
 """
 import web
-from six import StringIO
+from six import BytesIO
 import gzip
 
 class GZipMiddleware:
@@ -23,7 +23,7 @@ class GZipMiddleware:
             return default
 
         def compress(text, level=9):
-            f = StringIO()
+            f = BytesIO()
             gz = gzip.GzipFile(None, 'wb', level, fileobj=f)
             gz.write(text)
             gz.close()
@@ -41,6 +41,6 @@ class GZipMiddleware:
 
         data = self.app(environ, new_start_response)
         if response.compress:
-            return [compress("".join(data), 9)]
+            return [compress(b"".join(data), 9)]
         else:
             return data

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -1,12 +1,14 @@
 """Upstream customizations."""
 
-import os.path
-import web
-import random
-import hashlib
 import datetime
+import hashlib
+import io
+import os.path
+import random
 
 from six import PY3
+
+import web
 
 from infogami import config
 from infogami.infobase import client
@@ -69,11 +71,8 @@ def static_url(path):
     """
     pardir = os.path.pardir
     fullpath = os.path.abspath(os.path.join(__file__, pardir, pardir, pardir, pardir, "static", path))
-    with open(fullpath, 'r') as in_file:
-        data = in_file.read()
-    if PY3:
-        data = data.encode("utf-8")
-    digest = hashlib.md5(data).hexdigest()
+    with io.open(fullpath, 'rb') as in_file:
+        digest = hashlib.md5(in_file.read()).hexdigest()
     return "/static/%s?v=%s" % (path, digest)
 
 class DynamicDocument:

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -6,6 +6,8 @@ import random
 import hashlib
 import datetime
 
+from six import PY3
+
 from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate, app, types
@@ -67,8 +69,11 @@ def static_url(path):
     """
     pardir = os.path.pardir
     fullpath = os.path.abspath(os.path.join(__file__, pardir, pardir, pardir, pardir, "static", path))
-    with open(fullpath) as in_file:
-        digest = hashlib.md5(in_file.read().encode("utf-8")).hexdigest()
+    with open(fullpath, 'r') as in_file:
+        data = in_file.read()
+    if PY3:
+        data = data.encode("utf-8")
+    digest = hashlib.md5(data).hexdigest()
     return "/static/%s?v=%s" % (path, digest)
 
 class DynamicDocument:

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -10,9 +10,8 @@ from infogami import config
 from infogami.infobase import client
 from infogami.utils import delegate, app, types
 from infogami.utils.view import public, safeint, render
+from infogami.utils.view import render_template  # noqa: F401 used for its side effects
 from infogami.utils.context import context
-
-from utils import render_template  # noqa: F401  render_template used for side effects
 
 from openlibrary import accounts
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -67,7 +67,8 @@ def static_url(path):
     """
     pardir = os.path.pardir
     fullpath = os.path.abspath(os.path.join(__file__, pardir, pardir, pardir, pardir, "static", path))
-    digest = hashlib.md5(open(fullpath).read()).hexdigest()
+    with open(fullpath) as in_file:
+        digest = hashlib.md5(in_file.read().encode("utf-8")).hexdigest()
     return "/static/%s?v=%s" % (path, digest)
 
 class DynamicDocument:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -713,7 +713,7 @@ def get_donation_include(include):
     html = ''
     if include == 'true' and "dev" in web.ctx.features:
         try:
-            html += opener.open(url_banner_source + param, timeout=3).read()
+            html += opener.open(url_banner_source + param, timeout=3).read().decode("utf-8")
             # Donation banner is temporarily (Jan 2020) disabled on prod, but available on dev (so that it can be used
             # for testing). To avoid it appearing like it's working, display a warning if it loads correctly that it's
             # disabled on prod.

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -16,7 +16,9 @@ from six.moves import urllib
 
 from openlibrary.core.models import Subject
 from openlibrary.core.lending import add_availability
+from openlibrary.plugins.worksearch.search import work_search
 from openlibrary.utils import str_to_key, finddict
+
 
 __all__ = [
     "SubjectEngine", "get_subject"
@@ -219,7 +221,6 @@ class SubjectEngine:
         else:
             kw = {}
 
-        from search import work_search
         result = work_search(
             q, offset=offset, limit=limit, sort=sort, **kw)
         if not result:

--- a/openlibrary/solr/solrwriter.py
+++ b/openlibrary/solr/solrwriter.py
@@ -1,6 +1,5 @@
 """Interface to update solr.
 """
-import httplib
 import logging
 import re
 
@@ -28,7 +27,7 @@ class SolrWriter(object):
 
     def get_conn(self):
         if self.conn is None:
-            self.conn = httplib.HTTPConnection(self.host)
+            self.conn = six.moves.http_client.HTTPConnection(self.host)
         return self.conn
 
     def request(self, xml):

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -175,7 +175,7 @@ def update_keys(keys):
     logger.debug("Args: %s" % str(args))
     update_work.load_configs(args.ol_url, args.config, 'default')
 
-    keys = (k for k in keys if k.count("/") == 2 and k.split("/")[1] in ["books", "authors", "works"])
+    keys = [k for k in keys if k.count("/") == 2 and k.split("/")[1] in ("books", "authors", "works")]
 
     count = 0
     for chunk in web.group(keys, 100):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
Fixes to boot the server on Docker and display the home page w/ no Python 3 exceptions.
1. Fix an absolute import for Python 3
2. Convert a string literal to a bytes literal for Python 3
```
File "/openlibrary/openlibrary/solr/solrwriter.py", line 3, in <module>
     import httplib

File "/openlibrary/openlibrary/plugins/worksearch/subjects.py", line 222, in get_subject
     from search import work_search
 ModuleNotFoundError: No module named 'search'

File "/openlibrary/openlibrary/plugins/upstream/code.py", line 70, in static_url
     digest = hashlib.md5(open(fullpath).read()).hexdigest()
 TypeError: Unicode-objects must be encoded before hashing

File "/openlibrary/openlibrary/plugins/upstream/utils.py", line 716, in get_donation_include
     html += opener.open(url_banner_source + param, timeout=3).read()
 TypeError: can only concatenate str (not "bytes") to str

File "/openlibrary/openlibrary/core/middleware.py", line 44, in __call__
     return [compress("".join(data), 9)]
 TypeError: sequence item 0: expected str instance, bytes found

File "/openlibrary/openlibrary/core/middleware.py", line 27, in compress
     gz = gzip.GzipFile(None, 'wb', level, fileobj=f)
   File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/gzip.py", line 232, in _write_gzip_header
     self.fileobj.write(b'\037\213')             # magic header
 TypeError: string argument expected, got 'bytes'

File "/openlibrary/infogami/infobase/server.py", line 98, in g
     result = d.json_data if isinstance(d, JSON) else json.dumps(d)
   File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/json/__init__.py", line 231, in dumps
     return _default_encoder.encode(obj)
   File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/json/encoder.py", line 199, in encode
     chunks = self.iterencode(o, _one_shot=True)
   File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/json/encoder.py", line 257, in iterencode
     return _iterencode(o, 0)
   File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/json/encoder.py", line 179, in default
     raise TypeError(f'Object of type {o.__class__.__name__} '
 TypeError: Object of type datetime is not JSON serializable
```
# Next up...
```
Traceback (most recent call last):
File "/openlibrary/infogami/utils/template.py", line 143, in saferender
  result = t(*a, **kw)
File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/site-packages/web/template.py", line 987, in __call__
  return BaseTemplate.__call__(self, *a, **kw)
File "/home/openlibrary/.pyenv/versions/3.8.3/lib/python3.8/site-packages/web/template.py", line 898, in __call__
  return self.t(*a, **kw)
File "/openlibrary/openlibrary/templates/type/edition/view.html", line 315, in __template__
  </div>
TypeError: '>' not supported between instances of 'Nothing' and 'int'
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
