### PR TITLE
Split coverstore and postgres into separate docker services

### DIFF
--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -3,6 +3,7 @@
 db_parameters:
     dbn: "postgres"
     db: "coverstore"
+    host: db
 
 data_root: "/var/lib/coverstore"
 default_image: "static/images/empty.gif"

--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -6,7 +6,3 @@ db_parameters:
 
 data_root: "/var/lib/coverstore"
 default_image: "static/images/empty.gif"
-
-# Redirects to this, if the requested cover is not found in the coverstore. Useful for dev-instance
-# XXX this should be deprecated now that coverstore is in docker!!!
-upstream_base_url: http://covers.openlibrary.org/

--- a/conf/infobase.yml
+++ b/conf/infobase.yml
@@ -3,6 +3,7 @@
 db_parameters:
     engine: postgres
     database: openlibrary
+    host: db
 
 account_bot: /people/AccountBot
 user_root: /people/

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -15,7 +15,7 @@ smtp_server: localhost
 dummy_sendmail: True
 debug: True
 
-coverstore_url: http://0.0.0.0:8081/
+coverstore_url: http://covers:8081
 
 state_dir: var/run
 

--- a/docker-compose.infogami-local.yml
+++ b/docker-compose.infogami-local.yml
@@ -10,3 +10,8 @@ services:
       - INFOGAMI=local
     volumes:
       - ./vendor/infogami:/openlibrary/vendor/infogami
+  covers:
+    environment:
+      - INFOGAMI=local
+    volumes:
+      - ./vendor/infogami:/openlibrary/vendor/infogami

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     ports:
       - 8080:80
       - 7000:7000
-      - 8081:8081
       - 3000:3000
     volumes:
       # Persistent volume mount for installed git submodules
@@ -45,7 +44,22 @@ services:
     image: memcached
     networks:
       - webnet
-  #covers:
+  covers:
+    image: oldev:latest
+    environment:
+      - PYENV_VERSION=${PYENV_VERSION:-}
+      - INFOGAMI=${INFOGAMI:-}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
+    command: docker/ol-covers-start.sh
+    ports:
+      - 8081:8081
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+    networks:
+      - webnet
 networks:
   webnet:
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - 8080:80
       - 7000:7000
       - 3000:3000
+    depends_on:
+      - db
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
@@ -27,6 +29,7 @@ services:
       - .:/openlibrary
     networks:
       - webnet
+      - dbnet
   solr:
     image: olsolr:latest
     build:
@@ -44,6 +47,16 @@ services:
     image: memcached
     networks:
       - webnet
+  db:
+    image: postgres:9.3
+    networks:
+      - dbnet
+    volumes:
+      - .:/openlibrary
+      # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
+      # if the db is empty (which as of now is always, since we don't store the
+      # postgres data anywhere).
+      - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh
   covers:
     image: oldev:latest
     environment:
@@ -60,8 +73,10 @@ services:
       - .:/openlibrary
     networks:
       - webnet
+      - dbnet
 networks:
   webnet:
+  dbnet:
 volumes:
   solr-data:
   ol-vendor:

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -2,18 +2,6 @@ FROM openlibrary/olbase:latest
 
 WORKDIR /openlibrary
 
-# Setup db
-USER postgres
-RUN /etc/init.d/postgresql start \
-  && createuser -s openlibrary \
-  && createdb openlibrary \
-  && psql --quiet openlibrary < openlibrary/core/users.sql \
-  && psql --quiet openlibrary < openlibrary/core/schema.sql \
-  && createdb coverstore \
-  && psql --quiet coverstore < openlibrary/coverstore/schema.sql \
-  && psql --quiet openlibrary < scripts/dev-instance/dev_db.pg_dump \
-  && pg_ctlcluster 9.5 main stop
-
 USER root
 # oldev currently runs coverstore in the same container:
 RUN mkdir -p /var/lib/coverstore \

--- a/docker/ol-covers-start.sh
+++ b/docker/ol-covers-start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CONFIG=conf/coverstore.yml
+
+python --version
+
+# TODO: remove this once db service added
+su postgres -c "/etc/init.d/postgresql start"
+
+# su doesn't forward any environment variables, which kinda breaks pyenv
+# So we include the variables pyenv needs here to forward
+read -r -d '' PY_ENV_VARS << EOM
+PATH="$PATH"
+PYENV_VERSION="$PYENV_VERSION"
+EOM
+
+su openlibrary -c "$PY_ENV_VARS && scripts/coverstore-server $CONFIG \
+    --gunicorn --workers 1 --max-requests 250 --bind :8081"

