### PR TITLE
Use the specific Cite book Wikipedia template for citations

### DIFF
--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -57,7 +57,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                         </div>
                         <p>$_('Copy and paste this code into your Wikipedia page.') <a href="https://en.wikipedia.org/wiki/Template:Cite_book" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
                         <form method="get">
-                            <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{Cite book
+                            <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{cite book
                 $for k, v in page.wp_citation_fields.items():
                    |$k = $v
                 }}</textarea>

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -52,8 +52,8 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                 <div class="hidden">
                     <div class="coverFloat" id="wikicode">
                         <div class="coverFloatHead">
-                          <h2>_(Wikipedia citation)</h2>
-                          <a class="dialog--close">&times;<span class="shift">_(Close)</span></a>
+                          <h2>Wikipedia citation</h2>
+                          <a class="dialog--close">&times;<span class="shift">Close</span></a>
                         </div>
                         <p>$_('Copy and paste this code into your Wikipedia page.') <a href="https://en.wikipedia.org/wiki/Template:Cite_book" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
                         <form method="get">

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -52,12 +52,12 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                 <div class="hidden">
                     <div class="coverFloat" id="wikicode">
                         <div class="coverFloatHead">
-                          <h2>Wikipedia citation</h2>
-                          <a class="dialog--close">&times;<span class="shift">Close</span></a>
+                          <h2>_(Wikipedia citation)</h2>
+                          <a class="dialog--close">&times;<span class="shift">_(Close)</span></a>
                         </div>
-                        <p>$_('Copy and paste this code into your Wikipedia page.') <a href="http://en.wikipedia.org/wiki/Template:Cite#Citing_books" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
+                        <p>$_('Copy and paste this code into your Wikipedia page.') <a href="https://en.wikipedia.org/wiki/Template:Cite_book" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
                         <form method="get">
-                            <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{Citation
+                            <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{Cite book
                 $for k, v in page.wp_citation_fields.items():
                    |$k = $v
                 }}</textarea>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
* Uses the more specific / book focused CS1 template https://en.wikipedia.org/wiki/Template:Cite_book
* Adds some i18n using existing strings

### Technical
<!-- What should be noted about the implementation? -->
Why is the Wikipedia Citation buried in the History template? It was hard to locate. The "other data formats" tools are positioned _near_ the History section, but functionally they have nothing to do with History. I don't want to move anything as part of this small PR, but it would make sense to split them out into their own UI component / template at some point.
**EDIT** I found the commit where it was moved https://github.com/internetarchive/openlibrary/commit/519b4e7dbad27bb997973403b9b99de377fa1cdd -- makes technical sense to move from where it was, but conceptually it should be separate from History.

I'm deliberately choosing to not replace `publication-place` with `location` because although it's not clear from the template examples, `location` is an alias for `place`, which means place where the "story" was written. I think `publication-place` is a more accurate description of out metadata.


> **place:** For news stories with a dateline, that is, the location where the story was written. If the name of the location changed over time use the name as stated in the publication or at the time of the source's publication. In earlier versions of the template this was the publication place, and for compatibility, will be treated as the publication place if the publication-place parameter is absent; see that parameter for further information. Alias: location
> 
> **publication-place:** Geographical place of publication; generally not wikilinked; omit when the name of the work includes the publication place; examples: The Boston Globe, The Times of India. Displays after the title. If the name of the publication place changed over time use the name as stated in the publication or at the time of the source's publication. If only one of publication-place, place, or location is defined, it will be treated as the publication place and will show after the title; if publication-place and place or location are defined, then place or location is shown before the title prefixed with "written at" and publication-place is shown after the title.

(from https://en.wikipedia.org/wiki/Template:Cite_book#Publisher)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 