### PR TITLE
[performance] Reduce the amount of critical path JavaScript  that is loaded

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -17,7 +17,7 @@
       "maxSize": "1KB"
     },
     {
-      "path": "static/build/carousel-partials.*.js",
+      "path": "static/build/carousels-partials.*.js",
       "maxSize": "1KB"
     },
     {
@@ -45,7 +45,7 @@
       "maxSize": "30KB"
     },
     {
-      "path": "static/build/rt-validation.*.js",
+      "path": "static/build/realtime-account-validation.*.js",
       "maxSize": "1KB"
     },
     {
@@ -53,7 +53,7 @@
       "maxSize": "137KB"
     },
     {
-      "path": "static/build/goodreads.*.js",
+      "path": "static/build/goodreads-import.*.js",
       "maxSize": "2KB"
     },
     {

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -17,12 +17,60 @@
       "maxSize": "1KB"
     },
     {
+      "path": "static/build/carousel-partials.*.js",
+      "maxSize": "1KB"
+    },
+    {
+      "path": "static/build/covers.*.js",
+      "maxSize": "8KB"
+    },
+    {
+      "path": "static/build/add-book.*.js",
+      "maxSize": "1KB"
+    },
+    {
       "path": "static/build/readmore.*.js",
       "maxSize": "1KB"
     },
     {
+      "path": "static/build/patron-metadata.*.js",
+      "maxSize": "5KB"
+    },
+    {
+      "path": "static/build/user-website.*.js",
+      "maxSize": "3KB"
+    },
+    {
+      "path": "static/build/page-barcodescanner.*.js",
+      "maxSize": "30KB"
+    },
+    {
+      "path": "static/build/rt-validation.*.js",
+      "maxSize": "1KB"
+    },
+    {
+      "path": "static/build/readinglog-stats.*.js",
+      "maxSize": "137KB"
+    },
+    {
+      "path": "static/build/goodreads.*.js",
+      "maxSize": "2KB"
+    },
+    {
+      "path": "static/build/admin.*.js",
+      "maxSize": "1KB"
+    },
+    {
+      "path": "static/build/search.*.js",
+      "maxSize": "1KB"
+    },
+    {
+      "path": "static/build/tabs.*.js",
+      "maxSize": "5KB"
+    },
+    {
       "path": "static/build/all.js",
-      "maxSize": "124KB"
+      "maxSize": "115KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -1,6 +1,7 @@
 /**
  * Functionality for templates/covers
  */
+import 'jquery-ui/ui/widgets/sortable';
 
 //cover/change.html
 export function initCoversChange() {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -167,7 +167,7 @@ jQuery(function () {
 
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
-        import(/* webpackChunkName: "rt-validation" */'./realtime_account_validation.js')
+        import(/* webpackChunkName: "realtime-account-validation" */'./realtime_account_validation.js')
             .then(module => module.initRealTimeValidation());
     }
     // conditionally load readmore button based on class in the page
@@ -177,12 +177,12 @@ jQuery(function () {
     }
     // conditionally loads Goodreads import based on class in the page
     if (document.getElementsByClassName('import-table').length) {
-        import(/* webpackChunkName: "goodreads" */'./goodreads_import.js')
+        import(/* webpackChunkName: "goodreads-import" */'./goodreads_import.js')
             .then(module => module.initGoodreadsImport());
     }
     // conditionally loads Related Carousels based on class in the page
     if (document.getElementsByClassName('RelatedWorksCarousel').length) {
-        import(/* webpackChunkName: "carousel-partials" */'./carousels_partials.js')
+        import(/* webpackChunkName: "carousels-partials" */'./carousels_partials.js')
             .then(module => module.initCarouselsPartials());
     }
     // Enable any carousels in the page

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,8 +1,6 @@
 import 'jquery';
 import 'jquery-validation';
 import 'jquery-ui/ui/widgets/dialog';
-import 'jquery-ui/ui/widgets/sortable';
-import 'jquery-ui/ui/widgets/tabs';
 import 'jquery-ui/ui/widgets/autocomplete';
 // For dialog boxes (e.g. add to list)
 import 'jquery-colorbox';
@@ -29,7 +27,6 @@ import '../../../../static/css/js-all.less';
 // polyfill Promise support for IE11
 import Promise from 'promise-polyfill';
 import { confirmDialog, initDialogs } from './dialog';
-import initTabs from './tabs.js';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
@@ -72,10 +69,17 @@ jQuery(function () {
     const $markdownTextAreas = $('textarea.markdown');
     // Live NodeList is cast to static array to avoid infinite loops
     const $carouselElements = $('.carousel--progressively-enhanced');
+    const $tabs = $('#tabsAddbook,#tabsAddauthor,.tabs:not(.ui-tabs)');
+
     initDialogs();
     // expose ol_confirm_dialog method
     $.fn.ol_confirm_dialog = confirmDialog;
-    initTabs($('#tabsAddbook,#tabsAddauthor,.tabs:not(.ui-tabs)'));
+
+    if ($tabs.length) {
+        import(/* webpackChunkName: "tabs" */ './tabs')
+            .then((module) => module.initTabs($tabs));
+    }
+
     initValidate($);
     autocompleteInit($);
     addNewFieldInit($);
@@ -163,7 +167,7 @@ jQuery(function () {
 
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
-        import('./realtime_account_validation.js')
+        import(/* webpackChunkName: "rt-validation" */'./realtime_account_validation.js')
             .then(module => module.initRealTimeValidation());
     }
     // conditionally load readmore button based on class in the page
@@ -173,12 +177,12 @@ jQuery(function () {
     }
     // conditionally loads Goodreads import based on class in the page
     if (document.getElementsByClassName('import-table').length) {
-        import('./goodreads_import.js')
+        import(/* webpackChunkName: "goodreads" */'./goodreads_import.js')
             .then(module => module.initGoodreadsImport());
     }
     // conditionally loads Related Carousels based on class in the page
     if (document.getElementsByClassName('RelatedWorksCarousel').length) {
-        import('./carousels_partials.js')
+        import(/* webpackChunkName: "carousel-partials" */'./carousels_partials.js')
             .then(module => module.initCarouselsPartials());
     }
     // Enable any carousels in the page
@@ -198,7 +202,7 @@ jQuery(function () {
     }
 
     if (window.READINGLOG_STATS_CONFIG) {
-        import(/* webpackChunkName: "readinglog_stats" */ './readinglog_stats')
+        import(/* webpackChunkName: "readinglog-stats" */ './readinglog_stats')
             .then(module => module.init(window.READINGLOG_STATS_CONFIG));
     }
 
@@ -209,25 +213,27 @@ jQuery(function () {
     }
 
     if (document.getElementsByClassName('modal-link').length) {
-        import(/* webpackChunkName: "patron_metadata" */ './patron-metadata')
+        import(/* webpackChunkName: "patron-metadata" */ './patron-metadata')
             .then((module) => module.initPatronMetadata());
     }
 
-    if (document.getElementsByClassName('manageCovers').length) {
+    const manageCoversElement = document.getElementsByClassName('manageCovers').length;
+    const addCoversElement = document.getElementsByClassName('imageIntro').length;
+    const saveCoversElement = document.getElementsByClassName('imageSaved');
+
+    if (addCoversElement || manageCoversElement || saveCoversElement) {
         import(/* webpackChunkName: "covers" */ './covers')
-            .then((module) => module.initCoversChange());
-    }
-
-    // Load from iframe
-    if (document.getElementsByClassName('imageIntro').length) {
-        import('./covers')
-            .then((module) => module.initCoversAddManage());
-    }
-
-    // Load from iframe
-    if (document.getElementsByClassName('imageSaved').length) {
-        import('./covers')
-            .then((module) => module.initCoversSaved());
+            .then((module) => {
+                if (manageCoversElement) {
+                    module.initCoversChange();
+                }
+                if (addCoversElement) {
+                    module.initCoversAddManage();
+                }
+                if (saveCoversElement) {
+                    module.initCoversSaved();
+                }
+            });
     }
 
     if (document.getElementById('addbook')) {

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -1,7 +1,7 @@
 const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
 import 'jquery-ui/ui/widgets/tabs';
 
-export default function initTabs($node) {
+export function initTabs($node) {
     $node.tabs(TABS_OPTIONS);
     $node.filter('.autohash').on('tabsselect', function(event, ui) {
         document.location.hash = ui.panel.id;

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -1,4 +1,5 @@
 const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
+import 'jquery-ui/ui/widgets/tabs';
 
 export default function initTabs($node) {
     $node.tabs(TABS_OPTIONS);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Working towards #2340

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
* Removes some of the jquery ui off the critical path, constraining it to the covers feature and where tabs are used.
* Cleans up asynchronous loading of modules and bundle testing
* Reduces the critical path by around 10kb

### Technical
Should not change any functionality - only concerned with when code is loaded.

### Testing
* On a book page, click change cover. Check the covers are sortable and tabs display.
* On book edit page, check tabs are functional.
* 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cdrini @mekarpeles 