### PR TITLE
Drop redundant line

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -171,5 +171,4 @@ jQuery(function () {
     });
     $('.column').disableSelection();
     $('.trash').disableSelection();
-    $('#topNotice').hide();
 });


### PR DESCRIPTION
There is no topNotice element on
/books/OL28775995M/Der_Todeskanal/manage-covers
or
/books/OL28775995M/Der_Todeskanal/add-cover

so there is no need to hide the element. This rule was copied across
from existing inline JS 55a6a39 but presumably relates to a time when
the Internet Archive header was rendered on these pages.

Fixes: #4665

### Screenshot
<img width="897" alt="Screen Shot 2021-02-23 at 12 21 13 PM" src="https://user-images.githubusercontent.com/148752/108902974-a0b89c80-75d1-11eb-8f85-f645718c796a.png">

