### PR TITLE
Make solr's docker up command more like web's

### DIFF
--- a/conf/solr/start.sh
+++ b/conf/solr/start.sh
@@ -1,29 +1,19 @@
 #!/bin/bash
 
-# Default to dev env
-ENV=${ENV:-dev}
-# How much memory to use
-JAVA_MEM=${JAVA_MEM:-}
+ln -sf /etc/solr/${SOLR_CONFIG} /etc/solr/conf/solrconfig.xml
 
-ln -sf /etc/solr/conf/solrconfig-$ENV.xml /etc/solr/conf/solrconfig.xml
-
-# On dev, don't use haproxy; make tomcat serve directly to 8983
-if [ "$ENV" = "dev" ] ; then
-    sed -i 's/8080/8983/g' /var/lib/tomcat7/conf/server.xml;
-fi
-
-if [ "$ENV" = "prod" ] ; then
-    # Default to 10 G of memory on prod
-    JAVA_MEM="${JAVA_MEM:-10g}"
-
-    # Load balance with haproxy
-    service haproxy start
-fi
+if [ "$HAPROXY" = "true" ] ; then
+  # Load balance with haproxy
+  service haproxy start
+else
+  # Not using haproxy; make tomcat serve directly to 8983
+  sed -i 's/8080/8983/g' /var/lib/tomcat7/conf/server.xml;
+fi;
 
 # Set Tomcat's java options
 TOMCAT_JAVA_OPTS='-Djava.awt.headless=true -XX:+UseConcMarkSweepGC'
-if [ -n "$JAVA_MEM" ] ; then
-  TOMCAT_JAVA_OPTS="${TOMCAT_JAVA_OPTS} -Xmx${JAVA_MEM} -Xms${JAVA_MEM}"
+if [ -n "$EXTRA_TOMCAT_JAVA_OPTS" ] ; then
+  TOMCAT_JAVA_OPTS="${TOMCAT_JAVA_OPTS} ${EXTRA_TOMCAT_JAVA_OPTS}"
 fi;
 echo 'export JAVA_OPTS="${JAVA_OPTS} '"${TOMCAT_JAVA_OPTS}"'"' > /usr/share/tomcat7/bin/setenv.sh
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -16,3 +16,8 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - ../booklending_utils:/booklending_utils
+  solr:
+    environment:
+      - SOLR_CONFIG=conf/solrconfig-prod.xml
+      - HAPROXY=true
+      - EXTRA_TOMCAT_JAVA_OPTS=-Xmx10g -Xms10g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       dockerfile: docker/Dockerfile.olsolr
     restart: always
     environment:
-      - ENV=${ENV:-dev}
+      - SOLR_CONFIG=conf/solrconfig-dev.xml
     ports:
       - 8983:8983
     volumes:

--- a/scripts/solr_builder/README.md
+++ b/scripts/solr_builder/README.md
@@ -106,7 +106,7 @@ time sudo docker-compose run --no-deps --rm -v $HOME:/backup solr \
     bash -c "tar xf /backup/solrbuilder-2020-03-02.tar.gz"
 
 # Start the service
-sudo ENV=prod docker-compose up -d --no-deps solr
+sudo docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d --no-deps solr
 ```
 
 ## Resetting


### PR DESCRIPTION
Closes #

Refactor

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested locally (not on prod):

#### Works with dev settings
1. `docker-compose up -d solr`
2. `localhost:8983/solr/admin`, search for `*:*`, results show up :+1:
3. `localhost:8983/admin?stat` Haproxy is not started

#### Works with prod settings
1. Modify `docker-compose.production.yml` to have a feasible amount memory for solr (I used `1g`)
2. `docker-compose -f docker-compose.yml docker-compose.production.yml up -d solr`
3. `localhost:8983/solr/admin`, search for `*:*`, results show up :+1:
4. `localhost:8983/admin?stat` Haproxy is running

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
