### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'v2'

### DIFF
--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -60,7 +60,8 @@ class subjects(delegate.page):
             'lending_edition_s': '*'
         })
 
-        subj.v2 = True
+        if subj:
+            subj.v2 = True
         delegate.context.setdefault('bodyid', 'subject')
         if not subj or subj.work_count == 0:
             web.ctx.status = "404 Not Found"


### PR DESCRIPTION
Fixes: https://sentry.archive.org/sentry/ol-web/issues/3825 which occurs on both Python 2 and Python 3.

The filters might cause valid subjects not to be returned as evidenced by the test two lines further down.

NOTE: There is an open TODO on lines 56 and 57.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
