### PR TITLE
Add Seed back to models

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -16,7 +16,8 @@ from openlibrary.core.ratings import Ratings
 from openlibrary.utils.isbn import to_isbn_13, isbn_13_to_isbn_10, canonical
 from openlibrary.core.vendors import create_edition_from_amazon_metadata
 
-from openlibrary.core.lists.model import ListMixin
+# Seed might look unused, but removing it causes an error :/
+from openlibrary.core.lists.model import ListMixin, Seed
 from . import cache, waitinglist
 
 from six.moves import urllib


### PR DESCRIPTION
Getting an error on prod: /opt/openlibrary/deploys/openlibrary/824a904/openlibrary/templates/recentchanges/lists/comment.html: error in processing template: AttributeError: 'module' object has no attribute 'Seed' (falling back to default template)

<!-- What issue does this PR close? -->
Closes #4019 . Hotfix; looks like there's some python black magic going on here :/

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] No errors on https://dev.openlibrary.org/people/ScarTissue/lists

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 
