### PR TITLE
Fixed focus outlines hidden

### DIFF
--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -34,7 +34,6 @@
   &__item {
     float: left;
     height: 100%;
-    padding: 2px;
     margin: 0 10px;
     min-height: 1px;
     overflow: hidden;

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -34,6 +34,7 @@
   &__item {
     float: left;
     height: 100%;
+    padding: 2px;
     margin: 0 10px;
     min-height: 1px;
     overflow: hidden;

--- a/static/css/components/category-item.less
+++ b/static/css/components/category-item.less
@@ -51,6 +51,7 @@ p {
 // FIXME: Selector should be weakened OR removed
 .carousel {
   .category-item {
+    padding: 2px;
     font-family: @georgia_serif-1;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4012 

2px padding was added so that when one tab through the site the outlines are properly visible **but due to this "1 hour borrow" doesn't fit.** (check 3rd image)
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![1](https://user-images.githubusercontent.com/64412143/101982205-3bbefd00-3c98-11eb-89a6-9a5917dd6624.JPG)
![2](https://user-images.githubusercontent.com/64412143/101982207-3e215700-3c98-11eb-8020-e7b9d4ca4c1d.JPG)
![3](https://user-images.githubusercontent.com/64412143/101982209-4083b100-3c98-11eb-8b68-624495c3f379.JPG)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jamesachamp 