### PR TITLE
Improve i18n support on templates

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -93,7 +93,7 @@ window.q.push( function(){
                     $if edition.publishers:
                         $ edition_name = "; ".join(edition.publishers) + ' edition'
                     $else:
-                        $ edition_name = "Unknown publisher" + ' edition'
+                        $ edition_name = _('Unknown publisher edition')
 
                     $if edition.publish_date:
                         $ edition_name = truncate(edition_name, 20) + ", " + edition.publish_date

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -55,7 +55,7 @@ $jsdef render_work_autocomplete_item(item):
         <div class="ac_work" title="Select this work">
             <div class="cover">
                 $if item.cover_i:
-                    <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="Cover of $item.title">
+                    <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="$_('Cover of: %(title)s', title=item.title)">
             </div>
             <span class="olid">$item.key.split('/')[2]</span>
             <span class="name">
@@ -122,7 +122,7 @@ window.q.push(function() {
     <div class="formBackLeft">
         <div class="formElement">
             <div class="label">
-                <label for="edition-title">Title</label>
+                <label for="edition-title">$_('Title')</label>
                 <span class="tip">$_("Enter the title of this specific edition.")</span>
             </div>
             <div class="input">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -22,7 +22,7 @@ $jsdef render_language_field(i, language):
       <input name="languages--$i" class="language language-autocomplete" type="text" id="language-$i" value="$language.name"/>
       <input name="edition--languages--$i--key" type="hidden" id="language-$i-key" value="$language.key" />
       <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this language')">[x]</a>
-      <br/><a href="javascript:;" class="add small">Add another language?</a>
+      <br/><a href="javascript:;" class="add small">$_('Add another language?')</a>
     </div>
 
 $# Render the ith translated_from language input field
@@ -65,7 +65,7 @@ $jsdef render_work_autocomplete_item(item):
             </span>
             <span class="byline">
                 $if item.author_name:
-                    by <span class="authors">${', '.join(item.author_name)}</span>
+                    $_('by') <span class="authors">${', '.join(item.author_name)}</span>
             </span>
             &bull;
             $if item.edition_count == 1:
@@ -271,7 +271,7 @@ window.q.push(function() {
                             $ work = book.works[0]
                             $for i, a in enumerate(work.get_authors()):
                                 <tr class="repeat-item">
-                                    <td align="right"><strong>Author</strong></td>
+                                    <td align="right"><strong>$_('Author')</strong></td>
                                     <td>$a.name</td>
                                     <td></td>
                                 </tr>
@@ -302,7 +302,7 @@ window.q.push(function() {
 
         <fieldset class="minor formBackRight">
 
-            <legend>Languages</legend>
+            <legend>$_('Languages')</legend>
 
             <div class="formElement" id="languages">
                 <div class="label">
@@ -378,7 +378,7 @@ window.q.push(function() {
 
         <div class="formElement">
             <div class="label">
-                <label for="edition-toc">Table of Contents</label>
+                <label for="edition-toc">$_('Table of Contents')</label>
                 <span class="tip">$:_('Use a "*" for an indent, a "|" to add a column, and line breaks for new lines. Like this:')</span><br/><br/>
         <pre class="smaller gray"> * Part 1 | THIS WORLD | 1
         ** Chapter 1 | Of the Nature of Flatland | 3
@@ -461,7 +461,7 @@ window.q.push(function() {
 							$ set1 = [id_dict[name] for name in popular if name in id_dict]
                             $ set2 = sorted([id for id in edition_config.identifiers if id.name not in popular], key=lambda id:id.label)
 
-                                <option value="">Select one of many...</option>
+                                <option value="">$_('Select one of many...')</option>
                                 $for id in set1:
                                     <option value="$id.name">$id.label</option>
                                 <optgroup label="----------"></optgroup>
@@ -665,7 +665,7 @@ $if ctx.user and ctx.user.is_admin():
         <div class="formElement">
             <div class="label">
                 <label for="edition-first_sentence">$_("Additional Metadata")</label>
-                <span class="tip">This field can accept arbitrary key:value pairs</span>
+                <span class="tip">$_('This field can accept arbitrary key:value pairs')</span>
             </div>
             <div class="input">
                 <textarea name="additional_metadata" id="additional_metadata" rows="15" cols="50">foo:bar</textarea>

--- a/openlibrary/templates/books/edit/excerpts.html
+++ b/openlibrary/templates/books/edit/excerpts.html
@@ -16,7 +16,7 @@ $def with (work)
             </div>
             <div class="input">
                 <input type="text" name="pages" id="excerpts-pages" value="" tabindex="0" onblur="\$('#repeat-exc').addClass('darkgreen');" style="width:60px!important;"/>
-                <span class="tip fixthis"><input type="checkbox" name="first--sentence" id="first--sentence" tabindex="0"/> This is the first sentence.</span>
+                <span class="tip fixthis"><input type="checkbox" name="first--sentence" id="first--sentence" tabindex="0"/> $_('This is the first sentence.')</span>
             </div>
 
         </div>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -30,7 +30,7 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
     <td class="book">
       <span class="hidden sort-key">$edition_sort_key</span>
       <div class="cover">
-          <a href="$book.url()"><img src="$url" alt="Cover of: $book.title" title="Cover of: $book.title"/></a>
+          <a href="$book.url()"><img src="$url" alt="$_('Cover of: %(title)s', title=book.title)" title="$_('Cover of: %(title)s', title=book.title)"/></a>
       </div>
 
       <div class="title">

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -15,7 +15,7 @@ $if size == "M":
     <div class="coverMagic cover-animation">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
-                    class="coverLook dialog--open" title="Pull up a bigger book cover"><img itemprop="image" src="$cover_url" srcset="$cover_lg 2x" class="cover" alt="Cover of: $title | $author_names"/></a>
+                    class="coverLook dialog--open" title="$_('Pull up a bigger book cover')"><img itemprop="image" src="$cover_url" srcset="$cover_lg 2x" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">
@@ -26,7 +26,7 @@ $if size == "M":
             </div>
     </div>
 $else:
-    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" srcset="$cover_lg 2x" height="58" title="$title" alt="We need a book cover for: $title"/>
+    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" srcset="$cover_lg 2x" height="58" title="$title" alt="$_('We need a book cover for: %(title)s', title=title)"/>
 
 <div class="hidden">
     <div class="coverFloat" id="seeImage">

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -15,7 +15,7 @@ $if size == "M":
     <div class="coverMagic cover-animation">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
-                    class="coverLook dialog--open" title="$_('Pull up a bigger book cover')"><img itemprop="image" src="$cover_url" srcset="$cover_lg 2x" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
+                    class="coverLook dialog--open" title="$_('Pull up a bigger book cover')"><img itemprop="image" src="$cover_url" srcset="$cover_lg 2x" class="cover" alt="$_('Cover of: %(title)s by %(authors)s', title=title, authors=author_names)"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">

--- a/openlibrary/templates/covers/book_cover_single_edition.html
+++ b/openlibrary/templates/covers/book_cover_single_edition.html
@@ -11,7 +11,7 @@ $if size == "M":
     <div class="coverMagic">
         <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
             <a href="$cover_lg" aria-controls="seeImage"
-                class="coverLook dialog--open" title="$_('View a larger book cover')"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
+                class="coverLook dialog--open" title="$_('View a larger book cover')"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s by %(authors)s', title=title, authors=author_names)"/></a>
         </div>
         <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
             <div class="innerBorder">

--- a/openlibrary/templates/covers/book_cover_single_edition.html
+++ b/openlibrary/templates/covers/book_cover_single_edition.html
@@ -11,7 +11,7 @@ $if size == "M":
     <div class="coverMagic">
         <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
             <a href="$cover_lg" aria-controls="seeImage"
-                class="coverLook dialog--open" title="View a larger book cover"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
+                class="coverLook dialog--open" title="$_('View a larger book cover')"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
         </div>
         <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
             <div class="innerBorder">
@@ -22,7 +22,7 @@ $if size == "M":
         </div>
     </div>
 $else:
-    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" alt="We need a book cover for: $title"/>
+    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" alt="$_('We need a book cover for: %(title)s', title=title)"/>
 
 <div class="hidden">
     <div class="coverFloat" id="seeImage">

--- a/openlibrary/templates/covers/book_cover_small.html
+++ b/openlibrary/templates/covers/book_cover_small.html
@@ -11,7 +11,7 @@ $if cover_url is False:
 $if size == "S":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
-                <a href="$book.key" title="$_('Go to the main page for %(title)s', title=title)"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
+                <a href="$book.key" title="$_('Go to the main page for %(title)s', title=title)"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s by %(authors)s', title=title, authors=author_names)"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');clear:left;">
                 <a href="$book.key" title="$_('Go to the main page for %(title)s', title=title)"><img src="/images/icons/avatar_book-sm.png" height="58" alt="$_('We need a book cover for: %(title)s', title=title)"/></a>

--- a/openlibrary/templates/covers/book_cover_small.html
+++ b/openlibrary/templates/covers/book_cover_small.html
@@ -11,11 +11,11 @@ $if cover_url is False:
 $if size == "S":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
-                <a href="$book.key" title="Go to the main page for $title"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
+                <a href="$book.key" title="$_('Go to the main page for %(title)s', title=title)"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');clear:left;">
-                <a href="$book.key" title="Go to the main page for $title"><img src="/images/icons/avatar_book-sm.png" height="58" alt="We need a book cover for: $title"/></a>
+                <a href="$book.key" title="$_('Go to the main page for %(title)s', title=title)"><img src="/images/icons/avatar_book-sm.png" height="58" alt="$_('We need a book cover for: %(title)s', title=title)"/></a>
             </div>
     </div>
 $else:
-    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" title="Go to the main page for $title" alt="$title"/>
+    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" title="$_('Go to the main page for %(title)s', title=title)" alt="$title"/>

--- a/openlibrary/templates/covers/book_cover_work.html
+++ b/openlibrary/templates/covers/book_cover_work.html
@@ -11,14 +11,14 @@ $if size == "M":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
-                    class="coverLook dialog--open" title="View a larger book cover"><img src="$cover_url" class="cover" alt="Cover of: $title $_('by') $author_names"/></a>
+                    class="coverLook dialog--open" title="$_('View a larger book cover')"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
-                <img src="/images/icons/avatar_book-sm.png" height="58" alt="We need a book cover for: $title"/>
+                <img src="/images/icons/avatar_book-sm.png" height="58" alt="$_('We need a book cover for: %(title)s', title=title)"/>
             </div>
     </div>
 $else:
-    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" alt="We need a book cover for: $title"/>
+    <img src="$(cover_url or '/images/icons/avatar_book-sm.png')" height="58" alt="$_('We need a book cover for: %(title)s', title=title)"/>
 
 <div class="hidden">
     <div class="coverFloat" id="seeImage">

--- a/openlibrary/templates/covers/book_cover_work.html
+++ b/openlibrary/templates/covers/book_cover_work.html
@@ -11,7 +11,7 @@ $if size == "M":
     <div class="coverMagic">
             <div class="SRPCover bookCover" style="display: $cond(cover_url, 'block', 'none');">
                 <a href="$cover_lg" aria-controls="seeImage"
-                    class="coverLook dialog--open" title="$_('View a larger book cover')"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s', title=title) $_('by') $author_names"/></a>
+                    class="coverLook dialog--open" title="$_('View a larger book cover')"><img src="$cover_url" class="cover" alt="$_('Cover of: %(title)s by %(authors)s', title=title, authors=author_names)"/></a>
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <img src="/images/icons/avatar_book-sm.png" height="58" alt="$_('We need a book cover for: %(title)s', title=title)"/>

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -8,23 +8,23 @@ $if not ctx.user:
 $if doc.type.key == '/type/author':
     $ add_url = doc.url('/add-photo')
     $ manage_url = doc.url('/manage-photos')
-    $ title = "Author Photos"
+    $ title = _('Author Photos')
     $if doc.get_photo():
-        $ change = "Manage Author Photos"
+        $ change = _('Manage Author Photos')
         $ size = "smaller"
     $else:
-        $ change = "Add Author Photo"
+        $ change = _('Add Author Photo')
         $ size = "smallest"
 $else:
     $ add_url = doc.url('/add-cover')
     $ manage_url = doc.url('/manage-covers')
-    $ title = "Book Covers"
+    $ title = _('Book Covers')
 
     $if doc.get_cover():
-        $ change = "Manage Covers"
+        $ change = _('Manage Covers')
         $ size = "smaller"
     $else:
-        $ change = "Add Cover Image"
+        $ change = _('Add Cover Image')
         $ size = "smallest"
 
 <div class="$size sansserif manageCoversContainer hidden--nojs">
@@ -42,8 +42,8 @@ $else:
 
         <div id="tabsImages" class="tabs tabsPop">
             <ul>
-                <li><a href="#imagesAdd">Add</a></li>
-                <li><a href="#imagesManage">Manage</a></li>
+                <li><a href="#imagesAdd">$_('Add')</a></li>
+                <li><a href="#imagesManage">$_('Manage')</a></li>
             </ul>
 
             <div id="imagesAdd">

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -2,7 +2,7 @@ $def with (list)
     <span class="imageLg">
         $ cover = list.get_cover() or list.get_default_cover()
         $ cover_url = cover and cover.url("M") or "/images/icons/avatar_book-sm.png"
-        <a href="$list.key"><img src="$cover_url" alt="Cover of: $list.name" title="Cover of: $list"/></a>
+        <a href="$list.key"><img src="$cover_url" alt="$_('Cover of:') $list.name" title="$_('Cover of:') $list"/></a>
     </span>
     <span class="details">
         $ owner = list.get_owner()
@@ -10,10 +10,10 @@ $def with (list)
         <span class="resultTitle $cond(is_owner, 'my-list')">
             $if is_owner:
                 <h3><a href="$list.key">$list.name</a></h3>
-                <span class="list-owner small grey"> by <a href="$owner.key">$_('You')</a></span>
+                <span class="list-owner small grey"> $:_('by <a href="$owner.key">You</a>')</span>
             $else:
-                <h3><a href="$list.key">$list.name</a> </h3>
-                <span class="list-owner small grey"> by  <a href="$owner.key">$owner.displayname</a></span>
+                <h3><a href="$list.key">$list.name</a></h3>
+                <span class="list-owner small grey"> $_('by') <a href="$owner.key">$owner.displayname</a></span>
 
             <div class="editions smaller">
                 $ungettext("1 item", "%(count)d items", len(list.seeds), count=len(list.seeds))

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -2,7 +2,7 @@ $def with (list)
     <span class="imageLg">
         $ cover = list.get_cover() or list.get_default_cover()
         $ cover_url = cover and cover.url("M") or "/images/icons/avatar_book-sm.png"
-        <a href="$list.key"><img src="$cover_url" alt="$_('Cover of:') $list.name" title="$_('Cover of:') $list"/></a>
+        <a href="$list.key"><img src="$cover_url" alt="$_('Cover of: %(title)s', title=list.name)" title="$_('Cover of: %(title)s', title=list.name)"/></a>
     </span>
     <span class="details">
         $ owner = list.get_owner()

--- a/openlibrary/templates/lists/snippet.html
+++ b/openlibrary/templates/lists/snippet.html
@@ -2,7 +2,7 @@ $def with (list)
 <span class="imageLg">
     $ cover = list.get_cover() or list.get_default_cover()
     $ cover_url = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
-    $ title = _("Cover of: %(listname)s", listname=list)
+    $ title = _("Cover of: %(title)s", title=list.name)
     <a href="$list.key"><img src="$cover_url" height="58" alt="$title" title="$title"/></a>
 </span>
 <div class="details">

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -82,7 +82,7 @@ $jsdef show_list(list, user_key):
     $ remove = (list.owner.key == user_key)
     <li>
         <span class="image">
-          <a href="$list.key"><img src="$list.cover_url" alt="Cover of: $list.name" title="Cover of: $list.name"/></a>
+          <a href="$list.key"><img src="$list.cover_url" alt="$_('Cover of: %(title)s', title=list.name)" title="$_('Cover of: %(title)s', title=list.name)"/></a>
         </span>
         <span class="data">
             <span class="label">

--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -36,7 +36,7 @@
         <input type="text" name="publisher" id="qtop-publisher" placeholder="" size="35">
       </div>
     </fieldset>
-    <input type="submit" class="generic-button generic-button-primary" value="Search">
+    <input type="submit" class="generic-button generic-button-primary" value="$_('Search')">
     <div class="searchPlus">
       <a href="/search/inside">$_('Full Text Search')</a>?
     </div>

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -21,6 +21,6 @@ $var title: Search results for Lists
       </ul>
     </div>
   $elif q:
-    <div>No results, <a href="/search/inside?q=$q">try a full-text search?</a></div>
+    <div>$:_('No results, <a href="/search/inside?q=$q">try a full-text search?</a>')</div>
 
 </div>

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -1,6 +1,6 @@
 $def with (q, lists)
 
-$var title: Search results for Lists
+$var title: $_('Search results for Lists')
 
 <div id="contentHead">
   <h1>$_("Lists")</h1>

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -21,6 +21,9 @@ $var title: Search results for Lists
       </ul>
     </div>
   $elif q:
-    <div>$:_('No results, <a href="/search/inside?q=$q">try a full-text search?</a>')</div>
+    <div>
+      <span class="red">$_("No results found.")</span>
+      <a href="/search/inside?$urlencode(dict(q=q))">$_('Search for books containing the phrase "%s"?', q)</a>
+    </div>
 
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Efforts towards i18n - #791

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add i18n support for message in several templates:
- Book edit:
  - books/edit.html
  - books/edit/edition.html
  - books/edit/excerpts.html
  - books/edition-sort.html
- Cover `title` and `alt` attributes + rationalization:
  - covers/book_cover.html
  - covers/book_cover_single_edition.html
  - covers/book_cover_small.html
  - covers/book_cover_work.html
  - lists/preview.html
  - lists/snippet.html
  - lists/widget.html
- Cover management:
  - covers/change.html
- Search:
  - search/advancedsearch.html
  - search/lists.html

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 