### PR TITLE
4474/refactor/moving inline js out of lib

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -156,6 +156,12 @@ jQuery(function () {
         $('#cboxSlideshow').attr({'aria-label': 'Slideshow button', 'aria-hidden': 'true'});
     }
 
+    //conditionally load javascript for the wikipedia citation button 
+    if(document.getElementById('wikilink')) {
+        import('./wikipedia_citation_button.js')
+            .then((module) => module.WikipediaCitationButtonPressed());
+    }
+
     $(document).on('click', '.slide-toggle', function () {
         $(`#${$(this).attr('aria-controls')}`).slideToggle();
     });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -33,6 +33,8 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
+//load javascript for the wikipedia citation button
+import WikipediaCitationButtonPressed from './wikipedia_citation_button';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -88,6 +90,7 @@ jQuery(function () {
     addFadeInFunctionsTojQuery($);
     jQueryRepeat($);
     initAnalytics($);
+    WikipediaCitationButtonPressed($);
     init($);
     // conditionally load functionality based on what's in the page
     if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
@@ -154,12 +157,6 @@ jQuery(function () {
     }
     if ($('#cboxSlideshow').length) {
         $('#cboxSlideshow').attr({'aria-label': 'Slideshow button', 'aria-hidden': 'true'});
-    }
-
-    //conditionally load javascript for the wikipedia citation button
-    if (document.getElementById('wikilink')) {
-        import('./wikipedia_citation_button')
-            .then((module) => module.WikipediaCitationButtonPressed());
     }
 
     $(document).on('click', '.slide-toggle', function () {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -158,7 +158,7 @@ jQuery(function () {
 
     //conditionally load javascript for the wikipedia citation button 
     if(document.getElementById('wikilink')) {
-        import('./wikipedia_citation_button.js')
+        import('./wikipedia_citation_button')
             .then((module) => module.WikipediaCitationButtonPressed());
     }
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -33,8 +33,6 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
-//load javascript for the wikipedia citation button
-import WikipediaCitationButtonPressed from './wikipedia_citation_button';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -90,7 +88,6 @@ jQuery(function () {
     addFadeInFunctionsTojQuery($);
     jQueryRepeat($);
     initAnalytics($);
-    WikipediaCitationButtonPressed($);
     init($);
     // conditionally load functionality based on what's in the page
     if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
@@ -162,4 +159,6 @@ jQuery(function () {
     $(document).on('click', '.slide-toggle', function () {
         $(`#${$(this).attr('aria-controls')}`).slideToggle();
     });
+
+    $('#wikiselect').on('focus', function(){$(this).select();})
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -156,8 +156,8 @@ jQuery(function () {
         $('#cboxSlideshow').attr({'aria-label': 'Slideshow button', 'aria-hidden': 'true'});
     }
 
-    //conditionally load javascript for the wikipedia citation button 
-    if(document.getElementById('wikilink')) {
+    //conditionally load javascript for the wikipedia citation button
+    if (document.getElementById('wikilink')) {
         import('./wikipedia_citation_button')
             .then((module) => module.WikipediaCitationButtonPressed());
     }

--- a/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
+++ b/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
@@ -1,3 +1,0 @@
-export default function WikipediaCitationButtonPressed() {
-    $('#wikiselect').on('focus', function(){$(this).select();})
-}

--- a/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
+++ b/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
@@ -1,5 +1,5 @@
 export function WikipediaCitationButtonPressed() {
-    $('#wikilink').click( function() {
+    $('#wikilink').click(function() {
         $('#wikiselect').focus(function(){$(this).select();})
     })
 }

--- a/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
+++ b/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
@@ -1,5 +1,5 @@
 export function WikipediaCitationButtonPressed() {
-    window.q.push(function(){
-        ('#wikiselect').focus(function(){this.select();})
-    });
+    $('#wikilink').click( function() {
+        $('#wikiselect').focus(function(){$(this).select();})
+    })
 }

--- a/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
+++ b/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
@@ -1,5 +1,3 @@
-export function WikipediaCitationButtonPressed() {
-    $('#wikilink').click(function() {
-        $('#wikiselect').focus(function(){$(this).select();})
-    })
+export default function WikipediaCitationButtonPressed() {
+    $('#wikiselect').on('focus', function(){$(this).select();})
 }

--- a/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
+++ b/openlibrary/plugins/openlibrary/js/wikipedia_citation_button.js
@@ -1,0 +1,5 @@
+export function WikipediaCitationButtonPressed() {
+    window.q.push(function(){
+        ('#wikiselect').focus(function(){this.select();})
+    });
+}

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -65,13 +65,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                     </div>
                 </div>
 
-                <script type="text/javascript">
-                <!--
-                window.q.push(function(){
-                    \$('#wikiselect').focus(function(){\$(this).select();})
-                });
-                //-->
-                </script>
+            <!-- script for when the wikipedia citation button is pressed is at ../../plugins/openlibrary/js/wikipedia_citation_button.js -->
     </div>
 
     <table class="history">

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -64,8 +64,6 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                         </form>
                     </div>
                 </div>
-
-            <!-- script for when the wikipedia citation button is pressed is at ../../plugins/openlibrary/js/wikipedia_citation_button.js -->
     </div>
 
     <table class="history">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Works on #4474 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
history.html: The script used to select the whole text when the textarea was clicked for the wikipedia citation link, steps below.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
history.html : tested on a book page, specifically /books/OL26337700M
1. Scroll down to  `Download catalog record: RDF / JSON / OPDS | Wikipedia citation`
2. Click on Wikipedia citation, a window opens. Click on the textarea, the whole text is selected automatically and if you click, you can choose which part manually.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
