### PR TITLE
move inline js for edition edit page validation

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -32,59 +32,65 @@ function getJqueryElements(selector){
     return jQueryElementArray;
 }
 
-export function initEditionEditPage() {
-    $(function () {
-        const dataConfig = JSON.parse(document.querySelector('#edition-edit-page').dataset.config);
-        $('#roles').repeat({
-            vars: {prefix: 'edition--'},
-            validate: function (data) {
-                if (data.role == '' || data.role == '---') {
-                    return error('#role-errors', '#select-role', dataConfig['Please select a role.']);
-                }
-                if (data.name == '') {
-                    return error('#role-errors', '#role-name', dataConfig['You need to give this ROLE a name.'].replace(/ROLE/, data.role));
-                }
-                $('#role-errors').hide();
-                return true;
+export function initRoleValidation() {
+    const dataConfig = JSON.parse(document.querySelector('#roles').dataset.config);
+    $('#roles').repeat({
+        vars: {prefix: 'edition--'},
+        validate: function (data) {
+            if (data.role == '' || data.role == '---') {
+                return error('#role-errors', '#select-role', dataConfig['Please select a role.']);
             }
-        });
-        $('#identifiers').repeat({
-            vars: {prefix: 'edition--'},
-            validate: function (data) {
-                if (data.name == '' || data.name == '---') {
-                    return error('#id-errors', 'select-id', dataConfig['Please select an identifier.'])
-                }
-                const label = $('#select-id').find(`option[value=${data.name}]`).html();
-                if (data.value == '') {
-                    return error('#id-errors', 'id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
-                }
-                if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
-                    return error('#id-errors', 'id-value', dataConfig['ID ids cannot contain whitespace.'].replace(/ID/, label));
-                }
-                if (data.name == 'isbn_10' && data.value.length != 10) {
-                    return error('#id-errors', 'id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
-                }
-                if (data.name == 'isbn_13' && data.value.replace(/-/g, '').length != 13) {
-                    return error('#id-errors', 'id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
-                }
-                $('id-errors').hide();
-                return true;
+            if (data.name == '') {
+                return error('#role-errors', '#role-name', dataConfig['You need to give this ROLE a name.'].replace(/ROLE/, data.role));
             }
-        });
-        $('#classifications').repeat({
-            vars: {prefix: 'edition--'},
-            validate: function (data) {
-                if (data.name == '' || data.name == '---') {
-                    return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
-                }
-                if (data.value == '') {
-                    const label = $('#select-classification').find(`option[value=${data.name}]`).html();
-                    return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
-                }
-                $('#classification-errors').hide();
-                return true;
+            $('#role-errors').hide();
+            return true;
+        }
+    });
+}
+
+export function initIdentifierValidation() {
+    const dataConfig = JSON.parse(document.querySelector('#identifiers').dataset.config);
+    $('#identifiers').repeat({
+        vars: {prefix: 'edition--'},
+        validate: function (data) {
+            if (data.name == '' || data.name == '---') {
+                return error('#id-errors', 'select-id', dataConfig['Please select an identifier.'])
             }
-        });
+            const label = $('#select-id').find(`option[value=${data.name}]`).html();
+            if (data.value == '') {
+                return error('#id-errors', 'id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
+            }
+            if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
+                return error('#id-errors', 'id-value', dataConfig['ID ids cannot contain whitespace.'].replace(/ID/, label));
+            }
+            if (data.name == 'isbn_10' && data.value.length != 10) {
+                return error('#id-errors', 'id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
+            }
+            if (data.name == 'isbn_13' && data.value.replace(/-/g, '').length != 13) {
+                return error('#id-errors', 'id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
+            }
+            $('id-errors').hide();
+            return true;
+        }
+    });
+}
+
+export function initClassificationValidation() {
+    const dataConfig = JSON.parse(document.querySelector('#classifications').dataset.config);
+    $('#classifications').repeat({
+        vars: {prefix: 'edition--'},
+        validate: function (data) {
+            if (data.name == '' || data.name == '---') {
+                return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
+            }
+            if (data.value == '') {
+                const label = $('#select-classification').find(`option[value=${data.name}]`).html();
+                return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
+            }
+            $('#classification-errors').hide();
+            return true;
+        }
     });
 }
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -32,6 +32,62 @@ function getJqueryElements(selector){
     return jQueryElementArray;
 }
 
+export function initEditionEditPage() {
+    $(function () {
+        const dataConfig = JSON.parse(document.querySelector('#edition-edit-page').dataset.config);
+        $('#roles').repeat({
+            vars: {prefix: 'edition--'},
+            validate: function (data) {
+                if (data.role == '' || data.role == '---') {
+                    return error('#role-errors', '#select-role', dataConfig['Please select a role.']);
+                }
+                if (data.name == '') {
+                    return error('#role-errors', '#role-name', dataConfig['You need to give this ROLE a name.'].replace(/ROLE/, data.role));
+                }
+                $('#role-errors').hide();
+                return true;
+            }
+        });
+        $('#identifiers').repeat({
+            vars: {prefix: 'edition--'},
+            validate: function (data) {
+                if (data.name == '' || data.name == '---') {
+                    return error('#id-errors', 'select-id', dataConfig['Please select an identifier.'])
+                }
+                const label = $('#select-id').find(`option[value=${data.name}]`).html();
+                if (data.value == '') {
+                    return error('#id-errors', 'id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
+                }
+                if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
+                    return error('#id-errors', 'id-value', dataConfig['ID ids cannot contain whitespace.'].replace(/ID/, label));
+                }
+                if (data.name == 'isbn_10' && data.value.length != 10) {
+                    return error('#id-errors', 'id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
+                }
+                if (data.name == 'isbn_13' && data.value.replace(/-/g, '').length != 13) {
+                    return error('#id-errors', 'id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
+                }
+                $('id-errors').hide();
+                return true;
+            }
+        });
+        $('#classifications').repeat({
+            vars: {prefix: 'edition--'},
+            validate: function (data) {
+                if (data.name == '' || data.name == '---') {
+                    return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
+                }
+                if (data.value == '') {
+                    const label = $('#select-classification').find(`option[value=${data.name}]`).html();
+                    return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
+                }
+                $('#classification-errors').hide();
+                return true;
+            }
+        });
+    });
+}
+
 export function initLanguageMultiInputAutocomplete() {
     $(function() {
         getJqueryElements('.multi-input-autocomplete--language').forEach(jqueryElement => {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -57,7 +57,7 @@ export function initIdentifierValidation() {
             if (data.name == '' || data.name == '---') {
                 return error('#id-errors', 'select-id', dataConfig['Please select an identifier.'])
             }
-            const label = $('#select-id').find(`option[value=${data.name}]`).html();
+            const label = $('#select-id').find(`option[value='${data.name}']`).html();
             if (data.value == '') {
                 return error('#id-errors', 'id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
             }
@@ -85,7 +85,7 @@ export function initClassificationValidation() {
                 return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
             }
             if (data.value == '') {
-                const label = $('#select-classification').find(`option[value=${data.name}]`).html();
+                const label = $('#select-classification').find(`option[value='${data.name}']`).html();
                 return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
             }
             $('#classification-errors').hide();

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -97,6 +97,11 @@ jQuery(function () {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initEditRow());
     }
+    // conditionally load for edition edit page
+    if (document.querySelector('#edition-edit-page')) {
+        import(/* webpackChunkName: "user-website" */ './edit')
+            .then(module => module.initEditionEditPage());
+    }
     // conditionally load for language autocomplete
     if (document.querySelector('.multi-input-autocomplete--language')) {
         import(/* webpackChunkName: "user-website" */ './edit')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -140,6 +140,11 @@ jQuery(function () {
             });
     }
 
+    // conditionally load for author merge page
+    if (document.querySelector('#author-merge-page')) {
+        import('./merge')
+            .then(module => module.initAuthorMergePage());
+    }
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
         import('./realtime_account_validation.js')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -92,35 +92,48 @@ jQuery(function () {
         import(/* webpackChunkName: "editions-table" */ './editions-table')
             .then(module => module.initEditionsTable());
     }
+
+    const addRowButton = document.getElementById('add_row_button');
+    const roles = document.querySelector('#roles');
+    const identifiers = document.querySelector('#identifiers');
+    const classifications = document.querySelector('#classifications');
+    const autocompleteLanguage = document.querySelector('.multi-input-autocomplete--language');
+    const autocompleteWorks = document.querySelector('.multi-input-autocomplete--works');
+    const excerpts = document.getElementById('excerpts');
+    const links = document.getElementById('links');
+
     // conditionally load for user edit page
-    if (document.getElementById('add_row_button')) {
+    if (
+        addRowButton || roles || identifiers || classifications ||
+        autocompleteLanguage || autocompleteWorks || excerpts || links
+    ) {
         import(/* webpackChunkName: "user-website" */ './edit')
-            .then(module => module.initEditRow());
-    }
-    // conditionally load for role validation
-    if (document.querySelector('#roles')) {
-        import('./edit')
-            .then(module => module.initRoleValidation());
-    }
-    // conditionally load for identifier validation
-    if (document.querySelector('#identifiers')) {
-        import('./edit')
-            .then(module => module.initIdentifierValidation());
-    }
-    // conditionally load for classification validation
-    if (document.querySelector('#classifications')) {
-        import('./edit')
-            .then(module => module.initClassificationValidation());
-    }
-    // conditionally load for language autocomplete
-    if (document.querySelector('.multi-input-autocomplete--language')) {
-        import(/* webpackChunkName: "user-website" */ './edit')
-            .then(module => module.initLanguageMultiInputAutocomplete());
-    }
-    // conditionally load for works autocomplete
-    if (document.querySelector('.multi-input-autocomplete--works')) {
-        import(/* webpackChunkName: "user-website" */ './edit')
-            .then(module => module.initWorksMultiInputAutocomplete());
+            .then(module => {
+                if (addRowButton) {
+                    module.initEditRow();
+                }
+                if (excerpts) {
+                    module.initEdit();
+                }
+                if (links) {
+                    module.initEditLinks();
+                }
+                if (roles) {
+                    module.initRoleValidation();
+                }
+                if (identifiers) {
+                    module.initIdentifierValidation();
+                }
+                if (classifications) {
+                    module.initClassificationValidation();
+                }
+                if (autocompleteLanguage) {
+                    module.initLanguageMultiInputAutocomplete();
+                }
+                if (autocompleteWorks) {
+                    module.initWorksMultiInputAutocomplete();
+                }
+            });
     }
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
@@ -172,16 +185,6 @@ jQuery(function () {
     if (document.getElementsByClassName('modal-link').length) {
         import(/* webpackChunkName: "patron_metadata" */ './patron-metadata')
             .then((module) => module.initPatronMetadata());
-    }
-
-    if (document.getElementById('excerpts')) {
-        import (/* webpackChunkName: "books_edit" */ './edit.js')
-            .then((module) => module.initEdit());
-    }
-
-    if (document.getElementById('links')) {
-        import (/* webpackChunkName: "books_edit" */ './edit.js')
-            .then((module) => module.initEditLinks());
     }
 
     if (document.getElementsByClassName('manageCovers').length) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -97,10 +97,20 @@ jQuery(function () {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initEditRow());
     }
-    // conditionally load for edition edit page
-    if (document.querySelector('#edition-edit-page')) {
-        import(/* webpackChunkName: "user-website" */ './edit')
-            .then(module => module.initEditionEditPage());
+    // conditionally load for role validation
+    if (document.querySelector('#roles')) {
+        import('./edit')
+            .then(module => module.initRoleValidation());
+    }
+    // conditionally load for identifier validation
+    if (document.querySelector('#identifiers')) {
+        import('./edit')
+            .then(module => module.initIdentifierValidation());
+    }
+    // conditionally load for classification validation
+    if (document.querySelector('#classifications')) {
+        import('./edit')
+            .then(module => module.initClassificationValidation());
     }
     // conditionally load for language autocomplete
     if (document.querySelector('.multi-input-autocomplete--language')) {

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -73,7 +73,9 @@ $jsdef render_work_autocomplete_item(item):
             $else:
                 <span class="edition_count">$item.edition_count editions</span>
         </div>
-
+$ translatable_strings = ['Please select a role.', 'You need to give this ROLE a name.', 'Please select an identifier.', 'You need to give a value to ID.', 'ID ids cannot contain whitespace.', 'ID must be exactly 10 characters [0-9] or X.', 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4', 'Please select a classification.', 'You need to give a value to CLASS.']
+$ config = {translatable: _(translatable) for translatable in translatable_strings}
+<span id="edition-edit-page" data-config="$dumps(config)"></span>
 
 <fieldset class="major">
     <legend>$_("This Edition")</legend>
@@ -198,7 +200,7 @@ $jsdef render_work_autocomplete_item(item):
                     <span class="tip"></span>
                 </div>
                 <div class="input">
-                    <div id="role-errors" class="note hidden"></div>
+                    <div id="role-errors" class="note" style="display: none"></div>
                     <table class="identifiers">
                     <tbody>
                         <tr id="roles-form">
@@ -482,7 +484,7 @@ $jsdef render_work_autocomplete_item(item):
     <legend>$_("Classifications")</legend>
     <div class="formBack">
 
-        <div id="classification-errors" class="note hidden"></div>
+        <div id="classification-errors" class="note" style="display: none"></div>
         <div class="formElement">
             <div class="label">
                 <label for="select-classification">$_("Do you know any classifications of this edition?")</label>
@@ -649,78 +651,3 @@ $if ctx.user:
             </div>
         </div>
     </fieldset>
-
-<script type="text/javascript">
-<!--
-    window.q.push(function() {
-        // FIXME: Error code duplicated in various templates.
-        // Should be pushed into a macro.
-        function error(errordiv, input, message) {
-            \$(errordiv).show().html(message);
-            \$(input).focus();
-            return false;
-        }
-
-        \$("#roles").repeat({
-            vars: {
-                "prefix": "edition--"
-            },
-            validate: function(data) {
-                if (data.role == "" || data.role == "---") {
-                    return error("#role-errors", "#select-role", "$_('Please select a role.')");
-                }
-
-                if (data.name == "") {
-                    return error("#role-errors", "#role-name", "$_('You need to give this ROLE a name.')".replace(/ROLE/, data.role));
-                }
-
-                \$("#role-errors").hide();
-                return true;
-            }
-        });
-        \$("#identifiers").repeat({
-            vars: {
-                "prefix": "edition--"
-            },
-            validate: function(data) {
-                if (data.name == "" || data.name == "---") {
-                    return error("#id-errors", "select-id", "$_('Please select an identifier.')")
-                }
-                var label = \$("#select-id").find("option[value=" + data.name + "]").html();
-                if (data.value == "") {
-                    return error("#id-errors", "id-value", "$_('You need to give a value to ID.')".replace(/ID/, label));
-                }
-                if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
-                    return error("#id-errors", "id-value", "$_('ID ids cannot contain whitespace.')".replace(/ID/, label));
-                }
-                if (data.name == "isbn_10" && data.value.length != 10) {
-                    return error("#id-errors", "id-value", "$_('ID must be exactly 10 characters [0-9] or X.')".replace(/ID/, label));
-                }
-                if (data.name == "isbn_13" && data.value.replace(/-/g,'').length != 13) {
-                    return error("#id-errors", "id-value", "$_('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4')".replace(/ID/, label));
-                }
-                \$("id-errors").hide();
-                return true;
-            }
-        });
-        \$("#classifications").repeat({
-            vars: {
-                "prefix": "edition--"
-            },
-            validate: function(data) {
-                if (data.name == "" || data.name == "---") {
-                    return error("#classification-errors", "#select-classification", "$_('Please select a classification.')");
-                }
-
-                if (data.value == "") {
-                    var label = \$("#select-classification").find("option[value=" + data.name + "]").html();
-                    return error("#classification-errors", "#classification-value", "$_('You need to give a value to CLASS.')".replace(/CLASS/, label));
-                }
-
-                \$("#classification-errors").hide();
-                return true;
-            }
-        });
-    });
-//-->
-</script>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -73,9 +73,7 @@ $jsdef render_work_autocomplete_item(item):
             $else:
                 <span class="edition_count">$item.edition_count editions</span>
         </div>
-$ translatable_strings = ['Please select a role.', 'You need to give this ROLE a name.', 'Please select an identifier.', 'You need to give a value to ID.', 'ID ids cannot contain whitespace.', 'ID must be exactly 10 characters [0-9] or X.', 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4', 'Please select a classification.', 'You need to give a value to CLASS.']
-$ config = {translatable: _(translatable) for translatable in translatable_strings}
-<span id="edition-edit-page" data-config="$dumps(config)"></span>
+
 
 <fieldset class="major">
     <legend>$_("This Edition")</legend>
@@ -194,7 +192,7 @@ $ config = {translatable: _(translatable) for translatable in translatable_strin
         <fieldset class="minor formBackLeft">
             <legend>$_("Contributors")</legend>
 
-            <div class="formElement" id="roles">
+            <div class="formElement" id="roles" data-config="$dumps({'Please select a role.': _('Please select a role.'), 'You need to give this ROLE a name.': _('You need to give this ROLE a name.')})">
                 <div class="label">
                     <label for="select-role">$_("List the people involved")</label>
                     <span class="tip"></span>
@@ -405,8 +403,8 @@ $ config = {translatable: _(translatable) for translatable in translatable_strin
     </div>
 
 </fieldset>
-
-<fieldset class="major" id="identifiers">
+$ config = ({'Please select an identifier.': _('Please select an identifier.'), 'You need to give a value to ID.': _('You need to give a value to ID.'), 'ID ids cannot contain whitespace.': _('ID ids cannot contain whitespace.'), 'ID must be exactly 10 characters [0-9] or X.': _('ID must be exactly 10 characters [0-9] or X.'), 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4': _('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4')})
+<fieldset class="major" id="identifiers" data-config="$dumps(config)">
     <legend>$_("ID Numbers")</legend>
     <div class="formBack">
 
@@ -480,7 +478,7 @@ $ config = {translatable: _(translatable) for translatable in translatable_strin
     </div>
 </fieldset>
 
-<fieldset class="major" id="classifications">
+<fieldset class="major" id="classifications" data-config="$dumps({'Please select a classification.': _('Please select a classification.'), 'You need to give a value to CLASS.': _('You need to give a value to CLASS.')})">
     <legend>$_("Classifications")</legend>
     <div class="formBack">
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24926,7 +24926,6 @@
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
       "integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "chalk": "^4.1.0",
         "hash-sum": "^2.0.0",
@@ -24938,7 +24937,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -24948,7 +24946,6 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -24959,7 +24956,6 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -24968,29 +24964,25 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "emojis-list": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
           "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loader-utils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
           "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -25002,7 +24994,6 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24926,6 +24926,7 @@
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.2.0.tgz",
       "integrity": "sha512-TitGhqSQ61RJljMmhIGvfWzJ2zk9m1Qug049Ugml6QP3t0e95o0XJjk29roNEiPKJQBEi8Ord5hFuSuELzSp8Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "chalk": "^4.1.0",
         "hash-sum": "^2.0.0",
@@ -24937,6 +24938,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -24946,6 +24948,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -24956,6 +24959,7 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -24964,25 +24968,29 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "emojis-list": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
           "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loader-utils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
           "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -24994,6 +25002,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 18,
+        "branches": 15,
         "functions": 15,
         "lines": 19,
         "statements": 19


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Move validation part (the final part) of inline js for `openlibrary/templates/books/edit/edition.html` #4474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is mostly a refactor.
It also fixes one small regression where validation notifications weren't showing up for roles or classifications.

### Technical
<!-- What should be noted about the implementation? -->
This is following the patterns decided in #5136

To fix the regression of error messages not showing I simply copied the code that was working (for identifiers). Having inline styles is not ideal but while we have jquery which uses them it seemed ok. Open to ideas for a better solution but perhaps make a separate issue if it requires more than changing those two lines.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Check that validation works for roles, classifications, and identifiers on an edition edit page such as http://localhost:8080/books/OL24755423M/Odyssey_book_iv/edit

(see video for explanation)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/118408839-f45fe280-b622-11eb-892f-6945a03b31ee.mp4


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
