### PR TITLE
Correct pagination generation

### DIFF
--- a/openlibrary/macros/Pager.html
+++ b/openlibrary/macros/Pager.html
@@ -1,6 +1,6 @@
 $def with (page, num_found, results_per_page=20)
 
-$ pages = (num_found // results_per_page) + 1
+$ pages = ceil(num_found / results_per_page)
 $if pages != 1:
     $ pages_in_set = 10
     $ half = pages_in_set // 2

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -13,6 +13,7 @@ import random
 import datetime
 import logging
 from time import time
+import math
 
 import infogami
 
@@ -885,6 +886,7 @@ def setup_template_globals():
         'NEWLINE': '\n',
         'random': random.Random(),
         'get_lang': lambda: web.ctx.lang,
+        'ceil': math.ceil,
 
         # bad use of globals
         'is_bot': is_bot,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
No associated issue.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix pagination when number of results is a multiple of 20.
See this [OL Search](https://openlibrary.org/search?q=incal&mode=everything&page=2&lang=eng) for example.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Generate search giving Nx20 results.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
