### PR TITLE
Fix AttributeError: 'author_names'

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -85,8 +85,8 @@ $code:
         authors = cond(work, work and work.get_authors(), edition and edition.get_authors())
         if authors:
             return ', '.join('<a href="%s"%s>%s</a>' % (a.url(), schema_attribute, truncate(a.name, 40)) if a.name else "<em>Unknown author</em>" for a in authors)
-        elif edition.author_names:
-            return ('<span%s>' % (schema_attribute)) + ", ".join(edition.author_names) + "</span>"
+        elif (edition or work).author_names:
+            return ('<span%s>' % (schema_attribute)) + ", ".join((edition or work).author_names) + "</span>"
         else:
             return None
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://internetarchive.slack.com/archives/C0ETZV72L/p1610879197058400
NOTE: Instead of `(edition or work).author_names` we can write `page.author_names`
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refer: https://internetarchive.slack.com/archives/C0ETZV72L/p1610978647060400?thread_ts=1610879197.058400&cid=C0ETZV72L

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
https://openlibrary.org/works/OL15690362W/Walt_Disney_fun-to-read_library_(duplicate)
https://openlibrary.org/works/OL17355493W/The_Generic_names_of_moths_of_the_world._n_Vol._5_p_Pyraloidea_c_edited_by_I.W.B._Nye_vol._5_by_D.S.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/104930454-2d68ad00-59cb-11eb-87db-22f9de903df7.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
