### PR TITLE
Imports should be at the top of the file

### DIFF
--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -22,6 +22,7 @@
 @import (less) "less/breakpoints.less";
 @import (less) "less/mixins.less";
 @import (less) "less/font-families.less";
+@import (less) "legacy.less";
 
 /* stylelint-disable selector-max-specificity */
 body,
@@ -138,8 +139,6 @@ div#bottom,
   display: none;
 }
 /* stylelint-enable selector-max-specificity */
-// Import all common components
-@import (less) "legacy.less";
 
 // Defined in openlibrary/macros/EditButtons.html
 div.adminDelete {

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -10,10 +10,13 @@
 @import (less) "less/colors.less";
 @import (less) "less/breakpoints.less";
 @import (less) "less/mixins.less";
+// TODO: Only formElement and a few common styles are actually needed in this file
+// to render this simple page. We should list them explicitly once that's possible.
+@import (less) "legacy.less";
 
 body {
   text-align: left;
-  background-color: @white;
+  background-color: @white !important;
   overflow: hidden;
 }
 
@@ -106,11 +109,6 @@ footer,
   min-height: 30px;
   margin: 25px 0 15px;
 }
-
-// Import all common components
-// TODO: Only formElement and a few common styles are actually needed
-// to render this simple page. Once all.less is refactored, list them explicitly.
-@import (less) "legacy.less";
 
 @media all and ( min-width: @width-breakpoint-desktop ) {
   body {


### PR DESCRIPTION
page-form and page-edit both provide styles that override
the defaults specific for that page.

These will be cleaned up by the LESS compiler. To ensure that
the styles in this file override any defaults all imports must
be listed first.

This will address the issue with the change cover background not
being white.

Follow up to f996715949e5e370bf5b3bf28570beed680e4c3b

### Evidence

<img width="700" alt="Screen Shot 2021-02-02 at 9 10 20 PM" src="https://user-images.githubusercontent.com/148752/106701148-10230980-659b-11eb-8582-af7a3aa315a1.png">


### Stakeholders
@cdrini  @Yashs911