### PR TITLE
standardizes call to action as "borrow"

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -52,7 +52,7 @@ $elif availability.get('is_lendable'):
   $if availability.get('available_to_borrow'):
     $:macros.ReadButton(ocaid, borrow=True, listen=listen)
   $elif availability.get('available_to_browse'):
-    $:macros.ReadButton(ocaid, borrow=True, listen=listen, label=_('1 Hour Borrow'))
+    $:macros.ReadButton(ocaid, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
     $ wlsize = availability.get('users_on_waitlist') or availability.get('num_waitlist')
     $if waiting_loan:


### PR DESCRIPTION
Closes #4360 which standardizes all borrow calls to action as "Borrow" rather than e.g. 1h since all borrows now originate as 1 hour.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Within the PR, the code block logic for available_to_browse and available_to_borrow not merged in case we do want different copy in the future.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![openlibrary org_books_OL362125M_Rainbow_Six](https://user-images.githubusercontent.com/978325/103873144-35982280-5084-11eb-8334-2b5060e8e076.png)
![dev openlibrary org_books_OL362125M_Rainbow_Six](https://user-images.githubusercontent.com/978325/103873146-36c94f80-5084-11eb-9ae8-20100e4aa8bf.png)
![dev openlibrary org_ (2)](https://user-images.githubusercontent.com/978325/103873151-39c44000-5084-11eb-9514-196ee1d11670.png)
![dev openlibrary org_search_q=stellaluna mode=everything](https://user-images.githubusercontent.com/978325/103873156-3c269a00-5084-11eb-9fd7-e0c69049fb53.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @bfalling @brewsterkahle 