### PR TITLE
Prevent non-admins / non-librarians from being able to revert pages to previous versions

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -189,6 +189,12 @@ def setup_jquery_urls():
     web.template.Template.globals['jqueryui_url'] = jqueryui_url
     web.template.Template.globals['use_google_cdn'] = config.get('use_google_cdn', True)
 
+
+def user_is_admin_or_librarian():
+    user = web.ctx.site.get_user()
+    return user and (user.is_admin() or user.is_librarian())
+
+
 @public
 def get_document(key, limit_redirs=5):
     doc = None
@@ -214,9 +220,7 @@ class revert(delegate.mode):
         if v is None:
             raise web.seeother(web.changequery({}))
 
-        user = web.ctx.site.get_user()
-        if (not user or not web.ctx.site.can_write(key) or
-                not (user.is_admin() or user.is_librarian())):
+        if not web.ctx.site.can_write(key) or not user_is_admin_or_librarian():
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -215,8 +215,8 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         user = web.ctx.site.get_user()
-        if not user or not web.ctx.site.can_write(key) or
-           not (user.is_admin() or user.is_librarian()):
+        if (not user or not web.ctx.site.can_write(key) or
+                not (user.is_admin() or user.is_librarian())):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -215,7 +215,8 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         user = web.ctx.site.get_user()
-        if not user or not web.ctx.site.can_write(key) or not (user.is_admin() or user.is_librarian()):
+        if not user or not web.ctx.site.can_write(key) or
+           not (user.is_admin() or user.is_librarian()):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -215,7 +215,7 @@ class revert(delegate.mode):
             raise web.seeother(web.changequery({}))
 
         user = web.ctx.site.get_user()
-        if not user and (user.is_admin() or user.is_librarian() and web.ctx.site.can_write(key)):
+        if not user or not web.ctx.site.can_write(key) or not (user.is_admin() or user.is_librarian()):
             return render.permission_denied(web.ctx.fullpath, "Permission denied to edit " + key + ".")
 
         thing = web.ctx.site.get(key, i.v)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4089 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix
### Technical
<!-- What should be noted about the implementation? -->
This adjusts a permission check for page revert functionality.

Related past PRs: #2228 and #2280

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Refer to the steps to reproduce in the issue.  Injecting frontend code to revert a page as a non-admin, non-librarian should no longer succeed.  Doing so as a logged out user should now return a permission denied page instead of an error/stacktrace. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Logged in, non-admin, non-librarian now gets this:
![4089-post1](https://user-images.githubusercontent.com/72705998/99153696-fab6d700-265e-11eb-973f-4500a2bee236.png)

A logged out user now gets this:
![4089-post2](https://user-images.githubusercontent.com/72705998/99153791-a4966380-265f-11eb-8a35-88689ff1a673.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini 