### PR TITLE
Add make-integration-branch support for GH patch links

### DIFF
--- a/scripts/make-integration-branch-sample.txt
+++ b/scripts/make-integration-branch-sample.txt
@@ -13,3 +13,6 @@
 # Branches from other forks:
 # https://github.com/cdrini/openlibrary.git 314/hotfix/limit-subject-results
 #
+# PRs from forks that have been deleted:
+# https://github.com/internetarchive/openlibrary/pull/4215.patch
+#

--- a/scripts/make-integration-branch.sh
+++ b/scripts/make-integration-branch.sh
@@ -20,6 +20,9 @@ while read line; do
         :
     elif [[ ! -z $ONLY_STARRED && $line != "**"* ]] ; then
         :
+    elif [[ $branch == "https://github.com/internetarchive/openlibrary/pull/"*".patch" ]] ; then
+        echo -e "---\n$branch"
+        curl -L $branch | git am -3
     elif [[ $branch == "https://"* ]] ; then
         echo -e "---\n$branch"
         git pull $branch


### PR DESCRIPTION
When a fork is deleted, we can't pull down a PR's code! So add support for pulling down the patch.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
