### PR TITLE
Reenable dependabot for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+- package_manager: "python"
+  directory: "/"
+  update_schedule: "monthly"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
#3364 again now that we have dropped legacy Python

<!-- What issue does this PR close? -->
Reenable dependabot for Python dependencies.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
