### PR TITLE
Remove inline JS from subjects.html

### DIFF
--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -24,13 +24,6 @@ $ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), 
     </form>
 </div>
 
-<script type="text/javascript">
-<!--
-window.q.push( function () {
-    window.page = new Subject($:json_encode(page));
-} );
-//-->
-</script>
 <div class="contentBody">
 
   $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more={"url": page.key + ".json", "limit": len(page.works)})
@@ -103,16 +96,6 @@ $jsdef renderAuthors(authors):
 
 $ publishers_feature_enabled = "publishers" in ctx.features
 
-<script type="text/javascript">
-<!--
-window.q.push( function () {
-    var page = window.page;
-    $ page_key = page.key[page.key.rindex('/')+1:]
-    var page_key = "$page_key";
-    var publishers_feature_enabled = $:json_encode(publishers_feature_enabled);
-} );
-//-->
-</script>
 $jsdef renderPublishers(publishers):
     $for p in publishers:
         <span class="tag">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4474 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removed the following inline JS
https://github.com/internetarchive/openlibrary/blob/d91dbadaf4d5ab6e7e63052f0e7a740954440692/openlibrary/templates/subjects.html#L27-L33
After some research, I found the same code (`var page = new Subject($:json_encode(page));`) was used in publishers page, which was later moved inside the `charts inline script` in [this PR (#1556 Publisher Page is v2)](https://github.com/internetarchive/openlibrary/pull/1556/files#diff-ff9e79ed2c805098f0d7966b45a41b17b07578e3b7004cc650560d4f8ee2d707L42-R60). After that, the whole `charts inline script` was removed from both the subjects and publishers page to a separate graphs.js file in #2360.

But as we never moved `var page = new Subject($:json_encode(page));` inside `charts inline script` for subjects page so it was not removed in #2360.

Screenshots for some clarity :)
![image](https://user-images.githubusercontent.com/64412143/119250674-525e6e00-bbbf-11eb-9654-5169d09c4a14.png)
![image](https://user-images.githubusercontent.com/64412143/119250687-699d5b80-bbbf-11eb-8549-c6f3abd6e5ff.png)




https://github.com/internetarchive/openlibrary/blob/d91dbadaf4d5ab6e7e63052f0e7a740954440692/openlibrary/templates/subjects.html#L106-L115

The same code was removed from the publishers page in #5188, and after testing, I believe the code is dead.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 