### PR TITLE
Add i18n support to search/inside template

### DIFF
--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -1,6 +1,6 @@
 $def with (q, results, search_time, page=1, results_per_page=20)
 
-$var title: Search Open Library for $q
+$var title: $_('Search Open Library for %s', q)
 
 <div id="contentHead">
     <h1>$_("Search Inside")</h1>
@@ -23,7 +23,7 @@ $var title: Search Open Library for $q
 
         $if not num_found:
             $def escaped_query(): <strong>$q</strong>
-            <p class="sansserif red collapse">$_('No hits for: %(query)s', query=escaped_query()) </p>
+            <p class="sansserif red collapse">$:_('No hits for: %(query)s', query=escaped_query())</p>
 
         $else:
             <p class="search-results-stats">$ungettext('About 1 result found in %(seconds)s', 'About %(count)s results found in %(seconds)s', num_found, count=commify(num_found), seconds="%.2f" % search_time)</p>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Efforts towards i18n - #791

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add i18n support for title in search/inside template.
Fix escaped html tag.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Before:** No hits message with `strong` tag escaped
![image](https://user-images.githubusercontent.com/73437497/116986612-48d39b80-acce-11eb-8126-5b6e0f2d59df.png)

**After:** No hits message with escaped query and strong format
![image](https://user-images.githubusercontent.com/73437497/116987193-09f21580-accf-11eb-837d-1e10dce4cbb9.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
