### PR TITLE
Solves: Overflow on "Check Availability" button

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -97,7 +97,7 @@ $elif is_lendable and availability_st == 'borrow_unavailable' and not lending_st
   $# This _used_ to mean that the book was waitlistable, but no longer! Now show this little cop-out button
   <div class="cta-button-group">
     <a href="/ia/$ocaid" class="cta-btn cta-btn--available" title="$_('We were unable to determine the availability of this book! Click to check on Internet Archive.')"
-       data-ol-link-track="CTAClick|CheckAvailability">$_('Check Availability')</a>
+       data-ol-link-track="CTAClick|CheckAvailability">$_('Check')</a>
   </div>
 
 $elif is_lendable:

--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -172,7 +172,7 @@ function initAvailability() {
                                 .addClass('check-book-availability').addClass(btnClassName);
                             // FIXME: This is not translatable!
                             $(`${selector}[data-key=${book_key}]`)
-                                .text('Check Availability');
+                                .text('Check');
                             delete books[book_key];
                         }
                     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3916 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Capture](https://user-images.githubusercontent.com/43555219/96046094-91da1480-0e90-11eb-8601-6f79702add35.JPG)


### Stakeholders
<!-- @ tag stakeholders of this bug -->

### Thread Summary
Problem DIscovered:
1.The text(Check Availability) in the button overflows 
2. Fozt Size 16 to 13 will be too small

Can be Solution so far:
1. Set ```font-size:100%;```
2. button can be defined in em or rem
3. Can increase the size of the ```test-body-mobile``` from 80% to 90%
4. Can reduce the number of item from 6 to 5 in the carousel 
5. Font text can be changed from "Check Availability" to "Check"
6. Only show those who we are confirmed about whether it is under the category of "Borrow" or "Join the Waitlist" on the homepage
7. Can create a method for a check so that Check Availability can be categorized within "Borrow" or "Join the waitlist"
