### PR TITLE
Remove HTML escaping

### DIFF
--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -100,7 +100,7 @@ window.q.push(function(){
         modal: true,
         resizable: false,
         buttons: {
-            "$_('Yes, I\'m sure')": function() {
+            "$:_('Yes, I\'m sure')": function() {
                 var list_key = $:json_encode(list.key);
                 var seed_id = "#" + \$(this).data("seed-id");
                 var seed = \$(seed_id).find("span.seed-key").html();
@@ -131,7 +131,7 @@ window.q.push(function(){
         modal: true,
         resizable: false,
         buttons: {
-            "$_('Yes, I\'m sure')": function() {
+            "$:_('Yes, I\'m sure')": function() {
                 var list_key = $:json_encode(list.key);
                 var _this = this;
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3565 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This corrects issue where entity code is present in confirm dialog button.

### Technical
<!-- What should be noted about the implementation? -->
HTML encoding filter is now turned off for the strings that contain escaped apostrophes.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log into the Open Library instance where you will be testing.
2. Create a list that contains two books.
3. Navigate to the list that you created.
4. Click on "Remove this item?" and confirm that the text is correct.
5. Remove the item by clicking "Yes, I'm sure"
6. Repeat step 4 for the remaining item.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Removing one item from a list with multiple items:

![items_still_in_list](https://user-images.githubusercontent.com/28732543/93636052-3c116a00-f9c1-11ea-815f-604e4dd979f7.png)

Removing the last item from a list:

![last_item_removal](https://user-images.githubusercontent.com/28732543/93636078-492e5900-f9c1-11ea-8560-59e9263806b2.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
