### PR TITLE
Remove some old dependencies from olbase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ load_sample_data:
 	curl http://localhost:8080/_dev/process_ebooks # hack to show books in returncart
 
 reindex-solr:
-	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web/ -c conf/openlibrary.yml --data-provider=legacy
-	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web/ -c conf/openlibrary.yml --data-provider=legacy
+	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web:8080/ -c conf/openlibrary.yml --data-provider=legacy
+	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web:8080/ -c conf/openlibrary.yml --data-provider=legacy
 
 lint-diff:
 	git diff master -U0 | ./scripts/flake8-diff.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-web-start.sh
     ports:
-      - 8080:80
+      - 8080:8080
       - 3000:3000
     depends_on:
       - db
@@ -62,7 +62,7 @@ services:
     environment:
       - OL_CONFIG=conf/openlibrary.yml
       - PYENV_VERSION=${PYENV_VERSION:-}
-      - OL_URL=http://web/
+      - OL_URL=http://web:8080/
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -14,7 +14,6 @@ RUN groupadd --system openlibrary \
 # Misc OL dependencies
 RUN apt-get -qq update && apt-get install -y \
     nginx \
-    authbind \
     postgresql \
     build-essential \
     git \
@@ -62,8 +61,6 @@ RUN python3.9 -m pip install --upgrade pip wheel
 USER root
 # Add pyenv to root's bashrc as well
 RUN echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /root/.bashrc
-# enable users to bind to port 80
-RUN touch /etc/authbind/byport/80 && chmod 777 /etc/authbind/byport/80
 
 # Setup nginx
 RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/sites-available/ \
@@ -92,5 +89,5 @@ RUN python3.9 -m pip list --outdated
 
 # Expose Open Library and Infobase
 EXPOSE 80 7000
-CMD authbind --deep scripts/openlibrary-server conf/openlibrary.yml \
+CMD scripts/openlibrary-server conf/openlibrary.yml \
     --gunicorn --workers 4 --timeout 180 --bind :80

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -88,4 +88,4 @@ RUN python3.9 -m pip list --outdated
 # Expose Open Library and Infobase
 EXPOSE 80 7000
 CMD scripts/openlibrary-server conf/openlibrary.yml \
-    --gunicorn --workers 4 --timeout 180 --bind :80
+    --gunicorn --workers 4 --timeout 180 --bind :8080

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -13,7 +13,7 @@ RUN groupadd --system openlibrary \
 
 # Misc OL dependencies
 RUN apt-get -qq update && apt-get install -y \
-    postgresql \
+    postgresql-client \
     build-essential \
     git \
     libpq-dev \

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -29,6 +29,9 @@ RUN apt-get -qq update && apt-get install -y \
     parallel
 
 # Print gnu parallel citation
+USER openlibrary
+RUN echo 'will cite' | parallel --citation
+USER root
 RUN echo 'will cite' | parallel --citation
 
 # Install LTS version of node.js

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -13,7 +13,6 @@ RUN groupadd --system openlibrary \
 
 # Misc OL dependencies
 RUN apt-get -qq update && apt-get install -y \
-    nginx \
     postgresql \
     build-essential \
     git \
@@ -61,10 +60,6 @@ RUN python3.9 -m pip install --upgrade pip wheel
 USER root
 # Add pyenv to root's bashrc as well
 RUN echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /root/.bashrc
-
-# Setup nginx
-RUN ln -s /openlibrary/conf/nginx/sites-available/openlibrary.conf /etc/nginx/sites-available/ \
-    && ln -s /etc/nginx/sites-available/openlibrary.conf /etc/nginx/sites-enabled/
 
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
     && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -7,8 +7,7 @@ if [ -n "$BEFORE_START" ] ; then
   $BEFORE_START
 fi
 
-authbind --deep \
-  scripts/openlibrary-server "$OL_CONFIG" \
+scripts/openlibrary-server "$OL_CONFIG" \
   --gunicorn \
   $GUNICORN_OPTS \
   --bind :80

--- a/docker/ol-web-start.sh
+++ b/docker/ol-web-start.sh
@@ -10,4 +10,4 @@ fi
 scripts/openlibrary-server "$OL_CONFIG" \
   --gunicorn \
   $GUNICORN_OPTS \
-  --bind :80
+  --bind :8080


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
This is being published to docker hub as `olbase:docker-test-olbase-optimization`. To test locally:

```sh
# Download the custom tag, but register it locally as olbase:latest
echo "FROM openlibrary/olbase:docker-test-olbase-optimization" | docker build -t "openlibrary/olbase:latest" -
docker-compose build
docker-compose up -d
```

- [x] `docker-compose up -d` works on windows
- [x] `docker-compose up -d` works on linux
- [x] `docker-compose up -d` shows nothing weird in `home` logs

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
