### PR TITLE
Removed hover effects and fixed mobile nav menus' toggle buttons

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -65,11 +65,11 @@ $def with (page)
 
   <ul class="navigation-component">
     <li class="browse-menu">
-      <label role="button" for="toggle-browse-menu" class="browse-menu-button">$_('Browse') 
+      <label for="toggle-browse-menu" class="browse-menu-button">$_('Browse') 
         <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/>
       </label>
 
-      <input type="checkbox" class="navigation-component__checkbox" id="toggle-browse-menu">
+      <input role="button" type="checkbox" class="navigation-component__checkbox" id="toggle-browse-menu">
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>
@@ -81,11 +81,11 @@ $def with (page)
       </div>
     </li>
     <li class="more-menu">
-      <label role="button" for="toggle-more-menu" class="more-menu-button">$_('More') 
+      <label for="toggle-more-menu" class="more-menu-button">$_('More') 
         <img class="down-arrow" width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/>
       </label>
 
-      <input type="checkbox" class="navigation-component__checkbox" id="toggle-more-menu">
+      <input role="button" type="checkbox" class="navigation-component__checkbox" id="toggle-more-menu">
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">
           <li><a href="/books/add">$_("Add a Book")</a></li>
@@ -109,15 +109,15 @@ $def with (page)
   $if ctx.user:
     <div class="account-component">
       <div class="dropdown-avatar">        
-        <label role="button" for="toggle-account" id="userToggle" class="avatar account-button" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');">
+        <label for="toggle-account" id="userToggle" class="avatar account-button" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');">
         </label>
 
-        <label role="button" for="toggle-account" class="account-button">
+        <label for="toggle-account" class="account-button">
           <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
         </label>
       </div>
 
-      <input type="checkbox" class="account-component__checkbox" id="toggle-account">
+      <input role="button" type="checkbox" class="account-component__checkbox" id="toggle-account">
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
         <ul class="dropdown-menu">
           <li><a href="$ctx.user.key">$_("My Profile")</a></li>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -65,7 +65,11 @@ $def with (page)
 
   <ul class="navigation-component">
     <li class="browse-menu">
-      <a>$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
+      <label role="button" for="toggle-browse-menu" class="browse-menu-button">$_('Browse') 
+        <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/>
+      </label>
+
+      <input type="checkbox" class="navigation-component__checkbox" id="toggle-browse-menu">
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>
@@ -77,8 +81,11 @@ $def with (page)
       </div>
     </li>
     <li class="more-menu">
-      <a>$_('More') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
+      <label role="button" for="toggle-more-menu" class="more-menu-button">$_('More') 
+        <img class="down-arrow" width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/>
+      </label>
+
+      <input type="checkbox" class="navigation-component__checkbox" id="toggle-more-menu">
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">
           <li><a href="/books/add">$_("Add a Book")</a></li>
@@ -101,10 +108,16 @@ $def with (page)
 
   $if ctx.user:
     <div class="account-component">
-      <div class="dropdown-avatar">
-        <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
-        <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
+      <div class="dropdown-avatar">        
+        <label role="button" for="toggle-account" id="userToggle" class="avatar account-button" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');">
+        </label>
+
+        <label role="button" for="toggle-account" class="account-button">
+          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
+        </label>
       </div>
+
+      <input type="checkbox" class="account-component__checkbox" id="toggle-account">
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
         <ul class="dropdown-menu">
           <li><a href="$ctx.user.key">$_("My Profile")</a></li>

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -415,7 +415,7 @@
     display: none;
   }
 
-  // stylelint-disable-next-line selector-max-specificity 
+  // stylelint-disable-next-line selector-max-specificity
   &:checked ~ .navigation-dropdown-component ul {
     display: block;
   }
@@ -441,7 +441,7 @@
     display: none;
   }
 
-  // stylelint-disable-next-line selector-max-specificity 
+  // stylelint-disable-next-line selector-max-specificity
   &:checked ~ .navigation-dropdown-component ul {
     display: block;
   }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -61,18 +61,6 @@
         padding: 5px;
       }
     }
-
-    .account-component__checkbox {
-      display: none;
-
-      & ~ .navigation-dropdown-component ul {
-        display: none;
-      }
-
-      &:checked ~ .navigation-dropdown-component ul {
-        display: block;
-      }
-    }
   }
 
   .auth-component {
@@ -420,6 +408,19 @@
   }
 }
 
+.account-component__checkbox {
+  display: none;
+
+  & ~ .navigation-dropdown-component ul {
+    display: none;
+  }
+
+  // stylelint-disable-next-line selector-max-specificity 
+  &:checked ~ .navigation-dropdown-component ul {
+    display: block;
+  }
+}
+
 .hamburger-component__checkbox {
   opacity: 0;
   
@@ -440,6 +441,7 @@
     display: none;
   }
 
+  // stylelint-disable-next-line selector-max-specificity 
   &:checked ~ .navigation-dropdown-component ul {
     display: block;
   }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -61,6 +61,18 @@
         padding: 5px;
       }
     }
+
+    .account-component__checkbox {
+      display: none;
+
+      & ~ .navigation-dropdown-component ul {
+        display: none;
+      }
+
+      &:checked ~ .navigation-dropdown-component ul {
+        display: block;
+      }
+    }
   }
 
   .auth-component {
@@ -421,6 +433,18 @@
   }
 }
 
+.navigation-component__checkbox {
+  opacity: 0;
+
+  & ~ .navigation-dropdown-component ul {
+    display: none;
+  }
+
+  &:checked ~ .navigation-dropdown-component ul {
+    display: block;
+  }
+}
+
 .account-component {
   -webkit-box-flex: 1;
   -ms-flex: 1;
@@ -451,19 +475,6 @@
     position: relative;
     top: -2px;
   }
-}
-
-.hamburger-component,
-.navigation-component li,
-.account-component {
-  /* stylelint-disable selector-max-specificity */
-  .navigation-dropdown-component {
-    display: none;
-  }
-  &:hover .navigation-dropdown-component {
-    display: block;
-  }
-  /* stylelint-enable selector-max-specificity */
 }
 
 .logo-component {


### PR DESCRIPTION
### Issue Number
Closes #4444 

### What does this PR achieve? 
Fix

### Technical
<!-- What should be noted about the implementation? -->
I have used the [checkbox hack](https://css-tricks.com/the-checkbox-hack/) to fix the toggle buttons of the mobile navbar menus. Also, removed the hover effect from the buttons, since they led to a not-so-friendly user interface.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open OpenLibrary in development mode
2. Open the developer console and toggle to mobile view
3. Open the Browse menu/More options menu/Account dropdown
4. Click on it again to close it. 

### Screencast
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
I'm attaching a screencast for how it looks right now:

https://user-images.githubusercontent.com/52366674/106347861-a6c7a000-62e7-11eb-96fb-06e7cc33b7b0.mp4



<!-- ### Stakeholders -->
<!-- @ tag stakeholders of this bug -->
