### PR TITLE
Fix Advanced Search Color Contrast

### DIFF
--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -44,7 +44,7 @@
 @orange-five: hsl(23, 100%, 50%);
 
 // reds
-@red: hsl(8, 78%, 53%);
+@red: hsl(8, 78%, 49%);
 @dark-red: hsl(8, 70%, 44%);
 @red-two:hsl(4, 90%, 58%);
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4522

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
New Contrast ratio: **4.53:1**
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/107610740-4da52800-6c68-11eb-9fca-d62034cf5deb.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
