### PR TITLE
Resolve TypeError to render History section of the Page.

### DIFF
--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -1,8 +1,9 @@
 $def with (page)
 
+$ h = None
 $if "superfast" in ctx.features and "history_v2" not in ctx.features:
     $ h = page.get_history_preview()
-$else:
+$if not h:
     $ h = get_history(page)
 
 $ versions = h.recent + h.initial


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #3883, #3824 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Will resolve TypeError to render history section of `openlibrary/type/{page}`

### Technical
<!-- What should be noted about the implementation? -->
`h` variable was not receiving the value from the `get_history_preview` function, as suggested by @mekarpeles [here](https://github.com/internetarchive/openlibrary/issues/3883#issuecomment-708747380). I have made the necessary changes mentioned in the comment linked above.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The local tests were passed successfully.
To reproduce this PR changes:
1. Go to `openlibrary/templates/lib/history.html` and replace the first 7 lines of code with the below code:
```python
$def with (page)

$ h = None
$if "superfast" in ctx.features and "history_v2" not in ctx.features:
    $ h = page.get_history_preview()
$if not h:
    $ h = get_history(page)
```
2. Now navigate to `0.0.0.0:8080/type/work`, the history section gets rendered.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
It does not change any UI aspects but just to verify that this PR resolves the mentioned issues, I have added a screenshot:
![Screenshot from 2020-10-15 15-00-55](https://user-images.githubusercontent.com/57295877/96105092-43ac2c00-0ef7-11eb-87fe-1e3cf4f74083.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@nk4456542 ( I was assigned this issue ), @cdrini (lead)