### PR TITLE
UserList underneath WantToAdd Button #3630

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -181,27 +181,6 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                     <button class="nostyle-btn" type="submit">$_('Already Read')</button>
                   </form>
               </div>
-
-              $if not readinglogonly:
-                <div class="reading-lists">
-                  <p class="reading-list-title">$_('My Reading Lists:')</p>
-                  <div class="my-lists">
-                    $:render_my_lists(lists)
-                  </div>
-                  $if edition_key:
-                      <p class="create checkboxes">
-                        <label>
-                           <input type="checkbox" class="work-checkbox"
-                              $if use_work:
-                                checked
-                           /> <span>$_('Use this Work')</span>
-                        </label>
-                      </p>
-                  <p class="create"><a href="javascript:;" class="create-new-list">$_('Create a new list')</a>
-                    <a aria-controls="addList"
-                      class="hidden listClick dialog--open"></a>
-                  </p>
-                </div>
             </div>
           $else:
               $if username:
@@ -226,6 +205,26 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 </a>
       </div>
     </div>
+      $if work_key and not readinglogonly:
+        <div class="my-reading-lists">
+          <p class="reading-list-title">$_('My Reading Lists:')</p>
+          <div class="my-lists">
+            $:render_my_lists(lists)
+          </div>
+          $if edition_key:
+              <p class="create checkboxes">
+                <label>
+                   <input type="checkbox" class="work-checkbox"
+                      $if use_work:
+                        checked
+                   /> <span>$_('Use this Work')</span>
+                </label>
+              </p>
+          <p class="create"><a href="javascript:;" class="create-new-list">$_('Create a new list')</a>
+            <a aria-controls="addList"
+              class="hidden listClick dialog--open"></a>
+          </p>
+        </div>
 
 $jsdef render_widget_display(lists, limit, user_key):
     $for i, list in enumerate(lists):

--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -69,6 +69,51 @@
   }
 }
 
+.my-reading-lists {   
+    p {
+        font-size: .875em;
+        margin: 0 0 5px;
+        color: @grey;
+        a {
+          font-size: .875em;
+        }
+        span {
+          font-size: .8125em;
+        }
+      }
+    p.create {
+      border-top: 1px solid @lightest-grey;
+      padding: 5px 10px;
+      text-decoration: none;
+      font-weight: bold;
+    }
+    .reading-list-title {
+      padding: 5px 0 0 10px;
+      margin: 0;
+      font-size: .8em;
+      color: #666;
+    }
+    .my-lists {
+      background: @white;
+      max-height: 250px;
+      overflow-y: auto;
+      padding: 10px 15px;
+      p.create a {
+      color: @dark-grey;
+      text-decoration: none;
+    }
+      .list {
+      margin: 0;
+      font-size: 0.8em;
+      }
+      // stylelint-disable-next-line max-nesting-depth
+      p a {
+	display: block;
+      }
+      /* stylelint-enable selector-max-specificity */
+    }
+}op
+
 /* stylelint-disable selector-max-specificity */
 div#subjectLists {
   div.dropit {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3630 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
[In /openlibrary/templates/lists/widget.html] div.reading-lists container brought outside of div.dropdown. This made container outside of the fold i.e. underneath want-to-add button. Also, className of div.reading-lists changed to my-reading-lists so that formatting because of dropper can be removed and other useful formatting is retained by adding the code in [/static/css/components/dropper.less]
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
make css
docker-compose up
Click on a book to open its details, changes can be seen underneath Want to Read Button.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before.
![Screenshot from 2021-01-06 02-50-17](https://user-images.githubusercontent.com/62632865/103702985-d2978480-4fcc-11eb-80a8-421944468b6a.png)

After.
![Screenshot from 2021-01-06 02-50-02](https://user-images.githubusercontent.com/62632865/103702599-b85da680-4fcc-11eb-91c6-79057da18ebd.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 