### PR TITLE
Fix lint-diff in GHA and fix CI var for make lint

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Run tests
         run: |
           source ~/openlibrary_python_venv/bin/activate
-          make lint-diff
+          git fetch --no-tags --prune --depth=1 origin master
+          BASE_BRANCH="origin/master" make lint-diff
           make lint
           make test-py
           source scripts/run_doctests.sh

--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,12 @@ reindex-solr:
 	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web:8080/ -c conf/openlibrary.yml --data-provider=legacy
 
 lint-diff:
-	git diff master -U0 | ./scripts/flake8-diff.sh
+	git diff "$${BASE_BRANCH:-master}" -U0 | ./scripts/flake8-diff.sh
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
 	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --select=E9,F63,F7,F82 --show-source --statistics
-ifndef CONTINUOUS_INTEGRATION
+ifndef CI
 	# exit-zero treats all errors as warnings, only run this in local dev while fixing issue, not CI as it will never fail.
 	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
 endif


### PR DESCRIPTION
Fix. GitHub Actions uses `CI` instead of `CONTINUOUS_INTEGRATION`. Also GHA isn't finding master for `lint-diff` for some reason :/

### Technical
- Useful list of all GHA env vars: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables

### Testing
- [x] No errors from `make lint-diff` in CI
- [x] Not a ton of warnings from `make lint` in CI
 https://github.com/internetarchive/openlibrary/pull/5049/checks?check_run_id=2348433992

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @dhruvmanila 
