### PR TITLE
build: remove unused dependencies from `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ httpx==0.18.1
 internetarchive==2.0.2
 isbnlib==3.10.6
 lxml==4.6.3
+Pillow==8.2.0
 psycopg2==2.8.6
 pymarc==4.1.0
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,15 +11,12 @@ httpx==0.18.1
 internetarchive==2.0.2
 isbnlib==3.10.6
 lxml==4.6.3
-Pillow==8.2.0
 psycopg2==2.8.6
-Pygments==2.8.1
 pymarc==4.1.0
 python-dateutil==2.8.1
 python-memcached==1.59
 PyYAML==5.4.1
 requests==2.25.1
-schema==0.7.4
 sentry-sdk==1.1.0
 simplejson==3.17.2
 six==1.15.0


### PR DESCRIPTION
In my analysis of requirements.txt, I found out that these are unused.

We will be testing it whether that is actually the case and there aren't any hidden/indirect usage. I tried building it locally and it seems to work.

Ref: https://github.com/internetarchive/openlibrary/pull/5162#issuecomment-841347300

Also, I found out even if we do not include them in the requirements.txt, they will be installed as they are indirect dependencies of some other packages:
```console
❯ dc exec web cat requirements.txt
amightygirl.paapi5-python-sdk==1.0.0
Babel==2.9.1
beautifulsoup4==4.9.3
DBUtils==1.3
Deprecated==1.2.12
eventer==0.1.1
flup-py3==1.0.3
Genshi==0.7.5
gunicorn==20.1.0
httpx==0.18.1
internetarchive==2.0.2
isbnlib==3.10.6
lxml==4.6.3
psycopg2==2.8.6
pymarc==4.1.0
python-dateutil==2.8.1
python-memcached==1.59
PyYAML==5.4.1
requests==2.25.1
sentry-sdk==1.1.0
simplejson==3.17.2
six==1.15.0
sixpack-client==1.2.0
statsd==3.3.0
validate_email==1.3
web.py==0.62
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @mekarpeles 