### PR TITLE
Add clear observations buttons to book notes modal

### DIFF
--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -49,7 +49,7 @@ export function initPatronMetadata() {
                 </label>`);
             }
 
-            let $clearButton = $('<a class="clear-observations-btn" href="#">Clear Selection</a>');
+            let $clearButton = $('<a class="clear-observations-btn cta-btn" href="#">Clear Selection</a>');
 
             let $formSection = $(`<details class="aspect-section" open>
                                     <summary>${type}</summary>
@@ -65,7 +65,7 @@ export function initPatronMetadata() {
             $formSection.children('div').append($clearButton);
 
             if (!showClearButton) {
-                $clearButton.hide();
+                $clearButton.css('visibility', 'hidden');
             }
 
             $clearButton.on('click', function() {
@@ -263,9 +263,9 @@ function updateClearButtonVisibility($detailsSection) {
     });
 
     if (showButton) {
-        $button.show();
+        $button.css('visibility', 'visible');
     } else {
-        $button.hide();
+        $button.css('visibility', 'hidden');
     }
 }
 

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -47,6 +47,8 @@ export function initPatronMetadata() {
                 </label>`);
             }
 
+            let $clearButton = $('<a href="#">Clear Selection</a>');
+
             let $formSection = $(`<details class="aspect-section" open>
                                     <summary>${type}</summary>
                                     <div id="${id}-${type}-question">
@@ -54,9 +56,25 @@ export function initPatronMetadata() {
                                         <span class="pending-indicator hidden"></span>
                                         <span class="success-indicator hidden">Selection saved!</span>
                                         <span class="failure-indicator hidden">Submission failed</span>
-                                        ${$choices.prop('outerHTML')}
                                     </div>
                                 </details>`);
+
+            $formSection.children('div').append($choices);
+            $formSection.children('div').append($clearButton);
+
+            $clearButton.on('click', function() {
+                let $inputs = $choices.find('input');
+
+                $inputs.each(function() {
+                    if ($(this).prop('checked')) {
+                        $(this).prop('checked', false);
+                        $(this).trigger('change');
+                    }
+                });
+
+                // Prevent redirect
+                return false;
+            });
 
             /*
             Adds an observation submission state change event handler to this section of the form.

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -49,20 +49,22 @@ export function initPatronMetadata() {
                 </label>`);
             }
 
-            let $clearButton = $('<a class="clear-observations-btn cta-btn" href="#">Clear Selection</a>');
+            let $clearButton = $('<a class="clear-observations-btn" href="#">Clear &times</a>');
 
             let $formSection = $(`<details class="aspect-section" open>
                                     <summary>${type}</summary>
                                     <div id="${id}-${type}-question">
-                                        <h3>${observation.description}</h3>
-                                        <span class="pending-indicator hidden"></span>
-                                        <span class="success-indicator hidden">Selection saved!</span>
-                                        <span class="failure-indicator hidden">Submission failed</span>
+                                        <div class="form-question">
+                                            <h3>${observation.description}</h3>
+                                            <span class="pending-indicator hidden"></span>
+                                            <span class="success-indicator hidden">Selection saved!</span>
+                                            <span class="failure-indicator hidden">Submission failed</span>
+                                        </div>
                                     </div>
                                 </details>`);
 
             $formSection.children('div').append($choices);
-            $formSection.children('div').append($clearButton);
+            $formSection.find('.form-question').append($clearButton);
 
             if (!showClearButton) {
                 $clearButton.css('visibility', 'hidden');

--- a/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
+++ b/openlibrary/plugins/openlibrary/js/patron-metadata/index.js
@@ -30,6 +30,7 @@ export function initPatronMetadata() {
             let $choices = $(`<div class="${className}"></div>`);
             let choiceIndex = observation.values.length;
             let type = observation.label;
+            let showClearButton = false;
 
             for (const value of observation.values) {
                 let choiceId = `${id}-${observation.label}Choice${choiceIndex--}`;
@@ -38,6 +39,7 @@ export function initPatronMetadata() {
                 if (type in selectedValues
                     && selectedValues[type].includes(value)) {
                     checked = 'checked';
+                    showClearButton = true;
                 }
 
                 $choices.append(`
@@ -47,7 +49,7 @@ export function initPatronMetadata() {
                 </label>`);
             }
 
-            let $clearButton = $('<a href="#">Clear Selection</a>');
+            let $clearButton = $('<a class="clear-observations-btn" href="#">Clear Selection</a>');
 
             let $formSection = $(`<details class="aspect-section" open>
                                     <summary>${type}</summary>
@@ -61,6 +63,10 @@ export function initPatronMetadata() {
 
             $formSection.children('div').append($choices);
             $formSection.children('div').append($clearButton);
+
+            if (!showClearButton) {
+                $clearButton.hide();
+            }
 
             $clearButton.on('click', function() {
                 let $inputs = $choices.find('input');
@@ -230,9 +236,37 @@ function addChangeListeners(context) {
                 }
 
                 submitObservation($(this), workOlid, data, type);
+                updateClearButtonVisibility($(this).closest('details'));
             });
         })
     });
+}
+
+/**
+ * Updates visibility of a form details section's clear button.
+ *
+ * A clear button in each details section of the observations form should only be visible
+ * if at least one of the section's inputs is checked.  Given a reference to the details
+ * element, this function iterates over all of the section's inputs.  If an input is checked,
+ * the clear button is displayed in the UI.  Otherwise, it is hidden.
+ *
+ * @param {JQuery} $detailsSection Details section that contains button that will be updated
+ */
+function updateClearButtonVisibility($detailsSection) {
+    let $button = $detailsSection.find('.clear-observations-btn');
+    let showButton = false;
+
+    $detailsSection.find('input').each(function() {
+        if ($(this).prop('checked')) {
+            showButton = true;
+        }
+    });
+
+    if (showButton) {
+        $button.show();
+    } else {
+        $button.hide();
+    }
 }
 
 /**

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -112,6 +112,12 @@
     display: inline-block;
     margin-right: .5em;
   }
+
+  .clear-observations-btn {
+    background-color: @red;
+    width: max-content;
+    margin: 0 auto;
+  }
 }
 
 .book-notes-form {

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -113,10 +113,17 @@
     margin-right: .5em;
   }
 
+  .form-question {
+    display: flex;
+    align-items: center;
+  }
+
   .clear-observations-btn {
-    background-color: @red;
+    color: @red;
+    font-weight: bold;
     width: max-content;
-    margin: 0 auto;
+    margin: 0 0 0 auto;
+    text-decoration: none;
   }
 }
 
@@ -188,12 +195,14 @@
       margin-right: unset;
       display: block;
     }
-  }
 
-  .pending-indicator,
-  .success-indicator,
-  .failure-indicator {
-    display: block;
-    height: 1em;
+    .form-question {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .clear-observations-btn {
+      margin: .5em 0;
+    }
   }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a clear button to each section of the observations modal form.  When pressed, the button will deselect all inputs in the section.

### Technical
<!-- What should be noted about the implementation? -->
The button's visibility is dependent on whether an input is checked in the section.  If no input is checked, the section's clear button is hidden.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta tester:
1. Navigate to a book page and open the observations modal.
2. Find a section which has no checked inputs.  Ensure that the clear button is not present.
3. Check an input in section that you found in step 2.  Ensure that the clear button appears below the inputs.
4. Click the clear button.  Ensure that all of the inputs in the section are unchecked and that the button is hidden.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![clear-selections](https://user-images.githubusercontent.com/28732543/117730485-64511180-b1ba-11eb-9359-f5dc0cd9f0ce.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
