### PR TITLE
Correct undefined URL error

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -12,20 +12,22 @@ export function addModeInputsToForm($form, searchMode) {
     $('input[name=\'has_fulltext\']').remove();
 
     let url = $form.attr('action');
-    url = removeURLParameter(url, 'm');
-    url = removeURLParameter(url, 'has_fulltext');
-    url = removeURLParameter(url, 'subject_facet');
+    if(url) {
+        url = removeURLParameter(url, 'm');
+        url = removeURLParameter(url, 'has_fulltext');
+        url = removeURLParameter(url, 'subject_facet');
 
-    if (searchMode !== 'everything') {
-        $form.append('<input type="hidden" name="has_fulltext" value="true"/>');
-        url = `${url + (url.indexOf('?') > -1 ? '&' : '?')}has_fulltext=true`;
-    }
-    if (searchMode === 'printdisabled') {
-        $form.append('<input type="hidden" name="subject_facet" value="Protected DAISY"/>');
-        url += `${url.indexOf('?') > -1 ? '&' : '?'}subject_facet=Protected DAISY`;
-    }
+        if (searchMode !== 'everything') {
+            $form.append('<input type="hidden" name="has_fulltext" value="true"/>');
+            url = `${url + (url.indexOf('?') > -1 ? '&' : '?')}has_fulltext=true`;
+        }
+        if (searchMode === 'printdisabled') {
+            $form.append('<input type="hidden" name="subject_facet" value="Protected DAISY"/>');
+            url += `${url.indexOf('?') > -1 ? '&' : '?'}subject_facet=Protected DAISY`;
+        }
 
-    $form.attr('action', url);
+        $form.attr('action', url);
+    }
 }
 
 

--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -12,7 +12,7 @@ export function addModeInputsToForm($form, searchMode) {
     $('input[name=\'has_fulltext\']').remove();
 
     let url = $form.attr('action');
-    if(url) {
+    if (url) {
         url = removeURLParameter(url, 'm');
         url = removeURLParameter(url, 'has_fulltext');
         url = removeURLParameter(url, 'subject_facet');


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3665 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Manage covers was failing because `SearchUtils.addModeInputsToForm()` is being called for the add and manage covers form.  This function fails to set the URL for these forms, causing functionality to break.

### Technical
<!-- What should be noted about the implementation? -->
All code within `addModeInputsToForm()` that relies on a defined URL is now nested inside of an `if` statement that checks if the URL exists.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log into Open Library.
2. Navigate to a work.
3. Click on "Manage Covers" and attempt to add and remove a cover.
4. Test that search functionality is working properly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
