### PR TITLE
Fix search API non-working filters

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -353,7 +353,10 @@ def build_q_list(param):
                 if v:
                     q_list.append("(author_name:(%(name)s) OR author_alternative_name:(%(name)s))" % {'name': v})
 
-        check_params = ['title', 'publisher', 'oclc', 'lccn', 'contributor', 'subject', 'place', 'person', 'time']
+        check_params = [
+            'title', 'publisher', 'oclc', 'lccn', 'contributor', 'subject', 'place',
+            'person', 'time'
+        ]
         q_list += [
             '%s:(%s)' % (k, re_to_esc.sub(r'\\\g<0>', param[k]))
             for k in check_params if k in param

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -353,7 +353,7 @@ def build_q_list(param):
                 if v:
                     q_list.append("(author_name:(%(name)s) OR author_alternative_name:(%(name)s))" % {'name': v})
 
-        check_params = ['title', 'publisher', 'oclc', 'lccn', 'contribtor', 'subject', 'place', 'person', 'time']
+        check_params = ['title', 'publisher', 'oclc', 'lccn', 'contributor', 'subject', 'place', 'person', 'time']
         q_list += [
             '%s:(%s)' % (k, re_to_esc.sub(r'\\\g<0>', param[k]))
             for k in check_params if k in param

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1041,7 +1041,8 @@ class search_json(delegate.page):
                       time_facet=[],
                       first_publish_year=[],
                       publisher_facet=[],
-                      language=[])
+                      language=[],
+                      public_scan_b=[])
         if 'query' in i:
             query = json.loads(i.query)
         else:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1034,7 +1034,14 @@ class search_json(delegate.page):
     encoding = "json"
 
     def GET(self):
-        i = web.input()
+        i = web.input(author_key=[],
+                      subject_facet=[],
+                      person_facet=[],
+                      place_facet=[],
+                      time_facet=[],
+                      first_publish_year=[],
+                      publisher_facet=[],
+                      language=[])
         if 'query' in i:
             query = json.loads(i.query)
         else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4996

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix following filters in search API:
- author_key
- subject_facet
- person_facet
- place_facet
- time_facet
- first_publish_year
- publisher_facet
- language
- public_scan_b (EDIT: Default parameter added to mimic standard search  behaviour)



One misspelled string in `build_q_list` function (`contributor`).

### Technical
<!-- What should be noted about the implementation? -->
Default non-working filters to list value in `web.input()`.

Solr logs with query `q=a&mode=everything&language=tel`:
- Web interface search giving `fq=language:"tel"`:
> INFO: [] webapp=/solr path=/select params={fl=key,author_name,author_key,title,subtitle,edition_count,ia,has_fulltext,first_publish_year,cover_i,cover_edition_key,public_scan_b,lending_edition_s,lending_identifier_s,language,ia_collection_s&fq=type:work&fq=language:"tel"&q.op=AND&start=0&rows=20&spellcheck=true&spellcheck.count=3&facet=true&facet.field=has_fulltext&facet.field=author_facet&facet.field=language&facet.field=first_publish_year&facet.field=publisher_facet&facet.field=subject_facet&facet.field=person_facet&facet.field=place_facet&facet.field=time_facet&facet.field=public_scan_b&q=a&defType=dismax&qf=text+title^5+author_name^5&bf=sqrt(edition_count)^10} hits=3 status=0 QTime=31

- Original search API giving `fq=language:"t"&fq=language:"e"&fq=language:"l"`:
> INFO: [] webapp=/solr path=/select params={fl=*&fq=type:work&fq=language:"t"&fq=language:"e"&fq=language:"l"&q.op=AND&start=0&rows=100&spellcheck=true&spellcheck.count=3&facet=true&facet.field=has_fulltext&facet.field=author_facet&facet.field=language&facet.field=first_publish_year&facet.field=publisher_facet&facet.field=subject_facet&facet.field=person_facet&facet.field=place_facet&facet.field=time_facet&facet.field=public_scan_b&q=a&defType=dismax&qf=text+title^5+author_name^5&bf=sqrt(edition_count)^10&wt=json} hits=0 status=0 QTime=13

- Updated search API giving `fq=language:"tel"`:
> INFO: [] webapp=/solr path=/select params={fl=*&fq=type:work&fq=language:"tel"&q.op=AND&start=0&rows=100&spellcheck=true&spellcheck.count=3&facet=true&facet.field=has_fulltext&facet.field=author_facet&facet.field=language&facet.field=first_publish_year&facet.field=publisher_facet&facet.field=subject_facet&facet.field=person_facet&facet.field=place_facet&facet.field=time_facet&facet.field=public_scan_b&q=a&defType=dismax&qf=text+title^5+author_name^5&bf=sqrt(edition_count)^10&wt=json} hits=3 status=0 QTime=6

Same behaviour observed for the other non-working filters.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
