### PR TITLE
Drop mentions of v2

### DIFF
--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -57,8 +57,6 @@ class ReadableUrlProcessor:
         out = handler()
         V2_TYPES = ['works', 'books', 'people', 'authors',
                     'publishers', 'languages', 'account']
-        if out and any(web.ctx.path.startswith('/%s/' % _type) for _type in V2_TYPES):
-            out.v2 = True
 
         # Exclude noindex items
         if web.ctx.get('exclude'):

--- a/openlibrary/plugins/inside/code.py
+++ b/openlibrary/plugins/inside/code.py
@@ -23,7 +23,5 @@ class search_inside(delegate.page):
         results = fulltext_search(query, page=page, limit=RESULTS_PER_PAGE)
         search_time = time() - search_start
 
-        page = render_template('search/inside.tmpl', query, results, search_time,
+        return render_template('search/inside.tmpl', query, results, search_time,
                                page=page, results_per_page=RESULTS_PER_PAGE)
-        page.v2 = True  # page is mobile-first
-        return page

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -11,9 +11,7 @@ class home(delegate.page):
     path = "/developers/design"
 
     def GET(self):
-        template = render_template("design")
-        template.v2 = True
-        return template
+        return render_template("design")
 
 def setup():
     pass

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -46,7 +46,6 @@ def get_homepage():
         "home/index", stats=stats,
         blog_posts=blog_posts
     )
-    page.v2 = True    
     return dict(page)
 
 def get_cached_homepage():

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -20,9 +20,7 @@ class lists_home(delegate.page):
 
     def GET(self):
         delegate.context.setdefault('bodyid', 'lists')
-        template = render_template("lists/home")
-        template.v2 = True
-        return template
+        return render_template("lists/home")
 
 class lists(delegate.page):
     """Controller for displaying lists of a seed or lists of a person.

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -13,9 +13,7 @@ feature_flags = {}
 
 class status(delegate.page):
     def GET(self):
-        template = render_template("status", status_info, feature_flags)
-        template.v2 = True
-        return template
+        return render_template("status", status_info, feature_flags)
 
 @public
 def get_git_revision_short_hash():

--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -24,10 +24,8 @@ class contact(delegate.page):
         hashed_ip = hashlib.md5(web.ctx.ip.encode('utf-8')).hexdigest()
         has_emailed_recently = get_memcache().get('contact-POST-%s' % hashed_ip)
         recaptcha = has_emailed_recently and get_recaptcha()
-        template = render_template("support", email=email, url=i.path,
+        return render_template("support", email=email, url=i.path,
                                    recaptcha=recaptcha)
-        template.v2 = True
-        return template
 
     def POST(self):
         form = web.input()

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -199,9 +199,7 @@ class account(delegate.page):
     @require_login
     def GET(self):
         user = accounts.get_current_user()
-        page = render.account(user)
-        page.v2 = True
-        return page
+        return render.account(user)
 
 class account_create(delegate.page):
     """New account creation.
@@ -212,9 +210,7 @@ class account_create(delegate.page):
 
     def GET(self):
         f = self.get_form()
