### PR TITLE
Increase AmazonAPI wait time between calls

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -38,7 +38,7 @@ def setup(config):
     try:
         amazon_api = AmazonAPI(
             config_amz_api.key, config_amz_api.secret,
-            config_amz_api.id, throttling=0.8)
+            config_amz_api.id, throttling=0.5)
     except AttributeError:
         amazon_api = None
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -35,6 +35,7 @@ ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 def setup(config):
     global config_amz_api, amazon_api
     config_amz_api = config.get('amazon_api')
+    print("CCC:", config_amz_api, file=web.debug)
     try:
         amazon_api = AmazonAPI(
             config_amz_api.key, config_amz_api.secret,

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -35,11 +35,10 @@ ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 def setup(config):
     global config_amz_api, amazon_api
     config_amz_api = config.get('amazon_api')
-    logger.error(f"CCC: {config_amz_api}")
     try:
         amazon_api = AmazonAPI(
             config_amz_api.key, config_amz_api.secret,
-            config_amz_api.id, throttling=0.5)
+            config_amz_api.id, throttling=0.2)
     except AttributeError:
         amazon_api = None
 

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -38,7 +38,7 @@ def setup(config):
     try:
         amazon_api = AmazonAPI(
             config_amz_api.key, config_amz_api.secret,
-            config_amz_api.id, throttling=0.9)
+            config_amz_api.id, throttling=0.8)
     except AttributeError:
         amazon_api = None
 
@@ -110,7 +110,7 @@ class AmazonAPI:
             time.sleep(wait_time)
         self.last_query_time = time.time()
 
-        item_ids = asins if type(asins) is list else [asins]
+        item_ids = asins if isinstance(asins, list) else [asins]
         _resources = self.RESOURCES[resources or 'import']
         try:
             request = GetItemsRequest(partner_tag=self.tag,

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -35,7 +35,7 @@ ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 def setup(config):
     global config_amz_api, amazon_api
     config_amz_api = config.get('amazon_api')
-    print("CCC:", config_amz_api, file=web.debug)
+    logger.error(f"CCC: {config_amz_api}")
     try:
         amazon_api = AmazonAPI(
             config_amz_api.key, config_amz_api.secret,


### PR DESCRIPTION
Fixes: #3967 
Could be used instead of, or in combination with #4144

Increase wait time from 1.11 seconds between calls to 1.25 seconds.
```
>>> 1/.9  # <-- Current
1.1111111111111112  # seconds between calls
>>> 1/.8  # <-- Proposed
1.25  # seconds between calls
>>> 1/.7
1.4285714285714286  # seconds between calls
>>> 1/.6
1.6666666666666667
>>> 1/.5
2.0
>>> 1/.4
2.5
>>> 1/.3
3.3333333333333335
>>> 1/.2
5.0
```
Also, PEP8: _Object type comparisons should always use isinstance() instead of comparing types directly._

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

This does not deal with the issue of multiple callers but might provide a solution to the majority of failures.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
