### PR TITLE
Create docker-compose.production.yml

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,16 @@
+##
+## Production server config (wip)
+## You probably want to run:
+## docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml -f docker-compose.production.yml up -d
+##
+
+version: "3"
+services:
+  web:
+    environment:
+      - GUNICORN_OPTS= --workers 50 --timeout 300  # 5 minutes before reload
+      - OL_CONFIG=/olsystem/etc/openlibrary.yml
+      - PYENV_VERSION=3.8.6
+      - USE_NGINX=true
+    volumes:
+      - ../olsystem:/olsystem


### PR DESCRIPTION
<!-- What issue does this PR close? -->
A subset of #3938 to make it easier to review.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates docker-compose.production.yml to enable the creation of production instances of ol-web on Python 3.8 inside Docker.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
