### PR TITLE
Improve Amazon error detection

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -272,10 +272,13 @@ def _get_amazon_metadata(id_, id_type='isbn', resources=None):
 
     try:
         r = requests.get('http://%s/isbn/%s' % (affiliate_server_url, id_))
+        r.raise_for_status()
         return r.json().get('hit') or None
     except requests.exceptions.ConnectionError:
         logger.exception("Affiliate Server unreachable")
-        return None
+    except requests.exceptions.HTTPError:
+        logger.exception("Affiliate Server: id {} not found".format(id_))
+    return None
 
 
 def split_amazon_title(full_title):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

As reported by @seabelis [on Slack](https://internetarchive.slack.com/archives/C0ETZV72L/p1610379841273300)
Any idea what might cause this error?
```
/openlibrary/openlibrary/templates/type/edition/view.html: error in processing template:
    JSONDecodeError: Expecting value: line 1 column 1 (char 0) (falling back to default template)
```
https://openlibrary.org/books/OL31849729M/Lolita
Open LibraryOpen Library
Lolita (2016-10-13 edition) | Open Library
Lolita by Vladimir Nabokov, 2016-10-13, Anagrama edition, Hardcover in Spanish / español (59 kB)
https://covers.openlibrary.org/b/id/10540617-L.jpg

cclauss
https://openlibrary.org/books/OL31849729M/Lolita?debug=true indicates that we got a Response [404] when querying Amazon.
```
/openlibrary/openlibrary/core/vendors.py in _get_amazon_metadata
            return r.json().get('hit') or None 

Variable  | Value
--        | --
id_       | None
id_type   | 'isbn'
r         | <Response [404]>
resources | None
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR uses [`requests.Response.raise_for_status()`](https://requests.readthedocs.io/en/master/api/#requests.Response.raise_for_status) to detect and log any HTTPErrors.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
https://openlibrary.org/books/OL31849729M/Lolita?debug=true

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
