### PR TITLE
Add ISBN10 and ISBN13 numbers in a hidden div to enable edition filte…

### DIFF
--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -63,6 +63,11 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
           $if book.edition_name:
             - $book.edition_name
         </div>
+
+	<div class="hidden">
+		$isbn_10 $isbn_13
+	</div>
+
       </div>
     </td>
 


### PR DESCRIPTION
…ring/searching for those values.

<!-- What issue does this PR close? -->
Closes #2017 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
This adds another hidden div to the edition list with just the ISBN10 and ISBN13 numbers in it and nothing else.

### Testing / Screenshots
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verified this doesn't work without this PR:
![2017-pre1](https://user-images.githubusercontent.com/72705998/99622497-20393d00-29df-11eb-9d38-d048f57e3e59.png)

Before hiding the ISBNs, search/filter using an ISBN10 number to show that it matches one edition and to show which edition the example ISBN matches so we can more easily confirm that the same edition is matched when the ISBNs are hidden:
![2017-post1](https://user-images.githubusercontent.com/72705998/99622776-ab1a3780-29df-11eb-8cbf-cbbf40177e1f.png)

Search for the same ISBN now that the ISBNs are hidden:
![2017-post2](https://user-images.githubusercontent.com/72705998/99622843-c7b66f80-29df-11eb-8a9b-b46e19fc93cf.png)

Search for the ISBN13 from two screenshots up to confirm it matches the same edition:
![2017-post3](https://user-images.githubusercontent.com/72705998/99622871-d69d2200-29df-11eb-8529-df809fa0339b.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @mekarpeles @cdrini 