### PR TITLE
Add default image for book cover and author in search dropdown

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -27,7 +27,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
         return `
             <li>
                 <a href="${work.key}">
-                    <img src="//covers.openlibrary.org/b/id/${work.cover_i}-S.jpg?default=https://dev.openlibrary.org/static/images/icons/avatar_book-sm.png" alt=""/>
+                    <img src="//covers.openlibrary.org/b/id/${work.cover_i}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_book-sm.png" alt=""/>
                     <span class="book-desc">
                         <div class="book-title">${work.title}</div> by <span class="book-author">${author_name}</span>
                     </span>
@@ -38,7 +38,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
         return `
             <li>
                 <a href="/authors/${author.key}">
-                    <img src="http://covers.openlibrary.org/a/olid/${author.key}-S.jpg?default=https://dev.openlibrary.org/static/images/icons/avatar_author-lg.png" alt=""/>
+                    <img src="http://covers.openlibrary.org/a/olid/${author.key}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_author-lg.png" alt=""/>
                     <span class="author-desc"><div class="author-name">${author.name}</div></span>
                 </a>
             </li>`;

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -27,7 +27,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
         return `
             <li>
                 <a href="${work.key}">
-                    <img src="//covers.openlibrary.org/b/id/${work.cover_i}-S.jpg"/>
+                    <img src="//covers.openlibrary.org/b/id/${work.cover_i}-S.jpg?default=https://dev.openlibrary.org/static/images/icons/avatar_book-sm.png" alt=""/>
                     <span class="book-desc">
                         <div class="book-title">${work.title}</div> by <span class="book-author">${author_name}</span>
                     </span>
@@ -35,11 +35,10 @@ const RENDER_AUTOCOMPLETE_RESULT = {
             </li>`;
     },
     ['/search/authors'](author) {
-        // Todo: default author img to: https://dev.openlibrary.org/images/icons/avatar_author-lg.png
         return `
             <li>
                 <a href="/authors/${author.key}">
-                    <img src="http://covers.openlibrary.org/a/olid/${author.key}-S.jpg"/>
+                    <img src="http://covers.openlibrary.org/a/olid/${author.key}-S.jpg?default=https://dev.openlibrary.org/static/images/icons/avatar_author-lg.png" alt=""/>
                     <span class="author-desc"><div class="author-name">${author.name}</div></span>
                 </a>
             </li>`;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4691

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix broken thumbnails displayed in the dropdown when doing a search via the top search bar.
Fix author and work search.

### Technical
<!-- What should be noted about the implementation? -->
Just in case, `alt=""` added if default image not available.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![search-author-test](https://user-images.githubusercontent.com/73437497/109555309-a9c7d300-7ad5-11eb-80f2-51768e253781.jpg)
![search-work-test](https://user-images.githubusercontent.com/73437497/109555321-ae8c8700-7ad5-11eb-9eea-84fbb8bbcc43.jpg)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
