### PR TITLE
Add regular expression support to the spamcheck library.

### DIFF
--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -43,7 +43,7 @@ def is_spam(i=None):
     if i is None:
         i = web.input()
     text = str(dict(i)).lower()
-    return any(re.search(w.lower(),text) for w in spamwords)
+    return any(re.search(w.lower(), text) for w in spamwords)
 
 def is_spam_email(email):
     domain = email.split("@")[-1].lower()

--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -1,3 +1,4 @@
+import re
 import web
 
 def get_spam_words():
@@ -42,7 +43,7 @@ def is_spam(i=None):
     if i is None:
         i = web.input()
     text = str(dict(i)).lower()
-    return any(w.lower() in text for w in spamwords)
+    return any(re.search(w.lower(),text) for w in spamwords)
 
 def is_spam_email(email):
     domain = email.split("@")[-1].lower()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4138 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
This incorporates ```re.search()``` into the spamcheck library.  I figure the cost of this vs. just a string match is negligible given the relatively low frequency of updates and the relatively small size of text being matched against each time.  This should probably be tested on dev first to make sure the existing spamwords still work.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Confirm this doesn't break existing functionality:
1. Go to /admin/spamwords and choose one of the lines/phrases to use in the test.
1. Go to /books/add and add that phrase to the title field.  Add anything to the publisher field and any year in the "When was it published?" field.
1. Click the 'Add' button.  The addition should still fail, like it does without this PR.

Confirm that regular expressions work now:
1. Go to /admin/spamwords and add a regular expression, like: foo.*baz
1. Go to /books/add and add "foo bar baz" to the title, anything to the publisher field, and any year to the "When was it published?" field.
1. Click the 'Add' button.  This update should also fail.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @mekarpeles 