### PR TITLE
Travis CI: Add Python doctests and Python 3.9 release candidate again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
   - nvm install 12
   - nvm use 12
 install:
+  - pip install --upgrade pip wheel
   - pip install -r requirements_test.txt
   # refresh the git submodule ./vendor/infogami on some jobs
   - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,11 @@ jobs:
         - source scripts/test_py3.sh
     - name: “Python 3.8 on focal”
       python: "3.8"
+    - name: “Python 3.9-dev on focal”
+      python: "3.9-dev"
   allow_failures:
     - name: “Python 2.7 on Infogami master”
+    - python: "3.9-dev"
 # Ubuntu may have an old version of node, so make sure Node 12 is installed
 # and used instead. Should match Dockerfile.
 before_install:
@@ -38,7 +41,7 @@ before_install:
 install:
   - pip install -r requirements_test.txt
   # refresh the git submodule ./vendor/infogami on some jobs
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
+  - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
       pushd vendor/infogami && git pull origin master && popd;
     fi
 before_script: npm install
@@ -46,3 +49,4 @@ script:
   - make lint
   - make i18n
   - make test
+  - source scripts/run_doctests.sh


### PR DESCRIPTION
<!-- What issue does this PR close? -->
A subset of #3743 which should be easier to review and merge.  This adds doctests and a job in __allow_failures__ mode for Python 3.9 release candidate 1 to ensure that our codebase is compatible with 3.9 which is scheduled to GA in one month.

Unlike #3743, this PR does not remove the run `Python 3.8 make lint and selected pytests` as discussed https://github.com/internetarchive/openlibrary/pull/3743/files#r478746380

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
