### PR TITLE
Remove submit button for observations in book notes modal

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "9.4KB"
+      "maxSize": "9.5KB"
     },
     {
       "path": "static/build/page-edit.css",

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -340,60 +340,72 @@ class Observations(object):
 
         return list(oldb.query(query, vars=data))
 
+    def get_multi_choice(type):
+        for o in get_observations()['observations']:
+            if o['label'] == type:
+                return o['multi_choice']
+
     @classmethod
-    def persist_observations(cls, username, work_id, observations, edition_id=NULL_EDITION_VALUE):
+    def persist_observation(cls, username, work_id, observation, action, edition_id=NULL_EDITION_VALUE):
         """
+        TODO: update: 
         Insert or update a collection of observations.  If no records exist
         for the given work_id, new observations are inserted.
 
         """
 
-        def get_observation_ids(observations):
+        def get_observation_ids(observation):
             """
-            Given a list of observation key-value pairs, returns a list of observation IDs.
+            Given an observation key-value pair, returns an ObservationIds tuple.
 
-            return: List of observation IDs
+            return: An ObservationsIds tuple
             """
-            observation_ids = []
+            key = list(observation)[0]
+            item = next((o for o in OBSERVATIONS['observations'] if o['label'] == key))
 
-            for o in observations:
-                key = list(o)[0]
-                observation = next((o for o in OBSERVATIONS['observations'] if o['label'] == key))
-                
-                observation_ids.append(
-                    ObservationIds(
-                        observation['id'],
-                        next((v['id'] for v in observation['values'] if v['name'] == o[key]))
-                    )
-                )
-
-            return observation_ids
+            return ObservationIds(
+                item['id'],
+                next((v['id'] for v in item['values'] if v['name'] == observation[key]))
+            )
 
         oldb = db.get_db()
-        records = cls.get_patron_observations(username, work_id)
+        data = {
+            'username': username,
+            'work_id': work_id,
+            'edition_id': edition_id,
+            'observation_type': observation_ids.type_id,
+            'observation_value': observation_ids.value_id
+        }
 
-        observation_ids = get_observation_ids(observations)
+        where_clause = 'username=$username AND work_id=$work_id AND observation_type=$observation_type '
 
-        for r in records:
-            record_ids = ObservationIds(r['type'], r['value'])
-            # Delete values that are in existing records but not in submitted observations
-            if record_ids not in observation_ids:
-                cls.remove_observations(
-                    username,
-                    work_id,
-                    edition_id=edition_id,
-                    observation_type=r['type'],
-                    observation_value=r['value']
-                )
-            else:
-                # If same value exists in both existing records and observations, remove from observations
-                observation_ids.remove(record_ids)
-                    
-        if len(observation_ids):
-            # Insert all remaining observations
-            oldb.multiple_insert('observations', 
-                [{'username': username, 'work_id': work_id, 'edition_id': edition_id, 'observation_value': id.value_id, 'observation_type': id.type_id} for id in observation_ids]
+        
+        if action == 'delete':
+            # Delete observation and return:
+            where_clause += 'AND observation_value=$observation_value'
+
+            return oldb.delete(
+                'observations',
+                vars=data,
+                where=where_clause
             )
+        elif not cls.get_multi_choice(list(observation)[0]):
+            # A radio button value has changed.  Delete old value, if one exists:
+            oldb.delete(
+                'observations',
+                vars=data,
+                where=where_clause
+            )
+
+        # Insert new value and return:
+        return oldb.insert(
+            'observations',
+            username=username,
+            work_id=work_id,
+            edition_id=edition_id,
+            observation_type=observation_ids.type_id,
+            observation_value=observation_ids.value_id
+        )
 
     @classmethod
     def remove_observations(cls, username, work_id, edition_id=NULL_EDITION_VALUE, observation_type=None, observation_value=None):

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -341,17 +341,27 @@ class Observations(object):
         return list(oldb.query(query, vars=data))
 
     def get_multi_choice(type):
-        for o in get_observations()['observations']:
+        """
+        Searches for the given type in the observations object, and returns the type's 'multi_choice' value.
+
+        return: The multi_choice value for the given type
+        """
+        for o in OBSERVATIONS['observations']:
             if o['label'] == type:
                 return o['multi_choice']
 
     @classmethod
     def persist_observation(cls, username, work_id, observation, action, edition_id=NULL_EDITION_VALUE):
         """
-        TODO: update: 
-        Insert or update a collection of observations.  If no records exist
-        for the given work_id, new observations are inserted.
+        Inserts or deletes a single observation, depending on the given action.
 
+        If the action is 'delete', the observation will be deleted from the observations table.
+
+        If the action is 'add', and the observation type only allows a single value (multi_choice == True), 
+        an attempt is made to delete previous observations of the same type before the new observation is 
+        persisted.
+
+        Otherwise, the new observation is stored in the DB.
         """
 
         def get_observation_ids(observation):
@@ -369,6 +379,8 @@ class Observations(object):
             )
 
         oldb = db.get_db()
+        observation_ids = get_observation_ids(observation)
+
         data = {
             'username': username,
             'work_id': work_id,

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -462,10 +462,11 @@ class patron_observations(delegate.page):
 
         data = json.loads(web.data())
 
-        Observations.persist_observations(
+        Observations.persist_observation(
             data['username'],
             work_id,
-            data['observations']
+            data['observation'],
+            data['action']
         )
 
         def response(msg, status="success"):

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -1,13 +1,17 @@
 import '../../../../../static/css/components/metadata-form.less';
 
+// Event name for submission status updates:
 const OBSERVATION_SUBMISSION = 'observationSubmission';
-const ANY = 'allSections';
 
+// Used to denote a submission state change for all sections:
+const ANY_SECTION_TYPE = 'allSections';
+
+// Denotes all possible states of an observation submission:
 const SubmissionState = {
-    INITIAL: 1,
-    PENDING: 2,
-    SUCCESS: 3,
-    FAILURE: 4
+    INITIAL: 1, // Initial state --- nothing has been submitted yet.
+    PENDING: 2, // A submission has been made, but the server has not yet responded.
+    SUCCESS: 3, // The observation was successfully processed by the server.
+    FAILURE: 4  // Something went wrong while the observation was being processed by the server.
 };
 
 export function initPatronMetadata() {
@@ -55,12 +59,21 @@ export function initPatronMetadata() {
                                     </div>
                                 </details>`);
 
+            /*
+            Adds an observation submission state change event handler to this section of the form.
+
+            The handler displays the appropriate submission state indicator depending on the given submission
+            state.
+
+            The handler takes a section type, which identifies which section's submission state should
+            change, and the new submission state.
+            */
             $formSection.on(OBSERVATION_SUBMISSION, function(event, sectionType, submissionState) {
                 let pendingSpan = $(this).find('.pending-indicator')[0];
                 let successSpan = $(this).find('.success-indicator')[0];
                 let failureSpan = $(this).find('.failure-indicator')[0];
 
-                if (sectionType === type || sectionType === ANY) {
+                if (sectionType === type || sectionType === ANY_SECTION_TYPE) {
                     switch (submissionState) {
                     case SubmissionState.INITIAL:
                         pendingSpan.classList.add('hidden');
@@ -132,7 +145,8 @@ export function initPatronMetadata() {
                         })
                 })
         } else {
-            $('.aspect-section').trigger(OBSERVATION_SUBMISSION, [ANY, SubmissionState.INITIAL]);
+            // Hide all submission state indicators when the modal is reopened:
+            $('.aspect-section').trigger(OBSERVATION_SUBMISSION, [ANY_SECTION_TYPE, SubmissionState.INITIAL]);
             displayModal();
         }
     });
@@ -161,7 +175,14 @@ function addToggleListeners($toggleElements) {
 
 
 /**
- * TODO: documentation
+ * Adds change listeners to each input in the observations section of the modal.
+ *
+ * For each checkbox and radio button in the observations form, a change listener
+ * that triggers observation submissions is added.  On change, a payload containing
+ * the username, action type ('add' when an input is checked, 'delete' when unchecked),
+ * and observation type and value are sent to the back-end server.
+ *
+ * @param {Object}  context  An object containing the patron's username and the work's OLID.
  */
 function addChangeListeners(context) {
     let $questionSections = $('.aspect-section');
@@ -191,7 +212,12 @@ function addChangeListeners(context) {
 }
 
 /**
- * TODO: documentation
+ * Submits an observation to the server and triggers submission status change events.
+ *
+ * @param {JQuery}  $input      The checkbox or radio button that is firing the change event.
+ * @param {String}  workOlid    The OLID for the work being observed.
+ * @param {Object}  data        Payload that will be sent to the back-end server.
+ * @param {String}  sectionType Name of the input's section.
  */
 function submitObservation($input, workOlid, data, sectionType) {
     // Show spinner:

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -1,5 +1,15 @@
 import '../../../../../static/css/components/metadata-form.less';
 
+const OBSERVATION_SUBMISSION = 'observationSubmission';
+const ANY = 'allSections';
+
+const SubmissionState = {
+    INITIAL: 1,
+    PENDING: 2,
+    SUCCESS: 3,
+    FAILURE: 4
+};
+
 export function initPatronMetadata() {
     function displayModal() {
         $.colorbox({
@@ -16,39 +26,75 @@ export function initPatronMetadata() {
             let className = observation.multi_choice ? 'multi-choice' : 'single-choice';
             let $choices = $(`<div class="${className}"></div>`);
             let choiceIndex = observation.values.length;
+            let type = observation.label;
 
             for (const value of observation.values) {
-                let choiceId = `${observation.label}Choice${choiceIndex--}`;
+                let choiceId = `${type}Choice${choiceIndex--}`;
                 let checked = '';
 
-                if (observation.label in selectedValues
-                    && selectedValues[observation.label].includes(value)) {
+                if (type in selectedValues
+                    && selectedValues[type].includes(value)) {
                     checked = 'checked';
                 }
 
                 $choices.append(`
                 <label for="${choiceId}" class="${className}-label">
-                            <input type=${observation.multi_choice ? 'checkbox': 'radio'} name="${observation.label}" id="${choiceId}" value="${value}" ${checked}>
-                            ${value}
-                        </label>`);
+                    <input type=${observation.multi_choice ? 'checkbox': 'radio'} name="${type}" id="${choiceId}" value="${value}" ${checked}>
+                    ${value}
+                </label>`);
             }
 
-            $form.append(`
-              <details class="aspect-section">
-                <summary>${observation.label}</summary>
-                <div id="${observation.label}-question">
-                    <h3>${observation.description}</h3>
-                    ${$choices.prop('outerHTML')}
-                </div>
-              </details>
-            `);
-        }
+            let $formSection = $(`<details class="aspect-section" open>
+                                    <summary>${type}</summary>
+                                    <div id="${type}-question">
+                                        <h3>${observation.description}</h3>
+                                        <span class="pending-indicator hidden"></span>
+                                        <span class="success-indicator hidden">Selection saved!</span>
+                                        <span class="failure-indicator hidden">Submission failed</span>
+                                        ${$choices.prop('outerHTML')}
+                                    </div>
+                                </details>`);
 
+            $formSection.on(OBSERVATION_SUBMISSION, function(event, sectionType, submissionState) {
+                let pendingSpan = $(this).find('.pending-indicator')[0];
+                let successSpan = $(this).find('.success-indicator')[0];
+                let failureSpan = $(this).find('.failure-indicator')[0];
+
+                if (sectionType === type || sectionType === ANY) {
+                    switch (submissionState) {
+                    case SubmissionState.INITIAL:
+                        pendingSpan.classList.add('hidden');
+                        successSpan.classList.add('hidden');
+                        failureSpan.classList.add('hidden');
+                        break;
+                    case SubmissionState.PENDING:
+                        pendingSpan.classList.remove('hidden');
+
+                        successSpan.classList.add('hidden');
+                        failureSpan.classList.add('hidden');
+                        break;
+                    case SubmissionState.SUCCESS:
+                        successSpan.classList.remove('hidden');
+
+                        pendingSpan.classList.add('hidden');
+                        failureSpan.classList.add('hidden');
+                        break;
+                    case SubmissionState.FAILURE:
+                        failureSpan.classList.remove('hidden');
+
+                        pendingSpan.classList.add('hidden');
+                        successSpan.classList.add('hidden');
+                        break;
+                    }
+                }
+            })
+
+            $form.append($formSection);
+        }
         $form.append(`
             <div class="formElement metadata-submit">
               <div class="form-buttons">
                 <a class="small dialog--close plain" href="javascript:;" id="cancel-submission">${i18nStrings.close_text}</a>
-                <input class="cta-btn submit-btn" type="submit" value="${i18nStrings.submit_text}">
               </div>
             </div>`);
 
@@ -75,6 +121,7 @@ export function initPatronMetadata() {
                     })
                         .done(function(data) {
                             populateForm($('#user-metadata'), data.observations, selectedValues);
+                            addChangeListeners(context);
                             $('#cancel-submission').click(function() {
                                 $.colorbox.close();
                             })
@@ -85,47 +132,8 @@ export function initPatronMetadata() {
                         })
                 })
         } else {
+            $('.aspect-section').trigger(OBSERVATION_SUBMISSION, [ANY, SubmissionState.INITIAL]);
             displayModal();
-        }
-    });
-
-    $('#user-metadata').on('submit', function(event) {
-        event.preventDefault();
-
-        let context = JSON.parse(document.querySelector('#modal-link').dataset.context);
-        let result = {};
-
-        result['username'] = context.username;
-        let workId = context.work.split('/')[2];
-
-        if (context.edition) {
-            result['edition_id'] = context.edition.split('/')[2];
-        }
-
-        result['observations'] = [];
-
-        $(this).find('input[type=radio]:checked').each(function() {
-            let currentPair = {};
-            currentPair[$(this).attr('name')] = $(this).val()
-            result['observations'].push(currentPair);
-        })
-
-        $(this).find('input[type=checkbox]:checked').each(function() {
-            let currentPair = {};
-            currentPair[$(this).attr('name')] = $(this).val()
-            result['observations'].push(currentPair);
-        })
-
-        if (result['observations'].length > 0) {
-            $.ajax({
-                type: 'POST',
-                url: `/works/${workId}/observations`,
-                contentType: 'application/json',
-                data: JSON.stringify(result)
-            });
-            $.colorbox.close();
-        } else {
-            // TODO: Handle case where no data was submitted
         }
     });
 }
