### PR TITLE
Increase search bar component z-index

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -288,7 +288,7 @@
       border: 1px solid @dark-beige;
       border-radius: .3em;
       background-color: @grey-fafafa;
-      z-index: @z-index-level-5;
+      z-index: @z-index-level-6;
       position: relative;
     }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes [#3796 ](https://github.com/internetarchive/openlibrary/issues/3796)

Corrects issue where work menu overlaps search results if several results are displayed.

### Technical
<!-- What should be noted about the implementation? -->
Increased the z-index of the search bar component.  The z-index of the work menu and the search bar component were equal before this change.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2020-09-14 12-50-17](https://user-images.githubusercontent.com/28732543/93114987-4c57db00-f689-11ea-8578-80f650a932ca.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
