### PR TITLE
Fix Bad UI of User Lists

### DIFF
--- a/openlibrary/templates/lists/snippet.html
+++ b/openlibrary/templates/lists/snippet.html
@@ -19,7 +19,7 @@ $def with (list)
             $if list.description:
                 $:sanitize(format(list.description))
             $else:
-                <em>$_('No description.')</em>
+                <p>$_('No description.')</p>
         </span>
     </span>
 </span>

--- a/openlibrary/templates/lists/snippet.html
+++ b/openlibrary/templates/lists/snippet.html
@@ -5,8 +5,8 @@ $def with (list)
     $ title = _("Cover of: %(listname)s", listname=list)
     <a href="$list.key"><img src="$cover_url" height="58" alt="$title" title="$title"/></a>
 </span>
-<span class="details">
-    <span class="resultTitle">
+<div class="details">
+    <div class="resultTitle">
         <h3>
             <a href="$list.key" class="results"><b>$list.name</b></a>
         </h3>
@@ -21,5 +21,5 @@ $def with (list)
             $else:
                 <p>$_('No description.')</p>
         </div>
-    </span>
-</span>
+    </div>
+</div>

--- a/openlibrary/templates/lists/snippet.html
+++ b/openlibrary/templates/lists/snippet.html
@@ -15,11 +15,11 @@ $def with (list)
             $if list.last_update:
                 | $_('Last modified %(date)s', date=datestr(list.last_modified))
         </span>
-        <span class="detail">
+        <div class="detail">
             $if list.description:
                 $:sanitize(format(list.description))
             $else:
                 <p>$_('No description.')</p>
-        </span>
+        </div>
     </span>
 </span>

--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -47,7 +47,7 @@
     margin-bottom: 0;
   }
   li {
-    width: 270px;
+    width: 280px;
     margin-right: 10px;
   }
   span.imageLg {
@@ -72,6 +72,7 @@
     margin-top: 0;
     font-size: .6875em;
     color: @grey;
+    white-space: nowrap;
     padding-top: 3px;
     padding-bottom: 3px;
   }

--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -63,16 +63,15 @@
       height: auto;
     }
   }
-  span.details {
+  div.details {
     display: block;
     float: left;
-    width: 236px;
+    width: 260px;
   }
   span.editions {
     margin-top: 0;
     font-size: .6875em;
     color: @grey;
-    white-space: nowrap;
     padding-top: 3px;
     padding-bottom: 3px;
   }

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -29,7 +29,7 @@
     padding: 0 5px 0 15px;
   }
   h3 {
-    display: inline;
+    display: block;
     margin: 0;
     padding: 0;
     color: @dark-grey;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4794 
According to me, we should remove the No description from both the lists page and user lists.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Before:**
![image](https://user-images.githubusercontent.com/64412143/112728960-bd891c80-8f4f-11eb-9efd-b3ded3e14bee.png)
**Now:**
![image](https://user-images.githubusercontent.com/64412143/112728878-6420ed80-8f4f-11eb-8135-c14e12944fbb.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 