### PR TITLE
Allow cross origin access for cover images

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -39,11 +39,7 @@ urls = (
 )
 app = web.application(urls, locals())
 
-cors_paths = {
-    '/b/',
-    '/w/',
-}
-app.add_processor(CORSProcessor(cors_paths))
+app.add_processor(CORSProcessor())
 
 
 def get_cover_id(olkeys):

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -274,6 +274,7 @@ class cover:
             web.expires(10*60) # Allow the client to cache the image for 10 mins to avoid further requests
 
         web.header('Content-Type', 'image/jpeg')
+        web.header('Access-Control-Allow-Origin', '*')
         try:
             return read_image(d, size)
         except IOError:

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -22,6 +22,7 @@ from openlibrary.coverstore.utils import (
     rm_f,
     safeint,
 )
+from openlibrary.plugins.openlibrary.processors import CORSProcessor
 
 logger = logging.getLogger("coverstore")
 
@@ -37,6 +38,15 @@ urls = (
     '/([^ /]*)/delete', 'delete',
 )
 app = web.application(urls, locals())
+
+cors_paths = {
+    '/b/id/',
+    '/b/oclc/',
+    '/b/lccn/',
+    '/b/olid/'
+}
+app.add_processor(CORSProcessor(cors_paths))
+
 
 def get_cover_id(olkeys):
     """Return the first cover from the list of ol keys."""
@@ -274,7 +284,6 @@ class cover:
             web.expires(10*60) # Allow the client to cache the image for 10 mins to avoid further requests
 
         web.header('Content-Type', 'image/jpeg')
-        web.header('Access-Control-Allow-Origin', '*')
         try:
             return read_image(d, size)
         except IOError:

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -40,10 +40,8 @@ urls = (
 app = web.application(urls, locals())
 
 cors_paths = {
-    '/b/id/',
-    '/b/oclc/',
-    '/b/lccn/',
-    '/b/olid/'
+    '/b/',
+    '/w/',
 }
 app.add_processor(CORSProcessor(cors_paths))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -39,7 +39,7 @@ from openlibrary.plugins.openlibrary import processors
 
 delegate.app.add_processor(processors.ReadableUrlProcessor())
 delegate.app.add_processor(processors.ProfileProcessor())
-delegate.app.add_processor(processors.CORSProcessor())
+delegate.app.add_processor(processors.CORSProcessor(cors_prefixes={'/api/'}))
 
 try:
     from infogami.plugins.api import code as api

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -32,11 +32,11 @@ class CORSProcessor:
     """Processor to handle OPTIONS method to support
     Cross Origin Resurce Sharing.
     """
-    def __init__(self, valid_paths = {"/api/"}):
-        self.valid_paths = valid_paths
+    def __init__(self, cors_prefixes = None):
+        self.cors_prefixes = cors_prefixes
 
     def __call__(self, handler):
-        can_share = self.has_valid_path()
+        can_share = self.is_cors_path() if self.cors_prefixes else True
 
         if can_share or web.ctx.path.endswith(".json"):
             self.add_cors_headers()
@@ -45,8 +45,8 @@ class CORSProcessor:
         else:
             return handler()
 
-    def has_valid_path(self):
-        for path_segment in self.valid_paths:
+    def is_cors_path(self):
+        for path_segment in self.cors_prefixes:
             if web.ctx.path.startswith(path_segment):
                 return True
         return False

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -36,9 +36,7 @@ class CORSProcessor:
         self.cors_prefixes = cors_prefixes
 
     def __call__(self, handler):
-        can_share = self.is_cors_path() if self.cors_prefixes else True
-
-        if can_share or web.ctx.path.endswith(".json"):
+        if self.is_cors_path():
             self.add_cors_headers()
         if web.ctx.method == "OPTIONS":
             raise web.ok("")
@@ -46,6 +44,8 @@ class CORSProcessor:
             return handler()
 
     def is_cors_path(self):
+        if self.cors_prefixes is None or web.ctx.path.endswith(".json"):
+            return True
         for path_segment in self.cors_prefixes:
             if web.ctx.path.startswith(path_segment):
                 return True

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -32,13 +32,24 @@ class CORSProcessor:
     """Processor to handle OPTIONS method to support
     Cross Origin Resurce Sharing.
     """
+    def __init__(self, valid_paths = {"/api/"}):
+        self.valid_paths = valid_paths
+
     def __call__(self, handler):
-        if web.ctx.path.startswith("/api/") or web.ctx.path.endswith(".json"):
+        can_share = self.has_valid_path()
+
+        if can_share or web.ctx.path.endswith(".json"):
             self.add_cors_headers()
         if web.ctx.method == "OPTIONS":
             raise web.ok("")
         else:
             return handler()
+
+    def has_valid_path(self):
+        for path_segment in self.valid_paths:
+            if web.ctx.path.startswith(path_segment):
+                return True
+        return False
 
     def add_cors_headers(self):
         # Allow anyone to access GET and OPTIONS requests


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #3399

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `Access-Control-Allow-Origin: *` to Open Library image API responses.  This only solves the issue for images coming from the coverstore.  Requests redirected to IA will not include this header in their response.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
