### PR TITLE
remove docker development note from readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,8 +36,6 @@ Here's a quick public tour of Open Library to get your familiar with the service
 
 The development environment can be set up using the [Docker Instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md). You can also watch the [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4) for a more detailed explanation.
 
-Our `Docker` environment is in active development. Want to contribute? Here's our top-level [`Docker` todo-list](https://github.com/internetarchive/openlibrary/issues/1067) and a [list of open `Docker` issues](https://github.com/internetarchive/openlibrary/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Adocker).
-
 ### Developer's Guide
 
 For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide. 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
I didn't see an issue about this. I can make one if needed.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is just to improve documentation. There was a note in the readme about docker still being in active development. However, it linked to a close ticket and a label with no issues. As such, I don't think the note is needed anymore.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
I'm not sure who the stakeholders are but if you do I would appreciate it if you tagged them.
