### PR TITLE
Fixed 1 Hour Borrow Audio button flicker

### DIFF
--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -146,7 +146,7 @@ table#editions,
 
     div.title {
       float: left;
-      width: 350px;
+      width: 75%;
     }
 
     div.cover {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4342 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixed 1-hour button flicker.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ol sol](https://user-images.githubusercontent.com/64412143/103438220-e2266e80-4c56-11eb-9de0-0c178909fa2e.JPG)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
