### PR TITLE
Adds source to Author initial imports

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -193,8 +193,7 @@ def build_author_reply(authors_in, edits, source):
         new_author = 'key' not in a
         if new_author:
             a['key'] = web.ctx.site.new_key('/type/author')
-            if source.startswith('marc:'):
-                a['machine_comment'] = source[5:]
+            a['source_records'] = [source]
             edits.append(a)
         authors.append({'key': a['key']})
         author_reply.append({

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -583,7 +583,8 @@ def load_data(rec, account=None):
     # TOFIX: edition.authors has already been processed by import_authors() in build_query(), following line is a NOP?
     author_in = [import_author(a, eastern=east_in_by_statement(rec, a)) for a in edition.get('authors', [])]
     # build_author_reply() adds authors to edits
-    (authors, author_reply) = build_author_reply(author_in, edits, rec['source_records'][0])
+    (authors, author_reply) = build_author_reply(author_in, edits,
+                                                 rec['source_records'][0])
 
     if authors:
         edition['authors'] = authors

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -192,6 +192,8 @@ def build_author_reply(author_in, edits):
         new_author = 'key' not in a
         if new_author:
             a['key'] = web.ctx.site.new_key('/type/author')
+            if source_records[0].startswith('marc:'):
+                a['machine_comment'] = source_records[0][5:]
             edits.append(a)
         authors.append({'key': a['key']})
         author_reply.append({

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -180,11 +180,11 @@ def build_author_reply(authors_in, edits, source):
     Steps through an import record's authors, and creates new records if new,
     adding them to 'edits' to be saved later.
 
-    :param list authors_in: List of import sourced author dicts [{"name:" "Some One"}, ...], possibly with dates
+    :param list authors_in: import author dicts [{"name:" "Bob"}, ...], maybe dates
     :param list edits: list of Things to be saved later. Is modfied by this method.
-    :param str source: Source record e.g. marc:marc_records_scriblio_net/part01.dat:26456929:680
+    :param str source: Source record e.g. marc:marc_ex/part01.dat:26456929:680
     :rtype: tuple
-    :return: (list, list) authors [{"key": "/author/OL..A"}, ...], author_reply the JSON status response to return for each author
+    :return: (list, list) authors [{"key": "/author/OL..A"}, ...], author_reply
     """
 
     authors = []


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #1619

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a `source_records` metadata field (the same as used by editions) to indicate the source of a newly created Author.

This will be useful in tracking down ambiguities about author identity by anchoring the import to a specific external record. 
Previously the earliest imported edition of an Author had to be found to get the source. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Local testing JSON result of a newly imported author, showing correctly formatted `source_records`

```
{"name": "Kokuritsu Gekij\u014d Okinawa. Ch\u014dsa Y\u014dseika", "source_records": ["marc:marc_loc_2016/BooksAll.2016.part40.utf8:48680251:1475"], "created": {"type": "/type/datetime", "value": "2020-10-27T23:40:31.463959"}, "last_modified": {"type": "/type/datetime", "value": "2020-10-27T23:40:31.463959"}, "latest_revision": 1, "key": "/authors/OL11A", "type": {"key": "/type/author"}, "revision": 1}
````

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

No UI component to this PR

### Stakeholders
<!-- @ tag stakeholders of this bug -->
