### PR TITLE
Make Travis only run on master/PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# Only run travis when pushing to master branch (and PRs)
+branches:
+  only:
+    - master
+
 os: linux
 dist: focal
 language: python


### PR DESCRIPTION
We don't really need travis to run on pushes to non-master branches, since we only care about branches which have PRs open. This means fewer things in Travis, shorter queues, faster Travis runs.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
