### PR TITLE
Increase search bar component z-index

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -288,7 +288,7 @@
       border: 1px solid @dark-beige;
       border-radius: .3em;
       background-color: @grey-fafafa;
-      z-index: @z-index-level-6;
+      z-index: @z-index-level-17;
       position: relative;
     }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3904 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR will prevent any other component from overlapping autocomplete search results.

### Technical
<!-- What should be noted about the implementation? -->
This is a major increase in the z-index of the autocomplete results.  I chose to increase this z-index rather then decreasing the manage author photos component's z-index for the following reasons:

1. The manage photos component is also used to manage covers.  It may also be used in other places that I'm unaware of.  Changing this could have unintended affects elsewhere.
2. The z-index for the manage photos component is the second highest (`@z-index-level-16`).  I'm assuming that it's this high for some good reason that I'm unaware of.
3. Autocomplete results are only present when a patron is actively searching for something, and disappear when the search bar loses focus.  If a patron is searching for something, I doubt that they would want another component interfering with their results.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log into Open Library.
2. Navigate to an author's page and locate the area that triggers the manage photos component.  Remember this location.
3. Type something in the search bar that will yield many results, and wait for autocomplete results.
4. Move the cursor to the result that is in the same location that you found in step 2.  Observe whether or not the manage photos component appears.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
