### PR TITLE
4492/fix/stretched book covers

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -103,7 +103,7 @@ const Carousel = {
                 '"aria-hidden="false" role="option">' +
                 '<div class="book-cover">' +
                   '<a href="'}${work.key}" ${isClickable}>` +
-                    `<img class="bookcover" width="130" height="200" title="${
+                    `<img class="bookcover" title="${
                         work.title}" ` +
                       `src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg">` +
                   '</a>' +

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -36,7 +36,6 @@ $def render_carousel_cover(book, lazy):
       <a href="$(url)">
         $if cover_url:
           <img class="bookcover" loading="lazy"
-            width="130" height="200"
             title="$('%s%s'%(title,byline))"
             alt="$('%s%s'%(title,byline))"
           $if lazy:

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -21,5 +21,6 @@
     margin: 0 auto;
     box-shadow: 1px 2px 5px 0 @book-cover-shadow-color;
     border-radius: 3px;
+    object-fit: contain;
   }
 }

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -28,5 +28,7 @@
     margin: 0 auto;
     box-shadow: 1px 2px 5px 0 @book-cover-shadow-color;
     border-radius: 3px;
+    max-width: 100%;
+    max-height: 200px;
   }
 }

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -19,6 +19,9 @@
     a {
       display: block;
     }
+    a {
+      margin: auto;
+    }
   }
 
   img.bookcover {

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -11,6 +11,10 @@
     }
   }
   .book-cover {
+    height: 200px;
+    display: flex;
+    align-items: center;
+
     img,
     a {
       display: block;
@@ -21,6 +25,5 @@
     margin: 0 auto;
     box-shadow: 1px 2px 5px 0 @book-cover-shadow-color;
     border-radius: 3px;
-    object-fit: contain;
   }
 }


### PR DESCRIPTION
Closes #4492

Fixes UI issue where book cover images are stretched to fill the 130x200 px space allocated. Instead, now, they fit (max out on one axis & don't overflow any axis).

### Technical
Setting the `img` to `contain` the image still left the `img` elem at 130x200px. Thus its box shadow appeared peculiar. This was hinted at in https://github.com/internetarchive/openlibrary/issues/4492#issuecomment-771872381.

The solution was for the `img` tag to be allowed to collapse in size to the size of its image (equally better practice). The parent node `div.book-cover` then makes a restraint on the size.

### Simple fit (1st commit)
Home page
<img width="973" alt="Home" src="https://user-images.githubusercontent.com/1782820/117721184-742b1e80-b1d7-11eb-8470-2fe1171d8e49.png">

Subjects page
<img width="683" alt="Subjects" src="https://user-images.githubusercontent.com/1782820/117721195-768d7880-b1d7-11eb-90ce-f95edfa5e542.png">

### Box collapse (2nd commit)
Home page
<img width="974" alt="Home" src="https://user-images.githubusercontent.com/1782820/117730214-ee61a000-b1e3-11eb-9f72-67e34de9e312.png">

Subjects page
<img width="652" alt="Subjects" src="https://user-images.githubusercontent.com/1782820/117730220-ef92cd00-b1e3-11eb-849b-65e12c760abc.png">

### Anchor tag outside (3rd commit)

I found the following UI bug at various resolutions, the cause of which was that the `img.bookcover`'s `margin: 0 auto` rule wasn't taking affect

<img width="851" alt="Margin" src="https://user-images.githubusercontent.com/1782820/117731391-f91d3480-b1e5-11eb-942c-ce3148c213bf.png">

and the solution I found was to apply the margin on the anchor tag. I would have preferred a non-UI anchor tag, but I'm not sure why I have this preference and I'd have to go back to some HTML5/CSS3 principles to investigate. This works.

Finally, unlike the design described, my book covers stretch over 130px in width as long as they don't top 200px in height. This doesn't seem like a big loss & may actually be a better solution given the parent element widens gladly (fixed height) & we would lose a lot of usable space if working the other way round.

<img width="929" alt="Wide Pooh" src="https://user-images.githubusercontent.com/1782820/117732533-f91e3400-b1e7-11eb-9230-f4b9f8146883.png">

### Otherwise

I pushed that Winnie the Pooh sequel picture (great series) in via inspect element to test.

**NB** I have not tested the List page. I didn't know how to create a list. However, in lists the images don't use `img.bookcover` but instead a `span.bookcover` then containing the `img`. The images / book covers in a list view then display at their proper dimension already & don't stretch. (Please double-check.)

**Suggestion** if this PR is accepted: Provide / update a placeholder book cover image of a fuller dimension.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson @mekarpeles 