### PR TITLE
Fix list description not wrapping long strings

### DIFF
--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -37,6 +37,8 @@
   .loadmore {
     text-align: center;
   }
+
+  overflow-wrap: break-word;
 }
 
 .mybooks-list--clean {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses first part of #4974

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->
Nothing remarkable here.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Create a list
2. Add a description with a very long word (or URL)
3. Visit the first three pages listed in the PR that are listed as issues to see that the text now longer wraps on mobile and desktop.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<details>
  <summary>Spoiler</summary>
  
![image](https://user-images.githubusercontent.com/921217/113462443-abc6cf80-93bc-11eb-90a3-aa91ea732d86.png)
![image](https://user-images.githubusercontent.com/921217/113462459-b5e8ce00-93bc-11eb-93f5-f457fd704a54.png)
![image](https://user-images.githubusercontent.com/921217/113462495-d6b12380-93bc-11eb-88e0-1b6f0e6f0ba2.png)


  
</details>

### Stakeholders
<!-- @ tag stakeholders of this bug -->
