### PR TITLE
feat: Add cache to GitHub actions

### DIFF
--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -14,7 +14,12 @@ jobs:
           node-version: '14' # # Should match what's in our Dockerfile
       - uses: actions/cache@v2
         with:
-          path: '~/.npm'
+          # Caching node_modules isn't recommended because it can break across
+          # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
+          # But we pin the node version, and we don't update it that often anyways. And 
+          # we don't use `npm ci` specifically to try to get faster CI flows. So caching
+          # `node_modules` directly.
+          path: 'node_modules'
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -12,7 +12,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14' # # Should match what's in our Dockerfile
-      - run: npm install
+      - uses: actions/cache@v2
+        with:
+          path: '~/.npm'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
       - run: npm run lint
       - run: make git
       - run: make js

--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           path: '~/.npm'
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      - run: npm install
       - run: npm run lint
       - run: make git
       - run: make js

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -31,12 +31,12 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install -r requirements_test.txt
           pip list --outdated
+      - run: make git
+      - run: make i18n
       - name: Run tests
         run: |
           source ~/openlibrary_python_venv/bin/activate
           make lint-diff
-          make git
-          make i18n
           make lint
           make test-py
           source scripts/run_doctests.sh

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -18,15 +18,26 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      # https://lxml.de/installation.html#requirements
-      - run: sudo apt-get install libxml2-dev libxslt-dev
-      - run: pip install --upgrade pip setuptools wheel
-      - run: pip install -r requirements_test.txt
-      - run: pip list --outdated
-      - run: make lint-diff
-      - run: make git
-      - run: make i18n
-      - run: make lint
-      - run: make test-py
-      - run: source scripts/run_doctests.sh
-      - run: mypy .
+      - uses: actions/cache@v2
+        with:
+          path: ~/openlibrary_python_venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('requirements*.txt') }}
+      - run: python3 -m venv ~/openlibrary_python_venv
+      - name: Install dependencies
+        run: |
+          source ~/openlibrary_python_venv/bin/activate
+          # https://lxml.de/installation.html#requirements
+          sudo apt-get install libxml2-dev libxslt-dev
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements_test.txt
+          pip list --outdated
+      - name: Run tests
+        run: |
+          source ~/openlibrary_python_venv/bin/activate
+          make lint-diff
+          make git
+          make i18n
+          make lint
+          make test-py
+          source scripts/run_doctests.sh
+          mypy .

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -32,7 +32,10 @@ jobs:
           pip install -r requirements_test.txt
           pip list --outdated
       - run: make git
-      - run: make i18n
+      - name: Run make i18n
+        run: |
+          source ~/openlibrary_python_venv/bin/activate
+          make i18n
       - name: Run tests
         run: |
           source ~/openlibrary_python_venv/bin/activate


### PR DESCRIPTION
We will add cache to our Python tests which will store the entire virtual environment in which all our dependencies are installed.

The key for the cache will be the OS version and the hash of all the requirements.txt files (as the glob suggests). This means that if either the OS or any of the requirements file changes, the cache will be automatically updated.

Continuing from https://github.com/internetarchive/infogami/pull/161


<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
