### PR TITLE
Python 3: Fix AttributeError in Seed.type

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -317,6 +317,7 @@ class Seed:
     """
     def __init__(self, list, value):
         self._list = list
+        self._type = None
 
         self.value = value
         if isinstance(value, six.string_types):
@@ -392,6 +393,8 @@ class Seed:
         return datetime.datetime(*time.gmtime(t)[:6])
 
     def get_type(self):
+        if self._type:
+            return self._type
         type = self.document.type.key
 
         if type == "/type/edition":
@@ -404,6 +407,10 @@ class Seed:
             return "unknown"
 
     type = property(get_type)
+
+    @type.setter
+    def type(self, value):
+        self._type = value
 
     def get_title(self):
         if self.type == "work" or self.type == "edition":


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4015

Adds an `@type_setter()` method to the Seed class to be able to read and write `Seed.type` .

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
