### PR TITLE
Remove unused imports from coverstore utils.py

### DIFF
--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -11,7 +11,6 @@ import requests
 import web
 from six.moves.urllib.parse import splitquery, unquote, unquote_plus
 from six.moves.urllib.parse import urlencode as real_urlencode
-from six.moves.urllib.request import Request, urlopen
 
 from openlibrary.coverstore import config, oldb
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
These `urllib` imports are no longer required because we now use `requests`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
