### PR TITLE
Fix Search Result Overlap

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -174,7 +174,7 @@
     -webkit-box-ordinal-group: 6;
     -ms-flex-order: 5;
     order: 5;
-    z-index: @z-index-level-2;
+    z-index: @z-index-level-5;
 
     li {
       -ms-flex-preferred-size: 100%;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -225,7 +225,7 @@
     -webkit-box-flex: 1;
     -ms-flex: 1;
     flex: 1;
-    z-index: @z-index-level-1;
+    z-index: @z-index-level-4;
 
     // stylelint-disable selector-max-specificity
     // stylelint-disable max-nesting-depth

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -135,7 +135,7 @@ h2.edition-byline {
     top: 0;
     display: block;
     background: @white;
-    z-index: @z-index-level-4;
+    z-index: @z-index-level-3;
     padding-top: 10px;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3796 

Increases thez-index for search-component and decreases the z-index for sticky-menu

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/107239397-d3e62200-6a4e-11eb-9cdf-f9f4e18dd436.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
