### PR TITLE
Revert changes from #3752 causing editing to break on prod

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -642,12 +642,13 @@ class SaveBookHelper:
             if not subjects:
                 return
 
+            f = StringIO(subjects.encode('utf-8'))  # no unicode in csv module
             dedup = set()
-            with StringIO(subjects) as f:
-                for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
-                    if s.lower() not in dedup:
-                        yield s
-                        dedup.add(s.lower())
+            for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
+                s = s.decode('utf-8')
+                if s.lower() not in dedup:
+                    yield s
+                    dedup.add(s.lower())
 
         work.subjects = list(read_subject(work.get('subjects', '')))
         work.subject_places = list(read_subject(work.get('subject_places', '')))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3806 with least resistance. Will likely break on py3. Reverts the part of #3752 causing the editing error.

### Technical
No clue why it broke; no clue why it's fixed. Just reverting to unbreak editing.

### Testing
Confirmed editing works on dev.openlibrary.org

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
