### PR TITLE
Admin menu: Fix the path to https://openlibrary.org/status

### DIFF
--- a/openlibrary/templates/admin/menu.html
+++ b/openlibrary/templates/admin/menu.html
@@ -23,5 +23,5 @@ $def link(url, title):
     | $:link("/admin/inspect/store", _("Inspect store"))
     | $:link("/admin/inspect/memcache", _("Inspect memcache"))
     <strong style="padding: 0px 5px">•</strong>
-    $:link("/admin/status", _("Status"))
+    $:link("/status", _("Status"))
 </div>


### PR DESCRIPTION
https://openlibrary.org/admin/status does not exist but https://openlibrary.org/status does.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
