### PR TITLE
GitHub Action: Add test_javascript.yml

### DIFF
--- a/.github/workflows/test_javascript.yml
+++ b/.github/workflows/test_javascript.yml
@@ -1,0 +1,16 @@
+name: test_javascript
+on: [push] # pull_request,
+jobs:
+  test_javascript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12' # # Should match what's in our Dockerfile
+      - run: npm install
+      - run: npm run lint
+      - run: make js
+      - run: make css
+      - run: make components
+      - run: npm run tes

--- a/.github/workflows/test_javascript.yml
+++ b/.github/workflows/test_javascript.yml
@@ -13,4 +13,4 @@ jobs:
       - run: make js
       - run: make css
       - run: make components
-      - run: npm run tes
+      - run: npm run test

--- a/.github/workflows/test_javascript.yml
+++ b/.github/workflows/test_javascript.yml
@@ -10,6 +10,7 @@ jobs:
           node-version: '12' # # Should match what's in our Dockerfile
       - run: npm install
       - run: npm run lint
+      - run: make git
       - run: make js
       - run: make css
       - run: make components


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to  #4207,#4188

Because Travis CI no longer freely supports open-source projects.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
