### PR TITLE
Re-enable the Integration Tests in xfail mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,35 @@ jobs:
         - source scripts/test-py3.sh
     - name: “Python 3.8 on focal”
       python: "3.8"
+    - name: "Integration tests"
+      python: "3.8"
+      services:
+        - docker
+        - xvfb
+      addons:
+        chrome: stable
+      before_install:
+        - google-chrome --version  # "Google Chrome 84.0.4147.105" so install matching chromedriver
+        - wget http://chromedriver.storage.googleapis.com/84.0.4147.30/chromedriver_linux64.zip
+        - unzip chromedriver_linux64.zip -d $HOME/bin/
+        - whereis chromedriver  # chromedriver: /home/travis/bin/chromedriver
+        - # https://github.com/internetarchive/openlibrary/tree/master/docker
+        - docker build -t olbase:latest -f docker/Dockerfile.olbase .  # 8+ minutes on Travis CI
+        - docker-compose build web   # 50 seconds on Travis CI
+        - docker-compose build solr  # 32 seconds on Travis CI
+        - pushd vendor/infogami && git pull origin master && popd
+        - INFOGAMI=local PYENV_VERSION=3.8.5 docker-compose up -d
+        - google-chrome-stable --headless --no-sandbox --disable-gpu http://localhost:8080 &
+      install:
+        - pip install --upgrade pip wheel
+        - pip install --upgrade splinter pytest pyyaml
+      before_script: true  # Override the main before_script
+      script:
+        - pytest tests/integration
   allow_failures:
     - name: “Python 2.7 on Infogami master”
     - name: “Python 3.8 on focal”
+    - name: "Integration tests"
 # Ubuntu may have an old version of node, so make sure Node 12 is installed
 # and used instead. Should match Dockerfile.
 before_install:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - .:/openlibrary
       # If you're making changes to infogami, enable this, and set INFOGAMI=local when
       # starting docker-compose
-#      - ./vendor/infogami:/openlibrary/vendor/infogami
+      - ./vendor/infogami:/openlibrary/vendor/infogami
     networks:
       - webnet
   solr:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -22,7 +22,7 @@ $ python3 -m venv .venv
 $ source .venv/bin/activate
 $ python3 -m pip install --upgrade pip
 $ python3 -m pip install pytest pyyaml splinter
-Install Chrome and Chromedriver (see .travis.yml) for FireFox and Gekodriver
+Install Chrome and Chromedriver (see .travis.yml) or FireFox and Gekodriver
 * More info at https://chromedriver.chromium.org/
 ````
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -22,6 +22,8 @@ $ python3 -m venv .venv
 $ source .venv/bin/activate
 $ python3 -m pip install --upgrade pip
 $ python3 -m pip install pytest pyyaml splinter
+Install Chrome and Chromedriver (see .travis.yml) for FireFox and Gekodriver
+* More info at https://chromedriver.chromium.org/
 ````
 
 ## Running tests
@@ -35,6 +37,5 @@ Verify correct Open Library host in test files.
 For now, need to manually add an Edition to a new List just once.
 
 ````
-$ cd tests/integration
-$ pytest
+$ pytest tests/integration
 ````

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -9,7 +9,7 @@ requests. Some tests rely on the presence of certain data being present.
 
 ## Installation
 
-Tested on Python 2.7.6, 2.7.12, 3.5.4
+Tested on Python 2.7.6, 2.7.18, 3.8.5
 
 Google Chrome needs to be installed.
 
@@ -18,13 +18,16 @@ $ port install chromedriver (MacPorts)
  or
 $ brew install chromedriver (Homebrew)
 
-$ source activate openlibrary
-$ pip install splinter
-$ pip install pytest
-$ pip install pyyaml
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ python3 -m pip install --upgrade pip
+$ python3 -m pip install pytest pyyaml splinter
 ````
 
 ## Running tests
+
+Run Open Library in Docker as discussed at:
+https://github.com/internetarchive/openlibrary/tree/master/docker
 
 Verify correct Open Library host in test files.
 - Default: `http://localhost:8080`

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,23 +1,55 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
-import time
-import yaml
 import atexit
+import os
+import time
+
+import yaml
 from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException, WebDriverException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class OLSession(object):
     def __init__(self, timeout=10, domain="https://dev.openlibrary.org"):
