### PR TITLE
Allow dashes when entering isbn

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -732,8 +732,8 @@ $if ctx.user:
                 if (data.name == "isbn_10" && data.value.length != 10) {
                     return error("#id-errors", "id-value", "$_('ID must be exactly 10 characters [0-9] or X.')".replace(/ID/, label));
                 }
-                if (data.name == "isbn_13" && data.value.length != 13) {
-                    return error("#id-errors", "id-value", "$_('ID must be exactly 13 digits [0-9].')".replace(/ID/, label));
+                if (data.name == "isbn_13" && data.value.replace(/-/g,'').length != 13) {
+                    return error("#id-errors", "id-value", "$_('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4')".replace(/ID/, label));
                 }
                 \$("id-errors").hide();
                 return true;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4343 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Earlier in the books edit page, when entering ISBN 13, the validation function checked for 13 digits, but as per ISBN 13 standards, '-' dashes are also allowed. So, this PR fixes this problem.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![isbn](https://user-images.githubusercontent.com/53360510/104221822-77034600-5467-11eb-86b5-42bae7246700.png)
![isbnw](https://user-images.githubusercontent.com/53360510/104221840-7d91bd80-5467-11eb-9d98-28e91c082d42.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@serv @cclauss 