### PR TITLE
repr(Nothing()) —> "<Nothing>", not empty str

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -62,7 +62,9 @@ class TestModels:
 
         assert hasattr(work, 'any_attribute')  # hasattr() is True for all keys!
         assert isinstance(work.any_attribute, client.Nothing)
-        assert repr(work.any_attribute) == str(work.any_attribute) == ''
+        assert repr(work.any_attribute) == str(work.any_attribute)
+        # TODO (cclauss): Remove '' when internetarchive/infogami#151 lands
+        assert repr(work.any_attribute) in ('', '<Nothing>')
 
         work.new_attribute = 'new_attribute'
         assert isinstance(work.data, client.Nothing)  # Still Nothing

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -72,7 +72,7 @@ class TestModels:
 
         assert not work.hasattr('new_attribute')
         assert work._data == {'new_attribute': 'new_attribute'}
-        assert repr(work.data) == str(work.data) == ''
+        assert repr(work.data) == str(work.data) == '<Nothing>'
 
         assert callable(work.get_sorted_editions)  # Issue #3633
         assert work.get_sorted_editions() == []

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -62,9 +62,7 @@ class TestModels:
 
         assert hasattr(work, 'any_attribute')  # hasattr() is True for all keys!
         assert isinstance(work.any_attribute, client.Nothing)
-        assert repr(work.any_attribute) == str(work.any_attribute)
-        # TODO (cclauss): Remove '' when internetarchive/infogami#151 lands
-        assert repr(work.any_attribute) in ('', '<Nothing>')
+        assert repr(work.any_attribute) == str(work.any_attribute) == '<Nothing>'
 
         work.new_attribute = 'new_attribute'
         assert isinstance(work.data, client.Nothing)  # Still Nothing


### PR DESCRIPTION
`assert repr(work.any_attribute) in ('', '<Nothing>')` to align with internetarchive/infogami#151.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
