### PR TITLE
Fix merge authors with Unicode names

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -298,8 +298,7 @@ class merge_authors(delegate.page):
             return render_template("merge/authors", keys, top_books_from_author=top_books_from_author, formdata=formdata)
         else:
             # redirect to the master. The master will display a progressbar and call the merge_authors_json to trigger the merge.
-            master = web.ctx.site.get("/authors/" + i.master)
-            raise web.seeother(master.url() + "?merge=true&duplicates=" + ",".join(selected))
+            raise web.seeother("/authors/" + i.master + "/-/" + "?merge=true&duplicates=" + ",".join(selected))
 
 
 class merge_authors_json(delegate.page):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4225

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Directly compose the [`web.seeother()`](https://github.com/webpy/webpy/blob/master/web/webapi.py#L156-L163) redirect URL to short circuit the database call.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
