### PR TITLE
Use olbase on prod instead of oldev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,6 +5,9 @@
 version: "3.1"
 services:
   web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
     ports:
       # Debugger
       - 3000:3000
@@ -23,6 +26,9 @@ services:
       - infobase
 
   solr-updater:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
@@ -40,6 +46,9 @@ services:
       - ./docker/ol-db-init.sh:/docker-entrypoint-initdb.d/ol-db-init.sh
 
   covers:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
     ports:
       - 7075:7075
     volumes:
@@ -47,6 +56,9 @@ services:
       - .:/openlibrary
 
   infobase:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
     ports:
       - 7000:7000
     volumes:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -9,6 +9,7 @@ version: "3.1"
 services:
   web:
     profiles: ["ol-web1", "ol-web2"]
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -26,6 +27,7 @@ services:
 
   covers:
     profiles: ["ol-covers0"]
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -69,11 +71,8 @@ services:
 
   cron-jobs:
     profiles: ["ol-home0"]
-    image: "oldev:${OLDEV_TAG:-latest}"
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     hostname: "$HOSTNAME"
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
     user: root
     command: cron -f
     restart: always
@@ -89,6 +88,7 @@ services:
 
   infobase:
     profiles: ["ol-home0"]
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -119,14 +119,11 @@ services:
 
   affiliate-server:
     profiles: ["ol-home0"]
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: always
     hostname: "$HOSTNAME"
     environment:
       - AFFILIATE_CONFIG=/openlibrary.yml
-    image: "oldev:${OLDEV_TAG:-latest}"
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
     command: docker/ol-affiliate-server-start.sh
     ports:
       - 31337:31337
@@ -141,6 +138,7 @@ services:
 
   solr-updater:
     profiles: ["ol-home0"]
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: always
     hostname: "$HOSTNAME"
     environment:
@@ -157,10 +155,7 @@ services:
 
   importbot:
     profiles: ["ol-home0"]
-    image: "oldev:${OLDEV_TAG:-latest}"
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
+    image: "${OLIMAGE:-openlibrary/olbase:latest}"
     command: docker/ol-importbot-start.sh
     restart: always
     hostname: "$HOSTNAME"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -8,6 +8,9 @@
 version: "3.1"
 services:
   web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.oldev
     restart: always
     hostname: "$HOSTNAME"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 services:
   web:
-    image: "oldev:${OLDEV_TAG:-latest}"
+    image: "${OLIMAGE:-oldev:latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
@@ -40,7 +40,7 @@ services:
         max-file: "4"
 
   solr-updater:
-    image: "oldev:${OLDEV_TAG:-latest}"
+    image: "${OLIMAGE:-oldev:latest}"
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
@@ -63,7 +63,7 @@ services:
       - webnet
 
   covers:
-    image: "oldev:${OLDEV_TAG:-latest}"
+    image: "${OLIMAGE:-oldev:latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
@@ -83,7 +83,7 @@ services:
         max-file: "4"
 
   infobase:
-    image: "oldev:${OLDEV_TAG:-latest}"
+    image: "${OLIMAGE:-oldev:latest}"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,6 @@ services:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 4 --timeout 180}
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
     command: docker/ol-web-start.sh
     ports:
       - ${WEB_PORT:-8080}:8080
@@ -41,9 +38,6 @@ services:
 
   solr-updater:
     image: "${OLIMAGE:-oldev:latest}"
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
     command: docker/ol-solr-updater-start.sh
     restart: always
     hostname: "$HOSTNAME"
@@ -68,9 +62,6 @@ services:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --max-requests 250}
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
     command: docker/ol-covers-start.sh
     expose:
       - 7075
@@ -88,9 +79,6 @@ services:
       - PYENV_VERSION=${PYENV_VERSION:-}
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}
       - INFOBASE_OPTS=${INFOBASE_OPTS:-}
-    build:
-      context: .
-      dockerfile: docker/Dockerfile.oldev
     command: docker/ol-infobase-start.sh
     expose:
       - 7000

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -63,10 +63,12 @@ USER root
 # Add pyenv to root's bashrc as well
 RUN echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /root/.bashrc
 
-RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary \
- && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary \
- && mkdir /openlibrary \
- && chown openlibrary:openlibrary /openlibrary
+RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary \
+ && mkdir /openlibrary && chown openlibrary:openlibrary /openlibrary \
+ && mkdir -p /var/lib/coverstore && chown openlibrary:openlibrary /var/lib/coverstore \
+ # In order to write to solr-updater's named volume, this needs to be
+ # pre-created with the right permissions
+ && mkdir -p /solr-updater-data && chown openlibrary:openlibrary /solr-updater-data
 WORKDIR /openlibrary
 
 USER openlibrary
@@ -84,7 +86,4 @@ RUN ln -s vendor/infogami/infogami infogami \
  && make \
  && python3.9 -m pip list --outdated
 
-# Expose Open Library and Infobase
-EXPOSE 80 7000
-CMD scripts/openlibrary-server conf/openlibrary.yml \
-    --gunicorn --workers 4 --timeout 180 --bind :8080
+ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -1,25 +1,9 @@
 FROM openlibrary/olbase:latest
-
 WORKDIR /openlibrary
 
-USER root
-# oldev runs coverstore using the same Docker image
-RUN mkdir -p /var/lib/coverstore \
-    && chown openlibrary:openlibrary /var/lib/coverstore
-# In order to write to solr-updater's named volume, this needs to be
-# pre-created with the right permissions
-RUN mkdir -p /solr-updater-data \
-    && chown openlibrary:openlibrary /solr-updater-data
-
-USER openlibrary
 COPY requirements*.txt ./
 RUN python3.8 -m pip install -r requirements_test.txt
 RUN python3.9 -m pip install -r requirements_test.txt
 
 COPY package*.json ./
 RUN npm install
-
-# Expose Open Library, Infobase, Coverstore, and debugger
-EXPOSE 80 7000 7075 3000
-
-ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"] 

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -2,70 +2,46 @@
 
 set -o xtrace
 
-# https://github.com/internetarchive/openlibrary/wiki/Deployment-Scratchpad
+# See https://github.com/internetarchive/openlibrary/wiki/Deployment-Scratchpad
+SERVERS="ol-home0 ol-covers0 ol-web1 ol-web2"
+COMPOSE_FILE="docker-compose.yml:docker-compose.production.yml"
 
 # This script must be run on ol-home0 to start a new deployment.
-
-echo "Starting production deployment at $(date)"
-export HOSTNAME="${HOSTNAME:-$HOST}"
+HOSTNAME="${HOSTNAME:-$HOST}"
 if [[ $HOSTNAME != ol-home0.* ]]; then
     echo "FATAL: Must only be run on ol-home0" ;
     exit 1 ;
 fi
 
+# Install GNU parallel if not there
+# Check is GNU-specific because some hosts had something else called parallel installed
+[[ $(parallel --version 2>/dev/null) = GNU* ]] || sudo apt-get -y --no-install-recommends install parallel
+
+echo "Starting production deployment at $(date)"
+
 # `sudo git pull origin master` the core Open Library repos:
-### Needed to log into BOOKLENDING_UTILS
-REPO_DIRS="/opt/olsystem /opt/openlibrary"
-for SERVER in ol-home0 ol-covers0 ol-web1 ol-web2; do
-    if [[ $SERVER == ol-web* || $SERVER == ol-home* ]]; then
-        REPO_DIRS="$REPO_DIRS /opt/booklending_utils"
-    fi
-    for REPO_DIR in $REPO_DIRS; do
-        ssh $SERVER "cd $REPO_DIR && git pull origin master"
-    done
+parallel --quote -v ssh {1} "cd {2} && sudo git pull origin master" ::: $SERVERS ::: /opt/olsystem /opt/openlibrary
+
+# booklending utils requires login
+for SERVER in $SERVERS; do
+  ssh $SERVER 'if [ -d /opt/booklending_utils ]; then cd /opt/booklending_utils && sudo git pull origin master; fi'
 done
 
