### PR TITLE
DockerHub fix #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
-	if [ $(numFiles) -eq 0 ]; then \
+	if [ -z "$DOCKER_HUB" ]; then \
 		git submodule init; \
 		git submodule sync; \
 		git submodule update; \

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,14 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:
-	git submodule init
-	git submodule sync
-	git submodule update
+    	shopt -s nullglob dotglob
+    	files=(vendor/infogami/*)
+    	if [ "${#files[*]}" -eq "0" ]; then
+        	git submodule init
+        	git submodule sync
+        	git submodule update
+	fi
+    	shopt -u nullglob dotglob
 
 clean:
 	rm -rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
-	if [ -z "$DOCKER_HUB" ]; then \
-		git submodule init; \
+	if [ -z "$(DOCKER_HUB)" ]; then \
+		echo "not executing git submodules"; \
+        	git submodule init; \
 		git submodule sync; \
 		git submodule update; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
-ifneq ($(DOCKER_HUB),TRUE)
+	env
+ifneq ($(DOCKER_HUB),TRue)
 	@echo $(DOCKER_HUB)
 	git submodule init
 	git submodule sync

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BUILD=static/build
 ACCESS_LOG_FORMAT='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
 GITHUB_EDITOR_WIDTH=127
 FLAKE_EXCLUDE=./.*,scripts/20*,vendor/*,node_modules/*
+numFiles=$(shell ls ./vendor/infogami/|wc -l)
 
 define lessc
 	echo Compressing $(1).less; \
@@ -39,15 +40,12 @@ js:
 i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
-git:
-	shopt -s nullglob dotglob
-	files=(vendor/infogami/*)
-	if [ "${#files[*]}" -eq "0" ]; then
-		git submodule init
-		git submodule sync
-		git submodule update
-	fi
-	shopt -u nullglob dotglob
+git:	
+	if [ $(numFiles) -eq 0 ]; then \
+		git submodule init; \
+		git submodule sync; \
+		git submodule update; \
+	fi;
 
 clean:
 	rm -rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ i18n:
 
 git:	
 	env
-ifneq ($(DOCKER_HUB),TRue)
+ifneq ($(DOCKER_HUB),TRUE)
 	@echo $(DOCKER_HUB)
 	git submodule init
 	git submodule sync

--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,14 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:
-    	shopt -s nullglob dotglob
-    	files=(vendor/infogami/*)
-    	if [ "${#files[*]}" -eq "0" ]; then
-        	git submodule init
-        	git submodule sync
-        	git submodule update
+	shopt -s nullglob dotglob
+	files=(vendor/infogami/*)
+	if [ "${#files[*]}" -eq "0" ]; then
+		git submodule init
+		git submodule sync
+		git submodule update
 	fi
-    	shopt -u nullglob dotglob
+	shopt -u nullglob dotglob
 
 clean:
 	rm -rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,11 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
-	if [ -z $(DOCKER_HUB) ]; then \
-		echo "not executing git submodules"; \
-        	git submodule init; \
-		git submodule sync; \
-		git submodule update; \
-	fi;
+ifneq ($(DOCKER_HUB),TRUE)
+	git submodule init
+	git submodule sync
+	git submodule update
+endif
 
 clean:
 	rm -rf $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ i18n:
 
 git:	
 	env
-ifneq ($(DOCKER_HUB),TRUE)
+ifeq ($(DOCKER_HUB),FALSE)
 	@echo $(DOCKER_HUB)
 	git submodule init
 	git submodule sync

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
+#Do not run these on DockerHub since it recursively clones all the repos before build initiates
 ifeq ($(DOCKER_HUB),FALSE)
 	git submodule init
 	git submodule sync

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ BUILD=static/build
 ACCESS_LOG_FORMAT='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
 GITHUB_EDITOR_WIDTH=127
 FLAKE_EXCLUDE=./.*,scripts/20*,vendor/*,node_modules/*
-numFiles=$(shell ls ./vendor/infogami/|wc -l)
 
 define lessc
 	echo Compressing $(1).less; \
@@ -41,9 +40,7 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
-	env
 ifeq ($(DOCKER_HUB),FALSE)
-	@echo $(DOCKER_HUB)
 	git submodule init
 	git submodule sync
 	git submodule update

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:	
-	if [ -z "$(DOCKER_HUB)" ]; then \
+	if [ -z $(DOCKER_HUB) ]; then \
 		echo "not executing git submodules"; \
         	git submodule init; \
 		git submodule sync; \

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ i18n:
 
 git:	
 ifneq ($(DOCKER_HUB),TRUE)
+	@echo $(DOCKER_HUB)
 	git submodule init
 	git submodule sync
 	git submodule update

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,5 +1,7 @@
 FROM ubuntu:xenial
 
+ARG DOCKER_HUB=FALSE
+
 ENV LANG en_US.UTF-8
 
 # required for postgres

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd ../
-docker build -t olbase:latest --build-arg DOCKER_HUB=TRUE -f docker/Dockerfile.olbase .
+docker build -t $IMAGE_NAME --build-arg DOCKER_HUB=TRUE -f "$DOCKERFILE_PATH" .

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -t olbase:latest --build-arg DOCKER_HUB=TRUE -f docker/Dockerfile.olbase .
+docker build -t olbase:latest --build-arg DOCKER_HUB=TRUE -f Dockerfile.olbase .

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t olbase:latest --build-arg DOCKER_HUB=TRUE -f docker/Dockerfile.olbase .

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker build -t olbase:latest --build-arg DOCKER_HUB=TRUE -f Dockerfile.olbase .
+cd ../
+docker build -t olbase:latest --build-arg DOCKER_HUB=TRUE -f docker/Dockerfile.olbase .

--- a/docker/hooks/post_checkout
+++ b/docker/hooks/post_checkout
@@ -1,2 +1,2 @@
 #!/bin/bash
-export DOCKER_HUB=true
+export DOCKER_HUB=TRUE

--- a/docker/hooks/post_checkout
+++ b/docker/hooks/post_checkout
@@ -1,2 +1,0 @@
-#!/bin/bash
-export DOCKER_HUB=TRUE

--- a/docker/hooks/post_checkout
+++ b/docker/hooks/post_checkout
@@ -1,0 +1,1 @@
+export DOCKER_HUB=true

--- a/docker/hooks/post_checkout
+++ b/docker/hooks/post_checkout
@@ -1,1 +1,2 @@
+#!/bin/bash
 export DOCKER_HUB=true


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3615

@cdrini Seems like DockerHub is itself able to pull the submodules before the any of the steps in Dockerfile are run (effectively doing git pulling of submodules before the docker build)

Hence another solution for this issue, in addition to https://github.com/internetarchive/openlibrary/pull/3628 might be to add a check - for the sake of checking if DockerHub has already recursively cloned the submodules, and run git submodule commands in `git` rule of `Makefile` only when `vendor/infogami` is empty implying that submodule hasn't yet been cloned (we could have chosen any of the 3 submodules for checking if they're empty, the choice of `vendor/infogami` is entirely random).

This seems a better fix to the DockerHub publishing issue rather than the related PR: https://github.com/internetarchive/openlibrary/pull/3628

I was able to build on publish the image on DockerHub using this. 