### PR TITLE
Improve book notes modal

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "9.3KB"
+      "maxSize": "9.4KB"
     },
     {
       "path": "static/build/page-edit.css",

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -30,7 +30,7 @@ $if has_edition:
       <h2>$_("My Book Notes")</h2>
       <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
     </div>
-    <form id="book-notes-form" method="POST" action="$(work.key)/notes.json">
+    <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
       <p>My personal notes about this $book_descriptor:</p>
       <div>
         <textarea name="notes" rows="10">$(notes.notes if notes else "")</textarea>
@@ -40,7 +40,7 @@ $if has_edition:
     <div class="floaterHead">
       <h2>$_("Observations")</h2>
     </div>
-    <p id="observation-instructions">Additional observations about this $book_descriptor. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.</p>
+    <p class="observation-instructions">Additional observations about this $book_descriptor. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.</p>
     <form class="floatform" name="user-metadata" id="user-metadata"></form>
   </div>
 </div>

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -3,6 +3,7 @@ $def with (work, edition)
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ has_edition = edition is not None
 $ notes = work.get_users_notes(username)
+$ book_descriptor = _("work")
 
 $ i18n_strings = {
   $ "close_text": _("Close"),
@@ -17,6 +18,7 @@ $ context = {
 
 $if has_edition:
   $ context["edition"] = edition.key
+  $ book_descriptor = _("edition")
 
 <div class="cta-section patron-metadata">
   <a id="modal-link" href="javascript:;" data-context="$json_encode(context)" data-i18n="$json_encode(i18n_strings)">$_("My book notes")</a>
@@ -28,12 +30,12 @@ $if has_edition:
       <h2>$_("My Book Notes")</h2>
       <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
     </div>
-    <form method="POST" action="$(work.key)/notes.json">
-      <p>My personal notes about this book</p>
+    <form id="book-notes-form" method="POST" action="$(work.key)/notes.json">
+      <p>My personal notes about this $book_descriptor:</p>
       <div>
-        <textarea name="notes">$(notes.notes if notes else "")</textarea>
+        <textarea name="notes" rows="10">$(notes.notes if notes else "")</textarea>
       </div>
-      <input type="submit">
+      <button class="cta-btn"type="submit" form="book-notes-form">Save Note</button>
     </form>
     <form class="floatform" name="user-metadata" id="user-metadata"></form>
   </div>

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -37,6 +37,10 @@ $if has_edition:
       </div>
       <button class="cta-btn"type="submit" form="book-notes-form">Save Note</button>
     </form>
+    <div class="floaterHead">
+      <h2>$_("Observations")</h2>
+    </div>
+    <p id="observation-instructions">Additional observations about this $book_descriptor. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.</p>
     <form class="floatform" name="user-metadata" id="user-metadata"></form>
   </div>
 </div>

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -43,7 +43,7 @@ export function initPatronMetadata() {
             <div class="formElement metadata-submit">
               <div class="form-buttons">
                 <a class="small dialog--close plain" href="javascript:;" id="cancel-submission">${i18nStrings.close_text}</a>
-                <button id="observation-submit-btn" class="cta-btn submit" type="submit">${i18nStrings.submit_text}</button>
+                <input class="cta-btn submit-btn" type="submit" value="${i18nStrings.submit_text}">
               </div>
             </div>`);
 
@@ -117,10 +117,8 @@ export function initPatronMetadata() {
 
 /**
  * Resizes modal when a details element is opened or closed.
- * 
- * @param {ToggleEvent} event
  */
-function toggleHandler(event) {
+function toggleHandler() {
     let formHeight = $('#metadata-form').height();
 
     $('#cboxContent').height(formHeight + 22);
@@ -129,7 +127,7 @@ function toggleHandler(event) {
 
 /**
  * Adds a toggle handler to all details elements.
- * 
+ *
  * @param {JQuery} $toggleElements`Elements that will receive toggle handlers.
  */
 function addToggleListeners($toggleElements) {

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -29,9 +29,12 @@ export function initPatronMetadata() {
             }
 
             $form.append(`
-              <div class="formElement" id="${aspect.label}-question">
-                <h3>${aspect.description}</h3>
-                ${$choices.prop('outerHTML')}
+              <h3 class="collapsible">${aspect.label}</h3>
+              <div class="collapsible-content formElement">
+                <div id="${aspect.label}-question">
+                    <h3>${aspect.description}</h3>
+                    ${$choices.prop('outerHTML')}
+                </div>
               </div>`);
         }
 
@@ -42,6 +45,8 @@ export function initPatronMetadata() {
                 <a class="small dialog--close plain" href="javascript:;" id="cancel-submission">${i18nStrings.close_text}</a>
               </div>
             </div>`);
+
+        addCollapsibleListeners($('.collapsible', $form));
     }
 
     $('#modal-link').on('click', function() {
@@ -108,4 +113,51 @@ export function initPatronMetadata() {
         }
 
     });
+
+    // Collapse all expanded elements on modal close
+    $(document).on('cbox_closed', function() {
+        let $collapsibles = $('.collapsible');
+        $collapsibles.each(function() {
+            $(this).removeClass('active');
+            $(this).next().css('max-height', '');
+        })
+    })
+}
+
+/**
+ * Handles clicks on a collapsible element.
+ * 
+ * Toggles the "active" class on the collapible that was clicked, highlighting
+ * expanded section headings.  Resizes the maximum height of the collapsible 
+ * content divs, and the parenet element if necessary.
+ * 
+ * @param {ClickEvent} event
+ */
+function collapseHandler(event) {
+    this.classList.toggle('active');
+    let content = this.nextElementSibling;
+    let heightChange = content.scrollHeight;
+
+    if (content.style.maxHeight) {
+        content.style.maxHeight = null;
+        heightChange *= -1;
+    } else {
+        content.style.maxHeight = `${heightChange}px`;
+    }
+
+    $('#cboxContent').animate(
+        {
+            height: $('#cboxContent').height() + heightChange
+        }, 200, 'linear');
+}
+
+/**
+ * Adds a collapsible handler to all collapsible elements.
+ * 
+ * @param {JQuery} $collapsibleElements`Elements that will receive collapse handlers.
+ */
+function addCollapsibleListeners($collapsibleElements) {
+    $collapsibleElements.each(function() {
+        $(this).on('click', collapseHandler);
+    })
 }

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -29,13 +29,14 @@ export function initPatronMetadata() {
             }
 
             $form.append(`
-              <h3 class="collapsible">${aspect.label}</h3>
-              <div class="collapsible-content formElement">
+              <details class="aspect-section">
+                <summary>${aspect.label}</summary>
                 <div id="${aspect.label}-question">
                     <h3>${aspect.description}</h3>
                     ${$choices.prop('outerHTML')}
                 </div>
-              </div>`);
+              </details>
+            `);
         }
 
         $form.append(`
@@ -46,7 +47,7 @@ export function initPatronMetadata() {
               </div>
             </div>`);
 
-        addCollapsibleListeners($('.collapsible', $form));
+        addToggleListeners($('.aspect-section', $form));
     }
 
     $('#modal-link').on('click', function() {
@@ -111,53 +112,25 @@ export function initPatronMetadata() {
         } else {
             // TODO: Handle case where no data was submitted
         }
-
     });
-
-    // Collapse all expanded elements on modal close
-    $(document).on('cbox_closed', function() {
-        let $collapsibles = $('.collapsible');
-        $collapsibles.each(function() {
-            $(this).removeClass('active');
-            $(this).next().css('max-height', '');
-        })
-    })
 }
 
 /**
- * Handles clicks on a collapsible element.
+ * Resizes modal when a details element is opened or closed.
  * 
- * Toggles the "active" class on the collapible that was clicked, highlighting
- * expanded section headings.  Resizes the maximum height of the collapsible 
- * content divs, and the parenet element if necessary.
- * 
- * @param {ClickEvent} event
+ * @param {ToggleEvent} event
  */
-function collapseHandler(event) {
-    this.classList.toggle('active');
-    let content = this.nextElementSibling;
-    let heightChange = content.scrollHeight;
-
-    if (content.style.maxHeight) {
-        content.style.maxHeight = null;
-        heightChange *= -1;
-    } else {
-        content.style.maxHeight = `${heightChange}px`;
-    }
-
-    $('#cboxContent').animate(
-        {
-            height: $('#cboxContent').height() + heightChange
-        }, 200, 'linear');
+function toggleHandler(event) {
+    $('#cboxContent').height($('#metadata-form').height() + 22);
 }
 
 /**
- * Adds a collapsible handler to all collapsible elements.
+ * Adds a toggle handler to all details elements.
  * 
- * @param {JQuery} $collapsibleElements`Elements that will receive collapse handlers.
+ * @param {JQuery} $toggleElements`Elements that will receive toggle handlers.
  */
-function addCollapsibleListeners($collapsibleElements) {
-    $collapsibleElements.each(function() {
-        $(this).on('click', collapseHandler);
+function addToggleListeners($toggleElements) {
+    $toggleElements.each(function() {
+        $(this).on('toggle', toggleHandler);
     })
 }

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -41,9 +41,9 @@ export function initPatronMetadata() {
 
         $form.append(`
             <div class="formElement metadata-submit">
-              <div class="input">
-                <button type="submit">${i18nStrings.submit_text}</button>
+              <div class="form-buttons">
                 <a class="small dialog--close plain" href="javascript:;" id="cancel-submission">${i18nStrings.close_text}</a>
+                <button id="observation-submit-btn" class="cta-btn submit" type="submit">${i18nStrings.submit_text}</button>
               </div>
             </div>`);
 

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -121,7 +121,10 @@ export function initPatronMetadata() {
  * @param {ToggleEvent} event
  */
 function toggleHandler(event) {
-    $('#cboxContent').height($('#metadata-form').height() + 22);
+    let formHeight = $('#metadata-form').height();
+
+    $('#cboxContent').height(formHeight + 22);
+    $('#cboxLoadedContent').height(formHeight);
 }
 
 /**

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -37,6 +37,39 @@
   margin-top: 1em;
 }
 
+.collapsible {
+  cursor: pointer;
+  padding: .5em;
+  margin: .5em 0;
+  text-transform: capitalize;
+
+  &:after {
+    content: "\02795";
+    float: right;
+    padding-right: 18px;
+  }
+
+  &:hover {
+    background-color: hsla(206, 51%, 26%, .25);
+  }
+
+  &-content {
+    margin: 0;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease-out;
+  }
+}
+
+
+.active {
+  background-color: hsla(206, 51%, 26%, .25);
+
+  &:after {
+    content: "\2796";
+  }
+}
+
 @media screen and (max-width: @width-breakpoint-tablet) {
   .single-choice {
     display: inline-block;

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -1,8 +1,9 @@
 @import (less) "../less/breakpoints.less";
+@import (less) "../less/colors.less";
 
 .single-choice {
   display: flex;
-  margin-bottom: 1.5em;
+  margin-bottom: 0.5em;
 
   &-label {
     display: inline-block;
@@ -20,7 +21,7 @@
 .multi-choice {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 1.5em;
+  margin-bottom: 0.5em;
 
   &-label {
     flex: 0 0 25%;
@@ -37,36 +38,28 @@
   margin-top: 1em;
 }
 
-.collapsible {
-  cursor: pointer;
-  padding: .5em;
-  margin: .5em 0;
-  text-transform: capitalize;
-
-  &:after {
-    content: "\02795";
-    float: right;
-    padding-right: 18px;
-  }
-
-  &:hover {
+.aspect-section {
+  &[open] summary {
     background-color: hsla(206, 51%, 26%, .25);
   }
 
-  &-content {
-    margin: 0;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.2s ease-out;
+  summary {
+    cursor: pointer;
+    text-transform: capitalize;
+    font-size: 1em;
+    font-weight: 600;
+    color: @grey;
+    margin: 0.5em 0;
+    padding: 0.5em;
   }
-}
 
+  summary:hover {
+    background-color: hsla(206, 51%, 26%, .25);
+  }
 
-.active {
-  background-color: hsla(206, 51%, 26%, .25);
-
-  &:after {
-    content: "\2796";
+  div {
+    padding-left: 0.5em;
+    padding-bottom: 0.5em;
   }
 }
 

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -1,6 +1,6 @@
 @import (less) "../less/breakpoints.less";
 @import (reference) "../less/colors.less";
-@import (less) "./buttonBtn.less";
+@import (reference) "./buttonBtn.less";
 
 .single-choice {
   display: flex;

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -40,7 +40,7 @@
 
 .aspect-section {
   &[open] summary {
-    background-color: hsla(206, 51%, 26%, .25);
+    background-color: @blue-204764;
   }
 
   summary {
@@ -54,7 +54,7 @@
   }
 
   summary:hover {
-    background-color: hsla(206, 51%, 26%, .25);
+    background-color: @blue-204764;
   }
 
   div {

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -4,7 +4,7 @@
 
 .single-choice {
   display: flex;
-  margin-bottom: 0.5em;
+  margin-bottom: .5em;
 
   &-label {
     display: inline-block;
@@ -22,7 +22,7 @@
 .multi-choice {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 0.5em;
+  margin-bottom: .5em;
 
   &-label {
     flex: 0 0 25%;
@@ -35,33 +35,34 @@
   }
 }
 
-.metadata-submit {
-  .form-buttons {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
+.form-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 
-    #observation-submit-btn {
-      background-color: @green;
-      margin-left: 1.5em;
-      display: unset;
-    }
+  .submit-btn {
+    font-size: 1.2em;
+    width: auto;
+    background-color: @green;
+    margin-top: unset;
+    margin-left: 1.5em;
+    display: unset;
   }
 }
 
 .aspect-section {
-  &[open] summary {
-    background-color: @blue-204764;
-  }
-
   summary {
     cursor: pointer;
     text-transform: capitalize;
     font-size: 1em;
     font-weight: 600;
     color: @grey;
-    margin: 0.5em 0;
-    padding: 0.5em;
+    margin: .5em 0;
+    padding: .5em;
+  }
+
+  &[open] summary {
+    background-color: @blue-204764;
   }
 
   summary:hover {
@@ -69,12 +70,12 @@
   }
 
   div {
-    padding-left: 0.5em;
-    padding-bottom: 0.5em;
+    padding-left: .5em;
+    padding-bottom: .5em;
   }
 }
 
-#book-notes-form {
+.book-notes-form {
   width: 75%;
   margin: 1em auto;
 
@@ -88,13 +89,14 @@
   }
 
   button {
+    font-size: 1.2em;
     background-color: @green;
     width: unset;
     margin-left: auto;
   }
 }
 
-#observation-instructions {
+.observation-instructions {
   margin: 1em 2em;
 }
 
@@ -118,22 +120,21 @@
     flex: 0 0 50%;
   }
 
-  #book-notes-form {
+  .book-notes-form {
     button {
       width: 100%;
     }
   }
 
-  .metadata-submit {
-    .form-buttons {
-      flex-direction: column;
+  .form-buttons {
+    flex-direction: column;
 
-      #observation-submit-btn {
-        order: -1;
-        width: 100% !important;
-        margin-left: unset;
-        margin-bottom: 1.5em;
-      }
+    .submit-btn {
+      order: -1;
+      width: 100%;
+      margin-left: unset;
+      margin-bottom: 1.5em;
+      margin-top: .5em;
     }
   }
 }

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -1,5 +1,6 @@
 @import (less) "../less/breakpoints.less";
-@import (less) "../less/colors.less";
+@import (reference) "../less/colors.less";
+@import (less) "./buttonBtn.less";
 
 .single-choice {
   display: flex;
@@ -35,7 +36,17 @@
 }
 
 .metadata-submit {
-  margin-top: 1em;
+  .form-buttons {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    #observation-submit-btn {
+      background-color: @green;
+      margin-left: 1.5em;
+      display: unset;
+    }
+  }
 }
 
 .aspect-section {
@@ -63,6 +74,26 @@
   }
 }
 
+#book-notes-form {
+  width: 75%;
+  margin: 1em auto;
+
+  div {
+    width: 100%;
+    margin-bottom: 1em;
+
+    textarea {
+      width: 100%;
+    }
+  }
+
+  button {
+    background-color: @green;
+    width: unset;
+    margin-left: auto;
+  }
+}
+
 @media screen and (max-width: @width-breakpoint-tablet) {
   .single-choice {
     display: inline-block;
@@ -81,5 +112,24 @@
 
   .multi-choice-label {
     flex: 0 0 50%;
+  }
+
+  #book-notes-form {
+    button {
+      width: 100%;
+    }
+  }
+
+  .metadata-submit {
+    .form-buttons {
+      flex-direction: column;
+
+      #observation-submit-btn {
+        order: -1;
+        width: 100% !important;
+        margin-left: unset;
+        margin-bottom: 1.5em;
+      }
+    }
   }
 }

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -94,6 +94,10 @@
   }
 }
 
+#observation-instructions {
+  margin: 1em 2em;
+}
+
 @media screen and (max-width: @width-breakpoint-tablet) {
   .single-choice {
     display: inline-block;

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -19,6 +19,7 @@
 @baby-blue: hsl(240, 100%, 93%);
 @blue-9fafd1: hsl(221, 35%, 72%);
 @blue-3366ff: hsl(225, 100%, 60%);
+@blue-204764: hsla(206, 51%, 26%, .25);
 
 // green
 @green: hsl(130, 61%, 33%);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4781

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR improves the book notes modal by nesting questions in collapsible sections, clearly dividing the book notes and observations sections, adding some additional details to the observations section, and making some styling changes.

### Technical
<!-- What should be noted about the implementation? -->
Observations are nested using `<details>` elements, which are more a11y friendly than the [solution](https://github.com/Open-Book-Genome-Project/TheBestBookOn.com/pull/78) used in The Best Book On.
Toggling a details section doesn't resize the entire modal, only it's innermost div.  Colorbox's built in resize function was repositioning the modal lower on the page each time that it was called (regardless of the value of the `reposition` [setting](http://www.jacklmoore.com/colorbox/#setting-reposition)).  I've added a toggle handler to each details section that directly resizes the modal.  Whoever is working on #4595 should be mindful of this.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Large screens:
![modal_fullscreen](https://user-images.githubusercontent.com/28732543/110535029-bfe51d00-80ed-11eb-9d99-c735cd04c3ca.gif)

Small screens:
![modal_small_screen](https://user-images.githubusercontent.com/28732543/110535061-ce333900-80ed-11eb-9a15-06961b7d8750.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

Please squash this before merging.
