### PR TITLE
Setup ol-web1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ openlibrary.egg-info/
 pip-log.txt
 supervisord.pid
 vendor/apache-solr-1.4.0/
+vendor/infogami/
 vendor/solr/
 solr-update.offset
 openlibrary/mailserver/logs/lamson.err

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,16 @@
+##
+## Production server config (wip)
+## You probably want to run:
+## docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml -f docker-compose.production.yml up -d
+##
+
+version: "3"
+services:
+  web:
+    environment:
+      - PYENV_VERSION=3.8.5
+      - OL_CONFIG=/olsystem/etc/openlibrary.yml
+      - GUNICORN_OPTS= --workers 4 --timeout 180
+    volumes:
+      - ../olsystem:/olsystem
+    command: docker/ol-web1-start.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -127,10 +127,4 @@ Note: This is only if you already have an existing docker image, this command is
 ```bash
 # Launch a temporary container and run tests
 docker-compose run --rm web make test
-
-# Launch a temporary container on Python 3 using the local Infogami and then open in local webbrowser
-docker-compose down ; \
-    PYENV_VERSION=3.8.5 docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml up -d ; \
-    docker-compose logs -f --tail=10 web
-# In your browser, navigate to http://localhost:8080
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -127,4 +127,10 @@ Note: This is only if you already have an existing docker image, this command is
 ```bash
 # Launch a temporary container and run tests
 docker-compose run --rm web make test
