### PR TITLE
fix py3 bytes/str issue when viewing a MARC record

### DIFF
--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -173,7 +173,7 @@ def read_directory(data):
         directory = data[:dir_end].decode('utf-8')[24:]
         if len(directory) % 12 != 0:
             raise BadDictionary
-    iter_dir = (directory[i*12:(i+1)*12] for i in range(len(directory) / 12))
+    iter_dir = (directory[i * 12:(i + 1) * 12] for i in range(len(directory) // 12))
     return dir_end, iter_dir
 
 @deprecated('Use catalog.marc.MarcBinary instead.')
@@ -185,7 +185,7 @@ def get_tag_line(data, line):
     # handle off-by-one errors in MARC records
     if data[offset] != b'\x1e':
         offset += data[offset:].find(b'\x1e')
-    last = offset+length
+    last = offset + length
     if data[last] != b'\x1e':
         length += data[last:].find('b\x1e')
     tag_line = data[offset + 1:offset + length + 1]

--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -163,7 +163,7 @@ def get_subfields(line, want, is_marc8=False):
 
 @deprecated('Use catalog.marc.MarcBinary instead.')
 def read_directory(data):
-    dir_end = data.find('\x1e')
+    dir_end = data.find(b'\x1e')
     if dir_end == -1:
         raise BadDictionary
     directory = data[24:dir_end]
@@ -178,22 +178,17 @@ def read_directory(data):
 
 @deprecated('Use catalog.marc.MarcBinary instead.')
 def get_tag_line(data, line):
+    # Still used by catalog/marc/html.py
     length = int(line[3:7])
     offset = int(line[7:12])
 
     # handle off-by-one errors in MARC records
-    try:
-        if data[offset] != '\x1e':
-            offset += data[offset:].find('\x1e')
-        last = offset+length
-        if data[last] != '\x1e':
-            length += data[last:].find('\x1e')
-    except IndexError:
-        pass
+    if data[offset] != b'\x1e':
+        offset += data[offset:].find(b'\x1e')
+    last = offset+length
+    if data[last] != b'\x1e':
+        length += data[last:].find('b\x1e')
     tag_line = data[offset + 1:offset + length + 1]
-    if not line[0:2] == '00':
-        if tag_line[1:8] == '{llig}\x1f':
-            tag_line = tag_line[0] + u'\uFE20' + tag_line[7:]
     return tag_line
 
 @deprecated

--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -187,7 +187,7 @@ def get_tag_line(data, line):
         offset += data[offset:].find(b'\x1e')
     last = offset + length
     if data[last] != b'\x1e':
-        length += data[last:].find('b\x1e')
+        length += data[last:].find(b'\x1e')
     tag_line = data[offset + 1:offset + length + 1]
     return tag_line
 

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -32,7 +32,7 @@ class html_record():
         return ''.join(encode[k](v) for k, v in split_line(line[2:-1]))
 
     def html_line(self, tag, line):
-        if tag.startswith('00'):
+        if tag.startswith(b'00'):
             s = esc_sp(line[:-1].decode('utf-8', errors='replace'))
         else:
             s = esc_sp(line[0:2].decode('utf-8', errors='replace')) + ' ' + self.html_subfields(line)

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -32,7 +32,7 @@ class html_record():
         return ''.join(encode[k](v) for k, v in split_line(line[2:-1]))
 
     def html_line(self, tag, line):
-        tag = str(tag)
+        tag = tag.decode('utf-8')
         if tag.startswith('00'):
             s = esc_sp(line[:-1].decode('utf-8', errors='replace'))
         else:

--- a/openlibrary/catalog/marc/html.py
+++ b/openlibrary/catalog/marc/html.py
@@ -32,7 +32,8 @@ class html_record():
         return ''.join(encode[k](v) for k, v in split_line(line[2:-1]))
 
     def html_line(self, tag, line):
-        if tag.startswith(b'00'):
+        tag = str(tag)
+        if tag.startswith('00'):
             s = esc_sp(line[:-1].decode('utf-8', errors='replace'))
         else:
             s = esc_sp(line[0:2].decode('utf-8', errors='replace')) + ' ' + self.html_subfields(line)

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -14,8 +14,8 @@ def test_html_subfields():
 
 def test_html_line_marc8():
     samples = [
-        ('020', b'  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),
-        ('520', b'  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
+        (b'020', b'  \x1fa0123456789\x1e', '&nbsp;&nbsp; <b>$a</b>0123456789'),
+        (b'520', b'  end of wrapped\x1e', '&nbsp;&nbsp; end of wrapped'),
     ]
     hr = html_record(b'00053This is the leader.Now we are beyond the leader.')
     for tag, input_, output in samples:
@@ -25,7 +25,7 @@ def test_html_line_marc8():
 
 def test_html_line_utf8():
     samples = [
-        ('245', (b'10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k '
+        (b'245', (b'10\x1faDbu ma la \xca\xbejug pa\xca\xbei kar t\xcc\xa3i\xcc\x84k '
                  b':\x1fbDwags-brgyud grub pa\xca\xbei s\xcc\x81in\xcc\x87 rta /\x1f'
                  b'cKarma-pa Mi-bskyod-rdo-rje.\x1e'),
                 (u'10 <b>$a</b>Dbu ma la \u02bejug pa\u02bei kar \u1e6d\u012bk :<b>'

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -19,7 +19,7 @@ def test_html_line_marc8():
     ]
     hr = html_record(b'00053This is the leader.Now we are beyond the leader.')
     for tag, input_, output in samples:
-        expect = '<large>%s</large> <code>%s</code>' % (tag, output)
+        expect = '<large>%s</large> <code>%s</code>' % (tag.decode('utf-8'), output)
         assert hr.html_line(tag, input_) == expect
 
 
@@ -35,5 +35,5 @@ def test_html_line_utf8():
     hr = html_record(b'00053Thisais the leader.Now we are beyond the leader.')
     assert hr.is_marc8 == False
     for tag, input_, output in samples:
-        expect = '<large>%s</large> <code>%s</code>' % (tag, output)
+        expect = '<large>%s</large> <code>%s</code>' % (tag.decode('utf-8'), output)
         assert hr.html_line(tag, input_) == expect


### PR DESCRIPTION
Fixes the following errors:
```
<class 'TypeError'> at /show-records/marc_loc_2016/BooksAll.2016.part41.utf8:32007375:748
argument should be integer or bytes-like object, not 'str'
```
URL: 

https://openlibrary.org/show-records/marc_loc_2016/BooksAll.2016.part41.utf8:32007375:748
https://openlibrary.org/show-records/marc_loc_2016/BooksAll.2016.part41.utf8:32007375:748?debug=true



<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
