### PR TITLE
Support special access btn for patrons w/ approved print-disabilities

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -747,7 +747,10 @@ def audit_accounts(email, password, require_link=False,
             return {'error': 'accounts_not_connected'}
 
     if 'values' in ia_login:
-        s3_keys = ia_login['values']
+        s3_keys = {
+            'access': ia_login['values'].pop('access'),
+            'secret': ia_login['values'].pop('secret'),
+        }
         ol_account.save_s3_keys(s3_keys)
 
     # When a user logs in with OL credentials, the
@@ -765,6 +768,7 @@ def audit_accounts(email, password, require_link=False,
     web.ctx.conn.set_auth_token(ol_account.generate_login_code())
     return {
         'authenticated': True,
+        'special_access': getattr(ia_account, 'has_disability_access', False),
         'ia_email': ia_account.email,
         'ol_email': ol_account.email,
         'ia_username': ia_account.screenname,

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -648,6 +648,9 @@ class User(Thing):
             usergroup = '/usergroup/%s' % usergroup
         return usergroup in [g.key for g in self.usergroups]
 
+    def is_printdisabled(self):
+        return web.cookies().get('pd')
+
     def is_admin(self):
         return self.is_usergroup_member('/usergroup/admin')
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -43,6 +43,9 @@ $if user_loan:
       });
     </script>
 
+$elif ocaid and ctx.user and ctx.user.is_printdisabled():
+  $:macros.ReadButton(ocaid, listen=listen, printdisabled=True)
+
 $elif availability.get('is_readable'):
   $:macros.ReadButton(ocaid, listen=listen)
   $if secondary_action:

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -43,13 +43,13 @@ $if user_loan:
       });
     </script>
 
-$elif ocaid and ctx.user and ctx.user.is_printdisabled():
-  $:macros.ReadButton(ocaid, listen=listen, printdisabled=True)
-
 $elif availability.get('is_readable'):
   $:macros.ReadButton(ocaid, listen=listen)
   $if secondary_action:
     $:macros.BookSearchInside(ocaid)
+
+$elif ocaid and ctx.user and ctx.user.is_printdisabled():
+  $:macros.ReadButton(ocaid, listen=listen, printdisabled=True)
 
 $elif availability.get('is_lendable'):
   $if availability.get('available_to_borrow'):

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -6,7 +6,6 @@ $if printdisabled:
   $ action = "read"
   $ label = _("Special Access")
   $ title = _("Special ebook access from the Internet Archive for patrons with qualifying print disabilities")
-  $ stream_url = "https://archive.org/details/" + ocaid
 $elif (borrow and not loan):
   $ action = "borrow"
   $ label = label or _("Borrow")

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -5,7 +5,7 @@ $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 $if printdisabled:
   $ action = "read"
   $ label = _("Special Access")
-  $ title = _("Special print-disabled ebook access from Internet Archive")
+  $ title = _("Special ebook access from the Internet Archive for patrons with qualifying print disabilities")
   $ stream_url = "https://archive.org/details/" + ocaid
 $elif (borrow and not loan):
   $ action = "borrow"

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,6 +1,13 @@
-$def with(ocaid, borrow=False, listen=False, loan=None, label='')
+$def with(ocaid, borrow=False, listen=False, loan=None, label='', printdisabled=False)
 
-$if (borrow and not loan):
+$ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
+
+$if printdisabled:
+  $ action = "read"
+  $ label = _("♿ Special Access")
+  $ title = _("Special print-disabled ebook access from Internet Archive")
+  $ stream_url = "https://archive.org/details/" + ocaid
+$elif (borrow and not loan):
   $ action = "borrow"
   $ label = label or _("Borrow")
   $ title = _("Borrow ebook from Internet Archive")
@@ -9,12 +16,12 @@ $else:
   $ label = _("Read")
   $ title = _("Read ebook from Internet Archive")
 
-$ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
-
 <div class="cta-button-group">
   <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--available cta-btn--$(action)"
      $if loan:
        data-userid="$(loan['userid'])"
+     $elif printdisabled:
+       data-ol-link-track="CTAClick|PrintDisabled"
      $elif borrow:
        data-ol-link-track="CTAClick|Borrow"
      $else:

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -4,7 +4,7 @@ $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
 $if printdisabled:
   $ action = "read"
-  $ label = _("♿ Special Access")
+  $ label = _("Special Access")
   $ title = _("Special print-disabled ebook access from Internet Archive")
   $ stream_url = "https://archive.org/details/" + ocaid
 $elif (borrow and not loan):

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -53,8 +53,12 @@ def get_homepage():
 def get_cached_homepage():
     five_minutes = 5 * dateutil.MINUTE_SECS
     lang = web.ctx.get("lang", "en")
+    pd = web.cookies().get('pd', False)
+    key = "home.homepage." + lang
+    if pd:
+        key += '.pd'
     return cache.memcache_memoize(
-        get_homepage, "home.homepage." + lang, timeout=five_minutes)()
+        get_homepage, key, timeout=five_minutes)()
 
 class home(delegate.page):
     path = "/"

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -325,7 +325,7 @@ class account_login(delegate.page):
         if error:
             return self.render_error(error, i)
 
-        expires = i.remember and 3600 * 24 * 7
+        expires = 3600 * 24 * 7 if i.remember else ""
         web.setcookie('pd', int(audit.get('special_access')) or '',
                       expires=expires)
         web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token(),

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -325,7 +325,11 @@ class account_login(delegate.page):
         if error:
             return self.render_error(error, i)
 
-        expires = (i.remember and 3600 * 24 * 7) or ""
+        expires = i.remember and 3600 * 24 * 7
+
+        if email in ['mek@archive.org', 'brenton@archive.org', 'brewster@archive.org']:
+            web.setcookie('pd', 1, expires=expires)
+
         web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token(),
                       expires=expires)
         blacklist = ["/account/login", "/account/password", "/account/email",

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -326,10 +326,8 @@ class account_login(delegate.page):
             return self.render_error(error, i)
 
         expires = i.remember and 3600 * 24 * 7
-
-        if email in ['mek@archive.org', 'brenton@archive.org', 'brewster@archive.org']:
-            web.setcookie('pd', 1, expires=expires)
-
+        web.setcookie('pd', int(audit.get('special_access')) or '',
+                      expires=expires)
         web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token(),
                       expires=expires)
         blacklist = ["/account/login", "/account/password", "/account/email",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4490 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Request from directors, have Open Library provide patrons with qualified print-disabilities an accurate depiction of which books are available to them. Dates back to our 2018 roadmap:
https://docs.google.com/document/d/1wpa4f-r8jBimam-36CAZGQ_QjApegm10XfH85eG7KAE/edit#

### Technical
<!-- What should be noted about the implementation? -->

Uses the xauthn API which has been updates to return printdisability qualifications

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tested on dev.openlibrary.org (not yet on staging)

### Considerations

**May require care re: caching homepage carousel html!**

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![dev openlibrary org_search_q=test mode=ebooks has_fulltext=true](https://user-images.githubusercontent.com/978325/107150179-61bbf300-6911-11eb-832c-680a606f05b9.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
