### PR TITLE
str.decode() to bytes.decode() in plugins/openlibrary/opds.py

### DIFF
--- a/openlibrary/plugins/openlibrary/opds.py
+++ b/openlibrary/plugins/openlibrary/opds.py
@@ -252,7 +252,7 @@ def xmlsafe(s):
     XML cannot include certain characters mainly control ones with
     byte value below 32. This function strips them all.
     """
-    if isinstance(s, str):
+    if isinstance(s, bytes):
         s = s.decode('utf-8')
-    # ignore the first 32 bytes of ASCII, which are not allowd in XML
+    # ignore the first 32 bytes of ASCII, which are not allowed in XML
     return u"".join(c for c in s if ord(c) >= 0x20)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/sentry/ol-web/issues/9697 
Like #3744 
On Python 2 `bytes == str` so both have a `.decode()` method.
On Python 3 `bytes != str` and only `bytes` has a `.decode()` method.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Only `bytes` will be decoded.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
