### PR TITLE
Replace urllib with requests in openlibrary.core.fulltext

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -1,11 +1,10 @@
 import logging
+
 import requests
 import web
-
 from infogami import config
 from openlibrary.core.lending import get_availability_of_ocaids
 from openlibrary.plugins.openlibrary.home import format_book_data
-
 from six.moves import urllib
 
 

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -21,7 +21,7 @@ def fulltext_search_api(params):
     if not hasattr(config, 'plugin_inside'):
         return {'error': 'Unable to prepare search engine'}
     search_endpoint = config.plugin_inside['search_endpoint']
-    search_select = search_endpoint + '?' + urllib.parse.urlencode(params, 'utf-8')
+    search_select = search_endpoint + '?' + urlencode(params, 'utf-8')
 
     try:
         response = requests.get(search_select, timeout=30)

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -5,7 +5,7 @@ import web
 from infogami import config
 from openlibrary.core.lending import get_availability_of_ocaids
 from openlibrary.plugins.openlibrary.home import format_book_data
-from six.moves import urllib
+from six.moves.urllib.parse import urlencode
 
 # py3 uses json.decoder.JSONDecodeError
 try:

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     JSONDecodeError = ValueError
 
-
 logger = logging.getLogger("openlibrary.inside")
 
 
@@ -23,9 +22,9 @@ def fulltext_search_api(params):
     search_endpoint = config.plugin_inside['search_endpoint']
     search_select = search_endpoint + '?' + urlencode(params, 'utf-8')
 
+    logger.debug('URL: ' + search_select)
     try:
         response = requests.get(search_select, timeout=30)
-        logger.debug('URL: ' + search_select)
         response.raise_for_status()
         return response.json()
     except requests.HTTPError:

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -1,8 +1,7 @@
-
-import simplejson
 import logging
-
+import requests
 import web
+
 from infogami import config
 from openlibrary.core.lending import get_availability_of_ocaids
 from openlibrary.plugins.openlibrary.home import format_book_data
@@ -17,16 +16,17 @@ def fulltext_search_api(params):
     search_select = search_endpoint + '?' + urllib.parse.urlencode(params, 'utf-8')
 
     try:
-        json_data = urllib.request.urlopen(search_select, timeout=30).read()
+        response = requests.get(search_select, timeout=30)
         logger = logging.getLogger("openlibrary.inside")
         logger.debug('URL: ' + search_select)
-    except:
+        response.raise_for_status()
+    except Exception:
         return {'error': 'Unable to query search engine'}
-
-    try:
-        return simplejson.loads(json_data)
-    except:
-        return {'error': 'Error converting search engine data to JSON'}
+    else:
+        try:
+            return response.json()
+        except Exception:
+            return {'error': 'Error converting search engine data to JSON'}
 
 
 def fulltext_search(q, page=1, limit=100, js=False):

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,8 +1,15 @@
 from unittest.mock import Mock, patch
 
+import json
 import requests
 from infogami import config
 from openlibrary.core import fulltext
+
+# py3 uses json.decoder.JSONDecodeError
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
 
 
 class Test_fulltext_search_api:
@@ -26,7 +33,7 @@ class Test_fulltext_search_api:
     def test_bad_json(self):
         with patch("openlibrary.core.fulltext.requests.get") as mock_get:
             config.plugin_inside = {"search_endpoint": "mock"}
-            mock_response = Mock(json=Mock(side_effect=Exception("Not JSON")))
+            mock_response = Mock(json=Mock(side_effect=json.decoder.JSONDecodeError('Not JSON', 'Not JSON', 0)))
             mock_get.return_value = mock_response
 
             response = fulltext.fulltext_search_api({"q": "hello"})

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -33,7 +33,7 @@ class Test_fulltext_search_api:
     def test_bad_json(self):
         with patch("openlibrary.core.fulltext.requests.get") as mock_get:
             config.plugin_inside = {"search_endpoint": "mock"}
