### PR TITLE
Accessibility/Library Explorer bookshelf keyboard focus fix

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -1,5 +1,30 @@
 <template>
   <div class="shelf" :data-short="node.short">
+    <component
+      class="shelf-label"
+      :node="node"
+      :key="node.short"
+      :is="features.shelfLabel == 'slider' ? 'ClassSlider' : 'ShelfLabel'"
+    >
+      <template #extra-actions>
+        <button
+          :title="`See a list of the subsections of ${node.short}: ${node.name}`"
+          v-if="features.shelfLabel == 'slider' && node.children"
+          :class="{selected: showShelfIndex}"
+          @click="showShelfIndex = !showShelfIndex"
+        >
+          <IndexIcon />
+        </button>
+        <button
+          :title="`See more books in ${node.short}: ${node.name}`"
+          @click="expandBookshelf(parent, node)"
+          v-if="node.children && node.children.length"
+        >
+          <ExpandIcon />
+        </button>
+      </template>
+    </component>
+
     <OLCarousel
       class="shelf-carousel"
       ref="olCarousel"
@@ -59,31 +84,6 @@
         <div v-if="labels.includes('edition_count')">{{book.edition_count}} editions</div>
       </template>
     </OLCarousel>
-
-    <component
-      class="shelf-label"
-      :node="node"
-      :key="node.short"
-      :is="features.shelfLabel == 'slider' ? 'ClassSlider' : 'ShelfLabel'"
-    >
-      <template #extra-actions>
-        <button
-          :title="`See a list of the subsections of ${node.short}: ${node.name}`"
-          v-if="features.shelfLabel == 'slider' && node.children"
-          :class="{selected: showShelfIndex}"
-          @click="showShelfIndex = !showShelfIndex"
-        >
-          <IndexIcon />
-        </button>
-        <button
-          :title="`See more books in ${node.short}: ${node.name}`"
-          @click="expandBookshelf(parent, node)"
-          v-if="node.children && node.children.length"
-        >
-          <ExpandIcon />
-        </button>
-      </template>
-    </component>
 
     <ShelfIndex class="shelf-index" :node="node" v-if="showShelfIndex" />
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5034

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix keyboard focus on bookshelf in Library Explorer.
Focus first on shelf-label, then on shelf-carousel.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/73437497/114387931-57c5a300-9b93-11eb-877f-75f1b3e90b3d.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly 
