### PR TITLE
Replace simplejson with python json in openlibrary/solr package for 2308

### DIFF
--- a/openlibrary/solr/db_load_authors.py
+++ b/openlibrary/solr/db_load_authors.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import simplejson as json
+import json
 import web
 import re
 

--- a/openlibrary/solr/db_load_works.py
+++ b/openlibrary/solr/db_load_works.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import web
 import re
-import simplejson as json
+import json
 
 db = web.database(dbn='mysql', user='root', passwd='', db='openlibrary')
 db.printing = False

--- a/openlibrary/solr/process_stats.py
+++ b/openlibrary/solr/process_stats.py
@@ -15,7 +15,7 @@ How to run:
 from __future__ import print_function
 import sys
 import web
-import simplejson
+import json
 import logging
 
 from infogami import config
@@ -180,7 +180,7 @@ def process(data):
 
 def read_events():
     for line in sys.stdin:
-        doc = simplejson.loads(line.strip())
+        doc = json.loads(line.strip())
         yield doc
 
 def read_events_from_db(keys=None, day=None):
@@ -193,7 +193,7 @@ def read_events_from_db(keys=None, day=None):
         last_updated = LoanStats().get_last_updated()
         result = get_db().query("SELECT key, json FROM stats WHERE updated > $last_updated ORDER BY updated limit 10000", vars=locals())
     for row in result.list():
-        doc = simplejson.loads(row.json)
+        doc = json.loads(row.json)
         doc['key'] = row.key
         yield doc
 
@@ -233,7 +233,7 @@ def main(*args):
         for e in docs:
             try:
                 result = process(e['doc'])
-                print(simplejson.dumps(result))
+                print(json.dumps(result))
             except Exception:
                 logger.error("Failed to process %s", e['doc']['_id'], exc_info=True)
 

--- a/openlibrary/solr/read_dump.py
+++ b/openlibrary/solr/read_dump.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import re
-import simplejson as json
+import json
 import sys
 from time import time
 import web

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -9,7 +9,7 @@ import time
 from collections import defaultdict
 from unicodedata import normalize
 
-import simplejson as json
+import json
 import six
 from six.moves.http_client import HTTPConnection
 import web


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #2308

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
Refactor to replace simplejson with python json in openlibrary/solr package.  In most cases `simplejson` was being imported as `json` anyway.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Unit tests pass.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 