### PR TITLE
Do not allow requests.get() to silently fail

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -82,6 +82,11 @@ def do_we_want_it(isbn, work_id):
     url = '%s/book/marc/ol_dedupe.php' % lending.config_ia_domain
     r = requests.get(url, params=params)
     try:
+        r.raise_for_status() 
+    except requests.HTTPError as e:
+        logger.error("DWWI Failed for isbn %s with %s" % (isbn, e), exc_info=True)
+        return False, []
+    try:
         data = r.json()
         dwwi = data.get('response', 0)
         return dwwi==1, data.get('books', [])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

The Sentry issue below is difficult to understand because several lines of code are run before an issue is raised.  This change allows us to fail-fast and see details of the requests error.

Clarify the problem causing https://sentry.archive.org/sentry/ol-web/issues/4139/

https://2.python-requests.org/en/master/api/#requests.Response.raise_for_status

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
