### PR TITLE
Replace urllib with requests for 2852 in openlibrary/accounts/model s…

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -22,8 +22,6 @@ from infogami.infobase.client import ClientException
 
 from openlibrary.core import stats, helpers
 
-from six.moves import urllib
-
 logger = logging.getLogger("openlibrary.account.model")
 
 def append_random_suffix(text, limit=9999):
@@ -597,19 +595,17 @@ class InternetArchiveAccount(web.storage):
         from openlibrary.core import lending
         url = lending.config_ia_s3_auth_url
         try:
-            req = urllib.request.Request(url, headers={
+            response = requests.get(url, headers={
                 'Content-Type': 'application/json',
                 'authorization': 'LOW %s:%s' % (access_key, secret_key)
             })
-            f = urllib.request.urlopen(req)
-            response = f.read()
-            f.close()
-        except urllib.error.HTTPError as e:
-            try:
-                response = e.read()
-            except simplejson.decoder.JSONDecodeError:
-                return {'error': e.read(), 'code': e.code}
-        return simplejson.loads(response)
+            if not response.ok:
+                response.raise_for_status()
+            return response.json()
+        except requests.HTTPError as e:
+            return {'error': e.response.text, 'code': e.response.status_code}
+        except simplejson.errors.JSONDecodeError as e:
+            return {'error': e.message, 'code': response.status_code}
 
     @classmethod
     def get(cls, email, test=False, _json=False, s3_key=None, s3_secret=None, xauth_url=None):

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -599,8 +599,7 @@ class InternetArchiveAccount(web.storage):
                 'Content-Type': 'application/json',
                 'authorization': 'LOW %s:%s' % (access_key, secret_key)
             })
-            if not response.ok:
-                response.raise_for_status()
+            response.raise_for_status()
             return response.json()
         except requests.HTTPError as e:
             return {'error': e.response.text, 'code': e.response.status_code}


### PR DESCRIPTION
Replace urllib with requests for 2852 in openlibrary/accounts/model s3auth

<!-- What issue does this PR close? -->
Addresses #2852

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor to replace `urllib.openurl` with `requests.get`

### Technical
<!-- What should be noted about the implementation? -->
This is in the `s3auth` function, which should return a python object from the json returned.  I wasn't able to test the success case because I do not have aws keys so I don't really know what the endpoint will return.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
There isn't a unittest for this function, but if you do the following with working aws keys you should see it work.
```python
from openlibrary.core import lending
lending.config_ia_s3_auth_url = 'http://insert_real_url_here'
from openlibrary.accounts import model
resp = model.InternetArchiveAccount.s3auth('key here','secret here')
```


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
