### PR TITLE
Redirect get to account/import for #4264

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -861,6 +861,10 @@ class fetch_goodreads(delegate.page):
     path = "/account/import/goodreads"
 
     @require_login
+    def GET(self):
+        return render['account/import']()
+
+    @require_login
     def POST(self):
         import csv
         i = web.input(csv={})
@@ -868,7 +872,7 @@ class fetch_goodreads(delegate.page):
         csv_file = csv.reader(csv_payload.splitlines(), delimiter=',', quotechar='"')
         header = next(csv_file)
         books = {}
-        books_wo_isbns = {} 
+        books_wo_isbns = {}
         for book in list(csv_file):
             _book = dict(zip(header, book))
             _book['ISBN'] = _book['ISBN'].replace('"','').replace('=','')
@@ -879,7 +883,7 @@ class fetch_goodreads(delegate.page):
                 books[_book['ISBN13']] = _book
                 books[_book['ISBN13']]['ISBN'] = _book['ISBN13']
             else:
-                books_wo_isbns[_book['Book Id']] = _book     
+                books_wo_isbns[_book['Book Id']] = _book
         return render['account/import'](books, books_wo_isbns)
 
 class export_books(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -860,9 +860,8 @@ class import_books(delegate.page):
 class fetch_goodreads(delegate.page):
     path = "/account/import/goodreads"
 
-    @require_login
     def GET(self):
-        return render['account/import']()
+        raise web.seeother("/account/import")
 
     @require_login
     def POST(self):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4264

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix to redirect `GET /account/import/goodreads` to `/account/import` (with `require_login` decorator`)

### Technical
<!-- What should be noted about the implementation? -->
Followed the same pattern as class `import_books`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verify that http://localhost:8080/account/import/goodreads redirects you to login page if not logged in, or `/account/import` when you are logged in.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini
