### PR TITLE
from openlibrary.i18n import gettext as _

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -31,6 +31,9 @@ from infogami import config
 from infogami.infobase.utils import parse_datetime
 from infogami.utils.view import safeint
 
+# TODO: i18n should be moved to core or infogami
+from openlibrary.i18n import gettext as _  # noqa: F401
+
 __all__ = [
     "sanitize",
     "json_encode",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4040

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Reverts a change made in https://github.com/internetarchive/openlibrary/pull/3906#pullrequestreview-518213407 to reenable our internationalization of strings.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
