### PR TITLE
All workers share one AmazonAPI singleton

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -34,13 +34,15 @@ ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
 
 def setup(config):
     global config_amz_api, amazon_api
-    config_amz_api = config.get('amazon_api')
-    try:
-        amazon_api = AmazonAPI(
-            config_amz_api.key, config_amz_api.secret,
-            config_amz_api.id, throttling=0.9)
-    except AttributeError:
-        amazon_api = None
+    if not amazon_api:  # All workers share a single instance to avoid API throttling
+        config_amz_api = config.get('amazon_api')
+        try:
+            amazon_api = AmazonAPI(
+                config_amz_api.key, config_amz_api.secret,
+                config_amz_api.id, throttling=0.9)
+            logger.info("Created an AmazonAPI instance.")
+        except AttributeError:
+            amazon_api = None
 
 
 class AmazonAPI:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3967, #4144

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Avoid being rate limited on Amazon paapi5 requests by having all workers share one AmazonAPI singleton as discussed the Proposals section of #3967

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

BUMMER...  Does not work the way we want :-(
```
web_1        | 2020-11-26 21:28:32 [216] [openlibrary.vendors] [INFO] Created an AmazonAPI instance.
web_1        | 2020-11-26 21:28:32 [217] [openlibrary.vendors] [INFO] Created an AmazonAPI instance.
web_1        | 2020-11-26 21:28:32 [215] [openlibrary.vendors] [INFO] Created an AmazonAPI instance.
web_1        | 2020-11-26 21:28:32 [214] [openlibrary.vendors] [INFO] Created an AmazonAPI instance.
```
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
