### PR TITLE
Fix /admin/imports on localhost

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -6,6 +6,8 @@ import datetime
 import time
 import web
 
+from psycopg2.errors import UndefinedTable
+
 from . import db
 
 logger = logging.getLogger("openlibrary.imports")
@@ -98,10 +100,14 @@ class Stats:
             where = "status=$status"
         else:
             where = "1=1"
-        rows = db.select("import_item",
-            what="count(*) as count",
-            where=where,
-            vars=locals())
+        try:  # Database table import_item may not exist on localhost
+            rows = db.select("import_item",
+                what="count(*) as count",
+                where=where,
+                vars=locals())
+        except UndefinedTable:
+            logger.log_exception()
+            return 0
         return rows[0].count
 
     def get_count_by_status(self, date=None):

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -97,13 +97,13 @@ class Stats:
 
     def get_count(self, status=None):
         where = "status=$status" if status else "1=1"
-        try:  # Database table import_item may not exist on localhost
+        try:
             rows = db.select("import_item",
                 what="count(*) as count",
                 where=where,
                 vars=locals())
         except UndefinedTable:
-            logger.log_exception()
+            logger.exception("Database table import_item may not exist on localhost")
             return 0
         return rows[0].count
 

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -96,10 +96,7 @@ class Stats:
         return result[0].count
 
     def get_count(self, status=None):
-        if status:
-            where = "status=$status"
-        else:
-            where = "1=1"
+        where = "status=$status" if status else "1=1"
         try:  # Database table import_item may not exist on localhost
             rows = db.select("import_item",
                 what="count(*) as count",
@@ -142,10 +139,7 @@ class Stats:
     def get_items(self, date=None, order=None, limit=None):
         """Returns all rows with given added date.
         """
-        if date:
-            where = "added_time::date = $date"
-        else:
-            where = "1 = 1"
+        where = "added_time::date = $date" if date else "1 = 1"
         return db.select("import_item",
             where=where,
             order=order,

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -90,9 +90,13 @@ class Stats:
     def get_imports_per_hour(self):
         """Returns the number imports happened in past one hour duration.
         """
-        result = db.query(
-            "SELECT count(*) as count FROM import_item" +
-            " WHERE import_time > CURRENT_TIMESTAMP - interval '1' hour")
+        try:
+            result = db.query(
+                "SELECT count(*) as count FROM import_item" +
+                " WHERE import_time > CURRENT_TIMESTAMP - interval '1' hour")
+        except UndefinedTable:
+            logger.exception("Database table import_item may not exist on localhost")
+            return 0
         return result[0].count
 
     def get_count(self, status=None):


### PR DESCRIPTION
Fixes #2316

Database table `import_item` may not exist on localhost so detect and log [`psycopg2.errors.UndefinedTable`](https://www.psycopg.org/docs/errors.html) and return a count of 0 or an empty list.

Is there a way to solve this with less code by creating an empty `import_item` database table?

Should we reduce or eliminate the logging?

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
