### PR TITLE
Header Dropdown Accessibility

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -264,7 +264,7 @@ jQuery(function () {
     $('#wikiselect').on('focus', function(){$(this).trigger('select');})
 
     // Open one dropdown at a time.
-    $(".header-dropdown details").on("click", function () {
-        $("details[open]").not(this).removeAttr("open");
+    $('.header-dropdown details').on('click', function () {
+        $('details[open]').not(this).removeAttr('open');
     });
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -263,12 +263,8 @@ jQuery(function () {
 
     $('#wikiselect').on('focus', function(){$(this).trigger('select');})
 
-    // Clicking outside of menus closes menus
-    $(document).on('click', function (event) {
-        const $openMenus = $('.checkbox-menu :checked').parents('.checkbox-menu');
-        $openMenus
-            .filter((_, menu) => !$(event.target).closest(menu).length)
-            .find('[type=checkbox]')
-            .prop('checked', false);
+    // Open one dropdown at a time.
+    $(".header-dropdown details").on("click", function () {
+        $("details[open]").not(this).removeAttr("open");
     });
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -264,7 +264,11 @@ jQuery(function () {
     $('#wikiselect').on('focus', function(){$(this).trigger('select');})
 
     // Open one dropdown at a time.
-    $('.header-dropdown details').on('click', function () {
-        $('details[open]').not(this).removeAttr('open');
+    $(document).on('click', function (event) {
+        const $openMenus = $('.header-dropdown details[open]').parents('.header-dropdown');
+        $openMenus
+            .filter((_, menu) => !$(event.target).closest(menu).length)
+            .find('details')
+            .removeAttr('open');
     });
 });

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,26 +1,26 @@
 $def with (page)
 
 <header id="header-bar" class="header-bar">
-  <div class="hamburger-component checkbox-menu">
+  <div class="hamburger-component header-dropdown">
 
-    <label for="toggle-hamburger" class="hamburger-button">
-      <img src="/static/images/menu.png" alt="additional options menu"/>
-    </label>
+    <details>
+      <summary>
+        <img src="/static/images/menu.png" alt="additional options menu"/>
+      </summary>
+      <div class="hamburger-dropdown-component navigation-dropdown-component">
+        <ul class="dropdown-menu hamburger-dropdown-menu">
+          $if not ctx.user:
+            <li><a href="/account/login">$_("Log in")</a></li>
+            <li><a href="/account/create">$_("Sign up")</a></li>
 
-    <input role="button" type="checkbox" class="hamburger-component__checkbox" id="toggle-hamburger">
-    <div class="hamburger-dropdown-component navigation-dropdown-component">
-      <ul class="dropdown-menu hamburger-dropdown-menu">
-        $if not ctx.user:
-          <li><a href="/account/login">$_("Log in")</a></li>
-          <li><a href="/account/create">$_("Sign up")</a></li>
-
-        <li><a href="/books/add">$_("Add a Book")</a></li>
-        <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
-        <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
-        <li><a href="/developers">$_("Developer Center")</a></li>
-        <li><a href="/help">$_("Help & Support")</a></li>
-      </ul>
-    </div>
+          <li><a href="/books/add">$_("Add a Book")</a></li>
+          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
+          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
+          <li><a href="/developers">$_("Developer Center")</a></li>
+          <li><a href="/help">$_("Help & Support")</a></li>
+        </ul>
+      </div>
+    </details>
   </div>
 
   <div class="logo-component">
@@ -32,6 +32,46 @@ $def with (page)
       </div>
     </a>
   </div>
+
+  <ul class="navigation-component">
+    <li class="browse-menu header-dropdown">
+      <details>
+        <summary>
+          $_('Browse') 
+          <span class="shift">$_('Menu')</span>
+          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
+        </summary>
+        <div class="navigation-dropdown-component">
+          <ul class="dropdown-menu browse-menu-options">
+            <li><a href="/subjects">$_("Subjects")</a></li>
+            <li><a href="/lists">$_("Lists")</a></li>
+            <li><a href="/collections">$_("Collections")</a></li>
+            <li><a href="/k-12">$_("K-12 Student Library")</a></li>
+            <li><a href="/random">$_("Random Book")</a></li>
+            <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
+          </ul>
+        </div>
+      </details>
+    </li>
+    <li class="more-menu header-dropdown">
+      <details>
+        <summary>
+          $_('More') 
+          <span class="shift">$_('Menu')</span>
+          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
+        </summary>
+        <div class="navigation-dropdown-component">
+          <ul class="dropdown-menu more-menu-options">
+            <li><a href="/books/add">$_("Add a Book")</a></li>
+            <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
+            <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
+            <li><a href="/developers">$_("Developer Center")</a></li>
+            <li><a href="/help">$_("Help & Support")</a></li>
+          </ul>
+        </div>
+      </details>
+    </li>
+  </ul>
 
   <div class="search-component">
     <div class="search-bar-component">
@@ -63,42 +103,6 @@ $def with (page)
     </div>
   </div>
 
-  <ul class="navigation-component">
-    <li class="browse-menu checkbox-menu">
-      <label for="toggle-browse-menu" class="browse-menu-button">$_('Browse') 
-        <img class="down-arrow" width="7" height="4" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation"/>
-      </label>
-
-      <input role="button" type="checkbox" class="navigation-component__checkbox" id="toggle-browse-menu">
-      <div class="navigation-dropdown-component">
-        <ul class="dropdown-menu browse-menu-options">
-          <li><a href="/subjects">$_("Subjects")</a></li>
-          <li><a href="/lists">$_("Lists")</a></li>
-          <li><a href="/collections">$_("Collections")</a></li>
-          <li><a href="/k-12">$_("K-12 Student Library")</a></li>
-          <li><a href="/random">$_("Random Book")</a></li>
-          <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
-        </ul>
-      </div>
-    </li>
-    <li class="more-menu checkbox-menu">
-      <label for="toggle-more-menu" class="more-menu-button">$_('More') 
-        <img class="down-arrow" width="7" height="4" aria-hidden="true" alt="" role="presentation" src="/static/images/down-arrow.png"/>
-      </label>
-
-      <input role="button" type="checkbox" class="navigation-component__checkbox" id="toggle-more-menu">
-      <div class="navigation-dropdown-component">
-        <ul class="dropdown-menu more-menu-options">
-          <li><a href="/books/add">$_("Add a Book")</a></li>
-          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
-          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
-          <li><a href="/developers">$_("Developer Center")</a></li>
-          <li><a href="/help">$_("Help & Support")</a></li>
-        </ul>
-      </div>
-    </li>
-  </ul>
-
   $if not ctx.user:
     <ul class="auth-component">
       <li class="hide-me">
@@ -108,31 +112,29 @@ $def with (page)
     </ul>
 
   $if ctx.user:
-    <div class="account-component checkbox-menu">
-      <div class="dropdown-avatar">        
-        <label for="toggle-account" id="userToggle" class="avatar account-button" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');">
-        </label>
-
-        <label for="toggle-account" class="account-button">
-          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
-        </label>
-      </div>
-
-      <input role="button" type="checkbox" class="account-component__checkbox" id="toggle-account">
-      <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
-        <ul class="dropdown-menu">
-          <li><a href="$ctx.user.key">$_("My Profile")</a></li>
-          <li><a href="$homepath()/account/loans">$_("My Loans")</a></li>
-          <li><a href="$ctx.user.key/lists">$_("My Lists")</a></li>
-          <li><a href="/account/books">$_("My Reading Log")</a></li>
-          <li><a href="/account/books/already-read/stats">$_("My Reading Stats")</a></li>
-          <li><a href="$homepath()/account">$_("Settings")</a></li>
-          <li>
-            <form name="logout" action="/account/logout" method="post">
-              <a href="#" onclick="document.forms['logout'].submit()">$_("Log out")</a>
-            </form>
-          </li>
-        </ul>
-      </div>
+    <div class="account-component header-dropdown">
+      <details>
+        <summary>
+          <div class="dropdown-avatar">        
+            <div class="avatar dropdown-button" id="userToggle" aria-expanded="false" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></div>
+            <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
+          </div>
+        </summary>
+        <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
+          <ul class="dropdown-menu">
+            <li><a href="$ctx.user.key">$_("My Profile")</a></li>
+            <li><a href="$homepath()/account/loans">$_("My Loans")</a></li>
+            <li><a href="$ctx.user.key/lists">$_("My Lists")</a></li>
+            <li><a href="/account/books">$_("My Reading Log")</a></li>
+            <li><a href="/account/books/already-read/stats">$_("My Reading Stats")</a></li>
+            <li><a href="$homepath()/account">$_("Settings")</a></li>
+            <li>
+              <form name="logout" action="/account/logout" method="post">
+                <a href="#" onclick="document.forms['logout'].submit()">$_("Log out")</a>
+              </form>
+            </li>
+          </ul>
+        </div>
+      </details>
     </div>
 </header>

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -134,6 +134,10 @@
     order: 0;
     margin-right: 5px;
 
+    summary::marker {
+      content: "";
+    }
+
     label {
       background: transparent;
       border: none;
@@ -404,47 +408,8 @@
   }
 }
 
-.checkbox-menu, .checkbox-menu label {
-  cursor: pointer;
-}
-
-.account-component__checkbox {
-  display: none;
-
-  & ~ .navigation-dropdown-component ul {
-    display: none;
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  &:checked ~ .navigation-dropdown-component ul {
-    display: block;
-  }
-}
-
-.hamburger-component__checkbox {
-  opacity: 0;
-
-  & ~ .hamburger-dropdown-component ul {
-    display: none;
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  &:checked ~ .hamburger-dropdown-component ul {
-    display: block;
-  }
-}
-
-.navigation-component__checkbox {
-  opacity: 0;
-
-  & ~ .navigation-dropdown-component ul {
-    display: none;
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  &:checked ~ .navigation-dropdown-component ul {
-    display: block;
-  }
+div.search-facet:focus-within {
+  outline: 2px solid;
 }
 
 .account-component {
@@ -452,6 +417,12 @@
   -ms-flex: 1;
   flex: 1;
   position: relative;
+  cursor: pointer;
+
+  summary::marker {
+    content: "";
+  }
+
   .dropdown-avatar {
     .display-flex();
     -webkit-box-align: center;
@@ -473,6 +444,11 @@
 .navigation-component {
   text-align: center;
   position: relative;
+
+  summary::marker {
+    content: "";
+  }
+
   .down-arrow {
     position: relative;
     top: -2px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4929

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- [X] Details Tag Method
- [X] Removed Checkbox CSS
- [X] Open one dropdown at a time [JS]
- [X] Search-facet visible focus


To do:

- [X] Close dropdown when clicked outside.
- [ ] Check Browser Compatibility [Checked Chrome and Firefox]

### Technical
<!-- What should be noted about the implementation? -->
Implemented details tag dropdown to fix keyboard accessibility.
Detailed Discussion: #https://github.com/internetarchive/openlibrary/pull/4977
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/64412143/118355899-41df3f80-b590-11eb-8768-b84ac895f40b.mp4


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jdlrobson @bpmcneilly