### PR TITLE
Fixed Grammatical error

### DIFF
--- a/openlibrary/templates/type/edition/publisher_line.html
+++ b/openlibrary/templates/type/edition/publisher_line.html
@@ -4,7 +4,7 @@ $if edition:
   <h4 class="publisher">
   $if edition.publish_date or edition.publishers or edition.publish_places:
     <!-- TODO: this handcrafted concatenation will be difficult to internationalize -->
-    $_('This edition published')
+    $_('This edition was published')
       $if edition.publish_date:
         $_('in') <strong itemprop="datePublished">$edition.publish_date</strong>
       $if edition.publishers:


### PR DESCRIPTION
<!-- What issue does this PR close? -->


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It should be: This edition **was** published in 1998 by Bloomsbury in London, England.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ol](https://user-images.githubusercontent.com/64412143/101259831-50a80780-3751-11eb-83ad-3577e4023690.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
