### PR TITLE
Fix /search/inside.json limit + rm unreachable code

### DIFF
--- a/openlibrary/plugins/inside/code.py
+++ b/openlibrary/plugins/inside/code.py
@@ -4,7 +4,7 @@ import json
 import web
 
 from infogami.utils import delegate
-from infogami.utils.view import render_template
+from infogami.utils.view import render_template, safeint
 
 from openlibrary.core.fulltext import fulltext_search
 
@@ -12,7 +12,6 @@ RESULTS_PER_PAGE = 20
 
 
 class search_inside(delegate.page):
-
     path = '/search/inside'
 
     def GET(self):
@@ -25,8 +24,6 @@ class search_inside(delegate.page):
 
         return render_template('search/inside.tmpl', query, results, search_time,
                                page=page, results_per_page=RESULTS_PER_PAGE)
-        page.v2 = True  # page is mobile-first
-        return page
 
 
 class search_inside_json(delegate.page):
@@ -35,7 +32,7 @@ class search_inside_json(delegate.page):
 
     def GET(self):
         i = web.input(q='', page=1, limit=RESULTS_PER_PAGE)
-        limit = min(i.limit, RESULTS_PER_PAGE) if i.limit else RESULTS_PER_PAGE
+        limit = min(safeint(i.limit, RESULTS_PER_PAGE), RESULTS_PER_PAGE)
         query = i.q
         page = int(i.page)
         results = fulltext_search(query, page=page, limit=limit, js=True)


### PR DESCRIPTION
Closes #4999 . Fix ; this was not converting the string `i.limit` to an int.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] http://staging.openlibrary.org/search/inside.json?q=hello&limit=1 does not error

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@waldenn
