### PR TITLE
Add margin to sub-nav to improve UI for Recent Changes Page

### DIFF
--- a/static/css/components/subNav.less
+++ b/static/css/components/subNav.less
@@ -1,4 +1,5 @@
 .subNav {
+  margin-top: 10px;
   ul {
     list-style-type: none;
     li{


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3046 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
1. As suggested by @jdlrobson and agreed to the suggestions by @mekarpeles [here](https://github.com/internetarchive/openlibrary/pull/3207#pullrequestreview-383334434), I have made changes to the necessary file (static/css/components/subnav.less).
2. I added a margin-top of 10px on the sub-nav component of the above-mentioned file. If this was not what was expected to be changed, then, please do tell me, I will be happy to fix it.
3. Please do mention if I have done some mistakes, so that I can improve and not make those mistakes again. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I have ran the `docker-compose exec web bash make test`, all tests were passed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Image after the changes:
![Screenshot from 2020-10-12 17-36-29](https://user-images.githubusercontent.com/57295877/95746169-fa1fcf00-0cb3-11eb-86e2-a51d1d60b852.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
There were no assignees mentioned for this issue. 
