### PR TITLE
Display lists patron's list in which the book is already added.

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -104,8 +104,12 @@ $jsdef render_my_lists(lists, property='active'):
             <p class="list">
                 <a href="$list.key" class="add-to-list" data-list-key="$list.key">$list.name</a>
             </p>
+           
+$jsdef render_already_lists(lists, user_key):
+    $for list in lists:
+        $:show_list(list, user_key)
 
-$jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly, use_work):
+$jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly, use_work, user_key):
     <div class="dropit">
           $if edition_key and not work_key:
             <div class="dropper on edition-page-lists-dropdown">
@@ -226,6 +230,9 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 </a>
       </div>
     </div>
+    <ul id="already-lists" class="listLists">
+      $:render_already_lists(lists, user_key)
+    </ul>
 
 $jsdef render_widget_display(lists, limit, user_key):
     $for i, list in enumerate(lists):
@@ -258,7 +265,7 @@ $if include_header:
 $if include_widget:
   $if ctx.user or not work_key:
     <div class="widget-add $:(not work_key and 'old-style-lists')">
-      $:render_widget_add(user_lists, work_key, edition_key, users_work_read_status, ctx.user, page.url(), readinglog_only, False)
+      $:render_widget_add(user_lists, work_key, edition_key, users_work_read_status, ctx.user, page.url(), readinglog_only, False,user_key)
     </div>
   $else:
     <div class="dropit">
@@ -286,7 +293,7 @@ $if include_widget:
       $:macros.UserMetadata(work, edition)
 
 $if include_showcase:
-  <ul class="listLists">
+  <ul id="list-lists" class="listLists">
     $:render_widget_display(page_lists, 3, user_key)
   </ul>
 
@@ -543,13 +550,14 @@ window.q.push(function() {
             }
         }
         \$container.find(".my-lists").html(render_my_lists(listsThatDontContainIt, 'key'));
+        \$container.find("#already-lists").html(render_already_lists(listsThatContainIt, user_key));
         var filteredShowcaseLists = seed_info.lists;
         if (Lists.user_lists.length) {
             filteredShowcaseLists = filteredShowcaseLists.filter(function(list) {
                 return list.owner.key != Lists.user_lists[0].owner.key;
             });
         }
-        \$container.find(".listLists").html(render_widget_display(listsThatContainIt.concat(filteredShowcaseLists), 3, user_key));
+        \$container.find("#list-lists").html(render_widget_display(listsThatContainIt.concat(filteredShowcaseLists), 3, user_key));
         setup_widget_display_events();
     }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3630 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Display the patron's list contatining a particular work underneath `Want to Read Button`.  
This will help patron easily remove books from list already added.
### Technical
<!-- What should be noted about the implementation? -->
Added `id = "list-lists"` alongwith `class = "listsLists"` in Line 296. This is because `class = "listLists"` is also used in Line 233. And we need to insert different lists in both `ul`. Hence separate query was needed.  
Added a new parameter `user_key`  to `render_widget_add`.  
Apart from that, can modify the name of `id` and renderer in Line 233 from `alreay-lists` [It sounds ambiguous].
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Open [http://localhost:8080/books/OL7037695M/The_complete_works_of_Mark_Twain](http://localhost:8080/books/OL7037695M/The_complete_works_of_Mark_Twain)  
The changes can be seen beneath `Want to Read Button`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-02-14 01-03-25](https://user-images.githubusercontent.com/62632865/107859658-e30b0c80-6e60-11eb-8945-8731e1eb3e97.png)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jdlrobson 