### PR TITLE
Allow non-admins to edit the first sentence on a book page.

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -670,9 +670,8 @@ $if ctx.user and ctx.user.is_admin():
         </div>
     </fieldset>
 
-$if ctx.user and ctx.user.is_admin():
-    <fieldset class="major adminOnly">
-        <legend>$_("Admin Only")</legend>
+$if ctx.user:
+    <fieldset class="major">
         <div class="formElement">
             <div class="label">
                 <label for="edition-first_sentence">$_("First sentence")</label>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #228

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Removes the is_admin check and admin-related styling from the "first sentence" section of the book edit page.

### Testing / screenshots
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Added a test first sentence to a local book using the "Open Library" admin account.  Confirmed that the local AccountBot account was not an admin and could not see the "first sentence" edit box.
![228-pre1](https://user-images.githubusercontent.com/72705998/97794106-a74e7e80-1bb2-11eb-9377-aa5a3bf50520.png)

With this PR, AccountBot was able to see the edit box and successfully make an edit:
![228-post2](https://user-images.githubusercontent.com/72705998/97794048-d0bada80-1bb1-11eb-9461-f3a8b8ea7034.png)
![228-post1](https://user-images.githubusercontent.com/72705998/97794050-d2849e00-1bb1-11eb-932a-2a364e73bf40.png)

and it appears on the book page:
![228-post3](https://user-images.githubusercontent.com/72705998/97794123-fa283600-1bb2-11eb-92dd-de9e6877d634.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @seabelis 