### PR TITLE
Make some lending logs less verbose to better group in Sentry

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -164,11 +164,16 @@ def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
                     if subjects:
                         _q = ' OR '.join('subject:"%s"' % subject for subject in subjects)
             if not _q:
-                logger.error('compose_ia_url(limit={}, page={}, subject={}, query={}, '
-                    'work_id={}, _type={}, sorts={}, advanced={}) failed!'.format(
-                        limit, page, subject, query, work_id, _type, sorts, advanced
-                    )
-                )
+                logger.error('compose_ia_url failed!', extra={
+                    'limit': limit,
+                    'page': page,
+                    'subject': subject,
+                    'query': query,
+                    'work_id': work_id,
+                    '_type': _type,
+                    'sorts': sorts,
+                    'advanced': advanced,
+                })
                 return ''  # TODO: Should we just raise an excpetion instead?
             q += ' AND (%s) AND !openlibrary_work:(%s)' % (_q, work_id.split('/')[-1])
 
@@ -263,7 +268,15 @@ def get_available(limit=None, page=1, subject=None, query=None,
             "get_available(limit={}, page={}, subject={}, query={}, "
             "work_id={}, _type={}, sorts={}"
         )
-        logger.error(fmt.format(limit, page, subject, query, work_id, _type, sorts))
+        logger.error('get_available failed', extra={
+            'limit': limit,
+            'page': page,
+            'subject': subject,
+            'query': query,
+            'work_id': work_id,
+            '_type': _type,
+            'sorts': sorts,
+        })
     try:
         request = urllib.request.Request(url=url)
 


### PR DESCRIPTION
We were getting hundreds of these logged as separate events. Sentry uses the stack trace to determine whether to events are the same, but `logging.error` (unlike `logging.exception`) does not include the stack trace, so it only has the message to work off of. Sentry does, however, add any info in `extra` to its UI, so that's all still accessible.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Patch deployed on ol-web4, to stop the influx.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/6251786/93906248-f6f37d80-fcc9-11ea-9e78-7447f1b32230.png)


### Stakeholders
@mekarpeles @cclauss 
