### PR TITLE
Travis CI now supports 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ jobs:
         - safety check || true
     - name: Python 3.8 on focal
       python: "3.8"
-    - name: Python 3.9-dev on focal
-      python: "3.9-dev"
+    - name: Python 3.9 on focal
+      python: "3.9"
 
     - name: Node
       language: node_js
@@ -49,7 +49,7 @@ install:
     fi
 
 script:
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.9" ]; then
       make lint-diff;
     fi
   - make lint


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Just use the non-Dev version of Python 3.9 now that Travis CI finally supports it.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
