### PR TITLE
test_py3.sh: Add flake8 search for wildcard imports

### DIFF
--- a/scripts/test_py3.sh
+++ b/scripts/test_py3.sh
@@ -16,7 +16,7 @@ pytest --show-capture=all -v openlibrary/catalog/marc/tests/test_get_subjects.py
 pytest --show-capture=all -v openlibrary/catalog/marc/tests/test_parse.py || true  # internetarchive/openlibrary#3584
 pytest --show-capture=all -v openlibrary/tests/catalog/test_get_ia.py || true  # internetarchive/openlibrary#3584
 pytest --show-capture=all -v openlibrary/plugins/openlibrary/tests/test_home.py || true  # internetarchive/openlibrary#3670
-flake8 --exit-zero --count --select=E722 --show-source  # Show all the bare exceptions
+flake8 --exit-zero --count --select=E722,F403 --show-source  # Show bare exceptions and wildcard (*) imports
 safety check || true  # Show any insecure dependencies
 
 exit ${RETURN_CODE}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add `F403` | ‘from module import *’ used; unable to detect undefined names

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
