### PR TITLE
Send S3 keys in observation POST messages

### DIFF
--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -1,0 +1,19 @@
+"""Module for handling patron observation functionality"""
+
+import requests
+
+from infogami import config
+from openlibrary import accounts
+
+# URL for TheBestBookOn
+TBBO_URL = config.get('tbbo_url')
+
+def post_observation(data, s3_keys):
+    headers = {
+        'x-s3-access': s3_keys['access'],
+        'x-s3-secret': s3_keys['secret']
+    }
+
+    response = requests.post(TBBO_URL + '/api/observations', data=data, headers=headers)
+
+    return response.text

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -382,9 +382,11 @@ class observations(delegate.page):
 
     def POST(self):
         user = accounts.get_current_user()
-        account = OpenLibraryAccount.get_by_email(user.email)
-        s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
 
-        response = post_observation(web.data(), s3_keys)
+        if user:
+            account = OpenLibraryAccount.get_by_email(user.email)
+            s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
 
-        return delegate.RawText(response)
+            if s3_keys:
+                response = post_observation(web.data(), s3_keys)
+                return delegate.RawText(response)

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -19,6 +19,7 @@ from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.core import ia, db, models, lending, helpers as h
+from openlibrary.core.observations import post_observation
 from openlibrary.core.sponsorships import qualifies_for_sponsorship
 from openlibrary.core.vendors import (
     get_amazon_metadata, create_edition_from_amazon_metadata,
@@ -373,3 +374,17 @@ class price_api(delegate.page):
                     metadata['ocaid'] = ed.ocaid
 
         return json.dumps(metadata)
+
+
+class observations(delegate.page):
+    path = "/observations"
+    encoding = "json"
+
+    def POST(self):
+        user = accounts.get_current_user()
+        account = OpenLibraryAccount.get_by_email(user.email)
+        s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
+
+        response = post_observation(web.data(), s3_keys)
+
+        return delegate.RawText(response)

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -98,7 +98,7 @@ export function initPatronMetadata() {
         if (result['observations'].length > 0) {
             $.ajax({
                 type: 'POST',
-                url: `${context.the_best_book_on_url}/api/observations`,
+                url: '/observations',
                 contentType: 'application/json',
                 data: JSON.stringify(result)
             });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4442 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sends S3 keys to thebestbookon.com whenever a patron submits observations about a work.

### Technical
<!-- What should be noted about the implementation? -->
POSTs to TBBO now come from Open Library's server instead of the client.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 