### PR TITLE
Exceptions don't have e.message attribute in Py3

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -173,7 +173,7 @@ def sampleload(filename='sampledump.txt.gz'):
     else:
         f = open(filename)
 
-    queries = [simplejson.loads(line) for  line in f]
+    queries = [simplejson.loads(line) for line in f]
     print(web.ctx.site.save_many(queries))
 
 
@@ -378,7 +378,7 @@ class isbn_lookup(delegate.page):
                 return web.found(ed.key + ext)
         except Exception as e:
             logger.error(e)
-            return e.message
+            return repr(e)
 
         web.ctx.status = '404 Not Found'
         return render.notfound(web.ctx.path, create=False)
@@ -526,7 +526,7 @@ class _yaml(delegate.mode):
             if e.json:
                 msg = self.dump(simplejson.loads(e.json))
             else:
-                msg = e.message
+                msg = str(e)
             raise web.HTTPError(e.status, data=msg)
 
         return simplejson.loads(d)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4080 and https://sentry.archive.org/sentry/ol-web/issues/9042

Opens #4083 for the underlying TypeError.

![Screenshot 2020-11-12 at 16 18 45](https://user-images.githubusercontent.com/3709715/98958821-fbd2f180-2502-11eb-80fc-bed8f292ca52.png)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Suppresses an AttributeError so that the underlying TypeError is visible.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
