### PR TITLE
update Internet Archive mailing lists to match new values in petabox

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -519,8 +519,10 @@ class InternetArchiveAccount(web.storage):
             The slug / itemname is generated automatically from this value.
         :param unicode email:
         :param unicode password:
-        :param List[Union[Literal['announce-general'], Literal['announce-sf']]] notifications:
-            newsletters to subscribe user to
+        :param List[Union[Literal['ml_best_of'], Literal['ml_donors'], Literal['ml_events'], Literal['ml_updates']]] notifications:
+            newsletters to subscribe user to (NOTE: these must be kept in sync
+            with the values in the `MAILING_LIST_KEYS` array in
+            https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc)
         :param int retries: If the username is unavailable, how many
             subsequent attempts should be made to find an available
             username.

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -519,7 +519,10 @@ class InternetArchiveAccount(web.storage):
             The slug / itemname is generated automatically from this value.
         :param unicode email:
         :param unicode password:
-        :param List[Union[Literal['ml_best_of'], Literal['ml_donors'], Literal['ml_events'], Literal['ml_updates']]] notifications:
+        :param List[Union[
+                Literal['ml_best_of'], Literal['ml_donors'],
+                Literal['ml_events'], Literal['ml_updates']
+            ]] notifications:
             newsletters to subscribe user to (NOTE: these must be kept in sync
             with the values in the `MAILING_LIST_KEYS` array in
             https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -242,12 +242,13 @@ class account_create(delegate.page):
 
                 """NOTE: the values for the notifications must be kept in sync
                 with the values in the `MAILING_LIST_KEYS` array in
-                https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc 
+                https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc
                 Currently, per the fundraising/development team, the
                 "announcements checkbox" should map to BOTH `ml_best_of` and
                 `ml_updates`
                 """  # nopep8
-                notifications = ['ml_best_of', 'ml_updates'] if f.ia_newsletter.checked else []
+                mls = ['ml_best_of', 'ml_updates']
+                notifications = mls if f.ia_newsletter.checked else []
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,
                     notifications=notifications, verified=False, retries=USERNAME_RETRIES)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -239,7 +239,14 @@ class account_create(delegate.page):
                 # Create ia_account: require they activate via IA email
                 # and then login to OL. Logging in after activation with
                 # IA credentials will auto create and link OL account.
-                notifications = ['announce-general'] if f.ia_newsletter.checked else []
+
+                # NOTE: the values for the notifications must be kept in sync
+                # with the values in the `MAILING_LIST_KEYS` array in
+                # https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc
+                # Currently, per the fundraising/development team, the
+                # "announcements checkbox" should map to BOTH `ml_best_of` and
+                # `ml_updates`
+                notifications = ['ml_best_of', 'ml_updates'] if f.ia_newsletter.checked else []
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,
                     notifications=notifications, verified=False, retries=USERNAME_RETRIES)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -246,7 +246,7 @@ class account_create(delegate.page):
                 Currently, per the fundraising/development team, the
                 "announcements checkbox" should map to BOTH `ml_best_of` and
                 `ml_updates`
-                """"  # nopep8
+                """ # nopep8
                 notifications = ['ml_best_of', 'ml_updates'] if f.ia_newsletter.checked else []
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -240,12 +240,13 @@ class account_create(delegate.page):
                 # and then login to OL. Logging in after activation with
                 # IA credentials will auto create and link OL account.
 
-                # NOTE: the values for the notifications must be kept in sync
-                # with the values in the `MAILING_LIST_KEYS` array in
-                # https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc
-                # Currently, per the fundraising/development team, the
-                # "announcements checkbox" should map to BOTH `ml_best_of` and
-                # `ml_updates`
+                """NOTE: the values for the notifications must be kept in sync
+                with the values in the `MAILING_LIST_KEYS` array in
+                https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc 
+                Currently, per the fundraising/development team, the
+                "announcements checkbox" should map to BOTH `ml_best_of` and
+                `ml_updates`
+                """"  # nopep8
                 notifications = ['ml_best_of', 'ml_updates'] if f.ia_newsletter.checked else []
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -246,7 +246,7 @@ class account_create(delegate.page):
                 Currently, per the fundraising/development team, the
                 "announcements checkbox" should map to BOTH `ml_best_of` and
                 `ml_updates`
-                """ # nopep8
+                """  # nopep8
                 notifications = ['ml_best_of', 'ml_updates'] if f.ia_newsletter.checked else []
                 InternetArchiveAccount.create(
                     screenname=f.username.value, email=f.email.value, password=f.password.value,


### PR DESCRIPTION
The values for notifications (mailing lists) must be kept in sync with the values in
https://git.archive.org/ia/petabox/blob/master/www/common/MailSync/Settings.inc#L29-30
Currently, per the fundraising/development team, the announcements checkbox on signup forms should map to BOTH `ml_best_of` and `ml_updates`
