### PR TITLE
Make web port configurable via environment variable

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,10 @@
 
 version: "3.1"
 services:
+  web:
+    ports:
+      # Debugger
+      - 3000:3000
   covers:
     ports:
       - 7075:7075

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       dockerfile: docker/Dockerfile.oldev
     command: docker/ol-web-start.sh
     ports:
-      - 8080:8080
-      - 3000:3000
+      - ${WEB_PORT:-8080}:8080
     depends_on:
       - db
       - infobase


### PR DESCRIPTION
Feature. This allows us to have multiple openlibrarys running from the same server, without having to modify any files!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] `docker-compose up -d` starts on `8080`
- [x]  `WEB_PORT=9090 docker-compose up -d` starts on `9090`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
