### PR TITLE
Make testing infogami changes easier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: oldev:latest
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
+      # Branch to pull infogami from. Leave blank to use production infogami for py2, master for py3
+      # Set to "local" to not pull anything and use whatever you've got locally in vendor/infogami
+      # ^ NOTE: Also need to uncomment the infogami volume mount (below) if doing this!
       - INFOGAMI=${INFOGAMI:-}
     build:
       context: .
@@ -23,6 +26,9 @@ services:
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
       - .:/openlibrary
+      # If you're making changes to infogami, enable this, and set INFOGAMI=local when
+      # starting docker-compose
+#      - ./vendor/infogami:/openlibrary/vendor/infogami
     networks:
       - webnet
   solr:

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -8,14 +8,20 @@ COVER_CONFIG=conf/coverstore.yml
 
 python --version
 
-if [[ "$PYENV_VERSION" = 3* || -n $INFOGAMI ]]; then
-  pushd vendor/infogami
-  # Use Python 3 compatible infogami
-  git pull origin "${INFOGAMI:-master}"
-  popd
+if [[ "$INFOGAMI" = "local" ]]; then
+  # If we're using the local copy of infogami, don't pull anything
+  # and just use what's there
+  echo "Using local infogami"
 else
-  # Use production infogami
-  make git
+  if [[ "$PYENV_VERSION" = 3* || -n $INFOGAMI ]]; then
+    pushd vendor/infogami
+    # Use Python 3 compatible infogami
+    git pull origin "${INFOGAMI:-master}"
+    popd
+  else
+    # Use production infogami
+    make git
+  fi
 fi
 
 reindex-solr() {


### PR DESCRIPTION
Now, you can specify `INFOGAMI=local docker-compose up -d` and modify `docker-compose.yml` to set the infogami volume mount, and then you can make changes to host infogami and see it reflected in real time! You can also check out whatever fork/branch you want in vendor/infogami, and it will now be correct.

### Technical
- It's annoying that you need to modify the docker-compose.yml, but good enough for now (I couldn't think of a good quick alternative).

### Testing
Checked out infogami master on my host, then used INFOGAMI=local + enable the volume mount. Got a bunch of errors 🎉 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
