### PR TITLE
Define repr(Nothing()) and str(Nothing())

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -62,7 +62,8 @@ class TestModels:
 
         assert hasattr(work, 'any_attribute')  # hasattr() is True for all keys!
         assert isinstance(work.any_attribute, client.Nothing)
-        assert repr(work.any_attribute) == str(work.any_attribute) == '<Nothing>'
+        assert repr(work.any_attribute) == '<Nothing>'
+        assert str(work.any_attribute) == ''
 
         work.new_attribute = 'new_attribute'
         assert isinstance(work.data, client.Nothing)  # Still Nothing
@@ -72,7 +73,8 @@ class TestModels:
 
         assert not work.hasattr('new_attribute')
         assert work._data == {'new_attribute': 'new_attribute'}
-        assert repr(work.data) == str(work.data) == '<Nothing>'
+        assert repr(work.data) == '<Nothing>'
+        assert str(work.data) == ''
 
         assert callable(work.get_sorted_editions)  # Issue #3633
         assert work.get_sorted_editions() == []


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This PR must land just _before_ internetarchive/infogami#166 (so its tests will pass) and then internetarchive/infogami#166 should land because the two PRs are linked and tests will fail in one repo or the other until both are landed.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
