### PR TITLE
Don't need facets during autocomplete

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -195,9 +195,12 @@ export class SearchBar {
      */
     static composeSearchUrl(facetEndpoint, q, json=false, limit=null, fields=null) {
         let url = facetEndpoint;
-        if (json) url += '.json';
+        if (json) {
+            url += `.json?q=${q}&_facet=false&_spellcheck_count=0`;
+        } else {
+            url += `?q=${q}`;
+        }
 
-        url += `?q=${q}`;
         if (limit) url += `&limit=${limit}`;
         if (fields) url += `&fields=${fields.map(encodeURIComponent).join(',')}`;
         url += `&mode=${SearchUtils.mode.read()}`;


### PR DESCRIPTION
Autocomplete was still very slow; turns out it facets by default! -\_-. Disabled that.


### Technical
Used underscores for the `_facet` and `_spellcheck_count` since we might want to make this behave differently in the future.

### Testing
On dev; autocomplete works, and the requests made to solr (listening on logs) are _no longer_ including facets. (And are about ~15x faster :D 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 