### PR TITLE
Restore showmarc actions

### DIFF
--- a/openlibrary/code.py
+++ b/openlibrary/code.py
@@ -32,6 +32,9 @@ def setup():
 
     load_views()
 
+    # load actions
+    from . import actions
+    
     logger.info("loading complete.")
 
 def setup_logging():
@@ -48,5 +51,7 @@ def setup_logging():
 def load_views():
     """Registers all views by loading all view modules.
     """
+    from .views import showmarc
+    from .views import loanstats
 
 setup()


### PR DESCRIPTION
Hotfix. Blocking the deploy. This was removed in a recent PR (cc @jdlrobson ), but caused the marc endpoint (e.g. https://openlibrary.org/show-records/marc_loc_2016/BooksAll.2016.part41.utf8:32007375:748 ) to stop working. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jdlrobson 