### PR TITLE
Use integer division for pagination in macros/Pager.html

### DIFF
--- a/openlibrary/macros/Pager.html
+++ b/openlibrary/macros/Pager.html
@@ -3,7 +3,7 @@ $def with (page, num_found, results_per_page=20)
 $ pages = (num_found // results_per_page) + 1
 $if pages != 1:
     $ pages_in_set = 10
-    $ half = pages_in_set/2
+    $ half = pages_in_set // 2
     $if pages < pages_in_set:
         $ first_page_in_set = 1
         $ last_page_in_set = pages


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/sentry/ol-web/issues/9696 see the value for `half` which is a float, not int.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Use integer division to fix `TypeError: 'float' object cannot be interpreted as an integer`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
