### PR TITLE
Add release to Sentry init

### DIFF
--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -1,4 +1,5 @@
 import logging
+from subprocess import PIPE, Popen, STDOUT
 
 import sentry_sdk
 
@@ -12,6 +13,11 @@ def is_enabled():
     return hasattr(infogami.config, 'sentry') and infogami.config.sentry.enabled
 
 
+def get_software_version():  # -> str:
+    cmd = "git rev-parse --short HEAD --".split()
+    return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())
+
+
 def setup():
     logger.info("Setting up sentry (enabled={})".format(is_enabled()))
 
@@ -19,5 +25,6 @@ def setup():
         return
 
     sentry_sdk.init(dsn=infogami.config.sentry.dsn,
-                    environment=infogami.config.sentry.environment)
+                    environment=infogami.config.sentry.environment,
+                    release=get_software_version())
     delegate.add_exception_hook(lambda: sentry_sdk.capture_exception())

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -1,21 +1,17 @@
 import logging
-from subprocess import PIPE, Popen, STDOUT
 
 import sentry_sdk
 
 import infogami
 from infogami.utils import delegate
 
+from openlibrary.plugins.openlibrary.status import get_software_version
+
 logger = logging.getLogger("openlibrary.sentry")
 
 
 def is_enabled():
     return hasattr(infogami.config, 'sentry') and infogami.config.sentry.enabled
-
-
-def get_software_version():  # -> str:
-    cmd = "git rev-parse --short HEAD --".split()
-    return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -36,12 +36,9 @@ def get_features_enabled():
 def setup():
     "Basic startup status for the server"
     global status_info, feature_flags
-    version = get_software_version()
-    if bytes != str:  # Python 3
-        version = version.decode("utf-8")
     host = socket.gethostname()
     status_info = {
-        "Software version": version,
+        "Software version": get_software_version(),
         "Python version": sys.version.split()[0],
         "Host": host,
         "Start time": datetime.datetime.utcnow(),

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -2,8 +2,8 @@ import web
 
 import datetime
 import socket
-import subprocess
 import sys
+from subprocess import PIPE, Popen, STDOUT
 
 from infogami import config
 from infogami.utils import delegate
@@ -25,8 +25,10 @@ def get_git_revision_short_hash():
             if status_info and isinstance(status_info, dict) 
             else None)
 
-def get_software_version():
-    return subprocess.Popen("git rev-parse --short HEAD --".split(), stdout = subprocess.PIPE, stderr = subprocess.STDOUT).stdout.read().strip()
+
+def get_software_version():  # -> str:
+    cmd = "git rev-parse --short HEAD --".split()
+    return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())
 
 def get_features_enabled():
     return config.features


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3991  Add the git SHA to `sentry_sdk.init()` to simplify linking the software to Sentry issues.

As discussed at https://docs.sentry.io/product/releases the next step would be to open the integration between Sentry and GitHub but my current Sentry access rights do not allow me to do so...

![Screenshot 2020-11-04 at 15 53 02](https://user-images.githubusercontent.com/3709715/98128599-61e2c780-1eb8-11eb-9045-b733f6010dce.png)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`get_software_version()` was tested in the Python 2 REPL and Python 3 REPL

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
