### PR TITLE
Add 'noindex' meta tag to people pages that are less than 30 days old.

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -112,9 +112,7 @@ def safesort(iterable, key=None, reverse=False):
     return sorted(iterable, key=safekey, reverse=reverse)
 
 def days_since(then, now=None):
-    if now is None:
-        now = datetime.now()
-    delta = then - now
+    delta = then - (now or datetime.now())
     return abs(delta.days)
 
 def datestr(then, now=None, lang=None, relative=True):

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -35,7 +35,7 @@ __all__ = [
     "sanitize",
     "json_encode",
     "safesort",
-    "datestr", "format_date",
+    "days_since", "datestr", "format_date",
     "sprintf", "cond", "commify", "truncate", "datetimestr_utc",
     "urlsafe", "texsafe",
     "percentage", "affiliate_id", "bookreader_host",
@@ -110,6 +110,12 @@ def safesort(iterable, key=None, reverse=False):
         k = key(x)
         return (k.__class__.__name__, k)
     return sorted(iterable, key=safekey, reverse=reverse)
+
+def days_since(then, now=None):
+    if now is None:
+        now = datetime.now()
+    delta = then - now
+    return abs(delta.days)
 
 def datestr(then, now=None, lang=None, relative=True):
     """Internationalized version of web.datestr."""

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -111,6 +111,7 @@ def safesort(iterable, key=None, reverse=False):
         return (k.__class__.__name__, k)
     return sorted(iterable, key=safekey, reverse=reverse)
 
+
 def days_since(then, now=None):
     delta = then - (now or datetime.now())
     return abs(delta.days)

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -115,6 +115,7 @@ def days_since(then, now=None):
     delta = then - (now or datetime.now())
     return abs(delta.days)
 
+
 def datestr(then, now=None, lang=None, relative=True):
     """Internationalized version of web.datestr."""
     lang = lang or web.ctx.get('lang') or "en"

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -4,6 +4,8 @@ $var title: $page.displayname
 $ settings = page.get_users_settings()
 $ owners_page = ctx.user and ctx.user.key == page.key
 $ is_public = settings and settings.get('public_readlog', 'no') == "yes"
+$if days_since(page.created) < 30:
+  $ putctx('robots', 'noindex')
 
 $if "lists" in ctx.features:
     $ lists = page.get_lists(limit=3)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4010

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
This adds the 'noindex' meta tag to newer people pages but not list pages.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
On dev, go to /recentchanges, click on a recently created people page, look at the source HTML, and search for "robots".  You should see:
```
    <meta name="robots" content="noindex" />
```
If testing in a local dev instance, see below.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
```
$ echo -- && grep days_since openlibrary/templates/type/user/view.html && curl -s localhost:8080/people/openlibrary | egrep "robots|Joined" && echo --
--
$if days_since(page.created) < 30:
    <i>Joined March 20, 2013</i>
--


$ echo -- && sed -i 's/< 30/< 2800/' openlibrary/templates/type/user/view.html && grep days_since openlibrary/templates/type/user/view.html && curl -s localhost:8080/people/openlibrary | egrep "robots|Joined" && echo --
--
$if days_since(page.created) < 2800:
    <meta name="robots" content="noindex" />
    <i>Joined March 20, 2013</i>
--

```

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @mekarpeles 