### PR TITLE
Change alt attribute of adobe logo

### DIFF
--- a/openlibrary/templates/account/borrow.html
+++ b/openlibrary/templates/account/borrow.html
@@ -264,7 +264,7 @@ $if len(loans) == 0 and len(waitinglist) == 0:
     <div class="contentSpacer"></div>
     <div class="contentQuarter">
         <h3>$_("Help/Downloads")</h3>
-        <img src="/images/logo_adobeACS.png" alt="logo: Adobe" width="43" height="72" class="left" style="margin-right:10px;"/>
+        <img src="/images/logo_adobeACS.png" alt="" width="43" height="72" class="left" style="margin-right:10px;"/>
         <p class="small sansserif collapse"><a href="http://www.adobe.com/products/digitaleditions/#fp">$_("Download Adobe Digital Editions")</a></p>
         <p class="small sansserif">$:_('<a href="http://www.adobe.com/products/digitaleditions/help/">Help</a> on adobe.com')</p>
     </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4642

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
There is only one image which needs to be fixed in the `Loans Page`
Fix for the alt attribute of Adobe logo:
The text beside the logo, explains the pusrpose of the image. An alt attribute describing the image will create repetition. So, it's better to assign `alt=""` .
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly 