### PR TITLE
Add scripts/deployment/are_servers_in_sync.sh

### DIFF
--- a/scripts/deployment/are_servers_in_sync.sh
+++ b/scripts/deployment/are_servers_in_sync.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+REPO_DIRS="/opt/olsystem /opt/openlibrary /opt/openlibrary/vendor/infogami /opt/booklending_utils"
+for REPO_DIR in $REPO_DIRS; do
+    echo $REPO_DIR
+    SERVERS="ol-home0 ol-covers0 ol-web1 ol-web2"
+    for SERVER in $SERVERS; do
+	#ssh $SERVER "cd $REPO_DIR; hostname ; sudo git checkout master ; sudo git pull ; git rev-parse HEAD"
+	ssh $SERVER "cd $REPO_DIR; hostname ; git rev-parse HEAD"
+    done
+    echo "---"
+done
+
+for SERVER in $SERVERS; do
+    ssh $SERVER "hostname | docker image ls | grep oldev | grep latest"
+done


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This utility script helps to ensure that the servers `ol-home0`, `ol-covers0`, `ol-web1`, and `ol-web2` have the same:
1. Git hash for /opt/olsystem
2. Git hash for /opt/openlibrary
3. Git hash for /opt/openlibrary/vendor/infogami
4. Git hash for /opt/booklending_utils -- NOTE: ol-covers0 does not need /opt/booklending_utils
5. Docker SHA for oldev:latest

This helps to determine if we have successfully completed all steps of `scripts/deployment/deploy.sh` and are ready to run `scripts/deployment/restart_servers.sh`.  A successful run looks like:
```
/opt/olsystem
ol-home0.us.archive.org
8dd5db642b42c3bda075487db10f1d1b1c043d3c
ol-covers0.us.archive.org
8dd5db642b42c3bda075487db10f1d1b1c043d3c
ol-web1.us.archive.org
8dd5db642b42c3bda075487db10f1d1b1c043d3c
ol-web2.us.archive.org
8dd5db642b42c3bda075487db10f1d1b1c043d3c
---
/opt/openlibrary
ol-home0.us.archive.org
949fc58639ee8f650ea962edd2bb00ba18566a5c
ol-covers0.us.archive.org
949fc58639ee8f650ea962edd2bb00ba18566a5c
ol-web1.us.archive.org
949fc58639ee8f650ea962edd2bb00ba18566a5c
ol-web2.us.archive.org
949fc58639ee8f650ea962edd2bb00ba18566a5c
---
/opt/openlibrary/vendor/infogami
ol-home0.us.archive.org
beef7532bd237b7f495b0f49708abc954d278408
ol-covers0.us.archive.org
beef7532bd237b7f495b0f49708abc954d278408
ol-web1.us.archive.org
beef7532bd237b7f495b0f49708abc954d278408
ol-web2.us.archive.org
beef7532bd237b7f495b0f49708abc954d278408
---
/opt/booklending_utils
ol-home0.us.archive.org
0d8a94f07eb84eb841f5b10b05d8667a11e30e2f
ol-covers0.us.archive.org
fatal: not a git repository (or any of the parent directories): .git
ol-web1.us.archive.org
0d8a94f07eb84eb841f5b10b05d8667a11e30e2f
ol-web2.us.archive.org
0d8a94f07eb84eb841f5b10b05d8667a11e30e2f
---
oldev                latest                                     50a5c1c919b3        10 days ago         2.88GB
oldev                latest                                     50a5c1c919b3        10 days ago         2.88GB
oldev                latest                                     50a5c1c919b3        10 days ago         2.88GB
oldev                latest                                     50a5c1c919b3        10 days ago         2.88GB
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