+
+# Launch a temporary container on Python 3 using the local Infogami and then open in local webbrowser
+docker-compose down ; \
+    PYENV_VERSION=3.8.5 docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml up -d ; \
+    docker-compose logs -f --tail=10 web
+# In your browser, navigate to http://localhost:8080
 ```

--- a/docker/ol-web1-start.sh
+++ b/docker/ol-web1-start.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
 python --version
-ln --verbose --symbolic opt/olsystem/etc/nginx/nginx.conf      /etc/nginx/nginx.conf
-ln --verbose --symbolic opt/olsystem/etc/nginx/sites-available /etc/nginx/sites-available
-ln --verbose --symbolic opt/olsystem/etc/haproxy/haproxy.cfg   /etc/haproxy/haproxy.cfg
+
+sudo rm -f /etc/haproxy/haproxy.cfg
+sudo ln --verbose --symbolic opt/olsystem/etc/haproxy/haproxy.cfg   /etc/haproxy/haproxy.cfg
+
+sudo mkdir /etc/nginx || true
+sudo ln --verbose --symbolic opt/olsystem/etc/nginx/nginx.conf      /etc/nginx/nginx.conf
+sudo ln --verbose --symbolic opt/olsystem/etc/nginx/sites-available /etc/nginx/sites-available
+
+ls -l /etc/haproxy /etc/nginx
+
 authbind --deep \
   scripts/openlibrary-server "$OL_CONFIG" \
   --gunicorn \

--- a/docker/ol-web1-start.sh
+++ b/docker/ol-web1-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+python --version
+ln --verbose --symbolic opt/olsystem/etc/nginx/nginx.conf      /etc/nginx/nginx.conf
+ln --verbose --symbolic opt/olsystem/etc/nginx/sites-available /etc/nginx/sites-available
+ln --verbose --symbolic opt/olsystem/etc/haproxy/haproxy.cfg   /etc/haproxy/haproxy.cfg
+authbind --deep \
+  scripts/openlibrary-server "$OL_CONFIG" \
+  --gunicorn \
+  $GUNICORN_OPTS \
+  --bind :80

--- a/scripts/2010/01/report_errors.py
+++ b/scripts/2010/01/report_errors.py
@@ -5,7 +5,10 @@ from collections import defaultdict
 from optparse import OptionParser
 
 import web
-from BeautifulSoup import BeautifulSoup
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    from BeautifulSoup import BeautifulSoup
 
 TEMPLATE = """\
 $def with (hostname, date, dir, errors)

--- a/scripts/setup_web1.sh
+++ b/scripts/setup_web1.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# CAUTION: To git clone infogami, environment variables must be set...
+
+# apt list --installed
+sudo apt-get update
+sudo apt-get install -y docker.io docker-compose haproxy
+docker --version        # 19.03.8
+docker-compose version  #  1.25.0
+haproxy -v              #  2.0.13-2ubuntu0.1
+sudo systemctl start docker
+sudo systemctl enable docker
+
+sudo groupadd --system openlibrary
+sudo useradd --no-log-init --system --gid openlibrary --create-home openlibrary
+
+cd /opt
+ls -l  # nothing
+
+sudo git clone https://github.com/internetarchive/openlibrary
+# sudo git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/internetarchive/olsystem
+sudo chown openlibrary /opt/*
+ls -l  # openlibrary, olsystem owned by openlibrary
+
+cd /opt/openlibrary
+sudo docker-compose down && \
+    sudo docker-compose up --no-deps -d memcached && \
+    sudo docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml -f docker-compose.production.yml up --no-deps -d web

--- a/scripts/setup_web1.sh
+++ b/scripts/setup_web1.sh
@@ -27,6 +27,13 @@ sudo chown openlibrary /opt/*
 ls -l  # openlibrary, olsystem owned by openlibrary
 
 cd /opt/openlibrary
+
+git remote -v  # TEMPORARY UNTIL THIS PR LANDS...
+sudo git remote add cclauss https://github.com/cclauss/openlibrary
+sudo git fetch cclauss Setup-ol-web1
+sudo git checkout Setup-ol-web1
+git branch
+
 sudo docker-compose down && \
     sudo docker-compose up --no-deps -d memcached && \
     sudo docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml -f docker-compose.production.yml up --no-deps -d web

--- a/scripts/setup_web1.sh
+++ b/scripts/setup_web1.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # CAUTION: To git clone infogami, environment variables must be set...
+if [[ -z ${GITHUB_TOKEN} ]]; then
+    echo "FATAL: Can not git clone olsystem" ;
+    exit 1 ;
+fi
 
 # apt list --installed
 sudo apt-get update
@@ -18,7 +22,7 @@ cd /opt
 ls -l  # nothing
 
 sudo git clone https://github.com/internetarchive/openlibrary
-# sudo git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/internetarchive/olsystem
+sudo git clone https://${GITHUB_USERNAME:-$USER}:${GITHUB_TOKEN}@github.com/internetarchive/olsystem
 sudo chown openlibrary /opt/*
 ls -l  # openlibrary, olsystem owned by openlibrary
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1. Adds `/vendor/infogami` to `.gitignore` so local changes are not pushed into PRs
2. Adds `docker-compose.production.yml` with minor changes from `docker-compose.staging.yml`
3. Adds `docker/ol-web1-start.sh` with minor changes from `docker/ol-web-start.sh`
4. Adds Python 2 and 3 compatible import to `scripts/2010/01/report_errors.py`
5.  Adds `scripts/setup_web1.sh` to build the `ol-web1` server from a clean Ubuntu install

The wokflow will be:
1. Log into ol-web1 that have a fresh Ubuntu install.
2. Run `scripts/setup_web1.sh` that will install and configure docker, haproxy, openlibrary, olsystem
    * `GITHUB_USERNAME=cclauss GITHUB_TOKEN=mytoken scripts/setup_web1.sh`
    * These are required for git cloning olsystem
3. `scripts/setup_web1.sh` will run `docker-compose.production.yml`
4. `docker-compose.production.yml`  will run `scripts/setup_web1.sh`

% `ls -l /etc/haproxy /etc/nginx`
```
/etc/haproxy:
total 4
drwxr-xr-x 2 root root 4096 Oct  3 16:33 errors
lrwxrwxrwx 1 root root   36 Oct  3 19:07 haproxy.cfg -> opt/olsystem/etc/haproxy/haproxy.cfg

/etc/nginx:
total 0
lrwxrwxrwx 1 root root 33 Oct  3 19:04 nginx.conf -> opt/olsystem/etc/nginx/nginx.conf
lrwxrwxrwx 1 root root 38 Oct  3 19:06 sites-available -> opt/olsystem/etc/nginx/sites-available
```
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
