### PR TITLE
Simplify z-indexes in header

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -154,7 +154,7 @@
     -webkit-box-ordinal-group: 2;
     -ms-flex-order: 1;
     order: 1;
-    z-index: @z-index-level-1;
+    z-index: @z-index-level-negative;
 
     .logo-icon {
       position: relative;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -22,6 +22,8 @@
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  z-index: @z-index-level-2;
+  position: relative;
 
   .account-component {
     -webkit-box-flex: 0;
@@ -46,7 +48,6 @@
 
     .account-dropdown {
       position: absolute;
-      z-index: @z-index-level-5;
       text-align: right;
       // Note, it must be padding so that the gap between the icon and
       // the dropdown menu is included in the hover-trigger area (#1575)
@@ -125,7 +126,6 @@
 
   .hamburger-dropdown-component {
     position: absolute;
-    z-index: @z-index-level-5;
   }
 
   .hamburger-component {
@@ -154,6 +154,7 @@
     -webkit-box-ordinal-group: 2;
     -ms-flex-order: 1;
     order: 1;
+    z-index: @z-index-level-1;
 
     .logo-icon {
       position: relative;
@@ -174,7 +175,9 @@
     -webkit-box-ordinal-group: 6;
     -ms-flex-order: 5;
     order: 5;
-    z-index: @z-index-level-5;
+    // Despite occuring later in the DOM, this header should be overlayed underneath the items above
+    // e.g. search and account dropdowns.
+    z-index: @z-index-level-negative;
 
     li {
       -ms-flex-preferred-size: 100%;
@@ -197,7 +200,6 @@
 
       .dropdown-menu {
         position: absolute;
-        z-index: @z-index-level-5;
         text-align: left;
         width: 100%;
         top: 4px;
@@ -225,7 +227,6 @@
     -webkit-box-flex: 1;
     -ms-flex: 1;
     flex: 1;
-    z-index: @z-index-level-4;
 
     // stylelint-disable selector-max-specificity
     // stylelint-disable max-nesting-depth
@@ -286,7 +287,6 @@
       border: 1px solid @dark-beige;
       border-radius: .3em;
       background-color: @grey-fafafa;
-      z-index: @z-index-level-17;
       position: relative;
     }
 
@@ -303,7 +303,6 @@
 
     .search-dropdown {
       position: relative;
-      z-index: @z-index-level-5;
 
       /* stylelint-disable selector-max-specificity */
       .search-results {
@@ -354,7 +353,6 @@
 
     .search-facet-selector {
       display: none;
-      z-index: @z-index-level-2;
       margin-top: 3px;
       padding: 13px 10px 0;
       font-size: 14px;
@@ -376,7 +374,6 @@
         font-family: inherit;
         font-weight: inherit;
         color: inherit;
-        z-index: @z-index-level-1;
         background: none;
         border: none;
         cursor: pointer;

--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -6,6 +6,8 @@
   background-color: @white;
   border-radius: 5px;
   border: 1px solid @dark-beige;
+  z-index: @z-index-level-1;
+  position: relative;
 }
 
 // For pages without a header we don't want a margin.

--- a/static/css/less/z-index.less
+++ b/static/css/less/z-index.less
@@ -1,3 +1,4 @@
+@z-index-level-negative: -1;
 @z-index-level-1: 1;
 @z-index-level-2: 2;
 @z-index-level-3: 3;


### PR DESCRIPTION

Z-indexs are inherited so we need to set the header at a value
above the content area and make sure that the second row of items
and logo always appears below the dropdowns when open

There is no need for the z-index madness!

Fixes: #4685
Fixes: #4718

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<img width="626" alt="Screen Shot 2021-02-27 at 4 06 07 PM" src="https://user-images.githubusercontent.com/148752/109403898-b4d40500-7915-11eb-986c-22c317e51e6c.png">
### Stakeholders
<!-- @ tag stakeholders of this bug -->
