### PR TITLE
Add work subtitle in topline of bookpage

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -150,7 +150,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
       </div>
 
       <div class="work-line">
-        $_("An edition of") <a href="$work.key?edition=$(ocaid)">$work_title</a>
+        $_("An edition of") <a href="$work.key?edition=$(ocaid)">$work_title$cond(work.subtitle, ': %s' % work.subtitle)</a>
         $if work.first_publish_year:
           ($work.first_publish_year)
       </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
As per Community Call discussion

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added work-subtitle in the topline. For all the pages (edition + work).
Do we want it only on the work page???

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/113280445-eae41a80-9301-11eb-987a-4c08e70bcde1.png)
![image](https://user-images.githubusercontent.com/64412143/113280405-dc95fe80-9301-11eb-9584-b62b077cb7cb.png)
![image](https://user-images.githubusercontent.com/64412143/113280509-03543500-9302-11eb-818f-d6a265d3d549.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 