### PR TITLE
Fetch related works when document is loaded

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -3,8 +3,8 @@ import '../../../../static/css/components/carousel--js.less';
 import Carousel from './carousel/Carousel';
 
 export function initCarouselsPartials() {
-    $('.loadingIndicator').removeClass('hidden');
-    jQuery(window).load(function () {
+    
+    let fetchRelatedWorks = function() {
         $.ajax({
             url: '/partials',
             type: 'GET',
@@ -29,5 +29,13 @@ export function initCarouselsPartials() {
                 }
             }
         });
-    });
+    };
+
+    $('.loadingIndicator').removeClass('hidden');
+
+    if(document.readyState === 'complete') {
+        fetchRelatedWorks();
+    } else {
+        $(window).on('load', fetchRelatedWorks);
+    }
 }

--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -3,7 +3,7 @@ import '../../../../static/css/components/carousel--js.less';
 import Carousel from './carousel/Carousel';
 
 export function initCarouselsPartials() {
-    
+
     let fetchRelatedWorks = function() {
         $.ajax({
             url: '/partials',
@@ -33,7 +33,7 @@ export function initCarouselsPartials() {
 
     $('.loadingIndicator').removeClass('hidden');
 
-    if(document.readyState === 'complete') {
+    if (document.readyState === 'complete') {
         fetchRelatedWorks();
     } else {
         $(window).on('load', fetchRelatedWorks);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3818

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR ensures that the AJAX call for the related works carousels only occurs when the document has fully loaded.  Thanks to @shaneriley for identifying the issue, here: https://github.com/internetarchive/openlibrary/issues/3818#issuecomment-712361206

### Technical
<!-- What should be noted about the implementation? -->
If `document.readyState === 'complete'` when the carousel partials are initialized, the related works AJAX call is made.  Otherwise, the AJAX call is attached as a callback to `window.onload`.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I was able to test both cases locally in Chrome.
Navigating directly to a book page typically caused the code inside of the `document.readyState === 'complete'` if block to execute. Navigating away from that page and pressing Chrome's back button typically caused the code in the `else` block to execute.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
