### PR TITLE
Fix Lists Page Images Accessibility

### DIFF
--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -30,15 +30,16 @@ $var title: $_('Lists')
     <!-- FOR EACH LIST -->
     $for list in lists:
         <div class="listEntry">
-            <div class="cover">
-                $ cover = list.get_cover() or list.get_default_cover()
-                $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
-                <a href="$list.key"><img src="$cover_url" alt="Cover of: $list.name" title="Cover of: $list"/></a>
-            </div>
             <div class="data">
                 <div class="name">
                     $ owner = list.get_owner()
-                    <a href="$list.key" class="title results">$:_('%(listname)s </a> from <a href="%(key)s">%(owner)s</a>', key=owner.key, listname=list.name, owner=owner.displayname)
+                    <a href="$list.key" class="title results">
+                        <div class="cover">
+                            $ cover = list.get_cover() or list.get_default_cover()
+                            $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
+                            <img src="$cover_url" alt=""/>
+                        </div>
+                        $:_('%(listname)s </a> from <a href="%(key)s">%(owner)s</a>', key=owner.key, listname=list.name, owner=owner.displayname)
                 </div>
                 <div class="meta">
                     $ msg = ungettext("1 item", "%(count)d items", len(list.seeds))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4633 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Combined the `cover` Div and `name` Div because the cover image for a list is a book cover of the book present in that list but the alt attribute says alt="Cover of: listname" and according to @bpmcneilly the alt text needs to inform users where they will go if they activates the link. So the best solution was to bring the cover inside the name and make the `alt=""`.

**For more Reference:** https://github.com/internetarchive/openlibrary/issues/4633#issuecomment-783681715

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/110229797-042bbe00-7f32-11eb-8875-869e2f4480c3.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly 