### PR TITLE
Define infobase_nginx in docker-compose.production.yml

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -36,3 +36,11 @@ services:
     volumes:
       - ../olsystem:/olsystem
       -  /1:/1
+  infobase_nginx:
+    image: nginx:1.4.6
+    restart: always
+    deploy:
+      replicas: 1
+    expose: 7000
+    volumes:
+      - ../olsystem/etc/nginx /etc/nginx


### PR DESCRIPTION
Closes #4130

`deploy` will be ignored in our current environments but will become useful in environments when `restart` is ignored.
* https://hub.docker.com/_/nginx
* https://docs.docker.com/compose/compose-file/#deploy
* https://docs.docker.com/compose/compose-file/#restart
* https://testdriven.io/blog/dockerizing-django-with-postgres-gunicorn-and-nginx/#nginx

Do we need to do something special with `/var` ?

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
