### PR TITLE
Improve user /lists page performance by remove top subjects

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -244,9 +244,6 @@ class ListMixin:
 
         return sorted(process_all(), reverse=True, key=lambda s: s["count"])
 
-    def get_top_subjects(self, limit=20):
-        return self._get_all_subjects()[:limit]
-
     def get_subjects(self, limit=20):
         def get_subject_type(s):
             if s.url.startswith("/subjects/place:"):

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -27,14 +27,5 @@ $def with (list)
                 $if list.description:
                     $:format(list.description)
             </span>
-
-            <div class="subjects">
-                $ subjects = list.get_top_subjects(limit=5)
-                $if subjects:
-                    <!-- TODO: I18N Needs to be improved for LTR languages -->
-                    $_('Themes:')
-                    $for s in subjects[:5]:
-                        <a href="$s.url">$s.title</a>$cond(loop.last, "", ",")
-            </div>
         </span>
     </span>


### PR DESCRIPTION
This is making a lot of expensive requests to solr, and providing very minimal value.

<!-- What issue does this PR close? -->
Closes #3896

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] http://staging.openlibrary.org/people/Hermgirl/lists 11s → 2s
- [x] http://staging.openlibrary.org/people/seabelis/lists 45s → 6s
 
### Screenshot
| Before | After | 
| --- | --- |
| ![image](https://user-images.githubusercontent.com/6251786/110182375-a33da200-7dda-11eb-95ac-803fc90657cc.png)  | ![image](https://user-images.githubusercontent.com/6251786/110182315-8c974b00-7dda-11eb-937a-96d9ab3184f1.png) |


### Stakeholders
@mekarpeles  @seabelis
