### PR TITLE
Display work authors with no name as "Unknown author" in works search…

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -37,6 +37,9 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
           <em>$_('Unknown author')</em>
         $else:
           $for a in doc.authors:
+            $if not (hasattr(a, 'name') and a.name) and not (hasattr(a, 'author') and hasattr(a.author, 'name') and a.author.name):
+              <em>$_('Unknown author')</em>$(',' if not loop.last else '')
+              $continue
             <a itemprop="author" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
       </span>
       <span class="resultPublisher">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #1845 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
This implementation doesn't try to link to corrupted author entities that have no name attribute.

### Testing / screenshots
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
* Created a local work with no author and verified that searching for that work breaks /search. I verified that this PR fixes /search for that work.

Before:
![1845-pre1](https://user-images.githubusercontent.com/72705998/97787262-469d5280-1b6e-11eb-9a80-fb89b00ee65b.png)

After:
![1845-post1](https://user-images.githubusercontent.com/72705998/97787276-4e5cf700-1b6e-11eb-8ae5-fdb7a2b2a49d.png)

and with multiple authors:
![1845-post5](https://user-images.githubusercontent.com/72705998/97788076-4fdcee00-1b73-11eb-9a07-76fa18c528d4.png)

* Also verified that the author page was broken before and that it renders properly with this PR

Before:
![1845-pre4](https://user-images.githubusercontent.com/72705998/97787670-ef4cb180-1b70-11eb-8be4-80949b21422a.png)

After:
![1845-post4](https://user-images.githubusercontent.com/72705998/97787672-f2e03880-1b70-11eb-8e98-bb952cd55fbd.png)

and with multiple authors:
![1845-post6](https://user-images.githubusercontent.com/72705998/97788116-9e8a8800-1b73-11eb-8a35-dcfdbd7444c4.png)

Finally, I imported the author and work from the Github issue and verified that this PR resolves that specific instance too:
![1845-post7](https://user-images.githubusercontent.com/72705998/97788457-502ab880-1b76-11eb-86d8-875cf4968480.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 