### PR TITLE
Use current_thread and access name attribute directly instead of deprecated access in Python 3.10.

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -140,7 +140,7 @@ class memcache_memoize:
             self.update(*args, **kw)
         finally:
             # Remove current thread from active threads
-            self.active_threads.pop(threading.currentThread().getName(), None)
+            self.active_threads.pop(threading.current_thread().name, None)
 
             # remove the flag
             self.memcache.delete(key)


### PR DESCRIPTION
Closes #5156 

### Technical

Fixes deprecation warnings in Python 3.10
