### PR TITLE
json.dumps(indent) is an int or str, not bool

### DIFF
--- a/openlibrary/plugins/inside/code.py
+++ b/openlibrary/plugins/inside/code.py
@@ -40,4 +40,4 @@ class search_inside_json(delegate.page):
         page = int(i.page)
         results = fulltext_search(query, page=page, limit=limit, js=True)
         web.header('Content-Type', 'application/json')
-        return delegate.RawText(json.dumps(results, indent=True))
+        return delegate.RawText(json.dumps(results, indent=4))

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -968,7 +968,7 @@ class search_json(delegate.page):
                                spellcheck_count=spellcheck_count)
 
         web.header('Content-Type', 'application/json')
-        return delegate.RawText(json.dumps(response, indent=True))
+        return delegate.RawText(json.dumps(response, indent=4))
 
 def setup():
     from openlibrary.plugins.worksearch import subjects


### PR DESCRIPTION
https://docs.python.org/3/library/json.html#json.dump

> If indent is a non-negative integer or string, then JSON array elements and object members will be pretty-printed with that indent level. An indent level of 0, negative, or "" will only insert newlines. None (the default) selects the most compact representation. Using a positive integer indent indents that many spaces per level. If indent is a string (such as "\t"), that string is used to indent each level.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
