### PR TITLE
Do not hardcode SolrWriter(host)

### DIFF
--- a/openlibrary/solr/process_stats.py
+++ b/openlibrary/solr/process_stats.py
@@ -242,7 +242,8 @@ def fix_subject_key(doc, name, prefix):
         doc[name] = [v.replace(prefix, '') for v in doc[name]]
 
 def update_solr(docs):
-    solr = SolrWriter("localhost:8983")
+    # stats_solr is defined in olsystem etc/openlibrary.yml
+    solr = SolrWriter(config.stats_solr or "localhost:8983")
     for doc in docs:
         # temp fix for handling already processed data
         doc = dict((k, v) for k, v in doc.items() if v is not None)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Blocked by #4387
Subtask of #4383

The solr/process_stats cron jobs will run in a Docker container on `ol-home0` but need to access a solar instance that is running on `ol-home`.  This PR removes the hardcoding of localhost in favor of using config to obtain `stats_solr` as it is defined in olsystem etc/openlibrary.yml

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
