### PR TITLE
closes #4068, closes #4038 supplants #4069 - fix hmac borrowing

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -879,7 +879,6 @@ def make_ia_token(item_id, expiry_seconds):
     return token
 
 def ia_token_is_current(item_id, access_token):
-    access_key = make_access_key()
 
     # Check if token has expired
     try:

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -844,6 +844,7 @@ def get_ia_auth_dict(user, item_id, user_specified_loan_key, access_token):
         'token': make_ia_token(item_id, BOOKREADER_AUTH_SECONDS)
     }
 
+
 def ia_hash(token_data):
     access_key = make_access_key()
     if six.PY3:

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -854,6 +854,7 @@ def ia_hash(token_data):
         ).hexdigest()
     return hmac.new(access_key, token_data).hexdigest()
 
+
 def make_access_key():
     try:
         access_key = config.ia_access_secret


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4068
Closes #4038
Supplants & closes #4069

https://sentry.archive.org/sentry/ol-web/issues/9699
https://sentry.archive.org/sentry/ol-web/issues/9700

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

presumably must use md5 (while less secure) to match keys + process on IA side? Tried sha1 and the flow reported malformed url response.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Incognito, logged out -- log in to non-admin account on OL, borrow a book, go to OL loans dashboard, click read of same book. Should log you in to archive.org automatically and show book (checked out)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss @cdrini 