### PR TITLE
Fix DeprecationWarning invalid escape sequences

### DIFF
--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -213,7 +213,7 @@ def get_first_tag(data, want): # return first line of wanted tag
         if line[:3] in want:
             return get_tag_line(data, line)
 
-re_dates = re.compile('^\(?(\d+-\d*|\d*-\d+)\)?$')
+re_dates = re.compile(r'^\(?(\d+-\d*|\d*-\d+)\)?$')
 
 @deprecated
 def get_person_content(line, is_marc8=False):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -413,7 +413,7 @@ class account_validation(delegate.page):
 
     @staticmethod
     def validate_email(email):
-        if not (email and re.match('.*@.*\..*', email)):
+        if not (email and re.match(r'.*@.*\..*', email)):
             return _('Must be a valid email address')
 
         ol_account = OpenLibraryAccount.get(email=email)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes pytest warnings on Python 3.10:
```
=============================== warnings summary ===============================
openlibrary/catalog/marc/fast_parse.py:216
  /home/runner/work/openlibrary/openlibrary/openlibrary/catalog/marc/fast_parse.py:216: DeprecationWarning: invalid escape sequence \(
    re_dates = re.compile('^\(?(\d+-\d*|\d*-\d+)\)?$')

openlibrary/plugins/upstream/account.py:416
  /home/runner/work/openlibrary/openlibrary/openlibrary/plugins/upstream/account.py:416: DeprecationWarning: invalid escape sequence \.
    if not (email and re.match('.*@.*\..*', email)):
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
