### PR TITLE
Fix entityTypeSchema undefined it no entity_type

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -38,10 +38,12 @@ $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and qu
     //-->
     </script>
 
-$if page.birth_date or page.death_date:
-    $ entityTypeSchema = "https://schema.org/Person"
-$elif page.entity_type:
+$# Most authors are people, so only use org in the exceptional case that
+$# the record explicitly is labelled as such.
+$if page.entity_type == 'org':
     $ entityTypeSchema = "https://schema.org/Organization"
+$else:
+    $ entityTypeSchema = "https://schema.org/Person"
 
 $ bodyattrs = ctx.setdefault('bodyattrs', [])
 $ bodyattrs.append('itemscope')


### PR DESCRIPTION
Fix. Causing an error because it would sometimes be undefined. Most authors are people, so we can lax this to only use Organization in the very rare case that org is explicitly defined.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
http://staging.openlibrary.org/authors/OL3028905A/Jon_Richardson No longer throw the error it threw before.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@nk4456542 @hornc 
