### PR TITLE
Fix/Correct examples link on edit page

### DIFF
--- a/openlibrary/templates/books/edit/about.html
+++ b/openlibrary/templates/books/edit/about.html
@@ -28,7 +28,7 @@ $def with (work)
     <div class="formElement">
         <div class="label">
             <label for="about-people">$_("A person? Or, people?")</label>
-            <span class="tip">$_("For example:") <i><a href="/subjects/people/Theodore_Roosevelt">Theodore Roosevelt</a>, <a href="/subjects/people/Julian_of_Norwich">Julian of Norwich</a>, <a href="/subjects/people/Tintin">Tintin</a></i></span>
+            <span class="tip">$_("For example:") <i><a href="/subjects/person:Theodore_Roosevelt">Theodore Roosevelt</a>, <a href="/subjects/person:Julian_of_Norwich">Julian of Norwich</a>, <a href="/subjects/person:Tintin">Tintin</a></i></span>
         </div>
         <div class="input">
             $ subjects = []
@@ -42,7 +42,7 @@ $def with (work)
     <div class="formElement">
         <div class="label">
             <label for="about-places">$_("Note any places mentioned?")</label>
-            <span class="tip">$_("For example:") <i><a href="/subjects/places/London">London</a>, <a href="/subjects/places/Atlantis">Atlantis</a>, <a href="/subjects/places/Omaha">Omaha</a></i></span>
+            <span class="tip">$_("For example:") <i><a href="/subjects/place:London">London</a>, <a href="/subjects/place:Atlantis">Atlantis</a>, <a href="/subjects/place:Omaha">Omaha</a></i></span>
         </div>
         <div class="input">
             $ subjects = []
@@ -56,7 +56,7 @@ $def with (work)
     <div class="formElement bottom">
         <div class="label">
             <label for="about-time">$_("When is it set or about?")</label>
-            <span class="tip">$_("For example:") <i><a href="/subjects/time/1984">1984</a>, <a href="/subjects/time/the_middle_ages">The Middle Ages</a>, <a href="/subjects/time/1810-1890">1810-1890</a></i></span>
+            <span class="tip">$_("For example:") <i><a href="/subjects/time:1984">1984</a>, <a href="/subjects/time:the_middle_ages">The Middle Ages</a>, <a href="/subjects/time:1810-1890">1810-1890</a></i></span>
         </div>
         <div class="input">
             $ subjects = []


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Not linked to an issue.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix person/place/time examples link redirecting to `404` error page on work edit page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
