### PR TITLE
Add openlibrary/tests/core/test_lists_model.py

### DIFF
--- a/openlibrary/tests/core/test_lists_model.py
+++ b/openlibrary/tests/core/test_lists_model.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+
+from openlibrary.core.lists.model import Seed
+
+
+@pytest.mark.xfail(sys.version_info >= (3, ), reason="does not work on Python 3")
+def test_seed_with_string():
+    seed = Seed([1, 2, 3], "subject/Politics and government")
+    assert seed._list == [1, 2, 3]
+    assert seed.value == "subject/Politics and government"
+    assert seed.key == "subject/Politics and government"
+    assert seed.type == "subject"
+    assert seed._solrdata is None
+
+
+class NotAString(object):
+    def __init__(self):
+        self.key = "not_a_string.key"
+
+
+@pytest.mark.xfail(sys.version_info >= (3, ), reason="does not work on Python 3")
+def test_seed_with_nonstring():
+    seed = Seed((1, 2, 3), NotAString())
+    assert seed._list == (1, 2, 3)
+    assert isinstance(seed.value, NotAString)
+    assert hasattr(seed, "key")
+    assert hasattr(seed, "type") is False
+    assert isinstance(seed.get_document(), NotAString)
+    assert isinstance(seed.document, NotAString)
+    seed.value = "New value"
+    # assert seed.get_document() == "New value"
+    assert isinstance(seed.document, NotAString)
+ 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Put tests in place that pass on Python 2 but we expect to fail on Python 3.  Once these tests are in place we can fix an attempt to rewrite a property which is only allowed in old-style classes which no longer exist in Python 3.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
