### PR TITLE
Fix Home Page Keyboard Accessibility

### DIFF
--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -32,6 +32,7 @@
   }
 
   &__item {
+    padding: 2px;
     float: left;
     height: 100%;
     margin: 0 10px;

--- a/static/css/components/home.less
+++ b/static/css/components/home.less
@@ -34,6 +34,7 @@ div.chartHome a:hover,
           display: block;
         }
         .ticks {
+          margin-top: 2px;
           font-family: @georgia_serif-2;
           font-size: 1.125em;
           font-weight: 700;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4898 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- Fix partially hidden outlines.

- As mentioned here https://github.com/internetarchive/openlibrary/pull/4255#pullrequestreview-564799249 currently it is impacting the book covers (as for 6 books the width changes from 128px to 124px) but after https://github.com/internetarchive/openlibrary/pull/4926 the max-width will become 1060px and all bookcovers will have 130px width with some margins left so adding `padding: 2px;` will not change the width.
Tested on staging as currently its max-width is 1060px 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/113256260-8c5d7300-92e6-11eb-851a-d759c1e49bec.png)
![image](https://user-images.githubusercontent.com/64412143/113256405-c62e7980-92e6-11eb-894e-049d330ece7a.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly