### PR TITLE
Create solr-updater docker service AGAIN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ dumps/
 openlibrary.egg-info/
 pip-log.txt
 supervisord.pid
-vendor/apache-solr-1.4.0/
-vendor/solr/
-solr-update.offset
 openlibrary/mailserver/logs/lamson.err
 openlibrary/mailserver/logs/lamson.log
 openlibrary/mailserver/logs/logger.log

--- a/docker-compose.infogami-local.yml
+++ b/docker-compose.infogami-local.yml
@@ -25,3 +25,8 @@ services:
       - INFOGAMI=local
     volumes:
       - ./vendor/infogami:/openlibrary/vendor/infogami
+  solr-updater:
+    environment:
+      - INFOGAMI=local
+    volumes:
+      - ./vendor/infogami:/openlibrary/vendor/infogami

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -108,6 +108,18 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+  solr-updater:
+    restart: always
+    hostname: "$HOSTNAME"
+    environment:
+      - OL_CONFIG=/olsystem/etc/openlibrary.yml
+      - PYENV_VERSION=3.8.6
+    volumes:
+      - ../olsystem:/olsystem
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
 
 secrets:
     petabox_seed:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,16 @@ services:
       - OL_CONFIG=conf/openlibrary.yml
       - PYENV_VERSION=${PYENV_VERSION:-}
     volumes:
-      - solr-updater.offset:/solr-updater.offset
+      # Persistent volume mount for installed git submodules
+      - ol-vendor:/openlibrary/vendor
+      # The above volume mounts is required so that the local dev bind mount below
+      # does not clobber the data generated inside the image / container
+      - .:/openlibrary
+      - solr-updater-data:/solr-updater-data
+    networks:
+      - webnet
+      - dbnet
+
   memcached:
     image: memcached
     networks:
@@ -156,7 +165,7 @@ networks:
   dbnet:
 volumes:
   solr-data:
-  solr-updater.offset:
+  solr-updater-data:
   ol-vendor:
   ol-build:
   ol-nodemodules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,19 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+  solr-updater:
+    image: oldev:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
+    command: docker/ol-solr-updater-start.sh
+    restart: always
+    hostname: "$HOSTNAME"
+    environment:
+      - OL_CONFIG=conf/openlibrary.yml
+      - PYENV_VERSION=${PYENV_VERSION:-}
+    volumes:
+      - solr-updater.offset:/solr-updater.offset
   memcached:
     image: memcached
     networks:
@@ -143,6 +156,7 @@ networks:
   dbnet:
 volumes:
   solr-data:
+  solr-updater.offset:
   ol-vendor:
   ol-build:
   ol-nodemodules:

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -6,6 +6,10 @@ USER root
 # oldev runs coverstore using the same Docker image
 RUN mkdir -p /var/lib/coverstore \
     && chown openlibrary:openlibrary /var/lib/coverstore
+# In order to write to solr-updater's named volume, this needs to be
+# pre-created with the right permissions
+RUN mkdir -p /solr-updater-data \
+    && chown openlibrary:openlibrary /solr-updater-data
 
 USER openlibrary
 COPY requirements*.txt ./

--- a/docker/ol-home-start.sh
+++ b/docker/ol-home-start.sh
@@ -26,9 +26,3 @@ fi
 echo "Waiting for postgres..."
 until pg_isready --host db; do sleep 5; done
 make reindex-solr
-
-# solr updater
-python scripts/new-solr-updater.py \
-  -c $CONFIG \
-  --state-file solr-update.offset \
-  --ol-url http://web/

--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python --version
+python scripts/new-solr-updater.py \
+    -c $OL_CONFIG \
+    --state-file solr-update.offset \
+    --ol-url http://web/

--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -3,5 +3,5 @@
 python --version
 python scripts/new-solr-updater.py \
     -c $OL_CONFIG \
-    --state-file solr-update.offset \
+    --state-file /solr-updater-data/solr-update.offset \
     --ol-url http://web/


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4244 (which got in a bad git state and was closed)
Related to #4060

Borrows from https://github.com/internetarchive/olsystem/blob/master/etc/supervisor/conf.d/solr-updater.conf to build a Docker service that can be run from ol-home0 to execute solr-updater.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
