### PR TITLE
Fix py2-web -> py3-covers bug + Improve error reporting in plugins/upstream/covers.py

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -73,12 +73,13 @@ class add_cover(delegate.page):
         try:
             if six.PY3:
                 files = {'data': BytesIO(data)}
-                resp = requests.post(upload_url, data=params, files=files)
+                response = requests.post(upload_url, data=params, files=files)
             else:
                 params['data'] = data
                 payload = requests.compat.urlencode(params).encode('utf-8')
-                resp = requests.post(upload_url, data=payload)
-            return web.storage(resp.json())
+                response = requests.post(upload_url, data=payload)
+            response.raise_for_status()
+            return web.storage(response.json())
         except requests.HTTPError as e:
             return web.storage({'error': e.read()})
 

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -82,7 +82,7 @@ class add_cover(delegate.page):
             response.raise_for_status()
             return web.storage(response.json())
         except requests.HTTPError as e:
-            logger.exception()
+            logger.exception(str(e))
             return web.storage({'error': str(e)})
 
     def save(self, book, coverid, url=None):

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -1,6 +1,7 @@
 """Handle book cover/author photo upload.
 """
 from io import BytesIO
+from logging import getLogger
 
 import requests
 import six
@@ -12,7 +13,7 @@ from openlibrary import accounts
 from openlibrary.plugins.upstream.models import Image
 from openlibrary.plugins.upstream.utils import get_coverstore_url, render_template
 
-
+logger = getLogger("openlibrary." + __file__)
 def setup():
     pass
 
@@ -81,6 +82,7 @@ class add_cover(delegate.page):
             response.raise_for_status()
             return web.storage(response.json())
         except requests.HTTPError as e:
+            logger.exception()
             return web.storage({'error': str(e)})
 
     def save(self, book, coverid, url=None):

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -1,11 +1,11 @@
 """Handle book cover/author photo upload.
 """
-from io import BytesIO
 from logging import getLogger
 
 import requests
 import six
 import web
+from six import BytesIO
 
 from infogami.utils import delegate
 from infogami.utils.view import safeint
@@ -72,14 +72,9 @@ class add_cover(delegate.page):
             upload_url = "http:" + upload_url
 
         try:
-            if six.PY3:
-                files = {'data': BytesIO(data)}
-                response = requests.post(upload_url, data=params, files=files)
-            else:
-                params['data'] = data
-                payload = requests.compat.urlencode(params).encode('utf-8')
-                response = requests.post(upload_url, data=payload)
-            response.raise_for_status()
+
+            files = {'data': BytesIO(data)}
+            response = requests.post(upload_url, data=params, files=files)
             return web.storage(response.json())
         except requests.HTTPError as e:
             logger.exception(str(e))

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -81,7 +81,7 @@ class add_cover(delegate.page):
             response.raise_for_status()
             return web.storage(response.json())
         except requests.HTTPError as e:
-            return web.storage({'error': e.read()})
+            return web.storage({'error': str(e)})
 
     def save(self, book, coverid, url=None):
         book.covers = [coverid] + [cover.id for cover in book.get_covers()]

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -13,7 +13,7 @@ from openlibrary import accounts
 from openlibrary.plugins.upstream.models import Image
 from openlibrary.plugins.upstream.utils import get_coverstore_url, render_template
 
-logger = getLogger("openlibrary." + __file__)
+logger = getLogger("openlibrary.plugins.upstream.covers")
 def setup():
     pass
 
@@ -72,12 +72,11 @@ class add_cover(delegate.page):
             upload_url = "http:" + upload_url
 
         try:
-
             files = {'data': BytesIO(data)}
             response = requests.post(upload_url, data=params, files=files)
             return web.storage(response.json())
         except requests.HTTPError as e:
-            logger.exception(str(e))
+            logger.exception("Covers upload failed")
             return web.storage({'error': str(e)})
 
     def save(self, book, coverid, url=None):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sentry shows us many have many JSONDecodeErrors which are often caused because we do not detect errors as they happen but instead wait until the json decoder raises. https://sentry.archive.org/sentry/ol-web/?query=JSONDecodeError

Here we will fast-fail by catching and logging `requests` errors while we still have enough context to debug those errors.

```
2020-11-25 19:20:58 [216] [openlibrary.logger] [INFO] solr request: http://ol-solr1:8983/solr/select?wt=json&q=key%3A%22%2Fworks%2FOL4226152W%22&start=0&fl=cover_edition_key%2Ccover_id%2Cedition_key%2Cfirst_publish_year%2Chas_fulltext%2Clending_edition_s%2Cchecked_out%2Cpublic_scan_b%2Cia
/openlibrary/openlibrary/plugins/upstream/utils.py:744: FutureWarning: This search is broken in 1.3 and earlier, and will be fixed in a future version.  If you rely on the current behaviour, change it to './/item'
  return [parse_item(item) for item in tree.findall("//item")]
Traceback (most recent call last):
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/web/application.py", line 280, in process
    return self.handle()
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/web/application.py", line 271, in handle
    return self._delegate(fn, self.fvars, args)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/web/application.py", line 517, in _delegate
    return handle_class(cls)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/web/application.py", line 495, in handle_class
    return tocall(*args)
  File "/openlibrary/infogami/utils/app.py", line 187, in <lambda>
    HEAD = GET = POST = PUT = DELETE = lambda self: delegate()
  File "/openlibrary/infogami/utils/app.py", line 206, in delegate
    return getattr(cls(), method)(*args)
  File "/openlibrary/openlibrary/plugins/upstream/covers.py", line 37, in POST
    data = self.upload(key, i)
  File "/openlibrary/openlibrary/plugins/upstream/covers.py", line 81, in upload
    return web.storage(resp.json())
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/requests/models.py", line 900, in json
    return complexjson.loads(self.text, **kwargs)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/simplejson/__init__.py", line 518, in loads
    return _default_decoder.decode(s)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/home/openlibrary/.pyenv/versions/3.8.6/lib/python3.8/site-packages/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
