### PR TITLE
cache.py: Avoid dict changed size during iteration

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -157,7 +157,7 @@ class memcache_memoize:
 
         Used only in testing.
         """
-        for name, thread in self.active_threads.items():
+        for name, thread in list(self.active_threads.items()):
             thread.join()
 
     def encode_args(self, args, kw=None):


### PR DESCRIPTION
Subset of #4330

This code is ___only used in testing___ but it raises a RuntimeError on Apple Silicon M1 Macs.

See #4330 Screenshots, problem 4 for details.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
