### PR TITLE
Upgrade select Python dependencies

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -780,15 +780,15 @@ def save_error():
         os.makedirs(dir)
 
     error = web.safestr(web.djangoerror())
-    f = open(path, 'w')
-    f.write(error)
-    f.close()
-
+    with open(path, 'w') as f:
+        f.write(error)
+    logger.error("{} saved to {}".format(error, path))
     print('error saved to', path, file=web.debug)
     return name
 
 def internalerror():
-    i = web.input(_method='GET', debug='false')
+    i = web.input(_method='GET', debug='true')  # TODO: cclauss "false"
+    logger.error("internalerror() got {}".format(increment_error_count))
     name = save_error()
 
     # TODO: move this stats stuff to plugins\openlibrary\stats.py

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -780,15 +780,15 @@ def save_error():
         os.makedirs(dir)
 
     error = web.safestr(web.djangoerror())
-    with open(path, 'w') as f:
-        f.write(error)
-    logger.error("{} saved to {}".format(error, path))
+    f = open(path, 'w')
+    f.write(error)
+    f.close()
+
     print('error saved to', path, file=web.debug)
     return name
 
 def internalerror():
-    i = web.input(_method='GET', debug='true')  # TODO: cclauss "false"
-    logger.error("internalerror() got {}".format(increment_error_count))
+    i = web.input(_method='GET', debug='false')
     name = save_error()
 
     # TODO: move this stats stuff to plugins\openlibrary\stats.py

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -8,19 +8,19 @@ gunicorn==19.9.0
 internetarchive==1.8.5
 lxml==4.4.1
 Pillow==6.2.2; python_version < '3.0'
-Pillow==7.1.1; python_version >= '3.0'
+Pillow==7.2.0; python_version >= '3.0'
 pymarc==3.2.0; python_version < '3.6'
 pymarc==4.0.0; python_version >= '3.6'
 python-memcached==1.59
 simplejson==3.16.0
 web.py==0.39; python_version < '3.0'
-web.py==0.51; python_version >= '3.0'
+web.py==0.60; python_version >= '3.0'
 pystatsd==0.1.6; python_version < '3.0'
 statsd==3.3.0; python_version >= '3.0'
 PyYAML==4.2b4
 eventer==0.1.1
 validate_email==1.3
-six==1.14.0
+six==1.15.0
 sixpack-client==1.2.0
 psycopg2==2.8.4
 Pygments==2.4.2

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -13,8 +13,8 @@ pymarc==3.2.0; python_version < '3.6'
 pymarc==4.0.0; python_version >= '3.6'
 python-memcached==1.59
 simplejson==3.16.0
-web.py==0.39; python_version < '3.0'
-web.py==0.60; python_version >= '3.0'
+web.py==0.39; python_version < '3.5'
+web.py==0.61; python_version >= '3.5'
 pystatsd==0.1.6; python_version < '3.0'
 statsd==3.3.0; python_version >= '3.0'
 PyYAML==4.2b4

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,10 +3,10 @@
 # see .travis.yml for more details.
 
 -r requirements_common.txt
-flake8==3.7.9
+flake8==3.8.3
 mockcache==1.0.3; python_version < '3.0'
-pymemcache==3.1.1; python_version >= '3.0'
+pymemcache==3.2.0; python_version >= '3.0'
 ptvsd==4.3.2
 pytest==4.6.9; python_version < '3.0'
-pytest==5.4.1; python_version >= '3.0'
+pytest==5.4.3; python_version >= '3.0'
 safety==1.9.0; python_version >= '3.5'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This PR:
* upgrades `flake8` and `six` on both Python 2 and Python 3.
* upgrades [web.py](https://github.com/webpy/webpy/releases/tag/0.60) and other Python dependencies on Python 3 only.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
