### PR TITLE
Remove venv in python_tests

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,9 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         with:
-          path: ~/openlibrary_python_venv
+          path: ~/.cache/pip
           key: ${{ runner.os }}-venv-${{ hashFiles('requirements*.txt') }}
-      - run: python3 -m venv ~/openlibrary_python_venv
       - name: Install dependencies
         run: |
           source ~/openlibrary_python_venv/bin/activate
@@ -34,11 +33,9 @@ jobs:
       - run: make git
       - name: Run make i18n
         run: |
-          source ~/openlibrary_python_venv/bin/activate
           make i18n
       - name: Run tests
         run: |
-          source ~/openlibrary_python_venv/bin/activate
           git fetch --no-tags --prune --depth=1 origin master
           BASE_BRANCH="origin/master" make lint-diff
           make lint

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,7 +24,6 @@ jobs:
           key: ${{ runner.os }}-venv-${{ hashFiles('requirements*.txt') }}
       - name: Install dependencies
         run: |
-          source ~/openlibrary_python_venv/bin/activate
           # https://lxml.de/installation.html#requirements
           sudo apt-get install libxml2-dev libxslt-dev
           pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
We were getting errors on our workflows when trying to initialize the venv; it was complaining about `No such file or directory: '/home/runner/openlibrary_python_venv/bin/python'`. Disabling venv to fix master CI + unblock PRs.

Hotfix. We can switch back at our leisure once we figure out what went wrong :+1:

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @dhruvmanila @Yashs911 
