### PR TITLE
Update add method in bookshelves.py to address issue #4931

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -187,7 +187,7 @@ class Bookshelves(object):
         else:
             where = "work_id=$work_id AND username=$username"
             return oldb.update('bookshelves_books', where=where,
-                               bookshelf_id=bookshelf_id, vars=data)
+                               bookshelf_id=bookshelf_id, edition_id=edition_id, vars=data)
 
     @classmethod
     def remove(cls, username, work_id, bookshelf_id=None):


### PR DESCRIPTION
Add edition_id=edition_id to update method at line 189

<!-- What issue does this PR close? -->
Closes #4931

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
Modifies the update call in the add method to update the edition_id field in addition to the bookshelf_id. In other use cases, where the edition_id is empty or unchanged, no behavior change will be seen. 

### Testing
Add /books/OL24948639M/ to your reading log.

Submit a POST to  https://openlibrary.org/works/OL460810W/bookshelves.json with an add action and a specific edition_id: {'action':'add', 'redir':false, 'bookshelf_id':1, 'edition_id':'/books/OL7656518M', 'dont_remove':true}

If working correctly, the edition of the book on your reading log should change in the UI.

### Stakeholders
@mheiman
@mekarpeles 
