### PR TITLE
Remove Docker Toolbox instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,9 +64,9 @@ For example, to access Solr admin, go to http://localhost:8983/solr/admin/
 While running the `oldev` container, gunicorn is configured to auto-reload modified files. To see the effects of your changes in the running container, the following apply:
 
 - **Editing python files or web templates?** Simply save the file; gunicorn will auto-reload it.
-- **Editing frontend css or js?** Run `docker-compose exec web npm run-script build-assets`. This will re-generate the assets in the persistent `ol-build` volume mount (so the latest changes will be available between stopping / starting  `web` containers). Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
-- **Editing pip packages?** Rebuild the `web` service: `docker-compose build web`
-- **Editing npm packages?** Run `docker-compose exec web npm install` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)
+- **Editing frontend css or js?** Run `docker-compose exec home npm run-script build-assets`. This will re-generate the assets in the persistent `ol-build` volume mount (so the latest changes will be available between stopping / starting  `web` containers). Note, if you want to view the generated output you will need to attach to the container (`docker-compose exec web bash`) to examine the files in the volume, not in your local dir.
+- **Editing pip packages?** Rebuild the `home` service: `docker-compose build home`
+- **Editing npm packages?** Run `docker-compose exec home npm install` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)
 - **Editing core dependencies?** You will most likely need to do a full rebuild. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;)
 
 ## Useful Runtime Commands
@@ -79,16 +79,16 @@ docker-compose logs web # Show all logs (onetime)
 docker-compose logs -f --tail=10 web # Show last 10 lines and follow
 
 # Analyze a container
-docker-compose exec web bash # Launch terminal in `web` service
+docker-compose exec home bash # Launch terminal in `home` service
 
 # Run tests while container is running
-docker-compose exec web make test
+docker-compose exec home make test
 
 # Install Node.js modules (if you get an error running tests)
 # Important: npm jobs need to be run inside the Docker environment.
-docker-compose exec web npm install
+docker-compose exec home npm install
 # build JS/CSS assets:
-docker-compose exec web npm run build-assets
+docker-compose exec home npm run build-assets
 ```
 
 ## Rebuilding the Docker Image
@@ -110,7 +110,7 @@ Pull the changes into your openlibrary repository: ```git pull```
 When pulling down new changes you will need to rebuild the JS/CSS assets:
 ```bash
 # build JS/CSS assets:
-docker-compose exec web npm run build-assets
+docker-compose exec home npm run build-assets
 ```
 Note: This is only if you already have an existing docker image, this command is unnecessary the first time you build.
 
@@ -118,7 +118,7 @@ Note: This is only if you already have an existing docker image, this command is
 
 ```bash
 # Launch a temporary container and run tests
-docker-compose run --rm web make test
+docker-compose run --no-deps --rm home make test
 
 # Launch a temporary container on Python 3 using the local Infogami and then open in local webbrowser
 # PYENV_VERSION can be set to: 2.7.6, 3.8.6, or 3.9.0

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,20 +21,14 @@ git reset --hard HEAD
 
 Before attempting to build openlibrary using the docker instructions below, please follow this checklist. If you encounter an error, this section may serve as a troubleshooting guide:
 
-- These instructions require `docker-ce 18.*` or `docker-ce 19.*` ([Debian](https://docs.docker.com/install/linux/docker-ce/debian/#install-docker-engine---community-1), [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-engine---community-1))
-- You will need to first install `docker-compose`
+- Install `docker-ce`: https://docs.docker.com/get-docker/ (tested with version 19.*)
+- Install `docker-compose`: https://docs.docker.com/compose/install/
 - Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. You can modify an existing openlibrary repository using `git remote rm origin` and then `git remote add origin git@github.com:internetarchive/openlibrary.git`
 
 ### For All Users
 All commands are from the project root directory:
 
 ```bash
-# Docker Toolbox Users ONLY:
-docker-machine start default # Start the docker daemon
-
-# You might want to stop the machine once you are done coding; it takes up
-# a lot of RAM. Run: docker-machine stop default
-
 # build images
 docker-compose build # 15+ min (Win10Home/Dec 2018)
 
@@ -64,8 +58,6 @@ This exposes the following ports:
 | 8983 | Solr                   |
 
 For example, to access Solr admin, go to http://localhost:8983/solr/admin/
-
-If you are using Docker for Mac or Docker for Windows (or the older Docker Toolbox), use the Docker Machine IP instead of `localhost`. For example, `http://192.168.99.100:8080`. To find the IP address, use the command `docker-machine ip`. On Mac you can use the shell command `open http://$(docker-machine ip):8080`.
 
 ## Code Updates
 


### PR DESCRIPTION
Windows users will now be significantly less likely to need Docker Toolbox; this was required since Windows Home didn't support Hyper-V (required for Docker Desktop). But Docker Desktop now can use WSL2 instead of Hyper-V to run.

These instructions were also confusing folks, and causing them to accidentally run docker using a VM

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jamesachamp 
