### PR TITLE
move inline js for author merge page

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -107,6 +107,11 @@ jQuery(function () {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => module.initWorksMultiInputAutocomplete());
     }
+    // conditionally load for author merge page
+    if (document.querySelector('#author-merge-page')) {
+        import(/* webpackChunkName: "user-website" */ './merge')
+            .then(module => module.initAuthorMergePage());
+    }
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
         import('./realtime_account_validation.js')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -109,7 +109,7 @@ jQuery(function () {
     }
     // conditionally load for author merge page
     if (document.querySelector('#author-merge-page')) {
-        import(/* webpackChunkName: "user-website" */ './merge')
+        import('./merge')
             .then(module => module.initAuthorMergePage());
     }
     // conditionally load real time signup functionality based on class in the page

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -1,38 +1,36 @@
 export function initAuthorMergePage() {
-    $(function () {
-        $('#save').click(function () {
-            const n = $('#mergeForm input[type=radio]:checked').length;
-            if (n === 0) {
-                $('#noMaster').dialog('open');
+    $('#save').click(function () {
+        const n = $('#mergeForm input[type=radio]:checked').length;
+        if (n === 0) {
+            $('#noMaster').dialog('open');
+        } else {
+            $('#confirmMerge').dialog('open');
+        }
+        return false;
+    });
+    $('div.radio:first input[type=radio]').prop('checked', true);
+    $('div.checkbox:first input[type=checkbox]').prop('checked', true);
+    $('div.author:first').addClass('master');
+    $('#include input[type=radio]').mouseover(function () {
+        $(this).parent().parent().addClass('mouseoverHighlight', 300);
+    });
+    $('#include input[type=radio]').mouseout(function () {
+        $(this).parent().parent().removeClass('mouseoverHighlight', 100);
+    });
+    $('#include input[type=radio]').click(function () {
+        const previousMaster = $('.merge').find('div.master');
+        previousMaster.removeClass('master mergeSelection');
+        previousMaster.find('input[type=checkbox]').prop('checked', false);
+        $(this).parent().parent().addClass('master');
+        $(this).parent().parent().find('input[type=checkbox]').prop('checked', true);
+    });
+    $('#include input[type=checkbox]').on('change', function () {
+        if (!$(this).parent().parent().hasClass('master')) {
+            if ($(this).is(':checked')) {
+                $(this).parent().parent().addClass('mergeSelection');
             } else {
-                $('#confirmMerge').dialog('open');
+                $(this).parent().parent().removeClass('mergeSelection');
             }
-            return false;
-        });
-        $('div.radio:first input[type=radio]').prop('checked', true);
-        $('div.checkbox:first input[type=checkbox]').prop('checked', true);
-        $('div.author:first').addClass('master');
-        $('#include input[type=radio]').mouseover(function () {
-            $(this).parent().parent().addClass('mouseoverHighlight', 300);
-        });
-        $('#include input[type=radio]').mouseout(function () {
-            $(this).parent().parent().removeClass('mouseoverHighlight', 100);
-        });
-        $('#include input[type=radio]').click(function () {
-            const previousMaster = $('.merge').find('div.master');
-            previousMaster.removeClass('master mergeSelection');
-            previousMaster.find('input[type=checkbox]').prop('checked', false);
-            $(this).parent().parent().addClass('master');
-            $(this).parent().parent().find('input[type=checkbox]').prop('checked', true);
-        });
-        $('#include input[type=checkbox]').on('change', function () {
-            if (!$(this).parent().parent().hasClass('master')) {
-                if ($(this).is(':checked')) {
-                    $(this).parent().parent().addClass('mergeSelection');
-                } else {
-                    $(this).parent().parent().removeClass('mergeSelection');
-                }
-            }
-        });
+        }
     });
 }

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -1,0 +1,38 @@
+export function initAuthorMergePage() {
+    $(function () {
+        $('#save').click(function () {
+            const n = $('#mergeForm input[type=radio]:checked').length;
+            if (n === 0) {
+                $('#noMaster').dialog('open');
+            } else {
+                $('#confirmMerge').dialog('open');
+            }
+            return false;
+        });
+        $('div.radio:first input[type=radio]').prop('checked', true);
+        $('div.checkbox:first input[type=checkbox]').prop('checked', true);
+        $('div.author:first').addClass('master');
+        $('#include input[type=radio]').mouseover(function () {
+            $(this).parent().parent().addClass('mouseoverHighlight', 300);
+        });
+        $('#include input[type=radio]').mouseout(function () {
+            $(this).parent().parent().removeClass('mouseoverHighlight', 100);
+        });
+        $('#include input[type=radio]').click(function () {
+            const previousMaster = $('.merge').find('div.master');
+            previousMaster.removeClass('master mergeSelection');
+            previousMaster.find('input[type=checkbox]').prop('checked', false);
+            $(this).parent().parent().addClass('master');
+            $(this).parent().parent().find('input[type=checkbox]').prop('checked', true);
+        });
+        $('#include input[type=checkbox]').on('change', function () {
+            if (!$(this).parent().parent().hasClass('master')) {
+                if ($(this).is(':checked')) {
+                    $(this).parent().parent().addClass('mergeSelection');
+                } else {
+                    $(this).parent().parent().removeClass('mergeSelection');
+                }
+            }
+        });
+    });
+}

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -1,47 +1,8 @@
 $def with (keys, top_books_from_author, formdata=None)
 
-<script type="text/javascript">
-window.q.push(function(){
-    \$('#save').click(function(){
-        var n = \$("#mergeForm input[type=radio]:checked").length;
-        if (n == 0) {
-            \$('#noMaster').dialog('open');
-            return false;
-        } else {
-            \$('#confirmMerge').dialog('open');
-            return false;
-        };
-    });
-    \$("div.radio:first input[type=radio]").prop("checked",true);
-    \$("div.checkbox:first input[type=checkbox]").prop("checked",true);
-    \$("div.author:first").addClass("master");
-    \$("#include input[type=radio]").mouseover(function(){
-        \$(this).parent().parent().addClass("mouseoverHighlight",300);
-    });
-    \$("#include input[type=radio]").mouseout(function(){
-        \$(this).parent().parent().removeClass("mouseoverHighlight",100);
-    });
-    \$("#include input[type=radio]").click(function(){
-        var previousMaster = \$(".merge").find("div.master");
-        previousMaster.removeClass("master mergeSelection");
-        previousMaster.find("input[type=checkbox]").prop('checked', false);
-        \$(this).parent().parent().addClass("master");
-        \$(this).parent().parent().find("input[type=checkbox]").prop('checked', true);
-    });
-    \$("#include input[type=checkbox]").on("change", function() {
-        if (!\$(this).parent().parent().hasClass("master")) {
-            if (\$(this).is(":checked")) {
-                \$(this).parent().parent().addClass("mergeSelection");
-            } else {
-                \$(this).parent().parent().removeClass("mergeSelection");
-            }
-        }
-    });
-});
-</script>
-
 $var title: $_("Merge Authors")
 
+<span id="author-merge-page"></span>
 <div id="contentHead">
     <h1>$_("Merge Authors")</h1>
 </div>

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -2,7 +2,7 @@ $def with (keys, top_books_from_author, formdata=None)
 
 $var title: $_("Merge Authors")
 
-<span id="author-merge-page"></span>
+<span id="author-merge-page"><!--This span is used to determine that the page-specific javascript should be loaded--></span>
 <div id="contentHead">
     <h1>$_("Merge Authors")</h1>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Refactor to move inline js for `openlibrary/templates/merge/authors.html` #4474

### Technical
<!-- What should be noted about the implementation? -->
Nothing special. This was a straightforward change.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to a url like [this one](http://localhost:8080/authors/merge?key=OL18319A&key=OL22098A&key=OL81837A&key=OL20585A&key=OL9A&key=OL1434011A&key=OL1518080A&key=OL21774A&key=OL3437837A&key=OL3116423A&key=OL4A&key=OL1A&key=OL3A&key=OL18283A&key=OL24522A&key=OL2722241A&key=OL6848355A&key=OL19864A&key=OL2180017A&key=OL2660280A&key=OL2A&key=OL3116481A&key=OL3116644A&key=OL8A&key=OL6860521A&key=OL2622837A&key=OL2250A&key=OL1388798A&key=OL22122A&key=OL327356A&key=OL6A&key=OL1385835A&key=OL7A&key=OL2188410A) and follow steps in video.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/118409971-d4332200-b628-11eb-8574-9c7e6e454fed.mp4


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
