### PR TITLE
Improve merge author UI

### DIFF
--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -27,6 +27,9 @@ window.q.push(function(){
         previousMaster.find("input[type=checkbox]").attr('checked', false);
         \$(this).parent().parent().addClass("master");
         \$(this).parent().parent().find("input[type=checkbox]").attr('checked', true);
+
+        \$(this).parent().parent().insertAfter(\$("div.header"));
+        \$(this).parent().parent().removeClass("mouseoverHighlight");
     });
     \$("#include input[type=checkbox]").on("change", function() {
         if (!\$(this).parent().parent().hasClass("master")) {

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -22,7 +22,9 @@ window.q.push(function(){
         \$(this).parent().parent().animate({backgroundColor:'#fff'},100);
     });
     \$("#include input[type=radio]").click(function(){
-        \$(".merge").find("div.master").removeClass("master");
+        var previousMaster = \$(".merge").find("div.master");
+        previousMaster.removeClass("master");
+        previousMaster.find("input[type=checkbox]").attr('checked', false);
         \$(this).parent().parent().addClass("master");
         \$(this).parent().parent().find("input[type=checkbox]").attr('checked', true);
     });

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -16,17 +16,26 @@ window.q.push(function(){
     \$("div.checkbox:first input[type=checkbox]").attr("checked","checked");
     \$("div.author:first").addClass("master");
     \$("#include input[type=radio]").mouseover(function(){
-        \$(this).parent().parent().animate({backgroundColor:'#fefde6'},300);
+        \$(this).parent().parent().addClass("mouseoverHighlight",300);
     });
     \$("#include input[type=radio]").mouseout(function(){
-        \$(this).parent().parent().animate({backgroundColor:'#fff'},100);
+        \$(this).parent().parent().removeClass("mouseoverHighlight",100);
     });
     \$("#include input[type=radio]").click(function(){
         var previousMaster = \$(".merge").find("div.master");
-        previousMaster.removeClass("master");
+        previousMaster.removeClass("master mergeSelection");
         previousMaster.find("input[type=checkbox]").attr('checked', false);
         \$(this).parent().parent().addClass("master");
         \$(this).parent().parent().find("input[type=checkbox]").attr('checked', true);
+    });
+    \$("#include input[type=checkbox]").on("change", function() {
+        if (!\$(this).parent().parent().hasClass("master")) {
+            if (\$(this).is(":checked")) {
+                \$(this).parent().parent().addClass("mergeSelection");
+            } else {
+                \$(this).parent().parent().removeClass("mergeSelection");
+            }
+        }
     });
 });
 </script>

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -14,7 +14,7 @@ window.q.push(function(){
     });
     \$("div.radio:first input[type=radio]").attr("checked","checked");
     \$("div.checkbox:first input[type=checkbox]").attr("checked","checked");
-    \$("div.author:first").addClass("master");
+    \$("div.author:first").addClass("master sticky");
     \$("#include input[type=radio]").mouseover(function(){
         \$(this).parent().parent().addClass("mouseoverHighlight",300);
     });
@@ -23,9 +23,9 @@ window.q.push(function(){
     });
     \$("#include input[type=radio]").click(function(){
         var previousMaster = \$(".merge").find("div.master");
-        previousMaster.removeClass("master mergeSelection");
+        previousMaster.removeClass("master mergeSelection sticky");
         previousMaster.find("input[type=checkbox]").attr('checked', false);
-        \$(this).parent().parent().addClass("master");
+        \$(this).parent().parent().addClass("master sticky");
         \$(this).parent().parent().find("input[type=checkbox]").attr('checked', true);
     });
     \$("#include input[type=checkbox]").on("change", function() {

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -14,7 +14,7 @@ window.q.push(function(){
     });
     \$("div.radio:first input[type=radio]").attr("checked","checked");
     \$("div.checkbox:first input[type=checkbox]").attr("checked","checked");
-    \$("div.author:first").addClass("master sticky");
+    \$("div.author:first").addClass("master");
     \$("#include input[type=radio]").mouseover(function(){
         \$(this).parent().parent().addClass("mouseoverHighlight",300);
     });
@@ -23,9 +23,9 @@ window.q.push(function(){
     });
     \$("#include input[type=radio]").click(function(){
         var previousMaster = \$(".merge").find("div.master");
-        previousMaster.removeClass("master mergeSelection sticky");
+        previousMaster.removeClass("master mergeSelection");
         previousMaster.find("input[type=checkbox]").attr('checked', false);
-        \$(this).parent().parent().addClass("master sticky");
+        \$(this).parent().parent().addClass("master");
         \$(this).parent().parent().find("input[type=checkbox]").attr('checked', true);
     });
     \$("#include input[type=checkbox]").on("change", function() {

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -27,9 +27,6 @@ window.q.push(function(){
         previousMaster.find("input[type=checkbox]").attr('checked', false);
         \$(this).parent().parent().addClass("master");
         \$(this).parent().parent().find("input[type=checkbox]").attr('checked', true);
-
-        \$(this).parent().parent().insertAfter(\$("div.header"));
-        \$(this).parent().parent().removeClass("mouseoverHighlight");
     });
     \$("#include input[type=checkbox]").on("change", function() {
         if (!\$(this).parent().parent().hasClass("master")) {

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -27,16 +27,11 @@ div.merge {
     }
     .master {
       background-color: @light-yellow!important;
-    }
-    .mergeSelection {
-      background-color: @lighter-yellow;
-    }
-    .mouseoverHighlight {
-      background-color: @lighter-yellow;
-    }
-    .sticky {
       position: sticky;
       top: 0;
+    }
+    .mergeSelection, .mouseoverHighlight {
+      background-color: @lighter-yellow;
     }
     .data {
       padding: 0 5px;

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -28,6 +28,12 @@ div.merge {
     .master {
       background-color: @light-yellow!important;
     }
+    .mergeSelection {
+      background-color: @lighter-yellow;
+    }
+    .mouseoverHighlight {
+      background-color: @lighter-yellow;
+    }
     .data {
       padding: 0 5px;
     }

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -34,6 +34,10 @@ div.merge {
     .mouseoverHighlight {
       background-color: @lighter-yellow;
     }
+    .sticky {
+      position: sticky;
+      top: 0;
+    }
     .data {
       padding: 0 5px;
     }

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -57,6 +57,7 @@
 @brown: hsl(40, 32%, 29%);
 @brown-3a301e: hsl(39, 32%, 17%); // this color is only used once
 @light-yellow: hsl(58, 100%, 90%);
+@lighter-yellow: hsl(58, 92%, 95%);
 @dark-beige:hsl(64, 9%, 71%);
 @light-beige:hsl(48, 29%, 93%);
 @beige-two:hsl(63, 26%, 84%);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #668 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The following changes to the author merge UI in order to help librarians avoid merging incorrect records:

1. When a new primary record is selected, it is moved to the top of the list.
2. Previous primary record's merge checkbox is unchecked on primary record change.
3. All non-primary records that selected for merging now have a light yellow background color.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the merge author page, ensuring that two or more author IDs are passed as keys.
2. Select a new primary record and ensure that the following occurs:
    - The new primary is moved to the top of the list of records.
    - The old primary record's checkbox is unchecked.
3. Check and uncheck the checkboxes of non-primary records, and ensure that the background color changes accordingly.
4. Merge records to ensure that the merge functionality is working as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![merge_authors_ui](https://user-images.githubusercontent.com/28732543/94726585-736e0800-032b-11eb-88d3-8c3c603dd780.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
