### PR TITLE
Make covers service configurable like web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - INFOGAMI=${INFOGAMI:-}
+      - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
+      - GUNICORN_OPTS=${GUNICORN_OPTS:- --workers 1 --max-requests 250}
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev

--- a/docker/ol-covers-start.sh
+++ b/docker/ol-covers-start.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 python --version
-scripts/coverstore-server conf/coverstore.yml \
+scripts/coverstore-server "$COVERSTORE_CONFIG" \
     --gunicorn \
-    --workers 1 \
-    --max-requests 250 \
+    $GUNICORN_OPTS \
     --bind :8081


### PR DESCRIPTION
Refactor covers service yml so that we can configure it correctly for production.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested `docker-compose up -d` brings up covers, and it stays up.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
