### PR TITLE
Fast fail if there is no user in add_book.py

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -244,8 +244,10 @@ def add_cover(cover_url, ekey, account=None):
     coverstore_url = config.get('coverstore_url').rstrip('/')
     upload_url = coverstore_url + '/b/upload2'
     if upload_url.startswith('//'):
-        upload_url = '{0}:{1}'.format(web.ctx.get('protocol', 'http'), upload_url)
+        upload_url = '{}:{}'.format(web.ctx.get('protocol', 'http'), upload_url)
     user = account or accounts.get_current_user()
+    if not user:
+        raise RuntimeError("accounts.get_current_user() failed")
     params = {
         'author': user.get('key') or user.get('_key'),
         'data': None,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/sentry/ol-web/issues/3815

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In `add_user`:
```
    if not user:
        raise RuntimeError("accounts.get_current_user() failed")
```
because unauthenticated users should not be allowed to add books.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
