### PR TITLE
Correct dialog box typo

### DIFF
--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -673,7 +673,7 @@ msgid "Remove Seed"
 msgstr "Quitar elemento"
 
 #: view.html:158
-msgid "You are about the remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
+msgid "You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?"
 msgstr "Estás a punto de quitar el último elemento de la lista. Eso borrará toda la lista. ¿Estás seguro de que quieres continuar?"
 
 #: view.html:220

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -733,7 +733,7 @@ msgstr "Supprimer cette élément"
 
 #: view.html:158
 msgid ""
-"You are about the remove the last item in the list. That will delete the "
+"You are about to remove the last item in the list. That will delete the "
 "whole list. Are you sure you want to continue?"
 msgstr ""
 "Vous êtes sur le point de supprimer le dernier élément de la liste. Cela "

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -709,7 +709,7 @@ msgstr ""
 
 #: view.html:158
 msgid ""
-"You are about the remove the last item in the list. That will delete the "
+"You are about to remove the last item in the list. That will delete the "
 "whole list. Are you sure you want to continue?"
 msgstr ""
 

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -153,7 +153,7 @@ window.q.push(function(){
 <div id="contentBody">
     <div id="remove-seed-dialog" class="hidden" title="$_('Remove seed')">$_('Are you sure you want to remove this item from the list?')</div>
     <div id="delete-list-dialog" class="hidden" title="$_('Remove Seed')">
-        $_('You are about the remove the last item in the list. That will delete the whole list. Are you sure you want to continue?')
+        $_('You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?')
     </div>
 
     $def render_authors(authors):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes [#3810](https://github.com/internetarchive/openlibrary/issues/3810) 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This fixes typo found in dialog that appears when a user tries to delete the last book in a list.

### Technical
<!-- What should be noted about the implementation? -->
Existing i18n mappings have been updated as well.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Create and navigate to a list the contains a single book.
2. Select "Remove this item?"
3. Repeat steps one and two for French and Spanish language preferences.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2020-09-18 07-26-40](https://user-images.githubusercontent.com/28732543/93593015-457ae200-f981-11ea-8bf5-6af1ef631d62.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
