### PR TITLE
json.dump(indent) MUST be an int on Python 2

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -7,7 +7,7 @@ import re
 import six
 from six.moves.urllib.parse import urlsplit
 
-if six.PY2:  # json.dump(indent) MUST be an int on PY2
+if six.PY2:  # See #4525 json.dump(indent) MUST be an int on PY2
     import simplejson as json
 else:
     import json

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -2,10 +2,15 @@
 """
 import web
 from datetime import datetime
-import json
 import re
 
+import six
 from six.moves.urllib.parse import urlsplit
+
+if six.PY2:  # json.dump(indent) MUST be an int on PY2
+    import simplejson as json
+else:
+    import json
 
 import babel
 import babel.core
@@ -22,8 +27,6 @@ try:
     from bs4 import BeautifulSoup
 except ImportError:
     BeautifulSoup = None
-
-import six
 
 from infogami import config
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes: https://dev.openlibrary.org/admin/people/AliceKirk?debug=true
Fails only when it is run on legacy Python with `TypeError: can't multiply sequence by non-int of type 'str'`

This PR conditionally loads `simplejson` only if we are still running on legacy Python.

This is a Python 2-only issue with https://docs.python.org/2/library/json.html#json.dump where `indent` must be an int while Py3 https://docs.python.org/3/library/json.html#json.dump and simplejson https://simplejson.readthedocs.io/en/latest/index.html#simplejson.dump allow `indent` a str as well.
* `python3 -c "import json ; json.dumps({'a': 1}, indent='    ')" ` # no problems
* `python2 -c "import simplejson ; simplejson.dumps({'a': 1}, indent='    ')" ` # no problems
* `python2 -c "import json ; json.dumps({'a': 1}, indent='    ')" ` # ___TypeError___

@dherbst Your review, please.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2021-02-02 at 10 49 37](https://user-images.githubusercontent.com/3709715/106582681-8d6f5f80-6544-11eb-9e61-3fe113b47fc0.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
