### PR TITLE
Observation statistics component improvements

### DIFF
--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -3,7 +3,7 @@ $def with(work, edition, reader_observations, work_title, key)
 <a name="reader-observations" class="section-anchor"></a>      
 
 <div class="tab-section">
-  <h2 class="observation-title">Reader Observations</h2>
+  <h2 class="observation-title">$_('Reader Observations')</h2>
   <div class="work-line">$work_title</div>
   $if reader_observations['total_respondents'] > 1:
     <h4 class="observer-count">
@@ -24,10 +24,10 @@ $def with(work, edition, reader_observations, work_title, key)
       </div>
   $else:
     <hr>
-    <div class="no-stats-message">At least two people must submit observations before this information can be displayed.</div>
+    <div class="no-stats-message">$_('At least two people must submit observations before this information can be displayed.')</div>
   <hr>
   $if ctx.user:
-    $:macros.UserMetadata(work, edition, 'Share your observations', 'stats', 'stats-link')
+    $:macros.UserMetadata(work, edition, _('Add your observations'), 'stats', 'stats-link')
   $else:
-    <a class="stats-link" href="/account/login?redirect=$key">Log in to share your observations</a>
+    <a class="stats-link" href="/account/login?redirect=$key">$_('Log in to add your observations')</a>
 </div>

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -5,7 +5,7 @@ $def with(work, edition, reader_observations, work_title, key)
 <div class="tab-section">
   <h2 class="observation-title">Reader Observations</h2>
   <div class="work-line">$work_title</div>
-  $if reader_observations['total_respondents']:
+  $if reader_observations['total_respondents'] > 1:
     <h4 class="observer-count">
       $:ungettext('Based on observations from <strong>%(count)s</strong> patron', 'Based on observations from <strong>%(count)s</strong> patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
     </h4>
@@ -24,13 +24,10 @@ $def with(work, edition, reader_observations, work_title, key)
       </div>
   $else:
     <hr>
-    <div class="no-stats-message">No observations submitted for this work.</div>
+    <div class="no-stats-message">At least two people must submit observations before this information can be displayed.</div>
   <hr>
   $if ctx.user:
-    $if reader_observations['total_respondents']:
-      $:macros.UserMetadata(work, edition, 'Share your observations', 'stats', 'stats-link')
-    $else:
-      $:macros.UserMetadata(work, edition, 'Be the first to share your observations', 'stats', 'stats-link')
+    $:macros.UserMetadata(work, edition, 'Share your observations', 'stats', 'stats-link')
   $else:
     <a class="stats-link" href="/account/login?redirect=$key">Log in to share your observations</a>
 </div>

--- a/static/css/components/observationStats.less
+++ b/static/css/components/observationStats.less
@@ -20,5 +20,6 @@
 .stats-link {
   margin: .5em auto .25em;
   display: block;
-  width: max-content;
+  width: 80%;
+  text-align: center;
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR ensures that the observation statistics component only displays data if two or more people have submitted observations for a book.

Also, hard-coded strings in this component have been replaced with i18n strings.

### Technical
<!-- What should be noted about the implementation? -->
This will cause a merge conflict with #5089.  I can rebase once either PR is merged.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Before deploying to testing, locate a book that only one patron has reviewed.

After deployment, while logged in as a beta-tester:

1. Navigate to the page that you previously identified and ensure that no observations are present in the component.
2. Navigate to a page where two or more people have submitted reviews, ensuring that the observations *are* present in the component.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![stats_component_new_copy](https://user-images.githubusercontent.com/28732543/117020374-600d8b80-acc4-11eb-8a08-3871d0c14d1b.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
