### PR TITLE
Fix Edition Table 'Listen' roll-over glitch

### DIFF
--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -14,7 +14,8 @@ table#editions,
   font-family: @lucida_sans_serif-1;
 
   .cta-button-group {
-    min-width: 180px;
+    width: 185px;
+    margin: 0 auto;
   }
 
   thead {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4575 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changed min-width to a fixed width.
### Screenshot
**Old:** (minor glitch for Borrow button and major for Special Access)
![captured (2)](https://user-images.githubusercontent.com/64412143/107731803-df6e6d00-6d1c-11eb-9fe8-0b3c2d5ebe3f.gif)
**New:**
![captured (1)](https://user-images.githubusercontent.com/64412143/107731521-3758a400-6d1c-11eb-82b1-4c19a13b8d01.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jamesachamp @jdlrobson 