### PR TITLE
adding title to the iframe for accesibilty

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -762,7 +762,10 @@ def get_donation_include(include):
 
     html = """
     <div id="donato"></div>
-    <script src="%s" data-platform="ol"></script>
+    <script src="%s" data-platform="ol">
+        const iframe = document.querySelector("iframe");
+        iframe.title = "Internet Archive Donation"
+    </script>
     """ % script_src
     return html
 


### PR DESCRIPTION
What I understand after searching the whole open library, that there are many places where i frame are present 

Here are the files 
openlibrary\macros\BookPreview.html 
openlibrary\macros\iframe.html
(I have a suspicion that these two files are dead code, not 100% sure tho)
openlibrary\plugins\openlibrary\js\covers.js (Line 45 function add_iframe())

About this PR, I got to know that the i frame is being created by this script 
https://archive.org/includes/donate.js

and as this is the script in internet archive not open library we need to manually add the title which i did in this PR

Please Review @bpmcneilly 