### PR TITLE
pyupgrade  --py38-plus openlibrary/tests

### DIFF
--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -98,7 +98,7 @@ class TestGetIA():
             f"{item}: expected instanceof MarcBinary, got {type(result)}"
         field_245 = next(result.read_fields(['245']))
         title = next(field_245[1].get_all_subfields())[1].encode('utf8')
-        print(f"{item}:\n\tUNICODE: [{result.leader()[9]}]\n\tTITLE: {title}"
+        print(f"{item}:\n\tUNICODE: [{result.leader()[9]}]\n\tTITLE: {title}")
 
     @pytest.mark.parametrize('bad_marc', bad_marcs)
     def test_incorrect_length_marcs(self, bad_marc, monkeypatch):

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import pytest
 from openlibrary.catalog import get_ia
@@ -16,11 +15,11 @@ class MockResponse:
 
 
 def return_test_marc_bin(url):
-    assert url, "return_test_marc_bin({})".format(url)
+    assert url, f"return_test_marc_bin({url})"
     return return_test_marc_data(url, "bin_input")
 
 def return_test_marc_xml(url):
-    assert url, "return_test_marc_xml({})".format(url)
+    assert url, f"return_test_marc_xml({url})"
     return return_test_marc_data(url, "xml_input")
 
 def return_test_marc_data(url, test_data_subdir="xml_input"):
@@ -86,7 +85,7 @@ class TestGetIA():
 
         result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(result, MarcXml), \
-            "%s: expected instanceof MarcXml, got %s" % (item, type(result))
+            "{}: expected instanceof MarcXml, got {}".format(item, type(result))
 
     @pytest.mark.parametrize('item', bin_items)
     def test_no_marc_xml(self, item, monkeypatch):
@@ -96,10 +95,10 @@ class TestGetIA():
 
         result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(result, MarcBinary), \
-            "%s: expected instanceof MarcBinary, got %s" % (item, type(result))
+            "{}: expected instanceof MarcBinary, got {}".format(item, type(result))
         field_245 = next(result.read_fields(['245']))
         title = next(field_245[1].get_all_subfields())[1].encode('utf8')
-        print("%s:\n\tUNICODE: [%s]\n\tTITLE: %s" % (item, result.leader()[9], title))
+        print("{}:\n\tUNICODE: [{}]\n\tTITLE: {}".format(item, result.leader()[9], title))
 
     @pytest.mark.parametrize('bad_marc', bad_marcs)
     def test_incorrect_length_marcs(self, bad_marc, monkeypatch):

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -24,7 +24,7 @@ def return_test_marc_xml(url):
 
 def return_test_marc_data(url, test_data_subdir="xml_input"):
     filename = url.split('/')[-1]
-    test_data_dir = "/../../catalog/marc/tests/test_data/%s/" % test_data_subdir
+    test_data_dir = f"/../../catalog/marc/tests/test_data/{test_data_subdir}/"
     path = os.path.dirname(__file__) + test_data_dir + filename
     return MockResponse(open(path, mode='rb').read())
 
@@ -85,7 +85,7 @@ class TestGetIA():
 
         result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(result, MarcXml), \
-            "{}: expected instanceof MarcXml, got {}".format(item, type(result))
+            f"{item}: expected instanceof MarcXml, got {type(result)}"
 
     @pytest.mark.parametrize('item', bin_items)
     def test_no_marc_xml(self, item, monkeypatch):
@@ -95,10 +95,10 @@ class TestGetIA():
 
         result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(result, MarcBinary), \
-            "{}: expected instanceof MarcBinary, got {}".format(item, type(result))
+            f"{item}: expected instanceof MarcBinary, got {type(result)}"
         field_245 = next(result.read_fields(['245']))
         title = next(field_245[1].get_all_subfields())[1].encode('utf8')
-        print("{}:\n\tUNICODE: [{}]\n\tTITLE: {}".format(item, result.leader()[9], title))
+        print(f"{item}:\n\tUNICODE: [{result.leader()[9]}]\n\tTITLE: {title}"
 
     @pytest.mark.parametrize('bad_marc', bad_marcs)
     def test_incorrect_length_marcs(self, bad_marc, monkeypatch):

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 from openlibrary.catalog.utils import (
     author_dates_match, flip_name,
@@ -14,7 +12,7 @@ def test_author_dates_match():
     full_different = {'name': 'John Smith', 'death_date': '12 June 1688', 'key': '/a/OL6398453A', 'birth_date': '01 December 1650', 'type': _atype}
     no_death = {'name': 'John Smith', 'key': '/a/OL6398454A', 'birth_date': '1650', 'type': _atype}
     no_dates = {'name': 'John Smith', 'key': '/a/OL6398455A', 'type': _atype}
-    non_match = {'name': 'John Smith', 'death_date': u'1999', 'key': '/a/OL6398456A', 'birth_date': '1950', 'type': _atype}
+    non_match = {'name': 'John Smith', 'death_date': '1999', 'key': '/a/OL6398456A', 'birth_date': '1950', 'type': _atype}
     different_name = {'name': 'Jane Farrier', 'key': '/a/OL6398457A', 'type': _atype}
 
     assert author_dates_match(basic, basic)
@@ -36,21 +34,21 @@ def test_flip_name():
 def test_pick_first_date():
     assert pick_first_date(["Mrs.", "1839-"]) == {'birth_date': '1839'}
     assert pick_first_date(["1882-."]) == {'birth_date': '1882'}
-    assert pick_first_date(["1900-1990.."]) == {'birth_date': u'1900', 'death_date': u'1990'}
+    assert pick_first_date(["1900-1990.."]) == {'birth_date': '1900', 'death_date': '1990'}
     assert pick_first_date(["4th/5th cent."]) == {'date': '4th/5th cent.'}
 
 def test_pick_best_name():
-    names = [u'Andre\u0301 Joa\u0303o Antonil', u'Andr\xe9 Jo\xe3o Antonil', 'Andre? Joa?o Antonil']
+    names = ['Andre\u0301 Joa\u0303o Antonil', 'Andr\xe9 Jo\xe3o Antonil', 'Andre? Joa?o Antonil']
     best = names[1]
     assert pick_best_name(names) == best
 
-    names = [u'Antonio Carvalho da Costa', u'Anto\u0301nio Carvalho da Costa', u'Ant\xf3nio Carvalho da Costa']
+    names = ['Antonio Carvalho da Costa', 'Anto\u0301nio Carvalho da Costa', 'Ant\xf3nio Carvalho da Costa']
     best = names[2]
     assert pick_best_name(names) == best
 
 def test_pick_best_author():
-    a1 = {u'name': u'Bretteville, Etienne Dubois abb\xe9 de', u'death_date': u'1688', 'key': u'/a/OL6398452A', u'birth_date': u'1650', u'title': u'abb\xe9 de', u'personal_name': u'Bretteville, Etienne Dubois', u'type': {u'key': u'/type/author'}, }
-    a2 = {u'name': u'Bretteville, \xc9tienne Dubois abb\xe9 de', u'death_date': u'1688', u'key': u'/a/OL4953701A', u'birth_date': u'1650', u'title': u'abb\xe9 de', u'personal_name': u'Bretteville, \xc9tienne Dubois', u'type': {u'key': u'/type/author'}, }
+    a1 = {'name': 'Bretteville, Etienne Dubois abb\xe9 de', 'death_date': '1688', 'key': '/a/OL6398452A', 'birth_date': '1650', 'title': 'abb\xe9 de', 'personal_name': 'Bretteville, Etienne Dubois', 'type': {'key': '/type/author'}, }
+    a2 = {'name': 'Bretteville, \xc9tienne Dubois abb\xe9 de', 'death_date': '1688', 'key': '/a/OL4953701A', 'birth_date': '1650', 'title': 'abb\xe9 de', 'personal_name': 'Bretteville, \xc9tienne Dubois', 'type': {'key': '/type/author'}, }
     assert pick_best_author([a1, a2])['key'] == a2['key']
 
 def combinations(items, n):
@@ -63,20 +61,20 @@ def combinations(items, n):
 
 def test_match_with_bad_chars():
     samples = [
-        [u'Machiavelli, Niccolo, 1469-1527', u'Machiavelli, Niccol\xf2 1469-1527'],
-        [u'Humanitas Publica\xe7\xf5es', 'Humanitas Publicac?o?es'],
-        [u'A pesquisa ling\xfc\xedstica no Brasil',
+        ['Machiavelli, Niccolo, 1469-1527', 'Machiavelli, Niccol\xf2 1469-1527'],
+        ['Humanitas Publica\xe7\xf5es', 'Humanitas Publicac?o?es'],
+        ['A pesquisa ling\xfc\xedstica no Brasil',
           'A pesquisa lingu?i?stica no Brasil'],
-        [u'S\xe3o Paulo', 'Sa?o Paulo'],
-        [u'Diccionario espa\xf1ol-ingl\xe9s de bienes ra\xedces',
-         u'Diccionario Espan\u0303ol-Ingle\u0301s de bienes rai\u0301ces'],
-        [u'Konfliktunterdru?ckung in O?sterreich seit 1918',
-         u'Konfliktunterdru\u0308ckung in O\u0308sterreich seit 1918',
-         u'Konfliktunterdr\xfcckung in \xd6sterreich seit 1918'],
-        [u'Soi\ufe20u\ufe21z khudozhnikov SSSR.',
-         u'Soi?u?z khudozhnikov SSSR.',
-         u'Soi\u0361uz khudozhnikov SSSR.'],
-        [u'Andrzej Weronski', u'Andrzej Wero\u0144ski', u'Andrzej Weron\u0301ski'],
+        ['S\xe3o Paulo', 'Sa?o Paulo'],
+        ['Diccionario espa\xf1ol-ingl\xe9s de bienes ra\xedces',
+         'Diccionario Espan\u0303ol-Ingle\u0301s de bienes rai\u0301ces'],
+        ['Konfliktunterdru?ckung in O?sterreich seit 1918',
+         'Konfliktunterdru\u0308ckung in O\u0308sterreich seit 1918',
+         'Konfliktunterdr\xfcckung in \xd6sterreich seit 1918'],
+        ['Soi\ufe20u\ufe21z khudozhnikov SSSR.',
+         'Soi?u?z khudozhnikov SSSR.',
+         'Soi\u0361uz khudozhnikov SSSR.'],
+        ['Andrzej Weronski', 'Andrzej Wero\u0144ski', 'Andrzej Weron\u0301ski'],
     ]
     for l in samples:
         for a, b in combinations(l, 2):
@@ -84,13 +82,13 @@ def test_match_with_bad_chars():
 
 def test_strip_count():
     input = [
-        ('Side by side', [ u'a', u'b', u'c', u'd' ]),
-        ('Side by side.', [ u'e', u'f', u'g' ]),
-        ('Other.', [ u'h', u'i' ]),
+        ('Side by side', [ 'a', 'b', 'c', 'd' ]),
+        ('Side by side.', [ 'e', 'f', 'g' ]),
+        ('Other.', [ 'h', 'i' ]),
     ]
     expect = [
-        ('Side by side', [ u'a', u'b', u'c', u'd', u'e', u'f', u'g' ]),
-        ('Other.', [ u'h', u'i' ]),
+        ('Side by side', [ 'a', 'b', 'c', 'd', 'e', 'f', 'g' ]),
+        ('Other.', [ 'h', 'i' ]),
     ]
     assert strip_count(input) == expect
 
@@ -108,9 +106,9 @@ def test_remove_trailing_dot():
 
 mk_norm_conversions = [
         ("Hello I'm a  title.", "helloi'matitle"),
-        (u"Hello I'm a  title.", "helloi'matitle"),
+        ("Hello I'm a  title.", "helloi'matitle"),
         ('Forgotten Titles: A Novel.', 'forgottentitlesanovel'),
-        (u'Kitāb Yatīmat ud-Dahr', u'kitābyatīmatuddahr'),
+        ('Kitāb Yatīmat ud-Dahr', 'kitābyatīmatuddahr'),
 ]
 
 @pytest.mark.parametrize('title,expected', mk_norm_conversions)

--- a/openlibrary/tests/core/test_connections.py
+++ b/openlibrary/tests/core/test_connections.py
@@ -14,7 +14,7 @@ class MockConnection:
                 return json.dumps(self.docs[key])
         if path == "/get_many":
             keys = json.loads(data['keys'])
-            return json.dumps(dict((k, self.docs[k]) for k in keys))
+            return json.dumps({k: self.docs[k] for k in keys})
         else:
             return None
 

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,7 +1,7 @@
 try:  # Python 3
     from unittest.mock import Mock, patch
 except ImportError:  # Python 2
-    from mock import Mock, patch
+    from unittest.mock import Mock, patch
 
 import requests
 from infogami import config

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,8 +1,4 @@
-try:  # Python 3
-    from unittest.mock import Mock, patch
-except ImportError:  # Python 2
-    from unittest.mock import Mock, patch
-
+from unittest.mock import Mock, patch
 import requests
 from infogami import config
 from openlibrary.core import fulltext

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -2,28 +2,28 @@ from openlibrary.core import helpers as h
 
 def test_sanitize():
     # plain html should pass through
-    assert h.sanitize(u"hello") == u"hello"
-    assert h.sanitize(u"<p>hello</p>") == u"<p>hello</p>"
+    assert h.sanitize("hello") == "hello"
+    assert h.sanitize("<p>hello</p>") == "<p>hello</p>"
 
     # broken html must be corrected
-    assert h.sanitize(u"<p>hello") == u"<p>hello</p>"
+    assert h.sanitize("<p>hello") == "<p>hello</p>"
 
     # css class is fine
-    assert h.sanitize(u'<p class="foo">hello</p>') == u'<p class="foo">hello</p>'
+    assert h.sanitize('<p class="foo">hello</p>') == '<p class="foo">hello</p>'
 
     # style attribute must be stripped
-    assert h.sanitize(u'<p style="color: red">hello</p>') == u'<p>hello</p>'
+    assert h.sanitize('<p style="color: red">hello</p>') == '<p>hello</p>'
 
     # style tags must be stripped
-    assert h.sanitize(u'<style type="text/css">p{color: red;}</style><p>hello</p>') == u'<p>hello</p>'
+    assert h.sanitize('<style type="text/css">p{color: red;}</style><p>hello</p>') == '<p>hello</p>'
 
     # script tags must be stripped
-    assert h.sanitize(u'<script>alert("dhoom")</script>hello') == u'hello'
+    assert h.sanitize('<script>alert("dhoom")</script>hello') == 'hello'
 
     # rel="nofollow" must be added absolute links
-    assert h.sanitize(u'<a href="https://example.com">hello</a>') == u'<a href="https://example.com" rel="nofollow">hello</a>'
+    assert h.sanitize('<a href="https://example.com">hello</a>') == '<a href="https://example.com" rel="nofollow">hello</a>'
     # relative links should pass through
-    assert h.sanitize(u'<a href="relpath">hello</a>') == u'<a href="relpath">hello</a>'
+    assert h.sanitize('<a href="relpath">hello</a>') == '<a href="relpath">hello</a>'
 
 def test_safesort():
     from datetime import datetime
@@ -42,19 +42,19 @@ def test_datestr():
     then = datetime(2010, 1, 1, 0, 0, 0)
 
     #assert h.datestr(then, datetime(2010, 1, 1, 0, 0, 0, 10)) == u"just moments ago"
-    assert h.datestr(then, datetime(2010, 1, 1, 0, 0, 1)) == u"1 second ago"
-    assert h.datestr(then, datetime(2010, 1, 1, 0, 0, 9)) == u"9 seconds ago"
+    assert h.datestr(then, datetime(2010, 1, 1, 0, 0, 1)) == "1 second ago"
+    assert h.datestr(then, datetime(2010, 1, 1, 0, 0, 9)) == "9 seconds ago"
 
-    assert h.datestr(then, datetime(2010, 1, 1, 0, 1, 1)) == u"1 minute ago"
-    assert h.datestr(then, datetime(2010, 1, 1, 0, 9, 1)) == u"9 minutes ago"
+    assert h.datestr(then, datetime(2010, 1, 1, 0, 1, 1)) == "1 minute ago"
+    assert h.datestr(then, datetime(2010, 1, 1, 0, 9, 1)) == "9 minutes ago"
 
-    assert h.datestr(then, datetime(2010, 1, 1, 1, 0, 1)) == u"1 hour ago"
-    assert h.datestr(then, datetime(2010, 1, 1, 9, 0, 1)) == u"9 hours ago"
+    assert h.datestr(then, datetime(2010, 1, 1, 1, 0, 1)) == "1 hour ago"
+    assert h.datestr(then, datetime(2010, 1, 1, 9, 0, 1)) == "9 hours ago"
 
-    assert h.datestr(then, datetime(2010, 1, 2, 0, 0, 1)) == u"1 day ago"
+    assert h.datestr(then, datetime(2010, 1, 2, 0, 0, 1)) == "1 day ago"
 
-    assert h.datestr(then, datetime(2010, 1, 9, 0, 0, 1)) == u"January 1, 2010"
-    assert h.datestr(then, datetime(2010, 1, 9, 0, 0, 1), lang='fr') == u'1 janvier 2010'
+    assert h.datestr(then, datetime(2010, 1, 9, 0, 0, 1)) == "January 1, 2010"
+    assert h.datestr(then, datetime(2010, 1, 9, 0, 0, 1), lang='fr') == '1 janvier 2010'
 
 def test_sprintf():
     assert h.sprintf('hello %s', 'python') == 'hello python'

--- a/openlibrary/tests/core/test_lists_model.py
+++ b/openlibrary/tests/core/test_lists_model.py
@@ -15,7 +15,7 @@ def test_seed_with_string():
     assert seed._solrdata is None
 
 
-class NotAString(object):
+class NotAString:
     def __init__(self):
         self.key = "not_a_string.key"
 
@@ -32,4 +32,3 @@ def test_seed_with_nonstring():
     seed.value = "New value"
     # assert seed.get_document() == "New value"
     assert isinstance(seed.document, NotAString)
- 

--- a/openlibrary/tests/core/test_olmarkdown.py
+++ b/openlibrary/tests/core/test_olmarkdown.py
@@ -8,18 +8,18 @@ def test_olmarkdown():
         # markdown always wraps the result in <p>.
         return "<p>%s\n</p>" % html
 
-    assert md(u"**foo**") == p(u"<strong>foo</strong>")
-    assert md(u"<b>foo</b>") == p(u'<b>foo</b>')
-    assert md(u"https://openlibrary.org") == p(
-            u'<a href="https://openlibrary.org" rel="nofollow">' +
-                u'https://openlibrary.org' +
-            u'</a>'
+    assert md("**foo**") == p("<strong>foo</strong>")
+    assert md("<b>foo</b>") == p('<b>foo</b>')
+    assert md("https://openlibrary.org") == p(
+            '<a href="https://openlibrary.org" rel="nofollow">' +
+                'https://openlibrary.org' +
+            '</a>'
         )
-    assert md(u"http://example.org") == p(
-            u'<a href="http://example.org" rel="nofollow">' +
-                u'http://example.org' +
-            u'</a>'
+    assert md("http://example.org") == p(
+            '<a href="http://example.org" rel="nofollow">' +
+                'http://example.org' +
+            '</a>'
         )
 
     # why extra spaces?
-    assert md(u"a\nb") == p(u"a<br/>\n   b")
+    assert md("a\nb") == p("a<br/>\n   b")

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from openlibrary.core.processors import readableurls as processors
 from infogami.infobase import client, common
 import web
@@ -92,41 +91,41 @@ def test_book_urls():
     f = get_readable_path
 
     # regular pages
-    assert f(u"/books/OL1M") == (u"/books/OL1M", u"/books/OL1M/foo")
-    assert f(u"/books/OL1M/foo") == (u"/books/OL1M", u"/books/OL1M/foo")
-    assert f(u"/books/OL1M/foo/edit") == (u"/books/OL1M/edit", u"/books/OL1M/foo/edit")
+    assert f("/books/OL1M") == ("/books/OL1M", "/books/OL1M/foo")
+    assert f("/books/OL1M/foo") == ("/books/OL1M", "/books/OL1M/foo")
+    assert f("/books/OL1M/foo/edit") == ("/books/OL1M/edit", "/books/OL1M/foo/edit")
 
     # with bad title
-    assert f(u"/books/OL1M/bar") == (u"/books/OL1M", u"/books/OL1M/foo")
-    assert f(u"/books/OL1M/bar/edit") == (u"/books/OL1M/edit", u"/books/OL1M/foo/edit")
+    assert f("/books/OL1M/bar") == ("/books/OL1M", "/books/OL1M/foo")
+    assert f("/books/OL1M/bar/edit") == ("/books/OL1M/edit", "/books/OL1M/foo/edit")
 
     # test /b/ redirects
-    assert f(u"/b/OL1M") == (u"/books/OL1M", u"/books/OL1M/foo")
-    assert f(u"/b/OL1M/foo/edit") == (u"/books/OL1M/edit", u"/books/OL1M/foo/edit")
+    assert f("/b/OL1M") == ("/books/OL1M", "/books/OL1M/foo")
+    assert f("/b/OL1M/foo/edit") == ("/books/OL1M/edit", "/books/OL1M/foo/edit")
 
     # test olid redirects
-    assert f(u"/whatever/OL1M") == (u"/books/OL1M", u"/books/OL1M/foo")
+    assert f("/whatever/OL1M") == ("/books/OL1M", "/books/OL1M/foo")
 
     # test encoding
-    assert f(u"/books/OL1M.json") == (u"/books/OL1M.json", u"/books/OL1M.json")
-    assert f(u"/books/OL1M", encoding="json") == (u"/books/OL1M", u"/books/OL1M")
+    assert f("/books/OL1M.json") == ("/books/OL1M.json", "/books/OL1M.json")
+    assert f("/books/OL1M", encoding="json") == ("/books/OL1M", "/books/OL1M")
 
 def test_list_urls():
     f = get_readable_path
 
-    print(f(u"/people/joe/lists/OL1L"))
+    print(f("/people/joe/lists/OL1L"))
 
-    assert f(u"/people/joe/lists/OL1L") == (
-        u"/people/joe/lists/OL1L",
-        u"/people/joe/lists/OL1L/foo"
+    assert f("/people/joe/lists/OL1L") == (
+        "/people/joe/lists/OL1L",
+        "/people/joe/lists/OL1L/foo"
     )
 
-    assert f(u"/people/joe/lists/OL1L/bar") == (
-        u"/people/joe/lists/OL1L",
-        u"/people/joe/lists/OL1L/foo"
+    assert f("/people/joe/lists/OL1L/bar") == (
+        "/people/joe/lists/OL1L",
+        "/people/joe/lists/OL1L/foo"
     )
 
-    assert f(u"/people/joe/lists/OL1L/bar/edit") == (
-        u"/people/joe/lists/OL1L/edit",
-        u"/people/joe/lists/OL1L/foo/edit"
+    assert f("/people/joe/lists/OL1L/bar/edit") == (
+        "/people/joe/lists/OL1L/edit",
+        "/people/joe/lists/OL1L/foo/edit"
     )

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -3,7 +3,7 @@ import unittest
 try:
     from unittest import mock
 except ImportError:
-    import mock
+    from unittest import mock
 
 from openlibrary.solr import update_work
 from openlibrary.solr.data_provider import DataProvider

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -1,9 +1,6 @@
 import pytest
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from openlibrary.solr import update_work
 from openlibrary.solr.data_provider import DataProvider


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Starts to modernize Python syntax using [`pyupgrade  --py38-plus **/*.py`](https://github.com/asottile/pyupgrade) in our `openlibrary/tests` directory.  This utility will allow us to automate the removal of the `six` dependency and remove unneeded imports, syntax, etc.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ensure that our automated tests continue to pass.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
