### PR TITLE
Use i18n strings for list deletion dialog buttons

### DIFF
--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -27,15 +27,24 @@ $if "type" in doc and doc.type.key == "/type/user":
                     .find(".listDelete a")
                     .click(function() {
                         \$('#delete-dialog')
-                            .ol_confirm_dialog(function(){
-                                var list_id = "#" + \$(this).data("list-id");
-                                var key = \$(list_id + " a:first").attr("href");
-                                var dialog = this;
+                            .ol_confirm_dialog(function(){},
+                            {
+                                buttons: {
+                                    "$:_('Yes, I\'m sure')": function() {
+                                        var list_id = "#" + \$(this).data("list-id");
+                                        var key = \$(list_id + " a:first").attr("href");
+                                        var dialog = this;
 
-                                \$.post(key + "/delete.json", function() {
-                                    \$(list_id).remove();
-                                    \$(dialog).dialog("close");
-                                });
+                                        \$.post(key + "/delete.json", function() {
+                                            \$(list_id).remove();
+                                            \$(dialog).dialog("close");
+                                        });
+                                    },
+                                    "$_('No, cancel')": function() {
+                                        \$(this).dialog("close");
+                                    }
+                                },
+                                closeText: "$_('Close')"
                             })
                             .data("list-id", \$(this).closest("li").attr("id"))
                             .dialog('open');


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3813

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I18n strings are now used for the text of the delete list dialog buttons.

### Technical
<!-- What should be noted about the implementation? -->
This change overrides the buttons set in the `confirmDialog` function found in `openlibrary/plugins/openlibrary/js/dialog.js`.  `confirmDialog` takes two arguments: A callback function and dialog box options.

The callback is used to set the default behavior of the confirmation button.  I couldn't think of a clean way to override the buttons and reference the callback, so I passed an empty function as the callback and put the original logic in the `buttons` option.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log into Open Library.
2. Create a list that contains at least one book.
3. Ensure that your language preference is set to Spanish or French (These are the only two translations available for these buttons as of writing).
4. Navigate to your lists.
5. Click on the trash can to open the dialog.
6. Ensure that the buttons are translated.
7. Select the affirmative option and ensure that the list is deleted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Delete list dialog with French language preference set:

![fr_dialog_buttons](https://user-images.githubusercontent.com/28732543/94352542-3dcbd500-0034-11eb-86f9-90c4693d1ccb.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
