### PR TITLE
Travis CI: Job “Python 3.8 on focal” is now mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
       python: "3.8"
   allow_failures:
     - name: “Python 2.7 on Infogami master”
-    - name: “Python 3.8 on focal”
 # Ubuntu may have an old version of node, so make sure Node 12 is installed
 # and used instead. Should match Dockerfile.
 before_install:


### PR DESCRIPTION
👍 ❤️ 🎉 🚀 It is now mandatory that Python 3 pass all pytests and doctests for the build to pass.