@@ -149,4 +157,59 @@ function addToggleListeners($toggleElements) {
     $toggleElements.each(function() {
         $(this).on('toggle', toggleHandler);
     })
+}
+
+
+/**
+ * TODO: documentation
+ */
+function addChangeListeners(context) {
+    let $questionSections = $('.aspect-section');
+    let username = context.username;
+    let workOlid = context.work.split('/')[2];
+
+    $questionSections.each(function() {
+        let $inputs = $(this).find('input')
+
+        $inputs.each(function() {
+            $(this).on('change', function() {
+                let type = $(this).attr('name');
+                let value = $(this).attr('value');
+                let observation = {};
+                observation[type] = value;
+
+                let data = {
+                    username: username,
+                    action: `${$(this).prop('checked') ? 'add': 'delete'}`,
+                    observation: observation
+                }
+
+                submitObservation($(this), workOlid, data, type);
+            });
+        })
+    });
+}
+
+/**
+ * TODO: documentation
+ */
+function submitObservation($input, workOlid, data, sectionType) {
+    // Show spinner:
+    $input.trigger(OBSERVATION_SUBMISSION, [sectionType, SubmissionState.PENDING]);
+
+    // Make AJAX call
+    $.ajax({
+        type: 'POST',
+        url: `/works/${workOlid}/observations`,
+        contentType: 'application/json',
+        data: JSON.stringify(data)
+    })
+        .done(function() {
+            // Show success message:
+            $input.trigger(OBSERVATION_SUBMISSION, [sectionType, SubmissionState.SUCCESS]);
+        })
+        .fail(function() {
+            // Show failure message:
+            $input.trigger(OBSERVATION_SUBMISSION, [sectionType, SubmissionState.FAILURE]);
+        });
 }

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -3,11 +3,11 @@
 @import (reference) "./buttonBtn.less";
 
 .failure-indicator {
-  color: red;
+  color: @red;
 }
 
 .success-indicator {
-  color: green;
+  color: @green;
 }
 
 .pending-indicator{
@@ -22,8 +22,8 @@
   width: 1em;
   height: 1em;
   border-radius: 50%;
-  border: 1px solid black;
-  border-color: black transparent black transparent;
+  border: 1px solid @black;
+  border-color: @black transparent;
   animation: pending-indicator 1.2s linear infinite;
 }
 
