### PR TITLE
Remove OL and Infogami volume mounts from production

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,12 @@ services:
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
+      # Persistent volume mount for generated css and js
+      - ol-build:/openlibrary/static/build
+      # Persistent volume mount for node_modules
+      - ol-nodemodules:/openlibrary/node_modules
+      # The above volume mounts are required so that the local dev bind mount below
+      # does not clobber the data generated inside the image / container
       - .:/openlibrary
   solr-updater:
     volumes:
@@ -35,6 +41,8 @@ services:
   home:
     volumes:
       - ol-vendor:/openlibrary/vendor
+      - ol-build:/openlibrary/static/build
+      - ol-nodemodules:/openlibrary/node_modules
       - .:/openlibrary
 volumes:
   ol-vendor:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -46,3 +46,5 @@ services:
       - .:/openlibrary
 volumes:
   ol-vendor:
+  ol-build:
+  ol-nodemodules:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,9 +8,33 @@ services:
     ports:
       # Debugger
       - 3000:3000
+    volumes:
+      # Persistent volume mount for installed git submodules
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  solr-updater:
+    volumes:
+      # Persistent volume mount for installed git submodules
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  db:
+    volumes:
+      - .:/openlibrary
   covers:
     ports:
       - 7075:7075
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
   infobase:
     ports:
       - 7000:7000
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  home:
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+volumes:
+  ol-vendor:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -55,3 +55,6 @@ services:
       - .:/openlibrary
 volumes:
   ol-vendor:
+  ol-build:
+  ol-nodemodules:
+

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -20,6 +20,12 @@ services:
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
+      # Persistent volume mount for generated css and js
+      - ol-build:/openlibrary/static/build
+      # Persistent volume mount for node_modules
+      - ol-nodemodules:/openlibrary/node_modules
+      # The above volume mounts are required so that the local dev bind mount below
+      # does not clobber the data generated inside the image / container
       - .:/openlibrary
   solr-updater:
     volumes:
@@ -44,6 +50,8 @@ services:
   home:
     volumes:
       - ol-vendor:/openlibrary/vendor
+      - ol-build:/openlibrary/static/build
+      - ol-nodemodules:/openlibrary/node_modules
       - .:/openlibrary
 volumes:
   ol-vendor:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -27,26 +27,6 @@ services:
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
       - .:/openlibrary
-  solr-updater:
-    volumes:
-      # Persistent volume mount for installed git submodules
-      - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
-  db:
-    volumes:
-      - .:/openlibrary
-  covers:
-    ports:
-      - 7075:7075
-    volumes:
-      - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
-  infobase:
-    ports:
-      - 7000:7000
-    volumes:
-      - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
   home:
     volumes:
       - ol-vendor:/openlibrary/vendor
@@ -57,4 +37,3 @@ volumes:
   ol-vendor:
   ol-build:
   ol-nodemodules:
-

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -18,3 +18,32 @@ services:
       - ../olsystem:/olsystem
       - ../booklending_utils:/booklending_utils
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
+      # Persistent volume mount for installed git submodules
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  solr-updater:
+    volumes:
+      # Persistent volume mount for installed git submodules
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  db:
+    volumes:
+      - .:/openlibrary
+  covers:
+    ports:
+      - 7075:7075
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  infobase:
+    ports:
+      - 7000:7000
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+  home:
+    volumes:
+      - ol-vendor:/openlibrary/vendor
+      - .:/openlibrary
+volumes:
+  ol-vendor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,15 +16,12 @@ services:
       - db
       - infobase
     volumes:
-      # Persistent volume mount for installed git submodules
-      - ol-vendor:/openlibrary/vendor
       # Persistent volume mount for generated css and js
       - ol-build:/openlibrary/static/build
       # Persistent volume mount for node_modules
       - ol-nodemodules:/openlibrary/node_modules
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
-      - .:/openlibrary
     networks:
       - webnet
       - dbnet
@@ -63,11 +60,8 @@ services:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_URL=http://web:8080/
     volumes:
-      # Persistent volume mount for installed git submodules
-      - ol-vendor:/openlibrary/vendor
       # The above volume mounts is required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
-      - .:/openlibrary
       - solr-updater-data:/solr-updater-data
     networks:
       - webnet
@@ -82,7 +76,6 @@ services:
     networks:
       - dbnet
     volumes:
-      - .:/openlibrary
       # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
       # if the db is empty (which as of now is always, since we don't store the
       # postgres data anywhere).
@@ -99,9 +92,6 @@ services:
     command: docker/ol-covers-start.sh
     expose:
       - 7075
-    volumes:
-      - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
     networks:
       - webnet
       - dbnet
@@ -123,9 +113,6 @@ services:
       - 7000
     depends_on:
       - db
-    volumes:
-      - ol-vendor:/openlibrary/vendor
-      - .:/openlibrary
     networks:
       - webnet
       - dbnet
@@ -142,10 +129,8 @@ services:
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-home-start.sh
     volumes:
-      - ol-vendor:/openlibrary/vendor
       - ol-build:/openlibrary/static/build
       - ol-nodemodules:/openlibrary/node_modules
-      - .:/openlibrary
     networks:
       - webnet
       - dbnet
@@ -159,6 +144,5 @@ networks:
 volumes:
   solr-data:
   solr-updater-data:
-  ol-vendor:
   ol-build:
   ol-nodemodules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,6 @@ services:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_URL=http://web:8080/
     volumes:
-      # The above volume mounts is required so that the local dev bind mount below
-      # does not clobber the data generated inside the image / container
       - solr-updater-data:/solr-updater-data
     networks:
       - webnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,6 @@ services:
     depends_on:
       - db
       - infobase
-    volumes:
-      # Persistent volume mount for generated css and js
-      - ol-build:/openlibrary/static/build
-      # Persistent volume mount for node_modules
-      - ol-nodemodules:/openlibrary/node_modules
-      # The above volume mounts are required so that the local dev bind mount below
-      # does not clobber the data generated inside the image / container
     networks:
       - webnet
       - dbnet
@@ -128,9 +121,6 @@ services:
       context: .
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-home-start.sh
-    volumes:
-      - ol-build:/openlibrary/static/build
-      - ol-nodemodules:/openlibrary/node_modules
     networks:
       - webnet
       - dbnet
@@ -144,5 +134,3 @@ networks:
 volumes:
   solr-data:
   solr-updater-data:
-  ol-build:
-  ol-nodemodules:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #4423 that removes volume mounts from production deployments but keeps them in place for standing and localhost deployments.  The goal is to simplify production deployments and rollbacks.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
