### PR TITLE
Python 3: Stats workaround for lang not in web.ctx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ htmlcov
 node_modules/
 .idea/
 venv/
+vendor/
 *.c
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ htmlcov
 node_modules/
 .idea/
 venv/
-vendor/
 *.c
 *.so

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -815,6 +815,8 @@ class readinglog_stats(delegate.page):
             }
             for a in web.ctx.site.get_many(list(author_keys))
         ]
+        # TODO: (cclauss) Python 3 workaround for lang not in web.ctx
+        # Was: lang=web.ctx.lang
         page = render['account/readinglog_stats'](
             json.dumps(works_json),
             json.dumps(authors_json),
@@ -823,7 +825,7 @@ class readinglog_stats(delegate.page):
             user.displayname,
             web.ctx.path.rsplit('/', 1)[0],
             key,
-            lang=web.ctx.lang,
+            lang=dict(web.ctx).get('lang', 'en')
         )
         page.v2 = True
         return page
@@ -887,7 +889,7 @@ class fetch_goodreads(delegate.page):
                               delimiter=',', quotechar='"')
         header = csv_file.next()
         books = {}
-        books_wo_isbns = {} 
+        books_wo_isbns = {}
         for book in list(csv_file):
             _book = dict(zip(header, book))
             _book['ISBN'] = _book['ISBN'].replace('"','').replace('=','')
@@ -898,7 +900,7 @@ class fetch_goodreads(delegate.page):
                 books[_book['ISBN13']] = _book
                 books[_book['ISBN13']]['ISBN'] = _book['ISBN13']
             else:
-                books_wo_isbns[_book['Book Id']] = _book     
+                books_wo_isbns[_book['Book Id']] = _book
         return render['account/import'](books, books_wo_isbns)
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->

On Python 3, the urls below will raise `AttributeError: 'ThreadedDict' object has no attribute 'lang'
* http://localhost:8080/people/openlibraryXXXX/books/already-read/stats
* http://localhost:8080/people/openlibraryXXXX/books/currently-reading/stats
* http://localhost:8080/people/openlibraryXXXX/books/want-to-read/stats

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This temporary workaround allows us to continue to experiment with OL on Python 3 while we search for why web.ctx.lang is not getting set on Python 3.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
