### PR TITLE
Hotfix/JS error from index.js 

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -171,7 +171,7 @@ jQuery(function () {
             .then((module) => module.initCoversSaved());
     }
 
-    if (document.getElementById('addbook').length) {
+    if (document.getElementById('addbook')) {
         import(/* webpackChunkName: "add-book" */ './add-book')
             .then(module => module.initAddBookImport());
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
No issue opened. Linked to #4474 and #4661.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Hotfix**

`length` call on `getElementById()` leads to JS error when id not found.

https://github.com/internetarchive/openlibrary/blob/a6da21f277032f6c016219e9d1ece671f401e1d6/openlibrary/plugins/openlibrary/js/index.js#L174

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 