### PR TITLE
2241/fix/edit form layout and wording

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -178,7 +178,7 @@ window.q.push(function() {
         
                 <div class="formElement">
                     <div class="label">
-                        <label for="edition-copyright_date">$_("Is there a copyright date?")</label>
+                        <label for="edition-copyright_date">$_("What is the copyright date?")</label>
                         <span class="tip">$_("The year following the copyright statement.")</span>
                     </div>
                     <div class="input">
@@ -188,7 +188,7 @@ window.q.push(function() {
 
                 <div class="formElement">
                     <div class="label">
-                        <label for="edition-edition_name">$_("Does this edition have a specific name?")</label>
+                        <label for="edition-edition_name">$_("Edition Name (if applicable):")</label>
                         <span class="tip">$_("For example:") <i>Centennial edition</i>; <i>First edition</i></span>
                     </div>
                     <div class="input">
@@ -198,7 +198,7 @@ window.q.push(function() {
         
                 <div class="formElement">
                     <div class="label">
-                        <label for="edition-series">$_("Is the book part of a series?")</label>
+                        <label for="edition-series">$_("Series Name (if applicable)")</label>
                         <span class="tip">$_("The name of the publisher's series.") $_("For example:") <i>The Story of Civilization, Part III</i></span>
                     </div>
                     <div class="input">
@@ -291,7 +291,7 @@ window.q.push(function() {
 
             <div class="formElement">
                 <div class="label">
-                    <label for="edition-by_statement">$_("Is there a By Statement?")</label>
+                    <label for="edition-by_statement">$_("By Statement:")</label>
                     <span class="tip">$_("For example:") <em>edited by David Anderson</em></span>
                 </div>
                 <div class="input">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -139,49 +139,77 @@ window.q.push(function() {
                 <input type="text" name="edition--subtitle" id="edition-subtitle" value="$book.subtitle"/>
             </div>
         </div>
+        <fieldset class="major">
+            <legend>$_("Publishing Info")</legend>
+        
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-publishers">$_("Who is the publisher?")</label>
+                        <span class="tip">$_("For example"): <em>Oxford University Press; Penguin; W.W. Norton</em></span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--publishers" id="edition-publishers" value="$'; '.join(book.publishers)"/>
+                    </div>
+                </div>
 
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-toc">Table of Contents</label>
-                <span class="tip">$:_('Use a "*" for an indent, a "|" to add a column, and line breaks for new lines. Like this:')</span><br/><br/>
-<pre class="smaller gray"> * Part 1 | THIS WORLD | 1
- ** Chapter 1 | Of the Nature of Flatland | 3
- ** Chapter 2 | Of the Climate and Houses in Flatland | 5
- * Part 2 | OTHER WORLDS | 42</pre>
-<br/>
-            </div>
-            <div class="input">
-                <textarea name="edition--table_of_contents" id="edition-toc" rows="5" cols="50">$book.get_toc_text()</textarea>
-            </div>
-        </div>
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-publish_places">$_("Where was the book published?")</label>
+                        <span class="tip">$_("City, Country please.") $_("For example:") <i>New York, USA; Sydney, Australia</i></span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--publish_places" id="edition-publish_places" value="$'; '.join(book.publish_places)"/>
+                    </div>
+                </div>
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-publish_date">$_("When was it published?")</label>
+                        <span class="tip">$_("You should be able to find this in the first few pages of the book.")</span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--publish_date" id="edition-publish_date" value="$book.publish_date"/>
+                    </div>
+                </div>
+        
+               
+        
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-copyright_date">$_("Is there a copyright date?")</label>
+                        <span class="tip">$_("The year following the copyright statement.")</span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--copyright_date" id="edition-copyright_date" value="$book.copyright_date"/>
+                    </div>
+                </div>
 
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-edition_name">$_("Does this edition have a specific name?")</label>
+                        <span class="tip">$_("For example:") <i>Centennial edition</i>; <i>First edition</i></span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--edition_name" id="edition-edition_name" value="$book.edition_name"/>
+                    </div>
+                </div>
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-series">$_("Is the book part of a series?")</label>
+                        <span class="tip">$_("The name of the publisher's series.") $_("For example:") <i>The Story of Civilization, Part III</i></span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--series--0" id="edition-series" value="$(book.series and book.series[0] or "")"/>
+                    </div>
+                </div>
+        </fieldset>
 
+        
 
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-title_other">$_("Is it known by any other titles?")</label>
-                <span class="tip">$_("Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here.")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--other_titles--0" id="edition-title_other" value="$(book.other_titles and book.other_titles[0])"/>
-                <div class="tip">$_("For example:") <i>Eaters of the Dead</i> $_("is an alternate title for") <i><a href='/books/OL24923038M'>The 13th Warrior</i></a>.</div>
-            </div>
-            $if book.other_titles and len(book.other_titles) > 1:
-                $for i, t in enumerate(book.other_titles):
-                    $if i > 0:
-                        <input type="hidden" name="edition--other_titles--$i" value="$book.other_titles[i]"/>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-edition_name">$_("Does this edition have a specific name?")</label>
-                <span class="tip">$_("For example:") <i>Centennial edition</i>; <i>First edition</i></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--edition_name" id="edition-edition_name" value="$book.edition_name"/>
-            </div>
-        </div>
+        
 
     </div>
 
@@ -194,15 +222,7 @@ window.q.push(function() {
 
     <div class="clearfix"></div>
 
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-notes">$_("Any notes about this specific edition?")</label>
-            <span class="tip">$_("Anything about the book that may be of interest.") $_("For example:") <i>A Plume Book</i>.</span>
-            </div>
-            <div class="input">
-                <textarea name="edition--notes" class="markdown" id="edition-notes" rows="3" cols="50">$book.notes</textarea>
-            </div>
-        </div>
+       
 
         <div class="clearfix"></div>
 
@@ -356,6 +376,46 @@ window.q.push(function() {
             </div>
         </div>
 
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-toc">Table of Contents</label>
+                <span class="tip">$:_('Use a "*" for an indent, a "|" to add a column, and line breaks for new lines. Like this:')</span><br/><br/>
+        <pre class="smaller gray"> * Part 1 | THIS WORLD | 1
+        ** Chapter 1 | Of the Nature of Flatland | 3
+        ** Chapter 2 | Of the Climate and Houses in Flatland | 5
+        * Part 2 | OTHER WORLDS | 42</pre>
+        <br/>
+            </div>
+            <div class="input">
+                <textarea name="edition--table_of_contents" id="edition-toc" rows="5" cols="50">$book.get_toc_text()</textarea>
+            </div>
+        </div>
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-notes">$_("Any notes about this specific edition?")</label>
+            <span class="tip">$_("Anything about the book that may be of interest.") $_("For example:") <i>A Plume Book</i>.</span>
+            </div>
+            <div class="input">
+                <textarea name="edition--notes" class="markdown" id="edition-notes" rows="3" cols="50">$book.notes</textarea>
+            </div>
+        </div>
+
+        <div class="formElement">
+            <div class="label">
+                <label for="edition-title_other">$_("Is it known by any other titles?")</label>
+                <span class="tip">$_("Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here.")</span>
+            </div>
+            <div class="input">
+                <input type="text" name="edition--other_titles--0" id="edition-title_other" value="$(book.other_titles and book.other_titles[0])"/>
+                <div class="tip">$_("For example:") <i>Eaters of the Dead</i> $_("is an alternate title for") <i><a href='/books/OL24923038M'>The 13th Warrior</i></a>.</div>
+            </div>
+            $if book.other_titles and len(book.other_titles) > 1:
+                $for i, t in enumerate(book.other_titles):
+                    $if i > 0:
+                        <input type="hidden" name="edition--other_titles--$i" value="$book.other_titles[i]"/>
+        </div>
+
         <div class="formElement formBackLeft">
             <div class="label">
                 <label for="edition--works--$0">$_("What work is this an edition of?")</label>
@@ -378,64 +438,6 @@ window.q.push(function() {
 
     </div>
 
-</fieldset>
-
-<fieldset class="major">
-    <legend>$_("Publishing Info")</legend>
-
-    <div class="formBack">
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-publishers">$_("Who is the publisher?")</label>
-                <span class="tip">$_("For example"): <em>Oxford University Press; Penguin; W.W. Norton</em></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--publishers" id="edition-publishers" value="$'; '.join(book.publishers)"/>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-publish_date">$_("When was it published?")</label>
-                <span class="tip">$_("You should be able to find this in the first few pages of the book.")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--publish_date" id="edition-publish_date" value="$book.publish_date"/>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-publish_places">$_("Where was the book published?")</label>
-                <span class="tip">$_("City, Country please.") $_("For example:") <i>New York, USA; Sydney, Australia</i></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--publish_places" id="edition-publish_places" value="$'; '.join(book.publish_places)"/>
-            </div>
-        </div>
-
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-copyright_date">$_("Is there a copyright date?")</label>
-                <span class="tip">$_("The year following the copyright statement.")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--copyright_date" id="edition-copyright_date" value="$book.copyright_date"/>
-            </div>
-        </div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-series">$_("Is the book part of a series?")</label>
-                <span class="tip">$_("The name of the publisher's series.") $_("For example:") <i>The Story of Civilization, Part III</i></span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--series--0" id="edition-series" value="$(book.series and book.series[0] or "")"/>
-            </div>
-        </div>
-    </div>
 </fieldset>
 
 <fieldset class="major" id="identifiers">
@@ -567,6 +569,7 @@ window.q.push(function() {
         </div>
     </div>
 </fieldset>
+
 
 
 <fieldset class="major" style="padding:0;">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2241

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Presents fields on edition edit form in a more logical sequence so edit flow corresponds with information as it is encountered in a typical book. Also changes wording of field labels from yes/no questions where yes/no is not the actual data being requested.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1068" alt="Screenshot 2020-11-05 at 16 38 43" src="https://user-images.githubusercontent.com/17739465/98263061-a3da3f00-1f86-11eb-862d-ce2632d4cbce.png">
<img width="992" alt="Screenshot 2020-11-05 at 16 39 00" src="https://user-images.githubusercontent.com/17739465/98263072-a76dc600-1f86-11eb-8e6f-7af90597178f.png">
<img width="1047" alt="Screenshot 2020-11-05 at 16 39 13" src="https://user-images.githubusercontent.com/17739465/98263076-a8065c80-1f86-11eb-983f-8959318f338a.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @dcapillae @leadsongdog @tfmorris @mekarpeles @tabshaikh 