### PR TITLE
Remove pystatsd in favor of statsd

### DIFF
--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -12,10 +12,7 @@ Based on the code in http://www.monkinetic.com/2011/02/statsd.html (pystatsd cli
 
 import logging
 
-try:
-    from pystatsd import Client as StatsClient
-except ImportError:
-    from statsd import StatsClient
+from statsd import StatsClient
 
 from infogami import config
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ pyyaml
 simplejson
 supervisor
 web.py==0.33
-pystatsd
+statsd
 eventer
 Pygments
 OL-GeoIP


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Completes the work started in #1486 and #2892 to remove [`pystatsd`](https://pypi.org/project/pystatsd/) which has not been released since 2013 with the more up-to-date [`statsd`](https://pypi.org/project/statsd/). 

This PR does not change the log names just in case those names are relied on elsewhere.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
