### PR TITLE
Add Python version to Attact Debugger webpage again

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -639,7 +639,8 @@ class permissions:
 
 class attach_debugger:
     def GET(self):
-        return render_template("admin/attach_debugger")
+        python_version = "{}.{}.{}".format(*sys.version_info)
+        return render_template("admin/attach_debugger", python_version)
 
     def POST(self):
         import ptvsd

--- a/openlibrary/templates/admin/attach_debugger.html
+++ b/openlibrary/templates/admin/attach_debugger.html
@@ -4,7 +4,7 @@ $var title: Attach Debugger
 
 <div id="contentHead">
     $:render_template("admin/menu")
-    <h1>Attach Debugger on Python $:python_version</h1>
+    <h1>Attach Debugger on Python $python_version</h1>
 </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/admin/attach_debugger.html
+++ b/openlibrary/templates/admin/attach_debugger.html
@@ -1,10 +1,10 @@
-$def with (keys="", error="")
+$def with (python_version, keys="", error="")
 
 $var title: Attach Debugger
 
 <div id="contentHead">
     $:render_template("admin/menu")
-    <h1>Attach Debugger</h1>
+    <h1>Attach Debugger on Python $:python_version</h1>
 </div>
 
 <div id="contentBody">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes #3680 which got in a bad git state.  My mistake was that I was doing `git commit -am"This is my commit message"` and the `-a` was picking up changes to `vendor/infogami`.  `-a` means all changes which is a good default but not what we want here.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When testing a version of Open Library, it is helpful to know which version of Python the OL web server is running on so this PR adds that information to the title of `http://localhost:8080/admin/attach_debugger`.

This page is only accessible by administrators so perhaps this information should be stored on a different page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2020-08-11 at 09 24 39](https://user-images.githubusercontent.com/3709715/89869485-b0800e80-dbb4-11ea-8615-15c9ee583842.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
