### PR TITLE
Trapezoid-shaped cover removed

### DIFF
--- a/openlibrary/macros/CoverImage.html
+++ b/openlibrary/macros/CoverImage.html
@@ -16,7 +16,7 @@ $ author_names = ", ".join(aname(a) for a in book.authors) or book.get('by_state
 $ cover_url = book.get_cover_url(size)
 
 $if size == "M":
-    <div class="coverMagic">
+    <div class="coverMagic cover-animation">
         $if cover_url:
             <div class="SRPCover bookCover">
                 <img src="$cover_url" class="cover" alt="$title $_.by $author_names"/>

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -12,7 +12,7 @@ $ cover_url = book.get_cover_url(size)
 $ cover_lg = book.get_cover_url("L")
 
 $if size == "M":
-    <div class="coverMagic">
+    <div class="coverMagic cover-animation">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
                     class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" srcset="$cover_lg 2x" class="cover" alt="Cover of: $title | $author_names"/></a>

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -11,13 +11,9 @@
 .editionCover {
   min-height: 10px;
   padding-right: 1.5em;
-
-  .illustration {
-    transform: perspective(800px) rotateX(10deg);
-    transition: transform 0.8s, opacity 0.8s
-  }
-  .illustration:hover {
+  .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
+    transition: transform 0.8s, opacity 0.8s;
     opacity: 0.8;
   }
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -17,7 +17,7 @@
   }
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
-    opacity .8;
+    opacity: .8;
   }
 }
 @import (less) "components/cover.less";

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -18,7 +18,6 @@
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
     transition: transform 0.8s, opacity 0.8s;
-    opacity: 0.8;
   }
 }
 @import (less) "components/cover.less";

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -13,11 +13,11 @@
   padding-right: 1.5em;
   .cover-animation {
     transform: perspective(0px) rotateX(0deg);
-    transition: transform 0.8s;
+    transition: transform 0.8s, opacity .8s;
   }
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
-    transition: transform 0.8s, opacity 0.8s;
+    opacity .8;
   }
 }
 @import (less) "components/cover.less";

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -11,6 +11,10 @@
 .editionCover {
   min-height: 10px;
   padding-right: 1.5em;
+  .cover-animation {
+    transform: perspective(0px) rotateX(0deg);
+    transition: transform 0.8s;
+  }
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
     transition: transform 0.8s, opacity 0.8s;


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Updates #3561 - trapezoid-shaped cover looks distorted

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
- Animation initial perspective changed
- Animation disabled for `Add Cover Image` button

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini 