### PR TITLE
Set default cache expiry

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -184,5 +184,5 @@ sentry:
     dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
     environment: 'local'
 
-# The Best Book On integration
+# Observations cache settings:
 observation_cache_duration: 86400

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -243,7 +243,9 @@ OBSERVATIONS = {
     ]
 }
 
-@cache.memoize(engine="memcache", key="observations", expires=config.get('observation_cache_duration'))
+cache_duration = config.get('observation_cache_duration') or 86400
+
+@cache.memoize(engine="memcache", key="observations", expires=cache_duration)
 def get_observations():
     """
     Returns a dictionary of observations that are used to populate forms for patron feedback about a book.

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -245,6 +245,7 @@ OBSERVATIONS = {
 
 cache_duration = config.get('observation_cache_duration') or 86400
 
+
 @cache.memoize(engine="memcache", key="observations", expires=cache_duration)
 def get_observations():
     """


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sets default expiry time of one day for observations cache entries.

### Technical
<!-- What should be noted about the implementation? -->
If the `observation_cache_duration` configuration is missing from `openlibrary.yml`,  `get_observations()` calls fail because `None` is being passed as the cache expiry time.  Setting a default time avoids this issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Remove the `observation_cache_duration` entry from `openlibrary.yml`.
2. Log in with an account that is a member of usergroup `beta-testers`.
3. Navigate to a book page and attempt to open the book notes modal.  If the modal is displayed, the `get_observations()` call has been successfully executed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
