### PR TITLE
Create query for random authors

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -888,9 +888,11 @@ def random_author_search(limit=10):
     search_results = run_solr_search(solr_select)
 
     docs = search_results.get('response', {}).get('docs', [])
-  
+
     assert docs, "random_author_search({}) returned no docs".format(limit)
-    assert len(docs) == limit, "random_author_search({}) returned {} docs".format(limit, len(docs))
+    assert len(docs) == limit, (
+        "random_author_search({}) returned {} docs".format(limit, len(docs))
+    )
 
     for doc in docs:
         # replace /authors/OL1A with OL1A

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1,5 +1,7 @@
 import web
+import random
 import re
+import string
 from lxml.etree import XML, XMLSyntaxError
 from infogami.utils import delegate, stats
 from infogami import config
@@ -869,6 +871,28 @@ class author_search_json(author_search):
         response = self.get_results(i.q, offset=offset, limit=limit)['response']
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response))
+
+
+@public
+def random_author_search(limit=10):
+    """
+    Returns a JSON string that contains a random list of authors.  Amount of authors 
+    returned is set be the given limit.
+    """
+    seed = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(10))
+    rows = '&rows=%d' %(limit)
+    sort = '&sort=random_%s+desc' % (seed)
+    solr_select = solr_select_url + "?fq=type:author&q.op=AND&q=*&wt=json" + rows + sort
+
+    d = run_solr_search(solr_select)
+    
+    docs = d.get('response', {}).get('docs', [])
+    for doc in docs:
+        # replace /authors/OL1A with OL1A
+        # The template still expects the key to be in the old format
+        doc['key'] = doc['key'].split("/")[-1]
+
+    return json.dumps(d['response'])
 
 
 @public

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -888,6 +888,10 @@ def random_author_search(limit=10):
     search_results = run_solr_search(solr_select)
 
     docs = search_results.get('response', {}).get('docs', [])
+  
+    assert docs, "random_author_search({}) returned no docs".format(limit)
+    assert len(docs) == limit, "random_author_search({}) returned {} docs".format(limit, len(docs))
+
     for doc in docs:
         # replace /authors/OL1A with OL1A
         # The template still expects the key to be in the old format

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -879,21 +879,21 @@ def random_author_search(limit=10):
     Returns a JSON string that contains a random list of authors.  Amount of authors
     returned is set be the given limit.
     """
-    s = string.ascii_letters + string.digits
-    seed = ''.join(random.choice(s) for _ in range(10))
+    letters_and_digits = string.ascii_letters + string.digits
+    seed = ''.join(random.choice(letters_and_digits) for _ in range(10))
     rows = '&rows=%d' % (limit)
     sort = '&sort=random_%s+desc' % (seed)
     solr_select = solr_select_url + "?fq=type:author&q.op=AND&q=*&wt=json" + rows + sort
 
-    d = run_solr_search(solr_select)
+    search_results = run_solr_search(solr_select)
 
-    docs = d.get('response', {}).get('docs', [])
+    docs = search_results.get('response', {}).get('docs', [])
     for doc in docs:
         # replace /authors/OL1A with OL1A
         # The template still expects the key to be in the old format
         doc['key'] = doc['key'].split("/")[-1]
 
-    return json.dumps(d['response'])
+    return json.dumps(search_results['response'])
 
 
 @public

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -876,16 +876,17 @@ class author_search_json(author_search):
 @public
 def random_author_search(limit=10):
     """
-    Returns a JSON string that contains a random list of authors.  Amount of authors 
+    Returns a JSON string that contains a random list of authors.  Amount of authors
     returned is set be the given limit.
     """
-    seed = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(10))
-    rows = '&rows=%d' %(limit)
+    s = string.ascii_letters + string.digits
+    seed = ''.join(random.choice(s) for _ in range(10))
+    rows = '&rows=%d' % (limit)
     sort = '&sort=random_%s+desc' % (seed)
     solr_select = solr_select_url + "?fq=type:author&q.op=AND&q=*&wt=json" + rows + sort
 
     d = run_solr_search(solr_select)
-    
+
     docs = d.get('response', {}).get('docs', [])
     for doc in docs:
         # replace /authors/OL1A with OL1A


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In support of #3296 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR creates a function that will return a number of random authors in JSON format.

### Technical
<!-- What should be noted about the implementation? -->
This implementation queries Solr for any author, and uses the [random sort field](https://lucene.apache.org/solr/4_9_0/solr-core/org/apache/solr/schema/RandomSortField.html) to get random results.  A new seed is generated each time the function is called (the same seed will yield the same results each time).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @ArunTeltia 