### PR TITLE
make header levels more accessible

### DIFF
--- a/openlibrary/templates/type/list/view.html
+++ b/openlibrary/templates/type/list/view.html
@@ -244,14 +244,14 @@ window.q.push(function(){
 
         $:render_template("type/list/exports", list)
 
-        <h3 class="collapse">$_('List Metadata')</h3>
+        <h2 class="collapse">$_('List Metadata')</h2>
         <div class="smaller lightgreen sansserif">$_('Derived from seed metadata')</div>
         <br/>
 
         $def render_subjects(label, subjects):
             $if subjects:
                 <div class="section">
-                    <h6 class="collapse black uppercase">$label</h6>
+                    <h3 class="collapse black uppercase">$label</h3>
                     <div class="sansserif">
                     $for subject in subjects:
                         <a href="$subject.url">$subject.title</a>$cond(not loop.last, ",", "")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5004 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix
In summary, we were using headers like this:

- H1
  - H3
    - H6
    - H6
    - H6
  - H2

Now, we're using them like this:
- H1
  - H2
    - H3
    - H3
    - H3
  - H2

Which is better for user accessibility (details in #5004)

### Technical
Since these elements are only used on this page and not shared there should be no risk of breaking other pages.

### Testing
Check the html on a page to see that it is using the correct headers.

### Screenshot
![image](https://user-images.githubusercontent.com/921217/113964030-63e1e700-97c6-11eb-864d-c14c3b7a0088.png)


### Stakeholders
@bpmcneilly 
