### PR TITLE
addbook.py: Fix encoding/decoding for StringIO

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -2,8 +2,6 @@
 
 import web
 import simplejson
-from collections import defaultdict
-from six import StringIO
 import csv
 import datetime
 
@@ -639,13 +637,25 @@ class SaveBookHelper:
         :rtype: web.storage
         """
         def read_subject(subjects):
+            """
+            >>> list(read_subject("A,B,C,B")) == [u'A', u'B', u'C']   # str
+            True
+            >>> list(read_subject(r"A,B,C,B")) == [u'A', u'B', u'C']  # raw
+            True
+            >>> list(read_subject(u"A,B,C,B")) == [u'A', u'B', u'C']  # Unicode
+            True
+            >>> list(read_subject(""))
+            []
+            """
             if not subjects:
                 return
-
-            f = StringIO(subjects.encode('utf-8'))  # no unicode in csv module
+            if six.PY2:
+                subjects = subjects.encode('utf-8')  # no unicode in csv module
+            f = six.StringIO(subjects)
             dedup = set()
             for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
-                s = s.decode('utf-8')
+                if six.PY2:
+                    s = s.decode('utf-8')
                 if s.lower() not in dedup:
                     yield s
                     dedup.add(s.lower())


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3752 #3806 #3807

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allow both Python 2 and Python 3 to produce identical results from `read_subject()`.

### Technical
<!-- What should be noted about the implementation? -->
This leaves the Python 2 encoding/decoding in place but allows Python 3 to deliver the same results.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Added doctests that pass on both Python 2 and Python 3.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
