### PR TITLE
4474/refactor/covers remove inline js

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -166,7 +166,7 @@ jQuery(function () {
     $('.column').sortable({
         connectWith: '.trash'
     });
-    $(''.trash').sortable({
+    $('.trash').sortable({
         connectWith: '.column'
     });
     $('.column').disableSelection();

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -163,13 +163,13 @@ jQuery(function () {
     $('#wikiselect').on('focus', function(){$(this).select();})
 
     // Functionality for manage.html
-    $(".column").sortable({
+    $('.column').sortable({
         connectWith: '.trash'
     });
-    $(".trash").sortable({
+    $(''.trash').sortable({
         connectWith: '.column'
     });
-    $(".column").disableSelection();
-    $(".trash").disableSelection();
-    $("#topNotice").hide();
+    $('.column').disableSelection();
+    $('.trash').disableSelection();
+    $('#topNotice').hide();
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -161,4 +161,15 @@ jQuery(function () {
     });
 
     $('#wikiselect').on('focus', function(){$(this).select();})
+
+    // Functionality for manage.html
+    $(".column").sortable({
+        connectWith: '.trash'
+    });
+    $(".trash").sortable({
+        connectWith: '.column'
+    });
+    $(".column").disableSelection();
+    $(".trash").disableSelection();
+    $("#topNotice").hide();
 });

--- a/openlibrary/templates/covers/manage.html
+++ b/openlibrary/templates/covers/manage.html
@@ -3,20 +3,6 @@ $def with (key, images)
 $putctx("bodyid", "form")
 $putctx('robots', 'noindex,nofollow')
 
-<script type="text/javascript">
-window.q.push(function () {
-    \$(".column").sortable({
-        connectWith: '.trash'
-    });
-    \$(".trash").sortable({
-        connectWith: '.column'
-    });
-    \$(".column").disableSelection();
-    \$(".trash").disableSelection();
-    \$("#topNotice").hide();
-});
-</script>
-
 <div class="imageIntro">
     $_("You can drag and drop thumbnails to reorder, or into the trash to delete them.")
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4474 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor  
### Technical
<!-- What should be noted about the implementation? -->
On the local build covers don't work like they do on the actual website, so I can't be 100% that my changes implement the functionality of manage.html correctly. Still, it appears the manage window works as it did before I made the changes.  
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
If you can, test the refactor on a build where the "Add cover image" functionality (under /books/OL###/Book_Title/edit) works as it does on the actual website. I tested it with the page "http://localhost:8080/books/OL24152177M"/Robinson_Crusoe/edit" on the local build.  
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![4472_ManageRefactor](https://user-images.githubusercontent.com/46735016/107859181-bbd32180-6e05-11eb-8fc4-76f03aa4e4f1.png)  
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 

Please let me know if there are any changes to make... I'm still new, so any feedback is appreciated! Looking ahead, I also saw that there is JavaScript in some of the HTML files under "covers" that contain variables and logic generated by "Webpack.py," I believe it was called. I thought about some ways to make the transfer to index.js work, but let me know if you would want me to take a crack at it and whether or not you have any ideas for solutions (see covers/change.html).