### PR TITLE
Ensuring Affiliate Links List Includes Only li Elements as Children

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -58,11 +58,15 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
     $for store in primary_stores:
       $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
     $if more_stores:
-      <details>
-        <summary>$_('More')</summary>
-        $for store in more_stores:
-          $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-      </details>
+      <li class="more">
+        <details>
+          <summary>$_('More')</summary>
+          <ul>
+            $for store in more_stores:
+              $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
+          </ul>
+        </details>
+      </li>
     
-    <p>When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.</p>
 </ul>
+<p>When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.</p>

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -78,14 +78,14 @@
     width: 49%;
   }
   // stylelint-enable selector-max-specificity
+}
 
-  .buy-options-table {
-    .more {
-      margin-left: 0;
+.buy-options-table {
+  .more {
+    margin-left: 0;
 
-      &::marker {
-        content: "";
-      }
+    &::marker {
+      content: "";
     }
   }
 }

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -78,6 +78,16 @@
     width: 49%;
   }
   // stylelint-enable selector-max-specificity
+
+  .buy-options-table {
+    .more {
+      margin-left: 0;
+
+      &::marker {
+        content: "";
+      }
+    }
+  }
 }
 
 .cta-section-title.world-cat-link{


### PR DESCRIPTION
This PR provides an update to contents in the Affiliate Links list. The HTML spec requires that list elements have only `li` elements as children, but previously we had both `p` & `details` elements as children of the `ul`.

### Technical

- Adding an `li` element around the `details` / `summary` content ensures any more stores this will be rendered to users in the same list
- The style changes should result in no visual breaking changes on the page overall

### Testing

- Ensure there are no visually breaking changes when "More" is displayed

### Stakeholders
@mekarpeles 
