### PR TITLE
Remove carousel_partials.js load event

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -33,9 +33,5 @@ export function initCarouselsPartials() {
 
     $('.loadingIndicator').removeClass('hidden');
 
-    if (document.readyState === 'complete') {
-        fetchRelatedWorks();
-    } else {
-        $(window).on('load', fetchRelatedWorks);
-    }
+    fetchRelatedWorks();
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses review notes from PR #4007

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes conditional that checks `readyState` of the document.

### Technical
<!-- What should be noted about the implementation? -->
This code is not loaded until the document is ready (evidenced [here](https://github.com/internetarchive/openlibrary/blob/5d00b71a745ceae062079842cc6c887191ce6b3a/openlibrary/plugins/openlibrary/js/index.js#L114)), making the `readyState` conditional redundant.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a book page.
2. Using your browser's development tools, ensure that the call to `/partials` has been made successfully.  On success, the loading indicator animation will be hidden and the related works carousel  will contain a `div` with class `related-books`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
@cdrini 
