### PR TITLE
Remove duplicate anchor text

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -12,8 +12,7 @@ $if render_once('book-preview-floater'):
       <div class="book-preview">
         <div class="floaterHead">
           <h2>$_('Preview Book')</h2>
-          <a class="dialog--close" data-key="book_preview"
-             title="$_('Close')">&times;<span class="shift">$_("Close")</span></a>
+          <a class="dialog--close" data-key="book_preview">&times;<span class="shift">$_("Close")</span></a>
         </div>
         <div class="iframe-container">
           <iframe style="width:100%; height:515px"></iframe>

--- a/openlibrary/macros/RecentChanges.html
+++ b/openlibrary/macros/RecentChanges.html
@@ -37,7 +37,7 @@ $def render_changes(bot, hash=""):
                     </div>
                 </td>
                 $if v.author:
-                    <td class="displayname"><a href="$homepath()$v.author.key" title="$v.author.displayname">$v.author.displayname</a></td>
+                    <td class="displayname"><a href="$homepath()$v.author.key">$v.author.displayname</a></td>
                 $elif v.ip and v.ip != '127.0.0.1':
                     <td class="history"><a href="/recentchanges?ip=$v.ip" title="When you see numbers here, that's the IP address of the anonymous editor">$v.ip</a></td>
                 $else:

--- a/openlibrary/templates/admin/ip/view.html
+++ b/openlibrary/templates/admin/ip/view.html
@@ -57,7 +57,7 @@ $def call_template(name, change):
             <td class="time">$datestr(c.timestamp)</td>
             <td class="path">$:call_template("path", c)</td>
             $if c.author:
-                <td class="displayname"><a rel="nofollow" href="$c.author.key" title="$c.author.displayname">$c.author.displayname</a></td>
+                <td class="displayname"><a rel="nofollow" href="$c.author.key">$c.author.displayname</a></td>
             $elif c.ip and c.ip != '127.0.0.1':
                 $ klass = cond(c.ip in get_blocked_ips(), 'red', "")
                 <td class="history"><a rel="nofollow" href="$changequery()" class="$klass" title="When you see numbers here, that's the IP address of the anonymous editor">$c.ip</a></td>

