### PR TITLE
Improve error reporting in solr.py

### DIFF
--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -93,11 +93,6 @@ class Solr:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
             response = requests.get(url, timeout=10)
-            try:
-                response.raise_for_status()
-            except requests.HTTPError:
-                logger.exception(url)
-                raise
         else:
             logger.info("solr request: %s ...", url)
             if not isinstance(payload, bytes):
@@ -106,11 +101,11 @@ class Solr:
                 "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
             }
             response = requests.post(url, data=payload, headers=headers, timeout=10)
-            try:
-                response.raise_for_status()
-            except requests.HTTPError:
-                logger.exception(url)
-                raise
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.exception(url)
+            raise
         return self._parse_solr_result(
             response.json(),
             doc_wrapper=doc_wrapper,

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -92,7 +92,12 @@ class Solr:
         if len(payload) < 500:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
-            jsonData = requests.get(url, timeout=10).json()
+            response = requests.get(url, timeout=10)
+            try:
+                response.raise_for_status()
+            except requests.HTTPError:
+                logger.exception(url)
+                raise
         else:
             logger.info("solr request: %s ...", url)
             if not isinstance(payload, bytes):
@@ -100,11 +105,14 @@ class Solr:
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
             }
-            jsonData = requests.post(
-                url, data=payload, headers=headers, timeout=10
-            ).json()
+            response = requests.post(url, data=payload, headers=headers, timeout=10)
+            try:
+                response.raise_for_status()
+            except requests.HTTPError:
+                logger.exception(url)
+                raise
         return self._parse_solr_result(
-            jsonData,
+            response.json(),
             doc_wrapper=doc_wrapper,
             facet_wrapper=facet_wrapper)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Sentry shows us many have many JSONDecodeErrors which are often caused because we do not detect errors as they happen but instead wait until the json decoder raises. https://sentry.archive.org/sentry/ol-web/?query=JSONDecodeError

Here we will fast-fail by catching and logging `requests` errors while we still have enough context to debug those errors.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
