### PR TITLE
Add tests for core.lending.compose_ia_url

### DIFF
--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -1,3 +1,5 @@
+import pytest
+
 from openlibrary.core import lending
 
 
@@ -26,3 +28,97 @@ class TestAddAvailability:
         r = f([{'ocaid': 'foo'}])
         print(r)
         assert r[0]['availability']['status'] == 'error'
+
+
+def test_get_work_authors_and_related_subjects():
+    """
+    def get_work_authors_and_related_subjects(work_id):
+    """
+    """
+    import web
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    actual = lending.get_work_authors_and_related_subjects(work_id="")
+    # Exception: db_parameters are not specified in the configuration
+    assert actual == "expected", actual
+    actual = lending.get_work_authors_and_related_subjects(work_id="OL3498798W")
+    assert actual == "expected", actual
+    """
+
+
+def test_cached_work_authors_and_subjects():
+    """
+    def cached_work_authors_and_subjects(work_id):
+    """
+    """
+    import web
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    actual = lending.cached_work_authors_and_subjects(work_id="")
+    # Exception: db_parameters are not specified in the configuration
+    expected = {'authors': [], 'subject': []}
+    assert actual == expected, actual
+    actual = lending.cached_work_authors_and_subjects(work_id="OL3498798W")
+    expected = {'authors': [], 'subject': []}
+    assert actual == expected, actual
+    """
+
+
+compose_ia_url_params_expected = {
+    None: (
+        "http://archive.org/advancedsearch.php?q=openlibrary_work%3A%28%2A%29+AND+"
+        "collection%3A%28inlibrary%29+AND+loans__status__status%3AAVAILABLE&fl%5B%5D="
+        "identifier&fl%5B%5D=openlibrary_edition&fl%5B%5D=openlibrary_work&fl%5B%5D="
+        "loans__status__status&rows=42&page=1&output=json&sort%5B%5D="
+    ),
+    (("subject", "testing"), ): (
+        "http://archive.org/advancedsearch.php?q=openlibrary_work%3A%28%2A%29+AND+"
+        "%28collection%3A%28inlibrary%29+OR+%28%21collection%3A%28printdisabled%29%29"
+        "%29+AND+loans__status__status%3AAVAILABLE+AND+openlibrary_subject%3Atesting"
+        "&fl%5B%5D=identifier&fl%5B%5D=openlibrary_edition&fl%5B%5D=openlibrary_work"
+        "&fl%5B%5D=loans__status__status&rows=42&page=1&output=json&sort%5B%5D="
+    ),
+    (("work_id", ""), ): (
+        "http://archive.org/advancedsearch.php?q=openlibrary_work%3A%28%2A%29+AND+"
+        "collection%3A%28inlibrary%29+AND+loans__status__status%3AAVAILABLE&fl%5B%5D="
+        "identifier&fl%5B%5D=openlibrary_edition&fl%5B%5D=openlibrary_work&fl%5B%5D="
+        "loans__status__status&rows=42&page=1&output=json&sort%5B%5D="
+    ),
+    (("work_id", "OL3498798W"), ("_type", "other")): (
+        "http://archive.org/advancedsearch.php?q=openlibrary_work%3A%28%2A%29+AND+"
+        "collection%3A%28inlibrary%29+AND+loans__status__status%3AAVAILABLE&fl%5B%5D="
+        "identifier&fl%5B%5D=openlibrary_edition&fl%5B%5D=openlibrary_work&fl%5B%5D="
+        "loans__status__status&rows=42&page=1&output=json&sort%5B%5D="
+    ),
+}
+
+# NOTE: lending.compose_ia_url(work_id="OL3498798W") defaults _type=None which raises
+#       AttributeError: 'NoneType' object has no attribute 'lower
+
+
+@pytest.mark.parametrize("params,expected", compose_ia_url_params_expected.items())
+def test_compose_ia_url(params, expected):
+    """
+    def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
+                   _type=None, sorts=None, advanced=True):
+    """
+    params = params or []  # Deal with None, etc.
+    actual = lending.compose_ia_url(**dict(params))
+    assert actual == expected, actual
+
+
+def test_BROKEN_compose_ia_url():
+    """
+    def compose_ia_url(limit=None, page=1, subject=None, query=None, work_id=None,
+                   _type=None, sorts=None, advanced=True):
+    """
+    """
+    import web
+    web.config.db_parameters = {"dbn": "sqlite", "db": ":memory:"}
+    actual = lending.compose_ia_url(work_id="OL3498798W", _type="authors")
+    # Exception: db_parameters are not specified in the configuration
+    expected = ""
+    assert actual == expected, actual
+
+    actual = lending.compose_ia_url(work_id="OL3498798W", _type="subjects")
+    expected = ""
+    assert actual == expected, actual
+    """


### PR DESCRIPTION
<!-- What issue does this PR close? -->
[core.lending.compose_ia_url()](https://github.com/internetarchive/openlibrary/search?q=compose_ia_url) has caused several issues where it returns an empty string instead of a URL so let's add some tests...

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
