### PR TITLE
List outdated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
   - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
       pushd vendor/infogami && git pull origin master && popd;
     fi
+  - pip list --outdated
 
 script:
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.9" ]; then

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -84,6 +84,7 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 RUN ln -s vendor/infogami/infogami infogami
 # run make to initialize git submodules, build css and js files
 RUN make
+RUN python3.9 -m pip list --outdated
 
 # Expose Open Library and Infobase
 EXPOSE 80 7000


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Runs `pip list --outdated` in the Docker build process for olbase and in Travis CI so we can see which dependencies are not up-to-date.  This is a substitute for the automated approach suggested in #3580 and #3364.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
