### PR TITLE
Add html/python cstyle string tests for po files

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -28,8 +28,14 @@ def _compile_translation(po, mo):
         print('failed to compile', po, file=web.debug)
         raise e
 
+
 def get_locales():
-    return [d for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))]
+    return [
+        d
+        for d in os.listdir(root)
+        if (os.path.isdir(os.path.join(root, d)) and
+            os.path.exists(os.path.join(root, d, 'messages.po')))
+    ]
 
 def extract_templetor(fileobj, keywords, comment_tags, options):
     """Extract i18n messages from web.py templates."""

--- a/openlibrary/i18n/cs/messages.po
+++ b/openlibrary/i18n/cs/messages.po
@@ -950,7 +950,7 @@ msgid "Either choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
 #: edit/addcover.html:22
-msgid "<u>Or</u></span>, paste in a URL to an image if it's on the web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in a URL to an image if it's on the web."
 msgstr ""
 
 #: edit/addcover.html:31
@@ -1382,7 +1382,7 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
 #: add.html:111
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
 msgstr ""
 
 #: add.html:119

--- a/openlibrary/i18n/de/messages.po
+++ b/openlibrary/i18n/de/messages.po
@@ -898,8 +898,8 @@ msgid "Either choose a JPG, GIF or PNG on your computer,"
 msgstr "Wählen Sie ein JPG, GIF oder PNG von Ihrem Computer aus,"
 
 #: edit/addcover.html:22
-msgid "<u>Or</u></span>, paste in a URL to an image if it's on the web."
-msgstr "<u>Oder</u></span> fügen Sie den Link zum Bild ein, wenn es im Internet verfügbar ist."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in a URL to an image if it's on the web."
+msgstr "<span class=\"highlight\"><u>Oder</u></span> fügen Sie den Link zum Bild ein, wenn es im Internet verfügbar ist."
 
 #: edit/addcover.html:31
 msgid "Upload"
@@ -1321,8 +1321,8 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr "Wählen Sie ein JPG, GIF oder PNG von Ihrem Computer,"
 
 #: add.html:111
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
-msgstr "<u>Oder</u></span> fügen Sie den Link zum Bild ein, wenn es im Internet verfügbar ist."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
+msgstr "<span class=\"highlight\"><u>Oder</u></span> fügen Sie den Link zum Bild ein, wenn es im Internet verfügbar ist."
 
 #: add.html:119
 msgid "Submit"

--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -2024,8 +2024,8 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr "Elige un JPG, GIF o PNG en tu ordenador,"
 
 #: add.html:126
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
-msgstr "<u>O</u></span> pega la URL de la imagen si está en la web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
+msgstr "<span class=\"highlight\"><u>O</u></span> pega la URL de la imagen si está en la web."
 
 #: add.html:134
 msgid "Submit"
@@ -2656,8 +2656,8 @@ msgstr "Listas activas"
 
 #: home.html:45
 #, python-format
-msgid "%(listname)s </a> from <a href=\"%(key)s\">%(owner)s</a>"
-msgstr "%(listname)s </a> de <a href=\"%(key)s\">%(owner)s</a>"
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 
 #: home.html:50 preview.html:27 snippet.html:20
 #, python-format

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -1133,7 +1133,7 @@ msgstr "Actions d'emprunt"
 msgid "There is one person waiting for this book."
 msgid_plural "There are %(n)d people waiting for this book."
 msgstr[0] "Une personne attend ce livre."
-msgstr[1] "%(n)s personnes attendent ce livre."
+msgstr[1] "%(n)d personnes attendent ce livre."
 
 #: borrow.html:121
 msgid "Not yet downloaded."
@@ -1234,7 +1234,7 @@ msgstr "Vous êtes la prochaine personne à recevoir ce livre."
 msgid "There is one person ahead of you in the waiting list."
 msgid_plural "There are %(count)d people ahead of you in the waiting list."
 msgstr[0] "Il y a 1 personne devant vous sur la liste d'attente."
-msgstr[1] "Il y a %(count)s personnes devant vous sur la liste d'attente."
+msgstr[1] "Il y a %(count)d personnes devant vous sur la liste d'attente."
 
 #: borrow.html:219
 msgid "You have less than an hour to borrow it."

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -1792,7 +1792,7 @@ msgid ""
 msgstr ""
 "Vous pouvez effectuer une recherche par nom d'auteur (comme <em>j k "
 "rowling</em>) ou par identifiant de Open Library (comme <a href=\" "
