### PR TITLE
Persist sort when clicking on carousel

### DIFF
--- a/openlibrary/macros/RawQueryCarousel.html
+++ b/openlibrary/macros/RawQueryCarousel.html
@@ -47,7 +47,7 @@ $else:
       fields = ['key', 'title', 'subtitle', 'editions', 'author_name', 'availability', 'cover_i', 'ia', 'id_project_gutenberg', 'id_librivox', 'id_standard_ebooks', 'id_openstax', 'providers']
       params = { 'q': query }
       # Don't need fields in the search UI url, since they don't do anything there
-      url = url or "/search?" + urlencode({'q': query})
+      url = url or "/search?" + urlencode({'q': query, 'sort': sort})
       if has_fulltext_only:
         params['has_fulltext'] = 'true'
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -25,7 +25,7 @@ $add_metatag(property="og:site_name", content="Open Library")
       }
     $:render_template("books/custom_carousel", key="trending", books=get_trending_books(books_only=True, since_days=0, since_hours=24, minimum=3, sort_by_count=False), title=_('Trending Books'), url="/trending/daily", test=test, load_more=load_more)
 
-    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", url="/search?q=ddc%3A8*+first_publish_year%3A%5B*+TO+1950%5D+publish_year%3A%5B2000+TO+*%5D+NOT+public_scan_b%3Afalse&mode=ebooks&has_fulltext=true", title=_('Classic Books'), key="public_domain", sort='random.hourly', use_cache=False, lazy=False, user_lang_only=True)
+    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", sort='random.hourly', use_cache=False, lazy=False, user_lang_only=True)
 
   $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, user_lang_only=True)
 


### PR DESCRIPTION
Small fix to make clicking the link for a query carousel persist the sort.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