-        with open('auth.yaml', 'r') as f:
-            self.config = yaml.load(f)
+        # set 'here' to 'openlibrary/tests/integration' regardless of working directory
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, '../../conf/openlibrary.yml')) as f:
+            self.config = yaml.load(f, Loader=yaml.SafeLoader)
+            OPENLIBRARY_USER_AUTH = {
+                'email': 'openlibrary@example.com',
+                'password': self.config.get('admin_password', 'password'),
+            }
+            self.config['accounts'] = {
+                'ia_blocked': OPENLIBRARY_USER_AUTH,
+                'ia_unverified': OPENLIBRARY_USER_AUTH,
+                'ia_verified': 'abc',
+                'ia_verified_mixedcase': 'abc',
+                'ia_create': "tryme",
+                'ia_create_conflict': True,
+
+                'ol_blocked': OPENLIBRARY_USER_AUTH,
+                'ol_unverified': 'abc',
+                'ol_verified': 'abc',
+                'ol_create': 'tryme',
+                'ol_create_conflict': True,
+
+                'linked': OPENLIBRARY_USER_AUTH,
+                'linked_blocked': True,
+
+                'unregistered': True,
+
+                'live1': OPENLIBRARY_USER_AUTH,
+                'live2': OPENLIBRARY_USER_AUTH,
+                'live3': OPENLIBRARY_USER_AUTH,
+            }
         try:
             self.driver = webdriver.Chrome()
-        except:
+        except WebDriverException:
             self.driver = webdriver.Firefox()
