### PR TITLE
localhost:80 -> web:8080 in openlibrary.yml

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -33,7 +33,7 @@ infobase_server: infobase:7000
 infobase_config_file: infobase.yml
 coverstore_config_file: coverstore.yml
 
-loanstatus_url: http://localhost/
+loanstatus_url: http://web:8080/
 ia_access_secret: foobar
 
 memcache_servers:
@@ -165,15 +165,15 @@ ia_ol_xauth_s3:
     s3_key: XXX
     s3_secret: XXX
 
-ia_loan_api_url: http://localhost/internal/fake/loans
-ia_xauth_api_url: http://localhost/internal/fake/xauth
+ia_loan_api_url: http://web:8080/internal/fake/loans
+ia_xauth_api_url: http://web:8080/internal/fake/xauth
 
 internal_tests_api_key: 8oPd1tx747YH374ohs48ZO5s2Nt1r9yD
 ia_availability_api_v2_url: https://archive.org/services/availability/
 ia_base_url: https://archive.org
 
 ia_civicrm_api:
-    url: http://localhost/internal/fake/civicrm
+    url: http://web:8080/internal/fake/civicrm
     api_key: XXX
     site_key: XXX
     auth: XXX


### PR DESCRIPTION
Hotfix. Follow up to #4727 . Causing pages on the dev environment to error trying to hit fake auth servers.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] http://localhost:8080/works/OL53924W/The_complete_works_of_Mark_Twain does not error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
