### PR TITLE
Refactor/Move inline js from books/edit/web template

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -82,25 +82,25 @@ export function initEdit() {
  *    - '#link-errors'
  */
 export function initEditLinks() {
-	$('#links').repeat({
-		vars: {
-			prefix: '$prefix'
-		},
-		validate: function(data) {
-			if ($.trim(data.url) == '' || $.trim(data.url) == 'http://') {
-				$('#link-errors').html('Please provide a URL.');
-				$('#link-errors').removeClass('hidden');
-				$('#link-url').focus();
-				return false;
-			}
-			if ($.trim(data.title) == '') {
-				$('#link-errors').html('Please provide a label.');
-				$('#link-errors').removeClass('hidden');
-				$('#link-label').focus();
-				return false;
-			}
-			$('#link-errors').addClass('hidden');
-			return true;
-		}
-	});
+    $('#links').repeat({
+        vars: {
+            prefix: '$prefix'
+        },
+        validate: function(data) {
+            if ($.trim(data.url) == '' || $.trim(data.url) == 'http://') {
+                $('#link-errors').html('Please provide a URL.');
+                $('#link-errors').removeClass('hidden');
+                $('#link-url').focus();
+                return false;
+            }
+            if ($.trim(data.title) == '') {
+                $('#link-errors').html('Please provide a label.');
+                $('#link-errors').removeClass('hidden');
+                $('#link-label').focus();
+                return false;
+            }
+            $('#link-errors').addClass('hidden');
+            return true;
+        }
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -71,3 +71,30 @@ export function initEdit() {
     update_len();
     show_hide_title();
 }
+
+/**
+ * Initializes links element on edit page.
+ *
+ * TODO
+ */
+export function initEditLinks() {
+	$('#links').repeat({
+		vars: {
+			prefix: '$prefix'
+		},
+		validate: function(data) {
+			if ($.trim(data.url) == '' || $.trim(data.url) == 'http://') {
+				$('#link-errors').show().html('Please provide a URL.');
+				$('#link-url').focus();
+				return false;
+			}
+			if ($.trim(data.title) == '') {
+				$('#link-errors').show().html('Please provide a label.');
+				$('#link-label').focus();
+				return false;
+			}
+			$('#link-errors').hide();
+			return true;
+		}
+	});
+}

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -76,7 +76,7 @@ export function initEdit() {
  * Initializes links element on edit page.
  *
  * Assumes presence of elements with id:
- *    - '#links'
+ *    - '#links' and 'data-prefix' attribute
  *    - '#link-label'
  *    - '#link-url'
  *    - '#link-errors'
@@ -84,16 +84,16 @@ export function initEdit() {
 export function initEditLinks() {
     $('#links').repeat({
         vars: {
-            prefix: '$prefix'
+            prefix: $('#links').data('prefix')
         },
         validate: function(data) {
-            if ($.trim(data.url) == '' || $.trim(data.url) == 'http://') {
+            if ($.trim(data.url) === '' || $.trim(data.url) === 'https://') {
                 $('#link-errors').html('Please provide a URL.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-url').focus();
                 return false;
             }
-            if ($.trim(data.title) == '') {
+            if ($.trim(data.title) === '') {
                 $('#link-errors').html('Please provide a label.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-label').focus();

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -75,7 +75,11 @@ export function initEdit() {
 /**
  * Initializes links element on edit page.
  *
- * TODO
+ * Assumes presence of elements with id:
+ *    - '#links'
+ *    - '#link-label'
+ *    - '#link-url'
+ *    - '#link-errors'
  */
 export function initEditLinks() {
 	$('#links').repeat({
@@ -84,16 +88,18 @@ export function initEditLinks() {
 		},
 		validate: function(data) {
 			if ($.trim(data.url) == '' || $.trim(data.url) == 'http://') {
-				$('#link-errors').show().html('Please provide a URL.');
+				$('#link-errors').html('Please provide a URL.');
+				$('#link-errors').removeClass('hidden');
 				$('#link-url').focus();
 				return false;
 			}
 			if ($.trim(data.title) == '') {
-				$('#link-errors').show().html('Please provide a label.');
+				$('#link-errors').html('Please provide a label.');
+				$('#link-errors').removeClass('hidden');
 				$('#link-label').focus();
 				return false;
 			}
-			$('#link-errors').hide();
+			$('#link-errors').addClass('hidden');
 			return true;
 		}
 	});

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -154,10 +154,12 @@ jQuery(function () {
         import (/* webpackChunkName: "books_edit" */ './edit.js')
             .then((module) => module.initEdit());
     }
+
 	if (document.getElementById('links')) {
         import (/* webpackChunkName: "books_edit" */ './edit.js')
             .then((module) => module.initEditLinks());
     }
+
     if (document.getElementsByClassName('manageCovers').length) {
         import(/* webpackChunkName: "covers" */ './covers')
             .then((module) => module.initCoversChange());

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -155,7 +155,7 @@ jQuery(function () {
             .then((module) => module.initEdit());
     }
 
-	if (document.getElementById('links')) {
+    if (document.getElementById('links')) {
         import (/* webpackChunkName: "books_edit" */ './edit.js')
             .then((module) => module.initEditLinks());
     }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -154,6 +154,10 @@ jQuery(function () {
         import (/* webpackChunkName: "books_edit" */ './edit.js')
             .then((module) => module.initEdit());
     }
+	if (document.getElementById('links')) {
+        import (/* webpackChunkName: "books_edit" */ './edit.js')
+            .then((module) => module.initEditLinks());
+    }
     if (document.getElementsByClassName('manageCovers').length) {
         import(/* webpackChunkName: "covers" */ './covers')
             .then((module) => module.initCoversChange());

--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -57,30 +57,6 @@ $def with (work, prefix="")
 
 </fieldset>
 
-<script type="text/javascript">
-    window.q.push(function() {
-        \$("#links").repeat({
-            vars: {
-                prefix: "$prefix"
-            },
-            validate: function(data) {
-                if (\$.trim(data.url) == "" || \$.trim(data.url) == "http://") {
-                    \$("#link-errors").show().html("$_('Please provide a URL.')");
-                    \$("#link-url").focus();
-                    return false;
-                }
-                if (\$.trim(data.title) == "") {
-                    \$("#link-errors").show().html("$_('Please provide a label.')");
-                    \$("#link-label").focus();
-                    return false;
-                }
-                \$("#link-errors").hide();
-                return true;
-            }
-        });
-    });
-</script>
-
 <div class="formElement">
     <div class="tip footnote"><span class="orange">*</span> $_('"Good" means no spammy links, please. Keep them relevant to the book. Irrelevant sites may be removed. Blatant spam will be deleted without remorse.')</div>
 </div>

--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -3,7 +3,7 @@ $def with (work, prefix="")
 <div id="link-errors" class="note hidden">
 </div>
 
-<fieldset class="major" id="links">
+<fieldset class="major" id="links" data-prefix="$prefix">
     <div id="links-form">
         <div class="formElement">
             $:_('Please connect Open Library records to <u>good</u><span class="orange">*</span> online resources.')

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 19,
+        "branches": 18,
         "functions": 15,
         "lines": 19,
         "statements": 19


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes `openlibrary/templates/books/edit/web.html` point from #4474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Move inline JavaScript from books/edit/web.html template to index.js and edit.js.
Fix `link-errors` message not being displayed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Open a work edit page and test the following in the `Links` section:
 - Click `Add Link` with no link name entered => Name error message displayed
 - Enter a name and click `Add Link` with no link url or 'http://' entered => Url error message displayed
 - Enter a name and url and click `Add Link` => No error message

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 