### PR TITLE
Fix BookNote update functionality

### DIFF
--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -110,7 +110,8 @@ class Booknotes(object):
             'booknotes',
             where="work_id=$work_id AND username=$username",
             notes=notes,
-            edition_id=edition_id
+            edition_id=edition_id,
+            vars=data
         )
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4792 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects KeyErrors that are thrown when an existing book note is updated.

### Technical
<!-- What should be noted about the implementation? -->
KeyErrors were due to `work_id` not being present in the `vars` dictionary.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Attempt to update an existing book note.  If successful, you will see a JSON string with a success message on the `/notes.json` page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 