### PR TITLE
remove inline js from user view

### DIFF
--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -44,7 +44,7 @@ $else:
 
 
     <h2>$_('Reading Log')</h2>
-    $if owners_page:     
+    $if owners_page:
         $if is_public:
             <p>$:_('You are publicly sharing the books you are <a href="%(username)s/books/currently-reading">currently reading</a>, <a href="%(username)s/books/already-read">have already read</a>, and <a href="%(username)s/books/want-to-read">want to read</a>.', username=page.key)</p>
         $else:
@@ -58,12 +58,6 @@ $else:
             <p>$_('This reader has chosen to make their Reading Log private.')</p>
 
     $if "lists" in ctx.features and lists:
-        <script type="text/javascript">
-        window.q.push(function(){
-            \$('ul#listResults li:nth-child(3)').css('padding-right','0');
-            \$('ul#listResults span.imageLg img').removeAttr('height');
-        });
-        </script>
         <div id="listsDisplay">
             <h2>$_('Lists')
             <span class="sansserif small"><a href="$page.key/lists">$_('See all')</a></span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Address for `openlibrary/templates/type/user/view.html`  #4474 


### Technical
The JS that was there has no impact on the desktop view, which I tested extensively. I also checked on mobile and didn't see any difference.

You can try dropping in some code like:
```
console.log(Array.from($('ul#listResults span.imageLg img')).map(img=>img.height));
$('ul#listResults span.imageLg img').removeAttr('height');
console.log(Array.from($('ul#listResults span.imageLg img')).map(img=>img.height));
```

Then you can see that the image height part at least was not doing anything.
The other line for padding zero also didn't seem to have an effect since with JS disabled padding right is already zero.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Check if the lists on the user page look ok.

### Screenshot
![image](https://user-images.githubusercontent.com/921217/116027891-b22e1d00-a5f1-11eb-91f3-faf7ad949eb7.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
