### PR TITLE
Make python CI not use infogami master

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-16.04  # Should match Dockerfile.olbase
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -24,7 +26,6 @@ jobs:
       - run: make lint-diff
       - run: make git
       - run: make i18n
-      - run: pushd vendor/infogami && git pull origin master && popd
       - run: make lint
       - run: make test-py
       - run: source scripts/run_doctests.sh


### PR DESCRIPTION
We don't want _all_ our CI to break on an infogami update we haven't adopted yet.

P0. Our CI is all going fail.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss 
