### PR TITLE
Fix search result and search inside color contrast + Fix missing 'less' on search result page

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -267,7 +267,7 @@ $elif param and len(docs):
                     <span class="small"><a href="$:add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
-                <div class="facetMoreLess"><span class="small" onclick="more('$header');false"><a href="javascript:;" id="${header}_more" class="orange">$_("more")</a></span> <span id="${header}_bull" class="header_bull small gray">&bull;</span> <span class="small" onclick="less('$header');false"><a href="javascript:;" id="${header}_less" class="orange hidden">$_("less")</a></span></div>
+                <div class="facetMoreLess"><span class="small" onclick="more('$header');false"><a href="javascript:;" id="${header}_more" class="red">$_("more")</a></span> <span id="${header}_bull" class="header_bull small gray">&bull;</span> <span class="small" onclick="less('$header');false"><a href="javascript:;" id="${header}_less" class="red hidden">$_("less")</a></span></div>
             </div>
         </div>
 <!-- /facets -->

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -1,6 +1,6 @@
 // A standard list of helpers
 .hidden {
-  display: none !important;
+  display: none;
 }
 .inline {
   display: inline;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -518,7 +518,7 @@ input {
 .search-results-stats {
   margin: 0;
   margin-bottom: 10px;
-  color: @light-grey;
+  color: @grey;
   font-size: .9em;
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4522 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1. Fix "more" and "less" color contrast (Search Result Page)
2. Fix missing "less" due to !important.
3. Fix color contrast of Search Inside Page

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/107752055-38053080-6d44-11eb-8abc-f264c90ef60e.png)

![image](https://user-images.githubusercontent.com/64412143/107752010-2885e780-6d44-11eb-89d1-562d281c8f4a.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
