### PR TITLE
Make Metric System as Default for Physical Values of the Book.

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -613,7 +613,7 @@ window.q.push(function() {
                     <span class="tip"></span>
                 </div>
                 <div class="input">
-                    $ weight = book.get_weight() or storage(value="", units="kilos")
+                    $ weight = book.get_weight() or storage(value="", units="grams")
                     <input name="edition--weight--value" type="number" step="any"
                            id="edition--weight--value" size="6" value="$weight.value"/>
                     <span class="tip">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -613,7 +613,7 @@ window.q.push(function() {
                     <span class="tip"></span>
                 </div>
                 <div class="input">
-                    $ weight = book.get_weight() or storage(value="", units="grams")
+                    $ weight = book.get_weight() or storage(value="", units="kilos")
                     <input name="edition--weight--value" type="number" step="any"
                            id="edition--weight--value" size="6" value="$weight.value"/>
                     <span class="tip">
@@ -625,7 +625,7 @@ window.q.push(function() {
 
             <fieldset class="minor formBackRight">
                 <legend>$_("Dimensions")</legend>
-                $ dimensions = book.get_physical_dimensions() or storage(height="", width="", depth="", units="inches")
+                $ dimensions = book.get_physical_dimensions() or storage(height="", width="", depth="", units="centimeters")
                   <span class="tip">
                     $:radiobuttons("edition--physical_dimensions--units", ["centimeters", "inches"], dimensions.units)
                   </span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2242 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Make the Metric System as Default for Physical Values of the Book while editing. Most comments in the issue favored the metric system so went with the metric.

### Technical
<!-- What should be noted about the implementation? -->
Not that much technical, just changed the default to `centimeters` from `inches` and to `kilos` from `grams`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`docker-compose exec web make test` returned no errors.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2020-11-21 03-52-50](https://user-images.githubusercontent.com/57295877/99855954-f7b36d80-2bad-11eb-8f77-5224f9554b74.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @cdrini 