### PR TITLE
fixes import bot issue #4459

### DIFF
--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -38,6 +38,8 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
 
 def do_import(item, servername=None, require_marc=True):
     response = ol_import_request(item, servername=servername, require_marc=require_marc)
+    if response:
+        response = response.decode("utf-8")
     print("Response:", response, file=sys.stderr)
     if response and response.startswith("{"):
         d = json.loads(response)


### PR DESCRIPTION
Closes #4459 



After investigation, it was revealed that the problems were (a) authentication was failing (somehow the importbot password got out of sync) and (b) we had a python3 error in processing the import response.

Auth error messages were a red herring, real issue was bytes v. strings in manage-imports.
Auth issue resolved w/ password reset for ImportBot. This PR addresses underlying IA import issue:

```
  File "scripts/manage-imports.py", line 207, in <module>
    main()
  File "scripts/manage-imports.py", line 200, in main
    return import_all(args, **flags)
  File "scripts/manage-imports.py", line 146, in import_all
    do_import(item, servername=servername, require_marc=require_marc)
  File "scripts/manage-imports.py", line 42, in do_import
    if response and response.startswith("{"):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

The following patch is on `ol-home0` and seems to be working for (b)

```
diff --git a/scripts/manage-imports.py b/scripts/manage-imports.py
index a85bb3303..b9d9ab8e3 100755
--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -38,6 +38,8 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
 def do_import(item, servername=None, require_marc=True):
     response = ol_import_request(item, servername=servername, require_marc=require_marc)
+    if response:
+        response = response.decode("utf-8")
```

May be verified either by `sudo docker logs --tail 20 openlibrary_importbot_1` 

```
0.0 (1): UPDATE import_item SET error = NULL, import_time = '2021-01-22T19:15:05.393627', ol_key = '/books/OL28996497M', status = 'modified' WHERE id=2429375
Response: {"success": true, "edition": {"key": "/books/OL26026643M", "status": "modified"}, "work": {"key": "/works/OL17442691W", "status": "modified"}}
0.0 (1): UPDATE import_item SET error = NULL, import_time = '2021-01-22T19:15:06.729273', ol_key = '/books/OL26026643M', status = 'modified' WHERE id=2429376
Response: {"authors": [{"key": "/authors/OL1394023A", "name": "Gabrielle Zevin", "status": "matched"}], "success": true, "edition": {"key": "/books/OL31879591M", "status": "created"}, "work": {"key": "/works/OL16819586W", "status": "modified"}}
0.0 (1): UPDATE import_item SET error = NULL, import_time = '2021-01-22T19:15:10.864725', ol_key = '/books/OL31879591M', status = 'created' WHERE id=2429377
2021-01-22 19:15:14 [160] [openlibrary.importer] [INFO] success: modified /books/OL11248471M
2021-01-22 19:15:14 [160] [openlibrary.imports] [INFO] set-status practicalwoodcar0000whee - modified None /books/OL11248471M
2021-01-22 19:15:14 [160] [openlibrary.importer] [INFO] importing tanzaniaafternye0000unse
2021-01-22 19:15:14 [160] [openlibrary.api] [INFO] POST /api/import/ia
2021-01-22 19:15:15 [160] [openlibrary.importer] [INFO] success: modified /books/OL2399156M
2021-01-22 19:15:15 [160] [openlibrary.imports] [INFO] set-status tanzaniaafternye0000unse - modified None /books/OL2399156M
2021-01-22 19:15:15 [160] [openlibrary.importer] [INFO] importing 10scarymonsters0000unse
2021-01-22 19:15:15 [160] [openlibrary.api] [INFO] POST /api/import/ia
2021-01-22 19:15:15 [160] [openlibrary.importer] [WARNING] Failed to contact OL server. error=HTTPSConnectionPool(host='openlibrary.org', port=443): Max retries exceeded with url: /api/import/ia (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:1124)')))
2021-01-22 19:15:15 [160] [openlibrary.importer] [INFO] sleeping for 5 seconds before next attempt.
2021-01-22 19:15:20 [160] [openlibrary.api] [INFO] POST /api/import/ia
2021-01-22 19:15:24 [160] [openlibrary.importer] [INFO] success: created /books/OL31879592M
2021-01-22 19:15:24 [160] [openlibrary.imports] [INFO] set-status 10scarymonsters0000unse - created None /books/OL31879592M
2021-01-22 19:15:24 [160] [openlibrary.importer] [INFO] importing oscarpetersonwil0000lees_h7u4
2021-01-22 19:15:24 [160] [openlibrary.api] [INFO] POST /api/import/ia
```

or https://openlibrary.org/admin/imports
![openlibrary org_admin_imports (1)](https://user-images.githubusercontent.com/978325/105535125-4c08c580-5ca3-11eb-9e08-4b4e25b3518d.png)

## Note

The https://openlibrary.org/admin/imports doesn't seem to be updating Summary By Date (perhaps a different issue w/ db stats on ol-home v. ol-home0?)

![openlibrary org_admin_imports](https://user-images.githubusercontent.com/978325/105535133-4e6b1f80-5ca3-11eb-9d22-249e41c22983.png)

EDIT: I think we're not seeing edits under summary because we're backfilling the queue entries from **several** months ago! :+1: 
