### PR TITLE
Create aggregate observations component for book pages

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "9.5KB"
+      "maxSize": "9.6KB"
     },
     {
       "path": "static/build/page-edit.css",

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -243,7 +243,7 @@ OBSERVATIONS = {
     ]
 }
 
-#@cache.memoize(engine="memcache", key="observations", expires=config.get('observation_cache_duration'))
+@cache.memoize(engine="memcache", key="observations", expires=config.get('observation_cache_duration'))
 def get_observations():
     """
     Returns a dictionary of observations that are used to populate forms for patron feedback about a book.

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -12,4 +12,8 @@ $def with (edition_count=1)
   <li>
     <a href="#edition-details">$_("This Edition")</a>
   </li>
+  $if ctx.user and ctx.user.is_beta_tester():
+    <li>
+      <a href="#reader-observations">$_("Reader Observations")</a>
+    </li>
 </ul>

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -12,6 +12,7 @@ $def with (edition_count=1)
   <li>
     <a href="#edition-details">$_("This Edition")</a>
   </li>
+  $# BookNotes feature:
   $if ctx.user and ctx.user.is_beta_tester():
     <li>
       <a href="#reader-observations">$_("Reader Observations")</a>

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -1,4 +1,4 @@
-$def with (work, edition)
+$def with (work, edition, id, classes='')
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ has_edition = edition is not None
@@ -12,19 +12,19 @@ $ i18n_strings = {
 
 $ context = {
   $ "username": username,
-  $ "work": work.key
+  $ "work": work.key,
+  $ "id": id
   $ }
 
 $if has_edition:
   $ context["edition"] = edition.key
   $ book_descriptor = _("edition")
 
-<div class="cta-section patron-metadata">
-  <a id="modal-link" href="javascript:;" data-context="$json_encode(context)" data-i18n="$json_encode(i18n_strings)">$_("My book notes")</a>
-</div>
+<div class="$classes">
+  <a class="modal-link" href="javascript:;" data-context="$json_encode(context)" data-i18n="$json_encode(i18n_strings)">$_("My book notes")</a>
 
 <div class="hidden">
-  <div id="metadata-form" class="floaterAdd">
+  <div id="$id-metadata-form" class="floaterAdd metadata-form">
     <div class="floaterHead">
       <h2>$_("My Book Notes")</h2>
       <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
@@ -42,6 +42,8 @@ $if has_edition:
       <h2>$_("Observations")</h2>
     </div>
     <p class="observation-instructions">Additional observations about this $book_descriptor. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.</p>
-    <form class="floatform" name="user-metadata" id="user-metadata"></form>
+    <form class="floatform" name="$id-user-metadata" id="$id-user-metadata"></form>
   </div>
 </div>
+
+

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -2,7 +2,7 @@ $def with (work, edition, link_text, id, classes='')
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ has_edition = edition is not None
-$ notes = work.get_users_notes(username) if has_edition else work.get_users_notes(username, edition.key.split('/')[-1])
+$ notes = work.get_users_notes(username) if not has_edition else work.get_users_notes(username, edition.key.split('/')[-1])
 $ book_descriptor = _("work")
 
 $ i18n_strings = {
@@ -36,7 +36,7 @@ $if has_edition:
         </div>
         $if has_edition:
           <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
-        <button class="cta-btn"type="submit" form="book-notes-form">Save Note</button>
+        <button class="cta-btn"type="submit">Save Note</button>
       </form>
       <div class="floaterHead">
         <h2>$_("Observations")</h2>

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -1,4 +1,4 @@
-$def with (work, edition, id, classes='')
+$def with (work, edition, link_text, id, classes='')
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ has_edition = edition is not None
@@ -21,7 +21,7 @@ $if has_edition:
   $ book_descriptor = _("edition")
 
 <div class="$classes">
-  <a class="modal-link" href="javascript:;" data-context="$json_encode(context)" data-i18n="$json_encode(i18n_strings)">$_("My book notes")</a>
+  <a class="modal-link" href="javascript:;" data-context="$json_encode(context)" data-i18n="$json_encode(i18n_strings)">$link_text</a>
 
 <div class="hidden">
   <div id="$id-metadata-form" class="floaterAdd metadata-form">

--- a/openlibrary/macros/UserMetadata.html
+++ b/openlibrary/macros/UserMetadata.html
@@ -23,27 +23,26 @@ $if has_edition:
 <div class="$classes">
   <a class="modal-link" href="javascript:;" data-context="$json_encode(context)" data-i18n="$json_encode(i18n_strings)">$link_text</a>
 
-<div class="hidden">
-  <div id="$id-metadata-form" class="floaterAdd metadata-form">
-    <div class="floaterHead">
-      <h2>$_("My Book Notes")</h2>
-      <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
-    </div>
-    <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
-      <p>My personal notes about this $book_descriptor:</p>
-      <div>
-        <textarea name="notes" rows="10">$(notes.notes if notes else "")</textarea>
+  <div class="hidden">
+    <div id="$id-metadata-form" class="floaterAdd metadata-form">
+      <div class="floaterHead">
+        <h2>$_("My Book Notes")</h2>
+        <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
       </div>
-      $if has_edition:
-        <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
-      <button class="cta-btn"type="submit">Save Note</button>
-    </form>
-    <div class="floaterHead">
-      <h2>$_("Observations")</h2>
+      <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
+        <p>My personal notes about this $book_descriptor:</p>
+        <div>
+          <textarea name="notes" rows="10">$(notes.notes if notes else "")</textarea>
+        </div>
+        $if has_edition:
+          <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
+        <button class="cta-btn"type="submit" form="book-notes-form">Save Note</button>
+      </form>
+      <div class="floaterHead">
+        <h2>$_("Observations")</h2>
+      </div>
+      <p class="observation-instructions">Additional observations about this $book_descriptor. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.</p>
+      <form class="floatform" name="$id-user-metadata" id="$id-user-metadata"></form>
     </div>
-    <p class="observation-instructions">Additional observations about this $book_descriptor. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.</p>
-    <form class="floatform" name="$id-user-metadata" id="$id-user-metadata"></form>
   </div>
 </div>
-
-

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -140,7 +140,7 @@ jQuery(function () {
             .then((module) => module.init());
     }
 
-    if (document.getElementById('modal-link')) {
+    if (document.getElementsByClassName('modal-link').length) {
         import(/* webpackChunkName: "patron_metadata" */ './patron-metadata')
             .then((module) => module.initPatronMetadata());
     }

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -148,7 +148,7 @@ export function initPatronMetadata() {
         } else {
             // Hide all submission state indicators when the modal is reopened:
             $('.aspect-section').trigger(OBSERVATION_SUBMISSION, [ANY_SECTION_TYPE, SubmissionState.INITIAL]);
-            displayModal();
+            displayModal(context.id);
         }
     });
 }

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -110,7 +110,7 @@ export function initPatronMetadata() {
               </div>
             </div>`);
 
-        addToggleListeners($('.aspect-section', $form));
+        addToggleListeners($('.aspect-section', $form), id);
     }
 
     $('.modal-link').on('click', function() {
@@ -155,12 +155,14 @@ export function initPatronMetadata() {
 
 /**
  * Resizes modal when a details element is opened or closed.
+ *
+ * @param {Event} event Toggle event that triggered this handler.
  */
-function toggleHandler() {
-    let formHeight = $('#metadata-form').height();
+function toggleHandler(event) {
+    let formHeight = $(`#${event.data.id}-metadata-form`).height();
 
-    $('#cboxContent').height(formHeight + 22);
-    $('#cboxLoadedContent').height(formHeight);
+    event.data.$element.closest('#cboxContent').height(formHeight + 22);
+    event.data.$element.closest('#cboxLoadedContent').height(formHeight);
 }
 
 /**
@@ -168,9 +170,12 @@ function toggleHandler() {
  *
  * @param {JQuery} $toggleElements`Elements that will receive toggle handlers.
  */
-function addToggleListeners($toggleElements) {
+function addToggleListeners($toggleElements, id) {
     $toggleElements.each(function() {
-        $(this).on('toggle', toggleHandler);
+        $(this).on('toggle', {
+            $element: $(this),
+            id: id
+        }, toggleHandler);
     })
 }
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -283,8 +283,9 @@ $if include_widget:
     $if include_rating:
       $:macros.StarRatings(work, edition)
 
+    $# BookNotes feature:
     $if ctx.user and ctx.user.is_beta_tester():
-      $:macros.UserMetadata(work, edition, 'cta', 'cta-section patron-metadata')
+      $:macros.UserMetadata(work, edition, _("My book notes"), 'cta', 'cta-section patron-metadata')
 
 
 $if include_showcase:

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -284,7 +284,7 @@ $if include_widget:
       $:macros.StarRatings(work, edition)
 
     $if ctx.user and ctx.user.is_beta_tester():
-      $:macros.UserMetadata(work, edition)
+      $:macros.UserMetadata(work, edition, 'cta', 'cta-section patron-metadata')
 
 
 $if include_showcase:

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -1,33 +1,36 @@
-$def with(work, edition, reader_observations, work_title)
+$def with(work, edition, reader_observations, work_title, key)
+
 <a name="reader-observations" class="section-anchor"></a>      
 
-<div class="tab-section edition-info">
-  <h2 class="work-title">Reader Observations</h2>
+<div class="tab-section">
+  <h2 class="observation-title">Reader Observations</h2>
   <div class="work-line">$work_title</div>
   $if reader_observations['total_respondents']:
-    <h4 class="publisher">
+    <h4 class="observer-count">
       $ungettext('Based on observations from %(count)s patron', 'Based on observations from %(count)s patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
     </h4>
     <hr>
     $for o in reader_observations['observations']:
       $ total = o['total_respondents']
       <div class="section">
-        <h3 class="edition-header" style="margin-bottom: 1em;">$o['description']</h3>
-        <div class="edition-description">
+        <h3 class="observation-header">$o['description']</h3>
+        <div>
           <p>
           $for v in o['values']:
             $ percentage = (v['count'] / total) * 100
-            <span style="margin-right: .5em;"><span style="font-weight: bold;">$v['value'].capitalize():</span> $int(percentage)%</span>
+            <span class="observation-percentage"><span class="observation-value">$v['value'].capitalize():</span> $int(percentage)%</span>
           </p>
         </div>
       </div>
   $else:
     <hr>
-    <div style="margin: .5em auto .25em; display: block;width: max-content;">No observations submitted for this work.</div>
-  <!-- If logged in render UserMetadata.html, passing edition and new section attribute -->
+    <div class="no-stats-message">No observations submitted for this work.</div>
   <hr>
-  $if reader_observations['total_respondents']:
-    <a href="javascript:;" style="margin: .5em auto .25em; display: block;width: max-content;">Share your observations</a>
+  $if ctx.user:
+    $if reader_observations['total_respondents']:
+      $:macros.UserMetadata(work, edition, 'Share your observations', 'stats', 'stats-link')
+    $else:
+      $:macros.UserMetadata(work, edition, 'Be the first to share your observations', 'stats', 'stats-link')
   $else:
-    <a href="javascript:;" style="margin: .5em auto .25em; display: block;width: max-content;">Be the first to share your observations</a>
+    <a class="stats-link" href="/account/login?redirect=$key">Log in to share your observations</a>
 </div>

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -7,7 +7,7 @@ $def with(work, edition, reader_observations, work_title, key)
   <div class="work-line">$work_title</div>
   $if reader_observations['total_respondents']:
     <h4 class="observer-count">
-      $ungettext('Based on observations from %(count)s patron', 'Based on observations from %(count)s patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
+      $:ungettext('Based on observations from <strong>%(count)s</strong> patron', 'Based on observations from <strong>%(count)s</strong> patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
     </h4>
     <hr>
     $for o in reader_observations['observations']:

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -11,7 +11,7 @@ $def with(work, edition, reader_observations, work_title, key)
     </h4>
     <hr>
     $for o in reader_observations['observations']:
-      $ total = o['total_respondents']
+      $ total = o['total_respondents_for_type']
       <div class="section">
         <h3 class="observation-header">$o['description']</h3>
         <div>

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -1,0 +1,33 @@
+$def with(work, edition, reader_observations, work_title)
+<a name="reader-observations" class="section-anchor"></a>      
+
+<div class="tab-section edition-info">
+  <h2 class="work-title">Reader Observations</h2>
+  <div class="work-line">$work_title</div>
+  $if reader_observations['total_respondents']:
+    <h4 class="publisher">
+      $ungettext('Based on observations from %(count)s patron', 'Based on observations from %(count)s patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
+    </h4>
+    <hr>
+    $for o in reader_observations['observations']:
+      $ total = o['total_respondents']
+      <div class="section">
+        <h3 class="edition-header" style="margin-bottom: 1em;">$o['description']</h3>
+        <div class="edition-description">
+          <p>
+          $for v in o['values']:
+            $ percentage = (v['count'] / total) * 100
+            <span style="margin-right: .5em;"><span style="font-weight: bold;">$v['value'].capitalize():</span> $int(percentage)%</span>
+          </p>
+        </div>
+      </div>
+  $else:
+    <hr>
+    <div style="margin: .5em auto .25em; display: block;width: max-content;">No observations submitted for this work.</div>
+  <!-- If logged in render UserMetadata.html, passing edition and new section attribute -->
+  <hr>
+  $if reader_observations['total_respondents']:
+    <a href="javascript:;" style="margin: .5em auto .25em; display: block;width: max-content;">Share your observations</a>
+  $else:
+    <a href="javascript:;" style="margin: .5em auto .25em; display: block;width: max-content;">Be the first to share your observations</a>
+</div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -437,6 +437,10 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
             </dl>
           </div>
       </div>
+
+      $if ctx.user and ctx.user.is_beta_tester():
+        $ reader_observations = get_observation_metrics(work['key'])
+        $:render_template("observations/stats_component", work, edition, reader_observations, work_title)
     </div>
 
     <div class="workFooter">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -438,9 +438,10 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
           </div>
       </div>
 
+      $# BookNotes feature:
       $if ctx.user and ctx.user.is_beta_tester():
         $ reader_observations = get_observation_metrics(work['key'])
-        $:render_template("observations/stats_component", work, edition, reader_observations, work_title)
+        $:render_template("observations/stats_component", work, edition, reader_observations, work_title, page.key)
     </div>
 
     <div class="workFooter">

--- a/static/css/base/headings.less
+++ b/static/css/base/headings.less
@@ -102,7 +102,8 @@ h3 {
 
 h4 {
   font-size: .8125em;
-  &.publisher {
+  &.publisher,
+  &.observer-count {
     font-family: @lucida_sans_serif-1;
     font-weight: normal;
   }

--- a/static/css/components/observationStats.less
+++ b/static/css/components/observationStats.less
@@ -1,0 +1,24 @@
+.observation-title {
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+
+.observation-header {
+  font-size: 14px;
+  margin: 0 0 1em 0;
+}
+
+.observation-percentage {
+  margin-right: .5em;
+}
+
+.observation-value {
+  font-weight: bold;
+}
+
+.no-stats-message,
+.stats-link {
+  margin: .5em auto .25em;
+  display: block;
+  width: max-content;
+}

--- a/static/css/components/observationStats.less
+++ b/static/css/components/observationStats.less
@@ -5,7 +5,7 @@
 
 .observation-header {
   font-size: 14px;
-  margin: 0 0 1em 0;
+  margin: 0 0 1em;
 }
 
 .observation-percentage {

--- a/static/css/page-book.less
+++ b/static/css/page-book.less
@@ -27,6 +27,7 @@
 @import (less) "components/donate.less";
 
 @import (less) "components/metadata-form.less";
+@import (less) "components/observationStats.less";
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
   @import (less) "components/edit-toolbar--tablet.less";


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4867

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates a new component for book pages which displays patron observation statistics for the work.  A new "Reader Observations" tab has been added above the editions table to provide quick access to the new component.

### Technical
<!-- What should be noted about the implementation? -->
The book notes modal, `UserMetadata.html`, has been modified to accept a unique ID as a parameter.  This allows multiple modals to be displayed on a single page.  This may not be absolutely necessary for this PR, but it will be needed for the upcoming consolidated book notes view PR.

A modal link is included at the bottom of the new component, prompting patrons to leave their own observations about the work.  This link opens the login page for folks who are not already logged in.

Observation counts will not include deleted observation types and values.  The assumption about deleted types and values is that a boolean 'deleted' entry will be included at the observation or value level if an entire observation or a single value is deleted.

Only observations that have been submitted are displayed in the new component.  If nobody has submitted a "pacing" observation for a work, the "pacing" observation will be absent from the component.  If a specific value for an observation has not been submitted for a work, that value will also not be present in the component.

Observations in the component are listed by type ID, ascending.  Values for each observation are listed by most submitted to least submitted.

Statistics in the observations component are not automatically refreshed when new observations are submitted.  The page must be refreshed before the changes are visible.

Feature flags are used for the new component and tab.  One must be a member of the "beta-testers" group to see them.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:

1. Navigate to a book page.
2. Ensure that the "Reader Observations" tab exists, and that clicking it links to the new component.
3. Ensure that the statistics in the component are correct (it may be helpful to query the `observations` table to verify).
4. Ensure that the modal link in the observations component opens the book notes modal.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Observations component (observations for work exist):

![component-has_observations](https://user-images.githubusercontent.com/28732543/113199829-8eb3c480-9235-11eb-8525-b4cf1c94287a.png)

Observations component (no observations submitted for work):

![component-no_observations](https://user-images.githubusercontent.com/28732543/113199874-9f643a80-9235-11eb-9585-1294b5655de4.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 
