### PR TITLE
ol_infobase.py: decode bytes, not str

### DIFF
--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -479,7 +479,7 @@ class OLIndexer(_Indexer):
         return doc
 
     def normalize_edition_title(self, title):
-        if isinstance(title, str):
+        if isinstance(title, bytes):
             title = title.decode('utf-8', 'ignore')
 
         if not isinstance(title, six.text_type):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
On Python 2 `bytes == str`.  (This code was written nine years ago.)
On Python 3 `bytes != str` and only `bytes` has a `.decode()` method.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
