### PR TITLE
Fix mockcache for Python 3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "vendor/infogami"]
 	path = vendor/infogami
 	url = git://github.com/internetarchive/infogami.git
+	ignore = all
 [submodule "vendor/js/wmd"]
 	path = vendor/js/wmd
 	url = git://github.com/internetarchive/wmd.git

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -87,15 +87,15 @@ logging_config_file: conf/logging.ini
 email_config_file: conf/email.ini
 
 lists:
-    seeds_db: http://127.0.0.1:5984/seeds
-    editions_db: http://127.0.0.1:5984/editions
-    works_db: http://127.0.0.1:5984/works
-    editions_view: http://127.0.0.1:5984/editions/_fti/_design/seeds/by_seed
+    seeds_db: http://localhost:5984/seeds
+    editions_db: http://localhost:5984/editions
+    works_db: http://localhost:5984/works
+    editions_view: http://localhost:5984/editions/_fti/_design/seeds/by_seed
 
 admin:
     nagios_url: http://monitor.us.archive.org/cgi-bin/nagios3/status.cgi?hostgroup=24.openlibrary&style=detail
     statsd_server: localhost:9090
-    admin_db: http://127.0.0.1:5984/admin
+    admin_db: http://localhost:5984/admin
 
 stats: # This section is used to state what stats need to be gathered.
     pageload.all:
@@ -165,8 +165,8 @@ ia_ol_xauth_s3:
     s3_key: XXX
     s3_secret: XXX
 
-ia_loan_api_url: http://127.0.0.1/internal/fake/loans
-ia_xauth_api_url: http://127.0.0.1/internal/fake/xauth
+ia_loan_api_url: http://localhost/internal/fake/loans
+ia_xauth_api_url: http://localhost/internal/fake/xauth
 
 internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_v1_url: https://archive.org/services/loans/beta/loan/index.php

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -301,8 +301,12 @@ class MemcacheCache(Cache):
             return olmemcache.Client(servers)
         else:
             web.debug("Could not find memcache_servers in the configuration. Used dummy memcache.")
-            import mockcache
-            return mockcache.Client()
+            try:
+                import mockcache
+                return mockcache.Client()
+            except ImportError:
+                from pymemcache.test.utils import MockMemcacheClient
+                return MockMemcacheClient()
 
     def get(self, key):
         key = web.safestr(key)

--- a/openlibrary/macros/EditButtons.html
+++ b/openlibrary/macros/EditButtons.html
@@ -17,7 +17,7 @@ $def with (comment=None)
     <button type="submit" class="larger" name="_save" title="$_('Save')">$_("Save")</button>
     &nbsp;
     <a href="javascript:history.go(-1);" class="small red">$_('Cancel')</a>
-    $if ctx.user and ctx.user.is_admin():
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
         <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete">$_("Delete Record")</button></span>
     $else:
         <div class="adminDelete">$:_('<em>Please Note:</em> Only Admins can delete things. <a href="/contact" class="blue">Let us know</a> if there\'s a problem.')</div>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -6,8 +6,6 @@ $var title: $this_title
 $putctx("robots", "noindex,nofollow")
 
 <script type="text/javascript">
-<!--
-
 function limitChars(textid, limit, infodiv) {
     var text = \$('#'+textid).val();
     var textlength = text.length;
@@ -42,10 +40,9 @@ window.q.push( function(){
         \$(window).scrollTop(\$("#contentHead").offset().top);
     }, 1000);
 } );
-//-->
 </script>
 
-<div id="contentHead">
+<div id="contentHead" class="editFormHead">
     $code:
         def find_mode():
             mode = query_param("mode")
