### PR TITLE
Add OLDEV_TAG environment variable

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -56,7 +56,7 @@ services:
       - db
 
   home:
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
     build:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -69,7 +69,7 @@ services:
 
   cron-jobs:
     profiles: ["ol-home0"]
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     hostname: "$HOSTNAME"
     build:
       context: .
@@ -123,7 +123,7 @@ services:
     hostname: "$HOSTNAME"
     environment:
       - AFFILIATE_CONFIG=/openlibrary.yml
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
@@ -157,7 +157,7 @@ services:
 
   importbot:
     profiles: ["ol-home0"]
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   web:
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
@@ -40,7 +40,7 @@ services:
         max-file: "4"
 
   solr-updater:
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
@@ -63,7 +63,7 @@ services:
       - webnet
 
   covers:
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
@@ -83,7 +83,7 @@ services:
         max-file: "4"
 
   infobase:
-    image: oldev:latest
+    image: "oldev:${OLDEV_TAG:-latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}


### PR DESCRIPTION
These will let us easily let us start a specific version.

<!-- What issue does this PR close? -->
Work towards #4830 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing

```
$ docker-compose config | grep image
WARNING: The HOSTNAME variable is not set. Defaulting to a blank string.
    image: oldev:latest
    image: postgres:9.3
    image: oldev:latest
    image: oldev:latest
    image: memcached
    image: olsolr:latest
    image: oldev:latest
    image: oldev:latest
```

```
$ OLDEV_TAG=333 docker-compose config | grep image
WARNING: The HOSTNAME variable is not set. Defaulting to a blank string.
    image: oldev:333
    image: postgres:9.3
    image: oldev:333
    image: oldev:333
    image: memcached
    image: olsolr:latest
    image: oldev:333
    image: oldev:333
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
