### PR TITLE
page is None in plugins/worksearch/publishers.py

### DIFF
--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -21,7 +21,7 @@ class publishers(subjects.subjects):
         key = key.replace("_", " ")
         page = subjects.get_subject(key, details=True)
 
-        if page.work_count == 0:
+        if not page or page.work_count == 0:
             web.ctx.status = "404 Not Found"
             return render_template('publishers/notfound.tmpl', key)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/sentry/ol-web/issues/3879

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Detect if `page = subjects.get_subject()` has failed and `page is None`.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
