### PR TITLE
coverstore golive mods

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -37,7 +37,7 @@ services:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
       # Needed for HTTPS, since this is a public server
-      - ../olsystem/etc/nginx/default-docker.conf:/etc/nginx/sites-enabled/default:ro
+      - ../olsystem/etc/nginx/sites-available/default-docker.conf:/etc/nginx/sites-enabled/default:ro
       # Needs access to openlibrary for static files
       - .:/openlibrary
       - ../olsystem:/olsystem


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4054

Ensure we mount the correct coverstore nginx settings from olsystem.

As discussed in https://internetarchive.slack.com/archives/G014GGN2A5S/p1606864836087400 

$ `diff --git a/docker-compose.production.yml b/docker-compose.production.yml`
```
index 7e160c669..e9f320d3d 100644
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -37,7 +37,7 @@ services:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
       # Needed for HTTPS, since this is a public server
-      - ../olsystem/etc/nginx/default-docker.conf:/etc/nginx/sites-enabled/default:ro
+      - ../olsystem/etc/nginx/sites-available/default-docker.conf:/etc/nginx/sites-enabled/default:ro
```
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
