### PR TITLE
Fix show less facet function on search page

### DIFF
--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -36,7 +36,8 @@ function less(header, start_facet_count, facet_inc) {
     const shown = $(`${facetEntry}:not(:hidden)`).length
     const total = $(facetEntry).length
     const increment_extra = (shown - start_facet_count) % facet_inc;
-    const next_shown = shown - ((increment_extra == 0) ? facet_inc:increment_extra);
+    const facet_dec = (increment_extra == 0) ? facet_inc:increment_extra;
+    const next_shown = Math.max(start_facet_count, shown - facet_dec);
     if (shown == total) {
         $(`#${header}_more`).show();
         $(`#${header}_bull`).show();

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -37,13 +37,13 @@ function less(header, start_facet_count, facet_inc) {
     const total = $(facetEntry).length
     const increment_extra = (shown - start_facet_count) % facet_inc;
     const next_shown = shown - ((increment_extra == 0) ? facet_inc:increment_extra);
-    if (next_shown == start_facet_count) {
-        $(`#${header}_less`).hide();
-        $(`#${header}_bull`).hide();
-    }
     if (shown == total) {
         $(`#${header}_more`).show();
         $(`#${header}_bull`).show();
+    }
+    if (next_shown == start_facet_count) {
+        $(`#${header}_less`).hide();
+        $(`#${header}_bull`).hide();
     }
     $(`${facetEntry}:not(:hidden)`).slice(next_shown, shown).addClass('ui-helper-hidden');
 }

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -35,7 +35,9 @@ function less(header, start_facet_count, facet_inc) {
     const facetEntry = `div.${header} div.facetEntry`
     const shown = $(`${facetEntry}:not(:hidden)`).length
     const total = $(facetEntry).length
-    if (shown - facet_inc == start_facet_count) {
+    const increment_extra = (shown - start_facet_count) % facet_inc;
+    const next_shown = shown - ((increment_extra == 0) ? facet_inc:increment_extra);
+    if (next_shown == start_facet_count) {
         $(`#${header}_less`).hide();
         $(`#${header}_bull`).hide();
     }
@@ -43,7 +45,7 @@ function less(header, start_facet_count, facet_inc) {
         $(`#${header}_more`).show();
         $(`#${header}_bull`).show();
     }
-    $(`${facetEntry}:not(:hidden)`).slice(shown - facet_inc, shown).addClass('ui-helper-hidden');
+    $(`${facetEntry}:not(:hidden)`).slice(next_shown, shown).addClass('ui-helper-hidden');
 }
 
 /**


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5064

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix show less facet function used on [Search page](https://openlibrary.org/search).
The `less()` function was able to hide all facets of a facet list in the `Zoom in` area when all available facets where displayed via the `more()` function.

### Technical
<!-- What should be noted about the implementation? -->
`less()` function now reverts the `more()` function action when reaching the end of the facet list (Especially, when remaining hidden facet number < `facet_inc`).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Test for facet list with `5 + N * 10 + X` nb of items where:

 - `N = 0` or `N > 0`
 - `X = 0` or `0 < X < 10`

(Default nb of displayed facet is currently `5` and increment `10`)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
