### PR TITLE
add markdown preview word wrap

### DIFF
--- a/static/css/legacy-wmd.less
+++ b/static/css/legacy-wmd.less
@@ -35,7 +35,7 @@
   border: 1px solid @lighter-grey;
   font-family: @georgia_serif-1;
   display: none;
-  margin-bottom: 10px;
+  overflow-wrap: anywhere;
 }
 
 .formElement .input .wmd-preview {
@@ -179,10 +179,6 @@ form.olform.books .formElement .input .wmd-preview {
 @media only screen and (min-width: @width-breakpoint-desktop) {
   // Styles are used on edit page
   // e.g. http://localhost:8080/works/OL61982W/Odyssey/edit
-  .formElement .input .wmd-preview {
-    width: 906px;
-    float: left;
-  }
   form.olform.books .formElement.librarian .input .wmd-preview {
     width: 798px;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4974

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the markdown preview so long strings of text wrap to stay inside their parent.

### Technical
<!-- What should be noted about the implementation? -->
This css will be applied to pages that use the markdown previewer. These can be found by looking a files using the class `markdown`. 

<details>
  <summary>Here is a list of those files</summary>
  
 
Page in screenshot:
https://github.com/internetarchive/openlibrary/blob/a61250b4ade345430e406d99eb04ae102713899a/openlibrary/templates/type/list/edit.html#L33 

Has a width manually set
https://github.com/internetarchive/openlibrary/blob/a61250b4ade345430e406d99eb04ae102713899a/openlibrary/templates/admin/case.html#L97

Has a width manually set
https://github.com/internetarchive/openlibrary/blob/a61250b4ade345430e406d99eb04ae102713899a/openlibrary/templates/admin/case.html#L112

https://github.com/internetarchive/openlibrary/blob/9a0a6e41e3a524d67cf6cce82aaccc6281407b57/openlibrary/templates/type/page/edit.html#L29

https://github.com/internetarchive/openlibrary/blob/9a0a6e41e3a524d67cf6cce82aaccc6281407b57/openlibrary/templates/type/user/edit.html#L52

https://github.com/internetarchive/openlibrary/blob/a61250b4ade345430e406d99eb04ae102713899a/openlibrary/templates/books/edit/about.html#L10

https://github.com/internetarchive/openlibrary/blob/6b87e3fd87861e44abb46d9105ce03446dc6be25/openlibrary/templates/type/author/edit.html#L54

https://github.com/internetarchive/openlibrary/blob/7cee172a16b6f9438ac910de0a7610284e7d12df/openlibrary/templates/books/edit/edition.html#L400
  
</details>

#### Changes
* Adding `overflow-wrap: anywhere;` presents no risk.
* Removing `margin-bottom: 10px;` is no risk because in every usage the parent div is of the class `input`. The class input has a margin-bottom.
  * In the case of the admin page it is not in an input div but rather in a table which gives the element positioning anyway. If someone can help me. If someone could help me verify this doesn't negatively impact the admin page that would be great.
* Removing `width: 906px;` is no risk because all of the usages of the class are either children of input (which have a width set to 100%) or have a width manually set in the html.
* Removing `float: left;` does not seem to have any impact.

The issue is fixed on: user, works, and author. The issue is not seen on the edition page.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I tested this in Brave for Mac using desktop mode and the mobile preview. I also checked with firefox on mac.
These are well supported and basic css features so it is unlikely that they will be broken on other platforms but I welcome people to double check.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/921217/114125803-e33cec80-9892-11eb-824d-b21461072e14.png) |![image](https://user-images.githubusercontent.com/921217/114125550-6a3d9500-9892-11eb-91fb-c400a24e9b19.png) | 
| ![image](https://user-images.githubusercontent.com/921217/114127280-d8378b80-9895-11eb-9cd6-3e6465da4caf.png) | ![image](https://user-images.githubusercontent.com/921217/114127301-e1285d00-9895-11eb-9930-42b64de69705.png) |



### Stakeholders
<!-- @ tag stakeholders of this bug -->
