### PR TITLE
new-solr-updater.py: Replace urlopen with requests.get

### DIFF
--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -80,7 +80,7 @@ class InfobaseLog:
             try:
                 response = requests.get(url)
                 response.raise_for_status()
-                data = response.json()["data"]
+                d = response.json()
             except requests.HTTPError:
                 logger.exception("Failed to open URL %s" % url)
                 if response.status_code == 111:
@@ -92,6 +92,7 @@ class InfobaseLog:
                 raise
             except json.JSONDecodeError:
                 logger.exception("Bad JSON: %s" % response.content)
+            data = d['data']
             # no more data is available
             if not data:
                 logger.debug("no more records found")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #2852
* `isort --profile black` to order the imports
* Replace `urlopen()` with `requests.get()`

The extra message on [`111` error](https://tools.ietf.org/html/rfc2616.html#page-149) is probably now obsolete because 111 seems to have been dropped from:
* https://requests.readthedocs.io/en/latest/api/#status-code-lookup
* https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#1xx_informational_response
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@dherbst 