### PR TITLE
Add Sentry to Coverstore

### DIFF
--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -7,3 +7,9 @@ db_parameters:
 
 data_root: "/var/lib/coverstore"
 default_image: "static/images/empty.gif"
+
+sentry:
+    enabled: false
+    # Dummy endpoint; where sentry logs are sent to
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    environment: 'local'

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -185,4 +185,4 @@ sentry:
     enabled: false
     # Dummy endpoint; where sentry logs are sent to
     dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
-    environment: 'production'
+    environment: 'local'

--- a/openlibrary/coverstore/server.py
+++ b/openlibrary/coverstore/server.py
@@ -7,6 +7,7 @@ import yaml
 import web
 
 from openlibrary.coverstore import config, code, archive
+from openlibrary.utils.sentry import Sentry
 
 
 def runfcgi(func, addr=('localhost', 8000)):
@@ -32,8 +33,19 @@ def load_config(configfile):
     if 'fastcgi' in d:
         web.config.fastcgi = d['fastcgi']
 
-def main(configfile, *args):
+
+def setup(configfile):
+    # type: (str) -> None
     load_config(configfile)
+
+    sentry = Sentry(getattr(config, 'sentry', {}))
+    if sentry.enabled:
+        sentry.init()
+        sentry.bind_to_webpy_app(code.app)
+
+
+def main(configfile, *args):
+    setup(configfile)
 
     if '--archive' in args:
         archive.archive()

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import requests
-import sentry_sdk
 import web
 import simplejson
 import json
@@ -37,7 +36,7 @@ from openlibrary.core.lending import get_work_availability, get_edition_availabi
 import openlibrary.core.stats
 from openlibrary.plugins.openlibrary.home import format_work_data
 from openlibrary.plugins.openlibrary.stats import increment_error_count  # noqa: E402
-from openlibrary.plugins.openlibrary import processors, sentry
+from openlibrary.plugins.openlibrary import processors
 
 delegate.app.add_processor(processors.ReadableUrlProcessor())
 delegate.app.add_processor(processors.ProfileProcessor())
@@ -799,8 +798,9 @@ def internalerror():
     increment_error_count('ol.internal-errors-segmented')
 
     # TODO: move this to plugins\openlibrary\sentry.py
-    if sentry.is_enabled():
-        sentry_sdk.capture_exception()
+    from openlibrary.plugins.openlibrary.sentry import sentry
+    if sentry.enabled:
+        sentry.capture_exception_webpy()
 
     if i.debug.lower() == 'true':
         raise web.debugerror()

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -1,26 +1,14 @@
-import logging
-
-import sentry_sdk
-
 import infogami
 from infogami.utils import delegate
+from openlibrary.utils.sentry import Sentry
 
-from openlibrary.plugins.openlibrary.status import get_software_version
-
-logger = logging.getLogger("openlibrary.sentry")
-
-
-def is_enabled():
-    return hasattr(infogami.config, 'sentry') and infogami.config.sentry.enabled
+sentry = None  # type: Sentry
 
 
 def setup():
-    logger.info("Setting up sentry (enabled={})".format(is_enabled()))
+    global sentry
+    sentry = Sentry(getattr(infogami.config, 'sentry', {}))
 
-    if not is_enabled():
-        return
-
-    sentry_sdk.init(dsn=infogami.config.sentry.dsn,
-                    environment=infogami.config.sentry.environment,
-                    release=get_software_version())
-    delegate.add_exception_hook(lambda: sentry_sdk.capture_exception())
+    if sentry.enabled:
+        sentry.init()
+        delegate.add_exception_hook(lambda: sentry.capture_exception_webpy())

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -1,14 +1,12 @@
-import web
-
 import datetime
 import socket
 import sys
-from subprocess import PIPE, Popen, STDOUT
 
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import render_template, public
 from openlibrary.core import stats
+from openlibrary.utils import get_software_version
 
 status_info = {}
 feature_flags = {}
@@ -25,10 +23,6 @@ def get_git_revision_short_hash():
             if status_info and isinstance(status_info, dict) 
             else None)
 
