### PR TITLE
Ensuring Color Contrast for Author Names When Cover Is Not Present

### DIFF
--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -161,7 +161,7 @@
 
   &--authors {
     position: relative;
-    color: @grey;
+    color: @dark-grey-two;
     padding: 4px 4px 0;
     font-size: .6875em;
     font-style: oblique;


### PR DESCRIPTION
This PR slightly darkens the author name when a book cover is not present (`.carousel__item__blankcover--authors`) from the `@grey` variable (`hsl(0, 0%, 40%)`) to `@dark-grey-two` which is a slightly darker grey at `hsl(0, 0%, 35%)`.

### Technical
The blank book cover background (`.carousel__item__blankcover`) uses `@lighter-grey` (`hsl(0, 0%, 87%)`). On this background color, the `@grey` text has a color contrast ratio of 4.23:1 while the `@dark-grey-two` text has a contrast ratio of 5.16:1. The minimum color contrast ratio for normal sized text should be 4.5:1.

### Testing

- Verify the colors have adjusted appropriately, and that a color contrast ratio of at least 4.5:1 exists between the text & background color.
- [WCAG Success Criteria 1.4.3, color contrast ](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum)

### Screenshot
The updated colors & contrast ratio appear on the left, and the current existing colors & contrast ratio appear on the right:
![Two versions of the unavailable book cover for Outrage by Robert Tanenbaum, with color contrast ratios from Firefox's dev tools](https://user-images.githubusercontent.com/3421881/117544214-44acc400-afd5-11eb-9507-0ef767b2d2a4.png)

### Stakeholders
