### PR TITLE
Docker: Set reasonable defaults for hostname and pyenv_version

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -12,6 +12,6 @@ services:
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      - PYENV_VERSION=${PYENV_VERSION:-"3.8.6"}
+      - PYENV_VERSION=3.8.6
     volumes:
       - ../olsystem:/olsystem

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,10 +8,10 @@ version: "3"
 services:
   web:
     restart: always
-    hostname: "$HOSTNAME"
+    hostname: ${HOSTNAME:-$HOST}
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      - PYENV_VERSION=3.8.6
+      - PYENV_VERSION=${PYENV_VERSION:-"3.8.6"}
     volumes:
       - ../olsystem:/olsystem

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -8,10 +8,10 @@ version: "3"
 services:
   web:
     restart: always
-    hostname: "$HOSTNAME"
+    hostname: ${HOSTNAME:-$HOST}
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-"3.8.6"}
-      - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - GUNICORN_OPTS= --workers 4 --timeout 180
+      - OL_CONFIG=/olsystem/etc/openlibrary.yml
+      - PYENV_VERSION=${PYENV_VERSION:-"3.8.6"}
     volumes:
       - ../olsystem:/olsystem

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -12,6 +12,6 @@ services:
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
-      - PYENV_VERSION=${PYENV_VERSION:-"3.8.6"}
+      - PYENV_VERSION=3.8.6
     volumes:
       - ../olsystem:/olsystem


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Modifies `docker-compose.production.yml` and `docker-compose.staging.yml` to ensure that:
1. `hostname` is properly set on both bash and zsh
2. $PYEVN_VERSION has a reasonable default if not set on the command line.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
