### PR TITLE
Ignore node_modules when testing python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ ifndef CONTINUOUS_INTEGRATION
 endif
 
 test-py:
-	pytest . --ignore=tests/integration --ignore=scripts/2011 --ignore=infogami --ignore=vendor
+	pytest . --ignore=tests/integration --ignore=scripts/2011 --ignore=infogami --ignore=vendor --ignore=node_modules
 
 test: 
 	make test-py && npm run test


### PR DESCRIPTION
It slows down testing _significantly_ locally; went from ~3min -> 1min :)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
