### PR TITLE
don't cache relatedworkcarousel partial; filling memcache

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -840,7 +840,10 @@ class Partials(delegate.page):
         partial = {}
         if component == "RelatedWorkCarousel":
             partial = _get_relatedcarousels_component(i.workid)
-        return delegate.RawText(simplejson.dumps(partial), content_type="application/json")
+        return delegate.RawText(
+            simplejson.dumps(partial),
+            content_type="application/json"
+        )
 
 
 def is_bot():

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -837,10 +837,10 @@ class Partials(delegate.page):
     def GET(self):
         i = web.input(workid=None, _component=None)
         component = i.pop("_component")
-        cached_component = {}
+        partial = {}
         if component == "RelatedWorkCarousel":
-            cached_component = get_cached_relatedcarousels_component(**i)
-        return delegate.RawText(simplejson.dumps(cached_component), content_type="application/json")
+            partial = _get_relatedcarousels_component(i.workid)
+        return delegate.RawText(simplejson.dumps(partial), content_type="application/json")
 
 
 def is_bot():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses half of #3818 -- removes caching. 3818 still requires fixing the javascript side of things.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Hit the partial endpoint
https://dev.openlibrary.org/partials?workid=OL16029764W&_component=RelatedWorkCarousel

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![dev openlibrary org_partials_workid=OL16029764W _component=RelatedWorkCarousel](https://user-images.githubusercontent.com/978325/96518431-c1d24080-121f-11eb-92fc-333abe6c52fa.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @tabshaikh 
