### PR TITLE
Define infobase_nginx and give web nodes access to ia.ini

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,3 +7,6 @@ services:
   covers:
     ports:
       - 7075:7075
+  infobase:
+    ports:
+      - 7000:7000

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ../booklending_utils:/booklending_utils
       - ../olsystem:/olsystem
-      - ../olsystem/etc/ia.ini:/openlibrary/.config/ia.ini
+      - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
 
   covers:
     restart: always

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -65,10 +65,8 @@ services:
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/infobase_nginx.conf:/etc/nginx/sites-enabled/infobase_nginx.conf:ro
-      # Needs access to openlibrary for static files
-      - .:/openlibrary
+      # Needs olsystem for black-listed IPs
       - ../olsystem:/olsystem
-      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
     ports:
       - 7000:7000
     networks:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,6 +8,8 @@ version: "3.1"
 services:
   web:
     restart: always
+    deploy:
+      replicas: 2
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
@@ -20,6 +22,8 @@ services:
 
   covers:
     restart: always
+    deploy:
+      replicas: 1
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 30 --max-requests 500
@@ -49,6 +53,8 @@ services:
 
   infobase:
     restart: always
+    deploy:
+      replicas: 1
     hostname: "$HOSTNAME"
     environment:
       - INFOBASE_OPTS= fastcgi

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,8 +8,6 @@ version: "3.1"
 services:
   web:
     restart: always
-    deploy:
-      replicas: 2
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
@@ -22,8 +20,6 @@ services:
 
   covers:
     restart: always
-    deploy:
-      replicas: 1
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 30 --max-requests 500
@@ -53,8 +49,6 @@ services:
 
   infobase:
     restart: always
-    deploy:
-      replicas: 1
     hostname: "$HOSTNAME"
     environment:
       - INFOBASE_OPTS= fastcgi

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,17 +8,19 @@ version: "3.1"
 services:
   web:
     restart: always
-    hostname: ${HOSTNAME:-$HOST}
+    hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - PYENV_VERSION=3.8.6
     volumes:
-      - ../olsystem:/olsystem
       - ../booklending_utils:/booklending_utils
+      - ../olsystem:/olsystem
+      - ../olsystem/etc/ia.ini:/openlibrary/.config/ia.ini
+
   covers:
     restart: always
-    hostname: ${HOSTNAME:-$HOST}
+    hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 30 --max-requests 500
       - COVERSTORE_CONFIG=/olsystem/etc/coverstore.yml
@@ -47,7 +49,7 @@ services:
 
   infobase:
     restart: always
-    hostname: ${HOSTNAME:-$HOST}
+    hostname: "$HOSTNAME"
     environment:
       - INFOBASE_OPTS= fastcgi
       - INFOBASE_CONFIG=/olsystem/etc/infobase.yml
@@ -55,6 +57,24 @@ services:
     volumes:
       - ../olsystem:/olsystem
       -  /1:/1
+  infobase_nginx:
+    image: nginx:1.19.4
+    restart: always
+    depends_on:
+      - infobase
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/infobase_nginx.conf:/etc/nginx/sites-enabled/infobase_nginx.conf:ro
+      # Needs access to openlibrary for static files
+      - .:/openlibrary
+      - ../olsystem:/olsystem
+      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
+    ports:
+      - 7000:7000
+    networks:
+      - webnet
+    secrets:
+      - petabox_seed
 
 secrets:
    petabox_seed:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -8,7 +8,7 @@ version: "3.1"
 services:
   web:
     restart: always
-    hostname: ${HOSTNAME:-$HOST}
+    hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-infobase-start.sh
-    ports:
-      - 7000:7000
+    expose:
+      - 7000
     depends_on:
       - db
     volumes:

--- a/docker/infobase_nginx.conf
+++ b/docker/infobase_nginx.conf
@@ -1,42 +1,18 @@
 server {
-      listen 8081;
-      server_name  infobase.openlibrary.org;
+    listen       7000;
 
-      include /run/secrets/petabox_seed;
-      root /openlibrary;
+    # Allow GET requests with large query strings.
+    # Required when querying for multiple infobase documents at once.
+    large_client_header_buffers 4 160k;
 
-      keepalive_timeout 5;
+    include /run/secrets/petabox_seed;
+    root /openlibrary;
 
-      location / {
-        proxy_pass http://infobase:7000;
-        proxy_set_header Host $http_host;
+    location / {
+        include /etc/nginx/fastcgi_params;
 
-        # Gunicorn takes IP from this header
-        proxy_set_header X-Forwarded-For $remote_addr;
+        fastcgi_pass_header X_REMOTE_IP;
 
-        # Hack to make the app pick the right url scheme even when the
-        # app server is http only.
-        proxy_set_header X-Scheme $scheme;
-      }
-
-      location ~ ^(/images/.*|favicon.ico|robots.txt)$ {
-        rewrite ^(.*)$ /static/$1 last;
-      }
-
-      location ~ ^/(y_key_[0-9a-f]+.html|google[0-9a-f]+.html|LiveSearchSiteAuth.xml)$ {
-        root /olsystem/www;
-      }
-
-      location /static {
-        autoindex on;
-        expires 1h;
-      }
-
-      location /static/build {
-        expires max;
-      }
-
-      location /static/sitemaps {
-        root /sitemaps;
-      }
+        fastcgi_pass infobase:7000;
+    }
 }

--- a/docker/infobase_nginx.conf
+++ b/docker/infobase_nginx.conf
@@ -1,0 +1,42 @@
+server {
+      listen 8081;
+      server_name  infobase.openlibrary.org;
+
+      include /run/secrets/petabox_seed;
+      root /openlibrary;
+
+      keepalive_timeout 5;
+
+      location / {
+        proxy_pass http://infobase:7000;
+        proxy_set_header Host $http_host;
+
+        # Gunicorn takes IP from this header
+        proxy_set_header X-Forwarded-For $remote_addr;
+
+        # Hack to make the app pick the right url scheme even when the
+        # app server is http only.
+        proxy_set_header X-Scheme $scheme;
+      }
+
+      location ~ ^(/images/.*|favicon.ico|robots.txt)$ {
+        rewrite ^(.*)$ /static/$1 last;
+      }
+
+      location ~ ^/(y_key_[0-9a-f]+.html|google[0-9a-f]+.html|LiveSearchSiteAuth.xml)$ {
+        root /olsystem/www;
+      }
+
+      location /static {
+        autoindex on;
+        expires 1h;
+      }
+
+      location /static/build {
+        expires max;
+      }
+
+      location /static/sitemaps {
+        root /sitemaps;
+      }
+}

--- a/requirements_common.txt
+++ b/requirements_common.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.6.3
 DBUtils==1.3
 Deprecated==1.2.7
 eventer==0.1.1
-flup==1.0.3; python_version < '3.0'
+flup==1.0.2; python_version < '3.0'
 flup-py3==1.0.3; python_version >= '3.0'
 Genshi==0.7.1
 gunicorn==19.9.0; python_version < '3.0'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4130,#4132 plus fixes the $HOST issue and provides access to etc/ia.ini to the web nodes.

`deploy` will be ignored in our current environments but will become useful in environments when `restart` is ignored.
* https://hub.docker.com/_/nginx
* https://docs.docker.com/compose/compose-file/#deploy
* https://docs.docker.com/compose/compose-file/#restart
* https://testdriven.io/blog/dockerizing-django-with-postgres-gunicorn-and-nginx/#nginx

Do we need to do something special with `/var` ?

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
