### PR TITLE
Add Python version to Server status page

### DIFF
--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -1,8 +1,9 @@
 import web
 
-import socket
 import datetime
+import socket
 import subprocess
+import sys
 
 from infogami import config
 from infogami.utils import delegate
@@ -34,10 +35,12 @@ def setup():
     "Basic startup status for the server"
     global status_info, feature_flags
     version = get_software_version()
-    host = socket.gethostname()
+    if bytes != str:  # Python 3
+        version = version.decode("utf-8")
     status_info = {
         "Software version": version,
-        "Host": host,
+        "Python version": sys.version.split()[0],
+        "Host": socket.gethostname(),
         "Start time": datetime.datetime.utcnow(),
     }
     feature_flags = get_features_enabled()

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -37,10 +37,11 @@ def setup():
     version = get_software_version()
     if bytes != str:  # Python 3
         version = version.decode("utf-8")
+    host = socket.gethostname()
     status_info = {
         "Software version": version,
         "Python version": sys.version.split()[0],
-        "Host": socket.gethostname(),
+        "Host": host,
         "Start time": datetime.datetime.utcnow(),
     }
     feature_flags = get_features_enabled()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add Python version to http://openlibrary.org/status.  Similar to #3681 but does not require administrative privileges to see the Python version.

Also, fix the issue where [`Software version is b'3580fcf'`](http://staging.openlibrary.org/status) instead of `3580fcf` on Python 3.

### Technical
<!-- What should be noted about the implementation? -->
% ` python3 -c "import sys ; print(sys.version.split()[0])" ` # --> 3.8.5

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
