### PR TITLE
Display new cover image in works page without refreshing the page

### DIFF
--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -39,6 +39,9 @@ function update_image(image) {
             \$("$cover_selector").attr('src', url)
                 .parents("div:first").show()
                 .next().hide();
+            \$("$cover_selector").attr('srcset', url)
+                .parents("div:first").show()
+                .next().hide();
         }
         else {
             // hide SRPCover and show SRPCoverBlank


### PR DESCRIPTION
Fixing the issue Regression - Cover change of work requires refresh to view #3395

<!-- What issue does this PR close? -->
Closes #3395

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This enables refreshing the cover image in the works page "https://openlibrary.org/works/..." immediately after update without the need for refreshing the page.

### Technical
<!-- What should be noted about the implementation? -->
openlibrary/templates/covers/change.html is changed. 'srcset' attribute in the img tag in bookCover class is also updated along with the 'src' attribute.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tabshaikh @seabelis 