### PR TITLE
Make delete queries solr8 compatible

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1214,7 +1214,7 @@ def make_delete_query(keys):
     Example:
 
     >>> make_delete_query(["/books/OL1M"])
-    '<delete><query>key:/books/OL1M</query></delete>'
+    '<delete><id>/books/OL1M</id></delete>'
 
     :param list[str] keys: Keys to create delete tags for. (ex: ["/books/OL1M"])
     :return: <delete> XML element as a string
@@ -1224,8 +1224,8 @@ def make_delete_query(keys):
     keys = [solr_escape(key) for key in keys]
     delete_query = Element('delete')
     for key in keys:
-        query = SubElement(delete_query,'query')
-        query.text = 'key:%s' % key
+        query = SubElement(delete_query, 'id')
+        query.text = key
     return tostring(delete_query, encoding="unicode")
 
 def update_author(akey, a=None, handle_redirects=True):

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -452,7 +452,7 @@ class Test_update_items:
         requests = update_work.update_author('/authors/OL23A')
         assert isinstance(requests, list)
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == '<delete><query>key:/authors/OL23A</query></delete>'
+        assert requests[0].toxml() == '<delete><id>/authors/OL23A</id></delete>'
 
     def test_redirect_author(self):
         update_work.data_provider = FakeDataProvider([
@@ -461,7 +461,7 @@ class Test_update_items:
         requests = update_work.update_author('/authors/OL24A')
         assert isinstance(requests, list)
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == '<delete><query>key:/authors/OL24A</query></delete>'
+        assert requests[0].toxml() == '<delete><id>/authors/OL24A</id></delete>'
 
 
     def test_update_author(self, monkeypatch):
@@ -503,7 +503,7 @@ class Test_update_items:
         assert isinstance(del_req, update_work.DeleteRequest)
         assert del_req.toxml().startswith("<delete>")
         for olid in olids:
-            assert "<query>key:%s</query>" % olid in del_req.toxml()
+            assert "<id>%s</id>" % olid in del_req.toxml()
 
 
 class TestUpdateWork:
@@ -515,19 +515,19 @@ class TestUpdateWork:
         requests = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/delete'}})
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'
+        assert requests[0].toxml() == '<delete><id>/works/OL23W</id></delete>'
 
     def test_delete_editions(self):
         requests = update_work.update_work({'key': '/works/OL23M', 'type': {'key': '/type/delete'}})
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == '<delete><query>key:/works/OL23M</query></delete>'
+        assert requests[0].toxml() == '<delete><id>/works/OL23M</id></delete>'
 
     def test_redirects(self):
         requests = update_work.update_work({'key': '/works/OL23W', 'type': {'key': '/type/redirect'}})
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.DeleteRequest)
-        assert requests[0].toxml() == '<delete><query>key:/works/OL23W</query></delete>'
+        assert requests[0].toxml() == '<delete><id>/works/OL23W</id></delete>'
 
 
 class Test_pick_cover_edition:


### PR DESCRIPTION
In new solr, key:/works/OL1W returns all the documents, with the matching document first. This seems like it's causing our `<delete>key:/works/OL1W</delete>` update queries to delete all documents! <delete><id>/works/OL1W</id></delete> seems to be recommended way now.

Note this works in Solr 3 as well, so just a refactor.

Extracted from #4337

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] Delete query deletes only 1 item in solr8
- [x] Delete query deletes only 1 item in solr3

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
