### PR TITLE
Add 2016 LOC MARC dump description to sources

### DIFF
--- a/openlibrary/templates/history/sources.html
+++ b/openlibrary/templates/history/sources.html
@@ -1,6 +1,7 @@
 $code:
     names = {
         "marc_loc_updates": "Library of Congress",
+        "marc_loc_2016": "Library of Congress",
         "marc_records_scriblio_net": "Scriblio",
         "talis_openlibrary_contribution": "Talis",
         "unc_catalog_marc": "University of North Carolina",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Minor UI tweak to display 'Library of Congress' rather than 'marc_loc_2016' for the source of the most recent publicly available LOC MARC records.

https://archive.org/details/marc_loc_2016 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/905545/88350580-a46c1280-cda7-11ea-9a4e-7061ea4525b0.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