-
-def get_software_version():  # -> str:
-    cmd = "git rev-parse --short HEAD --".split()
-    return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())
 
 def get_features_enabled():
     return config.features

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -1,6 +1,7 @@
 """Generic utilities"""
 
 import re
+from subprocess import PIPE, Popen, STDOUT
 
 to_drop = set(''';/?:@&=+$,<>#%"{}|\\^[]`\n\r''')
 
@@ -85,3 +86,8 @@ def is_number(s):
         return True
     except ValueError:
         return False
+
+
+def get_software_version():  # -> str:
+    cmd = "git rev-parse --short HEAD --".split()
+    return str(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.read().decode().strip())

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -1,0 +1,76 @@
+import logging
+
+import sentry_sdk
+import web
+from sentry_sdk.utils import capture_internal_exceptions
+
+from openlibrary.utils import get_software_version
+
+
+def header_name_from_env(env_name):
+    # type: (str) -> str
+    """
+    Convert an env name as stored in web.ctx.env to a "normal"
+    header name
+
+    >>> header_name_from_env('HTTP_FOO_BAR')
+    'foo-bar'
+    >>> header_name_from_env('CONTENT_LENGTH')
+    'content-length'
+    """
+    header_name = env_name
+    if env_name.startswith('HTTP_'):
+        header_name = env_name[5:]
+    return header_name.lower().replace('_', '-')
+
+
+def add_web_ctx_to_event(event, hint):
+    # type: (dict, dict) -> dict
+    if not web.ctx:
+        return event
+
+    with capture_internal_exceptions():
+        request_info = event.setdefault("request", {})
+
+        headers = {}
+        env = {}
+        for k, v in web.ctx.env.items():
+            if k.startswith('HTTP_') or k in ('CONTENT_LENGTH', 'CONTENT_TYPE'):
+                headers[header_name_from_env(k)] = v
+            else:
+                env[k] = v
+
+        request_info["url"] = web.ctx.home + web.ctx.fullpath
+        request_info["headers"] = headers
+        request_info["env"] = env
+        request_info["method"] = web.ctx.method
+    return event
+
+
+class Sentry:
+    def __init__(self, config):
+        # type: (dict) -> None
+        self.config = config
+        self.enabled = config.get('enabled')  # type: bool
+        self.logger = logging.getLogger("sentry")
+        self.logger.info("Setting up sentry (enabled={})".format(self.enabled))
+
+    def init(self):
+        sentry_sdk.init(dsn=self.config['dsn'],
+                        environment=self.config['environment'],
+                        release=get_software_version())
+
+    def bind_to_webpy_app(self, app):
+        # type: (web.application) -> None
+        _internalerror = app.internalerror
+
+        def capture_exception():
+            self.capture_exception_webpy()
+            return _internalerror()
+
+        app.internalerror = capture_exception
+
+    def capture_exception_webpy(self):
+        with sentry_sdk.push_scope() as scope:
+            scope.add_event_processor(add_web_ctx_to_event)
+            sentry_sdk.capture_exception()

--- a/scripts/coverstore-server
+++ b/scripts/coverstore-server
@@ -48,7 +48,7 @@ def start_gunicorn_server():
             
         def load(self):
             from openlibrary.coverstore import server, code
-            server.load_config(configfile)
+            server.setup(configfile)
             return code.app.wsgifunc(https_middleware)
             
     WSGIServer("%prog coverstore.yml --gunicorn [options]").run()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4053
(Mostly) closes #3830 

Feature. Add sentry logging to covers.

### Technical

Extracted shared logic into some utils, so adding to infobase shouldn't be very difficult.

### Testing
Tested:

- ✅ Locally enabling sentry for covers on py3 + introduce a `1/0`; event logged with request info
- ✅* Locally enabling sentry for covers on py3 + introduce a handled `1/0`; event logged (but _without_ request info)
    - Request info missing; but can fix in a future PR
- ❌ Locally enabling sentry for covers on py2 + introduce a `1/0`; event logged with request info
    - It wasn't logged at all :( Not sure why
- ✅ Locally enabling sentry and try web (py2) node with error; error gets logged.
- ✅ Test on staging.openlibrary.org that errors logged

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 
