### PR TITLE
Internationalize /templates/stats/readinglog.html

### DIFF
--- a/openlibrary/templates/stats/readinglog.html
+++ b/openlibrary/templates/stats/readinglog.html
@@ -1,19 +1,19 @@
 $def with (stats)
 
 <div id="contentBody">
-  <h1>Reading Log Stats</h1>
+  <h1>$_('Reading Log Stats')</h1>
 
   <div class="admin-section">
-    <h2># Books Logged</h2>
-    <p>The total number of books logged using the Reading Log feature</p>
+    <h2>$_('# Books Logged')</h2>
+    <p>$_('The total number of books logged using the Reading Log feature')</p>
     <table class="readinglog-stats">
       <tbody>
         <tr>
-          <th>All time</th>
+          <th>$_('All time')</th>
           <td>$stats['total_books_logged']['total']['count']</td>
         </tr>
         <tr>
-          <th>This Month</th>
+          <th>$_('This Month')</th>
           <td>$stats['total_books_logged']['month']['count']</td>
         </tr>
       </tbody>
@@ -21,16 +21,16 @@ $def with (stats)
   </div>
 
   <div class="admin-section">
-    <h2># Unique Users Logging Books</h2>
-    <p>The total number of unique users who have logged at least one book using the Reading Log feature</p>
+    <h2>$_('# Unique Users Logging Books')</h2>
+    <p>$_('The total number of unique users who have logged at least one book using the Reading Log feature')</p>
     <table class="readinglog-stats">
       <tbody>
         <tr>
-          <th>All time</th>
+          <th>$_('All time')</th>
           <td>$stats['total_users_logged']['total']['count']</td>
         </tr>
         <tr>
-          <th>This Month</th>
+          <th>$_('This Month')</th>
           <td>$stats['total_users_logged']['month']['count']</td>
         </tr>
       </tbody>
@@ -38,20 +38,20 @@ $def with (stats)
   </div>
 
   <div class="admin-section">
-    <h2># Books Starred</h2>
-    <p>The total number of books which have been starred</p>
+    <h2>$_('# Books Starred')</h2>
+    <p>$_('The total number of books which have been starred')</p>
     <table class="readinglog-stats">
       <tbody>
         <tr>
-          <th>All time</th>
+          <th>$_('All time')</th>
           <td>$stats['total_books_starred']['total']['count']</td>
         </tr>
         <tr>
-          <th>This Month</th>
+          <th>$_('This Month')</th>
           <td>$stats['total_books_starred']['month']['count']</td>
         </tr>
         <tr>
-          <th>Total # Unique Raters (all time)</th>
+          <th>$_('Total # Unique Raters (all time)')</th>
           <td>$stats['total_books_starred']['unique']['count']</td>
         </tr>
       </tbody>
@@ -59,37 +59,37 @@ $def with (stats)
   </div>
 
   <div class="admin-section">
-    <h3>Most Wanted Books (All Time)</h3>
+    <h3>$_('Most Wanted Books (All Time)')</h3>
     <div class="mybooks-list">
       <ul class="list-books" id="siteSearch">
         $for book in stats['leaderboard']['most_wanted_all']:
-            $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']))
       </ul>
     </div>
 
-    <h3>Most Wanted Books (This Month)</h3>
+    <h3>$_('Most Wanted Books (This Month)')</h3>
     <div class="mybooks-list">
       <ul class="list-books" id="siteSearch">
         $for book in stats['leaderboard']['most_wanted_month']:
-            $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']))
       </ul>
     </div>
 
-    <h2>Most Logged Books</h2>
-    <h3>Most Read Books (All Time)</h3>
+    <h2>$_('Most Logged Books')</h2>
+    <h3>$_('Most Read Books (All Time)')</h3>
     <div class="mybooks-list">
       <ul class="list-books" id="siteSearch">
         $for book in stats['leaderboard']['most_read']:
-            $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']))
       </ul>
     </div>
 
-    <h2>Most Rated Books</h2>
-    <h3>Most Rated Books (All Time)</h3>
+    <h2>$_('Most Rated Books')</h2>
+    <h3>$_('Most Rated Books (All Time)')</h3>
     <div class="mybooks-list">
       <ul class="list-books" id="siteSearch">
         $for book in stats['leaderboard']['most_rated_all']:
-            $:macros.SearchResultsWork(book['work'], decorations="Added %s %s" % (book['cnt'], 'times' if book['cnt'] > 0 else 'time'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']))
       </ul>
     </div>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #988 

A couple of notes:

- After reading [i18n's README](https://github.com/internetarchive/openlibrary/tree/master/openlibrary/i18n) and [Frontend Guide - internationalization for programmers](https://github.com/internetarchive/openlibrary/wiki/Frontend-Guide#internationalization-i18n---for-programmers), and after checking other internationalization commits, I still wasn't sure how to generate `messages.pot` or if it was my job or a maintainer's. After getting a "permission denied" when trying `docker-compose run web ./scripts/i18n-messages extract` I decided to give the PR a try and update with your feedback, if any.
- Also, even if under "Librarian resources", is https://github.com/internetarchive/openlibrary/wiki/Developer's-Guide-to-Data-Importing the way to go for programmers as well to import data? Basically, I wanted to see numbers on my local `/stats/readinglog`.

Hoping that this helps!

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
