### PR TITLE
make test: test JavaScript before Python and seperate tests for css and js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ ifndef CONTINUOUS_INTEGRATION
 	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif
 
-test-py:
-	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests
-
 test-js:
 	npm test
 
-test: test-py test-js
+test-py:
+	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests
+
+test: test-js test-py

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,16 @@ ifndef CONTINUOUS_INTEGRATION
 	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif
 
+test-css:
+	npm run test:css
+
 test-js:
-	npm test
+	npm run lint:js
+
+test-unit:
+	npm run test:unit
 
 test-py:
 	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests
 
-test: test-js test-py
+test: test-css test-js test-unit test-py

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-css:
 	npm run test:css
 
 test-js:
-	npm run lint:js
+	npm run test:js
 
 test-unit:
 	npm run test:unit
@@ -83,4 +83,5 @@ test-unit:
 test-py:
 	pytest openlibrary/tests openlibrary/mocks openlibrary/olbase openlibrary/plugins openlibrary/utils openlibrary/catalog openlibrary/coverstore scripts/tests
 
-test: test-css test-js test-unit test-py
+test: 
+	npm run test && make test-py

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "build-assets:js": "make js",
     "svg-min": "svgo --config .svgo.yml static/images/**/*.svg static/images/*.svg",
     "lint:fix": "eslint --config .eslintrc.json . --fix && stylelint --syntax less --fix static/css/",
-    "lint:js": "npm run build-assets:js && eslint --config .eslintrc.json .",
+    "lint:js": "eslint --config .eslintrc.json .",
     "test:unit": "jest --testRegex tests/unit/**/test.*.js",
-    "test:css": "npm run build-assets && bundlesize && stylelint --syntax less static/css/",
-    "test": "npm run test:css && npm run lint:js && npm run test:unit"
-  },
+    "test:css": "npm run build-assets:css && bundlesize && stylelint --syntax less static/css/",
+    "test:js": "npm run build-assets:js && npm run lint:js",
+    "test": "npm run build-assets && bundlesize && stylelint --syntax less static/css/ && npm run lint:js && npm run test:unit"
+  },  
   "devDependencies": {
     "@babel/core": "7.2.2",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "watch": "webpack --watch --mode=development --progress",
     "build-assets:webpack": "NODE_ENV=production webpack --mode=production",
     "build-assets": "make js && make css",
-    "check-bundles": "npm run build-assets && bundlesize",
+    "build-assets:css": "make css",
+    "build-assets:js": "make js",
     "svg-min": "svgo --config .svgo.yml static/images/**/*.svg static/images/*.svg",
     "lint:fix": "eslint --config .eslintrc.json . --fix && stylelint --syntax less --fix static/css/",
-    "lint:js": "eslint --config .eslintrc.json .",
+    "lint:js": "npm run build-assets:js && eslint --config .eslintrc.json .",
     "test:unit": "jest --testRegex tests/unit/**/test.*.js",
-    "test": "npm run check-bundles && stylelint --syntax less static/css/ && npm run lint:js && npm run test:unit"
+    "test:css": "npm run build-assets:css && bundlesize && stylelint --syntax less static/css/",
+    "test": "npm run test:css && npm run lint:js && npm run test:unit"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "eslint --config .eslintrc.json . --fix && stylelint --syntax less --fix static/css/",
     "lint:js": "npm run build-assets:js && eslint --config .eslintrc.json .",
     "test:unit": "jest --testRegex tests/unit/**/test.*.js",
-    "test:css": "npm run build-assets:css && bundlesize && stylelint --syntax less static/css/",
+    "test:css": "npm run build-assets && bundlesize && stylelint --syntax less static/css/",
     "test": "npm run test:css && npm run lint:js && npm run test:unit"
   },
   "devDependencies": {


### PR DESCRIPTION
As discussed on Slack, if the Python tests fail then the JavaScript tests are never run.  The JS tests are faster and more stable, so this PR proposes to run them first, not last.
Also Adding separate tests for css and js
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