-"/authors/OL23919A\"target = \"_ blank\"> <em>OL23919A</em> </a>)."
+"/authors/OL23919A\" target=\"_blank\"> <em>OL23919A</em> </a>)."
 
 #: edit.html:108
 msgid "What's It About?"
@@ -2300,8 +2300,8 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr "Choisissez un fichier JPG, GIF ou PNG sur votre ordinateur,"
 
 #: add.html:126
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
-msgstr "<u>Ou</u></span>, collez l'URL de l'image si elle est sur le web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
+msgstr "<span class=\"highlight\"><u>Ou</u></span>, collez l'URL de l'image si elle est sur le web."
 
 #: add.html:134
 msgid "Submit"
@@ -2386,7 +2386,7 @@ msgid ""
 msgstr ""
 "Tout comme Wikipédia, vous pouvez apporter de nouvelles informations ou "
 "corrections au catalogue. Vous pouvez parcourir les <a "
-"href=\"/subjects\">sujets</a>, les <a \"href=\"/authors\">auteurs</a> ou "
+"href=\"/subjects\">sujets</a>, les <a href=\"/authors\">auteurs</a> ou "
 "les <a href=\"/lists\">listes</a> que les membres ont créées. Si vous "
 "aimez les livres, pourquoi ne pas aider à créer une bibliothèque ?"
 
@@ -2452,7 +2452,7 @@ msgid ""
 "href=\"/recentchanges\">recent changes</a>"
 msgstr ""
 "Voici ce qui s'est passé au cours des 28 derniers jours. Plus de <a "
-"\"href=\"/recentchanges\">modifications récentes</a>"
+"href=\"/recentchanges\">modifications récentes</a>"
 
 #: stats.html:15 stats.html:17
 msgid "See all visitors to OpenLibrary.org"
@@ -3003,8 +3003,8 @@ msgstr "Listes actives"
 
 #: home.html:45
 #, python-format
-msgid "%(listname)s </a> from <a href=\"%(key)s\">%(owner)s</a>"
-msgstr "%(listname)s </a> de <a href=\"%(key)s\">%(owner)s</a>"
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 
 #: home.html:50 preview.html:27 snippet.html:20
 #, python-format

--- a/openlibrary/i18n/hr/messages.po
+++ b/openlibrary/i18n/hr/messages.po
@@ -2278,8 +2278,8 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr "Odaberi JPG, GIF ili PNG s tvog računala,"
 
 #: add.html:126
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
-msgstr "<u>Ili</u></span> upiši URL adresu, ako postoji na internetu."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
+msgstr "<span class=\"highlight\"><u>Ili</u></span> upiši URL adresu, ako postoji na internetu."
 
 #: add.html:134
 msgid "Submit"
@@ -2978,8 +2978,8 @@ msgstr "Popisi aktivnih"
 
 #: home.html:45
 #, python-format
-msgid "%(listname)s </a> from <a href=\"%(key)s\">%(owner)s</a>"
-msgstr "%(listname)s </a> od <a href=\"%(key)s\">%(owner)s</a>"
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "od <a href=\"%(key)s\">%(owner)s</a>"
 
 #: home.html:50 preview.html:27 snippet.html:20
 #, python-format

--- a/openlibrary/i18n/ja/messages.po
+++ b/openlibrary/i18n/ja/messages.po
@@ -2153,7 +2153,7 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
 #: add.html:126
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
 msgstr ""
 
 #: add.html:134
@@ -2818,7 +2818,7 @@ msgstr ""
 
 #: home.html:45
 #, python-format
-msgid "%(listname)s </a> from <a href=\"%(key)s\">%(owner)s</a>"
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr ""
 
 #: home.html:50 preview.html:27 snippet.html:20

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -2376,7 +2376,7 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
 #: covers/add.html:69
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
 msgstr ""
 
 #: BookPreview.html:19 DonateModal.html:15 UserMetadata.html:13

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -2294,8 +2294,8 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr "Wybierz plik JPG, GIF lub PNG z Twojego komputera."
 
 #: add.html:126
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
-msgstr "<u>Lub</u></span> wklej URL obrazu z adresu internetowego."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
+msgstr "<span class=\"highlight\"><u>Lub</u></span> wklej URL obrazu z adresu internetowego."
 
 #: add.html:134
 msgid "Submit"
@@ -2994,8 +2994,8 @@ msgstr "Aktywne Listy"
 
 #: home.html:45
 #, python-format
-msgid "%(listname)s </a> from <a href=\"%(key)s\">%(owner)s</a>"
-msgstr "%(listname)s </a><a href=\"%(key)s\">%(owner)s</a>"
+msgid "from <a href=\"%(key)s\">%(owner)s</a>"
+msgstr "<a href=\"%(key)s\">%(owner)s</a>"
 
 #: home.html:50 preview.html:27 snippet.html:20
 #, python-format

