### PR TITLE
remove overflow hidden from edit tools

### DIFF
--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -16,7 +16,6 @@ div.editButton {
 
 div#editInfo {
   float: right;
-  overflow: hidden;
   white-space: nowrap;
   text-align: right;
   > div {
@@ -32,7 +31,6 @@ div#editInfo {
 
 div#editTools {
   white-space: nowrap;
-  overflow: hidden;
   padding: 0 0 1rem;
 }
 @import "components/buttonLink.less";


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes part of #4940 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This makes it so that the activity indicators in the [edit-toolbar](https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#edit-toolbar) are not cutoff.


### Technical
I verified this works correctly on FF and Chrome for Mac.
I also used the dev tools in FF and Chrome to confirm that in the mobile view it looks fine.

The only edge case that I could come up with that might be why this css exists in the first place is a very long username.
This change to the css does have an impact on how very long usernames appear. Though, I'm not sure if the difference matters that much. See screenshots bellow.

| Before | After |
| --- | --- | 
| ![image](https://user-images.githubusercontent.com/921217/113247189-37721c00-9256-11eb-90f6-6114ab94a757.png) | ![image](https://user-images.githubusercontent.com/921217/113247211-448f0b00-9256-11eb-9198-788bd5ea1daa.png)|

This could be kind-of fixed by:
`overflow-wrap: break-word`, `width: 100%`, and removing `white-space: nowrap` (as pictured below)

<img src="https://user-images.githubusercontent.com/921217/113247814-72c11a80-9257-11eb-9e65-8ef1832e180b.png" width="300">


However, it still leaves us with the issue of the edit button not being on the same line as the editInfo
Which, could be addressed by changing to `width: 70%` like so

<img src="https://user-images.githubusercontent.com/921217/113248106-fe3aab80-9257-11eb-8737-50148ad9f7a7.png" width="400">

However, hardcoding numbers like that is kinda crumby...

So we would probably be better off using a more modern `display: flex` and `flex-direction: row-reverse` (because for some reason the html of the edit button comes before the html of the editinfo) on edittools. And a `min-width: 1%` on edit info to give it some width per [SO](https://stackoverflow.com/a/36150764/620699). And we get:

<img src="https://user-images.githubusercontent.com/921217/113248896-7fdf0900-9259-11eb-883b-d398dfff80a7.png" width="300">

This seems like we're on the right track until we take a peek on mobile:

| | Before | After |
| -- | -- | -- |
| Short Name | ![image](https://user-images.githubusercontent.com/921217/113249439-625e6f00-925a-11eb-967a-23b19f60fb7e.png) |  ![image](https://user-images.githubusercontent.com/921217/113249575-9df93900-925a-11eb-9b5d-02ff423b3ce2.png)
| Long Name | ![image](https://user-images.githubusercontent.com/921217/113249465-6e4a3100-925a-11eb-8c1b-f54d2f38e3f7.png) | ![image](https://user-images.githubusercontent.com/921217/113249526-8b7eff80-925a-11eb-8551-7425b48a0169.png)


As you can tell:
* In the old screenshots the edit button was on the left (Not sure why it's only like that on mobile, not sure if it is intentional)
* In the new screenshots the edit button is on the right (just like on the desktop) but isn't too pretty.

<details>
  <summary>what it could look like with justify content space between and a long name</summary>
  
  
![image](https://user-images.githubusercontent.com/921217/113250528-5d022400-925c-11eb-9493-9da57e30a67c.png)

  
</details> 

^^ we can add padding to this as needed.


### **_So I ask:_**
1. Shall we merge this working change without worrying for the long name edge case?
2. If we shall worry about the long name edge case:
    * Do we definitely want the edit button on the left side for mobile?
        * If yes, it is easy enough to add a media query so that the flex order is not reversed on mobile but is is just more code and cases.
        * If no, then I can `justify-content: space-between` and things will work nicely for both cases below
     * In either case, I'll probably end up removing a lot of css that is now easily done with flex.

I started this PR hoping to keep it simple. But as I looked for edge cases it blew up into this big thing.
Hope to hear guidance soon.

### Testing
Use the tab key to move from element to element on the page until you see these elements highlighted.



### Screenshot

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/921217/112927341-88481000-90b0-11eb-931c-527a66e7d89d.png)   ![image](https://user-images.githubusercontent.com/921217/112927437-af064680-90b0-11eb-883b-fedba6fe0a80.png)   ![image](https://user-images.githubusercontent.com/921217/112927489-c6ddca80-90b0-11eb-8caa-c3e5b59dc92e.png) | ![image](https://user-images.githubusercontent.com/921217/113246548-ed3c6b00-9254-11eb-896a-4e6f37f6c588.png) |

PS: I am using the dev tools to mark all three as active as once, that otherwise wouldn't be possible.

### Stakeholders
@bpmcneilly 
