### PR TITLE
Add LCCN and LC classification on reimport from MARC

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -742,13 +742,11 @@ def load(rec, account=None):
         e['ocaid'] = rec['ocaid']
         need_edition_save = True
 
+    # Add list fields to edition as needed
     edition_fields = [
-        'local_id', 'ia_box_id', 'ia_loaded_id', 'source_records']
-    # TODO:
-    # only consider `source_records` for newly created work
-    # or if field originally missing:
-    #if work_created and not e.get('source_records'):
-    #    edition_fields.append('source_records')
+        'local_id',
+        'source_records',
+        ]
     for f in edition_fields:
         if f not in rec:
             continue

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -745,6 +745,8 @@ def load(rec, account=None):
     # Add list fields to edition as needed
     edition_fields = [
         'local_id',
+        'lccn',
+        'lc_classifications',
         'source_records',
         ]
     for f in edition_fields:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2916

While importing 2016 LOC data dumps I noticed that many of the records are being matched as already existing, but some don't have the LCCN in the existing record. This PR fixes that, and also adds the related LC classification (#2916 )



<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested in local docker dev env -- 

1) imported a record  from `marc_loc_2016` item (record was `created` with all fields as expected)
2) deleted the relevant fields `lccn`, `lc_calssifications`
3) reimported the same record 
Expected and observed: edition record was `modified` and the `lccn` and `lc_calssifications` were populated. Without this change the edition would have simply been `matched` and the two fields would not have been populated.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->


![image](https://user-images.githubusercontent.com/905545/91005645-80605300-e62b-11ea-9d54-c61ed0229411.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 