### PR TITLE
fix MARC leader display bug

### DIFF
--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -17,7 +17,8 @@ class html_record():
     def __init__(self, data):
         assert len(data) == int(data[:5])
         self.data = data
-        self.is_marc8 = data[9] != b'a'[0]
+        self.leader = data[:24].decode('utf-8', errors='replace')
+        self.is_marc8 = self.leader[9] != u'a'
 
     def html(self):
         return '<br>\n'.join(self.html_line(t, l) for t, l in get_all_tag_lines(self.data))

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -9,7 +9,7 @@ def test_html_subfields():
         (b'  end of wrapped\x1e', 'end of wrapped'),
         (b'  \x1fa<whatever>\x1e', '<b>$a</b>&lt;whatever&gt;'),
     ]
-    hr = html_record("00053This is the leader.Now we are beyond the leader.")
+    hr = html_record(b'00053This is the leader.Now we are beyond the leader.')
     for input_, output in samples:
         assert hr.html_subfields(input_) == output
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Fixes a bug when viewing source MARC records: e.g. https://openlibrary.org/show-records/marc_records_scriblio_net/part01.dat:26456929:680

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
