### PR TITLE
Accessibility/Library Explorer subsection list keyboard focus order fix

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -25,6 +25,8 @@
       </template>
     </component>
 
+    <ShelfIndex class="shelf-index" :node="node" v-if="showShelfIndex" />
+
     <OLCarousel
       class="shelf-carousel"
       ref="olCarousel"
@@ -85,7 +87,6 @@
       </template>
     </OLCarousel>
 
-    <ShelfIndex class="shelf-index" :node="node" v-if="showShelfIndex" />
   </div>
 </template>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Linked to #4908

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix keyboard focus on subsection list in Library Explorer.
Focus first on subsection list when opened, then on shelf-carousel.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<details><summary>Original keyboard focus order</summary>
<img src="https://user-images.githubusercontent.com/73437497/115915730-03180700-a474-11eb-9371-a7af92646380.png"/>
</details>

<details><summary>Modified keyboard focus order</summary>
<img src="https://user-images.githubusercontent.com/73437497/115915774-17f49a80-a474-11eb-853c-b7bec9966a7d.png"/>
</details>

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly 
