### PR TITLE
Fix Header Keyboard Accessibility + Use JS for Dropdown menu

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -187,6 +187,10 @@ jQuery(function () {
 
     $('#wikiselect').on('focus', function(){$(this).select();})
 
+    $('.checkbox-menu').on('click',function(){
+        $(this).find('.dropdown-menu').toggle();
+    });
+
     // Clicking outside of menus closes menus
     $(document).on('click', function (event) {
         const $openMenus = $('.checkbox-menu :checked').parents('.checkbox-menu');

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -189,8 +189,8 @@ jQuery(function () {
 
     $('.dropdown-toggle').on('click',function(){
         $(this).find('.dropdown-menu').toggle();
-        $(this).find(".dropdown-button").attr("aria-expanded", function (i, attr) {
-            return attr == "true" ? "false" : "true";
+        $(this).find('.dropdown-button').attr('aria-expanded', function (i, attr) {
+            return attr == 'true' ? 'false' : 'true';
         });
     });
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -187,16 +187,19 @@ jQuery(function () {
 
     $('#wikiselect').on('focus', function(){$(this).select();})
 
-    $('.checkbox-menu').on('click',function(){
+    $('.dropdown-toggle').on('click',function(){
         $(this).find('.dropdown-menu').toggle();
+        $(this).find(".dropdown-button").attr("aria-expanded", function (i, attr) {
+            return attr == "true" ? "false" : "true";
+        });
     });
 
     // Clicking outside of menus closes menus
-    $(document).on('click', function (event) {
-        const $openMenus = $('.checkbox-menu :checked').parents('.checkbox-menu');
+    $('.dropdown-toggle').on('click', function (event) {
+        const $openMenus = $('.dropdown-menu :visible').parents('.dropdown-toggle');
         $openMenus
             .filter((_, menu) => !$(event.target).closest(menu).length)
-            .find('[type=checkbox]')
-            .removeAttr('checked');
+            .find('.dropdown-menu')
+            .toggle();
     });
 });

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,10 +1,10 @@
 $def with (page)
 
 <header id="header-bar" class="header-bar">
-  <div class="hamburger-component checkbox-menu">
-    <button type="button" class="hamburger-button"><img src="/static/images/menu.png" alt="additional options menu"/></button>
+  <div class="hamburger-component dropdown-toggle">
+    <button type="button" class="dropdown-button" id="mobile-hamburger-menu" aria-expanded="false"><img src="/static/images/menu.png" alt="additional options menu"/></button>
     <div class="hamburger-dropdown-component navigation-dropdown-component">
-      <ul class="dropdown-menu hamburger-dropdown-menu">
+      <ul class="dropdown-menu hamburger-dropdown-menu" aria-labelledby="mobile-hamburger-menu">
         $if not ctx.user:
           <li><a href="/account/login">$_("Log in")</a></li>
           <li><a href="/account/create">$_("Sign up")</a></li>
@@ -29,11 +29,11 @@ $def with (page)
   </div>
 
   <ul class="navigation-component">
-    <li class="browse-menu checkbox-menu">
-      <a href="javascript:;">$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
+    <li class="browse-menu dropdown-toggle">
+      <a href="javascript:;" role="button" class="dropdown-button" id="browse-dropdown-menu" aria-expanded="false">$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
 
       <div class="navigation-dropdown-component">
-        <ul class="dropdown-menu browse-menu-options">
+        <ul class="dropdown-menu browse-menu-options" aria-labelledby="browse-dropdown-menu">
           <li><a href="/subjects">$_("Subjects")</a></li>
           <li><a href="/lists">$_("Lists")</a></li>
           <li><a href="/k-12">$_("K-12 Student Library")</a></li>
@@ -42,11 +42,11 @@ $def with (page)
         </ul>
       </div>
     </li>
-    <li class="more-menu checkbox-menu">
-      <a href="javascript:;">$_('More') <img class="down-arrow"
+    <li class="more-menu dropdown-toggle">
+      <a href="javascript:;" role="button" class="dropdown-button" id="more-dropdown-menu" aria-expanded="false">$_('More') <img class="down-arrow"
         width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
-        <ul class="dropdown-menu more-menu-options">
+        <ul class="dropdown-menu more-menu-options" aria-labelledby="more-dropdown-menu">
           <li><a href="/books/add">$_("Add a Book")</a></li>
           <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
           <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
@@ -96,9 +96,9 @@ $def with (page)
     </ul>
 
   $if ctx.user:
-    <div class="account-component checkbox-menu">
+    <div class="account-component dropdown-toggle">
       <div class="dropdown-avatar">
-        <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
+        <button class="avatar dropdown-button" id="userToggle" aria-expanded="false" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
         <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
       </div>
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -2,12 +2,7 @@ $def with (page)
 
 <header id="header-bar" class="header-bar">
   <div class="hamburger-component checkbox-menu">
-
-    <label for="toggle-hamburger" class="hamburger-button">
-      <img src="/static/images/menu.png" alt="additional options menu"/>
-    </label>
-
-    <input role="button" type="checkbox" class="hamburger-component__checkbox" id="toggle-hamburger">
+    <button type="button" class="hamburger-button"><img src="/static/images/menu.png" alt="additional options menu"/></button>
     <div class="hamburger-dropdown-component navigation-dropdown-component">
       <ul class="dropdown-menu hamburger-dropdown-menu">
         $if not ctx.user:
@@ -65,11 +60,8 @@ $def with (page)
 
   <ul class="navigation-component">
     <li class="browse-menu checkbox-menu">
-      <label for="toggle-browse-menu" class="browse-menu-button">$_('Browse') 
-        <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/>
-      </label>
+      <a>$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
 
-      <input role="button" type="checkbox" class="navigation-component__checkbox" id="toggle-browse-menu">
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
           <li><a href="/subjects">$_("Subjects")</a></li>
@@ -81,11 +73,8 @@ $def with (page)
       </div>
     </li>
     <li class="more-menu checkbox-menu">
-      <label for="toggle-more-menu" class="more-menu-button">$_('More') 
-        <img class="down-arrow" width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/>
-      </label>
-
-      <input role="button" type="checkbox" class="navigation-component__checkbox" id="toggle-more-menu">
+      <a>$_('More') <img class="down-arrow"
+        width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">
           <li><a href="/books/add">$_("Add a Book")</a></li>
@@ -97,7 +86,6 @@ $def with (page)
       </div>
     </li>
   </ul>
-
   $if not ctx.user:
     <ul class="auth-component">
       <li class="hide-me">
@@ -108,16 +96,10 @@ $def with (page)
 
   $if ctx.user:
     <div class="account-component checkbox-menu">
-      <div class="dropdown-avatar">        
-        <label for="toggle-account" id="userToggle" class="avatar account-button" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');">
-        </label>
-
-        <label for="toggle-account" class="account-button">
-          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
-        </label>
+      <div class="dropdown-avatar">
+        <button class="avatar" id="userToggle" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></button>
+        <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
       </div>
-
-      <input role="button" type="checkbox" class="account-component__checkbox" id="toggle-account">
       <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
         <ul class="dropdown-menu">
           <li><a href="$ctx.user.key">$_("My Profile")</a></li>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -60,7 +60,7 @@ $def with (page)
 
   <ul class="navigation-component">
     <li class="browse-menu checkbox-menu">
-      <a>$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
+      <a href="javascript:;">$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
 
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu browse-menu-options">
@@ -73,7 +73,7 @@ $def with (page)
       </div>
     </li>
     <li class="more-menu checkbox-menu">
-      <a>$_('More') <img class="down-arrow"
+      <a href="javascript:;">$_('More') <img class="down-arrow"
         width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
       <div class="navigation-dropdown-component">
         <ul class="dropdown-menu more-menu-options">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -28,6 +28,35 @@ $def with (page)
     </a>
   </div>
 
+  <ul class="navigation-component">
+    <li class="browse-menu checkbox-menu">
+      <a href="javascript:;">$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
+
+      <div class="navigation-dropdown-component">
+        <ul class="dropdown-menu browse-menu-options">
+          <li><a href="/subjects">$_("Subjects")</a></li>
+          <li><a href="/lists">$_("Lists")</a></li>
+          <li><a href="/k-12">$_("K-12 Student Library")</a></li>
+          <li><a href="/random">$_("Random Book")</a></li>
+          <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
+        </ul>
+      </div>
+    </li>
+    <li class="more-menu checkbox-menu">
+      <a href="javascript:;">$_('More') <img class="down-arrow"
+        width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
+      <div class="navigation-dropdown-component">
+        <ul class="dropdown-menu more-menu-options">
+          <li><a href="/books/add">$_("Add a Book")</a></li>
+          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
+          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
+          <li><a href="/developers">$_("Developer Center")</a></li>
+          <li><a href="/help">$_("Help & Support")</a></li>
+        </ul>
+      </div>
+    </li>
+  </ul>
+
   <div class="search-component">
     <div class="search-bar-component">
       <div class="search-bar">
@@ -58,34 +87,6 @@ $def with (page)
     </div>
   </div>
 
-  <ul class="navigation-component">
-    <li class="browse-menu checkbox-menu">
-      <a href="javascript:;">$_('Browse') <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/></a>
-
-      <div class="navigation-dropdown-component">
-        <ul class="dropdown-menu browse-menu-options">
-          <li><a href="/subjects">$_("Subjects")</a></li>
-          <li><a href="/lists">$_("Lists")</a></li>
-          <li><a href="/k-12">$_("K-12 Student Library")</a></li>
-          <li><a href="/random">$_("Random Book")</a></li>
-          <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
-        </ul>
-      </div>
-    </li>
-    <li class="more-menu checkbox-menu">
-      <a href="javascript:;">$_('More') <img class="down-arrow"
-        width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/></a>
-      <div class="navigation-dropdown-component">
-        <ul class="dropdown-menu more-menu-options">
-          <li><a href="/books/add">$_("Add a Book")</a></li>
-          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
-          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
-          <li><a href="/developers">$_("Developer Center")</a></li>
-          <li><a href="/help">$_("Help & Support")</a></li>
-        </ul>
-      </div>
-    </li>
-  </ul>
   $if not ctx.user:
     <ul class="auth-component">
       <li class="hide-me">

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -30,9 +30,6 @@ td {
 h1 {
   margin: 20px;
 }
-button {
-  outline: none;
-}
 body,
 p,
 li {

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -92,6 +92,7 @@
   }
 
   .dropdown-menu {
+    display: none;
     text-align: left;
     background-color: @light-beige;
     border: 1px solid @dark-beige;
@@ -134,7 +135,7 @@
     order: 0;
     margin-right: 5px;
 
-    label {
+    button {
       background: transparent;
       border: none;
     }
@@ -481,7 +482,10 @@
 
 .logo-component {
   margin: 0 0 5px;
-
+  img,
+  a {
+    display: block;
+  }
   a {
     color: @black;
     text-decoration: none !important;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -455,6 +455,18 @@
   /* stylelint-enable selector-max-specificity */
 }
 
+.client-js {
+  .hamburger-component,
+  .navigation-component li,
+  .account-component {
+  /* stylelint-disable selector-max-specificity */
+    &:hover .dropdown-menu {
+      display: none;
+    }
+  /* stylelint-enable selector-max-specificity */
+  }
+}
+
 .logo-component {
   margin: 0 0 5px;
   img,

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -405,7 +405,7 @@
   }
 }
 
-.checkbox-menu {
+.dropdown-toggle {
   cursor: pointer;
 }
 

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -405,47 +405,8 @@
   }
 }
 
-.checkbox-menu, .checkbox-menu label {
+.checkbox-menu {
   cursor: pointer;
-}
-
-.account-component__checkbox {
-  display: none;
-
-  & ~ .navigation-dropdown-component ul {
-    display: none;
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  &:checked ~ .navigation-dropdown-component ul {
-    display: block;
-  }
-}
-
-.hamburger-component__checkbox {
-  opacity: 0;
-
-  & ~ .hamburger-dropdown-component ul {
-    display: none;
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  &:checked ~ .hamburger-dropdown-component ul {
-    display: block;
-  }
-}
-
-.navigation-component__checkbox {
-  opacity: 0;
-
-  & ~ .navigation-dropdown-component ul {
-    display: none;
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  &:checked ~ .navigation-dropdown-component ul {
-    display: block;
-  }
 }
 
 .account-component {
@@ -459,6 +420,7 @@
     -ms-flex-align: center;
     align-items: center;
     .avatar {
+      cursor: pointer;
       border: none;
       margin-right: 5px;
       background-size: cover;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -442,6 +442,19 @@
   }
 }
 
+.hamburger-component,
+.navigation-component li,
+.account-component {
+  /* stylelint-disable selector-max-specificity */
+  .dropdown-menu {
+    display: none;
+  }
+  &:hover .dropdown-menu {
+    display: block;
+  }
+  /* stylelint-enable selector-max-specificity */
+}
+
 .logo-component {
   margin: 0 0 5px;
   img,

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -455,18 +455,6 @@
   /* stylelint-enable selector-max-specificity */
 }
 
-.client-js {
-  .hamburger-component,
-  .navigation-component li,
-  .account-component {
-  /* stylelint-disable selector-max-specificity */
-    &:hover .dropdown-menu {
-      display: none;
-    }
-  /* stylelint-enable selector-max-specificity */
-  }
-}
-
 .logo-component {
   margin: 0 0 5px;
   img,
@@ -613,6 +601,15 @@
       opacity: 0;
       position: absolute;
     }
+  }
+  .hamburger-component,
+  .navigation-component li,
+  .account-component {
+    /* stylelint-disable selector-max-specificity */
+    &:hover .dropdown-menu {
+      display: none;
+    }
+    /* stylelint-enable selector-max-specificity */
   }
 }
 


### PR DESCRIPTION
Closes #4900
Related to #4929
<!-- What issue does this PR close? -->

- Remove checkbox and implement JS for dropdown.
- Fallback hover effect if no JS
- Fixes Keyboard Navigation for Header
- Improves Accessibility
- Less CSS
- Removes outline: 0; declarations from buttons. Refer to https://github.com/internetarchive/openlibrary/issues/4900#issuecomment-812593038

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
To Do:

- [X] Fix Multiple Dropdown at the same time.
- [X] Refactor CSS and remove checkbox hack CSS
- [ ] Fix select dropdown focus invisible due to `opacity: 0;`
- [x] Remove Button `outline: 0;`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/64412143/113473199-aaada500-9485-11eb-98f7-aa7654fbb1bc.mp4


https://user-images.githubusercontent.com/64412143/113498829-34b14880-952e-11eb-962f-d61d63d8983f.mp4


![image](https://user-images.githubusercontent.com/64412143/113474165-daf84200-948b-11eb-8624-140ac83adc8f.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson @mekarpeles @bpmcneilly 