### PR TITLE
.gitignore: vendor/infogami/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ openlibrary.egg-info/
 pip-log.txt
 supervisord.pid
 vendor/apache-solr-1.4.0/
+vendor/infogami/
 vendor/solr/
 solr-update.offset
 openlibrary/mailserver/logs/lamson.err


### PR DESCRIPTION
I was not successful with the proposed solution in https://github.com/internetarchive/openlibrary/pull/3636#discussion_r463121645

<!-- What issue does this PR close? -->
I keep creating PRs that pull in `vendor/infogami/` which should be ignored like `vendor/solr/` is.  Trying to rework or recreate these PRs is frustrating.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
