### PR TITLE
Refactor sort options on search and author page

### DIFF
--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -1,5 +1,6 @@
-$ param = {}
-$ sort = param.get('sort', None)
+$def with (exclude, default)
+
+$ sort = 'sort'
 
 <span class="tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:10px;"/>
     $code:

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -1,27 +1,27 @@
-$def with (exclude, default)
-
-$ sort = 'sort'
+$def with (selected_sort, exclude=None, default_sort='relevance')
 
 <span class="tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:10px;"/>
     $code:
       sort_options = [
-        { 'sort': None, 'name': _("Relevance"), 'ga_key': 'Relevance' },
+        { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
         { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
         { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
         { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
-        { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': sort and sort.startswith('random') },
+        { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and sort.startswith('random') },
       ]
     $for sort_option in sort_options:
-      $ is_selected = sort_option.get('selected') or sort_option['sort'] == sort
+      $if exclude and sort_option['sort'] in exclude:
+        $continue
+      $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort
       $if is_selected:
           <strong class="lightgreen">$sort_option['name']</strong>
       $else:
-          <a href="$changequery(sort=sort_option['sort'])"
+          <a href="$changequery(sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
              data-ol-link-track="SearchSort|$sort_option['ga_key']"
           >$sort_option['name']</a>
       $if not loop.last:
           |
-    $if sort and sort.startswith('random'):
+    $if selected_sort and sort.startswith('random'):
       (<a href="$changequery(sort='random_%s' % today().timestamp())"
          data-ol-link-track="SearchSort|RandomShuffle"
       >$_('Shuffle')</a>)

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -7,7 +7,7 @@ $def with (selected_sort, exclude=None, default_sort='relevance')
         { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
         { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
         { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
-        { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and sort.startswith('random') },
+        { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
       ]
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:
@@ -21,7 +21,7 @@ $def with (selected_sort, exclude=None, default_sort='relevance')
           >$sort_option['name']</a>
       $if not loop.last:
           |
-    $if selected_sort and sort.startswith('random'):
+    $if selected_sort and selected_sort.startswith('random'):
       (<a href="$changequery(sort='random_%s' % today().timestamp())"
          data-ol-link-track="SearchSort|RandomShuffle"
       >$_('Shuffle')</a>)

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -1,0 +1,27 @@
+$ param = {}
+$ sort = param.get('sort', None)
+
+<span class="tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:10px;"/>
+    $code:
+      sort_options = [
+        { 'sort': None, 'name': _("Relevance"), 'ga_key': 'Relevance' },
+        { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
+        { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
+        { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
+        { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': sort and sort.startswith('random') },
+      ]
+    $for sort_option in sort_options:
+      $ is_selected = sort_option.get('selected') or sort_option['sort'] == sort
+      $if is_selected:
+          <strong class="lightgreen">$sort_option['name']</strong>
+      $else:
+          <a href="$changequery(sort=sort_option['sort'])"
+             data-ol-link-track="SearchSort|$sort_option['ga_key']"
+          >$sort_option['name']</a>
+      $if not loop.last:
+          |
+    $if sort and sort.startswith('random'):
+      (<a href="$changequery(sort='random_%s' % today().timestamp())"
+         data-ol-link-track="SearchSort|RandomShuffle"
+      >$_('Shuffle')</a>)
+</span>

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -12,7 +12,7 @@ $def with (selected_sort, exclude=None, default_sort='relevance')
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:
         $continue
-      $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort
+      $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort or (selected_sort is None and sort_option['sort'] == default_sort)
       $if is_selected:
           <strong class="lightgreen">$sort_option['name']</strong>
       $else:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -146,7 +146,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 </h2>
                 <p id="books">
                 $if books.num_found > 1:
-                    $:render_template("search/sort_options.html", exclude=('relevance'), default='editions')
+                    $:render_template("search/sort_options.html", exclude='relevance', default_sort='editions')
 
                 <p>
                   $if input(mode="everything").mode == "everything":

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -146,7 +146,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 </h2>
                 <p id="books">
                 $if books.num_found > 1:
-                    $:render_template("search/sort_options.html", exclude='relevance', default_sort='editions')
+                    $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
 
                 <p>
                   $if input(mode="everything").mode == "everything":

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -144,18 +144,9 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     $ungettext("1 work", "%(count)d works", books.num_found, count=books.num_found)
                     <span class="count smaller"><a href="/books/add?author=$page.key">$_('Add another?')</a></span>
                 </h2>
-                <p id="books"><span class="tools">
+                <p id="books">
                 $if books.num_found > 1:
-                    <img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:5px;"/>
-                    $if books.sort == 'editions':
-                        <strong class="lightgreen">$_('Most Editions')</strong> | <a href="$changequery(sort='old')#editions">$_('First Published')</a> | <a href="$changequery(sort='new')#editions">$_('Most Recent')</a>
-                    $elif books.sort == 'old':
-                        <a href="$changequery(sort=None)#editions">$_('Most Editions')</a> | <strong class="lightgreen">$_('First Published')</strong> | <a href="$changequery(sort='new')#editions">$_('Most Recent')</a>
-                    $elif books.sort == 'new':
-                        <a href="$changequery(sort=None)#editions">$_('Most Editions')</a> |  <a href="$changequery(sort='old')#editions">$_('First Published')</a> | <strong class="lightgreen">$_('Most Recent')</strong>
-                    $elif books.sort == 'title':
-                        <a href="$changequery(sort=None)#editions">$_('Most Editions')</a> |  <a href="$changequery(sort='old')#editions">$_('First Published')</a> | <a href="$changequery(sort='new')#editions">$_('Most Recent')</a> | <strong class="lightgreen">$_('Title')</strong>
-                </span>
+                    $:render_template("search/sort_options.html", exclude=('relevance'), default='editions')
 
                 <p>
                   $if input(mode="everything").mode == "everything":

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -89,7 +89,7 @@ $if param and not error and num_found:
         <span class="darkgreen"><strong>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</strong></span>
 &nbsp;
       $if num_found > 1:
-        $:render_template("search/sort_options.html")
+        $:render_template("search/sort_options.html", sort)
         <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
     </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -89,7 +89,7 @@ $if param and not error and num_found:
         <span class="darkgreen"><strong>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</strong></span>
 &nbsp;
       $if num_found > 1:
-        $:render_template("search/sort_options.html")
+        $:render_template("search/sort_options.html", exclude=None, default='relevance')
         <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
     </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -89,32 +89,8 @@ $if param and not error and num_found:
         <span class="darkgreen"><strong>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</strong></span>
 &nbsp;
       $if num_found > 1:
-        <span class="tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:10px;"/>
-          $code:
-            sort_options = [
-              { 'sort': None, 'name': _("Relevance"), 'ga_key': 'Relevance' },
-              { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
-              { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
-              { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
-              { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': sort and sort.startswith('random') },
-            ]
-          $for sort_option in sort_options:
-            $ is_selected = sort_option.get('selected') or sort_option['sort'] == sort
-            $if is_selected:
-                <strong class="lightgreen">$sort_option['name']</strong>
-            $else:
-                <a href="$changequery(sort=sort_option['sort'])"
-                   data-ol-link-track="SearchSort|$sort_option['ga_key']"
-                >$sort_option['name']</a>
-            $if not loop.last:
-                |
-          $if sort and sort.startswith('random'):
-            (<a href="$changequery(sort='random_%s' % today().timestamp())"
-               data-ol-link-track="SearchSort|RandomShuffle"
-            >$_('Shuffle')</a>)
-
-          <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
-        </span>
+        $:render_template("search/sort_options.html")
+        <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
     </div>
 
 $ facet_map = (

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -89,7 +89,7 @@ $if param and not error and num_found:
         <span class="darkgreen"><strong>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</strong></span>
 &nbsp;
       $if num_found > 1:
-        $:render_template("search/sort_options.html", exclude=None, default='relevance')
+        $:render_template("search/sort_options.html")
         <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
     </div>
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -535,6 +535,7 @@ input {
 
 // openlibrary/templates/work_search.html
 .advanced-search {
+  font-size: 12px;
   float: right;
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4662 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Move the sort options code to a new file (sort_options.html in template/search)

**Blockers:**
1. On selecting a sort option its color doesn't change.
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 