### PR TITLE
Make vue builds run in sequence :( They must be stateful :(

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ js:
 components: $(COMPONENTS_DIR)/*.vue
 	mkdir --parents $(BUILD)
 	rm -rf $(BUILD)/components
-	parallel --verbose -q \
-		npx vue-cli-service build --no-clean --mode production --dest $(BUILD)/components/production --target wc --name "ol-{1/.}" "{1}" \
+	# Run these silly things one at a time, because they don't support parallelization :(
+	parallel --verbose -q --jobs 1 \
+		npx vue-cli-service build --no-clean --mode production --dest $(BUILD)/components/production --target wc --name "ol-{/.}" "{}" \
 	::: $^
 
 i18n:


### PR DESCRIPTION
Aaaand this is why auto-merging is bad :P (Also: Why I need to go on holiday next week :D )  Continuations of #4749 

Vue was just building one component X times :( If you were lucky, it would be LibraryExplorer. Sometimes it would build HelloWorld 3 times :/


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] `make components` works and lists different file sizes for each build.
- [x] On staging, but merge works endpoint and /explore work

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
