### PR TITLE
update login referer check to prevent redir to IA

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -307,7 +307,7 @@ class account_login(delegate.page):
     def GET(self):
         referer = web.ctx.env.get('HTTP_REFERER', '/')
         # Don't set referer on user activation
-        if '//archive.org/account/verify.php' in referer:
+        if 'archive.org' in referer:
             referer = None
         i = web.input(redirect=referer)
         f = forms.Login()


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Closes #4277

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

when a patron registers an account, they click an email to activate on Archive.org. Once activated, archive.org provides a link to login on Open Library. But Open Library is checking/setting the referrer incorrectly so that on OL login, the patron was being redirected back to IA (bad experience). This change-set updates the referrer check to prevent redir back to archive.org on login. 

### Technical
<!-- What should be noted about the implementation? -->

The only case I can imagine this breaking is for borrows where patron is logging in to OL to then access some IA borrow/read link through OL, but I don't think such an exact case exists and unblocking creation / login flow is paramount to patron's experience.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Create an account on production and login (should be brought to OL)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @cdrini @cclauss @bfalling 