### PR TITLE
Conditionally display general date field on author profile

### DIFF
--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -73,7 +73,7 @@ $putctx("robots", "noindex,nofollow")
                             </div>
                         </div>
 
-                        $if not page.birth_date and not page.death_date and page.date:
+                        $if page.date:
                           <div class="formElement contentQuarter" id="date">
                                   <div class="label dateLabelAcc">
                                       <label for="date">$_("Date")</label>

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -73,6 +73,17 @@ $putctx("robots", "noindex,nofollow")
                             </div>
                         </div>
 
+                        $if not page.birth_date and not page.death_date and page.date:
+                          <div class="formElement contentQuarter" id="date">
+                                  <div class="label dateLabelAcc">
+                                      <label for="date">$_("Date")</label>
+                                  </div>
+                                 <div class="input deathInputAcc">
+                                      <input type="text" name="author--date" id="date" value="$page.date"/>
+                                  </div>
+                             </div>
+
+
                         <div class="formElement contentQuarter">
                             <div class="label tipAcc">
                                 <span class="tip">$_('We\'re not storing structured dates (yet) so a date like "21 May 2000" is recommended.')</span>

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -54,6 +54,7 @@ $putctx("robots", "noindex,nofollow")
                                     class="markdown olform__input--large" id="wmd-input" rows="6">$page.bio</textarea>
                             </div>
                         </div>
+                        
 
                         <div class="formElement contentQuarter" id="birthDate">
                             <div class="label birthLabelAcc">
@@ -73,22 +74,27 @@ $putctx("robots", "noindex,nofollow")
                             </div>
                         </div>
 
+                        <div class="formElement contentQuarter">
+                            <div class="label tipAcc">
+                                <span class="tip">$_('We\'re not storing structured dates (yet) so a date like "21 May 2000" is recommended.')</span>
+                            </div>
+                        </div>
+
+                        <div class="clearfix"></div>
+
                         $if page.date:
-                          <div class="formElement contentQuarter" id="date">
+                        
+                            <div class="formElement contentQuarter" id="date">
                                   <div class="label dateLabelAcc">
                                       <label for="date">$_("Date")</label>
                                   </div>
                                  <div class="input deathInputAcc">
                                       <input type="text" name="author--date" id="date" value="$page.date"/>
                                   </div>
-                             </div>
-
-
-                        <div class="formElement contentQuarter">
-                            <div class="label tipAcc">
-                                <span class="tip">$_('We\'re not storing structured dates (yet) so a date like "21 May 2000" is recommended.')</span>
                             </div>
-                        </div>
+                            <div class="formElement contentQuarter">
+                                <span class="tip">$_('This is a deprecated field. You can help improve this record by removing this date and populating the "Date of birth" and "Date of death" fields. Thanks!')</span>
+                            </div>
 
                         <div class="clearfix"></div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3421 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes uneditable date on author records.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to http://localhost:8080/authors/OL1095882A/Cid
Add birth or death date.
Save.
See if general date is displayed (should not be).
ALSO
Try to edit/remove general date field. Should no longer appear on profile once saved.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="952" alt="Screenshot 2020-12-13 at 12 29 19" src="https://user-images.githubusercontent.com/17739465/102010523-de31bb80-3d3e-11eb-9030-5a59e99d4eea.png">
<img width="664" alt="Screenshot 2020-12-13 at 12 28 57" src="https://user-images.githubusercontent.com/17739465/102010524-deca5200-3d3e-11eb-946d-630f6379e1da.png">
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@SouthGoingZax @tfmorris @cdrini @hornc 