### PR TITLE
[library-explorer] Perf tweaks/fixes

### DIFF
--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -199,7 +199,9 @@ hr {
 
   .book {
     position: relative;
+    margin-left: 10px;
   }
+  .book-end-wrapper + .book { margin-left: 20px;}
 
   .cover-label {
     background: rgba(0, 0, 0, .5);
@@ -408,6 +410,7 @@ hr {
     opacity: .8;
     transition: opacity .2s;
   }
+  .book-end-wrapper + .book { margin-left: 60px; }
   .book:hover .cover {
     opacity: 1;
   }
@@ -428,11 +431,6 @@ hr {
     margin-left: -100px;
   }
 
-  .book:first-child .book-3d,
-  .book-end-start + .book .book-3d {
-    margin-left: 120px !important;
-  }
-
   .book:hover {
     z-index: 1;
   }
@@ -445,7 +443,9 @@ hr {
   .book {
     transform: rotateX(20deg);
     transform-style: preserve-3d;
+    margin-left: 18px;
   }
+  .book-end-wrapper + .book { margin-left: 40px; }
   .books-carousel {
     perspective: 2000px;
   }
@@ -558,13 +558,8 @@ hr {
 
   .shelf-carousel {
     border: 0;
-    background-color: #563822;
-    background-image: linear-gradient(
-      to bottom,
-      rgba(0, 0, 0, .36),
-      #563822 50px
-    );
-    margin: 0;
+    margin: 0 10px;
+    @media (max-width: 450px) { margin: 0; }
   }
 
   .class-slider.shelf-label {

--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -3,11 +3,12 @@
     <BookRoom
       :classification="settingsState.selectedClassification"
       :filter="computedFilter"
+      :sort="sortState.order"
       :class="bookRoomClass"
       :features="bookRoomFeatures"
     />
 
-    <LibraryToolbar :filterState="filterState" :settingsState="settingsState" />
+    <LibraryToolbar :filterState="filterState" :settingsState="settingsState" :sortState="sortState" />
   </div>
 </template>
 
@@ -17,6 +18,7 @@ import LibraryToolbar from './LibraryExplorer/components/LibraryToolbar';
 import DDC from './LibraryExplorer/ddc.json';
 import LCC from './LibraryExplorer/lcc.json';
 import { recurForEach } from './LibraryExplorer/utils.js';
+import maxBy from 'lodash/maxBy';
 
 class FilterState {
     constructor() {
@@ -65,6 +67,7 @@ export default {
                 longName: 'Dewey Decimal Classification',
                 field: 'ddc',
                 fieldTransform: ddc => ddc,
+                chooseBest: ddcs => maxBy(ddcs, ddc => ddc.replace(/[\d.]/g, '') ? ddc.length : 100 + ddc.length),
                 root: recurForEach({ children: DDC }, n => {
                     n.position = 'root';
                     n.offset = 0;
@@ -82,6 +85,7 @@ export default {
                         .replace(/\.0+$/, ' ')
                         .replace(/-+/, '')
                         .replace(/0+(\.\D)/, ($0, $1) => $1),
+                chooseBest: lccs => maxBy(lccs, lcc => lcc.length),
                 root: recurForEach({ children: LCC }, n => {
                     n.position = 'root';
                     n.offset = 0;
@@ -91,6 +95,10 @@ export default {
         ];
         return {
             filterState: new FilterState(),
+
+            sortState: {
+                order: 'editions',
+            },
 
             settingsState: {
                 selectedClassification: classifications[0],

--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -560,6 +560,12 @@ hr {
     border: 0;
     margin: 0 10px;
     @media (max-width: 450px) { margin: 0; }
+    background-color: #563822;
+    background-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, .36),
+      #563822 50px
+    );
   }
 
   .class-slider.shelf-label {

--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -6,6 +6,7 @@
       :sort="sortState.order"
       :class="bookRoomClass"
       :features="bookRoomFeatures"
+      :appSettings="settingsState"
     />
 
     <LibraryToolbar :filterState="filterState" :settingsState="settingsState" :sortState="sortState" />
@@ -103,6 +104,8 @@ export default {
             settingsState: {
                 selectedClassification: classifications[0],
                 classifications,
+
+                labels: ['classification'],
 
                 styles: {
                     book: {
@@ -218,12 +221,6 @@ hr {
     font-size: .8em;
     opacity: .9;
     line-height: .8em;
-    padding: 0;
-  }
-  .cover-label a {
-    padding: 6px;
-    color: white;
-    text-decoration: underline;
   }
 }
 

--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -57,7 +57,7 @@ export default {
                 filter: '',
                 /** @type { '' | 'true' | 'false' } */
                 has_ebook: 'true',
-                language: '',
+                languages: [],
                 age: '',
                 year: '[1985 TO 9998]'
             },
@@ -107,8 +107,9 @@ export default {
                 filters.push(`has_fulltext:${this.filterState.has_ebook}`);
             }
 
-            if (this.filterState.language) {
-                filters.push(`language:${this.filterState.language}`);
+            if (this.filterState.languages.length) {
+                const langs = this.filterState.languages.map(lang => lang.key.split('/')[2]);
+                filters.push(`language:(${langs.join(' OR ')})`);
             }
             if (this.filterState.age) {
                 filters.push(`subject:${this.filterState.age}`);

--- a/openlibrary/components/LibraryExplorer.vue
+++ b/openlibrary/components/LibraryExplorer.vue
@@ -125,7 +125,12 @@ export default {
                         options: ['mockup', 'wip'],
                         selected: 'wip'
                     },
-                }
+
+                    scrollbar: {
+                        options: ['default', 'thin', 'hidden'],
+                        selected: 'thin',
+                    },
+                },
             },
         };
     },
@@ -456,14 +461,6 @@ hr {
   background: linear-gradient(180deg,#ebdfc5 100px, #dbbe9f 1600px,#cba37e 4800px);
   background-position: scroll;
 
-  // Chrome-specific scroll fixes
-  .books-carousel {
-    &::-webkit-scrollbar { height: 10px; }
-    &::-webkit-scrollbar-thumb { background: rgba(255,255,255, 0.35); }
-    &::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255, 0.25); }
-    &::-webkit-scrollbar-track { background: rgba(0, 0, 0, 0.2); }
-  }
-
   .classification-short {
     opacity: .6;
   }
@@ -606,5 +603,20 @@ hr {
     height: 4px;
     bottom: 0;
   }
+}
+
+.book-room.style--scrollbar--thin {
+  .books-carousel { scrollbar-width: thin; }
+
+  // Chrome-specific scroll fixes
+  .books-carousel::-webkit-scrollbar { height: 6px; }
+  .books-carousel::-webkit-scrollbar-thumb { background: rgba(255,255,255, 0.35); }
+  .books-carousel::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255, 0.25); }
+  .books-carousel::-webkit-scrollbar-track { background: rgba(0, 0, 0, 0.2); }
+}
+
+.book-room.style--scrollbar--hidden {
+  .books-carousel { scrollbar-width: none; }
+  .books-carousel::-webkit-scrollbar { height: 0; }
 }
 </style>

--- a/openlibrary/components/LibraryExplorer/components/BookRoom.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookRoom.vue
@@ -65,6 +65,7 @@
           :features="features"
           :classification="classification"
           :filter="filter"
+          :sort="sort"
         />
       </div>
       <!-- Gap --> <div style="width: 70px; height: 1px; flex-shrink: 0" />
@@ -89,6 +90,7 @@ export default {
         classification: Object,
         appSettings: Object,
 
+        sort: String,
         filter: {
             default: '',
             type: String

--- a/openlibrary/components/LibraryExplorer/components/BookRoom.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookRoom.vue
@@ -64,6 +64,7 @@
           :expandBookshelf="expandBookshelf"
           :features="features"
           :classification="classification"
+          :labels="appSettings.labels"
           :filter="filter"
           :sort="sort"
         />

--- a/openlibrary/components/LibraryExplorer/components/BooksCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/BooksCarousel.vue
@@ -9,7 +9,7 @@
         <FlatBookCover :book="book"/>
       </slot>
 
-      <div class="cover-label" style="padding: 6px; text-align: center;">
+      <div class="cover-label">
         <slot name="cover-label" v-bind:book="book"/>
       </div>
     </a>
@@ -107,5 +107,11 @@ div.cover {
 
 .cover-label {
   flex-shrink: 0;
+  padding: 2px;
+  text-align: left;
+}
+
+.cover-label div {
+  padding: 2px 4px;
 }
 </style>

--- a/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
@@ -7,6 +7,7 @@
       :node="lvl"
       :classification="classification"
       :expandBookshelf="expandBookshelf"
+      :labels="labels"
       :features="features"
       :filter="filter"
       :sort="sort"
@@ -27,6 +28,7 @@ export default {
         classification: Object,
         node: Object,
         expandBookshelf: Function,
+        labels: Array,
         features: Object,
         filter: String,
         sort: String,

--- a/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Bookshelf.vue
@@ -9,6 +9,7 @@
       :expandBookshelf="expandBookshelf"
       :features="features"
       :filter="filter"
+      :sort="sort"
     />
   </div>
 </template>
@@ -28,6 +29,7 @@ export default {
         expandBookshelf: Function,
         features: Object,
         filter: String,
+        sort: String,
     },
 
 };

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -248,6 +248,19 @@ export default {
 
         fullLanguageSelect(newVal) {
             this.filterState.languages = newVal;
+        },
+
+        ['sortState.order'](newVal) {
+            const desiredLabel = {
+                editions: 'edition_count',
+                new: 'first_publish_year',
+                old: 'first_publish_year',
+                ddc_sort: 'classification',
+                lcc_sort: 'classification',
+            }[newVal];
+            if (desiredLabel && !this.settingsState.labels.includes(desiredLabel)) {
+                this.settingsState.labels.push(desiredLabel);
+            }
         }
     },
 

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -149,6 +149,23 @@
                 </label>
               </div>
             </div>
+            <div class="horizontal-selector">
+              <div class="label">Label Fields</div>
+              <div class="options">
+                <label>
+                  <input type="checkbox" v-model="settingsState.labels" value="classification">
+                  Classifications
+                </label>
+                <label>
+                  <input type="checkbox" v-model="settingsState.labels" value="first_publish_year">
+                  First Publish Year
+                </label>
+                <label>
+                  <input type="checkbox" v-model="settingsState.labels" value="edition_count">
+                  Number of Editions
+                </label>
+              </div>
+            </div>
           </main>
         </details>
 

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -68,7 +68,7 @@
                     <input type="radio" v-model="quickLanguageSelect" value>Any
                   </label>
                   <label v-for="lang of top3Languages" :key="lang.key">
-                    <input type="radio" v-model="quickLanguageSelect" :value="lang">{{lang.name}}
+                    <input type="radio" v-model="quickLanguageSelect" :value="lang">{{lang.name.split(' / ')[0]}}
                   </label>
                   <label>
                     <input type="radio" v-model="quickLanguageSelect" value="custom">

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -14,8 +14,10 @@
             </div>
           </summary>
           <main>
-            <input class="filter" v-model="filterState.filter" placeholder="Custom filter...">
-            <!-- <small>{{computedFilter}}</small> -->
+            <div class="filter-wrapper">
+              <input class="filter" v-model="filterState.filter" placeholder="Custom filter...">
+              <small class="computed-filter" title="This part of your filter is determined by the controls below">{{computedFilters}}</small>
+            </div>
             <div class="click-controls">
               <div class="horizontal-selector">
                 <div class="label">First Published Year</div>
@@ -79,6 +81,7 @@
                       track-by="key"
                       label="name"
                       :loading="langLoading"
+                      selectLabel=""
                       @search-change="findLanguage"
                     >
                     </multiselect>
@@ -102,7 +105,7 @@
             <div class="horizontal-selector">
               <div class="label">Classification</div>
               <div class="options">
-                <label v-for="c of settingsState.classifications" :key="c.name">
+                <label v-for="c of settingsState.classifications" :key="c.name" :title="c.longName">
                   <input type="radio" v-model="settingsState.selectedClassification" :value="c">
                   {{c.name}}
                 </label>
@@ -207,6 +210,12 @@ export default {
             return Object.values(this.filterState).filter(v => v?.length).length;
         },
 
+        computedFilters() {
+            const parts = this.filterState.solrQueryParts();
+            const computedParts = parts[0] == this.filterState.filter ? parts.slice(1) : parts;
+            return computedParts.length ? ` AND ${computedParts.join(' AND ')}` : '';
+        },
+
         top3Languages() {
             return this.topLanguages.slice(0, 3);
         },
@@ -264,6 +273,7 @@ export default {
     width: auto;
     min-height: 0;
     display: inline-block;
+    color: currentColor;
 
     .multiselect__tags {
       background: transparent;
@@ -287,7 +297,14 @@ export default {
 
     .multiselect__placeholder {
       margin: 0;
-      color: inherit;
+      color: currentColor;
+    }
+
+    .multiselect__input:focus {
+      width: 100px !important;
+      height: 100%;
+      margin: 0;
+      padding: 2px !important;
     }
   }
 
@@ -376,18 +393,50 @@ export default {
     display: inline-block;
     padding: 2px 4px;
     padding-top: 3px;
+
+    &[title] {
+      text-decoration: underline;
+      text-decoration-style: dotted;
+    }
   }
 }
 
-input.filter {
-  padding: 6px;
-  max-width: 100%;
-  width: 300px;
-  box-sizing: border-box;
-  font-family: inherit;
-  font-size: inherit;
-  border-radius: 4px;
+.filter-wrapper {
   border: 1px solid currentColor;
+  background: white;
+
+  border-radius: 4px;
+  max-width: 100%;
+  box-sizing: border-box;
+  display: inline-block;
+
+  input.filter {
+    max-width: 100%;
+    margin: 1px;
+    padding: 5px;
+    width: 150px;
+    font-family: inherit;
+    font-size: inherit;
+    border: 0;
+    border-radius: inherit;
+    transition: width 0.2s;
+    &:not(:placeholder-shown), &:focus {
+      width: 300px;
+    }
+  }
+
+  small.computed-filter {
+    background: rgba(125,125,125,0.2);
+    font-size: inherit;
+    display: inline-block;
+    opacity: 0.8;
+    font-style: oblique;
+    padding: 6px;
+    padding-right: 8px;
+    border-left: 1px dotted grey;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
 }
 
 .feedback-panel {

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -117,6 +117,13 @@
                   <label>
                     <input type="radio" v-model="sortState.order" :value="`${settingsState.selectedClassification.field}_sort asc`">Shelf Order
                   </label>
+                  <label>
+                    <input type="radio" v-model="sortState.order" :value="randomWithSeed">Random
+                    <button
+                      v-if="sortState.order.startsWith('random')"
+                      @click="sortState.order = randomWithSeed = 'random_' + Date.now()"
+                    >Shuffle</button>
+                  </label>
                 </div>
               </div>
           </main>
@@ -231,6 +238,9 @@ export default {
             quickLanguageSelect: '',
             fullLanguageSelect: [],
             langLoading: false,
+            // By default we just send sort=random to the OL API, but when shuffle
+            // is clicked, we add a seed to the end (e.g. random_1235)
+            randomWithSeed: 'random',
         }
     },
 

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -18,7 +18,7 @@
             <!-- <small>{{computedFilter}}</small> -->
             <div class="click-controls">
               <div class="horizontal-selector">
-                <div>First Published Year</div>
+                <div class="label">First Published Year</div>
                 <div class="options">
                   <label>
                     <input type="radio" v-model="filterState.year" value>Any
@@ -35,7 +35,7 @@
                 </div>
               </div>
               <div class="horizontal-selector">
-                <div>Has ebook/preview?</div>
+                <div class="label">Has ebook/preview?</div>
                 <div class="options">
                   <label>
                     <input type="radio" v-model="filterState.has_ebook" value>Any
@@ -49,7 +49,7 @@
                 </div>
               </div>
               <div class="horizontal-selector">
-                <div>Age Range</div>
+                <div class="label">Age Range</div>
                 <div class="options">
                   <label>
                     <input type="radio" v-model="filterState.age" value>Any
@@ -60,7 +60,7 @@
                 </div>
               </div>
               <div class="horizontal-selector">
-                <div>Language</div>
+                <div class="label">Language</div>
                 <div class="options">
                   <label>
                     <input type="radio" v-model="quickLanguageSelect" value>Any
@@ -100,7 +100,7 @@
           </summary>
           <main class="click-controls">
             <div class="horizontal-selector">
-              <div>Classification</div>
+              <div class="label">Classification</div>
               <div class="options">
                 <label v-for="c of settingsState.classifications" :key="c.name">
                   <input type="radio" v-model="settingsState.selectedClassification" :value="c">
@@ -109,7 +109,7 @@
               </div>
             </div>
             <div class="horizontal-selector" v-for="(opts, name) of styles" :key="name">
-              <div>{{name}} style</div>
+              <div class="label">{{name}} style</div>
               <div class="options">
                 <label v-for="cls of opts.options" :key="cls">
                   <input type="radio" v-model="opts.selected" :value="cls">
@@ -204,7 +204,7 @@ export default {
             return `https://twitter.com/intent/tweet?${new URLSearchParams(this.tweet)}`;
         },
         activeFiltersCount() {
-            return Object.values(this.filterState).filter(v => v).length;
+            return Object.values(this.filterState).filter(v => v?.length).length;
         },
 
         top3Languages() {
@@ -313,16 +313,8 @@ export default {
     pointer-events: all;
     display: flex;
     border-radius: 4px 4px 0 0;
+    overflow: hidden;
     box-shadow: 0 0 5px rgba(0, 0, 0, .2);
-    // white/grey:
-    // background: linear-gradient(
-    //   to bottom,
-    //   #e9e9e9,
-    //   white 10%,
-    //   #e9e9e9 90%,
-    //   #b6b6b6
-    // );
-    // white/page-colored
     background: linear-gradient(to bottom, #fff, #ebdfc5 150%);
     max-width: 100%;
     max-height: 80vh;
@@ -367,6 +359,13 @@ export default {
 
 .horizontal-selector {
   margin-right: 10px;
+  margin-top: 5px;
+
+  .label {
+    font-size: 0.9em;
+    margin-left: 5px;
+    margin-bottom: -2px;
+  }
 
   .options {
     border: 1px solid currentColor;
@@ -375,7 +374,8 @@ export default {
 
   .options label {
     display: inline-block;
-    padding: 4px;
+    padding: 2px 4px;
+    padding-top: 3px;
   }
 }
 
@@ -385,6 +385,7 @@ input.filter {
   width: 300px;
   box-sizing: border-box;
   font-family: inherit;
+  font-size: inherit;
   border-radius: 4px;
   border: 1px solid currentColor;
 }

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -16,7 +16,7 @@
           <main>
             <div class="filter-wrapper">
               <input class="filter" v-model="filterState.filter" placeholder="Custom filter...">
-              <small class="computed-filter" title="This part of your filter is determined by the controls below">{{computedFilters}}</small>
+              <small class="computed-filter" v-if="inDebugMode">{{computedFilters}}</small>
             </div>
             <div class="click-controls">
               <div class="horizontal-selector">

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -274,6 +274,9 @@ export default {
     min-height: 0;
     display: inline-block;
     color: currentColor;
+    transition: background-color 0.2s;
+    border-radius: 4px;
+    &:hover, &:focus, &:focus-within { background: white; }
 
     .multiselect__tags {
       background: transparent;
@@ -293,6 +296,67 @@ export default {
     .multiselect__tag {
       margin-bottom: -5px;
       margin-top: 0;
+      display: inline-flex;
+      padding: 0;
+      align-items: center;
+
+      & > span {
+        padding-left: 6px;
+      }
+    }
+
+    .multiselect__tag-icon {
+      position: static;
+      margin-left: 0;
+      &:after {
+        font-size: 24px;
+        font-weight: 100;
+      }
+    }
+
+    .multiselect__tag {
+      margin-right: 0;
+      margin-left: 10px;
+    }
+
+    .multiselect__tags-wrap:first-child .multiselect__tag {
+      margin-left: 0;
+    }
+
+    // Jumbo up for touch devices...
+    .multiselect__tag {
+      min-height: 34px;
+    }
+    .multiselect__tag-icon {
+      width: 34px;
+      height: 34px;
+      line-height: 34px;
+    }
+
+    @media (pointer: fine) {
+      // Make drop down arrow smaller on non-touch devices
+      .multiselect__tags {
+        padding-right: 22px;
+      }
+      .multiselect__select {
+        width: 22px;
+      }
+
+      // Make the "X" button smaller for non-touch devices
+      .multiselect__tag {
+        min-height: 0;
+      }
+      .multiselect__tag-icon {
+        width: 22px;
+        height: 22px;
+        line-height: 22px;
+      }
+
+      // Make the dropdown options less spaced out for non-touch devices
+      .multiselect__option {
+        min-height: 0;
+        padding: 6px;
+      }
     }
 
     .multiselect__placeholder {
@@ -301,10 +365,17 @@ export default {
     }
 
     .multiselect__input:focus {
-      width: 100px !important;
+      width: 100% !important;
       height: 100%;
       margin: 0;
       padding: 2px !important;
+    }
+
+    .multiselect__content {
+      display: flex !important;
+      // Since this control is always at the bottom for us, have the results in
+      // reverse order, so that the likeliest match is closest to the input field.
+      flex-direction: column-reverse;
     }
   }
 

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -96,6 +96,35 @@
           <summary>
             <div class="chunky-icon">
               <div class="chunky-icon--icon">
+                <SortIcon/>
+              </div>
+              <div class="chunky-icon--label">Sort</div>
+            </div>
+          </summary>
+          <main class="click-controls">
+              <div class="horizontal-selector">
+                <div>Sort Order</div>
+                <div class="options">
+                  <label>
+                    <input type="radio" v-model="sortState.order" value="editions">Most Editions
+                  </label>
+                  <label>
+                    <input type="radio" v-model="sortState.order" value="new">Newest
+                  </label>
+                  <label>
+                    <input type="radio" v-model="sortState.order" value="old">Oldest
+                  </label>
+                  <label>
+                    <input type="radio" v-model="sortState.order" :value="`${settingsState.selectedClassification.field}_sort asc`">Shelf Order
+                  </label>
+                </div>
+              </div>
+          </main>
+        </details>
+        <details>
+          <summary>
+            <div class="chunky-icon">
+              <div class="chunky-icon--icon">
                 <SettingsIcon/>
               </div>
               <div class="chunky-icon--label">Settings</div>
@@ -149,6 +178,7 @@
 import lucenerQueryParser from 'lucene-query-parser';
 import SettingsIcon from './icons/SettingsIcon';
 import FilterIcon from './icons/FilterIcon';
+import SortIcon from './icons/SortIcon';
 import FeedbackIcon from './icons/FeedbackIcon';
 import CONFIGS from '../configs';
 import Multiselect from 'vue-multiselect';
@@ -156,6 +186,7 @@ import Multiselect from 'vue-multiselect';
 export default {
     components: {
         FilterIcon,
+        SortIcon,
         SettingsIcon,
         FeedbackIcon,
         Multiselect,
@@ -164,6 +195,7 @@ export default {
     props: {
         filterState: Object,
         settingsState: Object,
+        sortState: Object,
     },
 
     data() {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -71,6 +71,16 @@ class CarouselCoordinator {
 
 const carouselCoordinator = new CarouselCoordinator();
 
+async function waitUntil(predicate, sleep = 100, maxSleep = 2000) {
+    for (let slept = 0; slept < maxSleep; slept += sleep) {
+        if (predicate()) return;
+        else {
+            await new Promise(res => setTimeout(res, sleep));
+        }
+    }
+    throw new Error('We waited, but nothing happened!');
+}
+
 export default {
     components: { BooksCarousel },
     props: {
@@ -150,7 +160,10 @@ export default {
         }) : null;
     },
 
-    mounted() {
+    async mounted() {
+        // We should only start observing once we're connected to the document,
+        // otherwise Chrome seems to never fire isVisible sometimes.
+        await waitUntil(() => this.$el.isConnected);
         this.intersectionObserver.observe(this.$el);
     },
     beforeDestroy() {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -48,6 +48,9 @@ export default {
     props: {
         query: String,
         node: Object,
+        sort: {
+            default: 'editions',
+        },
         limit: {
             type: Number,
             default: 20
@@ -75,7 +78,8 @@ export default {
             return `${CONFIGS.OL_BASE_SEARCH}/search?${new URLSearchParams({
                 q: this.query,
                 offset: this.offset,
-                limit: this.limit
+                sort: this.sort,
+                limit: this.limit,
             })}`;
         },
 
@@ -91,6 +95,14 @@ export default {
     },
     watch: {
         query() {
+            this.status = 'Start';
+            this.results.splice(0, this.results.length);
+            this.numFound = null;
+            this.error = null;
+            if (this.isVisible) this.debouncedReloadResults();
+        },
+
+        sort() {
             this.status = 'Start';
             this.results.splice(0, this.results.length);
             this.numFound = null;
@@ -144,7 +156,8 @@ export default {
                 q: this.query,
                 offset,
                 limit: this.limit,
-                fields: 'key,title,author_name,cover_i,ddc,lcc,lending_edition_s'
+                sort: this.sort,
+                fields: 'key,title,author_name,cover_i,ddc,lcc,lending_edition_s',
             });
 
             const url = `${CONFIGS.OL_BASE_SEARCH}/search.json?${params.toString()}`;

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -47,15 +47,14 @@ class CarouselCoordinator {
     constructor() {
         this.maxRenderedOffscreen = Math.ceil(navigator.deviceMemory) || 8;
         this.currentlyRenderedOffscreen = [];
-        this.log = false;
     }
 
     registerRenderedOffscreenCarousel(carousel) {
         this.currentlyRenderedOffscreen.push(carousel);
-        this.log && console.log('CarouselCoordinator', `Now ffscreen -- ${carousel.query}`);
+        // console.log('CarouselCoordinator', `Now ffscreen -- ${carousel.query}`);
         if (this.currentlyRenderedOffscreen.length > this.maxRenderedOffscreen) {
             const toRemove = this.currentlyRenderedOffscreen.shift();
-            this.log && console.log('CarouselCoordinator', `Culling offscreen carousel -- ${carousel.query}`);
+            // console.log('CarouselCoordinator', `Culling offscreen carousel -- ${carousel.query}`);
             toRemove.unrender();
         }
     }
@@ -63,7 +62,7 @@ class CarouselCoordinator {
     registerOnscreenCarousel(carousel) {
         const index = this.currentlyRenderedOffscreen.indexOf(carousel);
         if (index != -1) {
-            this.log && console.log('CarouselCoordinator', `Carousel no longer offscreen -- ${carousel.query}`);
+            // console.log('CarouselCoordinator', `Carousel no longer offscreen -- ${carousel.query}`);
             this.currentlyRenderedOffscreen.splice(index, 1);
         }
     }

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -92,7 +92,7 @@ export default {
         },
         limit: {
             type: Number,
-            default: 20
+            default: screen.width > 450 ? 20 : 8,
         }
     },
     data() {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -157,7 +157,7 @@ export default {
                 offset,
                 limit: this.limit,
                 sort: this.sort,
-                fields: 'key,title,author_name,cover_i,ddc,lcc,lending_edition_s',
+                fields: 'key,title,author_name,cover_i,ddc,lcc,lending_edition_s,first_publish_year,edition_count',
             });
 
             const url = `${CONFIGS.OL_BASE_SEARCH}/search.json?${params.toString()}`;

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -48,6 +48,7 @@ export default {
     props: {
         query: String,
         node: Object,
+        fetchCoordinator: Object,
         sort: {
             default: 'editions',
         },
@@ -66,8 +67,8 @@ export default {
 
             /** @type {IntersectionObserver} */
             intersectionObserver: null,
-
             isVisible: false,
+            intersectionRatio: 0,
 
             /** @type {AbortController} */
             lastFetchAbortController: null,
@@ -138,6 +139,7 @@ export default {
             // lack of support for `isIntersecting`.
             // See: https://github.com/w3c/IntersectionObserver/issues/211
             const isIntersecting = entries[0].intersectionRatio > 0;
+            this.intersectionRatio = entries[0].intersectionRatio;
             this.isVisible = isIntersecting;
         },
 
@@ -163,6 +165,9 @@ export default {
             const url = `${CONFIGS.OL_BASE_SEARCH}/search.json?${params.toString()}`;
 
             this.status = 'Loading';
+            const fetch = this.fetchCoordinator ?
+                this.fetchCoordinator.fetch.bind(this.fetchCoordinator, { priority: () => 10 + this.intersectionRatio, name: this.query }) :
+                fetch;
             try {
                 const r = await fetch(url, {
                     cache,

--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -36,8 +36,8 @@
       </template>
 
       <template v-slot:cover-label="{ book }">
-        <span
-          v-if="book[classification.field]"
+        <div
+          v-if="book[classification.field] && labels.includes('classification')"
           :title="
             book[classification.field]
               .map(classification.fieldTransform)
@@ -45,8 +45,9 @@
           "
           >{{
             classification.fieldTransform(classification.chooseBest(book[classification.field]))
-          }}</span
-        >
+          }}</div>
+        <div v-if="labels.includes('first_publish_year')">{{book.first_publish_year}}</div>
+        <div v-if="labels.includes('edition_count')">{{book.edition_count}} editions</div>
       </template>
     </OLCarousel>
 
@@ -102,6 +103,7 @@ export default {
         node: Object,
         parent: Object,
 
+        labels: Array,
         classification: Object,
         expandBookshelf: Function,
         features: Object,

--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -122,7 +122,7 @@ class FetchCoordinator {
     }
 
     enqueue(fetchRequest) {
-        console.log(`Enqueing request #${this.requestedFetches.length + 1}: ${fetchRequest.name}`);
+        // console.log(`Enqueing request #${this.requestedFetches.length + 1}: ${fetchRequest.name}`);
         this.requestedFetches.push(fetchRequest);
         this.activate();
     }
@@ -140,7 +140,7 @@ class FetchCoordinator {
         this.timeout = null;
         while ((this.maxConcurrent - this.runningRequests > 0) && this.requestedFetches.length) {
             const topRequest = maxBy(this.requestedFetches, f => f.priority());
-            console.log(`Completing request w p=${topRequest.priority()}: ${topRequest.name}`)
+            // console.log(`Completing request w p=${topRequest.priority()}: ${topRequest.name}`)
             this.runningRequests++;
             fetch(...topRequest.args)
                 .then(r => {

--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -17,6 +17,7 @@
           ? node.children[node.position]
           : node
       "
+      :sort="sort"
     >
       <template #book-end-start>
         <div class="book-end-start">
@@ -43,7 +44,7 @@
               .join('\n')
           "
           >{{
-            classification.fieldTransform(book[classification.field][0])
+            classification.fieldTransform(classification.chooseBest(book[classification.field]))
           }}</span
         >
       </template>
@@ -105,6 +106,7 @@ export default {
         expandBookshelf: Function,
         features: Object,
         filter: String,
+        sort: String,
     },
 
     data() {

--- a/openlibrary/components/LibraryExplorer/components/icons/SortIcon.vue
+++ b/openlibrary/components/LibraryExplorer/components/icons/SortIcon.vue
@@ -1,0 +1,22 @@
+<template>
+  <svg
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:svg="http://www.w3.org/2000/svg"
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    viewBox="0 0 4.2742091 4.2333331"
+    version="1.1"
+  >
+    <path
+      d="M 2.9951642,0.83271585 V 3.1419466 M 2.1750393,1.6267067 3.0082368,0.79350925 3.8352594,1.6267067"
+      style="stroke: currentColor; stroke-width: 0.4; fill: none; stroke-linecap:round;stroke-linejoin:round;"
+    ></path>
+    <path
+      d="M 1.2440267,3.4398244 V 1.1305936 M 2.0641516,2.6458335 1.2309541,3.479031 0.4039315,2.6458335"
+      style="stroke: currentColor; stroke-width: 0.4; fill: none; stroke-linecap:round;stroke-linejoin:round;"
+    ></path>
+  </svg>
+</template>

--- a/openlibrary/components/LibraryExplorer/configs.js
+++ b/openlibrary/components/LibraryExplorer/configs.js
@@ -7,11 +7,12 @@ const CONFIGS = {
     OL_BASE_COVERS: urlParams.get('ol_base_covers') || 'covers.openlibrary.org',
     OL_BASE_SEARCH: urlParams.get('ol_base_search') || OL_BASE_DEFAULT || '',
     OL_BASE_BOOKS: urlParams.get('ol_base_books') || OL_BASE_DEFAULT || '',
+    OL_BASE_LANGS: urlParams.get('ol_base_langs') || OL_BASE_DEFAULT || '',
     OL_BASE_PUBLIC: urlParams.get('ol_base') || 'openlibrary.org',
     DEBUG_MODE: urlParams.get('debug') == 'true',
 };
 
-for (const key of ['OL_BASE_COVERS', 'OL_BASE_SEARCH', 'OL_BASE_BOOKS']) {
+for (const key of ['OL_BASE_COVERS', 'OL_BASE_SEARCH', 'OL_BASE_BOOKS', 'OL_BASE_LANGS']) {
     if (CONFIGS[key] && !CONFIGS[key].startsWith('http')) {
         CONFIGS[key] = `https://${CONFIGS[key]}`;
     }

--- a/openlibrary/components/LibraryExplorer/configs.js
+++ b/openlibrary/components/LibraryExplorer/configs.js
@@ -1,7 +1,7 @@
 const urlParams = new URLSearchParams(location.search);
 
 const IS_VUE_APP =  document.title == 'Vue App';
-const OL_BASE_DEFAULT = IS_VUE_APP ? 'openlibrary.org' : urlParams.get('ol_base');
+const OL_BASE_DEFAULT = urlParams.get('ol_base') || (IS_VUE_APP ? 'openlibrary.org' : '');
 
 const CONFIGS = {
     OL_BASE_COVERS: urlParams.get('ol_base_covers') || 'covers.openlibrary.org',

--- a/openlibrary/components/LibraryExplorer/lcc.json
+++ b/openlibrary/components/LibraryExplorer/lcc.json
@@ -373,7 +373,7 @@
     "query": "lcc:E*",
     "children": [
       {
-        "name": "E does not have any subclasses.",
+        "name": "E does not have any subclasses",
         "short": "E",
         "query": "lcc:E--*",
         "count": 138490
@@ -387,10 +387,16 @@
     "query": "lcc:F*",
     "children": [
       {
-        "name": "F does not have any subclasses, however Canadian Universities and the Canadian National Library use FC for Canadian History, a subclass that the LC has not officially adopted, but which it has agreed not to use for anything else[7][8]",
+        "name": "F does not have any official subclasses",
         "short": "F",
         "query": "lcc:F--*",
         "count": 260680
+      },
+      {
+        "name": "Canadian History (Unofficial)",
+        "short": "FC",
+        "query": "lcc:FC*",
+        "count": 2980
       }
     ],
     "count": 264350
@@ -929,12 +935,7 @@
     "name": "Language and Literature",
     "short": "P",
     "query": "lcc:P*",
-    "count": 2180107
-  },
-  {
-    "name": "The PN-subclass shelf.",
-    "short": "PN-subclass",
-    "query": "lcc:[PN TO subclass]",
+    "count": 2180107,
     "children": [
       {
         "name": "Philology. Linguistics",
@@ -1050,8 +1051,7 @@
         "query": "lcc:PZ*",
         "count": 286328
       }
-    ],
-    "count": 3169021
+    ]
   },
   {
     "name": "Science",

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -1,9 +1,11 @@
 """Language pages
 """
 
+from infogami.plugins.api.code import jsonapi
 from infogami.utils import delegate, stats
 from infogami.utils.view import render_template, safeint
 import web
+import json
 import logging
 
 from . import subjects
@@ -40,18 +42,37 @@ class languages_json(subjects.subjects_json):
         return key.replace("_", " ")
 
 
+def get_top_languages(limit):
+    from . import search
+    result = search.get_solr().select('*:*', rows=0, facets=['language'], facet_limit=limit)
+    return [
+        web.storage(
+            name=get_language_name(row.value),
+            key='/languages/' + row.value,
+            count=row.count
+        )
+        for row in result['facets']['language']
+    ]
+
+
 class index(delegate.page):
     path = "/languages"
 
     def GET(self):
-        from . import search
-        result = search.get_solr().select('*:*', rows=0, facets=['language'], facet_limit=500)
-        languages = [web.storage(name=get_language_name(row.value), key='/languages/' + row.value, count=row.count)
-                    for row in result['facets']['language']]
-        return render_template("languages/index", languages)
+        return render_template("languages/index", get_top_languages(500))
 
     def is_enabled(self):
         return True
+
+
+class index_json(delegate.page):
+    path = "/languages"
+    encoding = "json"
+
+    @jsonapi
+    def GET(self):
+        return json.dumps(get_top_languages(15))
+
 
 class language_search(delegate.page):
     path = '/search/languages'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8505,23 +8505,6 @@
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -8545,13 +8528,6 @@
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.635.tgz",
           "integrity": "sha512-RRriZOLs9CpW6KTLmgBqyUdnY0QNqqWs0HOtuQGGEMizOTNNn1P7sGRBxARnUeLejOsgwjDyRqT3E/CSst02ZQ==",
           "dev": true
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-          "dev": true,
-          "optional": true
         },
         "fast-deep-equal": {
           "version": "3.1.3",
@@ -8627,18 +8603,6 @@
                 "has-flag": "^4.0.0"
               }
             }
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "make-dir": {
@@ -8849,58 +8813,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
           "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
           "dev": true
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-              "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-              "dev": true,
-              "optional": true
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
         }
       }
     },
@@ -22827,7 +22739,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -25928,7 +25840,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -31295,6 +31207,100 @@
           "dev": true
         }
       }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.1.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "emojis-list": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "vue-multiselect": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
+      "integrity": "sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w==",
+      "dev": true
     },
     "vue-style-loader": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "svgo": "1.3.2",
     "vue": "2.6.12",
     "vue-async-computed": "3.9.0",
+    "vue-multiselect": "2.1.6",
     "vue-template-compiler": "2.6.12",
     "webpack": "4.46.0",
     "webpack-cli": "4.5.0"


### PR DESCRIPTION
- Closes #4362 
- Based of #4081 and #4608. This likely the diff you seek: https://github.com/internetarchive/openlibrary/pull/4609/files/b29c42f8e2747327090ee8e44bf5ee65064c4aae..6055423897f8e2d01042eb0d748737857c430a04

### Technical
- Coordinates fetches so that fetches for things on the screen happen before things that are off screen
- To reduce memory usage, the number of off-screen carousels is now limited
- Reduce number of books on mobile devices
- Cleans up some broken LCC shelves
- Fixes carousels appearing blank in Chrome (#4362)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
No visible changes (except perf!)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
