### PR TITLE
fix loans across workers to not cache

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -483,8 +483,6 @@ def _get_ia_loan(identifier, userid):
     ia_loan = ia_lending_api.get_loan(identifier, userid)
     return ia_loan and Loan.from_ia_loan(ia_loan)
 
-
-@cache.memoize(engine="memory", key="get_loans_of_user")
 def get_loans_of_user(user_key):
     """TODO: Remove inclusion of local data; should only come from IA"""
     account = OpenLibraryAccount.get(username=user_key.split('/')[-1])


### PR DESCRIPTION
In plugins/upstream/borrow.py within borrow endpoint, the last step before we redirect to bookreader auth link (which performs IA login during redirect) is to fetch (what _was_ cached) loan data. If the book didn't exist in the loan data (which is possible, because of caching) then we'd redirect to the book on archive.org w/o performing the bridge authlink login.

NB: Another more performant solution (if this PR blows up production, which it might because book pages currently do a LoanStatus check which includes a hit to user.loans which was previously cached) then we can simply create a cached and uncached version and then have the borrow logic hit the _uncached_ version.

<!-- What issue does this PR close? -->
Related to #4068 -- testing complicated by the absence of easily reproducible lending.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
