### PR TITLE
Validation errors on homepage resolved

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -30,11 +30,7 @@ $def render_carousel_cover(book, lazy):
     $ author_names = ''
   $ modifier = ''
   $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
-
-  $if lazy:
-    $ img_attr = 'data-lazy'
-  $else:
-    $ img_attr = 'src'
+  $ img_attr = 'src'
 
   <div class="book carousel__item">
     <div class="book-cover">
@@ -43,7 +39,7 @@ $def render_carousel_cover(book, lazy):
           <img class="bookcover" loading="lazy"
             width="130" height="200"
             title="$('%s%s'%(title,byline))"
-            $img_attr="$(cover_url)"/>
+            $img_attr ="$(cover_url)"/>
         $else:
           <div class="carousel__item__blankcover">
             <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -30,7 +30,10 @@ $def render_carousel_cover(book, lazy):
     $ author_names = ''
   $ modifier = ''
   $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
-  $ img_attr = 'src'
+  $if lazy:
+    $ img_attr = 'data-lazy'
+  $else:
+    $ img_attr = 'src'
 
   <div class="book carousel__item">
     <div class="book-cover">

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -39,7 +39,7 @@ $def render_carousel_cover(book, lazy):
           <img class="bookcover" loading="lazy"
             width="130" height="200"
             title="$('%s%s'%(title,byline))"
-            $img_attr ="$(cover_url)"/>
+            $img_attr="$(cover_url)"/>
         $else:
           <div class="carousel__item__blankcover">
             <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -24,7 +24,7 @@ $if subjects:
               <p class="category-title">$presentable_subject_name</p>
               $if subject:
                 $ count = commify(subject.get('work_count', ''))
-                <p class="category-count" name="">$ungettext('1 Book', '%(count)s Books', subject.get('work_count'), count=count)</p>
+                <p class="category-count">$ungettext('1 Book', '%(count)s Books', subject.get('work_count'), count=count)</p>
             </a>
           </div>
       </div>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -61,7 +61,7 @@ $def with (page)
   <ul class="navigation-component">
     <li class="browse-menu">
       <a>$_('Browse') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('Browse')"   src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="$_('Browse')" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>
@@ -74,7 +74,7 @@ $def with (page)
     </li>
     <li class="my-books-menu">
       <a>$_('My Books') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('My Books')"   src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="$_('My Books')" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu my-books-menu-options">
           <li><a href="/account/loans">$_("My Loans")</a></li>
@@ -86,7 +86,7 @@ $def with (page)
     </li>
     <li class="more-menu">
       <a>$_('More') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('More')"   src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="$_('More')" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">
           <li><a href="/books/add">$_("Add a Book")</a></li>
@@ -111,7 +111,7 @@ $def with (page)
     <div class="account-component">
       <div class="dropdown-avatar">
         <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
-        <img class="down-arrow" aria-hidden="true" alt="$_('My Account')"   src="/static/images/down-arrow.png"/>
+        <img class="down-arrow" aria-hidden="true" alt="$_('My Account')" src="/static/images/down-arrow.png"/>
       </div>
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
         <ul class="dropdown-menu">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -74,7 +74,7 @@ $def with (page)
     </li>
     <li class="my-books-menu">
       <a>$_('My Books') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('My Books')" src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu my-books-menu-options">
           <li><a href="/account/loans">$_("My Loans")</a></li>
@@ -86,7 +86,7 @@ $def with (page)
     </li>
     <li class="more-menu">
       <a>$_('More') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('More')" src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">
           <li><a href="/books/add">$_("Add a Book")</a></li>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -61,7 +61,7 @@ $def with (page)
   <ul class="navigation-component">
     <li class="browse-menu">
       <a>$_('Browse') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('Browse')" src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>
@@ -111,7 +111,7 @@ $def with (page)
     <div class="account-component">
       <div class="dropdown-avatar">
         <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
-        <img class="down-arrow" aria-hidden="true" alt="$_('My Account')" src="/static/images/down-arrow.png"/>
+        <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
       </div>
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
         <ul class="dropdown-menu">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -61,7 +61,7 @@ $def with (page)
   <ul class="navigation-component">
     <li class="browse-menu">
       <a>$_('Browse') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('Browse')" role="presentation" src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="$_('Browse')"   src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>
@@ -74,7 +74,7 @@ $def with (page)
     </li>
     <li class="my-books-menu">
       <a>$_('My Books') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('My Books')" role="presentation" src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="$_('My Books')"   src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu my-books-menu-options">
           <li><a href="/account/loans">$_("My Loans")</a></li>
@@ -86,7 +86,7 @@ $def with (page)
     </li>
     <li class="more-menu">
       <a>$_('More') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="$_('More')" role="presentation" src="/static/images/down-arrow.png"/></a>
+        width="7" height="4" aria-hidden="true" alt="$_('More')"   src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">
           <li><a href="/books/add">$_("Add a Book")</a></li>
@@ -111,7 +111,7 @@ $def with (page)
     <div class="account-component">
       <div class="dropdown-avatar">
         <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
-        <img class="down-arrow" aria-hidden="true" alt="$_('My Account')" role="presentation" src="/static/images/down-arrow.png"/>
+        <img class="down-arrow" aria-hidden="true" alt="$_('My Account')"   src="/static/images/down-arrow.png"/>
       </div>
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
         <ul class="dropdown-menu">

--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -8,7 +8,7 @@ $if not is_bot():
 	<a href="https://archive.org"><img alt="Internet Archive logo" src="/static/images/ia-logo.svg" width="160"></a>
       </div>
       <div class="iaBarMessage">
-        <a class="ghost-btn" style="text-underline" href="https://archive.org/donate?platform=ol" data-ol-link-track="IABar|DonateButton">Donate <span class="heart" aria-hidden="true">♥</span></a>
+        <a class="ghost-btn" href="https://archive.org/donate?platform=ol" data-ol-link-track="IABar|DonateButton">Donate <span class="heart" aria-hidden="true">♥</span></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3877 

### Technical
<!-- What should be noted about the implementation? -->

- Removed data-lazy, did not find any use for that specific attribute anywhere else in the code, validator wants src attribute on every image. 
- `role="presentation"` is not recommended with images having a non empty alt tag. Source: [ARIA practices](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/presentation/PresentationRoleExamples.html), since alt is a more important attribute, decided to let it stay.
- `text-underline` has no style associated with it.
- The only error remaining is the `Stray start tag script` which the validator does not like is because the scripts in openlibrary/templates/site/footer.html are outside the `<body>` tag. Since all the scripts are related to analytics and therefore belong before the HTML page ends, we can ignore this error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Selection_002](https://user-images.githubusercontent.com/54721958/94974663-d7135380-052c-11eb-9144-31b33954d084.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 