### PR TITLE
closes #3782 fixes statsd memcache sampling rate

### DIFF
--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -44,6 +44,7 @@ def put(key, value):
         l.debug("Putting %s as %s" % (value, key))
         client.timing(key, value)
 
+
 def increment(key, n=1, rate=1.0):
     "Increments the value of ``key`` by ``n``"
     global client

--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -41,19 +41,19 @@ def put(key, value):
     "Records this ``value`` with the given ``key``. It is stored as a millisecond count"
     global client
     if client:
-        l.debug("Putting %s as %s"%(value, key))
+        l.debug("Putting %s as %s" % (value, key))
         client.timing(key, value)
 
-def increment(key, n=1):
+def increment(key, n=1, rate=1.0):
     "Increments the value of ``key`` by ``n``"
     global client
     if client:
-        l.debug("Incrementing %s"% key)
+        l.debug("Incrementing %s" % key)
         for i in range(n):
             try:
-                client.increment(key)
+                client.increment(key, sample_rate=rate)
             except AttributeError:
-                client.incr(key)
+                client.incr(key, rate=rate)
 
 
 client = create_stats_client()

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -88,9 +88,9 @@ def stats_hook():
                 memcache_misses += 1
 
     if memcache_hits:
-        graphite_stats.increment('ol.memcache.hits', memcache_hits)
+        graphite_stats.increment('ol.memcache.hits', memcache_hits, rate=0.025)
     if memcache_misses:
-        graphite_stats.increment('ol.memcache.misses', memcache_misses)
+        graphite_stats.increment('ol.memcache.misses', memcache_misses, rate=0.025)
 
     for name, value in stats_summary.items():
         name = name.replace(".", "_")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3782 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Any way to check to check this specific node is sending fewer memcached results?
Otherwise, I think we should soft-deploy / patch this on ol-web1, and ol-web2 and ping @samuel-archive 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@samuel-archive @cdrini @cclauss 