### PR TITLE
Refactor/Move inline js from work_search template

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -173,12 +173,12 @@ jQuery(function () {
 
     if (document.getElementById('searchFacets')) {
         import(/* webpackChunkName: "search" */ './search')
-            .then((module) => module.initSearchFacets());
-    }
-
-    if (document.getElementById('adminTiming')) {
-        import(/* webpackChunkName: "search" */ './search')
-            .then((module) => module.initAdminTiming());
+            .then((module) => {
+                module.initSearchFacets();
+                if (document.getElementById('adminTiming')) {
+                    module.initAdminTiming();
+                }
+            });
     }
 
     if ($('#cboxPrevious').length) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -176,6 +176,11 @@ jQuery(function () {
             .then((module) => module.initSearchFacets());
     }
 
+    if (document.getElementById('adminTiming')) {
+        import(/* webpackChunkName: "search" */ './search')
+            .then((module) => module.initAdminTiming());
+    }
+
     if ($('#cboxPrevious').length) {
         $('#cboxPrevious').attr({'aria-label': 'Previous button', 'aria-hidden': 'true'});
     }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -171,6 +171,11 @@ jQuery(function () {
             .then((module) => module.initAdmin());
     }
 
+    if (document.getElementById('searchFacets')) {
+        import(/* webpackChunkName: "search" */ './search')
+            .then((module) => module.initSearchFacets());
+    }
+
     if ($('#cboxPrevious').length) {
         $('#cboxPrevious').attr({'aria-label': 'Previous button', 'aria-hidden': 'true'});
     }

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -1,3 +1,14 @@
+/**
+ * Functionalities for templates/work_search.
+ */
+
+/**
+ * Displays more facets by removing the ui-helper-hidden class.
+ *
+ * @param {String} header class name
+ * @param {Number} start_facet_count initial number of displayed facets
+ * @param {Number} facet_inc number of hidden facets to be displayed
+ */
 function more(header, start_facet_count, facet_inc) {
     const facetEntry = `div.${header} div.facetEntry`
     const shown = $(`${facetEntry}:not(:hidden)`).length
@@ -13,6 +24,13 @@ function more(header, start_facet_count, facet_inc) {
     $(`${facetEntry}:hidden`).slice(0, facet_inc).removeClass('ui-helper-hidden');
 }
 
+/**
+ * Hides facets by adding the ui-helper-hidden class.
+ *
+ * @param {String} header class name
+ * @param {Number} start_facet_count initial number of displayed facets
+ * @param {Number} facet_inc number of displayed facets to be hidden
+ */
 function less(header, start_facet_count, facet_inc) {
     const facetEntry = `div.${header} div.facetEntry`
     const shown = $(`${facetEntry}:not(:hidden)`).length
@@ -28,6 +46,12 @@ function less(header, start_facet_count, facet_inc) {
     $(`${facetEntry}:not(:hidden)`).slice(shown - facet_inc, shown).addClass('ui-helper-hidden');
 }
 
+/**
+ * Initializes searchFacets element.
+ *
+ * Hides '.header_bull' element and adds onclick events to '.header_(more|less)' elements.
+ * Assumes presence of element with '#searchFacets' id and 'data-config' attribute.
+ */
 export function initSearchFacets() {
     const data_config_json = $('#searchFacets').data('config');
     const start_facet_count = data_config_json['start_facet_count'];
@@ -44,6 +68,9 @@ export function initSearchFacets() {
 
 let readapi_starttime = 0;
 
+/**
+ * Displays difference between readapi_starttime and now in '#adminTiming' element.
+ */
 function readapi_callback() {
     const endtime = Date.now();
     const duration = (endtime - readapi_starttime) / 1000;
@@ -53,14 +80,19 @@ function readapi_callback() {
     }
 }
 
+/**
+ * Initializes adminTiming element.
+ *
+ * Calls read_multiget API for a list of works.
+ * Assumes presence of element with '#adminTiming' id and 'data-wks' attribute.
+ */
 export function initAdminTiming() {
     const readapi_percent = 100;
     if (Math.random() * 100 < readapi_percent) {
         readapi_starttime = Date.now();
-        const ol = 'openlibrary.org';
         const wks = $('#adminTiming').data('wks');
         $.ajax({
-            url: `https://${ol}/api/volumes/brief/json/${wks}?listofworks=True&no_details=True&stats=True`,
+            url: `https://openlibrary.org/api/volumes/brief/json/${wks}?listofworks=True&no_details=True&stats=True`,
             dataType: 'jsonp',
             success: readapi_callback
         });

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -87,14 +87,12 @@ function readapi_callback() {
  * Assumes presence of element with '#adminTiming' id and 'data-wks' attribute.
  */
 export function initAdminTiming() {
-    const readapi_percent = 100;
-    if (Math.random() * 100 < readapi_percent) {
-        readapi_starttime = Date.now();
-        const wks = $('#adminTiming').data('wks');
-        $.ajax({
-            url: `https://openlibrary.org/api/volumes/brief/json/${wks}?listofworks=True&no_details=True&stats=True`,
-            dataType: 'jsonp',
-            success: readapi_callback
-        });
-    }
+    // ALL admin views are sampled.
+    readapi_starttime = Date.now();
+    const wks = $('#adminTiming').data('wks');
+    $.ajax({
+        url: `https://openlibrary.org/api/volumes/brief/json/${wks}?listofworks=True&no_details=True&stats=True`,
+        dataType: 'jsonp',
+        success: readapi_callback
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -1,0 +1,45 @@
+function more(header, start_facet_count, facet_inc) {
+    const div_header = "div." + header
+    const facetEntry = div_header + " div.facetEntry"
+    const shown = $(facetEntry + ":not(:hidden)").length
+    const total = $(facetEntry).length
+    if (shown == start_facet_count) {
+        $("#" + header + "_less").show();
+        $("#" + header + "_bull").show();
+    }
+    if (shown + facet_inc >= total) {
+        $("#" + header + "_more").hide();
+        $("#" + header + "_bull").hide();
+    }
+    $(facetEntry + ":hidden").slice(0, facet_inc).removeClass('ui-helper-hidden');
+}
+
+function less(header, start_facet_count, facet_inc) {
+    const div_header = "div." + header
+    const facetEntry = div_header + " div.facetEntry"
+    const shown = $(facetEntry + ":not(:hidden)").length
+    const total = $(facetEntry).length
+    if (shown - facet_inc == start_facet_count) {
+        $("#" + header + "_less").hide();
+        $("#" + header + "_bull").hide();
+    }
+    if (shown == total) {
+        $("#" + header + "_more").show();
+        $("#" + header + "_bull").show();
+    }
+    $(facetEntry + ":not(:hidden)").slice(shown - facet_inc, shown).addClass('ui-helper-hidden');
+}
+
+export function initSearchFacets() {
+    const data_config_json = $('#searchFacets').data('config');
+    const start_facet_count = data_config_json['start_facet_count'];
+    const facet_inc = data_config_json['facet_inc'];
+
+    $(".header_bull").hide();
+    $('.header_more').on('click', function(){
+        more($(this).data('header'), start_facet_count, facet_inc);
+    });
+    $('.header_less').on('click', function(){
+        less($(this).data('header'), start_facet_count, facet_inc);
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -1,33 +1,31 @@
 function more(header, start_facet_count, facet_inc) {
-    const div_header = "div." + header
-    const facetEntry = div_header + " div.facetEntry"
-    const shown = $(facetEntry + ":not(:hidden)").length
+    const facetEntry = `div.${header} div.facetEntry`
+    const shown = $(`${facetEntry}:not(:hidden)`).length
     const total = $(facetEntry).length
     if (shown == start_facet_count) {
-        $("#" + header + "_less").show();
-        $("#" + header + "_bull").show();
+        $(`#${header}_less`).show();
+        $(`#${header}_bull`).show();
     }
     if (shown + facet_inc >= total) {
-        $("#" + header + "_more").hide();
-        $("#" + header + "_bull").hide();
+        $(`#${header}_more`).hide();
+        $(`#${header}_bull`).hide();
     }
-    $(facetEntry + ":hidden").slice(0, facet_inc).removeClass('ui-helper-hidden');
+    $(`${facetEntry}:hidden`).slice(0, facet_inc).removeClass('ui-helper-hidden');
 }
 
 function less(header, start_facet_count, facet_inc) {
-    const div_header = "div." + header
-    const facetEntry = div_header + " div.facetEntry"
-    const shown = $(facetEntry + ":not(:hidden)").length
+    const facetEntry = `div.${header} div.facetEntry`
+    const shown = $(`${facetEntry}:not(:hidden)`).length
     const total = $(facetEntry).length
     if (shown - facet_inc == start_facet_count) {
-        $("#" + header + "_less").hide();
-        $("#" + header + "_bull").hide();
+        $(`#${header}_less`).hide();
+        $(`#${header}_bull`).hide();
     }
     if (shown == total) {
-        $("#" + header + "_more").show();
-        $("#" + header + "_bull").show();
+        $(`#${header}_more`).show();
+        $(`#${header}_bull`).show();
     }
-    $(facetEntry + ":not(:hidden)").slice(shown - facet_inc, shown).addClass('ui-helper-hidden');
+    $(`${facetEntry}:not(:hidden)`).slice(shown - facet_inc, shown).addClass('ui-helper-hidden');
 }
 
 export function initSearchFacets() {
@@ -35,7 +33,7 @@ export function initSearchFacets() {
     const start_facet_count = data_config_json['start_facet_count'];
     const facet_inc = data_config_json['facet_inc'];
 
-    $(".header_bull").hide();
+    $('.header_bull').hide();
     $('.header_more').on('click', function(){
         more($(this).data('header'), start_facet_count, facet_inc);
     });
@@ -46,13 +44,12 @@ export function initSearchFacets() {
 
 let readapi_starttime = 0;
 
-function readapi_callback(data, textStatus, jqXHR) {
+function readapi_callback() {
     const endtime = Date.now();
-    //document.write(data.stats.summary.toSource());
     const duration = (endtime - readapi_starttime) / 1000;
-    const disp = document.getElementById("adminTiming");
+    const disp = document.getElementById('adminTiming');
     if (disp) {
-        disp.innerHTML += '<br/><br/><span class="adminOnly">Read API call took ' + duration + ' seconds</span>';
+        disp.innerHTML += `<br/><br/><span class="adminOnly">Read API call took ${duration} seconds</span>`;
     }
 }
 
@@ -63,7 +60,7 @@ export function initAdminTiming() {
         const ol = 'openlibrary.org';
         const wks = $('#adminTiming').data('wks');
         $.ajax({
-            url: 'https://' + ol + '/api/volumes/brief/json/' + wks + '?listofworks=True&no_details=True&stats=True',
+            url: `https://${ol}/api/volumes/brief/json/${wks}?listofworks=True&no_details=True&stats=True`,
             dataType: 'jsonp',
             success: readapi_callback
         });

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -43,3 +43,29 @@ export function initSearchFacets() {
         less($(this).data('header'), start_facet_count, facet_inc);
     });
 }
+
+let readapi_starttime = 0;
+
+function readapi_callback(data, textStatus, jqXHR) {
+    const endtime = Date.now();
+    //document.write(data.stats.summary.toSource());
+    const duration = (endtime - readapi_starttime) / 1000;
+    const disp = document.getElementById("adminTiming");
+    if (disp) {
+        disp.innerHTML += '<br/><br/><span class="adminOnly">Read API call took ' + duration + ' seconds</span>';
+    }
+}
+
+export function initAdminTiming() {
+    const readapi_percent = 100;
+    if (Math.random() * 100 < readapi_percent) {
+        readapi_starttime = Date.now();
+        const ol = 'openlibrary.org';
+        const wks = $('#adminTiming').data('wks');
+        $.ajax({
+            url: 'https://' + ol + '/api/volumes/brief/json/' + wks + '?listofworks=True&no_details=True&stats=True',
+            dataType: 'jsonp',
+            success: readapi_callback
+        });
+    }
+}

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -40,47 +40,6 @@ $else:
 
 $ start_facet_count = 5
 $ facet_inc = 10
-<script type="text/javascript">
-<!--
-start_facet_count = $start_facet_count
-facet_inc = $facet_inc
-
-function more(header) {
-    div_header = "div." + header
-    facetEntry = div_header + " div.facetEntry"
-    shown = \$(facetEntry + ":not(:hidden)").length
-    total = \$(facetEntry).length
-    if (shown == start_facet_count) {
-        \$("#" + header + "_less").show();
-        \$("#" + header + "_bull").show();
-    }
-    if (shown + facet_inc >= total) {
-        \$("#" + header + "_more").hide();
-        \$("#" + header + "_bull").hide();
-    }
-    \$(facetEntry +":hidden").slice(0,facet_inc).removeClass('ui-helper-hidden');
-}
-
-function less(header) {
-    div_header = "div." + header
-    facetEntry = div_header + " div.facetEntry"
-    shown = \$(facetEntry + ":not(:hidden)").length
-    total = \$(facetEntry).length
-    if (shown - facet_inc == start_facet_count) {
-        \$("#" + header + "_less").hide();
-        \$("#" + header + "_bull").hide();
-    }
-    if (shown == total) {
-        \$("#" + header + "_more").show();
-        \$("#" + header + "_bull").show();
-    }
-    \$(facetEntry + ":not(:hidden)").slice(shown-facet_inc,shown).addClass('ui-helper-hidden');
-}
-window.q.push(function(){
-    \$(".header_bull").hide();
-});
-//-->
-</script>
 
 <div>
 $if param and not error and num_found:
@@ -245,7 +204,7 @@ $if error:
     <h3>BARF! Search engine ERROR!</h3>
     <pre>$error.decode('utf-8', 'ignore')</pre>
 $elif param and len(docs):
-    <div id="searchFacets">
+    <div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})">
         <h3 class="collapse">$_("Zoom In")</h3>
         <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">$_("Focus your results using these") <a href="/search/howto">$_("filters")</a></div>
         $for header, label in facet_map:
@@ -279,7 +238,15 @@ $elif param and len(docs):
                     <span class="small"><a href="$:add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
-                <div class="facetMoreLess"><span class="small" onclick="more('$header');false"><a href="javascript:;" id="${header}_more" class="red">$_("more")</a></span> <span id="${header}_bull" class="header_bull small gray">&bull;</span> <span class="small" onclick="less('$header');false"><a href="javascript:;" id="${header}_less" class="red ui-helper-hidden">$_("less")</a></span></div>
+                <div class="facetMoreLess">
+                    <span class="header_more small" data-header="$header">
+                        <a href="javascript:;" id="${header}_more" class="red">$_("more")</a>
+                    </span>
+                    <span id="${header}_bull" class="header_bull small gray">&bull;</span>
+                    <span class="header_less small" data-header="$header">
+                        <a href="javascript:;" id="${header}_less" class="red ui-helper-hidden">$_("less")</a>
+                    </span>
+                </div>
             </div>
         </div>
 <!-- /facets -->

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -253,34 +253,10 @@ $elif param and len(docs):
     </div>
 
     $if param and not error and len(docs):
-        $ readapi_percent = 100
-        $if ctx.user and ctx.user.is_admin():
-            <div id="adminTiming" class="small sansserif clearfix"><br/><span class="adminOnly">Searching solr took $("%.2f" % search_secs) seconds</span></div>
-            $ readapi_percent = 100
         $ wks = '|'.join([w.key for w in works])
-        $ ol = 'openlibrary.org'
-        <script type="text/javascript">
-        <!--
-        window.q.push( function () {
-            function readapi_callback(data, textStatus, jqXHR) {
-                endtime = Date.now();
-                //document.write(data.stats.summary.toSource());
-                duration = (endtime - starttime) / 1000;
-                disp = document.getElementById("adminTiming");
-                if (disp) {
-                    disp.innerHTML += '<br/><br/><span class="adminOnly">Read API call took ' + duration + ' seconds</span>';
-                }
-            }
-            if (Math.random() * 100 < $readapi_percent) {
-                starttime = Date.now();
-                \$.ajax({
-                    url: 'https://$ol/api/volumes/brief/json/$wks?listofworks=True&no_details=True&stats=True',
-                    dataType: 'jsonp',
-                    success: readapi_callback
-                });
-            }
-        });
-        //-->
-        </script>
+        $if ctx.user and ctx.user.is_admin():
+            <div id="adminTiming" class="small sansserif clearfix" data-wks="$wks">
+                <br/><span class="adminOnly">Searching solr took $("%.2f" % search_secs) seconds</span>
+            </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes `openlibrary/templates/work_search.html` point from #4474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Move inline JavaScript from work_search.html template to index.js and search.js.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Search Facets:
- expand available filter item list in the `Zoom in` area with the `more` button
- reduce available filter item list in the `Zoom in` area with the `less` button
- verify bullet between `more` and `less` button is hidden when `less` button is hidden

Admin Timing:
- Connect as admin
- Verify that `Read API call took XX seconds` message appears at the bottom of the search results

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 