### PR TITLE
4289/feature/extend anti spam functionality to list pages

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -12,6 +12,7 @@ import six
 from openlibrary.core import formats, cache
 import openlibrary.core.helpers as h
 from openlibrary.utils import dateutil
+from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.worksearch import subjects
 
 
@@ -153,6 +154,9 @@ class lists_json(delegate.page):
             tags=data.get('tags', []),
             seeds=seeds
         )
+
+        if spamcheck.is_spam(lst):
+            raise self.forbidden()
 
         try:
             result = site.save(lst.dict(),

--- a/openlibrary/templates/lists/header.html
+++ b/openlibrary/templates/lists/header.html
@@ -61,6 +61,8 @@ $elif type == "/type/work":
 
 $elif type == "/type/user":
     $var title: $doc.displayname
+    $if days_since(doc.created) < 30:
+       $ putctx('robots', 'noindex')
     $:render_user()
 
 $else:

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -12,6 +12,8 @@ $if list.description:
 $var title: $list.name
 
 $putctx("description", meta_description)
+$if days_since(list.created) < 30:
+  $ putctx('robots', 'noindex')
 
 $add_metatag(property="twitter:card", content="summary")
 $add_metatag(property="twitter:site", content="@openlibrary")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4289 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
This does three things:
1. integrates the spamcheck library into the list creation process, returning a 403 if the change is identified as spam
2. adds the noindex meta tag into /people/.../lists pages for accounts <30 days old
3. adds the noindex meta tag to individual list pages (/people/.../lists/OLXXXL/YYY) for lists <30 days old (even if created by an account older than 30 days).

For the third item, the current approach would remove the incentive for spammers to create "sleeper" accounts and later start spamming lists, and it's not clear to me how much benefit there is to legitimate, older accounts to having new lists indexed within the first 30 days, so the cost of the current approach seemed small to me.  It should be trivial to change the third item to only add the meta tag for new lists created by **new** accounts, if that's preferred.  

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Search the page source for https://openlibrary.org/people/ScarTissue/lists (an account older than 30 days) for "noindex" and verify it is **not** there.
2. Repeat for https://openlibrary.org/people/nazlihatunnisa/lists (an account created today) and verify that "noindex" **is** in there.
3. Create a new list and repeat the search on that specific list's page and verify "noindex" **is** there (old account making a new list)
4. Repeat the search for https://openlibrary.org/people/ribbeck/lists/OL191326L/Credit (a list created today by an account created today) and verify it **is**  there.
5. Repeat for https://openlibrary.org/people/ScarTissue/lists/OL188936L/Test_Nov_2020 (a list created ~40 days ago) and verify it is *not* there.
6. Try creating a new list with a word from /admin/spamwords in either the description or title and confirm that the response is a 403 and the new list is **not** created.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
noindex being added to a new list created by an old account:
![image](https://user-images.githubusercontent.com/72705998/102448016-0c84f480-3fe6-11eb-89f1-5425fe0d674e.png)

200 with "foobaz" in the spamwords list but not anywhere in the new list:
![image](https://user-images.githubusercontent.com/72705998/102445679-e6a92100-3fe0-11eb-9d2e-23854b8eb527.png)

403 with "foobaz" in the name:
![image](https://user-images.githubusercontent.com/72705998/102445620-c2e5db00-3fe0-11eb-9c37-b1a91337f189.png)

403 with "foobaz" in the description:
![image](https://user-images.githubusercontent.com/72705998/102445647-d6914180-3fe0-11eb-987f-cc9296c07332.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini @cclauss 
