### PR TITLE
Fix set div padding to 0 to remove stats graph underline tail

### DIFF
--- a/static/css/components/home.less
+++ b/static/css/components/home.less
@@ -21,7 +21,6 @@ div.chartHome a:hover,
       .chartShow {
         width: 145px;
         height: 60px;
-        padding: 0 5px;
         border-bottom: 1px solid @grey;
         cursor: pointer;
       }

--- a/static/css/components/home.less
+++ b/static/css/components/home.less
@@ -21,6 +21,7 @@ div.chartHome a:hover,
       .chartShow {
         width: 145px;
         height: 60px;
+        margin: 0 5px;
         border-bottom: 1px solid @grey;
         cursor: pointer;
       }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes part of #2380

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR addresses the second part of the issue related to the stats charts at the bottom of the homepage:
> Fix the <a> link styling so that there isn't a little tail of underline extending to the left of the chart.
![64898334-9c95fa80-d63b-11e9-8ad1-dfbc856183f0](https://user-images.githubusercontent.com/13713037/116652779-e1c38900-a953-11eb-81ce-6f0e282d7a49.png)

### Technical
<!-- What should be noted about the implementation? -->
Turns out that the fix was not related to the `<a>` tag at all but to an extra 5px of padding on the `chartShow` div.  See [this screen recording](https://www.loom.com/share/07766921e4654660b82e6288ad291ef5) that shows the charts before and after removing padding.
UPDATE: To compensate for the lost padding in terms of indentation, I added a margin.  Thanks @Yashs911 !

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit the homepage
2. Scroll to the bottom and examine the stats charts
3. None of them should have a little grey tail sticking out of the left side

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
The docker image doesn't have any stats and thus no graphs created, so this picture doesn't show much, but please see [this screen recording](https://www.loom.com/share/07766921e4654660b82e6288ad291ef5) to prove that the fix I have suggested indeed works.
<img width="953" alt="Screen Shot 2021-04-30 at 1 25 32 AM" src="https://user-images.githubusercontent.com/13713037/116652459-36b2cf80-a953-11eb-8a7a-7886b6b1eb8e.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tmcw 
