### PR TITLE
Coverstore: Properly deal with covers = [None]

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -35,14 +35,11 @@ def get_cover_id(olkeys):
         doc = ol_get(olkey)
         if not doc:
             continue
-
-        if doc['key'].startswith("/authors"):
-            covers = doc.get('photos', [])
-        else:
-            covers = doc.get('covers', [])
-
-        # Sometimes covers is stored as [-1] to indicate no covers. Consider it as no covers.
-        if covers and covers[0] >= 0:
+        is_author = doc['key'].startswith("/authors")
+        covers = doc.get('photos' if is_author else 'covers', [])
+        # Sometimes covers is stored as [None] or [-1] to indicate no covers.
+        # If so, consider there are no covers.
+        if covers and (covers[0] or 0) >= 0:
             return covers[0]
 
 def _query(category, key, value):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/sentry/ol-covers/issues/11156

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Sometimes `covers` is stored as `[None]` or `[-1]` to indicate that there are no covers.  The current logic does `covers[0] <= 0` which will raise an uncaught TypeError when covers[0] is None.  This modification converts None to 0 to avoid the uncaught exception.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
