### PR TITLE
Exempt trusted-users from recaptcha

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -36,11 +36,14 @@ def get_recaptcha():
     def recaptcha_exempt():
         """Check to see if account is an admin, or more than two years old."""
         user = web.ctx.site.get_user()
-        if user and (user.is_admin() or user.is_librarian()):
-            return True
         account = user and user.get_account()
-        if not account:
+
+        if not (user and account):
             return False
+
+        if account.has_tag("trusted-user") or user.is_admin() or user.is_librarian():
+            return True
+
         create_dt = account.creation_time()
         now_dt = datetime.datetime.utcnow()
         delta = now_dt - create_dt


### PR DESCRIPTION
@seabelis wants the ability to bless patrons who are not yet in the librarians group (but who are trusted for some librarian tasks) to be able to skip recaptcha, since they've been manually vetted. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

uses the account.has_tags function to check whether patron is `trusted-user`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

This needs to go on staging and needs to be tested:
* librarians, admins, and trusted users should not see captcha
* others should see recaptcha unless they meet other pre-existing exemptions

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @seabelis 