### PR TITLE
Absolute imports for config in coverstore

### DIFF
--- a/openlibrary/coverstore/db.py
+++ b/openlibrary/coverstore/db.py
@@ -1,6 +1,8 @@
-import web
-import config
 import datetime
+
+import web
+
+from openlibrary.coverstore import config
 
 _categories = None
 _db = None

--- a/openlibrary/coverstore/oldb.py
+++ b/openlibrary/coverstore/oldb.py
@@ -3,8 +3,7 @@
 import web
 import simplejson
 
-import config
-
+from openlibrary.coverstore import config
 from openlibrary.utils import olmemcache
 
 __all__ = [


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Use absolute imports in coverstore for Python 3.

This enables advanced search on Python 3 like http://localhost:8080/search?q=twain&debug=true

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
