### PR TITLE
Remove uses of six.PY2 and six.PY3

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import requests
@@ -6,12 +7,6 @@ from infogami import config
 from openlibrary.core.lending import get_availability_of_ocaids
 from openlibrary.plugins.openlibrary.home import format_book_data
 from six.moves.urllib.parse import urlencode
-
-# py3 uses json.decoder.JSONDecodeError
-try:
-    from json.decoder import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
 
 logger = logging.getLogger("openlibrary.inside")
 
@@ -29,7 +24,7 @@ def fulltext_search_api(params):
         return response.json()
     except requests.HTTPError:
         return {'error': 'Unable to query search engine'}
-    except JSONDecodeError:
+    except json.decoder.JSONDecodeError:
         return {'error': 'Error converting search engine data to JSON'}
 
 

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -1,10 +1,11 @@
 """Generic helper functions to use in the templates and the webapp.
 """
-import web
 import json
 import re
 from datetime import datetime
 from urllib.parse import urlsplit
+
+import web
 
 import babel
 import babel.core
@@ -49,7 +50,7 @@ __docformat__ = "restructuredtext en"
 def sanitize(html, encoding='utf8'):
     """Removes unsafe tags and attributes from html and adds
     ``rel="nofollow"`` attribute to all external links.
-    Using encoding=None if passing unicode strings e.g. for Python 3.
+    Using encoding=None if passing Unicode strings.
     encoding="utf8" matches default format for earlier versions of Genshi
     https://genshi.readthedocs.io/en/latest/upgrade/#upgrading-from-genshi-0-6-x-to-the-development-version
     """

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -55,7 +55,7 @@ def print_dump(json_records, filter=None):
 
 def read_data_file(filename):
     for line in xopen(filename):
-        if six.PY3 and not isinstance(line, str):
+        if not isinstance(line, str):
             line = line.decode("utf-8")
         thing_id, revision, json_data = line.strip().split("\t")
         yield pgdecode(json_data)
@@ -76,7 +76,7 @@ def read_tsv(file, strip=True):
         file = xopen(file)
 
     for i, line in enumerate(file):
-        if six.PY3 and not isinstance(line, str):
+        if not isinstance(line, str):
             line = line.decode("utf-8")
         if i % 1000000 == 0:
             log(i)
@@ -114,7 +114,7 @@ def sort_dump(dump_file=None, tmpdir="/tmp/", buffer_size="1G"):
     # split the file into 256 chunks using hash of key
     log("splitting", dump_file)
     for i, line in enumerate(stdin):
-        if six.PY3 and not isinstance(line, bytes):
+        if not isinstance(line, bytes):
             line = line.encode("utf-8")
         if i % 1000000 == 0:
             log(i)
@@ -173,7 +173,7 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
 
     stdin = xopen(dump_file) if dump_file else sys.stdin
     for i, line in enumerate(stdin):
-        if six.PY3 and not isinstance(line, bytes):
+        if not isinstance(line, bytes):
             line = line.encode("utf-8")
         if i % 1000000 == 0:
             log(i)

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -649,13 +649,9 @@ class SaveBookHelper:
             """
             if not subjects:
                 return
-            if six.PY2:
-                subjects = subjects.encode('utf-8')  # no unicode in csv module
             f = six.StringIO(subjects)
             dedup = set()
             for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
-                if six.PY2:
-                    s = s.decode('utf-8')
                 if s.lower() not in dedup:
                     yield s
                     dedup.add(s.lower())

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -8,7 +8,6 @@ import hmac
 import re
 import requests
 import json
-import six
 import logging
 
 import web
@@ -841,19 +840,12 @@ def get_ia_auth_dict(user, item_id, user_specified_loan_key, access_token):
 
 def ia_hash(token_data):
     access_key = make_access_key()
-    if six.PY3:
-        return hmac.new(
-            access_key,
-            token_data.encode('utf-8'),
-            hashlib.md5
-        ).hexdigest()
-    return hmac.new(access_key, token_data).hexdigest()
+    return hmac.new(access_key, token_data.encode('utf-8'), hashlib.md5).hexdigest()
 
 
 def make_access_key():
     try:
-        access_key = config.ia_access_secret
-        return access_key if six.PY2 else access_key.encode('utf-8')
+        return config.ia_access_secret.encode('utf-8')
     except AttributeError:
         raise RuntimeError(
             "config value config.ia_access_secret is not present -- check your config"

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -6,8 +6,6 @@ import io
 import os.path
 import random
 
-from six import PY3
-
 import web
 
 from infogami import config

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -13,7 +13,6 @@ import logging
 import requests
 
 import six
-from six import PY3
 from six.moves import urllib
 from six.moves.collections_abc import MutableMapping
 from six.moves.urllib.parse import parse_qs, urlencode as parse_urlencode, urlparse, urlunparse
@@ -438,7 +437,7 @@ class Metatag:
 
     def __str__(self):
         attrs = ' '.join(
-            '%s="%s"' % (k, websafe(v) if PY3 else websafe(v).encode('utf8'))
+            '%s="%s"' % (k, websafe(v))
             for k, v in self.attrs.items())
         return '<%s %s />' % (self.tag, attrs)
 

--- a/openlibrary/solr/solrwriter.py
+++ b/openlibrary/solr/solrwriter.py
@@ -94,11 +94,9 @@ def add_field(doc, name, value):
             value = str(value)
         try:
             value = strip_bad_char(value)
-            if six.PY2 and isinstance(value, str):
-                value = value.decode('utf-8')
             field.text = normalize('NFC', value)
         except:
-            logger.error('Error in normalizing %r', value)
+            logger.exception('Error in normalizing %r', value)
             raise
         doc.append(field)
 

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -1,13 +1,8 @@
+from json.decoder import JSONDecodeError
 from unittest.mock import Mock, patch
 import requests
 from infogami import config
 from openlibrary.core import fulltext
-
-# py3 uses json.decoder.JSONDecodeError
-try:
-    from json.decoder import JSONDecodeError
-except ImportError:
-    JSONDecodeError = ValueError
 
 
 class Test_fulltext_search_api:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Manually remove uses of `six.PY2` and `six.PY3` from the codebase now that we have dropped support for legacy Python.

In later PRs we can use [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically remove other uses of the `six` module (like ~#4736~ and #4743) but it is better to first manually remove the uses of `six.PY2` and `six.PY3`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
