### PR TITLE
Replace urlopen with requests in openlibrary/views/showmarc

### DIFF
--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -121,7 +121,7 @@ class show_marc(app.view):
         try:
             response = requests.get(url, headers=headers)
             response.raise_for_status()
-            result = response.content
+            result = response.content[:100000]
         except requests.HTTPError as e:
             return "ERROR:" + str(e)
 

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -21,7 +21,7 @@ class show_ia(app.view):
 
     def GET(self, ia):
         error_404 = False
-        url = 'http://www.archive.org/download/%s/%s_meta.mrc' % (ia, ia)
+        url = 'https://archive.org/download/%s/%s_meta.mrc' % (ia, ia)
         try:
             response = requests.get(url)
             response.raise_for_status()
@@ -33,14 +33,14 @@ class show_ia(app.view):
                 return "ERROR:" + str(e)
 
         if error_404:  # no MARC record
-            url = 'http://www.archive.org/download/%s/%s_meta.xml' % (ia, ia)
+            url = 'https://archive.org/download/%s/%s_meta.xml' % (ia, ia)
             try:
                 response = requests.get(url)
                 response.raise_for_status()
                 data = response.content
             except requests.HTTPError as e:
                 return "ERROR:" + str(e)
-            raise web.seeother('http://www.archive.org/details/' + ia)
+            raise web.seeother('https://archive.org/details/' + ia)
 
         books = web.ctx.site.things({
             'type': '/type/edition',
@@ -114,7 +114,7 @@ class show_marc(app.view):
 
 
         r0, r1 = offset, offset+100000
-        url = 'https://www.archive.org/download/%s' % filename
+        url = 'https://archive.org/download/%s' % filename
         headers = {'Range': 'bytes=%d-%d' % (r0, r1)}
 
         try:

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -115,7 +115,7 @@ class show_marc(app.view):
         # print("record_locator: <code>%s</code><p/><hr>" % locator)
 
         r0, r1 = offset, offset+100000
-        url = 'http://www.archive.org/download/%s' % filename
+        url = 'https://www.archive.org/download/%s' % filename
         headers = {'Range': 'bytes=%d-%d' % (r0, r1)}
 
         try:

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -112,7 +112,7 @@ class show_marc(app.view):
         offset = int(offset)
         length = int(length)
 
-        # print "record_locator: <code>%s</code><p/><hr>" % locator
+        # print("record_locator: <code>%s</code><p/><hr>" % locator)
 
         r0, r1 = offset, offset+100000
         url = 'http://www.archive.org/download/%s' % filename

--- a/openlibrary/views/showmarc.py
+++ b/openlibrary/views/showmarc.py
@@ -112,7 +112,6 @@ class show_marc(app.view):
         offset = int(offset)
         length = int(length)
 
-        # print("record_locator: <code>%s</code><p/><hr>" % locator)
 
         r0, r1 = offset, offset+100000
         url = 'https://www.archive.org/download/%s' % filename


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related #2852 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor showmarc to replace urlopen with requests.

### Technical
<!-- What should be noted about the implementation? -->
Refactor showmarc to replace urlopen with requests.
Some pylint and pycodestyle changes for formatting.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
```python
r0 = 0
r1 = 894
filename = 'CollingswoodLibraryMarcDump10-27-2008/Collingswood.out'
url = 'http://www.archive.org/download/%s' % filename
headers = {'Range': 'bytes=%d-%d' % (r0, r1)}
response = requests.get(url, headers=headers)
response.raise_for_status()
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss @hornc 
