### PR TITLE
Render books/edit and edition/view templates when an associated autho…

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -84,7 +84,7 @@ window.q.push( function(){
         $ authors = work.authors and [a.author for a in work.authors]
         <h1 class="editFormBookTitle">$this_title</h1>
         $if authors:
-            $ all_authors = u"By {},".format(" ".join(author.name for author in authors))
+            $ all_authors = u"By {},".format(" ".join(author.name for author in authors if author.name))
             <h3 class="editFormBookAuthors">$all_authors[:-1]</h3>
         <div id="tabsAddbook">
             <ul>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -58,7 +58,7 @@ $code:
 
         title = cond(work, work.title, book.title)
         authors = cond(work, work and work.get_authors(), book.get_authors())
-        author_info = " by " + ", ".join(a.name for a in authors)
+        author_info = " by " + ", ".join(a.name if a.name else "Unknown author" for a in authors)
 
         format = ""
         if book.physical_format:
@@ -79,7 +79,7 @@ $code:
         schema_attribute = cond(include_schema, ' itemprop="author"', '')
         authors = cond(work, work and work.get_authors(), edition and edition.get_authors())
         if authors:
-            return ', '.join('<a href="%s"%s>%s</a>' % (a.url(), schema_attribute, truncate(a.name, 40)) for a in authors)
+            return ', '.join('<a href="%s"%s>%s</a>' % (a.url(), schema_attribute, truncate(a.name, 40)) if a.name else "<em>Unknown author</em>" for a in authors)
         elif edition.author_names:
             return ('<span%s>' % (schema_attribute)) + ", ".join(edition.author_names) + "</span>"
         else:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -58,7 +58,7 @@ $code:
 
         title = cond(work, work.title, book.title)
         authors = cond(work, work and work.get_authors(), book.get_authors())
-        author_info = " by " + ", ".join(a.name if a.name else "Unknown author" for a in authors)
+        author_info = " by " + ", ".join(a.name or "Unknown author" for a in authors)
 
         format = ""
         if book.physical_format:


### PR DESCRIPTION
…r entity has no name.

<!-- What issue does this PR close? -->
Closes #3695 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
This allows the book edit page to render, showing the corrupted author entity as a blank name.  The corrupt author can be removed if there are multiple authors.  It also enables the edition view page to render and uses the phrase "Unknown author" to be consistent with how [search results display the absence of an author](https://github.com/internetarchive/openlibrary/blob/5bd3ab9e3b5565190343e623c841fd40b4bbab3c/openlibrary/macros/SearchResultsWork.html#L37).  

### Testing / screenshots
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Imported the same work and author reported in the bug and verified that I could reproduce the issue:
![3695-pre1](https://user-images.githubusercontent.com/72705998/97792932-1e2f4b80-1ba2-11eb-841b-e34d637dd11d.png)

Verified the PR fixes the issue and shows "Unknown author" where the author name should be:
![3695-post1](https://user-images.githubusercontent.com/72705998/97792939-2ab3a400-1ba2-11eb-8005-b989920d7cfc.png)

Verified that the edit page was also broken for the same work, per a later comment on the issue:
![3695-pre2](https://user-images.githubusercontent.com/72705998/97792964-93028580-1ba2-11eb-8d00-0d10ab47ad4e.png)

And verified that this PR allows it to render:
![3695-post2](https://user-images.githubusercontent.com/72705998/97792970-9eee4780-1ba2-11eb-8d5d-d0fe9cdc7e24.png)

Also verified the the meta description contains "Unknown author":
![3695-post3](https://user-images.githubusercontent.com/72705998/97793025-4cf9f180-1ba3-11eb-8e2a-bda1bad90024.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 