### PR TITLE
Allow serials for scanning partner imports

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -267,7 +267,7 @@ class ia_importapi(importapi):
                 _ids = [get_subfield(f, id_subfield) for f in rec.read_fields([id_field]) if f and get_subfield(f, id_subfield)]
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
-            # Dont't add the book if the MARC record is a non-monograph item,
+            # Don't add the book if the MARC record is a non-monograph item,
             # unless it is a serial (etc) for a scanning partner.
             try:
                 raise_non_book_marc(rec, **next_data)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -142,7 +142,7 @@ class importapi:
 
 def raise_non_book_marc(marc_record, **kwargs):
     details = 'Item rejected'
-    # Is the item a serial instead of a book?
+    # Is the item a serial instead of a monograph?
     marc_leaders = marc_record.leader()
     if marc_leaders[7] == 's':
         raise BookImportError('item-is-serial', details, **kwargs)
@@ -267,11 +267,13 @@ class ia_importapi(importapi):
                 _ids = [get_subfield(f, id_subfield) for f in rec.read_fields([id_field]) if f and get_subfield(f, id_subfield)]
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
-            # Don't add the book if the MARC record is a non-book item
+            # Dont't add the book if the MARC record is a non-monograph item,
+            # unless it is a serial (etc) for a scanning partner.
             try:
                 raise_non_book_marc(rec, **next_data)
             except BookImportError as e:
-                return self.error(e.error_code, e.error, **e.kwargs)
+                if not (local_id and e.error_code == 'item-is-serial'):
+                    return self.error(e.error_code, e.error, **e.kwargs)
             result = add_book.load(edition)
 
             # Add next_data to the response as location of next record:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows some serials for which we have MARC records to be added to the catalog to enable lookup by `local_id` https://openlibrary.org/local_ids


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/905545/109712276-b434ba80-7c04-11eb-8bc3-ec384df2689f.png)
This is a periodical / serial from the Claremont MARC data, one of the problem barcodes that was not recognised previously: 
10010417724
record data at:
marc_claremont_school_theology/CSTMARC1_multibarcode.mrc:63202416:5

It is now imported, with all volume barcodes present:

```

```
### Stakeholders
<!-- @ tag stakeholders of this bug -->
