### PR TITLE
Remove references to /olsystem/bin/olenv

### DIFF
--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -1,5 +1,9 @@
-#!/olsystem/bin/olenv python
+#!/usr/bin/env python3
 """
+CAUTION: This file should continue to support both Python 2 and Python 3 until
+    issues internetarchive/openlibrary#4060 and internetarchive/openlibrary#4252
+    are resolved.
+
 Store count of unique IPs per day to infobase by parsing the nginx log files directly.
 
 This file is currently (17 July 2018) run on production using cron.

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -65,7 +65,7 @@ def import_ocaids(*ocaids, **kwargs):
     archive.org items into Open Library by ocaid
 
     Usage:
-        $ sudo -u openlibrary /olsystem/bin/olenv \
+        $ sudo -u openlibrary \
             HOME=/home/openlibrary OPENLIBRARY_RCFILE=/olsystem/etc/olrc-importbot \
             python scripts/manage-imports.py \
                 --config /olsystem/etc/openlibrary.yml \

--- a/scripts/solr_builder/README.md
+++ b/scripts/solr_builder/README.md
@@ -51,7 +51,7 @@ echo "${DAY_BEFORE_DUMP}:0" > solr-builder.offset
 Create `/etc/supervisor/conf.d/solrbuilder-solrupdater.conf` with:
 ```
 [program:solrbuilder-solrupdater]
-command=/olsystem/bin/olenv python /opt/openlibrary/openlibrary/scripts/new-solr-updater.py
+command=python3 /opt/openlibrary/openlibrary/scripts/new-solr-updater.py
   --config /opt/openlibrary/openlibrary/conf/solrbuilder-openlibrary.yml
   --state-file /opt/openlibrary/openlibrary/solr-builder.offset
   --socket-timeout 600

--- a/scripts/store_counts.py
+++ b/scripts/store_counts.py
@@ -1,4 +1,4 @@
-#!/olsystem/bin/olenv python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import sys


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Our cron jobs no longer need to rely on the defunct /olsystem/bin/olenv

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
