### PR TITLE
coverstore-server: detect out of date versions of six

### DIFF
--- a/scripts/coverstore-server
+++ b/scripts/coverstore-server
@@ -47,6 +47,11 @@ def start_gunicorn_server():
             pass
             
         def load(self):
+            import six  # See #3902 if the version of six is < 1.12.0
+            if tuple(int(x) for x in six.__version__.split(".")) < (1, 12):
+                raise ImportError(
+                    "Six module {} is too old".format(six.__version__)
+                )
             from openlibrary.coverstore import server, code
             server.load_config(configfile)
             return code.app.wsgifunc(https_middleware)

--- a/scripts/coverstore-server
+++ b/scripts/coverstore-server
@@ -48,7 +48,7 @@ def start_gunicorn_server():
             
         def load(self):
             import six  # See #3902 if the version of six is < 1.15.0
-            if tuple(int(x) for x in six.__version__.split(".")) < (1, 12):
+            if tuple(int(x) for x in six.__version__.split(".")) < (1, 15):
                 raise ImportError(
                     "Six module {} is too old".format(six.__version__)
                 )

--- a/scripts/coverstore-server
+++ b/scripts/coverstore-server
@@ -47,7 +47,7 @@ def start_gunicorn_server():
             pass
             
         def load(self):
-            import six  # See #3902 if the version of six is < 1.12.0
+            import six  # See #3902 if the version of six is < 1.15.0
             if tuple(int(x) for x in six.__version__.split(".")) < (1, 12):
                 raise ImportError(
                     "Six module {} is too old".format(six.__version__)


### PR DESCRIPTION
Closes #3902.  Fast-fail when coverstore-server is booting up by raising an ImportError if the version of [six](https://github.com/benjaminp/six/blob/master/CHANGES) is < 1.12.0.

Should we upgrade this to the current 1.15.0?

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