-# These commands were run once and probably do not need to be repeated
-sudo mkdir -p /opt/olimages
-sudo chown root:staff /opt/olimages
-sudo chmod g+w /opt/olimages
-sudo chmod g+s /opt/olimages
-docker image prune -f
+# Prune old images now ; this should remove any unused images
+parallel --quote -v ssh {} "docker image prune -f" ::: $SERVERS
 
-# Build the oldev Docker production image
-cd /opt/openlibrary
-d=`date +%Y-%m-%d`
-sudo git tag deploy-$d
-sudo git push origin deploy-$d
-export COMPOSE_FILE="docker-compose.yml:docker-compose.production.yml"
-# ~4 min
-time docker-compose build --pull web
+# Pull the latest docker images
+parallel --quote -v ssh {} "cd /opt/openlibrary && COMPOSE_FILE=\"$COMPOSE_FILE\" docker-compose --profile {} pull" ::: $SERVERS
 
 # Add a git SHA tag to the Docker image to facilitate rapid rollback
-echo "FROM oldev:latest" | docker build -t "oldev:$(git rev-parse HEAD)" -
-docker image ls
+cd /opt/openlibrary
+CUR_SHA=$(git rev-parse HEAD | head -c7)
+parallel --quote -v ssh {} "echo 'FROM openlibrary/olbase:latest' | docker build -t 'openlibrary/olbase:$CUR_SHA' -" ::: $SERVERS
 
-# Compress the image in a .tar.gz file for transfer to other hosts
-cd /opt/olimages
-# ~4 min
-time docker save oldev:latest | gzip > oldev_latest.tar.gz
-
-# Transfer the .tar.gz image and four repo dirs to other hosts
-for SERVER in ol-covers0 ol-web1 ol-web2; do
-    # ~4 min
-    time rsync -a --no-owner --group --verbose oldev_latest.tar.gz "$SERVER:/opt/olimages/"
-
-    # ~2 - 4 min
-    time ssh $SERVER docker image prune -f
-    # Decompress the .tar.gz image that was transfered from ol-home0
-    # ~4 min
-    time ssh $SERVER 'docker load < /opt/olimages/oldev_latest.tar.gz'
-
-    # Add a git SHA tag to the Docker image to facilitate rapid rollback
-    # Watch the quotes... Three strings concatinated
-    ssh $SERVER 'cd /opt/openlibrary && echo "FROM oldev:latest" | docker build -t "oldev:'$(git rev-parse HEAD)'" -'
-    ssh $SERVER docker image ls
-done
+# And tag the deploy!
+DEPLOY_TAG="deploy-$(date +%Y-%m-%d)"
+sudo git tag $DEPLOY_TAG
+sudo git push origin $DEPLOY_TAG
 
 echo "Finished production deployment at $(date)"
 echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"


### PR DESCRIPTION
As described in #5072 . ~Depends on #5082~

### Technical
- olbase now creates the dirs needed by coverstore/etc
- No Dockerfile exposes ports anymore, since that's done via docker-compose
- New environment variable, `OLIMAGE` can be used to override the image (eg for rollbacks we'd be able to do `OLIMAGE=openlibrary/olbase:SHA docker-compose ...`
- deploy script now no longer needs to gzip images/etc; each node just pulls the latests olbase from docker hub
- deploy.sh now uses GNU parallel to make things faster (waiting for these downloads sequentially would be annoying).

### Testing
- [x] Push up up to a `docker-test-*` branch to get on docker hub (Available at `openlibrary/olbase:docker-test-prod-olbase`)
- [x] `COMPOSE_FILE='docker-compose.yml;docker-compose.production.yml' OLIMAGE='openlibrary/olbase:docker-test-prod-olbase' docker-compose --profile ol-home0 pull` pulls the right images
- [x] Ensure `docker-compose build` works locally
- [x] Ensure `docker-compose up -d` works locally
- [x] Change `Dockerfile.oldev` to use the new olbase
    - [x] Ensure `docker-compose build` works locally
    - [x] Ensure `docker-compose up -d` works locally
- [x] Try it on staging to make sure olbase has no regressions due to EXPOSE removals
- Test doing a deploy -- This will likely need to happen after merging :/

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
