### PR TITLE
Add book titles to carousels

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -50,6 +50,11 @@ $def render_carousel_cover(book, lazy):
               <div class="carousel__item__blankcover--authors">$:macros.TruncateString(', '.join(author_names), 30)</div>
           </div>
       </a>
+      <div class="middle">
+        <div class="text">
+          <a href="$(url)">$title</a>
+        </div>
+      </div>
     </div>
     <div class="book-cta">
       $:macros.LoanStatus(book, work_key=work_key, listen=False, daisy=False)

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -50,10 +50,8 @@ $def render_carousel_cover(book, lazy):
               <div class="carousel__item__blankcover--authors">$:macros.TruncateString(', '.join(author_names), 30)</div>
           </div>
       </a>
-      <div class="middle">
-        <div class="text">
-          <a href="$(url)">$title</a>
-        </div>
+      <div class="book-cover__title">
+        <a href="$(url)" class="book-cover__title__text">$title</a>
       </div>
     </div>
     <div class="book-cta">

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -104,7 +104,7 @@
   text-align: center;
 }
 
-.book img.bookcover:hover {
+img.bookcover:hover {
   opacity: 0.3;
 }
 

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -97,6 +97,28 @@
   }
 }
 
+.book-cover .middle {
+  transition: .5s ease;
+  opacity: 0;
+  position: relative;
+  text-align: center;
+}
+
+.book img.bookcover:hover {
+  opacity: 0.3;
+}
+
+.book-cover:hover .middle {
+  opacity: 1;
+}
+
+.book-cover .text {
+  width: 100%;
+  background-color: #fff;
+  position: absolute;
+  bottom: 0;
+}
+
 .carousel__item .slick-loading {
   opacity: 0;
 }

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -97,7 +97,7 @@
   }
 }
 
-.book-cover .middle {
+.book-cover__title {
   transition: .5s ease;
   opacity: 0;
   position: relative;
@@ -108,13 +108,14 @@
   opacity: 0.3;
 }
 
-.book-cover:hover .middle {
+.book-cover:hover .book-cover__title {
   opacity: 1;
 }
 
-.book-cover .text {
+.book-cover__title__text {
   width: 100%;
-  background-color: #fff;
+  background-color: @primary-blue;
+  color: @white !important;
   position: absolute;
   bottom: 0;
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2084
Color Scheme used **background-color: blue**, **color: white**

**Blocker: As the title width is related to the class="book-cover" for viewport width<1200px it will appear outside the cover image**
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
https://user-images.githubusercontent.com/64412143/106097561-853aad00-615d-11eb-8e8e-197546397df1.mp4


https://user-images.githubusercontent.com/64412143/106101007-44459700-6163-11eb-9bfc-4b4796560c2e.mp4
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 