### PR TITLE
Use docker-compose profiles + cleanup old volume-mount cludges

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,32 +18,64 @@ services:
       # The above volume mounts are required so that the local dev bind mount below
       # does not clobber the data generated inside the image / container
       - .:/openlibrary
+    depends_on:
+      - db
+      - infobase
+
   solr-updater:
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
       - .:/openlibrary
+
   db:
+    image: postgres:9.3
+    networks:
+      - dbnet
     volumes:
       - .:/openlibrary
+      # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
+      # if the db is empty (which as of now is always, since we don't store the
+      # postgres data anywhere).
+      - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh
+
   covers:
     ports:
       - 7075:7075
     volumes:
       - ol-vendor:/openlibrary/vendor
       - .:/openlibrary
+
   infobase:
     ports:
       - 7000:7000
     volumes:
       - ol-vendor:/openlibrary/vendor
       - .:/openlibrary
+    depends_on:
+      - db
+
   home:
+    image: oldev:latest
+    environment:
+      - PYENV_VERSION=${PYENV_VERSION:-}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
+    command: docker/ol-home-start.sh
+    networks:
+      - webnet
+      - dbnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
     volumes:
       - ol-vendor:/openlibrary/vendor
       - ol-build:/openlibrary/static/build
       - ol-nodemodules:/openlibrary/node_modules
       - .:/openlibrary
+
 volumes:
   ol-vendor:
   ol-build:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -8,6 +8,7 @@
 version: "3.1"
 services:
   web:
+    profiles: ["ol-web1", "ol-web2"]
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -19,7 +20,12 @@ services:
       - ../olsystem:/olsystem
       - ../olsystem/etc/ia.ini:/home/openlibrary/.config/ia.ini
 
+  solr:
+    # TODO: Currently solr is deployed in a "special" way
+    profiles: []
+
   covers:
+    profiles: ["ol-covers0"]
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -28,7 +34,9 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - /1:/1
+
   covers_nginx:
+    profiles: ["ol-covers0"]
     image: nginx:1.19.4
     restart: always
     depends_on:
@@ -55,7 +63,12 @@ services:
       # Needed by default-docker.conf
       - ssl_certificate
       - ssl_certificate_key
+
+  memcached:
+    profiles: ["ol-covers0"]
+
   cron-jobs:
+    profiles: ["ol-home0"]
     image: oldev:latest
     hostname: "$HOSTNAME"
     build:
@@ -75,6 +88,7 @@ services:
       - ia_db_pw_file
 
   infobase:
+    profiles: ["ol-home0"]
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -84,7 +98,9 @@ services:
       - ../olsystem:/olsystem
       - infobase-writelog:/1/var/lib/openlibrary/infobase/log
       - infobase-errorlog:/1/var/log/openlibrary/infobase-errors
+
   infobase_nginx:
+    profiles: ["ol-home0"]
     image: nginx:1.19.4
     restart: always
     depends_on:
@@ -102,6 +118,7 @@ services:
       - petabox_seed
 
   affiliate-server:
+    profiles: ["ol-home0"]
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -121,7 +138,9 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+
   solr-updater:
+    profiles: ["ol-home0"]
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -135,7 +154,9 @@ services:
         max-file: "4"
     secrets:
       - ia_db_pw_file
+
   importbot:
+    profiles: ["ol-home0"]
     image: oldev:latest
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,6 @@ services:
     command: docker/ol-web-start.sh
     ports:
       - ${WEB_PORT:-8080}:8080
-    depends_on:
-      - db
-      - infobase
     networks:
       - webnet
       - dbnet
@@ -22,6 +19,7 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+
   solr:
     image: olsolr:latest
     build:
@@ -40,6 +38,7 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+
   solr-updater:
     image: oldev:latest
     build:
@@ -62,15 +61,7 @@ services:
     image: memcached
     networks:
       - webnet
-  db:
-    image: postgres:9.3
-    networks:
-      - dbnet
-    volumes:
-      # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
-      # if the db is empty (which as of now is always, since we don't store the
-      # postgres data anywhere).
-      - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh
+
   covers:
     image: oldev:latest
     environment:
@@ -90,6 +81,7 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+
   infobase:
     image: oldev:latest
     environment:
@@ -102,8 +94,6 @@ services:
     command: docker/ol-infobase-start.sh
     expose:
       - 7000
-    depends_on:
-      - db
     networks:
       - webnet
       - dbnet
@@ -111,21 +101,7 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
-  home:
-    image: oldev:latest
-    environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
-    command: docker/ol-home-start.sh
-    networks:
-      - webnet
-      - dbnet
-    logging:
-      options:
-        max-size: "512m"
-        max-file: "4"
+
 networks:
   webnet:
   dbnet:

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,0 +1,35 @@
+import os
+import yaml
+
+
+def p(*paths):
+    """Util to get absolute path from relative path"""
+    return os.path.join(os.path.dirname(__file__), *paths)
+
+
+class TestDockerCompose:
+    def test_all_root_services_must_be_in_prod(self):
+        """
+        Each service in docker-compose.yml should also be in
+        docker-compose.production.yml with a profile. Services without profiles will
+        match with any profile, meaning the service would get deployed everywhere!
+        """
+        with open(p('..', 'docker-compose.yml')) as f:
+            root_dc = yaml.load(f)  # type: dict
+        with open(p('..', 'docker-compose.production.yml')) as f:
+            prod_dc = yaml.load(f)  # type: dict
+        root_services = set(root_dc['services'].keys())
+        prod_services = set(prod_dc['services'].keys())
+        missing = root_services - prod_services
+        assert missing == set(), "docker-compose.production.yml missing services"
+
+    def test_all_prod_services_need_profile(self):
+        """
+        Without the profiles field, a service will get deployed to _every_ server. That
+        is not likely what you want. If that is what you want, add all server names to
+        this service to make things explicit.
+        """
+        with open(p('..', 'docker-compose.production.yml')) as f:
+            prod_dc = yaml.load(f)  # type: dict
+        for serv, opts in prod_dc['services'].items():
+            assert 'profiles' in opts, f"{serv} is missing 'profiles' field"


### PR DESCRIPTION
Refactor to remove some no longer needed deploy steps now that we no longer mount the repo.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
- Profiles let us simplify the `up` commands needed for each searver
- Since we're no longer using volume mounts, we no longer need to `down` before we `up`! Docker should automatically detect that oldev:latest has changed, and restart the right things.
- Also, no longer need `make i18n` since the built i18n files are in the image.
- Move dev only services to docker-compose.override.yml ; this makes things _way_ less error prone - it's now much harder to accidentally deploy a db service to prod.
- If a `profile` is not specified for a service, that service is _always_ started! Don't want that. Added a test to make sure no one accidentally does this.

### Testing
- [x] Only matching profiles start when so tagged
1. Added a `profiles: ["foo"]` to web in docker-compose.yml, and `profiles: []` to all other services (also in override)
2. `docker-compose --profile foo up -d --no-deps` only starts web

- [x] Can still `scale`
1. Added a `profiles: ["foo"]` to web & solr in docker-compose.yml, and `profiles: []` to all other services (also in override)
2. `docker-compose --profile foo up -d --no-deps --scale web=2` starts 2 web nodes, one solr node

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
