### PR TITLE
Add `Needs: Lead` label to Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: "Type: Bug, Needs: Triage"
+labels: "Type: Bug, Needs: Triage, Needs: Lead"
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: "Type: Feature, Needs: Triage"
+labels: "Type: Feature, Needs: Triage, Needs: Lead"
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -1,8 +1,8 @@
 ---
-name: Question
+name: Question & Discussion
 about: Propose an answerable question
 title: ''
-labels: "Type: Question, Needs: Triage"
+labels: "Type: Question, Needs: Triage, Needs: Lead, Needs: Community Discussion"
 assignees: ''
 ---
 
@@ -12,6 +12,9 @@ assignees: ''
 
 ### Additional context
 <!-- Add any other context or details here. -->
+
+### Issue resolution criteria
+<!-- When can this issue be closed? -->
 
 
 ### Stakeholders


### PR DESCRIPTION
Right now it's hard to query for what issues require leads. In our new lead guide #4282 the procedure is to leave `Needs: Triage` and assign a `Lead: @lead`. This PR will make it easier to identify issue which need a Lead label.