--- a/openlibrary/templates/admin/people/edits.html
+++ b/openlibrary/templates/admin/people/edits.html
@@ -63,7 +63,7 @@ window.q.push(function () {
             <td class="time">$datestr(c.timestamp)</td>
             <td class="path">$:call_template("path", c)</td>
             $if c.author:
-                <td class="displayname"><a rel="nofollow" href="$c.author.key" title="$c.author.displayname">$c.author.displayname</a></td>
+                <td class="displayname"><a rel="nofollow" href="$c.author.key">$c.author.displayname</a></td>
             $elif c.ip and c.ip != '127.0.0.1':
                 $ klass = cond(c.ip in get_blocked_ips(), 'red', "")
                 <td class="history"><a rel="nofollow" href="$changequery()" class="$klass" title="When you see numbers here, that's the IP address of the anonymous editor">$c.ip</a></td>

--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -41,7 +41,7 @@ $var title: $name
                     <td class="number">$v.revision</td>
                     <td class="history"><a href="$page.get_url(v=v.revision)" title="$_('View revision %s', v.revision)">$datestr(v.created)</a></td>
                     $if v.author:
-                        <td class="displayname" style="vertical-align: top;"><div class="truncatedisplayname"><a href="$homepath()$v.author.key" class="truncate" title="$v.author.displayname">$v.author.displayname</a></div></td>
+                        <td class="displayname" style="vertical-align: top;"><div class="truncatedisplayname"><a href="$homepath()$v.author.key" class="truncate">$v.author.displayname</a></div></td>
                     $elif v.ip and v.ip != '127.0.0.1':
                         <td class="history" style="vertical-align: top;"><a href="/recentchanges?ip=$v.ip">$v.ip</a></td>
                     $else:

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -74,7 +74,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                     $if v.author:
                         $ author_link = v.author.render_link(cls="truncate")
                     $elif v.ip and v.ip != "127.0.0.1":
-                        $ author_link = '<a rel="nofollow" href="/recentchanges?ip=%s" title="%s">%s</a>' % (v.ip, _('an anonymous user'), v.ip)
+                        $ author_link = '<a rel="nofollow" href="/recentchanges?ip=%s">%s</a>' % (v.ip, _('an anonymous user'), v.ip)
                     $else:
                         $ author_link = '<span>%s</span>' % (_('an anonymous user'))
                     $if v.revision == 1:

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -74,7 +74,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                     $if v.author:
                         $ author_link = v.author.render_link(cls="truncate")
                     $elif v.ip and v.ip != "127.0.0.1":
-                        $ author_link = '<a rel="nofollow" href="/recentchanges?ip=%s">%s</a>' % (v.ip, _('an anonymous user'), v.ip)
+                        $ author_link = '<a rel="nofollow" href="/recentchanges?ip=%s" title="%s">%s</a>' % (v.ip, _('an anonymous user'), v.ip)
                     $else:
                         $ author_link = '<span>%s</span>' % (_('an anonymous user'))
                     $if v.revision == 1:

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -6,12 +6,12 @@ $def with (page)
       <div>
         <h2>Open Library</h2>
         <ul>
-          <li><a href="/about/vision" title="$_('Vision')">$_('Vision')</a></li>
-          <li><a href="/volunteer" title="$_('Volunteer')">$_('Volunteer')</a></li>
+          <li><a href="/about/vision">$_('Vision')</a></li>
+          <li><a href="/volunteer">$_('Volunteer')</a></li>
           <li><a href="https://archive.org/about/jobs.php" title="$_('Jobs')">$_('Careers')</a></li>
-          <li><a href="https://blog.openlibrary.org/" title="$_('Blog')">$_('Blog')</a></li>
-          <li><a href="https://archive.org/about/terms.php" title="$_('Terms of Service')">$_('Terms of Service')</a></li>
-          <li><a href="https://archive.org/donate/?platform=ol" title="$_('Donate')">$_('Donate')</a></li>
+          <li><a href="https://blog.openlibrary.org/">$_('Blog')</a></li>
+          <li><a href="https://archive.org/about/terms.php">$_('Terms of Service')</a></li>
+          <li><a href="https://archive.org/donate/?platform=ol">$_('Donate')</a></li>
         </ul>
       </div>
       <div>
@@ -21,7 +21,7 @@ $def with (page)
           <li><a href="/search" title="$_('Explore Books')">$_('Books')</a></li>
           <li><a href="/search/authors" title="$_('Explore authors')">$_('Authors')</a></li>
           <li><a href="/subjects" title="$_('Explore subjects')">$_('Subjects')</a></li>
-          <li><a href="/advancedsearch" title="$_('Advanced Search')">$_('Advanced Search')</a></li>
+          <li><a href="/advancedsearch">$_('Advanced Search')</a></li>
           <li><a href="#top" title="$_('Navigate to top of this page')">$_('Return to Top')</a></li>
         </ul>
       </div>
@@ -38,7 +38,7 @@ $def with (page)
       <div>
         <h2>$:_('Help')</h2>
         <ul>
-          <li><a href="/help" title="$_('Help Center')">$_('Help Center')</a></li>
+          <li><a href="/help">$_('Help Center')</a></li>
           <li><a href="/contact?path=$request.path" title="$_('Problems')">$_('Report A Problem')</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_('Suggesting Edits')</a></li>
         </ul>

--- a/openlibrary/templates/recentchanges/new-account/path.html
+++ b/openlibrary/templates/recentchanges/new-account/path.html
@@ -2,5 +2,5 @@ $def with (change)
 
 <div class="truncatepath">
     $ user = change.get_changes()[0]
-    <a href="$homepath()$user.key" class="datalink" title="$user.key">$user.key</a>
+    <a href="$homepath()$user.key" class="datalink">$user.key</a>
 </div>

--- a/openlibrary/templates/recentchanges/render.html
+++ b/openlibrary/templates/recentchanges/render.html
@@ -32,7 +32,7 @@ $if "ip" in query and ctx.user and ctx.user.is_admin():
             <td class="time">$datestr(c.timestamp)</td>
             <td class="path">$:call_template("path", c)</td>
             $if c.author:
-                <td class="displayname"><a rel="nofollow" href="$c.author.key" title="$c.author.displayname">$c.author.displayname</a></td>
+                <td class="displayname"><a rel="nofollow" href="$c.author.key">$c.author.displayname</a></td>
             $elif c.ip and c.ip != '127.0.0.1':
                 $if ctx.user and ctx.user.is_admin():
                     $ ip_url = "/admin/ip/%s" % c.ip


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2718

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->
1. Searched for occurrences of anchor tag with 'title' attribute.
2. If 'title' attribute is same as anchor text, deleted that particular 'title' attribute from the anchor tag.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tabshaikh 