### PR TITLE
Minimal fix for Python 3: Add Cover Image hangs

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -71,7 +71,7 @@ class add_cover(delegate.page):
         try:
             payload = requests.compat.urlencode(params).encode('utf-8')
             return web.storage(requests.post(upload_url, data=payload).json())
-        except urllib.error.HTTPError as e:
+        except requests.HTTPError as e:
             return web.storage({'error': e.read()})
 
     def save(self, book, coverid, url=None):

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -1,15 +1,13 @@
 """Handle book cover/author photo upload.
 """
+import requests
 import web
-import simplejson
 
 from infogami.utils import delegate
 from infogami.utils.view import safeint
 from openlibrary import accounts
 from openlibrary.plugins.upstream.models import Image
 from openlibrary.plugins.upstream.utils import get_coverstore_url, render_template
-
-from six.moves import urllib
 
 
 def setup():
@@ -71,12 +69,10 @@ class add_cover(delegate.page):
             upload_url = "http:" + upload_url
 
         try:
-            response = urllib.request.urlopen(upload_url, urllib.parse.urlencode(params))
-            out = response.read()
+            payload = requests.compat.urlencode(params).encode('utf-8')
+            return web.storage(requests.post(upload_url, data=payload).json())
         except urllib.error.HTTPError as e:
-            out = {'error': e.read()}
-
-        return web.storage(simplejson.loads(out))
+            return web.storage({'error': e.read()})
 
     def save(self, book, coverid, url=None):
         book.covers = [coverid] + [cover.id for cover in book.get_covers()]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3687

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Take the `str` output of `urllib.parse.urlencode()` and encode it as `bytes` before using it as the data payload in a `urllib.request.urlopen()` call.

There are two branches of functionality in this dialog:
1. Browse for a local image and
    * `i.file.value` is  `bytes` that can not be decoded utf-8
    * Still raises `{"error": "internal server error"}`
2. Enter the URL of a remote image
    * The code in this PR solves the exception but the image does not come through.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
