### PR TITLE
Travis CI: pip --use-feature=2020-resolver is now default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 
 install:
   - pip install --upgrade pip setuptools wheel
-  - pip install --use-feature=2020-resolver -r requirements_test.txt
+  - pip install -r requirements_test.txt
   # refresh the git submodule ./vendor/infogami on some jobs
   - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
       pushd vendor/infogami && git pull origin master && popd;


### PR DESCRIPTION
We can now remove `--use-feature=2020-resolver` from pip commands because that is now the default.
https://blog.python.org/2020/11/pip-20-3-release-new-resolver.html

<!-- What issue does this PR close? -->
Closes  #4086, #4093

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
