### PR TITLE
Slick accessibility updates

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -13,7 +13,7 @@ const Carousel = {
      * @param {Number} loadMore.limit of new items to receive
      * @param {String} loadMore.pageMode of page e.g. `offset`
      */
-    add: function(selector, a, b, c, d, e, f, loadMore) {
+    add: function(selector, a, b, c, d, e, f, loadMore, title) {
         var responsive_settings, availabilityStatuses, addWork, url, default_limit;
 
         a = a || 6;
@@ -102,7 +102,7 @@ const Carousel = {
             }
 
             return `${'<div class="book carousel__item slick-slide slick-active" ' +
-                '"aria-hidden="false">' +
+                '"aria-hidden="false" role="listitem">' +
                 '<div class="book-cover">' +
                   '<a href="'}${work.key}" ${isClickable}>` +
                     `<img class="bookcover" width="130" height="200" title="${
@@ -194,6 +194,7 @@ const Carousel = {
             }
 
             $(`${selector} [aria-live]`).removeAttr('aria-live');
+            $(`${selector} .slick-track`).attr('role','list').attr('aria-label',title);
             setA11yAttributes();
 
             $(`${selector} button.slick-prev`).on('click', function () {

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -102,7 +102,7 @@ const Carousel = {
             }
 
             return `${'<div class="book carousel__item slick-slide slick-active" ' +
-                '"aria-hidden="false" role="option">' +
+                '"aria-hidden="false">' +
                 '<div class="book-cover">' +
                   '<a href="'}${work.key}" ${isClickable}>` +
                     `<img class="bookcover" width="130" height="200" title="${

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -66,12 +66,14 @@ const Carousel = {
         }
 
         $(selector).slick({
+            accessibility: false,
             infinite: false,
             speed: 300,
             slidesToShow: a,
             slidesToScroll: a,
             responsive: responsive_settings
         });
+        accessibilitySetup();
 
         availabilityStatuses = {
             open: {cls: 'cta-btn--available', cta: 'Read'},
@@ -178,6 +180,31 @@ const Carousel = {
                 }
             });
         }
+
+        function accessibilitySetup() {
+
+            function setA11yAttributes() {
+                //Ensuring offscreen elements do not receive focus
+                $(`${selector} [aria-hidden="true"] a[href]`).attr('tabindex', -1);
+                $(`${selector} [aria-hidden="false"] a[href]`).removeAttr('tabindex');
+
+                //Ensuring any disabled button elements do not receive focus
+                $(`${selector} button[aria-disabled="true"]`).attr('tabindex', -1);
+                $(`${selector} button[aria-disabled="false"]`).removeAttr('tabindex');
+            }
+
+            $(`${selector} [aria-live]`).removeAttr('aria-live');
+            setA11yAttributes();
+
+            $(`${selector} button.slick-prev`).on('click', function () {
+                $(`${selector} button.slick-next`).focus();
+            });
+            $(`${selector} button.slick-next`).on('click', function () {
+                $(`${selector} button.slick-prev`).focus();
+            });
+            $(selector).on('afterChange', setA11yAttributes);
+        }
+
     }
 };
 

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -31,7 +31,7 @@ $def render_carousel_cover(book, lazy):
   $ modifier = ''
   $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
 
-  <div class="book carousel__item">
+  <div class="book carousel__item" role="listitem">
     <div class="book-cover">
       <a href="$(url)">
         $if cover_url:
@@ -73,7 +73,7 @@ $if test or (books and len(books) >= min_books):
           $ }
         $else:
           $ load_more_config = {}
-        $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
+        $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config, title ]
         <div class="carousel carousel-$key carousel--progressively-enhanced"
           data-config="$json_encode(config)">
           $for index, book in enumerate(books or []):

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -58,7 +58,7 @@ $def render_carousel_cover(book, lazy):
   </div>
 
 $if test or (books and len(books) >= min_books):
-      <div class="carousel-section">
+      <div class="carousel-section" role="region" aria-label="$title">
       $if title and url:
         <div class="carousel-section-header">
           <h2 class="home-h2"><a href="$url">$title</a></h2>

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -2,7 +2,7 @@ $def with (test=False)
 
 $ subjects = get_cached_featured_subjects() if not test else []
 $if subjects:
-  <div class="carousel-section">
+  <div class="carousel-section" role="region" aria-label="$_('Browse by Subject')">
     <div class="carousel-section-header">
       <h2 class="home-h2"><a href="/subjects">$_('Browse by Subject')</a></h2>
     </div>

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -13,7 +13,7 @@ $if subjects:
         $for subject_name in subjects:
           $ subject = subjects[subject_name]
           $ presentable_subject_name = subject_name.replace('_', ' ').title()
-          <div class="category-item carousel__item">
+          <div class="category-item carousel__item" role="listitem">
             <a class="category-nostyle" data-ol-link-track="CarouselCategories"
                href="/subjects/$(subject_name)#sort=date_published&ebooks=true">
               <div class="category-icon">


### PR DESCRIPTION
This PR provides an approach to increase the accessibility of our slick slider carousels.

The existing implementation of the slick "accessibility" features is definitely lacking. While, in the long run, we may need to switch away from slick, this PR would ensure that we have some of the most needed accessibility in place while we look for other slider options in the future.

### Technical
The biggest issue with the "accessibility" features implemented by Slick are that they do not move keyboard focus appropriately for keyboard-only users, and their existing role of `listbox` isn't particularly valid for the type of control displayed. An [ARIA listbox role](https://www.w3.org/TR/wai-aria-practices/#Listbox) is intended to be something similar to an HTML `select` element.

It's impossible to leave the "accessibility" features on & simply write over the existing content because whenever a user updates the slider the library will reimpose its default roles. So, for this PR I simply opted to turn off all the accessibility features & add on from there. 

Doing this requires manually adding back in a few things we got "for free" previously, but the only thing of note is setting `tabindex="-1"` to the off-screen interactive elements in a slider to prevent them from receiving focus.

In terms of new features, this PR adds in:

- Removing buttons with `aria-disabled="true"` from being in the tab order
- Logical focus order updates when users activate the previous / next buttons in a slider
- An updated role of `list` & `listitem` for the carousel & its contents, along with a programmatic label
    - This will expose the carousel contents as the "Classic Books list", along with the number of items displayed on-screen
    - Lists will also allow some AT users to navigate between items in the carousel with shortcuts

The biggest downside of this PR is that there is additional JS we will need to maintain & we have to manually set up a lot of the elements here. As an example, because the `list` role is being added with the main slider & the `listitem` roles get added locations, it's easy to miss content & create a list with no list items. I did this accidentally when I forgot to add `role="listitem"` to the categories slider.

### Testing

- Verify any book slides offscreen do not receive focus & are programmatically hidden with `aria-hidden="true"`
- Ensure all carousels include both a `role` attribute with a value of `list` & that each carousel element has a `role` attribute with a value of `listitem`

### Screenshot
Here's a sample animation of the updated focus movement when navigating via the keyboard:
![A carousel labelled 'Classic Books' with a focus indicator tabbing through & navigating to previous content](https://user-images.githubusercontent.com/3421881/117377461-2d13f500-ae88-11eb-9789-4539af3a9f6d.gif)


### Stakeholders
@mekarpeles 