### PR TITLE
Replace urllib.urlopen with requests in loanstats.py for 2852

### DIFF
--- a/openlibrary/core/loanstats.py
+++ b/openlibrary/core/loanstats.py
@@ -6,17 +6,16 @@ import re
 import time
 import datetime
 import logging
-import simplejson
+import requests
 import web
 from infogami import config
 from .. import i18n
-
-from six.moves import urllib
 
 
 logger = logging.getLogger(__name__)
 
 re_solrescape = re.compile(r'([&|+\-!(){}\[\]^"~*?:])')
+
 
 class LoanStats:
     def __init__(self, region=None, library=None, country=None, collection=None, subject=None):
@@ -58,6 +57,7 @@ class LoanStats:
 
         if self.time_period:
             start, end = self.time_period
+
             def solrtime(t):
                 return t.isoformat() + "Z"
             params['fq'].append("start_time_dt:[%s TO %s]" % (solrtime(start), solrtime(end)))
@@ -67,11 +67,10 @@ class LoanStats:
 
         logger.info("SOLR query %s", params)
 
-        q = urllib.parse.urlencode(params, doseq=True)
+        q = requests.compat.urlencode(params, doseq=True)
         url = self.base_url + "/select?" + q
         logger.info("urlopen %s", url)
-        response = urllib.request.urlopen(url).read()
-        return simplejson.loads(response)
+        return requests.get(url).json()
 
     def solrescape(self, text):
         return re_solrescape.sub(r'\\\1', text)
@@ -109,7 +108,7 @@ class LoanStats:
     def _get_all_facet_counts(self):
         if not self._facet_counts:
             facets = [
-                "library_s","region_s", "country_s",
+                "library_s", "region_s", "country_s",
                 "ia_collections_id", "sponsor_s", "contributor_s",
                 "book_key_s", "author_keys_id", "resource_type_s",
                 "subject_facet", "place_facet", "person_facet", "time_facet"]
@@ -152,7 +151,7 @@ class LoanStats:
             "rows": 0,
             "facet": "on",
             "facet.mincount": 1,
-            "facet.limit": 100000, # don't limit
+            "facet.limit": 100000,  # don't limit
             "facet.field": ['start_day_s']
         }
         if resource_type != 'total':
@@ -171,7 +170,7 @@ class LoanStats:
             "rows": 0,
             "facet": "on",
             "facet.mincount": 1,
-            "facet.limit": 100000, # don't limit
+            "facet.limit": 100000,  # don't limit
             "facet.field": ['start_day_s']
         }
         if resource_type != 'total':

--- a/openlibrary/core/loanstats.py
+++ b/openlibrary/core/loanstats.py
@@ -7,6 +7,7 @@ import time
 import datetime
 import logging
 import requests
+from urllib.parse import urlencode
 import web
 from infogami import config
 from .. import i18n
@@ -67,7 +68,7 @@ class LoanStats:
 
         logger.info("SOLR query %s", params)
 
-        q = requests.compat.urlencode(params, doseq=True)
+        q = urlencode(params, doseq=True)
         url = self.base_url + "/select?" + q
         logger.info("urlopen %s", url)
         return requests.get(url).json()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #2852

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor to replace `urllib.urlopen` with `requests`.   Also cleaned up some lint/pycodestyle warnings about formatting.

### Technical
<!-- What should be noted about the implementation? -->
Uses `requests.compat` to remove the `urllib` import and only use `requests`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Manually tested to verify the code ran as expected, and unit tests pass.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