--- a/docker/ol-covers-start.sh
+++ b/docker/ol-covers-start.sh
@@ -4,9 +4,6 @@ CONFIG=conf/coverstore.yml
 
 python --version
 
-# TODO: remove this once db service added
-su postgres -c "/etc/init.d/postgresql start"
-
 # su doesn't forward any environment variables, which kinda breaks pyenv
 # So we include the variables pyenv needs here to forward
 read -r -d '' PY_ENV_VARS << EOM

--- a/docker/ol-db-init.sh
+++ b/docker/ol-db-init.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -o xtrace
+
+cd /openlibrary
+
+createuser --superuser openlibrary
+createdb openlibrary
+psql --quiet openlibrary < openlibrary/core/users.sql
+psql --quiet openlibrary < openlibrary/core/schema.sql
+createdb coverstore
+psql --quiet coverstore < openlibrary/coverstore/schema.sql
+psql --quiet openlibrary < scripts/dev-instance/dev_db.pg_dump

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -4,7 +4,6 @@
 # inside an container, bypass all upstart/services
 
 CONFIG=conf/openlibrary.yml
-COVER_CONFIG=conf/coverstore.yml
 
 python --version
 
@@ -61,10 +60,6 @@ su solrupdater -c "$PY_ENV_VARS && python scripts/new-solr-updater.py \
   -c $CONFIG \
   --state-file solr-update.offset \
   --ol-url http://web/" &
-
-# In dev mode, run the coverstore locally (in the background)
-su openlibrary -c "$PY_ENV_VARS && scripts/coverstore-server $COVER_CONFIG \
-    --gunicorn --workers 1 --max-requests 250 --bind :8081" &
 
 # ol server, running in the foreground to avoid exiting container
 su openlibrary -c "$PY_ENV_VARS && authbind --deep scripts/openlibrary-server $CONFIG \

--- a/docker/ol-docker-start.sh
+++ b/docker/ol-docker-start.sh
@@ -27,7 +27,7 @@ reindex-solr() {
   server=$1
   config=$2
   for thing in books authors; do
-    psql openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep "^/$thing/" \
+    psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep "^/$thing/" \
       | PYTHONPATH=$PWD xargs python openlibrary/solr/update_work.py -s $server -c $config --data-provider=legacy
   done
 }
@@ -37,9 +37,6 @@ echo "Starting ol services."
 # TODO: why does nginx appear not necessary?
 #echo "Starting nginx"
 #service nginx restart
-
-# postgres
-su postgres -c "/etc/init.d/postgresql start"
 
 # su doesn't forward any environment variables, which kinda breaks pyenv
 # So we include the variables pyenv needs here to forward
@@ -51,9 +48,8 @@ EOM
 # infobase
 su openlibrary -c "$PY_ENV_VARS && scripts/infobase-server conf/infobase.yml 7000" &
 
-# wait unit postgres is ready, then reindex solr
 export -f reindex-solr
-su openlibrary -c "$PY_ENV_VARS && until pg_isready; do sleep 5; done && reindex-solr localhost $CONFIG" &
+su openlibrary -c "$PY_ENV_VARS && until pg_isready --host db; do sleep 5; done && reindex-solr localhost $CONFIG" &
 
 # solr updater
 su solrupdater -c "$PY_ENV_VARS && python scripts/new-solr-updater.py \

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -208,11 +208,7 @@ class cover:
             return url.startswith("http://") or url.startswith("https://")
 
         def notfound():
-            if key in ["id", "olid"] and config.get("upstream_base_url"):
-                # this is only used in development
-                base = web.rstrips(config.upstream_base_url, "/")
-                raise web.redirect(base + web.ctx.fullpath)
-            elif config.default_image and i.default.lower() != "false" and not is_valid_url(i.default):
+            if config.default_image and i.default.lower() != "false" and not is_valid_url(i.default):
                 return read_file(config.default_image)
             elif is_valid_url(i.default):
                 raise web.seeother(i.default)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #1068
Closes #2115

### Technical
<!-- What should be noted about the implementation? -->

### Testing
To test:
1. Run `docker-compose build`
2. Run `docker-compose up -d`

Tests:
- [x] Website runs and I can make edits!
- [x] Can upload an image without an error (not the image doesn't show up as visible, but that's a pre-existing issue, I believe)
- [ ] Works with py2/py3 flags (i.e. both coverstore and web started with right version of python)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 
