### PR TITLE
Keep trimmed logs inside Docker for web, covers, infobase, and home

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -48,6 +48,10 @@ services:
       - 443:443
     networks:
       - webnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
     secrets:
       - petabox_seed
       # Needed by default-docker.conf
@@ -100,6 +104,11 @@ services:
       -  .:/openlibrary
     networks:
       - webnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
+
 secrets:
     petabox_seed:
       file: /opt/.petabox/seed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,10 @@ services:
     networks:
       - webnet
       - dbnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
   solr:
     image: olsolr:latest
     build:
@@ -84,6 +88,10 @@ services:
     networks:
       - webnet
       - dbnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
   infobase:
     image: oldev:latest
     environment:
@@ -105,6 +113,10 @@ services:
     networks:
       - webnet
       - dbnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
   home:
     image: oldev:latest
     environment:
@@ -122,6 +134,10 @@ services:
     networks:
       - webnet
       - dbnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
 networks:
   webnet:
   dbnet:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4327 #4326

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Repeat the error logging approach used for `solr` on the services web, covers, infobase, and home.  This keeps the error logs inside the Docker containers and limits their maximum size to 512M and their maximum number of files to four.

`infobase` production is a bit of a question because it contains:
```
    volumes:
      - infobase-writelog:/1/var/lib/openlibrary/infobase/log
      - infobase-errorlog:/1/var/log/openlibrary/infobase-errors
```

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
