### PR TITLE
Provide better error messages in plugins/worksearch/code.py

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -302,7 +302,8 @@ def execute_solr_query(url):
     return solr_result
 
 def parse_json(raw_file):
-    if raw_file is None:
+    raw_file = raw_file.content
+    if not raw_file:
         logger.error("Error parsing empty search engine response")
         return None
     try:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -819,7 +819,9 @@ class subject_search(delegate.page):
             "sort": "work_count desc"
         }
 
-        solr_select = solr_select_url + "?" + requests.compat.urlencode(params, 'utf-8')
+        solr_select = (
+            solr_select_url + "?" + requests.compat.urlencode(params, 'utf-8')
+        )
         results = run_solr_search(solr_select)
         response = results['response']
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -394,7 +394,7 @@ def run_solr_query(param=None, rows=100, page=1, sort=None, spellcheck_count=Non
     solr_result = execute_solr_query(url)
     if solr_result is None:
         return (None, url, q_list)
-    reply = solr_result.read()
+    reply = solr_result.content
     return (reply, url, q_list)
 
 def do_search(param, sort, page=1, rows=100, spellcheck_count=None):
@@ -736,7 +736,7 @@ def run_solr_search(solr_select):
     solr_result = execute_solr_query(solr_select)
     if not solr_result:
         logger.error("run_solr_search({}) failed".format(solr_select))
-    json_data = solr_result.read() if solr_result is not None else None
+    json_data = solr_result.content if solr_result is not None else None
     return parse_search_response(json_data)
 
 def parse_search_response(json_data):

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -287,6 +287,8 @@ def build_q_list(param):
 
 def parse_json_from_solr_query(url):
     solr_result = execute_solr_query(url)
+    if not solr_result:
+        logger.error("parse_json_from_solr_query({}) failed.".format(url))
     return parse_json(solr_result)
 
 def execute_solr_query(url):
@@ -731,6 +733,8 @@ def escape_colon(q, vf):
 
 def run_solr_search(solr_select):
     solr_result = execute_solr_query(solr_select)
+    if not solr_result:
+        logger.error("run_solr_search({}) failed.".format(solr_select))
     json_data = solr_result.read() if solr_result is not None else None
     return parse_search_response(json_data)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
https://sentry.archive.org/sentry/ol-web/issues/3768 has happened more than 10k times in the past month but is difficult to debug because `Error parsing empty search engine response` is logged in two different places and is logged too late to have the context of what solr_select or URL failed.  This  PR logs closer to the problem so we will have the context to debug worksearch issues.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![Screenshot 2020-11-03 at 15 20 27](https://user-images.githubusercontent.com/3709715/97996915-a4d56a00-1de8-11eb-9d4b-97a53b8a853f.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
