### PR TITLE
Fix meta tags on Python 3

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -432,7 +432,7 @@ class Metatag:
         self.attrs = attrs
 
     def __str__(self):
-        attrs = ' '.join('%s="%s"' % (k, websafe(v).encode('utf8')) for k, v in self.attrs.items())
+        attrs = ' '.join('%s="%s"' % (k, websafe(v)) for k, v in self.attrs.items())
         return '<%s %s />' % (self.tag, attrs)
 
     def __repr__(self):


### PR DESCRIPTION
Related to  #2181

When running with Python 3, meta tags are being corrupted (e.g. `<meta property="b'og:title'" ...>`). This is visible on openlibrary.org, e.g. view-source on https://openlibrary.org/books/OL18347472M/The_heart_of_the_matter. This patch removes the unnecessary `.encode` call to fix this.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit any page for a work, and check that the meta tags look like this:

```    <meta property="og:type" content="books.book" />```

instead of this (the current, incorrect behaviour):

```    <meta property="b'og:type'" content="b'books.book'" />```


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screen Shot 2020-11-14 at 18 42 26](https://user-images.githubusercontent.com/3709715/99153518-4ee6a900-26a9-11eb-8363-0d48adeee51d.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
