### PR TITLE
Switch python3 in workflow to python

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: ~/openlibrary_python_venv
           key: ${{ runner.os }}-venv-${{ hashFiles('requirements*.txt') }}
-      - run: python3 -m venv ~/openlibrary_python_venv
+      - run: python -m venv ~/openlibrary_python_venv
       - name: Install dependencies
         run: |
           source ~/openlibrary_python_venv/bin/activate


### PR DESCRIPTION
Hotfix CI inexplicably failing due to python3 missing from venv error.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @dhruvmanila @Yashs911 
<!-- @ tag stakeholders of this bug -->
