### PR TITLE
Fix redirects breaking list + list performance

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -367,38 +367,9 @@ class Seed:
         return self._solrdata
 
     def _load_solrdata(self):
-        if self.type == "edition":
-            return {
-                'ebook_count': int(bool(self.document.ocaid)),
-                'edition_count': 1,
-                'work_count': 1,
-                'last_update': self.document.last_modified
-            }
-        elif self.type != 'redirect':
-            # This code is fetching every document in the list from
-            # solr (1 at a time) and appears to be the source of (some of) our
-            # List performance issues.
-            q = self.get_solr_query_term()
-            if q:
-                solr = get_solr()
-                result = solr.select(q, fields=["edition_count", "ebook_count_i"])
-                last_update_i = [doc['last_update_i'] for doc in result.docs if 'last_update_i' in doc]
-                if last_update_i:
-                    last_update = self._inttime_to_datetime(last_update_i)
-                else:
-                    # if last_update is not present in solr, consider last_modfied of
-                    # that document as last_update
-                    if self.type in ['work', 'author']:
-                        last_update = self.document.last_modified
-                    else:
-                        last_update = None
-                return {
-                    'ebook_count': sum(doc.get('ebook_count_i', 0) for doc in result.docs),
-                    'edition_count': sum(doc.get('edition_count', 0) for doc in result.docs),
-                    'work_count': result.num_found,
-                    'last_update': last_update
-                }
-        return {}
+        return {
+            'last_update': self.document.last_modified
+        }
 
     def _inttime_to_datetime(self, t):
         return datetime.datetime(*time.gmtime(t)[:6])

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -368,7 +368,7 @@ class Seed:
 
     def _load_solrdata(self):
         return {
-            'last_update': self.document.last_modified
+            'last_update': self.document.get('last_modified')
         }
 
     def _inttime_to_datetime(self, t):

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -119,7 +119,7 @@ class ListMixin:
     def get_all_editions(self):
         """Returns all the editions of this list in arbitrary order.
 
-        The return value is an iterator over all the edtions. Each entry is a dictionary.
+        The return value is an iterator over all the editions. Each entry is a dictionary.
         (Compare the difference with get_editions.)
 
         This works even for lists with too many seeds as it doesn't try to
@@ -339,6 +339,12 @@ class Seed:
     def _get_document_basekey(self):
         return self.document.key.split("/")[-1]
 
+
+    def resolve_redir(self):
+        if self.type == 'redirect':
+            return web.ctx.site.get(self.document.location)
+        return self
+
     def get_solr_query_term(self):
         if self.type == 'edition':
             return "edition_key:" + self._get_document_basekey()
@@ -365,7 +371,7 @@ class Seed:
                 'work_count': 1,
                 'last_update': self.document.last_modified
             }
-        else:
+        elif self.type != 'redirect':
             q = self.get_solr_query_term()
             if q:
                 solr = get_solr()
@@ -402,6 +408,8 @@ class Seed:
             return "work"
         elif type == "/type/author":
             return "author"
+        elif type == "/type/redirect":
+            return "redirect"
         else:
             return "unknown"
 

--- a/openlibrary/macros/Profile.html
+++ b/openlibrary/macros/Profile.html
@@ -1,0 +1,19 @@
+$def with (component_times)
+
+<table>
+  <thead>
+    <tr>
+      <th>Component</th>
+      <th>Time</th>
+      <th>%</th>
+    </tr>
+  </thead>
+  <tbody>
+    $for component in sorted(component_times.items(), key=lambda x: x[1]):
+      <tr>
+        <td>$component[0]</td>
+        <td>$("%.2f" % component[1])</td>
+        <td>$("%.2f" % (component[1] / component_times['TotalTime'] * 100.))</td>
+      </tr>
+  </tbody>
+</table>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -481,21 +481,6 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
   $ component_times['TotalTime'] = time() - component_times['TotalTime']
 
   $if query_param('debug'):
-    <table>
-      <thead>
-        <tr>
-          <th>Component</th>
-          <th>Time</th>
-          <th>%</th>
-        </tr>
-      </thead>
-      <tbody>
-        $for component in sorted(component_times.items(), key=lambda x: x[1]):
-          <tr>
-            <td>$component[0]</td>
-            <td>$("%.2f" % component[1])</td>
-            <td>$("%.2f" % (component[1] / component_times['TotalTime'] * 100.))</td>
-          </tr>
-      </tbody>
-    </table>
+    $:macros.Profile(component_times)
+
 </div>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -7,7 +7,7 @@ $ component_times = {}
 $ component_times['TotalTime'] = time()
 
 $ page = safeint(query_param('page'), 1) - 1
-$ page_size = 25
+$ page_size = 50
 $ meta_cover_url = None # Add metatag for image at end of this template, if a cover image is present
 $ meta_description = title
 $if list.description:
@@ -293,4 +293,3 @@ window.q.push(function(){
 $if meta_cover_url is not None:
     $add_metatag(property="og:image", content=meta_cover_url)
     $add_metatag(property="twitter:image", content=meta_cover_url)
-

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -178,14 +178,10 @@ window.q.push(function(){
 
         <ul id="listResults" class="list-books">
           $ component_times['get_seeds'] = time()
-          $ seeds = list.get_seeds(sort=True)[page*page_size:page*page_size+page_size]
+          $ seeds = list.get_seeds(sort=True, resolve_redirects=True)[page*page_size:page*page_size+page_size]
           $ component_times['get_seeds'] = time() - component_times['get_seeds']
 
           $for seed in seeds:
-            $ url = seed.url
-            $if seed.type == 'redirect':
-              $ seed = seed.resolve_redir()
-              $ url = seed.url()
             <li id="seed-$loop.index" class="searchResultItem">
                 $ default_image = "https://openlibrary.org/images/icons/avatar_book-sm.png"
                 $ cover = seed.get_cover()
@@ -198,7 +194,7 @@ window.q.push(function(){
                 $if not meta_cover_url:
                     $ meta_cover_url = cover_url
                 <span class="bookcover">
-                    <a href="$url">
+                    <a href="$seed.url">
                       <img src="$cover_url" alt/>
                     </a>
                 </span>
@@ -208,7 +204,7 @@ window.q.push(function(){
                         $if seed.type in ['edition', 'work']:
                             $ doc = seed.document
                         <h3 class="booktitle">
-                            <a href="$url" class="results">$seed.title</a>
+                            <a href="$seed.url" class="results">$seed.title</a>
                         </h3>
                         $ work_editions_count = 0
                         $if seed.type in ['edition', 'work']:

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -264,13 +264,12 @@ window.q.push(function(){
                     </div>
                 </div>
 
-        $if False:
-          $ subjects = list.get_subjects()
+        $ subjects = list.get_subjects()
 
-          $:render_subjects(_("Subjects"), subjects.subjects)
-          $:render_subjects(_("People"), subjects.people)
-          $:render_subjects(_("Places"), subjects.places)
-          $:render_subjects(_("Times"), subjects.times)
+        $:render_subjects(_("Subjects"), subjects.subjects)
+        $:render_subjects(_("People"), subjects.people)
+        $:render_subjects(_("Places"), subjects.places)
+        $:render_subjects(_("Times"), subjects.times)
     </div>
 
     <div class="clearfix"></div>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -239,13 +239,6 @@ window.q.push(function(){
                         <span class="listDelete sansserif smaller">
                           <a href="javascript:;"><span></span>$_('Remove this item?')</a>
                         </span>
-                    $if doc.ia and doc.ia[0]:
-                        <a class="cta-btn print-disabled-only hidden" href="//archive.org/download/$(doc.ia[0])/$(doc.ia[0])_daisy.zip" title="$_('Protected DAISY')">
-                          <span class="actions">
-                            <span class="image daisy"></span>
-                          </span>
-                          <span class="label">$_('Download DAISY')</span>
-                        </a>
                     <span class="searchResultItemCTA-lending">
                     </span>
                 </span>

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -2,8 +2,12 @@ $def with (list)
 
 $ title = list.name
 $ title_with_site = _("%(name)s | Lists | Open Library", name=title)
+
+$ component_times = {}
+$ component_times['TotalTime'] = time()
+
 $ page = safeint(query_param('page'), 1) - 1
-$ page_size = 50
+$ page_size = 25
 $ meta_cover_url = None # Add metatag for image at end of this template, if a cover image is present
 $ meta_description = title
 $if list.description:
@@ -43,7 +47,9 @@ $jsdef render_seed_count(seed_count):
     </div>
     <h1>$list.name</h1>
     <p class="collapse sansserif">
+        $ component_times['render_seed_count'] = time()
         <span class="darkgreen" id="list-items-count"><strong>$:render_seed_count(len(list.seeds))</strong></span>
+        $ component_times['render_seed_count'] = time() - component_times['render_seed_count']
     </p>
 </div>
 
@@ -171,7 +177,15 @@ window.q.push(function(){
             $:format(list.description)
 
         <ul id="listResults" class="list-books">
-          $for seed in list.get_seeds(sort=True)[page*page_size:page*page_size+page_size]:
+          $ component_times['get_seeds'] = time()
+          $ seeds = list.get_seeds(sort=True)[page*page_size:page*page_size+page_size]
+          $ component_times['get_seeds'] = time() - component_times['get_seeds']
+
+          $for seed in seeds:
+            $ url = seed.url
+            $if seed.type == 'redirect':
+              $ seed = seed.resolve_redir()
+              $ url = seed.url()
             <li id="seed-$loop.index" class="searchResultItem">
                 $ default_image = "https://openlibrary.org/images/icons/avatar_book-sm.png"
                 $ cover = seed.get_cover()
@@ -184,20 +198,17 @@ window.q.push(function(){
                 $if not meta_cover_url:
                     $ meta_cover_url = cover_url
                 <span class="bookcover">
-                    <a href="$seed.url">
+                    <a href="$url">
                       <img src="$cover_url" alt/>
                     </a>
                 </span>
                 <span class="seed-key hidden">$seed.key</span>
                 <div class="details">
                     <div class="resultTitle">
-                        $ ebook = {}
                         $if seed.type in ['edition', 'work']:
-                            $ ebook = seed.document.get_ebook_info()
                             $ doc = seed.document
-                            <!-- $:json_encode(ebook) -->
                         <h3 class="booktitle">
-                            <a href="$seed.url" class="results">$seed.title</a>
+                            <a href="$url" class="results">$seed.title</a>
                         </h3>
                         $ work_editions_count = 0
                         $if seed.type in ['edition', 'work']:
@@ -221,9 +232,6 @@ window.q.push(function(){
                             $ungettext('- 1 work', '- %(count)s works', seed.work_count, count=commify(seed.work_count))
                         </span>
 
-                        $if 'daisy_url' in ebook:
-                            <div class="type small"><a href="$ebook['daisy_url']" title="$_('Protected DAISY')">$_('Download DAISY eBook for print disabled')</a></div>
-
                         $if seed.last_update:
                             <span class="time">
                                 $:_('Last updated <span>%(date)s</span>', date=datestr(seed.last_update))
@@ -235,7 +243,7 @@ window.q.push(function(){
                         <span class="listDelete sansserif smaller">
                           <a href="javascript:;"><span></span>$_('Remove this item?')</a>
                         </span>
-                    $if 'daisy_url' in ebook:
+                    $if doc.ia and doc.ia[0]:
                         <a class="cta-btn print-disabled-only hidden" href="//archive.org/download/$(doc.ia[0])/$(doc.ia[0])_daisy.zip" title="$_('Protected DAISY')">
                           <span class="actions">
                             <span class="image daisy"></span>
@@ -267,18 +275,21 @@ window.q.push(function(){
                     </div>
                 </div>
 
-        $ subjects = list.get_subjects()
+        $if False:
+          $ subjects = list.get_subjects()
 
-        $:render_subjects(_("Subjects"), subjects.subjects)
-        $:render_subjects(_("People"), subjects.people)
-        $:render_subjects(_("Places"), subjects.places)
-        $:render_subjects(_("Times"), subjects.times)
+          $:render_subjects(_("Subjects"), subjects.subjects)
+          $:render_subjects(_("People"), subjects.people)
+          $:render_subjects(_("Places"), subjects.places)
+          $:render_subjects(_("Times"), subjects.times)
     </div>
 
     <div class="clearfix"></div>
 
     $:macros.Pager(page+1, len(list.seeds), page_size)
 
+    $if query_param('debug'):
+      $:macros.Profile(component_times)
 
     $:render_template("lib/history", list)
 </div>
@@ -286,3 +297,4 @@ window.q.push(function(){
 $if meta_cover_url is not None:
     $add_metatag(property="og:image", content=meta_cover_url)
     $add_metatag(property="twitter:image", content=meta_cover_url)
+

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -206,13 +206,11 @@ window.q.push(function(){
                         <h3 class="booktitle">
                             <a href="$seed.url" class="results">$seed.title</a>
                         </h3>
-                        $ work_editions_count = 0
                         $if seed.type in ['edition', 'work']:
                             $if seed.type == "work":
                                 $ authors = seed.document.get_authors()
                             $else:
                                 $if seed.document.works:
-                                    $ work_editions_count = seed.document.works[0].edition_count
                                     $ authors = seed.document.works[0].get_authors()
                                 $else:
                                     $ authors = seed.document.get_authors()
@@ -220,12 +218,6 @@ window.q.push(function(){
                         <span class="meta">
                           <!-- FIXME: I18N using internal seed.type directly for display is not internationalizable -->
                           <span class="type small">$seed.type</span>
-                        $if seed.type == "edition" and seed.document.get('works'):
-                            $:ungettext('- <a href="%(url)s">1 edition</a> in catalog', '- <a href="%(url)s">%(count)s editions</a> in catalog', seed.work_count, count=commify(work_editions_count), url=seed.document.works[0].url())
-                        $elif seed.type == "work":
-                            $ungettext('- 1 edition', '- %(count)s editions', seed.edition_count, count=commify(seed.edition_count))
-                        $else:
-                            $ungettext('- 1 work', '- %(count)s works', seed.work_count, count=commify(seed.work_count))
                         </span>
 
                         $if seed.last_update:

--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -267,7 +267,7 @@ window.q.push(function(){
     <div class="clearfix"></div>
 
     $:macros.Pager(page+1, len(list.seeds), page_size)
-
+    $ component_times['TotalTime'] = time() - component_times['TotalTime']
     $if query_param('debug'):
       $:macros.Profile(component_times)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4563 

A patch to prevent Lists from breaking when Works are merged -- Just In Time resolves Work redirects to the correct record.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @seabelis 