### PR TITLE
Extend admin spamwords checking to account profile pages

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -884,20 +884,6 @@ class author_edit(delegate.page):
             return author
 
 
-class edit(core.edit):
-    """Overwrite ?m=edit behaviour for author, book and work pages."""
-    def GET(self, key):
-        page = web.ctx.site.get(key)
-
-        if web.re_compile('/(authors|books|works)/OL.*').match(key):
-            if page is None:
-                raise web.seeother(key)
-            else:
-                raise web.seeother(page.url(suffix="/edit"))
-        else:
-            return core.edit.GET(self, key)
-
-
 class daisy(delegate.page):
     path = "(/books/.*)/daisy"
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -11,6 +11,7 @@ from six import PY3
 import web
 
 from infogami import config
+from infogami.core import code as core
 from infogami.infobase import client
 from infogami.utils import delegate, app, types
 from infogami.utils.view import public, safeint, render
@@ -20,6 +21,7 @@ from infogami.utils.context import context
 from openlibrary import accounts
 
 from openlibrary.plugins.upstream import addbook, covers, merge_authors, models, utils
+from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.upstream import borrow, recentchanges  # TODO: unused imports?
 from openlibrary.plugins.upstream.utils import render_component
 
@@ -31,6 +33,28 @@ class static(delegate.page):
     def GET(self):
         host = 'https://%s' % web.ctx.host if 'openlibrary.org' in web.ctx.host else ''
         raise web.seeother(host + '/static' + web.ctx.path)
+
+
+class edit(core.edit):
+    """Overwrite ?m=edit behaviour for author, book, work, and people pages."""
+    def GET(self, key):
+        page = web.ctx.site.get(key)
+
+        if web.re_compile('/(authors|books|works)/OL.*').match(key):
+            if page is None:
+                raise web.seeother(key)
+            else:
+                raise web.seeother(page.url(suffix="/edit"))
+        else:
+            return core.edit.GET(self, key)
+
+    def POST(self, path):
+        if web.re_compile('/(people/[^/]+)').match(path) and spamcheck.is_spam():
+            return render_template('message.html', 'Oops',
+                                   'Something went wrong. Please try again later.')
+        return core.edit.POST(self, path)
+
+
 
 # handlers for change photo and change cover
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -48,11 +48,11 @@ class edit(core.edit):
         else:
             return core.edit.GET(self, key)
 
-    def POST(self, path):
-        if web.re_compile('/(people/[^/]+)').match(path) and spamcheck.is_spam():
+    def POST(self, key):
+        if web.re_compile('/(people/[^/]+)').match(key) and spamcheck.is_spam():
             return render_template('message.html', 'Oops',
                                    'Something went wrong. Please try again later.')
-        return core.edit.POST(self, path)
+        return core.edit.POST(self, key)
 
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4171 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
This moves the edit class out of addbook.py, since it relates to more than just adding books.  This utilizes the existing spamcheck library.  

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. If you want to see why this PR moves code out of addbook.py, then before applying this patch, visit the edit page for your account profile with the ```_profile=true``` URL parameter and search for "addbook" to confirm that it's used for more than book editing.
1. After applying this patch, pick a line from /admin/spamwords and try to add it to any text box in your profile.  The response should be an "Oops" page and the edit should fail.
1. Try adding a non-spamword to your profile page, and it should succeed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/72705998/100306293-e8d70d00-2f57-11eb-98c6-d63d9981aeb0.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini @cclauss 
