### PR TITLE
Improve structured data for book name

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -25,14 +25,14 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
 
   <div class="details">
       <div class="resultTitle">
-         <h3 class="booktitle">
-           <a itemprop="name" href="$(book_url)?edition=$(ocaid)"
+         <h3 itemprop="name" class="booktitle">
+           <a itemprop="url" href="$(book_url)?edition=$(ocaid)"
               class="results">$doc.title$(': ' + doc.subtitle if doc.get('subtitle', None) else '')</a>
            $if doc.get('publish_date'):
              ($(doc['publish_date']))
          </h3>
         </div>
-      <span class="bookauthor">$_('by')
+      <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">$_('by')
         $if not doc.authors:
           <em>$_('Unknown author')</em>
         $else:
@@ -40,7 +40,7 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
             $if not (hasattr(a, 'name') and a.name) and not (hasattr(a, 'author') and hasattr(a.author, 'name') and a.author.name):
               <em>$_('Unknown author')</em>$(',' if not loop.last else '')
               $continue
-            <a itemprop="author" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
+            <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
       </span>
       <span class="resultPublisher">
         $if doc.get('first_publish_year'):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4883 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix book `name` from `URL` to `name`
Fix author `@type` from `Thing` to `Organization` 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/112424592-b6e58400-8d5a-11eb-99d4-29d685011541.png)
I noticed that even changing `itemprop` from `name` to `URL` and back to `name` changes the URL domain, so I think we can go ahead with the solution???

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@hornc 