### PR TITLE
Change default search facet to 'everything'

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -114,7 +114,7 @@ PersistentValue.DEFAULT_OPTIONS = {
 
 
 const MODES = ['everything', 'ebooks', 'printdisabled'];
-const DEFAULT_MODE = 'ebooks';
+const DEFAULT_MODE = 'everything';
 /** Search mode; {@see MODES} */
 export const mode = new PersistentValue('mode', {
     default: DEFAULT_MODE,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3822

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Stores default search mode as 'everything' in local storage.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to Open Library.
2. In your browser's developer's tools, locate local storage and delete the data the is stored there.
3. Refresh the page.
4. Verify that `mode` is set to `everything`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
