### PR TITLE
Fix failing cron-jobs in Docker

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -61,6 +61,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+    user: root
     command: cron -f
     restart: always
     volumes:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4707
The root user should launch `cron-jobs` to avoid 
```
docker logs --tail=10 openlibrary_cron-jobs_1
cron: can't open or create /var/run/crond.pid: Permission denied
cron: can't open or create /var/run/crond.pid: Permission denied
...
```
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
