### PR TITLE
Fix our currently invalid Python GitHub Action

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: 3.8  # [3.8, 3.9]
+        python-version: [3.8, 3.9]
     runs-on: ubuntu-16.04  # Should match Dockerfile.olbase
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes [` The workflow is not valid. .github/workflows/python_tests.yml (Line: 12, Col: 25): Unexpected value '3.8' `](https://github.com/internetarchive/openlibrary/actions/runs/475086987) caused by #4385

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
