### PR TITLE
Discover insecure dependencies on Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ jobs:
       python: "2.7"
     - name: “Python 2.7 on Infogami master”
       python: "2.7"
+      script:
+        - make i18n
+        - make test
+        - pip install safety
+        - safety check || true
     - name: “Python 3.8 make lint and selected pytests”
       python: "3.8"
       before_script: true  # override npm install below


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[__Safety__](https://pypi.org/project/safety) is already run Travis CI on Python 3 in `scripts/test-py3.sh` which [currently only finds pyenv](https://travis-ci.org/github/internetarchive/openlibrary/jobs/708252529#L3748)

This PR adds a safety run Travis CI on Py2 which has older dependencies.  It [currently adds Pillow](https://travis-ci.org/github/internetarchive/openlibrary/jobs/710504108#L931). 
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
