### PR TITLE
Reduce travis file complexity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
 
 install:
   - pip install --upgrade pip setuptools wheel
-  - pip install --use-feature=2020-resolver -r requirements_test.txt
+  - pip install -r requirements_test.txt
 
 script:
   - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,9 @@ jobs:
     - name: Python 2.7
       python: "2.7"
 
-    - name: Python 2.7 on Infogami master
-      python: "2.7"
-      before_script:
-        # Use infogami master
-        - pushd vendor/infogami && git pull origin master && popd;
-
     - name: Python 3.8
       python: "3.8"
       before_script:
-        # Use infogami master
-        - pushd vendor/infogami && git pull origin master && popd;
         # Do more aggressive linting for newly added code
         - make lint-diff
 
@@ -40,9 +32,19 @@ jobs:
 install:
   - pip install --upgrade pip setuptools wheel
   - pip install -r requirements_test.txt
+  # Need to also test infogami-master
+  - git clone https://github.com/internetarchive/infogami.git vendor/infogami-master
+  # Remove symlink in favour of PYTHONPATH
+  - rm infogami
 
 script:
   - make lint
   - make i18n
-  - make test-py
-  - source scripts/run_doctests.sh
+  # Python 2 should also be tested against production infogami
+  - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ]; then
+      PYTHONPATH="$PYTHONPATH:$PWD/vendor/infogami" make test-py;
+      PYTHONPATH="$PYTHONPATH:$PWD/vendor/infogami" source scripts/run_doctests.sh;
+    fi
+  # Both should be tested against infogami-master
+  - PYTHONPATH="$PYTHONPATH:$PWD/vendor/infogami-master" make test-py
+  - PYTHONPATH="$PYTHONPATH:$PWD/vendor/infogami-master" source scripts/run_doctests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,26 @@ branches:
     - master
 
 os: linux
-dist: focal
+dist: xenial
 language: python
 jobs:
   include:
-    - name: Python 2.7 on xenial
+    - name: Python 2.7
       python: "2.7"
-      dist: xenial
-    - name: Python 2.7 on focal
-      python: "2.7"
+
     - name: Python 2.7 on Infogami master
       python: "2.7"
-      script:
-        - make i18n
-        - make test-py
-        - pip install safety
-        - safety check || true
-    - name: Python 3.8 on focal
+      before_script:
+        # Use infogami master
+        - pushd vendor/infogami && git pull origin master && popd;
+
+    - name: Python 3.8
       python: "3.8"
-    - name: Python 3.9 on focal
-      python: "3.9"
+      before_script:
+        # Use infogami master
+        - pushd vendor/infogami && git pull origin master && popd;
+        # Do more aggressive linting for newly added code
+        - make lint-diff
 
     - name: Node
       language: node_js
@@ -37,22 +37,11 @@ jobs:
         - make components
         - npm run test
 
-  allow_failures:
-    - name: Python 2.7 on Infogami master
-
 install:
   - pip install --upgrade pip setuptools wheel
   - pip install --use-feature=2020-resolver -r requirements_test.txt
-  # refresh the git submodule ./vendor/infogami on some jobs
-  - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ] || [ "$TRAVIS_JOB_NAME" == "Python 2.7 on Infogami master" ]; then
-      pushd vendor/infogami && git pull origin master && popd;
-    fi
-  - pip list --outdated
 
 script:
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.9" ]; then
-      make lint-diff;
-    fi
   - make lint
   - make i18n
   - make test-py


### PR DESCRIPTION
We hit Travis' new restrictions for public repos (see https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing ) last month, so trying to see if we can reduce how much time we spend running Travis. We hit the limit pretty late in the month though, on Nov 24th; so a few reductions might be all we need to do to get back into December.

Here I:
1) Only test on Xenial; that's what all our Dockerfiles use, and it's very unlikely we'll make a change that causes something to break on other versions of Ubuntu
2) Don't test on Python 3.9 ; it's very unlikely we'll introduce a change that causes 3.9 to break

That takes us from 6 jobs to 4 jobs :)

Python 3.9 was also the slowest (see e.g. https://travis-ci.com/github/internetarchive/openlibrary/builds/203778599 ), so this should reduce our total travis time by ~7.5min per build -- that's 42% !

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Need to wait for Dec 1st to test this with Travis

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