+        assert self.driver
 
         self.driver.set_window_size(1200, 1200)
         self.driver.implicitly_wait(timeout)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -39,7 +39,7 @@ errorLookup = {
     "invalid_email": "The email address you entered is invalid",
     "account_blocked": "This account has been blocked",
     "account_locked": "This account has been blocked",
-    "account_not_found": "Wrong email. Please try again",
+    "account_not_found": "No account was found with this email. Please try again",
     "account_incorrect_password": "Wrong password. Please try again",
     "account_bad_password": "Wrong password. Please try again",
     "account_not_verified": "This account must be verified before login can be completed",

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -4,7 +4,7 @@
 ol/ia auth bridge tests
 """
 
-import time
+import pytest
 import unittest
 from . import OLSession
 
@@ -82,6 +82,7 @@ class Xauth_Test(unittest.TestCase):
     # Test successfully linked account
     # ======================================================
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_linked(self):
         olsession.unlink(LINKED['email'])
         olsession.login(**LINKED)
@@ -100,30 +101,35 @@ class Xauth_Test(unittest.TestCase):
     # All combos of initial IA login audit
     # ======================================================
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_missing_password(self):
         olsession.login(IA_VERIFIED['email'], u'password')
         _error = errorLookup['account_bad_password']
         error = olsession.driver.find_element_by_class_name('note').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_incorrect_password(self):
         olsession.login(IA_VERIFIED['email'], u'password')
         _error = errorLookup['account_bad_password']
         error = olsession.driver.find_element_by_class_name('note').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_ia_blocked(self):
         olsession.login(**IA_BLOCKED)
         _error = errorLookup['account_locked']
         error = olsession.driver.find_element_by_class_name('note').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_ia_blocked_incorrect_password(self):
         olsession.login(IA_BLOCKED['email'], '')
         _error = errorLookup['account_bad_password']
         error = olsession.driver.find_element_by_class_name('note').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_ia_unverified(self):
         olsession.login(**IA_UNVERIFIED)
         _error = errorLookup['account_not_verified']
@@ -135,6 +141,7 @@ class Xauth_Test(unittest.TestCase):
     # successful audit for an IA account
     # ======================================================
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_connect_ol_blocked(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED)
@@ -144,6 +151,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_ia_verified_connect_ol_linked(self):
         # Link LINKED accounts
         olsession.unlink(LINKED['email'])
@@ -163,6 +171,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.unlink(LINKED['email'])
         olsession.unlink(OL_VERIFIED['email'])
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_connect_ol_unverified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED)
@@ -172,6 +181,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_connect_ia_unverified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED)
@@ -181,6 +191,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_CASE(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED_MIXED)
@@ -189,6 +200,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.logout()
         olsession.unlink(OL_VERIFIED['email'])
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_connect_ia_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED)
@@ -198,6 +210,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_connect_ol_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED)
@@ -216,6 +229,7 @@ class Xauth_Test(unittest.TestCase):
         # finalize by unlinking for future tests
         olsession.unlink(OL_VERIFIED['email'])
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ol_verified_connect_ol_blocked_linked(self):
         olsession.unlink(IA_VERIFIED['email'])
         olsession.login(**OL_VERIFIED)
@@ -225,6 +239,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_ol_verified_connect_ol_linked(self):
         # Link LINKED accounts
         olsession.unlink(LINKED['email'])
@@ -244,6 +259,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.unlink(LINKED['email'])
         olsession.unlink(OL_VERIFIED['email'])
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ol_verified_connect_ol_unverified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**OL_VERIFIED)
@@ -253,6 +269,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ol_verified_connect_ia_unverified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**OL_VERIFIED)
@@ -262,6 +279,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ol_verified_connect_ol_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**OL_VERIFIED)
@@ -271,6 +289,7 @@ class Xauth_Test(unittest.TestCase):
         error = olsession.driver.find_element_by_id('connectError').text
         self.assertTrue(error == _error, '%s != %s' % (error, _error))
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ol_verified_connect_ia_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**OL_VERIFIED)
@@ -295,6 +314,7 @@ class Xauth_Test(unittest.TestCase):
     # successful audit from an IA account
     # ======================================================
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ia_verified_create_registered_screenname(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_CREATE_CONFLICT)
@@ -308,6 +328,7 @@ class Xauth_Test(unittest.TestCase):
     # successful audit from an OL account
     # ======================================================
 
+    @pytest.mark.xfail(reason="TODO: TypeError")
     def test_ol_verified_create_registered_screenname(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**OL_CREATE_CONFLICT)

--- a/tests/integration/test_landing.py
+++ b/tests/integration/test_landing.py
@@ -20,30 +20,32 @@ class TestLanding:
         yield browser
         browser.quit()
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_categories_carousel(self, browser):
         url = self.host + '/'
         browser.visit(url)
         assert browser.is_element_present_by_css(".categoryCarousel")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_popular_carousel(self, browser):
         url = self.host + '/'
         browser.visit(url)
         assert browser.is_element_present_by_css("#CarouselPopular")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_read_carousel(self, browser):
         url = self.host + '/'
         browser.visit(url)
         assert browser.is_element_present_by_css("#read-carousel")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_return_carousel(self, browser):
         url = self.host + '/'
         browser.visit(url)
         assert browser.is_element_present_by_css("#returncart_carousel")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_waitlist_carousel(self, browser):
         url = self.host + '/'
         browser.visit(url)
         assert browser.is_element_present_by_css("#CarouselWaitlist")
-
-
-

--- a/tests/integration/test_loans.py
+++ b/tests/integration/test_loans.py
@@ -6,6 +6,7 @@ testing loans and waitlist
 
 import time
 import unittest
+import pytest
 from . import OLSession
 
 
@@ -125,6 +126,7 @@ class Borrow_Test(unittest.TestCase):
         self.assertTrue(cta.get_attribute('data-userid') == itemname,
                         'data-userid should be %s, was %s' % (itemname, userid))
 
+    @pytest.mark.xfail(reason="TODO: selenium.common.exceptions.NoSuchElementException")
     def test_ia_borrow_ol_read_ol_return(self):
         olsession.ia_login(test=self, **LIVE_USER1)
         olsession.login(test=self, **LIVE_USER1)
@@ -140,6 +142,7 @@ class Borrow_Test(unittest.TestCase):
         olsession.logout(test=self)
         olsession.ia_logout(test=self)
 
+    @pytest.mark.xfail(reason="TODO: selenium.common.exceptions.NoSuchElementException")
     def test_ol_borrow_ia_read_ol_return(self):
         olsession.ia_login(test=self, **LIVE_USER1)
         olsession.login(test=self, **LIVE_USER1)
@@ -156,6 +159,7 @@ class Borrow_Test(unittest.TestCase):
         olsession.logout(test=self)
         olsession.ia_logout(test=self)
 
+    @pytest.mark.xfail(reason="TODO: selenium.common.exceptions.NoSuchElementException")
     def test_waitinglist(self):
         olsession.ia_login(test=self, **LIVE_USER2)
         olsession.login(test=self, **LIVE_USER2)

--- a/tests/integration/test_microdata.py
+++ b/tests/integration/test_microdata.py
@@ -13,6 +13,7 @@ class TestMicrodata:
         yield browser
         browser.quit()
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_open_graph_metadata_on_work(self, browser):
         url = self.host + '/works/OL6037022W/Remix'
         browser.visit(url)

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -20,6 +20,7 @@ class TestSearch:
         assert browser.is_text_present('Search Inside')
         assert browser.is_element_present_by_css('.searchInsideForm')
 
+    @pytest.mark.xfail(reason="TODO: splinter.exceptions.ElementDoesNotExist")
     def test_search_inside_from_global_nav(self, browser):
         browser.visit(self.host)
         browser.find_by_css("#headerSearch input[name='q']").fill('black cat')
@@ -28,6 +29,7 @@ class TestSearch:
         assert browser.is_text_present('Search Inside')
         assert browser.is_element_present_by_css('.searchInsideForm')
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_metadata_search(self, browser):
         browser.visit(self.host + '/search')
         browser.find_by_css(".siteSearch > input[name='q']").fill('remix')
@@ -35,6 +37,7 @@ class TestSearch:
         assert browser.is_text_present('Search Results')
         assert browser.is_element_present_by_css('#searchResults li')
 
+    @pytest.mark.xfail(reason="TODO: splinter.exceptions.ElementDoesNotExist")
     def test_metadata_search_from_global_nav(self, browser):
         browser.visit(self.host)
         browser.find_by_css("#headerSearch input[name='q']").fill('remix')

--- a/tests/integration/test_sharing.py
+++ b/tests/integration/test_sharing.py
@@ -20,6 +20,7 @@ class TestSharing:
         yield browser
         browser.quit()
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_open_graph_metadata_on_author(self, browser):
         url = self.host + '/authors/OL1518080A/Lawrence_Lessig'
         browser.visit(url)
@@ -32,6 +33,7 @@ class TestSharing:
         assert browser.is_element_present_by_css("a[href*='facebook.com/sharer/sharer.php']")
         assert browser.is_element_present_by_css("a[href*='twitter.com/intent/tweet']")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_open_graph_metadata_on_work(self, browser):
         url = self.host + '/works/OL6037022W/Remix'
         browser.visit(url)
@@ -44,6 +46,7 @@ class TestSharing:
         assert browser.is_element_present_by_css("a[href*='facebook.com/sharer/sharer.php']")
         assert browser.is_element_present_by_css("a[href*='twitter.com/intent/tweet']")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")  # Fails on Travis CI but passes on macOS!
     def test_open_graph_metadata_on_edition(self, browser):
         url = self.host + '/books/OL24218235M/Remix'
         browser.visit(url)
@@ -56,6 +59,7 @@ class TestSharing:
         assert browser.is_element_present_by_css("a[href*='facebook.com/sharer/sharer.php']")
         assert browser.is_element_present_by_css("a[href*='twitter.com/intent/tweet']")
 
+    @pytest.mark.xfail(reason="TODO: AssertionError")
     def test_open_graph_metadata_on_list(self, browser):
         """Assumes that one list has been created with Remix as its entry"""
         browser.visit(self.host + '/lists')


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Instead of getting rid of our Integration Tests as discussed in #2725, let's re-enable them and set the ones that are not working in `pytest.mark.xfail` mode so that they can be fixed over time.

This approach allows us to keep the eight tests that already work and add new tests to cover the new Python 3 code.

This PR also adds a new Travis CI job to automatically run these user interface tests on all pull requests.  The problem is that building the Docker images from scratch takes 8+ minutes on Travis CI so the total job takes 12 minutes!  Perhaps this PR should be landed ___after___ #3615 so we can reuse that Docker Hub image.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The testing steps are discribed at
https://github.com/internetarchive/openlibrary/pull/3674/files#diff-6b1c0422e0532f9de8b00ee73de3d6acR21

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->

pushd tests/integration
pytest .
```
================================ test session starts ======================================
platform darwin -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /Users/cclauss/Python/itinerant_futurizer/openlibrary
collected 44 items

test_affiliate_links.py ..                                                                                                                                                                                                                                                        [  4%]
test_auth.py .xxxxxxxxxxxxxx.xxxxxxx.                                                                                                                                                                                                                                             [ 59%]
test_landing.py xxxxx                                                                                                                                                                                                                                                             [ 70%]
test_loans.py xxx                                                                                                                                                                                                                                                                 [ 77%]
test_microdata.py x.                                                                                                                                                                                                                                                              [ 81%]
test_search.py .xxx                                                                                                                                                                                                                                                               [ 90%]
test_sharing.py xx.x                                                                                                                                                                                                                                                              [100%]

=========================== 8 passed, 36 xfailed in 169.30s (0:02:49) ===========================
```