--- a/openlibrary/i18n/te/messages.po
+++ b/openlibrary/i18n/te/messages.po
@@ -312,7 +312,7 @@ msgstr[1] "%d రోజుల కోసం ఎదురు చూస్తున
 msgid "There is one person ahead of you in the waiting list."
 msgid_plural "There are %(count)s people ahead of you in the waiting list."
 msgstr[0] "ఒక్క మనిషి  మాత్రమే మీ కన్నా ముందు వేచిచూసి జాబితాలో ఉన్నాడు"
-msgstr[1] "%s  మనిషులు మీ కన్నా ముందు వేచిచూసి జాబితాలో ఉన్నాడు "
+msgstr[1] "%(count)s  మనిషులు మీ కన్నా ముందు వేచిచూసి జాబితాలో ఉన్నాడు "
 
 #: borrow.html:260
 msgid "There are 2 different sources for borrowing books through Open Library:"
@@ -1467,9 +1467,8 @@ msgid "Created %s"
 msgstr ""
 
 #: history.html:25
-#, fuzzy
 msgid "revision"
-msgstr "రివిజన్ %d"
+msgstr "రివిజన్"
 
 #: history.html:51 openlibrary/templates/history.html:36
 #, python-format

--- a/openlibrary/i18n/te/messages.po
+++ b/openlibrary/i18n/te/messages.po
@@ -331,7 +331,7 @@ msgid ""
 "The <a href=\"//archive.org/\">Internet Archive</a> and several partner "
 "libraries are offering thousands of eBooks for loan to anyone with an "
 "Open Library account, anywhere in the world."
-msgstr "<a href=\"//archive.org/\">అంతర్జాలపు ఆర్కైవ్ మరియు ఎన్నో భాగస్వాములతో కలిసి, గ్రంథాలయాలు కొన్నివేల ఈ-పుస్తకాలను,అందరికి అందుబాటులో ఉండే  గ్రంథాలయం ఖాతా ఉన్నవారికి ప్రపంచంలో ఎక్కడ ఉన్న రుణాలుగా ఇస్తోంది. "
+msgstr "<a href=\"//archive.org/\">అంతర్జాలపు ఆర్కైవ్</a> మరియు ఎన్నో భాగస్వాములతో కలిసి, గ్రంథాలయాలు కొన్నివేల ఈ-పుస్తకాలను,అందరికి అందుబాటులో ఉండే  గ్రంథాలయం ఖాతా ఉన్నవారికి ప్రపంచంలో ఎక్కడ ఉన్న రుణాలుగా ఇస్తోంది. "
 
 #: borrow.html:274
 msgid "physical books from your local library"

--- a/openlibrary/i18n/te/messages.po
+++ b/openlibrary/i18n/te/messages.po
@@ -951,7 +951,7 @@ msgid "Either choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
 #: edit/addcover.html:22
-msgid "<u>Or</u></span>, paste in a URL to an image if it's on the web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in a URL to an image if it's on the web."
 msgstr ""
 
 #: edit/addcover.html:31
@@ -1382,7 +1382,7 @@ msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
 #: add.html:111
-msgid "<u>Or</u></span>, paste in the image URL if it's on the web."
+msgid "<span class=\"highlight\"><u>Or</u></span>, paste in the image URL if it's on the web."
 msgstr ""
 
 #: add.html:119

