### PR TITLE
adding booklending_utils, ia.ini to staging

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -15,3 +15,5 @@ services:
       - PYENV_VERSION=3.8.6
     volumes:
       - ../olsystem:/olsystem
+      - ../booklending_utils:/booklending_utils
+      - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini


### PR DESCRIPTION
trivial changes to staging docker compose to add `internetarchive` `ia.ini` and `booklending_utils` to staging volume mounts