### PR TITLE
fix: restart_servers.sh for docker-compose --profile and $HOSTNAME

### DIFF
--- a/scripts/deployment/restart_servers.sh
+++ b/scripts/deployment/restart_servers.sh
@@ -22,10 +22,11 @@ else
 fi
 
 for SERVER in $SERVERS; do
+    HOSTNAME=$(host $SERVER | cut -d " " -f 1)
     EXTRA_OPTS=""
     if [[ $SERVER == ol-covers0* ]]; then
         EXTRA_OPTS="--scale covers=2"
     fi
 
-    ssh $SERVER "cd /opt/openlibrary; COMPOSE_FILE=$PRODUCTION HOSTNAME=$HOSTNAME docker-compose up --profile $SERVER --no-deps -d $EXTRA_OPTS"
+    ssh $SERVER "cd /opt/openlibrary; COMPOSE_FILE=$PRODUCTION HOSTNAME=$HOSTNAME docker-compose --profile $(echo $SERVER | cut -f1 -d '.') up --no-deps -d $EXTRA_OPTS"
 done


### PR DESCRIPTION
Fixes #5007
Related to #4936

Correct the docker-compose command and properly set the ___remote___ hostname.

@cdrini  @dhruvmanila

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
