### PR TITLE
Add webmanifest

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -16,6 +16,8 @@ $def with (page)
 
     <link rel="preconnect" href="https://analytics.archive.org">
 
+    <link rel="manifest" href="/static/manifest.webmanifest">
+
     <link href="/static/images/openlibrary-128x128.png" rel="apple-touch-icon" />
     <link href="/static/images/openlibrary-152x152.png" rel="apple-touch-icon" sizes="152x152" />
     <link href="/static/images/openlibrary-167x167.png" rel="apple-touch-icon" sizes="167x167" />

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+    "short_name": "Open Library",
+    "name": "Open Library: One webpage for every book ever published!",
+    "description": "An open, editable library catalog, building towards a web page for every book ever published.",
+    "icons": [
+        {
+            "src": "/static/images/openlibrary-192x192.png",
+            "type": "image/png",
+            "sizes": "192x192"
+        },
+        {
+            "src": "/static/images/openlibrary-512x512",
+            "type": "image/png",
+            "sizes": "512x512"
+        }
+    ],
+    "start_url": "/?source=pwa",
+    "background_color": "#e2dcc5",
+    "display": "standalone",
+    "scope": "/",
+    "theme_color": "#e2dcc5"
+}


### PR DESCRIPTION
Closes #3600

A simple `webmanifest` to make Open Library installable.

### Technical
The `webmanifest` added in this commit is a simple json file that describes the "web app", so that mobile browsers can prompt the user for installing it to the home screen as an app.

### Testing
Browsers require `https` for this to work, so it was a bit tricky to test that in the local dev environment. But below are some screenshots on how this works on Firefox for Android.

### Screenshot
![install](https://user-images.githubusercontent.com/939357/93682352-1efe9900-fa9e-11ea-89a0-127aceb499fc.jpg)

![icon](https://user-images.githubusercontent.com/939357/93682694-3b9ad100-fa9e-11ea-843d-418f46c7057c.jpg)



