### PR TITLE
Reduce /contact spam

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -22,7 +22,7 @@ import six
 __all__ = [
     "cached_property",
     "Cache", "MemoryCache", "MemcacheCache", "RequestCache",
-    "memoize", "memcache_memoize"
+    "memoize", "memcache_memoize", "get_memcache"
 ]
 
 DEFAULT_CACHE_LIFETIME = 2 * MINUTE_SECS

--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -9,6 +9,9 @@ from infogami.utils.view import render_template
 
 from openlibrary import accounts
 from openlibrary.core import stats
+from openlibrary.core.cache import get_memcache
+from openlibrary.plugins.upstream.addbook import get_recaptcha
+from openlibrary.utils.dateutil import MINUTE_SECS
 
 logger = logging.getLogger("openlibrary")
 
@@ -17,7 +20,10 @@ class contact(delegate.page):
         i = web.input(path=None)
         user = accounts.get_current_user()
         email = user and user.email
-        template = render_template("support", email=email, url=i.path)
+        has_emailed_recently = get_memcache().get('contact-POST-%s' % web.ctx.ip)
+        recaptcha = has_emailed_recently and get_recaptcha()
+        template = render_template("support", email=email, url=i.path,
+                                   recaptcha=recaptcha)
         template.v2 = True
         return template
 
@@ -31,6 +37,13 @@ class contact(delegate.page):
         useragent = web.ctx.env.get("HTTP_USER_AGENT","")
         if not all([email, topic, description]):
             return ""
+
+        recap = get_recaptcha()
+        if recap and not recap.validate():
+            return render_template("message.html",
+                'Recaptcha solution was incorrect',
+                'Please <a href="javascript:history.back()">go back</a> and try again.'
+            )
 
         default_assignees = config.get("support_default_assignees",{})
         topic_key = str(topic.replace(" ","_").lower())
@@ -47,6 +60,10 @@ class contact(delegate.page):
 
         message = SUPPORT_EMAIL_TEMPLATE % locals()
         sendmail(email, assignee, subject, message)
+
+        get_memcache().set(
+            'contact-POST-%s' % web.ctx.ip, "true", time=15 * MINUTE_SECS
+        )
         return render_template("email/case_created", assignee)
 
 def sendmail(from_address, to_address, subject, message):

--- a/openlibrary/templates/site/footer.html
+++ b/openlibrary/templates/site/footer.html
@@ -22,7 +22,7 @@ $if bodyid == 'user' or 'admin':
     });
     </script>
 
-    $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books']]):
+    $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books', '/contact']]):
         <!-- Must be loaded in Sign Up and Add new Books page -->
         <!-- Must be loaded for all edit pages having link /books/*/*/edit -->
         <script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -62,7 +62,7 @@ $def with (page)
     <!-- Drini, Google Search Console -->
     <meta name="google-site-verification" content="XYOJ9Uj0MBr6wk7kj1IkttXrqY-bbRstFMADTfEt354" />
 
-    $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books']]):
+    $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books', '/contact']]):
         <!-- Must be loaded in Sign Up and Add new Books page -->
         <!-- Must be loaded for all edit pages having link /books/*/*/edit -->
         <script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -1,4 +1,4 @@
-$def with (email=None, url=None, done = False)
+$def with (email=None, url=None, done=False, recaptcha=None)
 $# Template entry point for /contact page
 $var title: How can we help?
 
@@ -50,6 +50,10 @@ to see if your question is answered there. Thank you.</p>
  <div class="input"><input type="hidden" name="url" id="url" value="$url"/></div>
 <!-- </div> -->
 
+ $if recaptcha:
+   <div class="formElement">
+     <div class="g-recaptcha" data-sitekey="$:recaptcha.public_key"></div>
+   </div>
 
  <div class="formElement bottom">
  <div class="input">


### PR DESCRIPTION
Getting report of spam through the /contact endpoint; trying to limit it while still making it easy for people to file issues

### Technical
- IP is stored in memcache md5 hashed for 15min
- Admins/librarians/users with accounts > 30 days should never see the recaptcha and always be allowed to send emails.

### Testing
- Tested locally the g-recaptcha is added after second POST
- Test on dev
   - [x] Logged out user can send email without recaptcha
   - [x] Admin/librarian can send email without recaptcha
   - [x] Logged out users see a recaptcha on second email if it's within 15min of last POST
   - [x] Logged out users do not see a recaptcha on second email if it's been more than 15min since last POST

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/6251786/88353821-f0c63c80-cd2c-11ea-9e68-a51c3e0254f0.png)


### Stakeholders
@mekarpeles @JeffKaplan 
