### PR TITLE
remove inline js from publishers view

### DIFF
--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -33,54 +33,6 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 	</div>
 
     <script type="text/json+graph" id="graph-json-chartPubHistory">$:json_encode(page.publishing_history)</script>
-<script type="text/javascript">
-<!--
-// FIXME: Please move this text/javascript to webpack entry point after you've worked out what it's doing
-function parse_hash() {
-    try {
-    	var hash = document.location.hash || "#";
-    	var tokens = hash.substr(1).split("&");
-    	var d = {};
-    	for (var i in tokens) {
-    		if (tokens[i]) {
-    			var kv = tokens[i].split("=");
-    			d[kv[0]] = kv[1];
-    	    }
-    	}
-    	return d;
-    }
-    catch (error) {
-        // Work-around for IE weirdness
-        return {};
-    }
-}
-
-function set_hash(data) {
-	var d = parse_hash();
-
-	for (var k in data) {
-		if (data[k])
-			d[k] = data[k];
-		else
-			delete d[k];
-	}
-
-	var tokens = [];
-	for (var k in d) {
-		tokens[tokens.length] = k + "=" + d[k];
-	}
-
-    var hash = "#" + tokens.join("&");
-    var current_hash = document.location.hash || "#";
-
-    if (hash == current_hash)
-        return;
-	document.location.hash = hash;
-}
-
-var _hash = parse_hash();
-//-->
-</script>
 
     <div class="chart">
         <div class="chartYaxis">$_("Editions Published")</div>
@@ -139,13 +91,6 @@ $jsdef renderAuthors(authors):
 
 $ publishers_feature_enabled = "publishers" in ctx.features
 
-<script type="text/javascript">
-<!--
-    $ page_key = page.key[page.key.rindex('/')+1:]
-    var page_key = "$page_key";
-    var publishers_feature_enabled = $:json_encode(publishers_feature_enabled);
-//-->
-</script>
 $jsdef renderPublishers(publishers):
     $for p in publishers:
         <span class="tag">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Refactor to remove inline js for `openlibrary/templates/publishers/view.html` #4474

### Technical
As far as I can tell, this code is dead. I searched the codebase for usages, poked around with the debugger, and when I finally just deleted it nothing seems to have changed.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to [a publisher page](http://localhost:8080/publishers/Harper_&_Brothers) and see if there are any issues.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No UI changes


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 
