### PR TITLE
Speed up make css and make components by ~2x using gnu parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,7 @@ all: git css js components i18n
 
 css: static/css/page-*.less
 	mkdir --parents $(BUILD)
-	for asset in $^; do \
-		echo "Compressing $$asset"; \
-	    npx lessc $$asset $(BUILD)/$$(basename $$asset .less).css --clean-css="--s1 --advanced --compatibility=ie8"; \
-	done
+	parallel --verbose -q npx lessc {} $(BUILD)/{/.}.css --clean-css="--s1 --advanced --compatibility=ie8" ::: $^
 
 js:
 	mkdir --parents $(BUILD)
@@ -36,11 +33,9 @@ js:
 components: $(COMPONENTS_DIR)/*.vue
 	mkdir --parents $(BUILD)
 	rm -rf $(BUILD)/components
-	for component in $^; do \
-		echo $$component; \
-		npx vue-cli-service build --no-clean --mode development --dest $(BUILD)/components/development --target wc --name "ol-$$(basename $$component .vue)" "$$component"; \
-		npx vue-cli-service build --no-clean --mode production --dest $(BUILD)/components/production --target wc --name "ol-$$(basename $$component .vue)" "$$component"; \
-	done
+	parallel --verbose -q \
+		npx vue-cli-service build --no-clean --mode {2} --dest $(BUILD)/components/{2} --target wc --name "ol-{1/.}" "{1}" \
+	::: $^ ::: production development
 
 i18n:
 	$(PYTHON) ./scripts/i18n-messages compile

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -24,8 +24,14 @@ RUN apt-get -qq update && apt-get install -y \
     libffi-dev \
     curl \
     screen \
+# Editors (for our convenience)
     vim \
-    emacs
+    emacs \
+# util for running things in parallel
+    parallel
+
+# Print gnu parallel citation
+RUN echo 'will cite' | parallel --citation
 
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \


### PR DESCRIPTION
Feature:

css: 34s -> 15s
components: 90s -> 20s

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
- NOTE: This will be a breaking change to all developers, since it touches the olbase file :/ Folks will need to run `docker-compose up --pull` to get the latest olbase (after this is merged). Let's merge this around the same time as a python version update or something to bundle the changes.

### Testing

```sh
docker-compose run --rm -uroot home bash
```

```sh
apt-get install parallel
echo 'will cite' | parallel --citation 
make css # So fast!
make components # So snappier!
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 
