### PR TITLE
Smaller Docker images with apt-get --no-install-recommends

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -12,7 +12,7 @@ RUN groupadd --system openlibrary \
   && useradd --no-log-init --system --gid openlibrary --create-home openlibrary
 
 # Misc OL dependencies
-RUN apt-get -qq update && apt-get install -y \
+RUN apt-get -qq update && apt-get install --no-install-recommends -y \
     postgresql-client \
     build-essential \
     git \
@@ -36,13 +36,13 @@ RUN echo 'will cite' | parallel --citation
 
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install -y nodejs
+    && apt-get install --no-install-recommends -y nodejs
 
 # Install pyenv
 # Python build deps: https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
-RUN apt-get -qq update && apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+RUN apt-get -qq update && apt-get install --no-install-recommends -y build-essential \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
 
 # Install latest pyenv (https://github.com/pyenv/pyenv-installer)
 USER openlibrary

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -36,7 +36,7 @@ RUN echo 'will cite' | parallel --citation
 
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install --no-install-recommends -y nodejs
+    && apt-get install -y nodejs
 
 # Install pyenv
 # Python build deps: https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -40,9 +40,9 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
 
 # Install pyenv
 # Python build deps: https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
-RUN apt-get -qq update && apt-get install --no-install-recommends -y build-essential \
-    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-    libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+RUN apt-get -qq update && apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils \
+    tk-dev libffi-dev liblzma-dev python-openssl git
 
 # Install latest pyenv (https://github.com/pyenv/pyenv-installer)
 USER openlibrary

--- a/docker/Dockerfile.olsolr
+++ b/docker/Dockerfile.olsolr
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 
 RUN apt-get -qq update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y solr-tomcat haproxy cron && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends solr-tomcat haproxy cron && \
     ln -s /var/log/tomcat7/ /usr/share/tomcat7/logs && \
     ln -s /etc/tomcat7/ /usr/share/tomcat7/conf
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2656

Both `npm` (Node.js) and `pyenv` failed with `--no-install-recommends` (see commits).

The image size difference is insignificant.  My sense is that a better optimization would be to bundle all apt-get install commands into a single command and then do a [multi-stage build](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds).
```
Before: oldev        latest    c468ac0b4ce7   X hours ago   2.49GB
After:  oldev        latest    97a8e161b31b   Y hours ago   2.49GB
```
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The following commands work as expected:
% `docker-compose run --rm home make test `
% `docker-compose down && docker-compose up -d && docker-compose logs -f --tail=10`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
