### PR TITLE
Fixed validation errors on Editions page.

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -16,7 +16,7 @@ $if render_once('book-preview-floater'):
              title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div class="iframe-container">
-          <iframe width="100%" height="515"></iframe>
+          <iframe style="width:100%; height:515px"></iframe>
         </div>
         <p class="learn-more">
           <a data-key="book_preview_learn_more"

--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -5,7 +5,7 @@ $ rating = work and username and work.get_users_rating(username)
 $ edition_key = edition.key if edition else ""
 
 <form id="ratingsForm" method="POST" action="$(work.key)/ratings.json"
-      property="reviewRating" typeof="Rating" vocab="http://schema.org/" typeof="Books">
+      property="reviewRating" typeof="Rating" vocab="http://schema.org/">
   <meta property="worstRating" content="1"/>
   <meta property="bestRating" content="5"/>
   <input type="hidden" value="$edition_key" name="edition_id"/>

--- a/openlibrary/macros/databarDiff.html
+++ b/openlibrary/macros/databarDiff.html
@@ -4,7 +4,7 @@ $def with ()
     <div id="editHistory" style="display:block;">
         <a class="linkButton" href="$changequery(m='history')" title="View the editing history of this page">$_("History")</a>
     </div>
-    <div id="editButton">
+    <div class="editButton">
         <a class="linkButton" href="$changequery(m='None')" title="View this page (exit Comparison view)">$_("View")</a>
     </div>
 </div>

--- a/openlibrary/macros/databarEdit.html
+++ b/openlibrary/macros/databarEdit.html
@@ -5,7 +5,7 @@ $def with (page)
     <div id="editHistory">
         <a class="linkButton larger" href="$page.key?m=history" title="View the editing history of this page">$_("History")</a>
     </div>
-    <div id="editButton">
+    <div class="editButton">
         <a href="$page.key" title="View this page (exit Edit mode)" class="cancel">$_("Cancel")</a>
     </div>
 </div>

--- a/openlibrary/macros/databarHistory.html
+++ b/openlibrary/macros/databarHistory.html
@@ -7,7 +7,7 @@ $else:
 
 <div id="editTools" class="edit">
     $if not page.is_fake_record():
-        <div id="editButton">
+        <div class="editButton">
             <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
             <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
                data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>

--- a/openlibrary/macros/databarMerge.html
+++ b/openlibrary/macros/databarMerge.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 <div id="editTools" class="edit">
-    <div id="editButton">
+    <div class="editButton">
         <button type="submit" class="linkButton" name="$edit_url" title="Revert this entire merge" accesskey="u">$_("Undo All")</button>
     </div>
     <div id="editInfo">

--- a/openlibrary/macros/databarTemplate.html
+++ b/openlibrary/macros/databarTemplate.html
@@ -4,7 +4,7 @@ $def with (page)
     <div id="editHistory">
       <a class="linkButton larger" href="$changequery(m='history')" title="View this template's edit history" accesskey="h">$_("History")</a>
     </div>
-    <div id="editButton">
+    <div class="editButton">
         <a class="linkButton larger" href="$changequery(m='edit')" title="Edit this template"
            data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
     </div>

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -10,7 +10,7 @@ $else:
 
 <div id="editTools" class="edit">
     $if not page.is_fake_record():
-        <div id="editButton">
+        <div class="editButton">
           <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
           <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
              data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>

--- a/openlibrary/templates/recentchanges/header.html
+++ b/openlibrary/templates/recentchanges/header.html
@@ -4,7 +4,7 @@ $ label = label or change.kind.replace("_", " ").replace("-", " ").title()
 
 <div id="editTools" class="edit">
     $if change.can_undo() and "undo" in ctx.features:
-        <div id="editButton">
+        <div class="editButton">
             <form id="undo-form" method="POST">
                 <button class="larger" name="#" accesskey="u" id="undo-button" type="submit">Undo All</button>
             </form>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -234,7 +234,6 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
             <p class="first-published-date">
               $_("First published in %s", work.first_publish_year)
             </p>
-        </h3>
         <hr>
 
         $ component_times['SubjectsTags'] = time()
@@ -317,7 +316,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                 $ edit_url = page.url(suffix="/edit")
           $else:
             $ edit_url = page.key + "?m=edit"
-          <div id="editButton">
+          <div class="editButton">
             <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
             <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
               data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
@@ -411,8 +410,8 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
 
           $if has_any("physical_format", "pagination", "physical_dimensions", "weight"):
             <div class="section">
+                <h3 class="list-header collapse">$_("The Physical Object")</h3>
                 <dl class="meta">
-                    <h3 class="list-header collapse">$_("The Physical Object")</h3>
                     $:display_value(_("Format"), edition.physical_format)
                     $:display_value(_("Pagination"), edition.pagination)
                     $:display_value(_("Number of pages"), edition.number_of_pages, itemprop="numberOfPages")
@@ -423,8 +422,8 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
 
 
           <div class="section">
+            <h3 class="list-header collapse">$_("ID Numbers")</h3>
             <dl class="meta">
-                <h3 class="list-header collapse">$_("ID Numbers")</h3>
                 $:display_identifiers("Open Library", [storage(url=None, value=edition.key.split("/")[-1])])
                 $for name, values in edition.get_identifiers().multi_items():
                     $ identifier_label = values[0].label

--- a/static/css/components/edit-toolbar--tablet.less
+++ b/static/css/components/edit-toolbar--tablet.less
@@ -5,7 +5,7 @@
 
 /* stylelint-disable selector-max-specificity */
 div#editTools,
-div#editButton,
+div.editButton,
 div#editHistory {
   padding: 3px 1px 0 20px;
   float: right;

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -5,12 +5,12 @@
 
 /* stylelint-disable selector-max-specificity */
 div#editTools,
-div#editButton,
 div#editHistory {
   width: auto;
 }
 
-div#editButton {
+div.editButton {
+  width: auto;
   float: left;
 }
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -924,7 +924,7 @@ div.cclicense {
 // openlibrary/macros/databarDiff.html
 // openlibrary/macros/databarEdit.html
 // openlibrary/templates/recentchanges/header.html
-div#editButton,
+div.editButton,
 div#editHistory,
 div.revert.notice {
   button {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #163. 

### Technical
Error regarding `workid` can be ignored, its a custom attribute.

### Testing
Before: 
![Selection_009](https://user-images.githubusercontent.com/54721958/95132677-cad20500-077d-11eb-813b-1168ad28c30d.png)

After: 
![Selection_010](https://user-images.githubusercontent.com/54721958/95132780-efc67800-077d-11eb-8e2d-1d0df34db3df.png)

`text-underline` and `role:presentation` errors will be removed if PR #3878 is accepted. Proof: 

![Selection_008](https://user-images.githubusercontent.com/54721958/95134388-6c5a5600-0780-11eb-8139-d7e65e01cbcd.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 