### PR TITLE
GitHub Actions: Start testing on Node.js 14

### DIFF
--- a/.github/workflows/test_javascript.yml
+++ b/.github/workflows/test_javascript.yml
@@ -3,11 +3,14 @@ on: [push] # pull_request,
 jobs:
   test_javascript:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [12, 14]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: [12, 14] # # Should match what's in our Dockerfile
+          node-version: ${{ matrix.node }}  # Should match what's in our Dockerfile
       - run: npm install
       - run: npm run lint
       - run: make git

--- a/.github/workflows/test_javascript.yml
+++ b/.github/workflows/test_javascript.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '12' # # Should match what's in our Dockerfile
+          node-version: [12, 14] # # Should match what's in our Dockerfile
       - run: npm install
       - run: npm run lint
       - run: make git


### PR DESCRIPTION
Node.js is on v14.15.1 and Node.js 15 is current so it would make sense to upgrade the the newer LTS.
https://github.com/nodejs/Release

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
