### PR TITLE
Ability to sort search results by classification, random

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -80,6 +80,8 @@ ALL_FIELDS = [
     # Classifications
     "lcc",
     "ddc",
+    "lcc_sort",
+    "ddc_sort",
 ]
 FACET_FIELDS = [
     "has_fulltext",
@@ -235,9 +237,9 @@ def parse_query_fields(q):
             isbn = normalize_isbn(v)
             if isbn:
                 v = isbn
-        if field_name == 'lcc':
+        if field_name in ('lcc', 'lcc_sort'):
             v = lcc_transform(v)
-        if field_name == 'ddc':
+        if field_name == ('ddc', 'ddc_sort'):
             v = ddc_transform(v)
 
         yield {'field': field_name, 'value': v.replace(':', r'\:')}

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -117,10 +117,6 @@ SORTS = {
     'ddc_sort asc': 'ddc_sort asc',
     'ddc_sort desc': 'ddc_sort desc',
 
-    'title': 'title asc',
-    'title asc': 'title asc',
-    'title desc': 'title desc',
-
     # Random
     'random': 'random_1 asc',
     'random asc': 'random_1 asc',

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -103,13 +103,23 @@ FIELD_NAME_MAP = {
 }
 SORTS = {
     'editions': 'edition_count desc',
+
     'old': 'first_publish_year asc',
     'new': 'first_publish_year desc',
+
     'scans': 'ia_count desc',
+
+    # Classifications
+    'lcc_sort': 'lcc_sort asc',
     'lcc_sort asc': 'lcc_sort asc',
     'lcc_sort desc': 'lcc_sort desc',
+    'ddc_sort': 'ddc_sort asc',
     'ddc_sort asc': 'ddc_sort asc',
     'ddc_sort desc': 'ddc_sort desc',
+
+    'title': 'title asc',
+    'title asc': 'title asc',
+    'title desc': 'title desc',
 }
 OLID_URLS = {'A': 'authors', 'M': 'books', 'W': 'works'}
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -101,6 +101,16 @@ FIELD_NAME_MAP = {
     'by': 'author_name',
     'publishers': 'publisher',
 }
+SORTS = {
+    'editions': 'edition_count desc',
+    'old': 'first_publish_year asc',
+    'new': 'first_publish_year desc',
+    'scans': 'ia_count desc',
+    'lcc_sort asc': 'lcc_sort asc',
+    'lcc_sort desc': 'lcc_sort desc',
+    'ddc_sort asc': 'ddc_sort asc',
+    'ddc_sort desc': 'ddc_sort desc',
+}
 OLID_URLS = {'A': 'authors', 'M': 'books', 'W': 'works'}
 
 re_to_esc = re.compile(r'[\[\]:]')
@@ -629,7 +639,7 @@ class search(delegate.page):
         return render.work_search(
             i, ' '.join(q_list), do_search, get_doc,
             get_availability_of_ocaids, fulltext_search,
-            FACET_FIELDS)
+            FACET_FIELDS, SORTS)
 
 
 def works_by_author(akey, sort='editions', page=1, rows=100, has_fulltext=False, query=None):
@@ -930,23 +940,13 @@ def work_search(query, sort=None, page=1, offset=0, limit=100, fields='*', facet
     query: dict
     sort: str editions|old|new|scans
     """
-    sorts = {
-        'editions': 'edition_count desc',
-        'old': 'first_publish_year asc',
-        'new': 'first_publish_year desc',
-        'scans': 'ia_count desc',
-        'lcc_sort asc': 'lcc_sort asc',
-        'lcc_sort desc': 'lcc_sort desc',
-        'ddc_sort asc': 'ddc_sort asc',
-        'ddc_sort desc': 'ddc_sort desc',
-    }
     query['wt'] = 'json'
 
     try:
         (reply, solr_select, q_list) = run_solr_query(query,
                                                       rows=limit,
                                                       page=page,
-                                                      sort=sorts.get(sort),
+                                                      sort=SORTS.get(sort),
                                                       offset=offset,
                                                       fields=fields,
                                                       facet=facet,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -932,7 +932,11 @@ def work_search(query, sort=None, page=1, offset=0, limit=100, fields='*', facet
         'editions': 'edition_count desc',
         'old': 'first_publish_year asc',
         'new': 'first_publish_year desc',
-        'scans': 'ia_count desc'
+        'scans': 'ia_count desc',
+        'lcc_sort asc': 'lcc_sort asc',
+        'lcc_sort desc': 'lcc_sort desc',
+        'ddc_sort asc': 'ddc_sort asc',
+        'ddc_sort desc': 'ddc_sort desc',
     }
     query['wt'] = 'json'
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -412,6 +412,8 @@ def run_solr_query(param=None, rows=100, page=1, sort=None, spellcheck_count=Non
     return (reply, url, q_list)
 
 def do_search(param, sort, page=1, rows=100, spellcheck_count=None):
+    if sort:
+        sort = ','.join(SORTS[s.strip()] for s in sort.split(','))
     (reply, solr_select, q_list) = run_solr_query(
         param, rows, page, sort, spellcheck_count)
     is_bad = False
@@ -639,7 +641,7 @@ class search(delegate.page):
         return render.work_search(
             i, ' '.join(q_list), do_search, get_doc,
             get_availability_of_ocaids, fulltext_search,
-            FACET_FIELDS, SORTS)
+            FACET_FIELDS)
 
 
 def works_by_author(akey, sort='editions', page=1, rows=100, has_fulltext=False, query=None):
@@ -941,12 +943,13 @@ def work_search(query, sort=None, page=1, offset=0, limit=100, fields='*', facet
     sort: str editions|old|new|scans
     """
     query['wt'] = 'json'
-
+    if sort:
+        sort = ','.join(SORTS[s.strip()] for s in sort.split(','))
     try:
         (reply, solr_select, q_list) = run_solr_query(query,
                                                       rows=limit,
                                                       page=page,
-                                                      sort=SORTS.get(sort),
+                                                      sort=sort,
                                                       offset=offset,
                                                       fields=fields,
                                                       facet=facet,

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -90,14 +90,24 @@ $if param and not error and num_found:
 &nbsp;
       $if num_found > 1:
         <span class="tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:10px;"/>
-          $if sort == 'editions':
-            <a href="$changequery(sort=None)">$_("Relevance")</a> | <strong class="lightgreen">$_("Most Editions")</strong> | <a href="$changequery(sort='old')">$_("First Published")</a> | <a href="$changequery(sort='new')">$_("Most Recent")</a>
-          $elif sort == 'old':
-            <a href="$changequery(sort=None)">$_("Relevance")</a> |  <a href="$changequery(sort='editions')">$_("Most Editions")</a> | <strong class="lightgreen">$_("First Published")</strong> | <a href="$changequery(sort='new')">$_("Most Recent")</a>
-          $elif sort == 'new':
-            <a href="$changequery(sort=None)">$_("Relevance")</a> | <a href="$changequery(sort='editions')">$_("Most Editions")</a> | <a href="$changequery(sort='old')">$_("First Published")</a> | <strong class="lightgreen">$_("Most Recent")</strong>
-          $else:
-            <strong class="lightgreen">$_("Relevance")</strong> | <a href="$changequery(sort='editions')">$_("Most Editions")</a> | <a href="$changequery(sort='old')">$_("First Published")</a> | <a href="$changequery(sort='new')">$_("Most Recent")</a>
+          $code:
+            sort_options = [
+              { 'sort': None, 'name': _("Relevance"), 'ga_key': 'Relevance' },
+              { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
+              { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
+              { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
+              { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random' },
+            ]
+          $for sort_option in sort_options:
+            $ is_selected = sort_option['sort'] == sort
+            $if is_selected:
+                <strong class="lightgreen">$sort_option['name']</strong>
+            $else:
+                <a href="$changequery(sort=sort_option['sort'])"
+                   data-ol-link-track="SearchSort|$sort_option['ga_key']"
+                >$sort_option['name']</a>
+            $if not loop.last:
+                |
 
           <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
         </span>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,4 +1,4 @@
-$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields)
+$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields, valid_sorts)
 
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
 
@@ -22,15 +22,13 @@ $for p in ['q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor'
 $if list(param) == ['has_fulltext']:
     $ param = {}
 
-$ sorts = dict(editions='edition_count desc', old='first_publish_year asc', new='first_publish_year desc', scans='ia_count desc')
-
 $ error = None
 $if param:
     $ page = int(param.get('page', 1))
     $ sort = param.get('sort', None)
     $ rows = 20
     $ search_start = time()
-    $ results = do_search(param, sorts[sort] if sort else None, page, rows=rows, spellcheck_count=3)
+    $ results = do_search(param, valid_sorts[sort] if sort else None, page, rows=rows, spellcheck_count=3)
     $ search_secs = time() - search_start
     $ docs = results.docs
     $ facet_counts = results.facet_counts

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,4 +1,4 @@
-$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields, valid_sorts)
+$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields)
 
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
 
@@ -28,7 +28,7 @@ $if param:
     $ sort = param.get('sort', None)
     $ rows = 20
     $ search_start = time()
-    $ results = do_search(param, valid_sorts[sort] if sort else None, page, rows=rows, spellcheck_count=3)
+    $ results = do_search(param, sort, page, rows=rows, spellcheck_count=3)
     $ search_secs = time() - search_start
     $ docs = results.docs
     $ facet_counts = results.facet_counts

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -96,10 +96,10 @@ $if param and not error and num_found:
               { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
               { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
               { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
-              { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random' },
+              { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': sort and sort.startswith('random') },
             ]
           $for sort_option in sort_options:
-            $ is_selected = sort_option['sort'] == sort
+            $ is_selected = sort_option.get('selected') or sort_option['sort'] == sort
             $if is_selected:
                 <strong class="lightgreen">$sort_option['name']</strong>
             $else:
@@ -108,6 +108,10 @@ $if param and not error and num_found:
                 >$sort_option['name']</a>
             $if not loop.last:
                 |
+          $if sort and sort.startswith('random'):
+            (<a href="$changequery(sort='random_%s' % today().timestamp())"
+               data-ol-link-track="SearchSort|RandomShuffle"
+            >$_('Shuffle')</a>)
 
           <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
         </span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3574

Adds ability to sort by lcc/ddc to /search and /search.json

### Technical
- Note we're using the `ddc_sort`/`lcc_sort` fields, because solr does not support sorting on multi-valued fields, which is what `ddc` and `lcc` are. This does mean that some things will appear out of order when doing e.g. `ddc:8*` sorted by `ddc_sort`. So I also exposed `ddc_sort` as a search field we can use -- although this has the caveat that some works will be missing.
- Random sorting from the UI will (for now) always use the same seed, so that results are in a consistent order as you paginate. Longer term we might want a way to use another seed, or maybe use a seed that's relative to today, so that the order changes daily? The URLs do let you do e.g. `sort=random_my_seed` to get a new random.

### Testing
- [x] DDC sorting works http://staging.openlibrary.org/search.json?q=ddc_sort%3A[801.0%20TO%20801.3]&mode=everything&fields=ddc,key&sort=ddc_sort%20asc
- ~Title sorting works~ Not really
- [x] [Random sorting works](http://staging.openlibrary.org/search?q=key%3A(%2Fworks%2FOL18181363W%20OR%20%2Fworks%2FOL3481095W%20OR%20%2Fworks%2FOL4360244W%20OR%20%2Fworks%2FOL20017931W%20OR%20%2Fworks%2FOL20615204W%20OR%20%2Fworks%2FOL2363176W%20OR%20%2Fworks%2FOL17869588W%20OR%20%2Fworks%2FOL17784026W%20OR%20%2Fworks%2FOL21179764W%20OR%20%2Fworks%2FOL8870595W%20OR%20%2Fworks%2FOL21054973W%20OR%20%2Fworks%2FOL21673730W%20OR%20%2Fworks%2FOL20548582W%20OR%20%2Fworks%2FOL15279153W%20OR%20%2Fworks%2FOL19992836W%20OR%20%2Fworks%2FOL15691480W%20OR%20%2Fworks%2FOL16305795W%20OR%20%2Fworks%2FOL19923407W%20OR%20%2Fworks%2FOL16529029W%20OR%20%2Fworks%2FOL9242636W%20OR%20%2Fworks%2FOL17529769W%20OR%20%2Fworks%2FOL3345332W%20OR%20%2Fworks%2FOL20013209W%20OR%20%2Fworks%2FOL20015483W%20OR%20%2Fworks%2FOL19987474W%20OR%20%2Fworks%2FOL19992114W%20OR%20%2Fworks%2FOL17893900W%20OR%20%2Fworks%2FOL18435803W%20OR%20%2Fworks%2FOL17314666W%20OR%20%2Fworks%2FOL17358927W%20OR%20%2Fworks%2FOL15933199W%20OR%20%2Fworks%2FOL17858931W%20OR%20%2Fworks%2FOL18187603W%20OR%20%2Fworks%2FOL16853133W%20OR%20%2Fworks%2FOL16894393W%20OR%20%2Fworks%2FOL19976062W%20OR%20%2Fworks%2FOL20037832W%20OR%20%2Fworks%2FOL16885033W%20OR%20%2Fworks%2FOL19708155W%20OR%20%2Fworks%2FOL17921756W%20OR%20%2Fworks%2FOL21037237W%20OR%20%2Fworks%2FOL17786027W%20OR%20%2Fworks%2FOL17345141W%20OR%20%2Fworks%2FOL21294275W%20OR%20%2Fworks%2FOL9582417W%20OR%20%2Fworks%2FOL9357555W%20OR%20%2Fworks%2FOL20907853W%20OR%20%2Fworks%2FOL20005568W%20OR%20%2Fworks%2FOL3296483W%20OR%20%2Fworks%2FOL11983310W%20OR%20%2Fworks%2FOL7159886W%20OR%20%2Fworks%2FOL1662667W%20OR%20%2Fworks%2FOL19990553W%20OR%20%2Fworks%2FOL15285884W%20OR%20%2Fworks%2FOL6888879W%20OR%20%2Fworks%2FOL17900435W%20OR%20%2Fworks%2FOL5706069W%20OR%20%2Fworks%2FOL2977589W%20OR%20%2Fworks%2FOL1593701W%20OR%20%2Fworks%2FOL16451688W%20OR%20%2Fworks%2FOL16910779W%20OR%20%2Fworks%2FOL18215336W%20OR%20%2Fworks%2FOL17371695W%20OR%20%2Fworks%2FOL3521634W%20OR%20%2Fworks%2FOL17355199W%20OR%20%2Fworks%2FOL5739152W%20OR%20%2Fworks%2FOL20016962W%20OR%20%2Fworks%2FOL3191599W%20OR%20%2Fworks%2FOL20896695W%20OR%20%2Fworks%2FOL19752490W%20OR%20%2Fworks%2FOL18335154W%20OR%20%2Fworks%2FOL4582875W%20OR%20%2Fworks%2FOL16515210W%20OR%20%2Fworks%2FOL16868407W%20OR%20%2Fworks%2FOL3459949W%20OR%20%2Fworks%2FOL16025481W%20OR%20%2Fworks%2FOL1928280W%20OR%20%2Fworks%2FOL6208302W%20OR%20%2Fworks%2FOL17566265W%20OR%20%2Fworks%2FOL20652811W%20OR%20%2Fworks%2FOL22059158W%20OR%20%2Fworks%2FOL4370955W%20OR%20%2Fworks%2FOL19998526W%20OR%20%2Fworks%2FOL6218060W%20OR%20%2Fworks%2FOL16813953W%20OR%20%2Fworks%2FOL21179974W%20OR%20%2Fworks%2FOL7213898W%20OR%20%2Fworks%2FOL17872185W%20OR%20%2Fworks%2FOL17340085W%20OR%20%2Fworks%2FOL21584979W%20OR%20%2Fworks%2FOL21078916W%20OR%20%2Fworks%2FOL158519W%20OR%20%2Fworks%2FOL4114499W%20OR%20%2Fworks%2FOL19638041W%20OR%20%2Fworks%2FOL16844793W%20OR%20%2Fworks%2FOL20940485W%20OR%20%2Fworks%2FOL17392121W%20OR%20%2Fworks%2FOL20030448W%20OR%20%2Fworks%2FOL15920474W%20OR%20%2Fworks%2FOL20544657W)&mode=everything&sort=random_2.2)
- [x] Normal sorting works for
    - [x] relevance
    - [x] editions
    - [x] newest
    - [x] oldest

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
