### PR TITLE
Do not .decode a str in PY3, only in PY2

### DIFF
--- a/openlibrary/solr/solrwriter.py
+++ b/openlibrary/solr/solrwriter.py
@@ -94,7 +94,7 @@ def add_field(doc, name, value):
             value = str(value)
         try:
             value = strip_bad_char(value)
-            if isinstance(value, str):
+            if six.PY2 and isinstance(value, str):
                 value = value.decode('utf-8')
             field.text = normalize('NFC', value)
         except:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Contributes toward resolving #4542 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix to only `.decode` in PY2.

### Technical
<!-- What should be noted about the implementation? -->
Only necessary to `.decode` in PY2.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I think you have to hit the `add_field` function.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
N/A

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @cclauss 
