### PR TITLE
remove inline js for user edit page

### DIFF
--- a/openlibrary/macros/UserEditRow.html
+++ b/openlibrary/macros/UserEditRow.html
@@ -9,17 +9,13 @@ $ value = page[name]
     </div>
 $if unique:
     <div class="input">
-        <span id="inputs">
-            <input type="text" id="$name" name="$name" value="$value"/>
-        </span>
+        <input type="text" id="$name" name="$name" value="$value"/>
     </div>
 $else:
     $ value = value or [""]
     $for i, v in enumerate(value):
         <div class="input">
-            <span id="inputs">
-                <input type="text" name="$name#$i" value="$v"/>
-            </span>
+            <input type="text" name="$name#$i" value="$v"/>
             <span>
                 $if i == len(value) - 1:
                     <button id="add_row_button" type="button">$_('Add another')</button>

--- a/openlibrary/macros/UserEditRow.html
+++ b/openlibrary/macros/UserEditRow.html
@@ -9,16 +9,20 @@ $ value = page[name]
     </div>
 $if unique:
     <div class="input">
-        <input type="text" id="$name" name="$name" value="$value"/>
+        <span id="inputs">
+            <input type="text" id="$name" name="$name" value="$value"/>
+        </span>
     </div>
 $else:
     $ value = value or [""]
     $for i, v in enumerate(value):
         <div class="input">
-            <span><input type="text" name="$name#$i" id="$name#$i" value="$v"/></span>
+            <span id="inputs">
+                <input type="text" name="$name#$i" value="$v"/>
+            </span>
             <span>
                 $if i == len(value) - 1:
-                    <button onclick="add_row('$name')" type="button">$_('Add another')</button>
+                    <button id="add_row_button" type="button">$_('Add another')</button>
             </span>
         </div>
         $ label = ""

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -15,6 +15,18 @@ function update_len() {
     $('#excerpts-excerpt-len').html(2000 - len).css('color', color);
 }
 
+export function initEditRow(){
+    document.querySelector('#add_row_button').addEventListener('click', ()=>add_row('website'));
+}
+
+function add_row(name) {
+    const inputs = document.querySelector(`#clone_${name} #inputs`);
+    const cloned = inputs.children[0].cloneNode(true);
+    cloned.name = `${name}#${inputs.children.length}`;
+    cloned.value = '';
+    inputs.appendChild(cloned);
+}
+
 function show_hide_title() {
     if ($('#excerpts-display .repeat-item').length > 1) {
         $('#excerpts-so-far').show();

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -19,12 +19,16 @@ export function initEditRow(){
     document.querySelector('#add_row_button').addEventListener('click', ()=>add_row('website'));
 }
 
+/**
+ * Adds another input box below the last when adding multiple websites to user profile.
+ * @param string name - when prefixed with clone_ should match an element identifier in the page. e.g. if name would refer to clone_website
+**/
 function add_row(name) {
-    const inputs = document.querySelector(`#clone_${name} #inputs`);
-    const cloned = inputs.children[0].cloneNode(true);
-    cloned.name = `${name}#${inputs.children.length}`;
-    cloned.value = '';
-    inputs.appendChild(cloned);
+    const inputBoxes = document.querySelectorAll(`#clone_${name} input`);
+    const inputBox = document.createElement('input');
+    inputBox.name = `${name}#${inputBoxes.length}`;
+    inputBox.type = 'text';
+    inputBoxes[inputBoxes.length-1].after(inputBox);
 }
 
 function show_hide_title() {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -93,6 +93,11 @@ jQuery(function () {
         import(/* webpackChunkName: "editions-table" */ './editions-table')
             .then(module => module.initEditionsTable());
     }
+    // conditionally load for user edit page
+    if (document.getElementById('add_row_button')) {
+        import(/* webpackChunkName: "user-website" */ './edit')
+            .then(module => module.initEditRow());
+    }
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
         import('./realtime_account_validation.js')

--- a/openlibrary/templates/type/user/edit.html
+++ b/openlibrary/templates/type/user/edit.html
@@ -4,21 +4,6 @@ $ _x = ctx.setdefault('cssfile', 'edit')
 
 $var title: Editing $page.displayname
 
-<script type="text/javascript">
-function add_row(name) {
-    var clonediv = \$("#clone_" + name);
-    var n = clonediv.children().length;
-    var row = \$("div:last", clonediv);
-    var newrow = row.clone();
-
-    clonediv.append(newrow);
-
-    \$("span:last", row).html("");
-    \$("input", newrow).attr("name", name + "#" + n);
-    \$("input", newrow).attr("value", "");
-}
-</script>
-
 <div id="contentHead">
     <h1>
         <span class="tools">$_("Currently Editing:")</span>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "coverageThreshold": {
       "global": {
         "branches": 19,
-        "functions": 18,
+        "functions": 15,
         "lines": 19,
         "statements": 19
       }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses `openlibrary/templates/type/user/edit.html` for  #4474 with refactor

### Technical
The function looks like it was originally made to be very generic but is only used on this one page.

I refactored it to simplify things a bit while moving code out.

### Testing
Try adding / removing multiple websites from a user profile

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/116025599-9aa06580-a5ec-11eb-86c9-04f3eb27b109.mov



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
