### PR TITLE
Compressor().decompress(ctext) must be bytes, not str

### DIFF
--- a/openlibrary/utils/compress.py
+++ b/openlibrary/utils/compress.py
@@ -47,6 +47,8 @@ class Compressor(object):
         self.d_context = d.copy()
 
     def compress(self, text):
+        if not isinstance(text, str):
+            text = text.decode()
         c = self.c_context.copy()
         t = c.compress(text.encode())
         t2 = c.flush(zlib.Z_FINISH)
@@ -54,7 +56,7 @@ class Compressor(object):
 
     def decompress(self, ctext):
         if not isinstance(ctext, bytes):
-            ctext = ctext.encode("utf-8")
+            ctext = ctext.encode()
         d = self.d_context.copy()
         t = d.decompress(ctext)
         while d.unconsumed_tail:
@@ -69,6 +71,13 @@ def test_compressor():
     c = Compressor(__doc__)
     test_string = "zlib is a pretty good compression algorithm"
     ct = c.compress(test_string)
+    # print('initial length=%d, compressed=%d' % (len(test_string), len(ct)))
+    # the above string compresses from 43 bytes to 29 bytes using the
+    # current doc text as compression seed, not bad for such short input.
+    dt = c.decompress(ct)
+    assert dt == test_string, (dt, test_string)
+    # Test that utf-8 encoded bytes return the utf-8 string
+    ct = c.compress(test_string.encode("utf-8"))
     # print('initial length=%d, compressed=%d' % (len(test_string), len(ct)))
     # the above string compresses from 43 bytes to 29 bytes using the
     # current doc text as compression seed, not bad for such short input.

--- a/openlibrary/utils/compress.py
+++ b/openlibrary/utils/compress.py
@@ -32,6 +32,7 @@ result in compressed_record being 50% or less of the size of
 some_record, and restored_record being identical to some_record.
 """
 
+
 class Compressor(object):
     def __init__(self, seed):
         c = zlib.compressobj(9)
@@ -52,20 +53,28 @@ class Compressor(object):
         return t + t2
 
     def decompress(self, ctext):
+        if not isinstance(ctext, bytes):
+            ctext = ctext.encode("utf-8")
         d = self.d_context.copy()
         t = d.decompress(ctext)
         while d.unconsumed_tail:
             t += d.decompress(d.unconsumed_tail)
         return t.decode()
 
-def test():
+
+def test_compressor():
+    """
+    >>> test_compressor()  # Self-doctest this code.
+    """
     c = Compressor(__doc__)
     test_string = "zlib is a pretty good compression algorithm"
     ct = c.compress(test_string)
-    # print 'initial length=%d, compressed=%d'% (len(test_string), len(ct))
+    # print('initial length=%d, compressed=%d' % (len(test_string), len(ct)))
     # the above string compresses from 43 bytes to 29 bytes using the
     # current doc text as compression seed, not bad for such short input.
     dt = c.decompress(ct)
     assert dt == test_string, (dt, test_string)
 
-test()
+
+if __name__ == "__main__":
+    test_compressor()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4096, #4085 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures `decompress(self, ctext: bytes):` because legacy Python does not support type hints.  If ctext is not bytes then it is encoded.

Also, changed the tests to align with pytest discovery rules and also self-doctesting. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1154" alt="Inspect_Memcache" src="https://user-images.githubusercontent.com/3709715/99384588-ee858080-28cf-11eb-8f77-1559f7cb696b.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
