### PR TITLE
Refactor autocomplete unit tests

### DIFF
--- a/tests/unit/js/test.SearchBar.js
+++ b/tests/unit/js/test.SearchBar.js
@@ -157,7 +157,7 @@ describe('SearchBar', () => {
                 const getJSONStub = sandbox.stub($, 'getJSON');
 
                 sb.$input.val('Harry');
-                sb.$input.focus();
+                sb.$input.triggerHandler('focus');
                 expect(getJSONStub.callCount).toBe(1);
             });
         }
@@ -168,7 +168,7 @@ describe('SearchBar', () => {
             const sb = new SearchBar($(DUMMY_COMPONENT_HTML), {facet: 'title'});
             const getJSONStub = sandbox.stub($, 'getJSON');
             sb.$input.val('title:"Harry"');
-            sb.$input.focus();
+            sb.$input.triggerHandler('focus');
             expect(getJSONStub.callCount).toBe(1);
         });
 
@@ -178,7 +178,7 @@ describe('SearchBar', () => {
             const sb = new SearchBar($(DUMMY_COMPONENT_HTML), {facet: 'title'});
             const getJSONStub = sandbox.stub($, 'getJSON');
             sb.$input.val('');
-            sb.$input.focus();
+            sb.$input.triggerHandler('focus');
             expect(getJSONStub.callCount).toBe(0);
         });
 
@@ -191,7 +191,7 @@ describe('SearchBar', () => {
 
                 sb.$input.val('foo bar');
                 sb.facet.write(facet);
-                sb.$input.focus();
+                sb.$input.triggerHandler('focus');
                 expect(getJSONStub.callCount).toBe(0);
             });
         }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3870 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Triggering autocomplete in search bar unit tests is now done by invoking the focus handler.  This will ensure that our tests will continue to work properly when using newer versions of Jest.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 