### PR TITLE
Pip install booklending_utils on prod/staging

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -13,6 +13,7 @@ services:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - PYENV_VERSION=3.8.6
+      - BEFORE_START=pip install -e /booklending_utils
     volumes:
       - ../booklending_utils:/booklending_utils
       - ../olsystem:/olsystem

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -13,6 +13,7 @@ services:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - PYENV_VERSION=3.8.6
+      - BEFORE_START=pip install -e /booklending_utils
     volumes:
       - ../olsystem:/olsystem
       - ../booklending_utils:/booklending_utils

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 python --version
+
+# Provide a hook for us to specify pre-start tasks
+if [ -n "$BEFORE_START" ] ; then
+  $BEFORE_START
+fi
+
 authbind --deep \
   scripts/openlibrary-server "$OL_CONFIG" \
   --gunicorn \


### PR DESCRIPTION
Fix. This repo is needed on production, but not available/necessary for local dev.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ `docker-compose up --no-deps web` starts web without issue
- ✅ `docker-compose -f docker-compose.yml -f docker-compose.production.yml up --no-deps web` tries to install booklending
- ✅* Pip install works
    - Need to set owner of booklending_utils to something docker has access to :/
- ✅* Service starts up
    - There's some sort of perms issue with booklending_utils/ia? Made a local mod to booklending_utils to override this, but we can't commit a fix to that repo until we get feedback from its maintainer.


Tested: http://staging.openlibrary.org/sponsorship/eligibility/OL1099079M

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 