@@ -72,7 +69,9 @@ window.q.push( function(){
         else:
             title = _("Editing...")
             note = ""
-    <h1>$:title</h1>
+    <h2 class="editFormTitle">$:title</h2>
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
+        <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete">$_("Delete Record")</button></span>
     $if not ctx.user:
         $:render_template("lib/not_logged")
     $:note
@@ -82,36 +81,14 @@ window.q.push( function(){
     <form method="post" id="addWork" class="olform books validate" name="edit" action="">
 
         <input type="hidden" name="work--key" value="$work.key">
-    <div class="formElement title">
-        <div class="TitleAuthor sansserif">
-            <div class="label">
-                <label for="work-title">$_('Title')</label> <span class="tip">$:_("Use <b><i>Title: Subtitle</i></b> to add a subtitle.")</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
-            </div>
-            <div class="input">
-                <input name="work--title" type="text" id="work-title" class="required" value="$this_title"/>
-            </div>
-            <div class="label">
-                <label for="author-$0">$_('Author')</label>
-                <span class="tip">$:_('You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href="/authors/OL23919A" target="_blank"><em>OL23919A</em></a>).')</span>
-                <br/>
-                <div class="flash-messages">
-                    <noscript>
-                        <p class="error">
-                           <span>$:_('Author editing requires javascript')</span>
-                        </p>
-                    </noscript> 
-                </div>  
-            </div>
-            $ authors = work.authors and [a.author for a in work.authors]
-            $:render_template("books/author-autocomplete", authors, "authors", "work--authors")
-        </div>
-    </div>
-
+        $ authors = work.authors and [a.author for a in work.authors]
+        <h1 class="editFormBookTitle">$this_title</h1>
+        $if authors:
+            $ all_authors = "By {},".format(" ".join(author.name for author in authors))
+            <h3 class="editFormBookAuthors">$all_authors[:-1]</h3>
         <div id="tabsAddbook">
             <ul>
-                <li><a href="#about" id="link_about">$_("What's It About?")</a></li>
-                <li><a href="#excerpts" id="link_excerpts">$_("Add Excerpts")</a></li>
-                <li><a href="#web" id="link_web">$_("Links")</a></li>
+                <li><a href="#about" id="link_about">$_("Work Details")</a></li>
                 $if edition:
                     $if edition.publishers:
                         $ edition_name = "; ".join(edition.publishers) + ' edition'
@@ -125,15 +102,49 @@ window.q.push( function(){
             </ul>
 
             <div id="about">
-                $:render_template("books/edit/about", work)
-            </div>
-
-            <div id="excerpts">
-                $:render_template("books/edit/excerpts", work)
-            </div>
-
-            <div id="web">
-                $:render_template("books/edit/web", work, prefix="work--")
+                <fieldset class="major">
+                    <legend>$_("This Work")</legend>
+                    <div class="formBack">
+                        <div class="formElement formBackLeft">
+                            <div class="formElement title">
+                                <div class="TitleAuthor sansserif">
+                                    <div class="label">
+                                        <label for="work-title">$_('Title')</label> <span class="tip">$:_("Use <b><i>Title: Subtitle</i></b> to add a subtitle.")</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
+                                    </div>
+                                    <div class="input">
+                                        <input name="work--title" type="text" id="work-title" class="required" value="$this_title"/>
+                                    </div>
+                                    <div class="label">
+                                        <label for="author-$0">$_('Author')</label>
+                                        <span class="tip">$:_('You can search by author name (like <em>j k rowling</em>) or by Open Library ID (like <a href="/authors/OL23919A" target="_blank"><em>OL23919A</em></a>).')</span>
+                                        <br/>
+                                        <div class="flash-messages">
+                                            <noscript>
+                                                <p class="error">
+                                                <span>$:_('Author editing requires javascript')</span>
+                                                </p>
+                                            </noscript> 
+                                        </div>  
+                                    </div>
+                                    $:render_template("books/author-autocomplete", authors, "authors", "work--authors")
+                                </div>
+                            </div>
+                            $:render_template("books/edit/about", work)
+                        </div>
+                    </div>
+                </fieldset>
+                <fieldset class="major">
+                    <legend>$_("Add Excerpts")</legend>
+                    <div class="formBack" id="excerpts">
+                        $:render_template("books/edit/excerpts", work)
+                    </div>
+                </fieldset>
+                <fieldset class="major">
+                    <legend>$_("Links")</legend>
+                    <div class="formBack">
+                        $:render_template("books/edit/web", work, prefix="work--")
+                    </div>
+                </fieldset>
             </div>
 
             $if edition:
@@ -149,11 +160,7 @@ window.q.push( function(){
 
         $:macros.EditButtons(comment=work.comment_)
 
-        $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
-            <div class="adminOnly" style="position:absolute;top:20px;right:20px;"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete this book?')" id="deleteTop">$_("Delete Record")</button></div>
-
     </form>
-
     $if edition:
         $:render_template("books/edit/addfield", edition)
 

--- a/openlibrary/templates/books/edit/about.html
+++ b/openlibrary/templates/books/edit/about.html
@@ -1,6 +1,6 @@
 $def with (work)
 
-<fieldset class="major collapse">
+<fieldset class="major">
     <div class="formElement">
         <div class="label">
             <label for="about-about">$_("How would you describe this book?")</label>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -112,89 +112,12 @@ window.q.push(function() {
 });
 </script>
 
-
-<fieldset class="major">
-    <legend>$_("Publishing Info")</legend>
-
-    <div class="formBack">
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-publishers">$_("Who is the publisher?")</label>
-                <span class="tip">$_("For example"): <em>Oxford University Press; Penguin; W.W. Norton</em></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--publishers" id="edition-publishers" value="$'; '.join(book.publishers)"/>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-publish_date">$_("When was it published?")</label>
-                <span class="tip">$_("You should be able to find this in the first few pages of the book.")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--publish_date" id="edition-publish_date" value="$book.publish_date"/>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-publish_places">$_("Where was the book published?")</label>
-                <span class="tip">$_("City, Country please.") $_("For example:") <i>New York, USA; Sydney, Australia</i></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--publish_places" id="edition-publish_places" value="$'; '.join(book.publish_places)"/>
-            </div>
-        </div>
-
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-copyright_date">$_("Is there a copyright date?")</label>
-                <span class="tip">$_("The year following the copyright statement.")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--copyright_date" id="edition-copyright_date" value="$book.copyright_date"/>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-series">$_("Is the book part of a series?")</label>
-                <span class="tip">$_("The name of the publisher's series.") $_("For example:") <i>The Story of Civilization, Part III</i></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--series--0" id="edition-series" value="$(book.series and book.series[0] or "")"/>
-            </div>
-        </div>
-    </div>
-</fieldset>
-
 <fieldset class="major">
     <legend>$_("This Edition")</legend>
 
     <div class="formBack">
 
-        <div class="formElement formBackLeft">
-            <div class="label">
-                <label for="edition--works--$0">$_("What work is this an edition of?")</label>
-                <span class="tip">
-                    $_("Sometimes editions can be associated with the wrong work. You can correct that here.")
-                    $_("You can search by title or by Open Library ID (like")
-                    <a href="/works/OL262757W" target="_blank"><em>OL262757W</em></a>).
-                    <br/>
-                    $_("WARNING: Any edits made to the work from this page will be ignored.")
-                </span>
-            </div>
-            <div id="works">
-                $if book.works:
-                    $for i, work in enumerate(book.works):
-                        $:render_work_field(i, work)
-                $else:
-                    $:render_work_field(0, storage(title="", key=""))
-            </div>
-        </div>
+       
 
     <div class="formBackLeft">
         <div class="formElement">
@@ -261,6 +184,7 @@ window.q.push(function() {
         </div>
 
     </div>
+
     <div class="formBackRight">
         <div class="illustration">
             $:render_template("covers/book_cover", book)
@@ -354,7 +278,6 @@ window.q.push(function() {
                     <input name="edition--by_statement" type="text" id="edition-by_statement" value="$book.by_statement" />
                 </div>
             </div>
-
         </fieldset>
 
         <fieldset class="minor formBackRight">
@@ -433,8 +356,86 @@ window.q.push(function() {
             </div>
         </div>
 
+        <div class="formElement formBackLeft">
+            <div class="label">
+                <label for="edition--works--$0">$_("What work is this an edition of?")</label>
+                <span class="tip">
+                    $_("Sometimes editions can be associated with the wrong work. You can correct that here.")
+                    $_("You can search by title or by Open Library ID (like")
+                    <a href="/works/OL262757W" target="_blank"><em>OL262757W</em></a>).
+                    <br/>
+                    $_("WARNING: Any edits made to the work from this page will be ignored.")
+                </span>
+            </div>
+            <div id="works">
+                $if book.works:
+                    $for i, work in enumerate(book.works):
+                        $:render_work_field(i, work)
+                $else:
+                    $:render_work_field(0, storage(title="", key=""))
+            </div>
+        </div>
+
     </div>
 
+</fieldset>
+
+<fieldset class="major">
+    <legend>$_("Publishing Info")</legend>
+
+    <div class="formBack">
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-publishers">$_("Who is the publisher?")</label>
+                <span class="tip">$_("For example"): <em>Oxford University Press; Penguin; W.W. Norton</em></span>
+            </div>
+            <div class="input">
+                <input type="text" name="edition--publishers" id="edition-publishers" value="$'; '.join(book.publishers)"/>
+            </div>
+        </div>
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-publish_date">$_("When was it published?")</label>
+                <span class="tip">$_("You should be able to find this in the first few pages of the book.")</span>
+            </div>
+            <div class="input">
+                <input type="text" name="edition--publish_date" id="edition-publish_date" value="$book.publish_date"/>
+            </div>
+        </div>
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-publish_places">$_("Where was the book published?")</label>
+                <span class="tip">$_("City, Country please.") $_("For example:") <i>New York, USA; Sydney, Australia</i></span>
+            </div>
+            <div class="input">
+                <input type="text" name="edition--publish_places" id="edition-publish_places" value="$'; '.join(book.publish_places)"/>
+            </div>
+        </div>
+
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-copyright_date">$_("Is there a copyright date?")</label>
+                <span class="tip">$_("The year following the copyright statement.")</span>
+            </div>
+            <div class="input">
+                <input type="text" name="edition--copyright_date" id="edition-copyright_date" value="$book.copyright_date"/>
+            </div>
+        </div>
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-series">$_("Is the book part of a series?")</label>
+                <span class="tip">$_("The name of the publisher's series.") $_("For example:") <i>The Story of Civilization, Part III</i></span>
+            </div>
+            <div class="input">
+                <input type="text" name="edition--series--0" id="edition-series" value="$(book.series and book.series[0] or "")"/>
+            </div>
+        </div>
+    </div>
 </fieldset>
 
 <fieldset class="major" id="identifiers">

--- a/openlibrary/templates/books/edit/excerpts.html
+++ b/openlibrary/templates/books/edit/excerpts.html
@@ -3,7 +3,7 @@ $def with (work)
 <div id="excerpts-errors" class="note hidden">
 </div>
 
-<fieldset class="major collapse" id="addexcerpts">
+<fieldset class="major" id="addexcerpts">
     <div id="excerpts-form">
         <div class="formElement">
             <div>$_("If there are particular (short) passages you feel represent the book well, please feel free to transcribe them here.")</div>

--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -3,7 +3,7 @@ $def with (work, prefix="")
 <div id="link-errors" class="note hidden">
 </div>
 
-<fieldset class="major collapse" id="links">
+<fieldset class="major" id="links">
     <div id="links-form">
         <div class="formElement">
             $:_('Please connect Open Library records to <u>good</u><span class="orange">*</span> online resources.')
@@ -57,7 +57,6 @@ $def with (work, prefix="")
 </fieldset>
 
 <script type="text/javascript">
-<!--
     window.q.push(function() {
         \$("#links").repeat({
             vars: {
@@ -79,7 +78,6 @@ $def with (work, prefix="")
             }
         });
     });
-//-->
 </script>
 
 <div class="formElement">

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -72,7 +72,7 @@ window.q.push(function(){
             \$("#imagesAdd").html("");
             \$("#imagesManage").html("");
             $if doc.type.key == "/type/work":
-                \$('#imagesAdd').prepend('<div class="throbber"><h3>$_("One sec, we\'re searching for covers...")</h3></div>');
+                \$('#imagesAdd').prepend('<div class="throbber"><h3>$_("Searching for covers")</h3></div>');
             setTimeout(function() {
                 // add iframe to add images
                 add_iframe("#imagesAdd", "$:add_url");

--- a/openlibrary/templates/type/edition/book_title.html
+++ b/openlibrary/templates/type/edition/book_title.html
@@ -5,11 +5,11 @@ $ book_title = edition.get('title', '') or (work.title if work else '')
 <h1 class="work-title" itemprop="name">$book_title</h1>
 
 $if edition:
-  $if edition.subtitle or edition.edition_title or edition.edition_name:
+  $if edition.subtitle:
     <h2 class="work-subtitle">
-      $if edition.subtitle:
-        $edition.subtitle
-      $if edition.edition_title or edition.edition_name:
-        $if edition.subtitle:
-          &mdash;
-        $edition.edition_title $edition.edition_name
+      $edition.subtitle
+    </h2>
+  $if edition.edition_name:
+    <div class="work-line">
+      $edition.edition_name
+    </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -224,12 +224,16 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
       $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
 
       <a name="work-details" class="section-anchor"></a>
-      <div class="tab-section">
-        <h3><a href="$work.key">$work_title</a>
+      <div class="tab-section work-info">
+        <h2 class="work-title"><a href="$work.key">$work_title</a></h2>
+          $if work and work.subtitle:
+            <h3>
+              $work.subtitle
+            </h3>
           $if work and work.first_publish_year:
-            &mdash; <span class="first-published">
+            <p class="first-published-date">
               $_("First published in %s", work.first_publish_year)
-            </span>
+            </p>
         </h3>
         <hr>
 
@@ -304,10 +308,34 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
       </div>
 
       <a name="edition-details" class="section-anchor"></a>
-      <div class="tab-section">
+      <div class="tab-section edition-info">  
+        $if not page.is_fake_record():
+          $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
+            $if edition and page.type.key in ["/type/work"]:
+                $ edit_url = edition.url(suffix="/edit")
+            $else:
+                $ edit_url = page.url(suffix="/edit")
+          $else:
+            $ edit_url = page.key + "?m=edit"
+          <div id="editButton">
+            <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
+            <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
+              data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
+          </div>
         $if not edition:
           <p>$_("No editions available")</p>
         $if edition:
+          <h2 class="work-title" itemprop="name">$book_title</h2>
+          $if edition.subtitle:
+            <h3>
+              $edition.subtitle
+            </h3>
+          $if edition.edition_name:
+            <div class="work-line">
+              $edition.edition_name
+            </div> 
+          $:render_template("type/edition/publisher_line", edition)    
+          <hr>  
           $if edition.first_sentence:
             <div>
             <h3 class="collapse">$_("First Sentence")</h3>

--- a/static/css/base/helpers-misc.less
+++ b/static/css/base/helpers-misc.less
@@ -56,6 +56,25 @@ button {
   border-radius: 4px;
 }
 
+.editFormHead {
+  display: flex;
+  padding-bottom: 0;
+}
+
+.editFormTitle{
+  flex: 1;
+  margin: 0;
+}
+
+.editFormBookTitle{
+  color: @black;
+  margin: 0;
+}
+
+.editFormBookAuthors{
+  margin-top: 0;
+}
+
 .valid {
   padding: 5px 0 0 29px !important;
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -31,7 +31,7 @@ div.editionAbout {
   margin-bottom: 20px;
   h3 {
     font-size: 14px;
-    margin: 0 0 1em;
+    margin: 0 0 0em;
   }
 
   p {
@@ -43,6 +43,15 @@ div.editionAbout {
     margin: 0;
   }
 
+}
+
+.work-title{
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+
+.work-subtitle{
+  margin-top:0px;
 }
 
 .workFooter {
@@ -168,6 +177,19 @@ a.section-anchor {
 
 .meta dt, .meta dd {
   font-size: 12px;
+}
+
+.work-title{
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+
+.work-subtitle{
+  margin-top:0px;
+}
+
+.book-subtitle{
+  margin-bottom:0px;
 }
 
 @import (less) "components/readerStats.less";

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -104,6 +104,15 @@ div#subjectsPage{
   }
 }
 
+#authors{
+  div{
+    display: flex;
+  }
+  input.author.author-autocomplete{
+    flex: 1;
+  }
+}
+
 th.toggle-all {
   background: @primary-blue;
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.  The mockcache module that Python 2 uses has not been updated for Python 3 so substitute `pymemcache.test.utils.MockMemcacheClient`.

https://pymemcache.readthedocs.io/en/latest/apidoc/pymemcache.test.utils.html

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
