### PR TITLE
Fix Nothing is not JSON serializable

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -101,7 +101,7 @@ def sanitize(html, encoding='utf8'):
 def json_encode(d, **kw):
     """Same as json.dumps.
     """
-    return json.dumps(d, **kw)
+    return json.dumps(d or {}, **kw)
 
 
 def safesort(iterable, key=None, reverse=False):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4555

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Yet another subtle difference between simplejson and json.  @dherbst @Yashs911 

Convert a `Nothing` into an empty dict before performing a `json.dumps()` on it to avoid `TypeError: Object of type Nothing is not JSON serializable` as described in #4555.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
