### PR TITLE
.gitmodules: [submodule "vendor/infogami"] ignore = dirty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "vendor/infogami"]
 	path = vendor/infogami
 	url = git://github.com/internetarchive/infogami.git
+	ignore = dirty
 [submodule "vendor/js/wmd"]
 	path = vendor/js/wmd
 	url = git://github.com/internetarchive/wmd.git


### PR DESCRIPTION
As discussed at http://www.nils-haldenwang.de/frameworks-and-tools/git/how-to-ignore-changes-in-git-submodules

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
