### PR TITLE
Fix Individual Subject Page Images Accessibility

### DIFF
--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -38,6 +38,7 @@ $def render_carousel_cover(book, lazy):
           <img class="bookcover" loading="lazy"
             width="130" height="200"
             title="$('%s%s'%(title,byline))"
+            alt="Book Cover"
           $if lazy:
             data-lazy="$(cover_url)"
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -38,7 +38,7 @@ $def render_carousel_cover(book, lazy):
           <img class="bookcover" loading="lazy"
             width="130" height="200"
             title="$('%s%s'%(title,byline))"
-            alt="Book Cover"
+            alt="$('%s%s'%(title,byline))"
           $if lazy:
             data-lazy="$(cover_url)"
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -82,8 +82,7 @@ $jsdef show_list(list, user_key):
     $ remove = (list.owner.key == user_key)
     <li>
         <span class="image">
-          $ title = _('Cover of: %(listname)s', listname=list.name)
-          <a href="$list.key"><img src="$list.cover_url" alt="$title" title="$title"/></a>
+          <a href="$list.key"><img src="$list.cover_url" alt="Cover of: $list.name" title="Cover of: $list.name"/></a>
         </span>
         <span class="data">
             <span class="label">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4632 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes broken alt tag for list widget cover image.
Added alt="Book Cover" for Custom Carousel Books

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly 