### PR TITLE
Speed up lend/borrow by catching TooManyRequestsExceptions

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -126,8 +126,8 @@ class AmazonAPI:
         try:
             response = self.api.get_items(request)
         except ApiException as e:
-            if "TooManyRequestsException" in e.body:
-                logger.error(str(e))  # request was denied due to request throttling
+            if "TooManyRequestsException" in e.body:   # Amazon request throttling
+                logger.error("com.amazon.paapi5#TooManyRequestsException")
             else:
                 logger.exception("Amazon fetch failed for: %s" % ', '.join(item_ids))
             return None

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -126,8 +126,8 @@ class AmazonAPI:
         try:
             response = self.api.get_items(request)
         except ApiException as e:
-            if "TooManyRequestsException" in e.body.__type:
-                logger.error(e.body.__type)  # request denied due to request throttling
+            if "TooManyRequestsException" in e.body:
+                logger.error(str(e))  # request was denied due to request throttling
             else:
                 logger.exception("Amazon fetch failed for: %s" % ', '.join(item_ids))
             return None


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #3967, ~#4085~
Speed up paapi5 calls by catching `TooManyRequestsExceptions`.  We are currently not catching these exceptions so they dump a stack trace.  This Pull Request advocates just logging TooManyRequestsExceptions which should be much faster.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screen Shot 2020-11-22 at 23 06 20](https://user-images.githubusercontent.com/3709715/99918486-80015200-2d17-11eb-81b4-cfaabc9ee77d.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
