### PR TITLE
URL encode redirect locations in headers on borrow 

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -230,7 +230,7 @@ def get_groundtruth_availability(ocaid, s3_keys=None):
     including 1-hour borrows"""
     params = '?action=availability&identifier=' + ocaid
     url = S3_LOAN_URL % config_bookreader_host
-    # TODO: This does not handle unexpected responses from the availablity server.
+    # TODO: This does not handle unexpected responses from the availability server.
     r = requests.post(url + params, data=s3_keys)
     data = r.json().get('lending_status')
     # For debugging
@@ -309,7 +309,7 @@ def get_availability(key, ids):
     :param list of str ids:
     :rtype: dict
     """
-    ids = [id_ for id_ in ids if id_]
+    ids = [id_ for id_ in ids if id_]  # remove infogami.infobase.client.Nothing
     if not ids:
         return {}
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -230,9 +230,12 @@ def get_groundtruth_availability(ocaid, s3_keys=None):
     including 1-hour borrows"""
     params = '?action=availability&identifier=' + ocaid
     url = S3_LOAN_URL % config_bookreader_host
-    # TODO: This does not handle unexpected responses from the availability server.
-    r = requests.post(url + params, data=s3_keys)
-    data = r.json().get('lending_status')
+   try:
+        response = requests.post(url + params, data=s3_keys)
+        response.raise_for_status()
+    except requests.HTTPError:
+        pass  # TODO: Handle unexpected responses from the availability server.
+    data = response.json().get('lending_status')
     # For debugging
     data['__src__'] = 'core.models.lending.get_groundtruth_availability'
     return data

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -230,6 +230,7 @@ def get_groundtruth_availability(ocaid, s3_keys=None):
     including 1-hour borrows"""
     params = '?action=availability&identifier=' + ocaid
     url = S3_LOAN_URL % config_bookreader_host
+    # TODO: This does not handle unexpected responses from the availablity server.
     r = requests.post(url + params, data=s3_keys)
     data = r.json().get('lending_status')
     # For debugging
@@ -308,7 +309,7 @@ def get_availability(key, ids):
     :param list of str ids:
     :rtype: dict
     """
-
+    ids = [id_ for id_ in ids if id_]
     if not ids:
         return {}
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -139,7 +139,7 @@ class borrow(delegate.page):
         if not user or not ia_itemname or not s3_keys:
             web.setcookie(config.login_cookie_name, "", expires=-1)
             redirect_url = "/account/login?redirect=%s/borrow?action=%s" % (
-                edition.url(), action)
+                urllib.parse.quote(edition.url()), action)
             if i._autoReadAloud is not None:
                 redirect_url += '&_autoReadAloud=' + i._autoReadAloud
             raise web.seeother(redirect_url)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -129,7 +129,8 @@ class borrow(delegate.page):
         if availability and availability['status'] == 'open':
             raise web.seeother(archive_url)
 
-        error_redirect = (archive_url)
+        error_redirect = archive_url
+        edition_redirect = urllib.parse.quote(edition.url())
         user = accounts.get_current_user()
 
         if user:
@@ -139,7 +140,7 @@ class borrow(delegate.page):
         if not user or not ia_itemname or not s3_keys:
             web.setcookie(config.login_cookie_name, "", expires=-1)
             redirect_url = "/account/login?redirect=%s/borrow?action=%s" % (
-                urllib.parse.quote(edition.url()), action)
+                edition_redirect, action)
             if i._autoReadAloud is not None:
                 redirect_url += '&_autoReadAloud=' + i._autoReadAloud
             raise web.seeother(redirect_url)
@@ -147,15 +148,15 @@ class borrow(delegate.page):
         if action == 'return':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='return_loan')
             stats.increment('ol.loans.return')
-            raise web.seeother(edition.url())
+            raise web.seeother(edition_redirect)
         elif action == 'join-waitinglist':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='join_waitlist')
             stats.increment('ol.loans.joinWaitlist')
-            raise web.redirect(edition.url())
+            raise web.redirect(edition_redirect)
         elif action == 'leave-waitinglist':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='leave_waitlist')
             stats.increment('ol.loans.leaveWaitlist')
-            raise web.redirect(edition.url())
+            raise web.redirect(edition_redirect)
 
         # Intercept a 'borrow' action if the user has already
         # borrowed the book and convert to a 'read' action.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4804

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes https://sentry.archive.org/sentry/ol-web/issues/10505/ which looks like it would be preventing patrons from performing various borrow operations on any book with utf8 encoded titles.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