--- a/openlibrary/i18n/test_po_files.py
+++ b/openlibrary/i18n/test_po_files.py
@@ -1,0 +1,103 @@
+import os
+import re
+from itertools import groupby
+
+import pytest
+from babel.messages.pofile import read_po
+
+from openlibrary.i18n import get_locales
+
+root = os.path.dirname(__file__)
+# Fix these and then remove them from this list
+ALLOW_FAILURES = ('cs', 'hr', 'pl')
+
+
+def parse_cfmt(string: str):
+    """
+    Extract e.g. '%s' from cstyle python format strings
+    >>> parse_cfmt('hello %s')
+    ['%s']
+    >>> parse_cfmt(' by %(name)s')
+    ['%(name)s']
+    >>> parse_cfmt('%(count)d Lists')
+    ['%(count)d']
+    >>> parse_cfmt('100%% Complete!')
+    ['%%']
+    >>> parse_cfmt('%(name)s avez %(count)s listes.')
+    ['%(name)s', '%(count)s']
+    >>> parse_cfmt('')
+    []
+    >>> parse_cfmt('Hello World')
+    []
+    """
+    cfmt_re = r'''
+        (
+            %(?:
+                (?:\([a-zA-Z_][a-zA-Z0-9_]*?\))?   # e.g. %(blah)s
+                (?:[-+0 #]{0,5})                   # optional flags
+                (?:\d+|\*)?                        # width
+                (?:\.(?:\d+|\*))?                  # precision
+                (?:h|l|ll|w|I|I32|I64)?            # size
+                [cCdiouxXeEfgGaAnpsSZ]             # type
+            )
+        )
+        |                                # OR
+        %%                               # literal "%%"
+    '''
+
+    return [
+        m.group(0)
+        for m in re.finditer(cfmt_re, string, flags=re.VERBOSE)
+    ]
+
+
+def cfmt_fingerprint(string: str):
+    """
+    Get a fingerprint dict of the cstyle format in this string
+    >>> cfmt_fingerprint('hello %s')
+    {'%s': 1}
+    >>> cfmt_fingerprint('hello %s and %s')
+    {'%s': 2}
+    >>> cfmt_fingerprint('hello %(title)s. %(first)s %(last)s')
+    {'%(title)s': 1, '%(first)s': 1, '%(last)s': 1}
+    """
+    pieces = parse_cfmt(string)
+    return {
+        key: len(list(grp))
+        for key, grp in groupby(pieces)
+    }
+
+
+def gen_po_file_keys():
+    for locale in get_locales():
+        po_path = os.path.join(root, locale, 'messages.po')
+
+        catalog = read_po(open(po_path, 'rb'))
+        for key in catalog:
+            yield locale, key
+
+
+def gen_python_format_entries():
+    """Generate a tuple for every msgid/msgstr in our po files"""
+    for locale, key in gen_po_file_keys():
+        if not isinstance(key.id, str):
+            msgids, msgstrs = (key.id, key.string)
+        else:
+            msgids, msgstrs = ([key.id], [key.string])
+
+        for msgid, msgstr in zip(msgids, msgstrs):
+            if msgstr == "":
+                continue
+            if not ('%' in msgid or '%' in msgstr):
+                continue
+
+            if locale in ALLOW_FAILURES:
+                yield pytest.param(locale, msgid, msgstr, id=f'{locale}:{msgid}',
+                                   marks=pytest.mark.xfail)
+            else:
+                yield pytest.param(locale, msgid, msgstr, id=f'{locale}:{msgid}')
+
+
+@pytest.mark.parametrize("locale,msgid,msgstr", gen_python_format_entries())
+def test_python_format(locale: str, msgid: str, msgstr: str):
+    assert cfmt_fingerprint(msgid) == cfmt_fingerprint(msgstr)

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -59,7 +59,7 @@ $if status:
 
             <div class="formElement">
                 <div class="label">
-                    <label id="imageWeb" for="imageUrl"><span class="highlight">$:_("<u>Or</u></span>, paste in the image URL if it's on the web.")</label>
+                    <label id="imageWeb" for="imageUrl">$:_("<span class="highlight"><u>Or</u></span>, paste in the image URL if it's on the web.")</label>
                 </div>
                 <div class="input">
                     <input type="text" name="url" id="imageUrl" value="$data.get('url', 'http://')" onClick="if(!this._haschanged && this.value == 'http://'){this.value=''};this._haschanged=true;"/>

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -39,7 +39,9 @@ $var title: $_('Lists')
                             $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
                             <img src="$cover_url" alt=""/>
                         </div>
-                        $:_('%(listname)s </a> from <a href="%(key)s">%(owner)s</a>', key=owner.key, listname=list.name, owner=owner.displayname)
+                        %(listname)s
+                    </a>
+                    $:_('from <a href="%(key)s">%(owner)s</a>', key=owner.key, owner=owner.displayname)
                 </div>
                 <div class="meta">
                     $ msg = ungettext("1 item", "%(count)d items", len(list.seeds))


### PR DESCRIPTION
Fix. This prevents translations being added that could break the UI.

### Technical
- Currently annoying to run for a specific language :/ Should refactor i18n-messages script to be locale specific, and somehow call the pytests from these for the provided locale. Thoughts for a future PR.
- Disabled tests for cs, hr, pl; they had errors I couldn't resolve. Will create issues for domain experts. (Although I'm wondering if I should first do a `i18n update`... That'll shuffle things around a bunch, and might even delete some strings).

### Testing
- [x] `pytest openlibrary/i18n/test_po_files.py` passes
- [x] Introducing an html error causes it to fail
- [x] Introducing a python cstyle string discrepancy causes it to fail

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@lephemere 
