### PR TITLE
WIP: Fix scripts/view_marc.py for Python 3

### DIFF
--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -22,7 +22,10 @@ def translate(bytes_in, leader_says_marc8=False):
     if leader_says_marc8:
         data = marc8.translate(mnemonics.read(bytes_in))
     else:
-        data = bytes_in.decode('utf-8')
+        try:
+            data = bytes_in.decode('utf-8')
+        except AttributeError:
+            data = bytes_in
     return normalize('NFC', data)
 
 re_question = re.compile(r'^\?+$')
@@ -167,7 +170,7 @@ def read_directory(data):
         directory = data[:dir_end].decode('utf-8')[24:]
         if len(directory) % 12 != 0:
             raise BadDictionary
-    iter_dir = (directory[i*12:(i+1)*12] for i in range(len(directory) / 12))
+    iter_dir = (directory[i*12:(i+1)*12] for i in range(len(directory) // 12))
     return dir_end, iter_dir
 
 @deprecated('Use catalog.marc.MarcBinary instead.')

--- a/scripts/view_marc.py
+++ b/scripts/view_marc.py
@@ -37,5 +37,6 @@ if __name__ == '__main__':
         if ':' in source:
             data = get_from_archive(source)
         else:
-            data = open(source).read()
+            with open(source) as in_file:
+                data = in_file.read()
         show_book(data)

--- a/scripts/view_marc.py
+++ b/scripts/view_marc.py
@@ -43,6 +43,6 @@ if __name__ == '__main__':
 
 """
 If the source is opened in "r" mode then everything works the same on both Python 2 and
-Python 3 but if it is opened in "rb" mode then there is not change on Python 2 but on
+Python 3 but if it is opened in "rb" mode then there is no change on Python 2 but on
 Python 3 only the first line `leader: b'01441nam  2200301Ia 4504'` is printed.
 """

--- a/scripts/view_marc.py
+++ b/scripts/view_marc.py
@@ -1,12 +1,17 @@
-#!/usr/bin/python2.5
+#!/usr/bin/python3
+
 from __future__ import print_function
-from openlibrary.catalog.marc.fast_parse import *
-from openlibrary.catalog.get_ia import get_from_archive
-import sys
+
 import codecs
 import re
+import sys
 
-sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+import _init_path
+from openlibrary.catalog.get_ia import get_from_archive
+from openlibrary.catalog.marc.fast_parse import get_all_tag_lines, translate
+
+if bytes == str:  # PY2
+    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
 re_subtag = re.compile('\x1f(.)([^\x1f]*)')
 
@@ -25,9 +30,12 @@ def show_book(data):
             print(tag, line[0:2], fmt_subfields(line))
 
 if __name__ == '__main__':
-    source = sys.argv[1]
-    if ':' in source:
-        data = get_from_archive(source)
-    else:
-        data = open(source).read()
-    show_book(data)
+    SAMPLE = ("openlibrary/catalog/marc/tests/test_data/bin_input/"
+              "0descriptionofta1682unit_meta.mrc")
+    sources = sys.argv[1:] or [SAMPLE]
+    for source in sources:
+        if ':' in source:
+            data = get_from_archive(source)
+        else:
+            data = open(source).read()
+        show_book(data)

--- a/scripts/view_marc.py
+++ b/scripts/view_marc.py
@@ -37,6 +37,12 @@ if __name__ == '__main__':
         if ':' in source:
             data = get_from_archive(source)
         else:
-            with open(source) as in_file:
+            with open(source, "r") as in_file:  # <-- TODO: (cclauss) Need help here!
                 data = in_file.read()
         show_book(data)
+
+"""
+If the source is opened in "r" mode then everything works the same on both Python 2 and
+Python 3 but if it is opened in "rb" mode then there is not change on Python 2 but on
+Python 3 only the first line `leader: b'01441nam  2200301Ia 4504'` is printed.
+"""


### PR DESCRIPTION
<!-- What issue does this PR close? -->
___ON HOLD:___ Until after #3584 is merged.

Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Enable scripts/view_marc.py to function on both Python 2 and Python 3.  Identical results are received from both:
* `python2 scripts/view_marc.py 2> /dev/null ` # -- and --
* `python3 scripts/view_marc.py 2> /dev/null`
in their relative docker containers.

There are [problems](https://github.com/internetarchive/openlibrary/pull/3717/files#diff-42a6ffda74755057435ba9e2930daa44R40) when opening .mrc files in bytes mode!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