@@ -183,7 +183,7 @@
       display: block;
     }
   }
-  
+
   .pending-indicator,
   .success-indicator,
   .failure-indicator {

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -2,6 +2,40 @@
 @import (reference) "../less/colors.less";
 @import (reference) "./buttonBtn.less";
 
+.failure-indicator {
+  color: red;
+}
+
+.success-indicator {
+  color: green;
+}
+
+.pending-indicator{
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}
+
+.pending-indicator:after {
+  content: " ";
+  display: block;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  border: 1px solid black;
+  border-color: black transparent black transparent;
+  animation: pending-indicator 1.2s linear infinite;
+}
+
+@keyframes pending-indicator {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .single-choice {
   display: flex;
   margin-bottom: .5em;
@@ -73,6 +107,11 @@
     padding-left: .5em;
     padding-bottom: .5em;
   }
+
+  h3 {
+    display: inline-block;
+    margin-right: .5em;
+  }
 }
 
 .book-notes-form {
@@ -136,5 +175,19 @@
       margin-bottom: 1.5em;
       margin-top: .5em;
     }
+  }
+
+  .aspect-section {
+    h3 {
+      margin-right: unset;
+      display: block;
+    }
+  }
+  
+  .pending-indicator,
+  .success-indicator,
+  .failure-indicator {
+    display: block;
+    height: 1em;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Observations are now POSTed to the server every time an input is checked or unchecked in the book notes modal.  A section-level submission indicator is displayed in order to notify patrons of the submission status.

Details sections in observations form are also now open by default.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:
1. Navigate to a book page.
2. Open the book notes modal.
3. Click on any observation radio button or checkbox.
4. Ensure that you receive a success message.
5. Refresh the page.
6. Open the modal again, ensuring that the previously selected radio button or checkbox is selected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Successful submission:

![ajax_success](https://user-images.githubusercontent.com/28732543/113069262-f282b280-918d-11eb-90b5-d40a50a0aaea.gif)

Failed submission:

![ajax_failure](https://user-images.githubusercontent.com/28732543/113069275-fb738400-918d-11eb-975b-6c4c48b27410.gif)

**Note:** Timeout added in above examples to better show the pending indicator.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 
