### PR TITLE
Update pyenv before installs

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -41,8 +41,8 @@ RUN curl https://pyenv.run | bash && \
 ENV PYENV_ROOT /home/openlibrary/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
-RUN pyenv install 2.7.6
-RUN pyenv install 3.8.5
+RUN pyenv update && pyenv install 2.7.6
+RUN pyenv update && pyenv install 3.8.5
 RUN pyenv global 2.7.6 3.8.5
 RUN pyenv rehash
 


### PR DESCRIPTION
Hotfix. Because docker caches the various layers, it's possible for a copy of pyenv to have been installed that didn't include definitions for python 3.8.5. This ensure that pyenv is up-to-date before trying to install python.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Did a build and insured the `pyenv install 3.8.5` step worked

### Stakeholders
@cclauss @aasifkhan7