### PR TITLE
Remove the Duplicate Delete Button on Edit Authors Page

### DIFF
--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -124,9 +124,5 @@ $putctx("robots", "noindex,nofollow")
                 $:macros.EditButtons(comment=page.comment_)
             </div>
 
-        $if ctx.user and ctx.user.is_admin():
-            <div class="adminOnly"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="deleteTop">$_("Delete Record")</button></div>
-
-
     </form>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4101 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the duplicate delete button present in the edit authors page.

### Technical
<!-- What should be noted about the implementation? -->
Removed the delete button present in the `openlibrary/templates/type/author/edit.html`.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I was not able to test this as the local setup is down, details in this issue #4090 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 