### PR TITLE
Disable vue development builds due to concurrency bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ components: $(COMPONENTS_DIR)/*.vue
 	mkdir --parents $(BUILD)
 	rm -rf $(BUILD)/components
 	parallel --verbose -q \
-		npx vue-cli-service build --no-clean --mode {2} --dest $(BUILD)/components/{2} --target wc --name "ol-{1/.}" "{1}" \
-	::: $^ ::: production development
+		npx vue-cli-service build --no-clean --mode production --dest $(BUILD)/components/production --target wc --name "ol-{1/.}" "{1}" \
+	::: $^
 
 i18n:
 	$(PYTHON) ./scripts/i18n-messages compile

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -146,8 +146,6 @@ def render_component(name, attrs=None, json_encode=True):
 
     if name not in included:
         url = static_url('build/components/production/ol-%s.min.js' % name)
-        if query_param('debug'):
-            url = static_url('build/components/development/ol-%s.js' % name)
         html += '<script src="%s"></script>' % url
         included.append(name)
 


### PR DESCRIPTION
Apparently these write to the same tmp file :/ The development builds haven't been that useful, so axing them to keep things fast.

This _must_ be merged before our next deploy.

<!-- What issue does this PR close? -->
Closes #4733

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] `docker-compose run --rm home make components` doesn't error

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
