### PR TITLE
Travis CI: make lint-diff mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,21 +15,13 @@ jobs:
         - make test
         - pip install safety
         - safety check || true
-    - name: “Python 3.8 make lint and selected pytests”
-      python: "3.8"
-      before_script: true  # override npm install below
-      script:
-        # On pull requests, run all flake8 tests on modified code
-        # if clause avoids `fatal: ambiguous argument 'origin/master'` on git push
-        - if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
-            make lint-diff;
-          fi
-        - source scripts/run_doctests.sh
-        - source scripts/test_py3.sh
-    - name: “Python 3.8 on focal”
-      python: "3.8"
-  allow_failures:
+      - name: “Python 3.8 on focal”
+        python: "3.8"
+      - name: “Python 3.9-dev on focal”
+        python: "3.9-dev"
+      allow_failures:
     - name: “Python 2.7 on Infogami master”
+    - python: "3.9-dev"
 # Ubuntu may have an old version of node, so make sure Node 12 is installed
 # and used instead. Should match Dockerfile.
 before_install:
@@ -38,7 +30,7 @@ before_install:
 install:
   - pip install -r requirements_test.txt
   # refresh the git submodule ./vendor/infogami on some jobs
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
+  - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
       pushd vendor/infogami && git pull origin master && popd;
     fi
 before_script: npm install
@@ -46,3 +38,4 @@ script:
   - make lint
   - make i18n
   - make test
+  - source scripts/run_doctests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         python: "3.8"
       - name: “Python 3.9-dev on focal”
         python: "3.9-dev"
-      allow_failures:
+  allow_failures:
     - name: “Python 2.7 on Infogami master”
     - python: "3.9-dev"
 # Ubuntu may have an old version of node, so make sure Node 12 is installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ install:
     fi
 before_script: npm install
 script:
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
+      make lint-diff;
+    fi
   - make lint
   - make i18n
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ jobs:
         - make test
         - pip install safety
         - safety check || true
-      - name: “Python 3.8 on focal”
-        python: "3.8"
-      - name: “Python 3.9-dev on focal”
-        python: "3.9-dev"
+    - name: “Python 3.8 on focal”
+      python: "3.8"
+    - name: “Python 3.9-dev on focal”
+      python: "3.9-dev"
   allow_failures:
     - name: “Python 2.7 on Infogami master”
     - python: "3.9-dev"

--- a/scripts/flake8-diff.sh
+++ b/scripts/flake8-diff.sh
@@ -5,4 +5,4 @@
 # E226 missing whitespace around arithmetic operator
 # F401 '._init_path' imported but unused
 # W504 line break after binary operator
-flake8 --diff --ignore=E226,F401,W504 --max-line-length=88 --statistics
+flake8 --diff --filename=*.py --ignore=E226,F401,W504 --max-line-length=88 --statistics


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Improved automated testing
* Run 450+ Python doctests on all Travis CI runs
* Run tests on Python 3.9 release candidate 1 in `allow_failures` mode.
* Drop an obsolete Python 3.8 run that is surpassed by normal test runs.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
