### PR TITLE
Deal with empty url in api.py browse

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -69,9 +69,10 @@ class browse(delegate.page):
         url = lending.compose_ia_url(
             query=i.q, limit=limit, page=page, subject=i.subject,
             work_id=i.work_id, _type=i._type, sorts=sorts)
+        works = lending.get_available(url=url) if url else []
         result = {
             'query': url,
-            'works': [work.dict() for work in lending.get_available(url=url)],
+            'works': [work.dict() for work in works],
         }
         return delegate.RawText(
             simplejson.dumps(result),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3948, #3950, #3955 

If `compose_ia_url()` returns an empty string for a URL then do not call `core.lending.get_available()` and set `works` to an empty list.

These three Sentry issues are all interrelated and happen a lot!
https://sentry.archive.org/sentry/ol-web/issues/5654 218k times in Sentry
https://sentry.archive.org/sentry/ol-web/issues/3807 522k times in Sentry
https://sentry.archive.org/sentry/ol-web/issues/3808 334k times in Sentry

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
