### PR TITLE
fixed URL for the "Installing Open Library" video

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Look through our issues related to [`contributing`](https://github.com/interneta
 ## Installing Open Library
 For instructions on setting up a local developer's instance of Open Library, please refer to the [Installation Guide](https://github.com/internetarchive/openlibrary#installation). 
 
-[![archive org_embed_openlibrary-developer-docs_zoom_0 mp4_autoplay=1 start=2](https://user-images.githubusercontent.com/978325/91351305-ef10ee00-e79c-11ea-9bfb-c2733696ec58.png)](https://archive.org/embed/openlibrary-developer-docs/zoom_0.mp4)
+[![archive org_details_openlibrary-developer-docs_zoom_0 mp4_autoplay=1 start=2](https://user-images.githubusercontent.com/978325/91351305-ef10ee00-e79c-11ea-9bfb-c2733696ec58.png)](https://archive.org/details/openlibrary-developer-docs/zoom_0.mp4)
 
 
 Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/Getting-Started). [Here's a handy cheat sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) if you are new to using Git.


### PR DESCRIPTION
bad URL in [CONTRIBUTING.md](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) previously loaded a blank screen.  changed the URL. problem resolved.

