### PR TITLE
/move inline js for edition edit part 1

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -142,6 +142,10 @@ export default function($) {
      * @param {Object} ac_opts - options given to override defaults of $.autocomplete; see that.
      */
     $.fn.setup_multi_input_autocomplete = function(autocomplete_selector, input_renderer, ol_ac_opts, ac_opts) {
+        console.log("multip input inputs", autocomplete_selector)
+        console.log("input_renderer",input_renderer, ol_ac_opts, ac_opts)
+        console.log("ol_ac_opts", ol_ac_opts)
+        console.log("ac_opts", ac_opts)
         var container = $(this);
 
         // first let's init any pre-existing inputs

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -142,10 +142,6 @@ export default function($) {
      * @param {Object} ac_opts - options given to override defaults of $.autocomplete; see that.
      */
     $.fn.setup_multi_input_autocomplete = function(autocomplete_selector, input_renderer, ol_ac_opts, ac_opts) {
-        console.log("multip input inputs", autocomplete_selector)
-        console.log("input_renderer",input_renderer, ol_ac_opts, ac_opts)
-        console.log("ol_ac_opts", ol_ac_opts)
-        console.log("ac_opts", ac_opts)
         var container = $(this);
 
         // first let's init any pre-existing inputs

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -27,7 +27,7 @@ function getJqueryElements(selector){
 
 export function initLanguageMultiInputAutocomplete() {
     $(function() {
-        getJqueryElements('.language_multi_input_autocomplete').forEach(jqueryElement=>{
+        getJqueryElements('.language_multi_input_autocomplete').forEach(jqueryElement => {
             jqueryElement.setup_multi_input_autocomplete(
                 'input.language-autocomplete',
                 // defined by jsdef
@@ -47,8 +47,7 @@ export function initLanguageMultiInputAutocomplete() {
 
 export function initWorksMultiInputAutocomplete() {
     $(function() {
-
-        getJqueryElements('.works_multi_input_autocomplete').forEach(jqueryElement=>{
+        getJqueryElements('.works_multi_input_autocomplete').forEach(jqueryElement => {
             const dataset = jqueryElement[0].dataset;
             jqueryElement.setup_multi_input_autocomplete(
                 'input.work-autocomplete',
@@ -70,12 +69,6 @@ export function initWorksMultiInputAutocomplete() {
                     formatItem: render_work_autocomplete_item
                 });
         });
-    });
-}
-
-export function initEditionEditPage(){
-    $(function() {
-
     });
 }
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -33,13 +33,49 @@ function render_language_field(i, language, title, isPriviligedUser){
     </div>`
 }
 
+function render_work_field(i, work, removeWorkText){
+    return `<div class="input">
+        <input name="works--${i}" class="work work-autocomplete" type="text" id="work-${i}"
+               value="${work.key.split('/')[-1]}"/>
+        <input name="edition--works--${i}--key" type="hidden" id="work-${i}-key" value="${work.key}"/>
+        <a href="javascript:;" class="remove red plain hidden" title="${removeWorkText}">[x]</a>
+    </div>`
+}
+
+function render_work_autocomplete_item(item, newWorkText){
+    if (item.key === '__new__') {
+        return `<div class="ac_work ac_addnew">
+            <span class="action">${newWorkText}</span>
+        </div>`
+    }
+
+    const coverImg = `<img src="https://covers.openlibrary.org/b/id/${item.cover_i}-M.jpg" alt="Cover of ${item.title}">`
+    const firstYearSpan = `<span class="first_publish_year">(${item.first_publish_year})</span>`
+    const byLine = `<span class="byline">by <span class="authors">${item.author_name.join(', ')}</span></span>`
+    return `
+        <div class="ac_work" title="Select this work">
+            <div class="cover">
+                ${item.cover_i ? coverImg : ''}
+            </div>
+            <span class="olid">${item.key.split('/').pop()}</span>
+            <span class="name">
+                <span class="title">${item.full_title}</span>
+                ${item.first_publish_year ? firstYearSpan : ''}
+            </span>
+            ${item.author_name ? byLine : ''}
+            &bull;
+            <span class="edition_count">${item.edition_count} edition${item.edition_count === 1 ? '' : 's'}</span>
+        </div>
+        `
+}
+
+
 
 export function initEditionEditPage(){
-    console.log('initEditionEditPage');
     const editionPageData = document.querySelector('[value="edition-edit-page"]');
-    console.log(editionPageData.dataset);
     const isPrivilegedUser = editionPageData.dataset.isprivilegeduser === 'true';
-    const worksNewName = editionPageData.dataset.worksnewname;
+    const newWorkText = editionPageData.dataset.newwork;
+    const removeWorkText = editionPageData.dataset.removework;
     const selectLanguage = editionPageData.dataset.selectlanguage;
     const removeLanguage = editionPageData.dataset.removelanguage;
     $(function() {
@@ -54,30 +90,21 @@ export function initEditionEditPage(){
                 });
         })
 
-
-        // $('#translated_from_languages').setup_multi_input_autocomplete(
-        //     'input.language-autocomplete',
-        //     render_translated_from_language_field,
-        //     { endpoint: '/languages/_autocomplete' },
-        //     {
-        //         max: 6,
-        //         formatItem: render_language_autocomplete_item
-        //     });
-        // $('#works').setup_multi_input_autocomplete(
-        //     'input.work-autocomplete',
-        //     render_work_field,
-        //     {
-        //         endpoint: '/works/_autocomplete',
-        //         addnew: isPrivilegedUser,
-        //         new_name: worksNewName,
-        //     },
-        //     {
-        //         minChars: 2,
-        //         max: 11,
-        //         matchSubset: false,
-        //         autoFill: false,
-        //         formatItem: render_work_autocomplete_item
-        //     });
+        $('#works').setup_multi_input_autocomplete(
+            'input.work-autocomplete',
+            (i, work) => render_work_field(i, work, removeWorkText),
+            {
+                endpoint: '/works/_autocomplete',
+                addnew: isPrivilegedUser,
+                new_name: newWorkText,
+            },
+            {
+                minChars: 2,
+                max: 11,
+                matchSubset: false,
+                autoFill: false,
+                formatItem: item => render_work_autocomplete_item(item, newWorkText)
+            });
     });
 }
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -15,60 +15,85 @@ function update_len() {
     $('#excerpts-excerpt-len').html(2000 - len).css('color', color);
 }
 
+/**
+ * Returns the HTML string for one item of the language input field dropdown.
+ * @param object item - has one property "name" which is shown to the user
+ * @param string title - the text to show when hovering over a dropdown item
+ * title is a parameter for i18n purposes
+**/
 function render_language_autocomplete_item(item, title){
     return `<div class="ac_language" title="${title}">
         <span class="name">${item.name}</span>
     </div>`
 }
 
-
-function render_language_field(i, language, title, addAnotherLanguage){
+/**
+ * Returns the HTML string for one language input field. Editions can have multiple languages and as such multiple of these fields.
+ * @param integer i - 0 is the first language, 1 is the second language, etc
+ * @param object language - has two properties, "name" which is shown to user and "key" which is sent to server
+ * @param string removeWorkTitle - the text to show when hovering over the remove button
+ * @param string addAnotherLanguageText - the text to show for adding another language
+ * removeButtonTitle and addAnotherLanguageText are parameters for i18n purposes
+**/
+function render_language_field(i, language, removeWorkTitle, addAnotherLanguageText){
     return `<div class="input">
         <input name="languages--${i}" class="language language-autocomplete" type="text" id="language-${i}"
                value="${language.name}"/>
         <input name="edition--languages--${i}--key" type="hidden" id="language-${i}-key" value="${language.key}"/>
-        <a href="javascript:;" class="remove red plain hidden" title="${title}">[x]</a>
-        <br/><a href="javascript:;" class="add small">${addAnotherLanguage}</a>
+        <a href="javascript:;" class="remove red plain hidden" title="${removeWorkTitle}">[x]</a>
+        <br/><a href="javascript:;" class="add small">${addAnotherLanguageText}</a>
     </div>`
 }
 
-function render_work_field(i, work, removeWorkText){
+/**
+ * Returns the HTML string for one work input field.
+ * @param integer i - 0 is the first work, 1 is the second work, etc
+ * @param object work - has one property, "key" which is sent to server and not shown to user
+ * @param string removeWorkTitle - the text to show when hovering over the remove button
+ * removeWorkText is a parameter for i18n purposes
+**/
+function render_work_field(i, work, removeWorkTitle){
     return `<div class="input">
         <input name="works--${i}" class="work work-autocomplete" type="text" id="work-${i}"
                value="${work.key.split('/')[-1]}"/>
         <input name="edition--works--${i}--key" type="hidden" id="work-${i}-key" value="${work.key}"/>
-        <a href="javascript:;" class="remove red plain hidden" title="${removeWorkText}">[x]</a>
+        <a href="javascript:;" class="remove red plain hidden" title="${removeWorkTitle}">[x]</a>
     </div>`
 }
 
-function render_work_autocomplete_item(item, newWorkText, by){
-    if (item.key === '__new__') {
+/**
+ * Returns the HTML string for one item of the work input field dropdown.
+ * @param object work - has many properties used to show the user key details of the work
+ * @param string newWorkText - the text to show when hovering over a dropdown item
+ * @param string by - the text to show when hovering over a dropdown item
+ * newWorkText and by are parameterized for i18n purposes
+**/
+function render_work_autocomplete_item(work, newWorkText, by){
+    if (work.key === '__new__') {
         return `<div class="ac_work ac_addnew">
             <span class="action">${newWorkText}</span>
         </div>`
     }
 
-    const coverImg = `<img src="https://covers.openlibrary.org/b/id/${item.cover_i}-M.jpg" alt="Cover of ${item.title}">`
-    const firstYearSpan = `<span class="first_publish_year">(${item.first_publish_year})</span>`
-    const byLine = `<span class="byline">${by} <span class="authors">${item.author_name.join(', ')}</span></span>`
+    const coverImg = `<img src="https://covers.openlibrary.org/b/id/${work.cover_i}-M.jpg" alt="Cover of ${work.title}">`
+    const firstYearSpan = `<span class="first_publish_year">(${work.first_publish_year})</span>`
+    const byLine = `<span class="byline">${by} <span class="authors">${work.author_name.join(', ')}</span></span>`
     return `
         <div class="ac_work" title="Select this work">
             <div class="cover">
-                ${item.cover_i ? coverImg : ''}
+                ${work.cover_i ? coverImg : ''}
             </div>
-            <span class="olid">${item.key.split('/').pop()}</span>
+            <span class="olid">${work.key.split('/').pop()}</span>
             <span class="name">
-                <span class="title">${item.full_title}</span>
-                ${item.first_publish_year ? firstYearSpan : ''}
+                <span class="title">${work.full_title}</span>
+                ${work.first_publish_year ? firstYearSpan : ''}
             </span>
-            ${item.author_name ? byLine : ''}
+            ${work.author_name ? byLine : ''}
             &bull;
-            <span class="edition_count">${item.edition_count} edition${item.edition_count === 1 ? '' : 's'}</span>
+            <span class="edition_count">${work.edition_count} edition${work.edition_count === 1 ? '' : 's'}</span>
         </div>
         `
 }
-
-
 
 export function initEditionEditPage(){
     const editionPageData = document.querySelector('[value="edition-edit-page"]');
@@ -77,13 +102,13 @@ export function initEditionEditPage(){
     const removeWorkText = editionPageData.dataset.removework;
     const selectLanguage = editionPageData.dataset.selectlanguage;
     const removeLanguage = editionPageData.dataset.removelanguage;
-    const anotherlangage = editionPageData.dataset.removelanguage;
+    const anotherLanguage = editionPageData.dataset.removelanguage;
     const by = editionPageData.dataset.by;
     $(function() {
         ['#languages','#translated_from_languages'].forEach((selector)=>{
             $(selector).setup_multi_input_autocomplete(
                 'input.language-autocomplete',
-                (i, language) => render_language_field(i, language, removeLanguage, anotherlangage),
+                (i, language) => render_language_field(i, language, removeLanguage, anotherLanguage),
                 { endpoint: '/languages/_autocomplete' },
                 {
                     max: 6,

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -47,14 +47,15 @@ export function initLanguageMultiInputAutocomplete() {
 export function initWorksMultiInputAutocomplete() {
     $(function() {
         getJqueryElements('.works_multi_input_autocomplete').forEach(jqueryElement => {
-            const dataset = jqueryElement[0].dataset;
+            /* Values in the html passed from Python code */
+            const dataConfig = JSON.parse(jqueryElement[0].dataset.config);
             jqueryElement.setup_multi_input_autocomplete(
                 'input.work-autocomplete',
                 render_work_field,
                 {
                     endpoint: '/works/_autocomplete',
-                    addnew: dataset.isprivilegeduser === 'true',
-                    new_name: dataset.newWorkText,
+                    addnew: dataConfig['isPrivilegedUser'] === 'true',
+                    new_name: dataConfig['-- Move to a new work'],
                 },
                 {
                     minChars: 2,

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -1,3 +1,6 @@
+/* global render_language_field, render_work_autocomplete_item, render_language_autocomplete_item, render_work_field */
+/* Globals are provided by the edit edition template */
+
 function error(errordiv, input, message) {
     $(errordiv).show().html(message);
     $(input).focus();
@@ -30,14 +33,10 @@ export function initLanguageMultiInputAutocomplete() {
         getJqueryElements('.language_multi_input_autocomplete').forEach(jqueryElement => {
             jqueryElement.setup_multi_input_autocomplete(
                 'input.language-autocomplete',
-                // defined by jsdef
-                // eslint-disable-next-line no-undef
                 render_language_field,
                 {endpoint: '/languages/_autocomplete'},
                 {
                     max: 6,
-                    // defined by jsdef
-                    // eslint-disable-next-line no-undef
                     formatItem: render_language_autocomplete_item
                 }
             );
@@ -51,8 +50,6 @@ export function initWorksMultiInputAutocomplete() {
             const dataset = jqueryElement[0].dataset;
             jqueryElement.setup_multi_input_autocomplete(
                 'input.work-autocomplete',
-                // defined by jsdef
-                // eslint-disable-next-line no-undef
                 render_work_field,
                 {
                     endpoint: '/works/_autocomplete',
@@ -64,8 +61,6 @@ export function initWorksMultiInputAutocomplete() {
                     max: 11,
                     matchSubset: false,
                     autoFill: false,
-                    // defined by jsdef
-                    // eslint-disable-next-line no-undef
                     formatItem: render_work_autocomplete_item
                 });
         });

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -15,121 +15,34 @@ function update_len() {
     $('#excerpts-excerpt-len').html(2000 - len).css('color', color);
 }
 
-/**
- * Returns the HTML string for one item of the language input field dropdown.
- * @param object item - has one property "name" which is shown to the user
- * @param string title - the text to show when hovering over a dropdown item
- * title is a parameter for i18n purposes
-**/
-function render_language_autocomplete_item(item, title){
-    return `<div class="ac_language" title="${title}">
-        <span class="name">${item.name}</span>
-    </div>`
-}
-
-/**
- * Returns the HTML string for one language input field. Editions can have multiple languages and as such multiple of these fields.
- * @param integer i - 0 is the first language, 1 is the second language, etc
- * @param object language - has two properties, "name" which is shown to user and "key" which is sent to server
- * @param string removeWorkTitle - the text to show when hovering over the remove button
- * @param string addAnotherLanguageText - the text to show for adding another language
- * removeButtonTitle and addAnotherLanguageText are parameters for i18n purposes
-**/
-function render_language_field(i, language, removeWorkTitle, addAnotherLanguageText){
-    return `<div class="input">
-        <input name="languages--${i}" class="language language-autocomplete" type="text" id="language-${i}"
-               value="${language.name}"/>
-        <input name="edition--languages--${i}--key" type="hidden" id="language-${i}-key" value="${language.key}"/>
-        <a href="javascript:;" class="remove red plain hidden" title="${removeWorkTitle}">[x]</a>
-        <br/><a href="javascript:;" class="add small">${addAnotherLanguageText}</a>
-    </div>`
-}
-
-/**
- * Returns the HTML string for one work input field.
- * @param integer i - 0 is the first work, 1 is the second work, etc
- * @param object work - has one property, "key" which is sent to server and not shown to user
- * @param string removeWorkTitle - the text to show when hovering over the remove button
- * removeWorkText is a parameter for i18n purposes
-**/
-function render_work_field(i, work, removeWorkTitle){
-    return `<div class="input">
-        <input name="works--${i}" class="work work-autocomplete" type="text" id="work-${i}"
-               value="${work.key.split('/')[-1]}"/>
-        <input name="edition--works--${i}--key" type="hidden" id="work-${i}-key" value="${work.key}"/>
-        <a href="javascript:;" class="remove red plain hidden" title="${removeWorkTitle}">[x]</a>
-    </div>`
-}
-
-/**
- * Returns the HTML string for one item of the work input field dropdown.
- * @param object work - has many properties used to show the user key details of the work
- * @param string newWorkText - the text to show when hovering over a dropdown item
- * @param string by - the text to show when hovering over a dropdown item
- * newWorkText and by are parameterized for i18n purposes
-**/
-function render_work_autocomplete_item(work, newWorkText, by){
-    if (work.key === '__new__') {
-        return `<div class="ac_work ac_addnew">
-            <span class="action">${newWorkText}</span>
-        </div>`
-    }
-
-    const coverImg = `<img src="https://covers.openlibrary.org/b/id/${work.cover_i}-M.jpg" alt="Cover of ${work.title}">`
-    const firstYearSpan = `<span class="first_publish_year">(${work.first_publish_year})</span>`
-    const byLine = `<span class="byline">${by} <span class="authors">${work.author_name.join(', ')}</span></span>`
-    return `
-        <div class="ac_work" title="Select this work">
-            <div class="cover">
-                ${work.cover_i ? coverImg : ''}
-            </div>
-            <span class="olid">${work.key.split('/').pop()}</span>
-            <span class="name">
-                <span class="title">${work.full_title}</span>
-                ${work.first_publish_year ? firstYearSpan : ''}
-            </span>
-            ${work.author_name ? byLine : ''}
-            &bull;
-            <span class="edition_count">${work.edition_count} edition${work.edition_count === 1 ? '' : 's'}</span>
-        </div>
-        `
-}
-
 export function initEditionEditPage(){
-    const editionPageData = document.querySelector('[value="edition-edit-page"]');
-    const isPrivilegedUser = editionPageData.dataset.isprivilegeduser === 'true';
-    const newWorkText = editionPageData.dataset.newwork;
-    const removeWorkText = editionPageData.dataset.removework;
-    const selectLanguage = editionPageData.dataset.selectlanguage;
-    const removeLanguage = editionPageData.dataset.removelanguage;
-    const anotherLanguage = editionPageData.dataset.removelanguage;
-    const by = editionPageData.dataset.by;
     $(function() {
         ['#languages','#translated_from_languages'].forEach((selector)=>{
             $(selector).setup_multi_input_autocomplete(
                 'input.language-autocomplete',
-                (i, language) => render_language_field(i, language, removeLanguage, anotherLanguage),
+                render_language_field,
                 { endpoint: '/languages/_autocomplete' },
                 {
                     max: 6,
-                    formatItem: item => render_language_autocomplete_item(item, selectLanguage)
+                    formatItem: render_language_autocomplete_item
                 });
         })
 
+        const worksDataset = document.querySelector('#works').dataset;
         $('#works').setup_multi_input_autocomplete(
             'input.work-autocomplete',
-            (i, work) => render_work_field(i, work, removeWorkText),
+            render_work_field,
             {
                 endpoint: '/works/_autocomplete',
-                addnew: isPrivilegedUser,
-                new_name: newWorkText,
+                addnew: worksDataset.isprivilegeduser === 'true',
+                new_name: worksDataset.newWorkText,
             },
             {
                 minChars: 2,
                 max: 11,
                 matchSubset: false,
                 autoFill: false,
-                formatItem: item => render_work_autocomplete_item(item, newWorkText, by)
+                formatItem: render_work_autocomplete_item
             });
     });
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -34,7 +34,7 @@ function getJqueryElements(selector){
 
 export function initLanguageMultiInputAutocomplete() {
     $(function() {
-        getJqueryElements('.language_multi_input_autocomplete').forEach(jqueryElement => {
+        getJqueryElements('.multi-input-autocomplete--language').forEach(jqueryElement => {
             jqueryElement.setup_multi_input_autocomplete(
                 'input.language-autocomplete',
                 render_language_field,
@@ -50,7 +50,7 @@ export function initLanguageMultiInputAutocomplete() {
 
 export function initWorksMultiInputAutocomplete() {
     $(function() {
-        getJqueryElements('.works_multi_input_autocomplete').forEach(jqueryElement => {
+        getJqueryElements('.multi-input-autocomplete--works').forEach(jqueryElement => {
             /* Values in the html passed from Python code */
             const dataConfig = JSON.parse(jqueryElement[0].dataset.config);
             jqueryElement.setup_multi_input_autocomplete(

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -15,6 +15,72 @@ function update_len() {
     $('#excerpts-excerpt-len').html(2000 - len).css('color', color);
 }
 
+function render_language_autocomplete_item(item, title){
+    return `<div class="ac_language" title="${title}">
+        <span class="name">${item.name}</span>
+    </div>`
+}
+
+
+function render_language_field(i, language, title, isPriviligedUser){
+    const removeButton = isPriviligedUser ? `<a href="javascript:;" class="remove red plain" title="${title}">[x]</a>` : '';
+    return `<div class="input">
+        <input name="languages--${i}" class="language language-autocomplete" type="text" id="language-${i}"
+               value="${language.name}"/>
+        <input name="edition--languages--${i}--key" type="hidden" id="language-${i}-key" value="${language.key}"/>
+        ${removeButton}
+        <br/><a href="javascript:;" class="add small">Add another language?</a>
+    </div>`
+}
+
+
+export function initEditionEditPage(){
+    console.log('initEditionEditPage');
+    const editionPageData = document.querySelector('[value="edition-edit-page"]');
+    console.log(editionPageData.dataset);
+    const isPrivilegedUser = editionPageData.dataset.isprivilegeduser === 'true';
+    const worksNewName = editionPageData.dataset.worksnewname;
+    const selectLanguage = editionPageData.dataset.selectlanguage;
+    const removeLanguage = editionPageData.dataset.removelanguage;
+    $(function() {
+        ['#languages','#translated_from_languages'].forEach((selector)=>{
+            $(selector).setup_multi_input_autocomplete(
+                'input.language-autocomplete',
+                (i, language) => render_language_field(i, language, removeLanguage, isPrivilegedUser),
+                { endpoint: '/languages/_autocomplete' },
+                {
+                    max: 6,
+                    formatItem: item => render_language_autocomplete_item(item, selectLanguage)
+                });
+        })
+
+
+        // $('#translated_from_languages').setup_multi_input_autocomplete(
+        //     'input.language-autocomplete',
+        //     render_translated_from_language_field,
+        //     { endpoint: '/languages/_autocomplete' },
+        //     {
+        //         max: 6,
+        //         formatItem: render_language_autocomplete_item
+        //     });
+        // $('#works').setup_multi_input_autocomplete(
+        //     'input.work-autocomplete',
+        //     render_work_field,
+        //     {
+        //         endpoint: '/works/_autocomplete',
+        //         addnew: isPrivilegedUser,
+        //         new_name: worksNewName,
+        //     },
+        //     {
+        //         minChars: 2,
+        //         max: 11,
+        //         matchSubset: false,
+        //         autoFill: false,
+        //         formatItem: render_work_autocomplete_item
+        //     });
+    });
+}
+
 export function initEditRow(){
     document.querySelector('#add_row_button').addEventListener('click', ()=>add_row('website'));
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -22,13 +22,12 @@ function render_language_autocomplete_item(item, title){
 }
 
 
-function render_language_field(i, language, title, isPriviligedUser){
-    const removeButton = isPriviligedUser ? `<a href="javascript:;" class="remove red plain" title="${title}">[x]</a>` : '';
+function render_language_field(i, language, title){
     return `<div class="input">
         <input name="languages--${i}" class="language language-autocomplete" type="text" id="language-${i}"
                value="${language.name}"/>
         <input name="edition--languages--${i}--key" type="hidden" id="language-${i}-key" value="${language.key}"/>
-        ${removeButton}
+        <a href="javascript:;" class="remove red plain hidden" title="${title}">[x]</a>
         <br/><a href="javascript:;" class="add small">Add another language?</a>
     </div>`
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -25,7 +25,11 @@ function update_len() {
  */
 function getJqueryElements(selector){
     const queryResult = $(selector);
-    return Array.from(queryResult).map((ele,index) => queryResult.eq(index));
+    const jQueryElementArray = [];
+    for (let i = 0; i < queryResult.length; i++){
+        jQueryElementArray.push(queryResult.eq(i))
+    }
+    return jQueryElementArray;
 }
 
 export function initLanguageMultiInputAutocomplete() {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -15,35 +15,67 @@ function update_len() {
     $('#excerpts-excerpt-len').html(2000 - len).css('color', color);
 }
 
-export function initEditionEditPage(){
+/**
+ * This is needed because jQuery has no forEach equivalent that works with jQuery elements instead of DOM elements
+ * @param selector css selector to be used by jQuery
+ * @returns {*[]} array of jQuery elements
+ */
+function getJqueryElements(selector){
+    const queryResult = $(selector);
+    return Array.from(queryResult).map((ele,index) => queryResult.eq(index));
+}
+
+export function initLanguageMultiInputAutocomplete() {
     $(function() {
-        ['#languages','#translated_from_languages'].forEach((selector)=>{
-            $(selector).setup_multi_input_autocomplete(
+        getJqueryElements('.language_multi_input_autocomplete').forEach(jqueryElement=>{
+            jqueryElement.setup_multi_input_autocomplete(
                 'input.language-autocomplete',
+                // defined by jsdef
+                // eslint-disable-next-line no-undef
                 render_language_field,
-                { endpoint: '/languages/_autocomplete' },
+                {endpoint: '/languages/_autocomplete'},
                 {
                     max: 6,
+                    // defined by jsdef
+                    // eslint-disable-next-line no-undef
                     formatItem: render_language_autocomplete_item
-                });
+                }
+            );
         })
+    });
+}
 
-        const worksDataset = document.querySelector('#works').dataset;
-        $('#works').setup_multi_input_autocomplete(
-            'input.work-autocomplete',
-            render_work_field,
-            {
-                endpoint: '/works/_autocomplete',
-                addnew: worksDataset.isprivilegeduser === 'true',
-                new_name: worksDataset.newWorkText,
-            },
-            {
-                minChars: 2,
-                max: 11,
-                matchSubset: false,
-                autoFill: false,
-                formatItem: render_work_autocomplete_item
-            });
+export function initWorksMultiInputAutocomplete() {
+    $(function() {
+
+        getJqueryElements('.works_multi_input_autocomplete').forEach(jqueryElement=>{
+            const dataset = jqueryElement[0].dataset;
+            jqueryElement.setup_multi_input_autocomplete(
+                'input.work-autocomplete',
+                // defined by jsdef
+                // eslint-disable-next-line no-undef
+                render_work_field,
+                {
+                    endpoint: '/works/_autocomplete',
+                    addnew: dataset.isprivilegeduser === 'true',
+                    new_name: dataset.newWorkText,
+                },
+                {
+                    minChars: 2,
+                    max: 11,
+                    matchSubset: false,
+                    autoFill: false,
+                    // defined by jsdef
+                    // eslint-disable-next-line no-undef
+                    formatItem: render_work_autocomplete_item
+                });
+        });
+    });
+}
+
+export function initEditionEditPage(){
+    $(function() {
+
     });
 }
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -17,8 +17,8 @@ function update_len() {
 
 /**
  * This is needed because jQuery has no forEach equivalent that works with jQuery elements instead of DOM elements
- * @param selector css selector to be used by jQuery
- * @returns {*[]} array of jQuery elements
+ * @param selector - css selector used by jQuery
+ * @returns {*[]} - array of jQuery elements
  */
 function getJqueryElements(selector){
     const queryResult = $(selector);

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -32,6 +32,7 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
+import {initLanguageMultiInputAutocomplete, initWorksMultiInputAutocomplete} from './edit';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -102,6 +103,16 @@ jQuery(function () {
     if (document.querySelector('[value="edition-edit-page"]')) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initEditionEditPage());
+    }
+    // conditionally load for language autocomplete
+    if (document.querySelector('.language_multi_input_autocomplete')) {
+        import(/* webpackChunkName: "user-website" */ './edit')
+            .then(module => module.initLanguageMultiInputAutocomplete());
+    }
+    // conditionally load for works autocomplete
+    if (document.querySelector('.works_multi_input_autocomplete')) {
+        import(/* webpackChunkName: "user-website" */ './edit')
+            .then(module => module.initWorksMultiInputAutocomplete());
     }
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -32,7 +32,6 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
-import {initEditionEditPage} from './edit';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -98,11 +98,6 @@ jQuery(function () {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initEditRow());
     }
-    // conditionally load for edition edit page
-    if (document.querySelector('[value="edition-edit-page"]')) {
-        import(/* webpackChunkName: "user-website" */ './edit')
-            .then(module => module.initEditionEditPage());
-    }
     // conditionally load for language autocomplete
     if (document.querySelector('.language_multi_input_autocomplete')) {
         import(/* webpackChunkName: "user-website" */ './edit')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -32,6 +32,7 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
+import {initEditionEditPage} from './edit';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -97,6 +98,11 @@ jQuery(function () {
     if (document.getElementById('add_row_button')) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initEditRow());
+    }
+    // conditionally load for edition edit page
+    if (document.querySelector('[value="edition-edit-page"]')) {
+        import(/* webpackChunkName: "user-website" */ './edit')
+            .then(module => module.initEditionEditPage());
     }
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -32,7 +32,6 @@ import '../../../../static/css/js-all.less';
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
 import initTabs from './tabs.js';
-import {initLanguageMultiInputAutocomplete, initWorksMultiInputAutocomplete} from './edit';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -99,12 +99,12 @@ jQuery(function () {
             .then(module => module.initEditRow());
     }
     // conditionally load for language autocomplete
-    if (document.querySelector('.language_multi_input_autocomplete')) {
+    if (document.querySelector('.multi-input-autocomplete--language')) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initLanguageMultiInputAutocomplete());
     }
     // conditionally load for works autocomplete
-    if (document.querySelector('.works_multi_input_autocomplete')) {
+    if (document.querySelector('.multi-input-autocomplete--works')) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initWorksMultiInputAutocomplete());
     }

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -269,7 +269,7 @@ $jsdef render_work_autocomplete_item(item):
 
             <legend>$_('Languages')</legend>
 
-            <div class="formElement language_multi_input_autocomplete" id="languages">
+            <div class="formElement language_multi_input_autocomplete">
                 <div class="label">
                     <label for="edition-language">$_("What language is this edition written in?")</label>
                     <span class="tip"></span>
@@ -313,7 +313,7 @@ $jsdef render_work_autocomplete_item(item):
                     </div>
                 </div>
 
-                <div class="transYes language_multi_input_autocomplete" id="translated_from_languages" style="$style_hidden">
+                <div class="transYes language_multi_input_autocomplete" style="$style_hidden">
                     <div class="label">
                         <label for="edition-translated_from"><span class="tip">$_("What language was the original written in?")</span></label>
                     </div>
@@ -392,7 +392,7 @@ $jsdef render_work_autocomplete_item(item):
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            <div id="works" class="works_multi_input_autocomplete"
+            <div class="works_multi_input_autocomplete"
                  data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
                  data-newWorkText="$_('-- Move to a new work')"
             >

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -3,8 +3,6 @@ $def with (work, book)
 $ edition_config = get_edition_config()
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 
-<span value="edition-edit-page"></span>
-
 $def radiobuttons(name, options, value):
     $for v in options:
         $ id = name + '--' + v.replace(' ', '-')

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -269,7 +269,7 @@ $jsdef render_work_autocomplete_item(item):
 
             <legend>$_('Languages')</legend>
 
-            <div class="formElement" id="languages">
+            <div class="formElement language_multi_input_autocomplete" id="languages">
                 <div class="label">
                     <label for="edition-language">$_("What language is this edition written in?")</label>
                     <span class="tip"></span>
@@ -313,7 +313,7 @@ $jsdef render_work_autocomplete_item(item):
                     </div>
                 </div>
 
-                <div class="transYes" id="translated_from_languages" style="$style_hidden">
+                <div class="transYes language_multi_input_autocomplete" id="translated_from_languages" style="$style_hidden">
                     <div class="label">
                         <label for="edition-translated_from"><span class="tip">$_("What language was the original written in?")</span></label>
                     </div>
@@ -392,7 +392,7 @@ $jsdef render_work_autocomplete_item(item):
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            <div id="works"
+            <div id="works" class="works_multi_input_autocomplete"
                  data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
                  data-newWorkText="$_('-- Move to a new work')"
             >

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -5,9 +5,10 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_libraria
 
 <data value="edition-edit-page"
       data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
-      data-worksNewName="$_('-- Move to a new work')"
-      data-selectLanguage="$_('Select this languagee')"
-      data-removeLanguage="$_('Remove this language')"
+      data-newwork="$_('-- Move to a new work')"
+      data-removework="$_('Remove this work')"
+      data-selectlanguage="$_('Select this language')"
+      data-removelanguage="$_('Remove this language')"
 ></data>
 
 $def radiobuttons(name, options, value):
@@ -18,10 +19,6 @@ $def radiobuttons(name, options, value):
         <label for="$id">$v</label>
         &nbsp;&nbsp;
 
-$jsdef render_language_autocomplete_item(item):
-    <div class="ac_language" title="$_('Select this language')">
-        <span class="name">$item.name</span>
-    </div>
 
 $# Render the ith language input field
 $jsdef render_language_field(i, language):
@@ -53,71 +50,6 @@ $jsdef render_work_field(i, work):
         $# <a href="javascript:;" class="add hidden">Add another work?</a>
     </div>
 
-$jsdef render_work_autocomplete_item(item):
-    $if item.key == "__new__":
-        <div class="ac_work ac_addnew">
-            <span class="action">$_('-- Move to a new work')</span>
-        </div>
-    $else:
-        <div class="ac_work" title="Select this work">
-            <div class="cover">
-                $if item.cover_i:
-                    <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="Cover of $item.title">
-            </div>
-            <span class="olid">$item.key.split('/')[2]</span>
-            <span class="name">
-                <span class="title">$item.full_title</span>
-                $if item.first_publish_year:
-                <span class="first_publish_year">($item.first_publish_year)</span>
-            </span>
-            <span class="byline">
-                $if item.author_name:
-                    by <span class="authors">${', '.join(item.author_name)}</span>
-            </span>
-            &bull;
-            $if item.edition_count == 1:
-                <span class="edition_count">$item.edition_count edition</span>
-            $else:
-                <span class="edition_count">$item.edition_count editions</span>
-        </div>
-
-<script type="text/javascript">
-window.q.push(function() {
-    // \$("#languages").setup_multi_input_autocomplete(
-    //     "input.language-autocomplete",
-    //     render_language_field,
-    //     { endpoint: "/languages/_autocomplete" },
-    //     {
-    //         max: 6,
-    //         formatItem: render_language_autocomplete_item
-    //     });
-
-    // \$("#translated_from_languages").setup_multi_input_autocomplete(
-    //     "input.language-autocomplete",
-    //     render_translated_from_language_field,
-    //     { endpoint: "/languages/_autocomplete" },
-    //     {
-    //         max: 6,
-    //         formatItem: render_language_autocomplete_item
-    //     });
-
-    // \$("#works").setup_multi_input_autocomplete(
-    //     "input.work-autocomplete",
-    //     render_work_field,
-    //     {
-    //         endpoint: "/works/_autocomplete",
-    //         addnew: $cond(is_privileged_user, 'true', 'false'),
-    //         new_name: '$_('-- Move to a new work')',
-    //     },
-    //     {
-    //         minChars: 2,
-    //         max: 11,
-    //         matchSubset: false,
-    //         autoFill: false,
-    //         formatItem: render_work_autocomplete_item
-    //     });
-});
-</script>
 
 <fieldset class="major">
     <legend>$_("This Edition")</legend>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -3,7 +3,7 @@ $def with (work, book)
 $ edition_config = get_edition_config()
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 
-<data value="edition-edit-page"
+<spam value="edition-edit-page"
       data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
       data-newwork="$_('-- Move to a new work')"
       data-removework="$_('Remove this work')"
@@ -11,7 +11,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_libraria
       data-removelanguage="$_('Remove this language')"
       data-anotherlangage="$_('Add another language?')"
       data-by="$_('by')"
-></data>
+></spam>
 
 $def radiobuttons(name, options, value):
     $for v in options:

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -82,7 +82,7 @@ $jsdef render_work_autocomplete_item(item):
 
     <div class="formBack">
 
-
+       
 
     <div class="formBackLeft">
         <div class="formElement">
@@ -106,8 +106,8 @@ $jsdef render_work_autocomplete_item(item):
         </div>
         <fieldset class="major">
             <legend>$_("Publishing Info")</legend>
-
-
+        
+        
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-publishers">$_("Who is the publisher?")</label>
@@ -127,7 +127,7 @@ $jsdef render_work_autocomplete_item(item):
                         <input type="text" name="edition--publish_places" id="edition-publish_places" value="$'; '.join(book.publish_places)"/>
                     </div>
                 </div>
-
+        
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-publish_date">$_("When was it published?")</label>
@@ -137,10 +137,10 @@ $jsdef render_work_autocomplete_item(item):
                         <input type="text" name="edition--publish_date" id="edition-publish_date" value="$book.publish_date"/>
                     </div>
                 </div>
-
-
-
-
+        
+               
+        
+        
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-copyright_date">$_("What is the copyright date?")</label>
@@ -160,7 +160,7 @@ $jsdef render_work_autocomplete_item(item):
                         <input type="text" name="edition--edition_name" id="edition-edition_name" value="$book.edition_name"/>
                     </div>
                 </div>
-
+        
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-series">$_("Series Name (if applicable)")</label>
@@ -172,9 +172,9 @@ $jsdef render_work_autocomplete_item(item):
                 </div>
         </fieldset>
 
+        
 
-
-
+        
 
     </div>
 
@@ -187,7 +187,7 @@ $jsdef render_work_autocomplete_item(item):
 
     <div class="clearfix"></div>
 
-
+       
 
         <div class="clearfix"></div>
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -267,7 +267,7 @@ $jsdef render_work_autocomplete_item(item):
 
             <legend>$_('Languages')</legend>
 
-            <div class="formElement language_multi_input_autocomplete">
+            <div class="formElement multi-input-autocomplete--language">
                 <div class="label">
                     <label for="edition-language">$_("What language is this edition written in?")</label>
                     <span class="tip"></span>
@@ -311,7 +311,7 @@ $jsdef render_work_autocomplete_item(item):
                     </div>
                 </div>
 
-                <div class="transYes language_multi_input_autocomplete" style="$style_hidden">
+                <div class="transYes multi-input-autocomplete--language" style="$style_hidden">
                     <div class="label">
                         <label for="edition-translated_from"><span class="tip">$_("What language was the original written in?")</span></label>
                     </div>
@@ -391,7 +391,7 @@ $jsdef render_work_autocomplete_item(item):
                 </span>
             </div>
             $ config = {'isPrivilegedUser': cond(is_privileged_user, 'true', 'false'), '-- Move to a new work': _('-- Move to a new work')}
-            <div class="works_multi_input_autocomplete" data-config="$dumps(config)">
+            <div class="multi-input-autocomplete--works" data-config="$dumps(config)">
                 $if book.works:
                     $for i, work in enumerate(book.works):
                         $:render_work_field(i, work)

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -390,10 +390,8 @@ $jsdef render_work_autocomplete_item(item):
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            <div class="works_multi_input_autocomplete"
-                 data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
-                 data-newWorkText="$_('-- Move to a new work')"
-            >
+            $ config = {'isPrivilegedUser': cond(is_privileged_user, 'true', 'false'), '-- Move to a new work': _('-- Move to a new work')}
+            <div class="works_multi_input_autocomplete" data-config="$dumps(config)">
                 $if book.works:
                     $for i, work in enumerate(book.works):
                         $:render_work_field(i, work)

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -3,6 +3,13 @@ $def with (work, book)
 $ edition_config = get_edition_config()
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 
+<data value="edition-edit-page"
+      data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
+      data-worksNewName="$_('-- Move to a new work')"
+      data-selectLanguage="$_('Select this languagee')"
+      data-removeLanguage="$_('Remove this language')"
+></data>
+
 $def radiobuttons(name, options, value):
     $for v in options:
         $ id = name + '--' + v.replace(' ', '-')
@@ -76,39 +83,39 @@ $jsdef render_work_autocomplete_item(item):
 
 <script type="text/javascript">
 window.q.push(function() {
-    \$("#languages").setup_multi_input_autocomplete(
-        "input.language-autocomplete",
-        render_language_field,
-        { endpoint: "/languages/_autocomplete" },
-        {
-            max: 6,
-            formatItem: render_language_autocomplete_item
-        });
+    // \$("#languages").setup_multi_input_autocomplete(
+    //     "input.language-autocomplete",
+    //     render_language_field,
+    //     { endpoint: "/languages/_autocomplete" },
+    //     {
+    //         max: 6,
+    //         formatItem: render_language_autocomplete_item
+    //     });
 
-    \$("#translated_from_languages").setup_multi_input_autocomplete(
-        "input.language-autocomplete",
-        render_translated_from_language_field,
-        { endpoint: "/languages/_autocomplete" },
-        {
-            max: 6,
-            formatItem: render_language_autocomplete_item
-        });
+    // \$("#translated_from_languages").setup_multi_input_autocomplete(
+    //     "input.language-autocomplete",
+    //     render_translated_from_language_field,
+    //     { endpoint: "/languages/_autocomplete" },
+    //     {
+    //         max: 6,
+    //         formatItem: render_language_autocomplete_item
+    //     });
 
-    \$("#works").setup_multi_input_autocomplete(
-        "input.work-autocomplete",
-        render_work_field,
-        {
-            endpoint: "/works/_autocomplete",
-            addnew: $cond(is_privileged_user, 'true', 'false'),
-            new_name: '$_('-- Move to a new work')',
-        },
-        {
-            minChars: 2,
-            max: 11,
-            matchSubset: false,
-            autoFill: false,
-            formatItem: render_work_autocomplete_item
-        });
+    // \$("#works").setup_multi_input_autocomplete(
+    //     "input.work-autocomplete",
+    //     render_work_field,
+    //     {
+    //         endpoint: "/works/_autocomplete",
+    //         addnew: $cond(is_privileged_user, 'true', 'false'),
+    //         new_name: '$_('-- Move to a new work')',
+    //     },
+    //     {
+    //         minChars: 2,
+    //         max: 11,
+    //         matchSubset: false,
+    //         autoFill: false,
+    //         formatItem: render_work_autocomplete_item
+    //     });
 });
 </script>
 
@@ -117,7 +124,7 @@ window.q.push(function() {
 
     <div class="formBack">
 
-       
+
 
     <div class="formBackLeft">
         <div class="formElement">
@@ -141,8 +148,8 @@ window.q.push(function() {
         </div>
         <fieldset class="major">
             <legend>$_("Publishing Info")</legend>
-        
-        
+
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-publishers">$_("Who is the publisher?")</label>
@@ -162,7 +169,7 @@ window.q.push(function() {
                         <input type="text" name="edition--publish_places" id="edition-publish_places" value="$'; '.join(book.publish_places)"/>
                     </div>
                 </div>
-        
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-publish_date">$_("When was it published?")</label>
@@ -172,10 +179,10 @@ window.q.push(function() {
                         <input type="text" name="edition--publish_date" id="edition-publish_date" value="$book.publish_date"/>
                     </div>
                 </div>
-        
-               
-        
-        
+
+
+
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-copyright_date">$_("What is the copyright date?")</label>
@@ -195,7 +202,7 @@ window.q.push(function() {
                         <input type="text" name="edition--edition_name" id="edition-edition_name" value="$book.edition_name"/>
                     </div>
                 </div>
-        
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-series">$_("Series Name (if applicable)")</label>
@@ -207,9 +214,9 @@ window.q.push(function() {
                 </div>
         </fieldset>
 
-        
 
-        
+
+
 
     </div>
 
@@ -222,7 +229,7 @@ window.q.push(function() {
 
     <div class="clearfix"></div>
 
-       
+
 
         <div class="clearfix"></div>
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -3,15 +3,7 @@ $def with (work, book)
 $ edition_config = get_edition_config()
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 
-<spam value="edition-edit-page"
-      data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
-      data-newwork="$_('-- Move to a new work')"
-      data-removework="$_('Remove this work')"
-      data-selectlanguage="$_('Select this language')"
-      data-removelanguage="$_('Remove this language')"
-      data-anotherlangage="$_('Add another language?')"
-      data-by="$_('by')"
-></spam>
+<span value="edition-edit-page"></span>
 
 $def radiobuttons(name, options, value):
     $for v in options:
@@ -21,6 +13,10 @@ $def radiobuttons(name, options, value):
         <label for="$id">$v</label>
         &nbsp;&nbsp;
 
+$jsdef render_language_autocomplete_item(item):
+    <div class="ac_language" title="$_('Select this language')">
+        <span class="name">$item.name</span>
+    </div>
 
 $# Render the ith language input field
 $jsdef render_language_field(i, language):
@@ -51,6 +47,34 @@ $jsdef render_work_field(i, work):
         $# Limit to only 1
         $# <a href="javascript:;" class="add hidden">Add another work?</a>
     </div>
+
+$jsdef render_work_autocomplete_item(item):
+    $if item.key == "__new__":
+        <div class="ac_work ac_addnew">
+            <span class="action">$_('-- Move to a new work')</span>
+        </div>
+    $else:
+        <div class="ac_work" title="Select this work">
+            <div class="cover">
+                $if item.cover_i:
+                    <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="$_('Cover of: %(title)s', title=item.title)">
+            </div>
+            <span class="olid">$item.key.split('/')[2]</span>
+            <span class="name">
+                <span class="title">$item.full_title</span>
+                $if item.first_publish_year:
+                <span class="first_publish_year">($item.first_publish_year)</span>
+            </span>
+            <span class="byline">
+                $if item.author_name:
+                    $_('by') <span class="authors">${', '.join(item.author_name)}</span>
+            </span>
+            &bull;
+            $if item.edition_count == 1:
+                <span class="edition_count">$item.edition_count edition</span>
+            $else:
+                <span class="edition_count">$item.edition_count editions</span>
+        </div>
 
 
 <fieldset class="major">
@@ -368,7 +392,10 @@ $jsdef render_work_field(i, work):
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            <div id="works">
+            <div id="works"
+                 data-isPrivilegedUser="$cond(is_privileged_user, 'true', 'false')"
+                 data-newWorkText="$_('-- Move to a new work')"
+            >
                 $if book.works:
                     $for i, work in enumerate(book.works):
                         $:render_work_field(i, work)

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 19,
+        "branches": 18,
         "functions": 15,
         "lines": 19,
         "statements": 19


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Move autocomplete part of inline js for `openlibrary/templates/books/edit/edition.html` #4474

I'll make a separate PR for rest of inline JS since this alone was a lot. This will be much easier when this is written in Vue.


### Technical
Moving some of the code generated server side to be generated client side was kind of a pain.
I'm following the advice in the main PR to use `data-*` attributes to pass data into the JS. Though it would be fantastic if there was a better way to do that.

Ideas for improving this would be appreciated but keep in mind the goal is to just move JS out of the python, not to change functionality.

After the next PR is done I'll be able to start #395

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
* Add a language
* Add a translation language
* Change the works

### Screenshot
https://user-images.githubusercontent.com/921217/116959788-6ce59d00-ac3a-11eb-90dc-f21cbe4920b6.mov

### Stakeholders
@jdlrobson 