### PR TITLE
Round off rating star to nearest integer instead of lower integer

### DIFF
--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -6,7 +6,7 @@ $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 <ul class="readers-stats" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
   <li class="avg-ratings">
     $if rating_stats.get('avg_rating'):
-      $:('<span class="readers-stats__star">★</span>' * int(rating_stats.get('avg_rating'))) <span itemprop="ratingValue">$(rating_stats['avg_rating'])</span>
+      $:('<span class="readers-stats__star">★</span>' * int((int(2 * float(rating_stats.get('avg_rating')))) - (int(rating_stats.get('avg_rating'))))) <span itemprop="ratingValue">$(rating_stats['avg_rating'])</span>
   </li>
   <li>
     <span itemprop="reviewCount">$rating_stats.get('num_ratings', 0)</span> $_("Ratings")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4371 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Rating Stats print stars after rounding off to the lower integer, so even rating like 3.99, 3.84 print 3★. 
Now rating like 3.0-3.49 will print 3★ , and 3.5-3.99 will print 4★

### Screenshot
Problem:
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ol](https://user-images.githubusercontent.com/64412143/103731116-6a679380-500a-11eb-81ab-13202fec35ac.PNG)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jamesachamp 