### PR TITLE
4774/feature/add fields to contact form

### DIFF
--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -29,6 +29,7 @@ class contact(delegate.page):
 
     def POST(self):
         form = web.input()
+        patron_name = form.get("name", "")
         email = form.get("email", "")
         topic = form.get("topic", "")
         description = form.get("question", "")
@@ -95,6 +96,7 @@ Topic: %(topic)s
 URL: %(url)s
 User-Agent: %(useragent)s
 OL-username: %(username)s
+Patron-name: %(patron_name)s
 """
 
 def setup():

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -16,13 +16,13 @@ $var title: $_('How can we help?')
 
  <div class="formElement">
  <div class="label"><label for="name">$_("Your Name")</label></div>
- <div class="input"><input type="text" class="input" name="name" id="name"/> ($_('Please fill this field if you are a patron'))</div>
+ <div class="input"><input type="text" class="input" name="name" id="name"/></div>
  </div>
  
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
  <div class="input"><input type="text" class="email" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
- <p>$_('If you wish to be contacted by another mean, please add your contact preference and details to your question.')</p>
+ <p>$_('If you wish to be contacted by other means, please add your contact preference and details to your question.')</p>
  </div>
 
  <div class="formElement">

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -16,13 +16,13 @@ $var title: $_('How can we help?')
 
  <div class="formElement">
  <div class="label"><label for="name">$_("Your Name")</label></div>
- <div class="input"><input type="text" class="input" name="name" id="name"/> (We'll need this if you are a patron)</div>
+ <div class="input"><input type="text" class="input" name="name" id="name"/> (Please fill this field if you are a patron)</div>
  </div>
  
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
  <div class="input"><input type="text" class = "email" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
- <p>If you want a reply with another mean, please append your contact preference and detail to your question.</p>
+ <p>If you wish to be contacted by another mean, please add your contact preference and details to your question.</p>
  </div>
 
  <div class="formElement">

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -16,13 +16,13 @@ $var title: $_('How can we help?')
 
  <div class="formElement">
  <div class="label"><label for="name">$_("Your Name")</label></div>
- <div class="input"><input type="text" class="input" name="name" id="name"/> (Please fill this field if you are a patron)</div>
+ <div class="input"><input type="text" class="input" name="name" id="name"/> ($_('Please fill this field if you are a patron'))</div>
  </div>
  
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
- <div class="input"><input type="text" class = "email" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
- <p>If you wish to be contacted by another mean, please add your contact preference and details to your question.</p>
+ <div class="input"><input type="text" class="email" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
+ <p>$_('If you wish to be contacted by another mean, please add your contact preference and details to your question.')</p>
  </div>
 
  <div class="formElement">

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -15,6 +15,11 @@ $var title: $_('How can we help?')
 <p>$:_('Please check our <a href="/help/">Help Pages</a> and <a href="/help/faq">Frequently Asked Questions</a> (FAQ) to see if your question is answered there. Thank you.')</p>
 
  <div class="formElement">
+ <div class="label"><label for="name">$_("Your Name [Optional]")</label></div>
+ <div class="input"><input type="text" class="input" name="name" id="name" value="$name"/></div>
+ </div>
+ 
+ <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
  <div class="input"><input type="text" class = "email" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
  </div>
@@ -22,7 +27,7 @@ $var title: $_('How can we help?')
  <div class="formElement">
    <div class="label"><label for="topic">$_("Topic")</label></div>
    <div class="input">
-     <select class = "required" name="topic" id="topic">
+     <select class="required" name="topic" id="topic">
        <option value="">$_('Select...')</option>
        <option value="Borrowing Books">$_('Borrowing Help')</option>
        <option value="Developer/Code">$_('Developer/Code Question')</option>
@@ -36,14 +41,13 @@ $var title: $_('How can we help?')
  </div>
 
  <div class="formElement">
-   <div class="label"><label for="question">$_("Your question")</label></div>
+   <div class="label"><label for="question">$_("Your Question")</label></div>
    <p><strong>$_('Note: our staff will likely only be able respond in English.')</strong></p>
    <div class="input">
-     <textarea id="question" name="question" class = "required" cols="40" rows="5"></textarea>
+     <textarea id="question" name="question" class="required" cols="40" rows="5"></textarea>
    </div>
    <p>$_('If you encounter an error message, please include it. For questions about our books, please provide the title/author or Open Library ID.')</p>
  </div>
-
 
  <!-- <div class="formElement"> -->
  <!-- <div class="label"><label for="url">$_("Which page were you looking at?")</label></div> -->

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -15,13 +15,14 @@ $var title: $_('How can we help?')
 <p>$:_('Please check our <a href="/help/">Help Pages</a> and <a href="/help/faq">Frequently Asked Questions</a> (FAQ) to see if your question is answered there. Thank you.')</p>
 
  <div class="formElement">
- <div class="label"><label for="name">$_("Your Name [Optional]")</label></div>
- <div class="input"><input type="text" class="input" name="name" id="name" value="$name"/></div>
+ <div class="label"><label for="name">$_("Your Name")</label></div>
+ <div class="input"><input type="text" class="input" name="name" id="name"/> (We'll need this if you are a patron)</div>
  </div>
  
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
  <div class="input"><input type="text" class = "email" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
+ <p>If you want a reply with another mean, please append your contact preference and detail to your question.</p>
  </div>
 
  <div class="formElement">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4774

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Contact form feature:
- Add `Your Name` input field
- Add one paragraph for contact preference
- Add name from new input field to support message content

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Contact form:**

![image](https://user-images.githubusercontent.com/73437497/113481269-d8e8b000-9498-11eb-9159-7a02830c243b.png)

**Support message content:**

> Description:
> Test question
> A new support case has been filed by Open Library <openlibrary@example.com>.
> Topic: Other
> URL: http://localhost:8080/
> User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:87.0) Gecko/20100101 Firefox/87.0
> OL-username: openlibrary
> Patron-name: John Doe

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 
