### PR TITLE
Add scripts/setup_covers1.sh

### DIFF
--- a/scripts/setup_covers1.sh
+++ b/scripts/setup_covers1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# This script is used to provision an ol-webX node _before_ docker gets on it.
+# This script is used to provision an ol-coversX node _before_ docker gets on it.
 
-SERVICE=${SERVICE:="web"}
+SERVICE=${SERVICE:="covers"}
 
 # CAUTION: To git clone olsystem, environment variables must be set...
 # Set $GITHUB_USERNAME or $USER will be used.
@@ -42,7 +42,7 @@ cd /opt/openlibrary
 sudo docker-compose build --pull $SERVICE
 
 sudo docker-compose down
-sudo docker-compose up -d --no-deps memcached
+# sudo docker-compose up -d --no-deps memcached  # TODO: Does covers use memcached?
 sudo docker-compose \
     -f docker-compose.yml \
     -f docker-compose.infogami-local.yml \

--- a/scripts/setup_covers1.sh
+++ b/scripts/setup_covers1.sh
@@ -44,7 +44,7 @@ cd /opt/openlibrary
 sudo docker-compose build --pull $SERVICE
 
 sudo docker-compose down
-sudo docker-compose up -d --no-deps memcached  # TODO: Does covers use memcached?
+sudo docker-compose up -d --no-deps memcached
 sudo docker-compose \
     -f docker-compose.yml \
     -f docker-compose.infogami-local.yml \

--- a/scripts/setup_covers1.sh
+++ b/scripts/setup_covers1.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # This script is used to provision an ol-coversX node _before_ docker gets on it.
 
-SERVICE=${SERVICE:="covers"}
+# Which Ubuntu release are we running on?  Do not fail if /etc/os-release does not exist.
+cat /etc/os-release | grep VERSION= || true  # VERSION="20.04.1 LTS (Focal Fossa)"
+SERVICE=${SERVICE:-"covers"}
 
 # CAUTION: To git clone olsystem, environment variables must be set...
 # Set $GITHUB_USERNAME or $USER will be used.
@@ -42,7 +44,7 @@ cd /opt/openlibrary
 sudo docker-compose build --pull $SERVICE
 
 sudo docker-compose down
-# sudo docker-compose up -d --no-deps memcached  # TODO: Does covers use memcached?
+sudo docker-compose up -d --no-deps memcached  # TODO: Does covers use memcached?
 sudo docker-compose \
     -f docker-compose.yml \
     -f docker-compose.infogami-local.yml \

--- a/scripts/setup_web1.sh
+++ b/scripts/setup_web1.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # This script is used to provision an ol-webX node _before_ docker gets on it.
 
-SERVICE=${SERVICE:="web"}
+# Which Ubuntu release are we running on?  Do not fail if /etc/os-release does not exist.
+cat /etc/os-release | grep VERSION= || true  # VERSION="20.04.1 LTS (Focal Fossa)"
+SERVICE=${SERVICE:-"web"}
 
 # CAUTION: To git clone olsystem, environment variables must be set...
 # Set $GITHUB_USERNAME or $USER will be used.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4053, #4054, #4055

Similar to #3938 but for `covers`, instead of for `web`

Allow us to convert `ol-covers1` with a fresh Ubuntu install into an Open Library covers node running Python 3.8 on Docker.
* [x] Does covers use memcached? A: YES.
* [x] Does covers need access to olsystem?
* [ ] If so, could/should it be a targeted subset of olsystem?
* [x] Does covers need access to infogami?
* [ ] Enable Sentry via #4055
* [x] `scripts/setup_covers1.sh` and `scripts/setup_web1.sh` are extremely similar:
    * Should we have just one script: `SERVICE=covers scripts/setup_ol_server.sh`
    * Can/should we rsync `/opt/olsystem` from `ol-home`?
    * Can/should we rsync `/opt/openlibrary` from `ol-home`?
    * Can/should we rsync `/opt/openlibrary/vendor/infogami` from `ol-home`?
* [x] Do we want to comment out `sudo docker-compose logs -f --tail=100 $SERVICE` ?

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
