### PR TITLE
add links to github workflow and label docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ Our login process on Open Library's dev instance is a bit funky. You need to cor
 
 ## Submitting Issues
 
+[Interacting with GitHub Issues](https://github.com/internetarchive/openlibrary/wiki/Interacting-with-GitHub-Issues) and [Using Managed Labels to Track Issues](https://github.com/internetarchive/openlibrary/wiki/Using-Managed-Labels-to-Track-Issues) explain how GitHub issues are triaged, labeled, and prioritized.
+
 ### Data Cleanup
 - If you notice a set of entries on Open Library which need to be updated (possibly in bulk) please report them as an issue to https://github.com/internetarchive/openlibrary-client (the Open Library Client).
 


### PR DESCRIPTION
This improves the documentation as mentioned in the [April 20th community call](https://docs.google.com/document/d/1YXh4SvaY9kyI-IIYnVQPDQIeDHoDcvvqvyHfkkTfPX8/edit#heading=h.rl2g3f40rflw).

Links to info on how we handle github issues and labels.