### PR TITLE
adding booklending_utils to volume mounts

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -15,4 +15,4 @@ services:
       - PYENV_VERSION=3.8.6
     volumes:
       - ../olsystem:/olsystem
-      - ../booklending_untils:/booklending_untils
+      - ../booklending_utils:/booklending_utils

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -15,3 +15,4 @@ services:
       - PYENV_VERSION=3.8.6
     volumes:
       - ../olsystem:/olsystem
+      - ../booklending_untils:/booklending_untils


### PR DESCRIPTION
Required for enabling sponsorship on docker prod web nodes
