### PR TITLE
Use checkbox hack for the hamburger menu

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -2,7 +2,10 @@ $def with (page)
 
 <header id="header-bar" class="header-bar">
   <div class="hamburger-component">
-    <button type="button" class="hamburger-button"><img src="/static/images/menu.png" alt="additional options menu"/></button>
+    <label for="toggle">
+      <button type="button" class="hamburger-button"><img src="/static/images/menu.png" alt="additional options menu"/></button>
+    </label>
+    <input type="checkbox" id="toggle">
     <div class="hamburger-dropdown-component navigation-dropdown-component">
       <ul class="dropdown-menu hamburger-dropdown-menu">
         $if not ctx.user:

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -2,10 +2,12 @@ $def with (page)
 
 <header id="header-bar" class="header-bar">
   <div class="hamburger-component">
-    <label for="toggle">
-      <button type="button" class="hamburger-button"><img src="/static/images/menu.png" alt="additional options menu"/></button>
+
+    <label role="button" for="toggle-hamburger" class="hamburger-button">
+      <img src="/static/images/menu.png" alt="additional options menu"/>
     </label>
-    <input type="checkbox" id="toggle">
+
+    <input type="checkbox" class="hamburger-component__checkbox" id="toggle-hamburger">
     <div class="hamburger-dropdown-component navigation-dropdown-component">
       <ul class="dropdown-menu hamburger-dropdown-menu">
         $if not ctx.user:
@@ -63,8 +65,7 @@ $def with (page)
 
   <ul class="navigation-component">
     <li class="browse-menu">
-      <a>$_('Browse') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
+      <a>$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -134,7 +134,7 @@
     order: 0;
     margin-right: 5px;
 
-    button {
+    label {
       background: transparent;
       border: none;
       cursor: pointer;
@@ -146,13 +146,16 @@
       padding: 0 3px;
     }
 
-
-    #toggle {
+    .hamburger-component__checkbox {
       opacity: 0;
-    }
+      
+      & ~ .hamburger-dropdown-component ul {
+        display: none;
+      }
 
-    #toggle:checked ~ .hamburger-dropdown-component ul {
-      display: block;
+      &:checked ~ .hamburger-dropdown-component ul {
+        display: block;
+      }
     }
   }
 
@@ -466,10 +469,10 @@
 
 .logo-component {
   margin: 0 0 5px;
-  img,
-  a {
-    display: block;
-  }
+  // img,
+  // a {
+  //   display: block;
+  // }
   a {
     color: @black;
     text-decoration: none !important;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -145,17 +145,17 @@
       height: 44px;
       padding: 0 3px;
     }
+  }
 
-    .hamburger-component__checkbox {
-      opacity: 0;
-      
-      & ~ .hamburger-dropdown-component ul {
-        display: none;
-      }
+  .hamburger-component__checkbox {
+    opacity: 0;
+    
+    & ~ .hamburger-dropdown-component ul {
+      display: none;
+    }
 
-      &:checked ~ .hamburger-dropdown-component ul {
-        display: block;
-      }
+    &:checked ~ .hamburger-dropdown-component ul {
+      display: block;
     }
   }
 
@@ -469,10 +469,7 @@
 
 .logo-component {
   margin: 0 0 5px;
-  // img,
-  // a {
-  //   display: block;
-  // }
+
   a {
     color: @black;
     text-decoration: none !important;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -417,6 +417,7 @@
     display: none;
   }
 
+  // stylelint-disable-next-line selector-max-specificity 
   &:checked ~ .hamburger-dropdown-component ul {
     display: block;
   }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -147,18 +147,6 @@
     }
   }
 
-  .hamburger-component__checkbox {
-    opacity: 0;
-    
-    & ~ .hamburger-dropdown-component ul {
-      display: none;
-    }
-
-    &:checked ~ .hamburger-dropdown-component ul {
-      display: block;
-    }
-  }
-
   .logo-component {
     -webkit-box-flex: 1;
     -ms-flex: 1;
@@ -419,6 +407,18 @@
         border-top: 4px solid currentColor;
       }
     }
+  }
+}
+
+.hamburger-component__checkbox {
+  opacity: 0;
+  
+  & ~ .hamburger-dropdown-component ul {
+    display: none;
+  }
+
+  &:checked ~ .hamburger-dropdown-component ul {
+    display: block;
   }
 }
 

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -145,6 +145,15 @@
       height: 44px;
       padding: 0 3px;
     }
+
+
+    #toggle {
+      opacity: 0;
+    }
+
+    #toggle:checked ~ .hamburger-dropdown-component ul {
+      display: block;
+    }
   }
 
   .logo-component {


### PR DESCRIPTION
### Issue number
Closes #4200

### What does this PR achieve? 
Fix

### Technical
<!-- What should be noted about the implementation? -->
I have tried using the [checkbox hack](https://css-tricks.com/the-checkbox-hack/) to fix the mobile hamburger issue. But it is not yet working as expected. The checkbox added to the [HTML file](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/lib/nav_head.html) and modified with the [CSS file](https://github.com/internetarchive/openlibrary/blob/master/static/css/components/header-bar.less) works as expected, but while inspecting the hamburger in the browser, its properties do not seem to change on trying to close it.  

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open openlibrary in development mode
2. Open the developer console and toggle to mobile view
3. Click on the "3-lines button" to open the menu
4. Click on it again to close it

 -  **Expected**: Step 4 should close the hamburger menu.
 - **Actual**: It doesn't do anything yet.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
I am attaching a screen-cast of what is happening at the moment. Help would be appreciated.

https://user-images.githubusercontent.com/52366674/104266344-772a3280-54b5-11eb-87ab-78cf703727ae.mp4

 

