### PR TITLE
Make work from an orphaned edition

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -415,6 +415,21 @@ class Edition(Thing):
         # all IA scans will have scanningcenter field set
         return bool(metadata.get("scanningcenter"))
 
+    def make_work_from_orphaned_edition(self):
+        """
+        Create a dummy work from an orphaned_edition.
+        """
+        return web.ctx.site.new('', {
+            'key': '',
+            'type': {'key': '/type/work'},
+            'title': self.title,
+            'authors': [
+                {'type': {'key': '/type/author_role'}, 'author': {'key': a['key']}}
+                for a in self.get('authors', [])],
+            'editions': [self],
+            'subjects': self.get('subjects', []),
+        })
+
 def some(values):
     """Returns the first value that is True from the values iterator.
     Works like any, but returns the value instead of bool(value).

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -486,6 +486,8 @@ class Work(Thing):
         return status_id
 
     def get_num_users_by_bookshelf(self):
+        if not self.key:  # a dummy work
+            return {'want-to-read': 0, 'currently-reading': 0, 'already-read': 0}
         work_id = extract_numeric_id_from_olid(self.key)
         num_users_by_bookshelf = Bookshelves.get_num_users_by_bookshelf_by_work_id(work_id)
         return {

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -495,12 +495,14 @@ class Work(Thing):
         }
 
     def get_rating_stats(self):
+        if not self.key:  # a dummy work
+            return {'avg_rating': 0, 'num_ratings': 0}
         work_id = extract_numeric_id_from_olid(self.key)
         rating_stats = Ratings.get_rating_stats(work_id)
         if rating_stats and rating_stats['num_ratings'] > 0:
             return {
-            'avg_rating': round(rating_stats['avg_rating'],2),
-            'num_ratings': rating_stats['num_ratings']
+                'avg_rating': round(rating_stats['avg_rating'], 2),
+                'num_ratings': rating_stats['num_ratings']
             }
 
     def _get_d(self):

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -13,6 +13,7 @@ $elif page.works:
   $ work = list(page.works)[0]
 $else:
   $ work = page.make_work_from_orphaned_edition()
+$ edition = storage({})
 
 $ component_times['get_sorted_editions'] = time()
 $ editions = work.get_sorted_editions()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -8,7 +8,7 @@ $ edition = page if page.key.startswith('/books') else storage({})
 $ page_type = page.key.split('/')[1]
 
 $ work = page if page.key.startswith('/works') else list(page.works + [None])[0]
-$ work = work or web.ctx.site.new('', {
+$ work = work or ctx.site.new('', {
   $ 'key': '',
   $ 'type': {'key': '/type/work'},
   $ 'title': edition.title,

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -4,11 +4,19 @@ $ component_times = {}
 $ component_times['TotalTime'] = time()
 
 $ tab = input(tab=None).tab
-$ editions = []
+$ edition = page if page.key.startswith('/books') else storage({})
 $ page_type = page.key.split('/')[1]
 
-$ work = page if page.key.startswith('/works') else list(page.works)[0]
-$ edition = storage({})
+$ work = page if page.key.startswith('/works') else list(page.works + None)[0]
+$ work = work or web.ctx.site.new('', {
+  $ 'key': '',
+  $ 'type': {'key': '/type/work'},
+  $ 'title': edition.title,
+  $ 'authors': [{'type': {'key': '/type/author_role'}, 'author': {'key': a['key']}}
+    $ for a in edition.get('authors', [])],
+    $ 'editions': [edition],
+  $ 'subjects': edition.get('subjects', []),
+$ })
 
 $ component_times['get_sorted_editions'] = time()
 $ editions = work.get_sorted_editions()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -7,7 +7,7 @@ $ tab = input(tab=None).tab
 $ edition = page if page.key.startswith('/books') else storage({})
 $ page_type = page.key.split('/')[1]
 
-$ work = page if page.key.startswith('/works') else list(page.works + None)[0]
+$ work = page if page.key.startswith('/works') else list(page.works + [None])[0]
 $ work = work or web.ctx.site.new('', {
   $ 'key': '',
   $ 'type': {'key': '/type/work'},

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -4,19 +4,15 @@ $ component_times = {}
 $ component_times['TotalTime'] = time()
 
 $ tab = input(tab=None).tab
-$ edition = page if page.key.startswith('/books') else storage({})
+$ editions = []
 $ page_type = page.key.split('/')[1]
 
-$ work = page if page.key.startswith('/works') else list(page.works + [None])[0]
-$ work = work or ctx.site.new('', {
-  $ 'key': '',
-  $ 'type': {'key': '/type/work'},
-  $ 'title': edition.title,
-  $ 'authors': [{'type': {'key': '/type/author_role'}, 'author': {'key': a['key']}}
-    $ for a in edition.get('authors', [])],
-    $ 'editions': [edition],
-  $ 'subjects': edition.get('subjects', []),
-$ })
+$if page.key.startswith('/works'):
+  $ work = page
+$elif page.works:
+  $ work = list(page.works)[0]
+$else:
+  $ work = page.make_work_from_orphaned_edition()
 
 $ component_times['get_sorted_editions'] = time()
 $ editions = work.get_sorted_editions()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3760, #4051, #4052, #4224

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Avoid an index error if not `page.works` and then create a work from an orphaned edition.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
