### PR TITLE
Add web-haproxy and web-nginx to docker-compose.production.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,9 @@
 
 version: "3.1"
 services:
+  web:
+    ports:
+      - 8080:80
   covers:
     ports:
       - 7075:7075

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -7,7 +7,7 @@
 
 version: "3.1"
 services:
-  www_haproxy:
+  web_haproxy:
     image: haproxy:2.3.5
     restart: always
     #depends_on:
@@ -35,7 +35,7 @@ services:
       # Needed by default-docker.conf
       - ssl_certificate
       - ssl_certificate_key
-  www_nginx:
+  web_nginx:
     image: nginx:1.19.4
     restart: always
     depends_on:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -7,6 +7,62 @@
 
 version: "3.1"
 services:
+  www_haproxy:
+    image: haproxy:2.3.5
+    restart: always
+    #depends_on:
+    #  - www_haproxy
+    volumes:
+      #- olsystem ... /etc/haproxy/haproxy.cfg
+      #- ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+      #- ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
+      # Needed for HTTPS, since this is a public server
+      - ../olsystem/etc/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro
+      # Needs access to openlibrary for static files
+      #- ../olsystem:/olsystem
+      #- /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - webnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
+    secrets:
+      - petabox_seed
+      # Needed by default-docker.conf
+      - ssl_certificate
+      - ssl_certificate_key
+  www_nginx:
+    image: nginx:1.19.4
+    restart: always
+    depends_on:
+      - www_haproxy
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
+      # Needed for HTTPS, since this is a public server
+      - ../olsystem/etc/nginx/sites-available/default-docker.conf:/etc/nginx/sites-enabled/default:ro
+      # Needs access to openlibrary for static files
+      - ../olsystem:/olsystem
+      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - webnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
+    secrets:
+      - petabox_seed
+      # Needed by default-docker.conf
+      - ssl_certificate
+      - ssl_certificate_key
+    
   web:
     restart: always
     hostname: "$HOSTNAME"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -10,6 +10,8 @@ services:
   web:
     restart: always
     hostname: "$HOSTNAME"
+    ports:
+      - 8080:80
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-web-start.sh
     ports:
-      - 8080:80
       - 3000:3000
+    expose:
+      - 8080:80
     depends_on:
       - db
       - infobase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - 3000:3000
     expose:
-      - 8080:80
+      - 80
     depends_on:
       - db
       - infobase


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #4252

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add `www-haproxy` and `www-nginx` to docker-compose.production.yml so we can replace the server `ol-www1` with a Docker-based `ol-www0`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Rejected by Jenkins:
```
The Compose file './docker-compose.yml' is invalid because:
services.web.expose is invalid: should be of the format 'PORT[/PROTOCOL]'
```
http://server.openjournal.foundation:8081/blue/organizations/jenkins/ol-staging%20deploy/detail/ol-staging%20deploy/171/pipeline/60

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
