### PR TITLE
Userlist Brought under Want To Read Button #3630

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -207,7 +207,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
     </div>
 	  $if work_key and not readinglogonly:
 		<div class="reading-lists">
-		  <p class="reading-list-title">$_('My Reading Lists:')</p>
+		  <p class="reading-list-title">$_('Add to existing list:')</p>
 		  <div class="my-lists">
 		    $:render_my_lists(lists)
 		  </div>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -181,27 +181,6 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                     <button class="nostyle-btn" type="submit">$_('Already Read')</button>
                   </form>
               </div>
-
-              $if not readinglogonly:
-                <div class="reading-lists">
-                  <p class="reading-list-title">$_('My Reading Lists:')</p>
-                  <div class="my-lists">
-                    $:render_my_lists(lists)
-                  </div>
-                  $if edition_key:
-                      <p class="create checkboxes">
-                        <label>
-                           <input type="checkbox" class="work-checkbox"
-                              $if use_work:
-                                checked
-                           /> <span>$_('Use this Work')</span>
-                        </label>
-                      </p>
-                  <p class="create"><a href="javascript:;" class="create-new-list">$_('Create a new list')</a>
-                    <a aria-controls="addList"
-                      class="hidden listClick dialog--open"></a>
-                  </p>
-                </div>
             </div>
           $else:
               $if username:
@@ -226,6 +205,26 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 </a>
       </div>
     </div>
+	  $if work_key and not readinglogonly:
+		<div class="reading-lists">
+		  <p class="reading-list-title">$_('My Reading Lists:')</p>
+		  <div class="my-lists">
+		    $:render_my_lists(lists)
+		  </div>
+		  $if edition_key:
+		      <p class="create checkboxes">
+		        <label>
+		           <input type="checkbox" class="work-checkbox"
+		              $if use_work:
+		                checked
+		           /> <span>$_('Use this Work')</span>
+		        </label>
+		      </p>
+		  <p class="create"><a href="javascript:;" class="create-new-list">$_('Create a new list')</a>
+		    <a aria-controls="addList"
+		      class="hidden listClick dialog--open"></a>
+		  </p>
+		</div>  
 
 $jsdef render_widget_display(lists, limit, user_key):
     $for i, list in enumerate(lists):

--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -42,31 +42,6 @@
     }
     /* stylelint-enable selector-max-specificity */
   }
-  .dropdown {
-    /* stylelint-disable selector-max-specificity */
-    p.create a {
-      color: @dark-grey;
-      text-decoration: none;
-    }
-    .reading-lists .reading-list-title {
-      background: @white;
-      padding: 5px 0 0 10px;
-      margin: 0;
-      font-size: .8em;
-    }
-    .my-lists {
-      background: @white;
-      max-height: 250px;
-      overflow-y: auto;
-      padding: 10px 15px;
-
-      // stylelint-disable-next-line max-nesting-depth
-      p a {
-        display: block;
-      }
-      /* stylelint-enable selector-max-specificity */
-    }
-  }
 }
 
 /* stylelint-disable selector-max-specificity */
