### PR TITLE
Fix related works carousel

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -9,7 +9,7 @@ export function initCarouselsPartials() {
             url: '/partials',
             type: 'GET',
             data: {
-                workid: $('.RelatedWorksCarousel').data('workId'),
+                workid: $('.RelatedWorksCarousel').data('workid'),
                 _component: 'RelatedWorkCarousel'
             },
             datatype: 'json',

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -461,7 +461,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
   </div>
 
   $ component_times['RelatedWorksCarousel'] = time()
-  <div class="RelatedWorksCarousel" data-workId="$work.key.split('/')[-1]">
+  <div class="RelatedWorksCarousel" data-workid="$work.key.split('/')[-1]">
     <div class="hidden loadingIndicator">
         <figure>
         <img src="/images/ajax-loader-bar.gif">

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -1,6 +1,6 @@
 // A standard list of helpers
 .hidden {
-  display: none;
+  display: none !important;
 }
 .inline {
   display: inline;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4592

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
PR ensures that `workid` is sent in `/partials` API calls, and the the `.hidden` CSS rule is honored.

### Technical
<!-- What should be noted about the implementation? -->
`data-workId` was being changed to `data-workid` in the generated HTML, so the jQuery `.data()` call was returning nothing.  As a result, the work ID was not included in the `/partials` request's query string.

Additionally, the `.hidden` CSS rule was being overridden by the `.loadingIndicator`'s `display` rule, causing an endless loading animation.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a book page.
2. Observe the related works carousel at the bottom of the page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
