### PR TITLE
Remove simplejson from coverstore

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -1,18 +1,27 @@
 from __future__ import print_function
-import web
-import simplejson
-import os
-import datetime
-import time
-import logging
+
 import array
+import datetime
+import json
+import logging
+import os
+import time
+
 import memcache
 import requests
+import web
 
 from openlibrary.coverstore import config, db, ratelimit
-from openlibrary.coverstore.coverlib import save_image, read_image, read_file
-from openlibrary.coverstore.utils import safeint, rm_f, random_string, ol_things, ol_get, changequery, download
-
+from openlibrary.coverstore.coverlib import read_file, read_image, save_image
+from openlibrary.coverstore.utils import (
+    changequery,
+    download,
+    ol_get,
+    ol_things,
+    random_string,
+    rm_f,
+    safeint,
+)
 
 logger = logging.getLogger("coverstore")
 
@@ -122,7 +131,7 @@ class upload2:
             (code, msg) = code__msg
             _cleanup()
             e = web.badrequest()
-            e.data = simplejson.dumps({"code": code, "message": msg})
+            e.data = json.dumps({"code": code, "message": msg})
             logger.exception("upload2.POST() failed: " + e.data)
             raise e
 
@@ -144,7 +153,7 @@ class upload2:
             error(ERROR_BAD_IMAGE)
 
         _cleanup()
-        return simplejson.dumps({"ok": "true", "id": d.id})
+        return json.dumps({"ok": "true", "id": d.id})
 
 def trim_microsecond(date):
     # ignore microseconds
@@ -382,7 +391,7 @@ class cover_details:
                 if isinstance(d['created'], datetime.datetime):
                     d['created'] = d['created'].isoformat()
                     d['last_modified'] = d['last_modified'].isoformat()
-                return simplejson.dumps(d)
+                return json.dumps(d)
             else:
                 raise web.notfound("")
         else:
@@ -423,12 +432,12 @@ class query:
                 }
             result = [process(r) for r in result]
 
-        json = simplejson.dumps(result)
+        json_data = json.dumps(result)
         web.header('Content-Type', 'text/javascript')
         if i.callback:
-            return "%s(%s);" % (i.callback, json)
+            return "%s(%s);" % (i.callback, json_data)
         else:
-            return json
+            return json_data
 
 class touch:
     def POST(self, category):

--- a/openlibrary/coverstore/oldb.py
+++ b/openlibrary/coverstore/oldb.py
@@ -1,7 +1,8 @@
 """Library to talk directly to OL database to avoid expensive API calls.
 """
+import json
+
 import web
-import simplejson
 
 from openlibrary.coverstore import config
 from openlibrary.utils import olmemcache
@@ -54,15 +55,15 @@ def get(key):
     # try memcache
     memcache = get_memcache()
     if memcache:
-        json = memcache.get(key)
-        if json:
-            return simplejson.loads(json)
+        json_data = memcache.get(key)
+        if json_data:
+            return json.loads(json_data)
 
     # try db
     db = get_db()
     try:
         thing = db.query("SELECT * FROM thing WHERE key=$key", vars=locals())[0]
         data = db.query("SELECT * FROM data WHERE data.thing_id=$thing.id AND data.revision=$thing.latest_revision", vars=locals())[0]
-        return simplejson.loads(data.data)
+        return json.loads(data.data)
     except IndexError:
         return None

--- a/openlibrary/coverstore/tests/test_webapp.py
+++ b/openlibrary/coverstore/tests/test_webapp.py
@@ -1,13 +1,12 @@
+import json
+from os import system
+from os.path import abspath, dirname, join, pardir
+
 import pytest
 import web
-import simplejson
-
-from os import system
-from os.path import abspath, join, dirname, pardir
-from openlibrary.coverstore import config, schema, code, coverlib, utils, archive
-
 from six.moves import urllib
 
+from openlibrary.coverstore import archive, code, config, coverlib, schema, utils
 
 static_dir = abspath(join(dirname(__file__), pardir, pardir, pardir, 'static'))
 
@@ -52,7 +51,7 @@ class WebTestCase:
 
     def jsonget(self, path):
         self.browser.open(path)
-        return simplejson.loads(self.browser.data)
+        return json.loads(self.browser.data)
 
     def upload(self, olid, path):
         """Uploads an image in static dir"""
@@ -61,7 +60,7 @@ class WebTestCase:
         path = join(static_dir, path)
         content_type, data = utils.urlencode({'olid': olid, 'data': open(path).read()})
         b.open('/b/upload2', data, {'Content-Type': content_type})
-        return simplejson.loads(b.data)['id']
+        return json.loads(b.data)['id']
 
     def delete(self, id, redirect_url=None):
         b = self.browser
@@ -125,7 +124,7 @@ class TestWebappWithDB(WebTestCase):
         content_type, data = utils.urlencode({'olid': 'OL1234M', 'data': filedata})
         b.open('/b/upload2', data, {'Content-Type': content_type})
         assert b.status == 200
-        id = simplejson.loads(b.data)['id']
+        id = json.loads(b.data)['id']
 
         self.verify_upload(id, filedata, {'olid': 'OL1234M'})
 
@@ -141,14 +140,14 @@ class TestWebappWithDB(WebTestCase):
         content_type, data = utils.urlencode({'olid': 'OL1234M', 'source_url': source_url})
         b.open('/b/upload2', data, {'Content-Type': content_type})
         assert b.status == 200
-        id = simplejson.loads(b.data)['id']
+        id = json.loads(b.data)['id']
 
         self.verify_upload(id, filedata, {'source_url': source_url, 'olid': 'OL1234M'})
 
     def verify_upload(self, id, data, expected_info={}):
         b = self.browser
         b.open('/b/id/%d.json' % id)
-        info = simplejson.loads(b.data)
+        info = json.loads(b.data)
         for k, v in expected_info.items():
             assert info[k] == v
 

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -1,15 +1,14 @@
 """Utilities for coverstore"""
 
-import os
+import json
 import mimetypes
-import simplejson
-import web
-
+import os
 import random
-import requests
 import socket
 import string
 
+import requests
+import web
 from six.moves.urllib.parse import splitquery, unquote, unquote_plus
 from six.moves.urllib.parse import urlencode as real_urlencode
 from six.moves.urllib.request import Request, urlopen
@@ -53,9 +52,9 @@ def ol_things(key, value):
             'limit': 10
         }
         try:
-            d = dict(query=simplejson.dumps(query))
+            d = dict(query=json.dumps(query))
             result = download(get_ol_url() + '/api/things?' + real_urlencode(d))
-            result = simplejson.loads(result)
+            result = json.loads(result)
             return result['result']
         except IOError:
             import traceback
@@ -68,8 +67,7 @@ def ol_get(olkey):
         return oldb.get(olkey)
     else:
         try:
-            result = download(get_ol_url() + olkey + ".json")
-            return simplejson.loads(result)
+            return json.loads(download(get_ol_url() + olkey + ".json"))
         except IOError:
             return None
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #2308

In coverstore, remove the third-party dependency [simplejson](https://pypi.org/project/simplejson) in favor of the Python standard library's [json module](https://docs.python.org/3/library/json.html). 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
