### PR TITLE
Make oldev entrypoint absolute path

### DIFF
--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -22,4 +22,4 @@ RUN npm install
 # Expose Open Library, Infobase, Coverstore, and debugger
 EXPOSE 80 7000 7075 3000
 
-ENTRYPOINT ["./docker/docker-entrypoint.sh"] 
+ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"] 


### PR DESCRIPTION
Fix. A relative path will cause problems when we set the working directory to something other than `/openlibrary`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
