### PR TITLE
Fix: bodyattrs should not be html escaped

### DIFF
--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -5,7 +5,7 @@ $ bodyclass = ctx.get('bodyclass', [])
 $ show_banners = bodyid != 'form'
 $ bodyattrs = ctx.get('bodyattrs', [])
 
-<body id="$bodyid" class="$(' '.join(bodyclass))" $(' '.join(bodyattrs))>
+<body id="$bodyid" class="$(' '.join(bodyclass))" $:(' '.join(bodyattrs))>
   <script>
       // Provide a signal that JS will load
       document.body.className += ' client-js';


### PR DESCRIPTION
Small fix for #3957 ; I missed this during testing!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@nk4456542 
