### PR TITLE
Move from urllib to requests in openlibrary/catalog/get_ia.py

### DIFF
--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -97,12 +97,12 @@ def files(identifier):
     url = item_file_url(identifier, 'files.xml')
     for i in range(5):
         try:
-            tree = etree.parse(urlopen_keep_trying(url))
+            tree = etree.fromstring(urlopen_keep_trying(url))
             break
         except xml.parsers.expat.ExpatError:
             sleep(2)
     try:
-        tree = etree.parse(urlopen_keep_trying(url))
+        tree = etree.fromstring(urlopen_keep_trying(url))
     except:
         print("error reading", url)
         raise

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -79,7 +79,7 @@ def get_marc_record_from_ia(identifier):
 
     # If that fails, try marc.bin
     if marc_bin_filename in filenames:
-        data = urlopen_keep_trying(item_base + marc_bin_filename).text
+        data = urlopen_keep_trying(item_base + marc_bin_filename).content
         return MarcBinary(data)
 
 

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -27,11 +27,11 @@ class NoMARCXML(IOError):
 
 
 # TODO: there are few other modules that call this, refactor to rename later to request_keep_trying
-def urlopen_keep_trying(url, headers=None):
+def urlopen_keep_trying(url, headers=None, **kwargs):
     """Tries to request the url three times, raises HTTPError if 403, 404, or 416.  Returns a requests.Response"""
     for i in range(3):
         try:
-            resp = requests.get(url, headers=headers)
+            resp = requests.get(url, headers=headers, **kwargs)
             resp.raise_for_status()
             return resp
         except requests.HTTPError as error:
@@ -155,10 +155,10 @@ def get_from_archive_bulk(locator):
 
     assert 0 < length < MAX_MARC_LENGTH
 
-    f = urlopen_keep_trying(url, headers={'Range': 'bytes=%d-%d' % (r0, r1)})
+    f = urlopen_keep_trying(url, headers={'Range': 'bytes=%d-%d' % (r0, r1)}, stream=True)
     data = None
     if f:
-        data = f.read(MAX_MARC_LENGTH)
+        data = f.raw.read(MAX_MARC_LENGTH)
         len_in_rec = int(data[:5])
         if len_in_rec != length:
             data, next_offset, next_length = get_from_archive_bulk('%s:%d:%d' % (filename, offset, len_in_rec))

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -155,7 +155,7 @@ def get_from_archive_bulk(locator):
 
     assert 0 < length < MAX_MARC_LENGTH
 
-    f = urlopen_keep_trying(url, {'Range': 'bytes=%d-%d' % (r0, r1)})
+    f = urlopen_keep_trying(url, headers={'Range': 'bytes=%d-%d' % (r0, r1)})
     data = None
     if f:
         data = f.read(MAX_MARC_LENGTH)

--- a/openlibrary/catalog/marc/marc_subject.py
+++ b/openlibrary/catalog/marc/marc_subject.py
@@ -54,7 +54,7 @@ archive_url = "http://archive.org/download/"
 def load_binary(ia):
     url = archive_url + ia + '/' + ia + '_meta.mrc'
     f = urlopen_keep_trying(url)
-    data = f.read()
+    data = f.text
     assert '<title>Internet Archive: Page Not Found</title>' not in data[:200]
     if len(data) != int(data[:5]):
         data = data.decode('utf-8').encode('raw_unicode_escape')
@@ -67,7 +67,7 @@ def load_binary(ia):
 def load_xml(ia):
     url = archive_url + ia + '/' + ia + '_marc.xml'
     f = urlopen_keep_trying(url)
-    root = etree.parse(f).getroot()
+    root = etree.fromstring(f.text).getroot()
     if root.tag == '{http://www.loc.gov/MARC21/slim}collection':
         root = root[0]
     return MarcXml(root)

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -6,6 +6,14 @@ from openlibrary.core import ia
 from openlibrary.catalog.marc.marc_xml import MarcXml
 from openlibrary.catalog.marc.marc_binary import MarcBinary, BadLength, BadMARC
 
+
+class MockResponse:
+    """MockResponse is used to pass the file back as a string instead of a file object.  This is because
+    this code was moved from urllib to requests."""
+    def __init__(self, text):
+        self.text = text
+
+
 def return_test_marc_bin(url):
     assert url, "return_test_marc_bin({})".format(url)
     return return_test_marc_data(url, "bin_input")
@@ -18,7 +26,7 @@ def return_test_marc_data(url, test_data_subdir="xml_input"):
     filename = url.split('/')[-1]
     test_data_dir = "/../../catalog/marc/tests/test_data/%s/" % test_data_subdir
     path = os.path.dirname(__file__) + test_data_dir + filename
-    return open(path, mode='rb')
+    return MockResponse(open(path, mode='rb').read())
 
 class TestGetIA():
     bad_marcs = ['dasrmischepriv00rein',  # binary representation of unicode interpreted as unicode codepoints

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -10,8 +10,9 @@ from openlibrary.catalog.marc.marc_binary import MarcBinary, BadLength, BadMARC
 class MockResponse:
     """MockResponse is used to pass the file back as a string instead of a file object.  This is because
     this code was moved from urllib to requests."""
-    def __init__(self, text):
-        self.text = text
+    def __init__(self, data):
+        self.text = data
+        self.content = data
 
 
 def return_test_marc_bin(url):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #2852

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor `openlibrary/catalog/get_ia.py` from using urllib to requests.  

### Technical
<!-- What should be noted about the implementation? -->
urllib returns a file type object from urlopen - but requests does not.  So I had to add an additional mock request object in the marc tests which reference some files.  

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
There are unittests for most of the calls to this.  

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
