### PR TITLE
fix(actions): Use exact Python version and update cache key

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8.8, 3.9.4]
+        python-version: [3.8.9, 3.9.4]
     runs-on: ubuntu-16.04  # Should match Dockerfile.olbase
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8.8, 3.9.4]
     runs-on: ubuntu-16.04  # Should match Dockerfile.olbase
     steps:
       - uses: actions/checkout@v2
@@ -20,10 +20,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-venv-${{ hashFiles('requirements*.txt') }}
+          path: ~/openlibrary_python_venv
+          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt') }}
       - name: Install dependencies
         run: |
+          source ~/openlibrary_python_venv/bin/python
           # https://lxml.de/installation.html#requirements
           sudo apt-get install libxml2-dev libxslt-dev
           pip install --upgrade pip setuptools wheel
@@ -32,9 +33,11 @@ jobs:
       - run: make git
       - name: Run make i18n
         run: |
+          source ~/openlibrary_python_venv/bin/python
           make i18n
       - name: Run tests
         run: |
+          source ~/openlibrary_python_venv/bin/python
           git fetch --no-tags --prune --depth=1 origin master
           BASE_BRANCH="origin/master" make lint-diff
           make lint

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8.9, 3.9.4]
+        python-version: [3.8, 3.9]
     runs-on: ubuntu-16.04  # Should match Dockerfile.olbase
     steps:
       - uses: actions/checkout@v2
@@ -20,12 +20,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         with:
-          path: ~/openlibrary_python_venv
-          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt') }}
-      - run: python -m venv ~/openlibrary_python_venv
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
       - name: Install dependencies
         run: |
-          source ~/openlibrary_python_venv/bin/activate
           # https://lxml.de/installation.html#requirements
           sudo apt-get install libxml2-dev libxslt-dev
           pip install --upgrade pip setuptools wheel
@@ -33,12 +31,9 @@ jobs:
           pip list --outdated
       - run: make git
       - name: Run make i18n
-        run: |
-          source ~/openlibrary_python_venv/bin/activate
-          make i18n
+        run: make i18n
       - name: Run tests
         run: |
-          source ~/openlibrary_python_venv/bin/activate
           git fetch --no-tags --prune --depth=1 origin master
           BASE_BRANCH="origin/master" make lint-diff
           make lint

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           path: ~/openlibrary_python_venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('requirements*.txt') }}
+      - run: python -m venv ~/openlibrary_python_venv
       - name: Install dependencies
         run: |
           source ~/openlibrary_python_venv/bin/python

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - run: python -m venv ~/openlibrary_python_venv
       - name: Install dependencies
         run: |
-          source ~/openlibrary_python_venv/bin/python
+          source ~/openlibrary_python_venv/bin/activate
           # https://lxml.de/installation.html#requirements
           sudo apt-get install libxml2-dev libxslt-dev
           pip install --upgrade pip setuptools wheel
@@ -34,11 +34,11 @@ jobs:
       - run: make git
       - name: Run make i18n
         run: |
-          source ~/openlibrary_python_venv/bin/python
+          source ~/openlibrary_python_venv/bin/activate
           make i18n
       - name: Run tests
         run: |
-          source ~/openlibrary_python_venv/bin/python
+          source ~/openlibrary_python_venv/bin/activate
           git fetch --no-tags --prune --depth=1 origin master
           BASE_BRANCH="origin/master" make lint-diff
           make lint


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the problem where the appropriate Python executable was not found.

### Technical
<!-- What should be noted about the implementation? -->

When we create a virtual environment using `python3 -m venv ... `, it creates a bin directory which contains symlink to the original Python interpreter. In our case, actions/setup-python upgraded the Python version from `3.8.8` -> `3.8.9` which removes the old version from the tool cache (where it stores the files) and only keeps the latest one. So, when the virtual environment was restored using the cache, the symlink was broken and thus the error.

Quoting from https://github.com/actions/setup-python#available-versions-of-python (Point 1.3):
> If 3.8.1 is installed for example, and 3.8.2 is released, expect 3.8.1 to be removed and replaced by 3.8.2 in the tools cache.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2021-04-16 at 08 33 29](https://user-images.githubusercontent.com/67177269/114967116-7aa4cf80-9e91-11eb-9611-54316564ed62.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @cclauss 