### PR TITLE
Added z-index to chart labels to show them on top of chart on hover

### DIFF
--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -63,7 +63,7 @@ export function loadEditionsGraph() {
             color: '#615132',
             'font-size': '11px',
             opacity: 0.90,
-            'z-index': 100 
+            'z-index': 100
         }).appendTo('body').customFadeIn(200);
     }
     previousPoint = null;

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -62,7 +62,8 @@ export function loadEditionsGraph() {
             'background-color': '#fffdcd',
             color: '#615132',
             'font-size': '11px',
-            opacity: 0.90
+            opacity: 0.90,
+            'z-index': 100 
         }).appendTo('body').customFadeIn(200);
     }
     previousPoint = null;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4925

### What does this PR achieve? 
Fix

### Technical
<!-- What should be noted about the implementation? -->
A large z-index value needed to be added to the chart labels so that they are visible over the chart if we hover over the bars on the chart. This has been done inside the [`showTooltip()`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/openlibrary/js/graphs/plot.js#L55) function inside `plot.js` where the CSS properties of the label are defined.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Changes can be tested on visiting localhost after adding the changes. Also, running `npm test` shows all test suites as passed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ol-1](https://user-images.githubusercontent.com/52366674/113472864-73d68f80-9483-11eb-9eb6-d749bae13ba7.png)
![ol-2](https://user-images.githubusercontent.com/52366674/113472869-7cc76100-9483-11eb-94ca-b848586b4a09.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
