### PR TITLE
Python3: Sort Publish date unknown

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -678,7 +678,7 @@ class Work(models.Work):
             edition_keys = web.ctx.site.things(db_query)
 
         editions = web.ctx.site.get_many(edition_keys)
-        editions.sort(key=lambda ed: ed.get_publish_year(), reverse=True)
+        editions.sort(key=lambda ed: ed.get_publish_year() or 0, reverse=True)
 
         availability = lending.get_availability_of_ocaids([
             ed.ocaid for ed in editions if ed.ocaid

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import logging
 import re
+import sys
 import simplejson
 import web
 
@@ -678,7 +679,7 @@ class Work(models.Work):
             edition_keys = web.ctx.site.things(db_query)
 
         editions = web.ctx.site.get_many(edition_keys)
-        editions.sort(key=lambda ed: ed.get_publish_year() or 0, reverse=True)
+        editions.sort(key=lambda ed: ed.get_publish_year() or -sys.maxsize, reverse=True)
 
         availability = lending.get_availability_of_ocaids([
             ed.ocaid for ed in editions if ed.ocaid


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes http://localhost:8080/works/OL61982W/Odyssey?edition=odysseybookiv00home?debug=true on Python 3
```
 2020-08-23 17:14:07 [openlibrary] [ERROR] Could not load donation banner
Traceback (most recent call last):
  File "/openlibrary/infogami/utils/template.py", line 144, in saferender
    result = t(*a, **kw)
  File "/home/openlibrary/.pyenv/versions/3.8.5/lib/python3.8/site-packages/web/template.py", line 969, in __call__
    return BaseTemplate.__call__(self, *a, **kw)
  File "/home/openlibrary/.pyenv/versions/3.8.5/lib/python3.8/site-packages/web/template.py", line 880, in __call__
    return self.t(*a, **kw)
  File "/openlibrary/openlibrary/templates/type/work/view.html", line 18, in __template__
  File "/openlibrary/openlibrary/plugins/upstream/models.py", line 681, in get_sorted_editions
    editions.sort(key=lambda ed: ed.get_publish_year(), reverse=True)
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
% `python2 -c "print(1 > None)" ` # True
% `python3 -c "print(1 > None)" ` # --> TypeError()
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: '>' not supported between instances of 'int' and 'NoneType'

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
