### PR TITLE
Clean up new-solr-updater + add solr8-updater service

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -153,6 +153,14 @@ services:
     secrets:
       - ia_db_pw_file
 
+  # This will replace solr-updater once we fully migrate to solr8
+  solr8-updater:
+    extends:
+      service: solr-updater
+    environment:
+      - STATE_FILE=solr8-update.offset
+      - EXTRA_OPTS=--solr-url http://ol-solr1:8984/solr/openlibrary
+
   importbot:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -155,11 +155,25 @@ services:
 
   # This will replace solr-updater once we fully migrate to solr8
   solr8-updater:
-    extends:
-      service: solr-updater
+    profiles: ["ol-home0"]
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    restart: always
+    hostname: "$HOSTNAME"
     environment:
+      - PYENV_VERSION=${PYENV_VERSION:-}
+      - OL_CONFIG=/olsystem/etc/openlibrary.yml
+      - OL_URL=https://openlibrary.org/
       - STATE_FILE=solr8-update.offset
-      - EXTRA_OPTS=--solr-url http://ol-solr1:8984/solr/openlibrary
+      - EXTRA_OPTS=--solr-url http://ol-solr1:8984/solr/openlibrary --initial-state '2021-04-12:0'
+    volumes:
+      - solr-updater-data:/solr-updater-data
+      - ../olsystem:/olsystem
+    secrets:
+      - ia_db_pw_file
+    command: docker/ol-solr-updater-start.sh
+    networks:
+      - webnet
+      - dbnet
 
   importbot:
     profiles: ["ol-home0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - OL_CONFIG=conf/openlibrary.yml
       - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_URL=http://web:8080/
+      - STATE_FILE=solr-update.offset
     volumes:
       - solr-updater-data:/solr-updater-data
     networks:

--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -2,7 +2,8 @@
 
 python --version
 python scripts/new-solr-updater.py $OL_CONFIG \
-    --state-file /solr-updater-data/solr-update.offset \
+    --state-file /solr-updater-data/$STATE_FILE \
     --ol-url "$OL_URL" \
     --exclude-edits-containing 'Bot' \
-    --socket-timeout 1800
+    --socket-timeout 1800 \
+    $EXTRA_OPTS

--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 python --version
-python scripts/new-solr-updater.py \
-    --config $OL_CONFIG \
+python scripts/new-solr-updater.py $OL_CONFIG \
     --state-file /solr-updater-data/solr-update.offset \
     --ol-url "$OL_URL" \
     --exclude-edits-containing 'Bot' \

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -72,6 +72,11 @@ def get_solr_base_url():
     return solr_base_url
 
 
+def set_solr_base_url(solr_url: str):
+    global solr_base_url
+    solr_base_url = solr_url
+
+
 def get_ia_collection_and_box_id(ia):
     """
     Get the collections and boxids of the provided IA id

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -9,10 +9,8 @@ Changes:
 import _init_path
 
 from six.moves import urllib
-import yaml
 import logging
 import json
-import argparse
 import datetime
 import time
 import web
@@ -26,22 +24,6 @@ from infogami import config
 
 logger = logging.getLogger("openlibrary.solr-updater")
 
-LOAD_IA_SCANS = False
-COMMIT = True
-args = {}
-
-
-def parse_arguments():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config')
-    parser.add_argument('--debugger', action="store_true", help="Wait for a debugger to attach before beginning.")
-    parser.add_argument('--state-file', default="solr-update.state")
-    parser.add_argument('--exclude-edits-containing', help="Don't index matching edits")
-    parser.add_argument('--ol-url', default="http://openlibrary.org/")
-    parser.add_argument('--socket-timeout', type=int, default=10)
-    parser.add_argument('--load-ia-scans', dest="load_ia_scans", action="store_true", default=False)
-    parser.add_argument('--no-commit', dest="commit", action="store_false", default=True)
-    return parser.parse_args()
 
 def read_state_file(path):
     try:
@@ -115,7 +97,8 @@ class InfobaseLog:
 
             self.offset = d['offset']
 
-def parse_log(records):
+
+def parse_log(records, load_ia_scans: bool):
     for rec in records:
         action = rec.get('action')
         if action == 'save':
@@ -144,7 +127,8 @@ def parse_log(records):
                 edition_key = data.get('book_key')
                 if edition_key:
                     yield edition_key
-            elif LOAD_IA_SCANS and data.get("type") == "ia-scan" and key.startswith("ia-scan/"):
+            elif (load_ia_scans and data.get("type") == "ia-scan" and
+                  key.startswith("ia-scan/")):
                 identifier = data.get('identifier')
                 if identifier and is_allowed_itemid(identifier):
                     yield "/books/ia:" + identifier
@@ -232,8 +216,26 @@ class Solr:
         logger.info("END commit")
 
 
-def process_args(args):
-    if args.debugger:
+def main(
+        ol_config: str,
+        debugger=False,
+        state_file='solr-update.state',
+        exclude_edits_containing: str = None,
+        ol_url='http://openlibrary.org/',
+        socket_timeout=10,
+        load_ia_scans=False,
+        commit=False,
+):
+    """
+    :param debugger: Wait for a debugger to attach before beginning
+    :param exclude_edits_containing: Don't index matching edits
+    """
+    global args
+    FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
+    logging.basicConfig(level=logging.INFO, format=FORMAT)
+    logger.info("BEGIN new-solr-updater")
+
+    if debugger:
         import debugpy
 
         logger.info("Enabling debugger attachment (attach if it hangs here)")
@@ -244,44 +246,28 @@ def process_args(args):
 
     # Sometimes archive.org requests blocks forever.
     # Setting a timeout will make the request fail instead of waiting forever.
-    socket.setdefaulttimeout(args.socket_timeout)
-
-    global LOAD_IA_SCANS, COMMIT
-    LOAD_IA_SCANS = args.load_ia_scans
-    COMMIT = args.commit
-
-
-def main():
-    global args
-    FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
-    logging.basicConfig(level=logging.INFO, format=FORMAT)
-
-    logger.info("BEGIN new-solr-updater")
-
-    args = parse_arguments()
-    process_args(args)
+    socket.setdefaulttimeout(socket_timeout)
 
     # set OL URL when running on a dev-instance
-    if args.ol_url:
-        host = web.lstrips(args.ol_url, "http://").strip("/")
+    if ol_url:
+        host = web.lstrips(ol_url, "http://").strip("/")
         update_work.set_query_host(host)
 
     logger.info(str(args))
-    logger.info("loading config from %s", args.config)
-    load_config(args.config)
+    logger.info("loading config from %s", ol_config)
+    load_config(ol_config)
 
-    state_file = args.state_file
     offset = read_state_file(state_file)
 
     logfile = InfobaseLog(config.get('infobase_server'),
-                          exclude=args.exclude_edits_containing)
+                          exclude=exclude_edits_containing)
     logfile.seek(offset)
 
     solr = Solr()
 
     while True:
         records = logfile.read_records()
-        keys = parse_log(records)
+        keys = parse_log(records, load_ia_scans)
         count = update_keys(keys)
 
         if logfile.tell() != offset:
@@ -290,7 +276,7 @@ def main():
             with open(state_file, "w") as f:
                 f.write(offset)
 
-        if COMMIT:
+        if commit:
             solr.commit(ndocs=count)
         else:
             logger.info("not doing solr commit as commit is off")
@@ -303,4 +289,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+    FnToCLI(main).run()

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -222,6 +222,7 @@ def main(
         state_file='solr-update.state',
         exclude_edits_containing: str = None,
         ol_url='http://openlibrary.org/',
+        solr_url: str = None,
         socket_timeout=10,
         load_ia_scans=False,
         commit=False,
@@ -229,6 +230,7 @@ def main(
     """
     :param debugger: Wait for a debugger to attach before beginning
     :param exclude_edits_containing: Don't index matching edits
+    :param solr_url: If wanting to override what's in the config file
     """
     global args
     FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
@@ -252,6 +254,9 @@ def main(
     if ol_url:
         host = web.lstrips(ol_url, "http://").strip("/")
         update_work.set_query_host(host)
+
+    if solr_url:
+        update_work.set_solr_base_url(solr_url)
 
     logger.info(str(args))
     logger.info("loading config from %s", ol_config)

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -25,12 +25,12 @@ from infogami import config
 logger = logging.getLogger("openlibrary.solr-updater")
 
 
-def read_state_file(path):
+def read_state_file(path, initial_state: str = None):
     try:
         return open(path).read()
     except IOError:
         logger.error("State file %s is not found. Reading log from the beginning of today", path)
-        return datetime.date.today().isoformat() + ":0"
+        return initial_state or f"{datetime.date.today().isoformat()}:0"
 
 def get_default_offset():
     return datetime.date.today().isoformat() + ":0"
@@ -226,11 +226,13 @@ def main(
         socket_timeout=10,
         load_ia_scans=False,
         commit=False,
+        initial_state: str = None,
 ):
     """
     :param debugger: Wait for a debugger to attach before beginning
     :param exclude_edits_containing: Don't index matching edits
     :param solr_url: If wanting to override what's in the config file
+    :param initial_state: State to use if state file doesn't exist. Defaults to today.
     """
     global args
     FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
@@ -262,7 +264,7 @@ def main(
     logger.info("loading config from %s", ol_config)
     load_config(ol_config)
 
-    offset = read_state_file(state_file)
+    offset = read_state_file(state_file, initial_state)
 
     logfile = InfobaseLog(config.get('infobase_server'),
                           exclude=exclude_edits_containing)


### PR DESCRIPTION
Progress towards #3317 

- Refactor new-solr-updater to use FnToCLI + Remove some globals
- Add new option for setting solr_base_url via CLI
- Add solr-updater service pointed at solr1

### Technical
- A refactor to simplify `new-solr-updater.py` and remove all the parse args.
- Add some new options to `new-solr-updater.py`
- Add `solr8-updater` service.

### Testing
- [x] ` COMPOSE_FILE='docker-compose.yml;docker-compose.production.yml' docker-compose config` This means there are no errors in the compose file, so won't bring any other services down.
- [ ] solr-updater healthy after `docker-compose up -d`
- Not tested 😬 ~Should be able to toss it onto staging with volume mounts to see if it works...~ Nope. Too annoying.
     - In order to test this service, since there are code changes, I'd need to either rebuild olbase with the new code, or use volume mounts to get the new code. Don't want to use volume mounts on prod... Testing has volume mounts, but don't want to transfer secrets to testing server. Since the compose file is fully functional, the only things this _can_ cause problems to is solr8-updater or solr-updater. Consider that sufficiently low risk.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
