### PR TITLE
Add random.hourly and random.daily sort options

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 import web
 import random
@@ -125,6 +126,8 @@ SORTS = {
     'random': 'random_1 asc',
     'random asc': 'random_1 asc',
     'random desc': 'random_1 desc',
+    'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
+    'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
 }
 OLID_URLS = {'A': 'authors', 'M': 'books', 'W': 'works'}
 
@@ -164,7 +167,8 @@ def process_sort(raw_sort):
         if sort.startswith('random_'):
             return sort if ' ' in sort else sort + ' asc'
         else:
-            return SORTS[sort]
+            solr_sort = SORTS[sort]
+            return solr_sort() if callable(solr_sort) else solr_sort
     return ','.join(process_individual_sort(s.strip()) for s in raw_sort.split(','))
 
 


### PR DESCRIPTION
Feature. These are useful for things like carousels, where we might want them to shuffle regularly.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] Hourly changes from hour to hour: http://staging.openlibrary.org/search?q=hello&mode=everything&sort=random.hourly
- [x] Daily changes shows things in a random order http://staging.openlibrary.org/search?q=hello&mode=everything&sort=random.daily
- [x] `random_*` still works: http://staging.openlibrary.org/search?q=hello&mode=everything&sort=random_custom

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