@@ -124,14 +99,6 @@ div#subjectLists {
 }
 
 .widget-add {
-  div.dropper {
-    div.dropdown p.create {
-      border-top: 1px solid @lightest-grey;
-      padding: 5px 10px;
-      text-decoration: none;
-      font-weight: bold;
-    }
-  }
   &.old-style-lists {
     div.dropper {
       margin: 0;

--- a/static/css/components/reading-lists.less
+++ b/static/css/components/reading-lists.less
@@ -1,49 +1,49 @@
-.reading-lists {   
-      display: none;
-    p {
-        font-size: .875em;
-        margin: 0 0 5px;
-        color: @grey;
-        a {
-          font-size: .875em;
-        }
-        span {
-          font-size: .8125em;
-        }
-      }
-    p.create {
-      border-top: 1px solid @lightest-grey;
-      padding: 5px 10px;
-      text-decoration: none;
-      font-weight: bold;
+.reading-lists {
+  display: none;
+  p {
+    font-size: .875em;
+    margin: 0 0 5px;
+    color: @grey;
+    a {
+      font-size: .875em;
     }
-    /* stylelint-disable selector-max-specificity */
-    p.create a {
-      color: @dark-grey;
-      text-decoration: none;
+    span {
+      font-size: .8125em;
     }
-    .reading-list-title {
-      padding: 5px 0 0 10px;
+  }
+  p.create {
+    border-top: 1px solid @lightest-grey;
+    padding: 5px 10px;
+    text-decoration: none;
+    font-weight: bold;
+  }
+  /* stylelint-disable selector-max-specificity */
+  p.create a {
+    color: @dark-grey;
+    text-decoration: none;
+  }
+  .reading-list-title {
+    padding: 5px 0 0 10px;
+    margin: 0;
+    font-size: .8em;
+    color: @grey;
+  }
+  .my-lists {
+    background: @white;
+    max-height: 250px;
+    overflow-y: auto;
+    padding: 10px 15px;
+    .list {
       margin: 0;
       font-size: .8em;
-      color: #666;
     }
-    .my-lists {
-      background: @white;
-      max-height: 250px;
-      overflow-y: auto;
-      padding: 10px 15px;
-      .list {
-      margin: 0;
-      font-size: 0.8em;
-      }
-      // stylelint-disable-next-line max-nesting-depth
-      p a {
-	display: block;
-      }
+    // stylelint-disable-next-line max-nesting-depth
+    p a {
+      display: block;
     }
+  }
 }
 
-.client-js .reading-lists {   
-         display: block;
-      }
+.client-js .reading-lists {
+  display: block;
+}

--- a/static/css/components/reading-lists.less
+++ b/static/css/components/reading-lists.less
@@ -1,0 +1,49 @@
+.reading-lists {   
+      display: none;
+    p {
+        font-size: .875em;
+        margin: 0 0 5px;
+        color: @grey;
+        a {
+          font-size: .875em;
+        }
+        span {
+          font-size: .8125em;
+        }
+      }
+    p.create {
+      border-top: 1px solid @lightest-grey;
+      padding: 5px 10px;
+      text-decoration: none;
+      font-weight: bold;
+    }
+    /* stylelint-disable selector-max-specificity */
+    p.create a {
+      color: @dark-grey;
+      text-decoration: none;
+    }
+    .reading-list-title {
+      padding: 5px 0 0 10px;
+      margin: 0;
+      font-size: .8em;
+      color: #666;
+    }
+    .my-lists {
+      background: @white;
+      max-height: 250px;
+      overflow-y: auto;
+      padding: 10px 15px;
+      .list {
+      margin: 0;
+      font-size: 0.8em;
+      }
+      // stylelint-disable-next-line max-nesting-depth
+      p a {
+	display: block;
+      }
+    }
+}
+
+.client-js .reading-lists {   
+         display: block;
+      }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -24,6 +24,7 @@
 @import (less) "components/illustration.less";
 @import (less) "components/rating-form.less";
 @import (less) "components/dropper.less";
+@import (less) "components/reading-lists.less";
 @import (less) "components/listLists.less";
 
 // Center (editionAbout)

--- a/static/css/page-subject.less
+++ b/static/css/page-subject.less
@@ -16,5 +16,6 @@
 @import (less) "components/link-box.less";
 @import (less) "components/widget-box.less";
 @import (less) "components/dropper.less";
+@import (less) "components/reading-lists.less";
 @import (less) "components/listLists.less";
 @import (less) "components/footer.less";


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3630 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
In [widget.html], div.reading-lists is moved out of div.dropper. This brought the User's list out of the fold and underneath the WantToRead Button. To remove formatting due to .dropper, the class name is changed to my-reading-lists. And further codes are added in dropper.less
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
make css
docker-compose up
Go to [http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain](http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain). Changes can be seen underneath Want to Read.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before.
![Screenshot from 2021-01-06 02-50-17](https://user-images.githubusercontent.com/62632865/103705611-5a7f8d80-4fd1-11eb-8a53-72b3d580d530.png)

After.
![Screenshot from 2021-01-06 02-50-02](https://user-images.githubusercontent.com/62632865/103705623-5f444180-4fd1-11eb-923b-7f6cf62c85a3.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 