### PR TITLE
Import jQuery-UI sortable widget

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,7 +1,8 @@
 import 'jquery';
 import 'jquery-migrate';
 import 'jquery-validation';
-import 'jquery-ui/ui/widgets/dialog'
+import 'jquery-ui/ui/widgets/dialog';
+import 'jquery-ui/ui/widgets/sortable';
 import 'jquery-ui/ui/widgets/tabs';
 // For dialog boxes (e.g. add to list)
 import '../../../../vendor/js/colorbox/1.5.14.js';


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4420 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Imported jQuery UI's Sortable widget in the main JS file.  Importing this widget fixes allows cover images to be added and removed without error.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Rebuild JS assets.
2. Navigate to a book page and attempt to upload a new book cover image.
3. Delete the newly uploaded image.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![manage_covers](https://user-images.githubusercontent.com/28732543/104643586-a0e08680-567a-11eb-8b78-66f45c45ba08.gif)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
