### PR TITLE
Make BookNotes edition-level

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -486,11 +486,12 @@ class Work(Thing):
         status_id = Bookshelves.get_users_read_status_of_work(username, work_id)
         return status_id
 
-    def get_users_notes(self, username):
+    def get_users_notes(self, username, edition_olid=None):
         if not username:
             return None
         work_id = extract_numeric_id_from_olid(self.key)
-        return Booknotes.get_patron_booknote(username, work_id)
+        edition_id = extract_numeric_id_from_olid(edition_olid) if edition_olid else -1
+        return Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)
 
     def get_num_users_by_bookshelf(self):
         if not self.key:  # a dummy work

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -12,11 +12,11 @@ CREATE TABLE ratings (
 CREATE TABLE booknotes (
     username text NOT NULL,
     work_id integer NOT NULL,
-    edition_id integer default null,
+    edition_id integer NOT NULL default -1,
     notes text NOT NULL,
     updated timestamp without time zone default (current_timestamp at time zone 'utc'),
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
-    primary key (username, work_id)
+    primary key (username, work_id, edition_id)
 );
 
 CREATE TABLE bookshelves (

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -2,7 +2,7 @@ $def with (work, edition)
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ has_edition = edition is not None
-$ notes = work.get_users_notes(username)
+$ notes = work.get_users_notes(username) if has_edition else work.get_users_notes(username, edition.key.split('/')[-1])
 $ book_descriptor = _("work")
 
 $ i18n_strings = {
@@ -34,7 +34,9 @@ $if has_edition:
       <div>
         <textarea name="notes" rows="10">$(notes.notes if notes else "")</textarea>
       </div>
-      <button class="cta-btn"type="submit" form="book-notes-form">Save Note</button>
+      $if has_edition:
+        <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
+      <button class="cta-btn"type="submit">Save Note</button>
     </form>
     <div class="floaterHead">
       <h2>$_("Observations")</h2>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `edition_id` to the `booknotes` table's primary key, enabling patrons to make notes for specific editions of a work.  

Also corrects a bug that was causing book notes submissions to fail.

### Technical
<!-- What should be noted about the implementation? -->
`form` attribute was removed from book notes submission button.  This was preventing the form from being submitted.

`edition_id` defaults to -1 for work-level book notes.

The following queries should be executed before merging this code:
```
ALTER TABLE booknotes ALTER COLUMN edition_id SET DEFAULT -1;
UPDATE booknotes SET edition_id = -1 WHERE edition_id IS NULL;
ALTER TABLE booknotes DROP CONSTRAINT booknotes_pkey;
ALTER TABLE booknotes ADD PRIMARY KEY (username, work_id, edition_id);
```
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:
1. Navigate to a book page for a work that has several editions.
2. Open the notes modal and submit a book note.
3. Refresh the page and reopen the modal, checking for the note that you just left.
4. Navigate to a page for a different edition of the same work.
5. Open the notes modal and make sure that the note that you previously left is not present.
6. Refresh the page, open the modal, and ensure that the correct note is present.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 