### PR TITLE
Changed read_ebook, borrow_ebook id's on buttons to classes

### DIFF
--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -12,14 +12,14 @@ $else:
 $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
 <div class="cta-button-group">
-  <a href="$(stream_url)" title="$title" id="$(action)_ebook"
+  <a href="$(stream_url)" title="$title" class="$(action)_ebook cta-btn cta-btn--available"
      $if loan:
        data-userid="$(loan['userid'])"
      $elif borrow:
        data-ol-link-track="CTAClick|Borrow"
      $else:
        data-ol-link-track="CTAClick|Read"
-     class="cta-btn cta-btn--available">$label</a>
+    >$label</a>
   $if listen:
     <a href="$(stream_url)&_autoReadAloud=show"
        title="$title using Read Aloud"

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -12,7 +12,7 @@ $else:
 $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
 <div class="cta-button-group">
-  <a href="$(stream_url)" title="$title" class="$(action)_ebook cta-btn cta-btn--available"
+  <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--available cta-btn--$(action)"
      $if loan:
        data-userid="$(loan['userid'])"
      $elif borrow:

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -110,7 +110,7 @@ export function initBorrowAndReadLinks() {
     /* eslint-disable no-unused-vars */
     // used in openlibrary/macros/AvailabilityButton.html and openlibrary/macros/LoanStatus.html
     $(document).ready(function(){
-        $('.borrow_ebook,.read_ebook').on('click', function(){
+        $('.cta-btn--borrow,.cta-btn--read').on('click', function(){
             $(this).removeClass('cta-btn cta-btn--available').addClass('cta-btn cta-btn--available--load');
         });
     });

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -110,7 +110,7 @@ export function initBorrowAndReadLinks() {
     /* eslint-disable no-unused-vars */
     // used in openlibrary/macros/AvailabilityButton.html and openlibrary/macros/LoanStatus.html
     $(document).ready(function(){
-        $('#borrow_ebook,#read_ebook').on('click', function(){
+        $('.borrow_ebook,.read_ebook').on('click', function(){
             $(this).removeClass('cta-btn cta-btn--available').addClass('cta-btn cta-btn--available--load');
         });
     });


### PR DESCRIPTION
Merger note: Please merge #4456 after merging this one.
-----
<!-- What issue does this PR close? -->
Closes #4447 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
Nit changes in the code. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The look of the button and the task it is supposed to do is fine, if there's any weird cases involving the buttons, do let me know.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
On prod: 
![Selection_022](https://user-images.githubusercontent.com/54721958/105419932-818ebe00-5c65-11eb-8afd-a15bfd11e1ab.png) 
After change: 
![Selection_021](https://user-images.githubusercontent.com/54721958/105419947-894e6280-5c65-11eb-9363-088446692eaf.png)
[No change in the look] 

Validation errors due to these also go away: 
Before: 
![Selection_019](https://user-images.githubusercontent.com/54721958/105420001-a2efaa00-5c65-11eb-937e-e0fa7f397183.png)
After: 
![Selection_020](https://user-images.githubusercontent.com/54721958/105420006-a71bc780-5c65-11eb-9603-d68ca87fbee9.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