-        page = render['account/create'](f)
-        page.v2 = True
-        return page
+        return render['account/create'](f)
 
     def get_form(self):
         """
@@ -248,15 +244,11 @@ class account_create(delegate.page):
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,
                     notifications=notifications, verified=False, retries=USERNAME_RETRIES)
-                page = render['account/verify'](username=f.username.value, email=f.email.value)
-                page.v2 = True
-                return page
+                return render['account/verify'](username=f.username.value, email=f.email.value)
             except ValueError:
                 f.note = LOGIN_ERRORS['max_retries_exceeded']
 
-        page = render['account/create'](f)
-        page.v2 = True
-        return page
+        return render['account/create'](f)
 
 
 del delegate.pages['/account/register']
@@ -320,9 +312,7 @@ class account_login(delegate.page):
         i = web.input(redirect=referer)
         f = forms.Login()
         f['redirect'].value = i.redirect
-        page = render.login(f)
-        page.v2 = True
-        return page
+        return render.login(f)
 
     def POST(self):
         i = web.input(username="", connect=None, password="", remember=False,
@@ -761,13 +751,11 @@ class public_my_books(delegate.page):
                     })[0]) for s in sponsorships)
             else:
                 books = readlog.get_works(key, page=i.page)
-            page = render['account/books'](
+            return render['account/books'](
                 books, key, sponsorship_count=len(sponsorships),
                 reading_log_counts=readlog.reading_log_counts, lists=readlog.lists,
                 user=user, logged_in_user=logged_in_user, public=is_public
             )
-            page.v2 = True
-            return page
         raise web.seeother(user.key)
 
 
@@ -810,7 +798,7 @@ class readinglog_stats(delegate.page):
             }
             for a in web.ctx.site.get_many(list(author_keys))
         ]
-        page = render['account/readinglog_stats'](
+        return render['account/readinglog_stats'](
             json.dumps(works_json),
             json.dumps(authors_json),
             len(works_json),
@@ -820,8 +808,6 @@ class readinglog_stats(delegate.page):
             key,
             lang=web.ctx.lang,
         )
-        page.v2 = True
-        return page
 
 
 class account_my_books_redirect(delegate.page):

--- a/openlibrary/plugins/upstream/recentchanges.py
+++ b/openlibrary/plugins/upstream/recentchanges.py
@@ -51,9 +51,7 @@ class index(delegate.page):
         if web.ctx.encoding in ["json", "yml"]:
             return self.handle_encoding(query, web.ctx.encoding)
 
-        page = render_template("recentchanges/index", query)
-        page.v2 = True
-        return page
+        return render_template("recentchanges/index", query)
 
     def handle_encoding(self, query, encoding):
         i = web.input(bot="", limit=100, offset=0, text="false")

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -545,9 +545,7 @@ class scan(delegate.page):
     path = "/barcodescanner"
 
     def GET(self):
-        page = render.barcodescanner()
-        page.v2 = True
-        return page
+        return render.barcodescanner()
 
 
 class search(delegate.page):
@@ -626,12 +624,10 @@ class search(delegate.page):
             if k in i:
                 v = re_to_esc.sub(r'\\\g<0>', i[k].strip())
                 q_list.append(k + ':' + v)
-        page = render.work_search(
+        return render.work_search(
             i, ' '.join(q_list), do_search, get_doc,
             get_availability_of_ocaids, fulltext_search,
             FACET_FIELDS)
-        page.v2 = True
-        return page
 
 
 def works_by_author(akey, sort='editions', page=1, rows=100, has_fulltext=False, query=None):
@@ -716,9 +712,7 @@ class advancedsearch(delegate.page):
     path = "/advancedsearch"
 
     def GET(self):
-        template = render_template("search/advancedsearch.html")
-        template.v2 = True
-        return template
+        return render_template("search/advancedsearch.html")
 
 
 def escape_colon(q, vf):

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -49,9 +49,7 @@ class index(delegate.page):
         result = search.get_solr().select('*:*', rows=0, facets=['language'], facet_limit=500)
         languages = [web.storage(name=get_language_name(row.value), key='/languages/' + row.value, count=row.count)
                     for row in result['facets']['language']]
-        page = render_template("languages/index", languages)
-        page.v2 = True
-        return page
+        return render_template("languages/index", languages)
 
     def is_enabled(self):
         return True

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -60,8 +60,6 @@ class subjects(delegate.page):
             'lending_edition_s': '*'
         })
 
-        if subj:
-            subj.v2 = True
         delegate.context.setdefault('bodyid', 'subject')
         if not subj or subj.work_count == 0:
             web.ctx.status = "404 Not Found"
@@ -69,7 +67,6 @@ class subjects(delegate.page):
         else:
             page = render_template("subjects", page=subj)
 
-        page.v2 = True
         return page
 
     def normalize_key(self, key):

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -50,8 +50,7 @@ $def with (page)
 
   </script>
 
-    <!-- Both v2 and v1 pages have a JavaScript execution queue that will
-    be emptied at the bottom of the page -->
+    <!-- JavaScript execution queue that will be emptied at the bottom of the page -->
     <script type="text/javascript">window.q = [];</script>
     $if "dev" in ctx.features:
         <link href="$static_url('build/page-dev.css')" rel="stylesheet" type="text/css"/>

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -69,9 +69,7 @@ class stats(app.view):
     def GET(self):
         counts = get_counts()
         counts.reading_log = cached_reading_log_summary()
-        template = app.render_template("admin/index", counts)
-        template.v2 = True
-        return template
+        return app.render_template("admin/index", counts)
 
 
 class lending_stats(app.view):

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -61,27 +61,21 @@ class show_ia(app.view):
         except ValueError:
             record = None
 
-        template = app.render_template("showia", ia, record, books)
-        template.v2 = True
-        return template
+        return app.render_template("showia", ia, record, books)
 
 
 class show_amazon(app.view):
     path = "/show-records/amazon:(.*)"
 
     def GET(self, asin):
-        template = app.render_template("showamazon", asin)
-        template.v2 = True
-        return template
+        return app.render_template("showamazon", asin)
 
 
 class show_bwb(app.view):
     path = "/show-records/bwb:(.*)"
 
     def GET(self, isbn):
-        template = app.render_template("showbwb", isbn)
-        template.v2 = True
-        return template
+        return app.render_template("showbwb", isbn)
 
 
 re_bad_meta_mrc = re.compile('^([^/]+)_meta\.mrc$')
@@ -138,6 +132,4 @@ class show_marc(app.view):
         except ValueError:
             record = None
 
-        template = app.render_template("showmarc", record, filename, offset, length, books)
-        template.v2 = True
-        return template
+        return app.render_template("showmarc", record, filename, offset, length, books)

--- a/static/css/js-all.less
+++ b/static/css/js-all.less
@@ -1,9 +1,6 @@
 /**
  * Styles here will load for all users, but only if JavaScript is enabled.
- * At time of writing, this stylesheet is render blocking unless a page that
- * is passed through the template engine enables "v2" via `page.v2 = True`
- * The long term plan for this stylesheet is not to be render blocking
- * on all pages.
+ * At time of writing, this stylesheet is not render blocking.
  */
 @import (less) "less/index.less";
 

--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -1,4 +1,3 @@
-// This CSS will load $if 'v2' in page
 #test-body-mobile {
   box-sizing: border-box;
   max-width: 960px;
@@ -24,7 +23,7 @@ body.full-width #test-body-mobile {
 }
 
 // The border-box padding model is much more friendly for responsive layouts
-// so we adopt it in all v2 pages
+// so we adopt it in all pages
 // https://www.paulirish.com/2012/box-sizing-border-box-ftw/
 * {
   box-sizing: border-box;


### PR DESCRIPTION
Follow up to aad55eb2887572a766dd91

* All pages are v2 now and the variable which was previously used
inside openlibrary/templates/site/body.html is no longer used so
this can be safely removed
* Update the CSS comment in static/css/js-all.less to reflect the
current status quo for that LESS file.

Fixes: #4174

<!-- What issue does this PR close? -->
Closes #4174

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
