### PR TITLE
Fix mockcache for Python 3

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -301,8 +301,12 @@ class MemcacheCache(Cache):
             return olmemcache.Client(servers)
         else:
             web.debug("Could not find memcache_servers in the configuration. Used dummy memcache.")
-            import mockcache
-            return mockcache.Client()
+            try:
+                import mockcache
+                return mockcache.Client()
+            except ImportError:
+                from pymemcache.test.utils import MockMemcacheClient
+                return MockMemcacheClient()
 
     def get(self, key):
         key = web.safestr(key)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3663 -- That PR got into a bad git state because of `/vendor/infogami` so this PR replaces it.

Fix.  The mockcache module that Python 2 uses has not been updated for Python 3 so substitute `pymemcache.test.utils.MockMemcacheClient`.

https://pymemcache.readthedocs.io/en/latest/apidoc/pymemcache.test.utils.html


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
