### PR TITLE
Fixing linter errors continued

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -58,8 +58,10 @@
 		"no-extra-semicolons": true,
 		"no-empty-source": true,
 		"font-family-no-duplicate-names": true,
-		"font-family-no-missing-generic-family-keyword": true,
+		"font-family-no-missing-generic-family-keyword": [true, {"ignoreFontFamilies": ["!important"]}],
 		"no-descending-specificity": true,
-		"string-quotes": ["double", {"avoidEscape":false}]
+		"string-quotes": ["double", {"avoidEscape":false}],
+		"declaration-bang-space-before": "always",
+		"declaration-colon-space-after": "always"
 	}
 }

--- a/openlibrary/macros/DonateModal.html
+++ b/openlibrary/macros/DonateModal.html
@@ -11,7 +11,7 @@ $ title = book.title
       <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
     </div>
     <hr>
-    <div class="donateModal">
+    <div class="donate__modal">
       <p class="cta">Hooray! You've discovered a title that's missing from our <a href="https://help.archive.org/hc/en-us/articles/360016554912-Borrowing-From-The-Lending-Library">library</a>. Can you help donate a copy?</p>
 
       <ol class="donation__instructions">

--- a/static/css/base/headings.less
+++ b/static/css/base/headings.less
@@ -12,7 +12,7 @@ h1 {
   &.publisher {
     color: @brown;
     font-size: 1.375em;
-    font-family: @georgia_serif-1!important;
+    font-family: @georgia_serif-1 !important;
     font-weight: normal !important;
     margin: 0;
   }

--- a/static/css/base/helpers-misc.less
+++ b/static/css/base/helpers-misc.less
@@ -51,7 +51,7 @@ button {
 }
 
 .adminOnly {
-  background-color: @orange!important;
+  background-color: @orange !important;
   padding: 4px;
   border-radius: 4px;
 }
@@ -86,11 +86,11 @@ button {
 .valid,
 .darkgreen,
 .pos {
-  color: @dark-green!important;
+  color: @dark-green !important;
 }
 
 .black {
-  color: @black!important;
+  color: @black !important;
 }
 
 .highlight {
@@ -98,52 +98,52 @@ button {
 }
 
 .orange {
-  color: @orange!important;
+  color: @orange !important;
 }
 
 .brown {
-  color: @brown!important;
+  color: @brown !important;
 }
 
 .teal {
-  color: @teal!important;
+  color: @teal !important;
 }
 
 .light {
   &green {
-    color: @olive!important;
+    color: @olive !important;
   }
   &grey,
   &gray {
-    color: @light-grey!important;
+    color: @light-grey !important;
   }
 }
 
 .blue {
-  color: @link-blue!important;
+  color: @link-blue !important;
 }
 
 .invalid,
 .attn,
 .neg,
 .red {
-  color: @red!important;
+  color: @red !important;
 }
 
 .yellow {
-  color: @light-yellow!important;
+  color: @light-yellow !important;
 }
 
 .lighter,
 .gray,
 .grey {
-  color: @grey!important;
+  color: @grey !important;
 }
 
 .dark {
   &gray,
   &grey {
-    color: @dark-grey!important;
+    color: @dark-grey !important;
   }
 }
 
@@ -190,11 +190,11 @@ button {
 
 .headline,
 .sansserif {
-  font-family: @lucida_sans_serif-1!important;
+  font-family: @lucida_sans_serif-1 !important;
 }
 
 .arial {
-  font-family: @arial_sans_serif!important;
+  font-family: @arial_sans_serif !important;
 }
 
 .nowrap {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -31,8 +31,7 @@ a.cta-btn {
   }
   // stylelint-disable-next-line selector-max-specificity
   .btn-icon.read-aloud {
-    // stylelint-disable-next-line function-url-quotes
-    background-image: url("/static/images/icons/read aloud.svg");
+    background-image: url(/static/images/icons/read%20aloud.svg);
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;

--- a/static/css/components/buttonsAndLinks.less
+++ b/static/css/components/buttonsAndLinks.less
@@ -65,13 +65,13 @@ a {
   }
   &.toggle {
     text-decoration: none;
-    color: @white!important;
-    background-color: @olive!important;
+    color: @white !important;
+    background-color: @olive !important;
     padding: 3px;
     border-radius: 3px;
     &:hover {
-      background-color: @link-blue!important;
-      color: @white!important;
+      background-color: @link-blue !important;
+      color: @white !important;
     }
   }
 }

--- a/static/css/components/chart.less
+++ b/static/css/components/chart.less
@@ -25,7 +25,7 @@
   &Yaxis {
     position: absolute;
     left: -65px;
-    top:60px;
+    top: 60px;
     text-align: center;
     vertical-align: middle;
     -webkit-transform: rotate(-90deg);

--- a/static/css/components/donate.less
+++ b/static/css/components/donate.less
@@ -39,7 +39,7 @@
   }
 }
 
-div.donateModal {
+.donate__modal {
   padding: 0 10px;
   ul li, ol li {
     font-size: .875em;

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -22,7 +22,7 @@ div#editInfo {
   > div {
     font-size: 11px;
     font-weight: normal;
-    color: @brown!important;
+    color: @brown !important;
     font-family: @lucida_sans_serif-1;
   }
   .smallest {

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -96,12 +96,12 @@ table#editions,
 .lists {
   table#editions {
     h3 {
-      font-family: @lucida_sans_serif-1!important;
+      font-family: @lucida_sans_serif-1 !important;
       font-size: .75em;
       display: inline;
     }
     th {
-      font-family: @lucida_sans_serif-1!important;
+      font-family: @lucida_sans_serif-1 !important;
       background-color: transparent;
       text-align: left;
       font-weight: normal;

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -110,7 +110,7 @@
   .tip {
     font-size: 11px;
     color: @grey;
-    font-family: @lucida_sans_serif-1!important;
+    font-family: @lucida_sans_serif-1 !important;
   }
 }
 

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -26,7 +26,7 @@ div.merge {
     }
   }
   .master {
-    background-color: @light-yellow!important;
+    background-color: @light-yellow !important;
     position: sticky;
     top: 0;
   }
@@ -48,7 +48,7 @@ div.merge {
       margin-bottom: 0 !important;
     }
     li {
-      color: @grey!important;
+      color: @grey !important;
       font-size: .75em;
     }
     label {

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -6,7 +6,7 @@
 @import "less/breakpoints.less";
 
 .page-banner {
-  display:none;
+  display: none;
   color: @white;
   font-family: @lucida_sans_serif-1;
   background: @black;
@@ -16,7 +16,7 @@
   border-bottom: 1px solid @beige;
 
   @media screen and (min-width: @width-breakpoint-tablet) {
-    display:block;
+    display: block;
   }
 
   &-black {

--- a/static/css/components/preview.less
+++ b/static/css/components/preview.less
@@ -4,8 +4,8 @@
 
 .book-preview {
   .iframe-container {
-    border-top: 1px solid rgb(238, 238, 238);
-    border-bottom: 1px solid rgb(238, 238, 238);
+    border-top: 1px solid @lightest-grey;
+    border-bottom: 1px solid @lightest-grey;
   }
 
   .learn-more {

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -77,7 +77,7 @@
 }
 
 .cta-section-title.world-cat-link{
-  margin-top:0;
+  margin-top: 0;
 }
 
 .sponsorship-card {

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -10,7 +10,7 @@
     list-style-type: none;
     display: inline;
     &:not(:last-child):after {
-      content:"·";
+      content: "·";
       margin: 0 4px;
     }
   }

--- a/static/css/components/widget-box.less
+++ b/static/css/components/widget-box.less
@@ -5,7 +5,7 @@
 .widget-box {
   .head {
     > div {
-      color: @olive!important;
+      color: @olive !important;
       font-size: 10px;
     }
   }
@@ -24,7 +24,7 @@
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .widget-box {
-    float:left;
-    width:282px;
+    float: left;
+    width: 282px;
   }
 }

--- a/static/css/components/wmd-prompt-dialog--js.less
+++ b/static/css/components/wmd-prompt-dialog--js.less
@@ -13,7 +13,7 @@
   .wmd-prompt-dialog {
     margin-left: 10px !important;
     margin-top: 10px !important;
-    top: 100px   !important;
+    top: 100px !important;
     left: 0 !important;
     right: 0 !important;
     width: 300px !important;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -47,7 +47,7 @@ div.editionAbout {
 }
 
 .work-subtitle{
-  margin-top:0;
+  margin-top: 0;
 }
 
 .workFooter {
@@ -181,7 +181,7 @@ a.section-anchor {
 }
 
 .book-subtitle{
-  margin-bottom:0;
+  margin-bottom: 0;
 }
 
 @import (less) "components/readerStats.less";

--- a/static/css/legacy-tools.less
+++ b/static/css/legacy-tools.less
@@ -152,7 +152,7 @@
     font-size: 100%;
     min-height: 32px;
     width: 250px;
-    font-family: @lucida_sans_serif-1!important;
+    font-family: @lucida_sans_serif-1 !important;
     font-weight: normal;
     outline: 0;
     position: relative;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1801,7 +1801,7 @@ div.addfield {
   // openlibrary/templates/recentchanges/render.html
   // openlibrary/templates/type/list/editions.html
   .historyPager {
-    text-align:center;
+    text-align: center;
     margin: 20px 0;
     width: 100%;
   }

--- a/static/css/page-admin.less
+++ b/static/css/page-admin.less
@@ -84,8 +84,8 @@ table.services {
 
 // openlibrary/templates/admin/index.html
 .stats-spacer {
-  width:250px;
-  height:35px;
+  width: 250px;
+  height: 35px;
   margin-left: 50px;
 }
 

--- a/static/css/page-barcodescanner.less
+++ b/static/css/page-barcodescanner.less
@@ -43,7 +43,7 @@
   canvas {
     position: absolute;
     top: 0;
-    left:0;
+    left: 0;
   }
 }
 #result-strip {

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -127,11 +127,11 @@ th.toggle-all {
   display: inline-block;
   height: 360px;
   overflow: auto;
-  width:100%;
+  width: 100%;
 }
 
 .import-table{
-  border:2px;
+  border: 2px;
   th {
     padding: 5px 10px;
   }
@@ -146,7 +146,7 @@ th.toggle-all {
     }
   }
   tbody{
-    width:100%;
+    width: 100%;
     tr {
       background-color: @white;
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Works on #4537, follow up to #4550

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor 

### Technical
<!-- What should be noted about the implementation? -->
After adding `"declaration-bang-space-before": "always",`, it was recognizing `!important` as its own font-family, hence ignored that in secondary options. 
Separated commits to go through the changes easier :) 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 