-            mock_response = Mock(json=Mock(side_effect=json.decoder.JSONDecodeError('Not JSON', 'Not JSON', 0)))
+            mock_response = Mock(json=Mock(side_effect=JSONDecodeError('Not JSON', 'Not JSON', 0)))
             mock_get.return_value = mock_response
 
             response = fulltext.fulltext_search_api({"q": "hello"})

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,0 +1,33 @@
+import requests
+from unittest.mock import Mock, patch
+
+from openlibrary.core import fulltext
+
+from infogami import config
+
+
+class Test_fulltext_search_api:
+    def test_config(self):
+        assert not hasattr(config, 'plugin_inside')
+        response = fulltext.fulltext_search_api({})
+        assert response == {'error': 'Unable to prepare search engine'}
+
+
+    def test_query_exception(self):
+        with patch('openlibrary.core.fulltext.requests.get') as mock_get:
+            config.plugin_inside = {'search_endpoint': 'mock'}
+            raiser = Mock(side_effect=requests.exceptions.HTTPError('Unable to Connect'))
+            mock_response = Mock()
+            mock_response.raise_for_status = raiser
+            mock_get.return_value = mock_response
+            response = fulltext.fulltext_search_api({'q':'hello'})
+            assert response == {'error': 'Unable to query search engine'}
+
+    def test_bad_json(self):
+        with patch('openlibrary.core.fulltext.requests.get') as mock_get:
+            config.plugin_inside = {'search_endpoint': 'mock'}
+            mock_response = Mock(json=Mock(side_effect=Exception('Not JSON')))
+            mock_get.return_value = mock_response
+
+            response = fulltext.fulltext_search_api({'q':'hello'})
+            assert response == {'error': 'Error converting search engine data to JSON'}

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock, patch
 
-import json
 import requests
 from infogami import config
 from openlibrary.core import fulltext

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,33 +1,33 @@
-import requests
 from unittest.mock import Mock, patch
 
-from openlibrary.core import fulltext
-
+import requests
 from infogami import config
+from openlibrary.core import fulltext
 
 
 class Test_fulltext_search_api:
     def test_config(self):
-        assert not hasattr(config, 'plugin_inside')
+        assert not hasattr(config, "plugin_inside")
         response = fulltext.fulltext_search_api({})
-        assert response == {'error': 'Unable to prepare search engine'}
-
+        assert response == {"error": "Unable to prepare search engine"}
 
     def test_query_exception(self):
-        with patch('openlibrary.core.fulltext.requests.get') as mock_get:
-            config.plugin_inside = {'search_endpoint': 'mock'}
-            raiser = Mock(side_effect=requests.exceptions.HTTPError('Unable to Connect'))
+        with patch("openlibrary.core.fulltext.requests.get") as mock_get:
+            config.plugin_inside = {"search_endpoint": "mock"}
+            raiser = Mock(
+                side_effect=requests.exceptions.HTTPError("Unable to Connect")
+            )
             mock_response = Mock()
             mock_response.raise_for_status = raiser
             mock_get.return_value = mock_response
-            response = fulltext.fulltext_search_api({'q':'hello'})
-            assert response == {'error': 'Unable to query search engine'}
+            response = fulltext.fulltext_search_api({"q": "hello"})
+            assert response == {"error": "Unable to query search engine"}
 
     def test_bad_json(self):
-        with patch('openlibrary.core.fulltext.requests.get') as mock_get:
-            config.plugin_inside = {'search_endpoint': 'mock'}
-            mock_response = Mock(json=Mock(side_effect=Exception('Not JSON')))
+        with patch("openlibrary.core.fulltext.requests.get") as mock_get:
+            config.plugin_inside = {"search_endpoint": "mock"}
+            mock_response = Mock(json=Mock(side_effect=Exception("Not JSON")))
             mock_get.return_value = mock_response
 
-            response = fulltext.fulltext_search_api({'q':'hello'})
-            assert response == {'error': 'Error converting search engine data to JSON'}
+            response = fulltext.fulltext_search_api({"q": "hello"})
+            assert response == {"error": "Error converting search engine data to JSON"}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #2852 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor `openlibrary.core.fulltext` to replace urllib.openurl with requests.get.  Adds unittests for the exception cases.

### Technical
<!-- What should be noted about the implementation? -->
The fulltext search api function is used in a couple of places;
- `plugins/inside/code.py`
- `plugins/worksearch/code.py`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Unit tests were added for exception cases.   You should also be able to do searches on staging in both "/search" and worksearch.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
