### PR TITLE
fixes #3687

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -132,7 +132,7 @@ class upload2:
             raise e
 
         source_url = i.source_url
-        data = i.data
+        data = web.data()
 
         if source_url:
             try:

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -480,7 +480,10 @@ class OLIndexer(_Indexer):
 
     def normalize_edition_title(self, title):
         if isinstance(title, str):
-            title = title.decode('utf-8', 'ignore')
+            try:
+                title = title.decode('utf-8', 'ignore')
+            except AttributeError:
+                pass
 
         if not isinstance(title, six.text_type):
             return ""

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -1,6 +1,7 @@
 """Handle book cover/author photo upload.
 """
 import web
+import requests
 import simplejson
 
 from infogami.utils import delegate
@@ -71,8 +72,8 @@ class add_cover(delegate.page):
             upload_url = "http:" + upload_url
 
         try:
-            response = urllib.request.urlopen(upload_url, urllib.parse.urlencode(params))
-            out = response.read()
+            response = requests.post(upload_url+"?"+urllib.parse.urlencode(params), data=data)
+            out = response.content
         except urllib.error.HTTPError as e:
             out = {'error': e.read()}
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3687 
Earlier the binary image data used to be passed in query params - this PR achieves to pass it through request body - which helps in avoiding errors related to encoding and decoding.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss
