### PR TITLE
Set max-requests for production gunicorn

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     hostname: "$HOSTNAME"
     environment:
-      - GUNICORN_OPTS= --workers 50 --timeout 300  # 5 minutes before reload
+      - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - PYENV_VERSION=3.8.6
     volumes:


### PR DESCRIPTION
This was causing perf issues when we switched to web1 & web2

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Deployed to web1 and web2 to curb excessive memory usage.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 
