### PR TITLE
Fix split_dump() to read in str, not bytes

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -169,7 +169,7 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
     files = {}
     for t in types:
         tname = t.split("/")[-1] + "s"
-        files[t] = xopen(format % tname, "wb")
+        files[t] = xopen(format % tname, "wt")
 
     stdin = xopen(dump_file) if dump_file else sys.stdin
     for i, line in enumerate(stdin):

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -173,11 +173,9 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
 
     stdin = xopen(dump_file) if dump_file else sys.stdin
     for i, line in enumerate(stdin):
-        if not isinstance(line, bytes):
-            line = line.encode("utf-8")
         if i % 1000000 == 0:
             log(i)
-        type, rest = line.split(b"\t", 1)
+        type, rest = line.split("\t", 1)
         if type in files:
             files[type].write(line)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4621

Should we read stdin as bytes?!?  https://stackoverflow.com/questions/32282448/read-stdin-as-binary

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
