### PR TITLE
Fix: docker testing cmd in README not working

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,5 +12,5 @@ repos:
         name: make lint-diff
         # Running git inside docker is slow for some reason, so do that outside and pipe
         # the results into docker.
-        entry: git diff master -U0 | docker-compose run --rm web ./scripts/flake8-diff.sh
+        entry: git diff master -U0 | docker-compose run --no-dep --rm home ./scripts/flake8-diff.sh
         language: script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,5 +12,5 @@ repos:
         name: make lint-diff
         # Running git inside docker is slow for some reason, so do that outside and pipe
         # the results into docker.
-        entry: git diff master -U0 | docker-compose run --no-dep --rm home ./scripts/flake8-diff.sh
+        entry: git diff master -U0 | docker-compose run --rm home ./scripts/flake8-diff.sh
         language: script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,6 @@ services:
       context: .
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-home-start.sh
-    depends_on:
-      - db
     volumes:
       - ol-vendor:/openlibrary/vendor
       - ol-build:/openlibrary/static/build

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -3,7 +3,7 @@ FROM openlibrary/olbase:latest
 WORKDIR /openlibrary
 
 USER root
-# oldev currently runs coverstore in the same container:
+# oldev runs coverstore using the same image
 RUN mkdir -p /var/lib/coverstore \
     && chown openlibrary:openlibrary /var/lib/coverstore
 
@@ -17,3 +17,5 @@ RUN npm ci
 
 # Expose Open Library, Infobase, Coverstore, and debugger
 EXPOSE 80 7000 8081 3000
+
+ENTRYPOINT ["./docker/docker-entrypoint.sh"] 

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -3,7 +3,7 @@ FROM openlibrary/olbase:latest
 WORKDIR /openlibrary
 
 USER root
-# oldev runs coverstore using the same image
+# oldev runs coverstore using the same Docker image
 RUN mkdir -p /var/lib/coverstore \
     && chown openlibrary:openlibrary /var/lib/coverstore
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -118,7 +118,7 @@ Note: This is only if you already have an existing docker image, this command is
 
 ```bash
 # Launch a temporary container and run tests
-docker-compose run --no-deps --rm home make test
+docker-compose run --rm home make test
 
 # Launch a temporary container on Python 3 using the local Infogami and then open in local webbrowser
 # PYENV_VERSION can be set to: 2.7.6, 3.8.6, or 3.9.0

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Init PYENV vars
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+exec "$@"

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -23,6 +23,7 @@ else
   fi
 fi
 
+echo "Waiting for postgres..."
 until pg_isready --host db; do sleep 5; done
 make reindex-solr
 


### PR DESCRIPTION
Fix `docker-compose run --rm home make test` not working. Also remove `db` as a hard dependency of `home` service.

### Technical
Previously, a sh subshell was opened when running something like `docker-compose run --rm home ./foo.sh`. This subshell would not have acces to the environment variables that make pyenv work, since it does not run .bashrc . We now specify a custom ENTRYPOINT that inits the right pyenv setup.

### Testing
- [x] `docker-compose build; docker-compose up -d` works (site is running)
    - [x] `docker-compose logs home | head -n 30` shows home is running and connected to db
- [x] `docker-compose run --rm home make test` works (tests run)
    - Note: very slow, but as slow as `bash`-ing and and running `make test`
- [x] `PYENV_VERSION=3.8.6 docker-compose -f docker-compose.yml -f docker-compose.infogami-local.yml run --rm home make test-py` works (tests run in py3)
- [x] `docker-compose run --rm home pwd` works and shows `/openlibrary`
- [x] `git update-index --add --chmod=+x docker-entrypoint.sh` new .sh file has right permissions

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 
