### PR TITLE
Remove simplejson dependency for 2308 in account/model

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -21,6 +21,14 @@ from infogami.infobase.client import ClientException
 
 from openlibrary.core import stats, helpers
 
+try:
+    try:
+        from simplejson.errors import JSONDecodeError
+    except ImportError:
+        from json.decoder import JSONDecodeError
+except ImportError:  # legacy Python
+    JSONDecodeError = ValueError
+
 logger = logging.getLogger("openlibrary.account.model")
 
 def append_random_suffix(text, limit=9999):
@@ -602,8 +610,7 @@ class InternetArchiveAccount(web.storage):
             return response.json()
         except requests.HTTPError as e:
             return {'error': e.response.text, 'code': e.response.status_code}
-        except ValueError as e:
-            # we cannot catch json.JSONDecodeError here yet because requests will import simplejson as json first.
+        except JSONDecodeError as e:
             return {'error': e.message, 'code': response.status_code}
 
     @classmethod

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -8,7 +8,6 @@ import hashlib
 import hmac
 import random
 import string
-import simplejson
 import uuid
 import logging
 import requests
@@ -603,7 +602,8 @@ class InternetArchiveAccount(web.storage):
             return response.json()
         except requests.HTTPError as e:
             return {'error': e.response.text, 'code': e.response.status_code}
-        except simplejson.errors.JSONDecodeError as e:
+        except ValueError as e:
+            # we cannot catch json.JSONDecodeError here yet because requests will import simplejson as json first.
             return {'error': e.message, 'code': response.status_code}
 
     @classmethod


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #2308 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Remove simplejson import - and change JSONDecodeError catch to ValueError because requests will import simplejson first, and we cannot catch json.JSONDecodeError until we remove simplejson.

### Technical
<!-- What should be noted about the implementation? -->
There isn't a unit test for this case.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Unit tests run.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
