### PR TITLE
Remove unused simplejson from openlibrary/utils/solr.py

### DIFF
--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -1,10 +1,10 @@
-"""Python library for accessing Solr.
-"""
+"""Python library for accessing Solr"""
+
+import logging
 import re
+
 import requests
 import web
-import simplejson
-import logging
 
 from six.moves import urllib
 
@@ -92,7 +92,7 @@ class Solr:
         if len(payload) < 500:
             url = url + "?" + payload
             logger.info("solr request: %s", url)
-            jsonData = requests.get(url, timeout=10).json()
+            json_data = requests.get(url, timeout=10).json()
         else:
             logger.info("solr request: %s ...", url)
             if not isinstance(payload, bytes):
@@ -100,11 +100,11 @@ class Solr:
             headers = {
                 "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
             }
-            jsonData = requests.post(
+            json_data = requests.post(
                 url, data=payload, headers=headers, timeout=10
             ).json()
         return self._parse_solr_result(
-            jsonData,
+            json_data,
             doc_wrapper=doc_wrapper,
             facet_wrapper=facet_wrapper)
 


### PR DESCRIPTION
We no longer need a json module because requests does it for us.

<!-- What issue does this PR close? -->
Subtask of #2308

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@dherbst

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
