### PR TITLE
Preserve exception info in covers.upload2

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -135,21 +135,29 @@ class upload2:
             logger.exception("upload2.POST() failed: " + e.data)
             raise e
 
-        source_url = i.source_url
+        source_url = i.source_url.strip()
         data = i.data
+        caught_exception = None  # useful for debugging
 
         if source_url:
             try:
                 data = download(source_url)
-            except:
+            except Exception as caught_exception:
                 error(ERROR_INVALID_URL)
 
         if not data:
             error(ERROR_EMPTY)
 
         try:
-            d = save_image(data, category=category, olid=i.olid, author=i.author, source_url=i.source_url, ip=i.ip)
-        except ValueError:
+            d = save_image(
+                data,
+                category=category,
+                olid=i.olid,
+                author=i.author,
+                source_url=source_url,
+                ip=i.ip,
+            )
+        except ValueError as caught_exception:
             error(ERROR_BAD_IMAGE)
 
         _cleanup()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4054, #4176

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Fix to preserve exception info in `caught_exception` for code that has proven difficult to debug.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
