### PR TITLE
adding `lang` to html template globals

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -884,6 +884,7 @@ def setup_template_globals():
         'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
         'NEWLINE': '\n',
         'random': random.Random(),
+        'lang': web.ctx.lang,
 
         # bad use of globals
         'is_bot': is_bot,

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -884,7 +884,7 @@ def setup_template_globals():
         'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
         'NEWLINE': '\n',
         'random': random.Random(),
-        'lang': web.ctx.lang,
+        'get_lang': lambda: web.ctx.lang,
 
         # bad use of globals
         'is_bot': is_bot,

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$get_lang()">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This is a prerequisite for #5013 to update https://github.com/internetarchive/openlibrary/blob/9a0a6e41e3a524d67cf6cce82aaccc6281407b57/openlibrary/templates/site/head.html#L4 so that it generically uses:
`<html xmlns="http://www.w3.org/1999/xhtml" lang="$get_lang()">`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
