### PR TITLE
Fix Chart Y-axis alignment

### DIFF
--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -95,11 +95,7 @@ export function loadEditionsGraph() {
     dateFrom = plot.getAxes().xaxis.min.toFixed(0);
     dateTo = plot.getAxes().xaxis.max.toFixed(0);
 
-    if (jQuery.support.opacity) {
-        $('.chartYaxis').css({top: '60px', left: '-60px'})
-    } else {
-        $('.chartYaxis').css({top: '0', left: '0'})
-    }
+    $('.chartYaxis').css({top: '60px', left: '-60px'});
 
     if (dateFrom == (dateTo - 1)) {
         $('.clickdata').text(`Published in ${dateFrom}`);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Given our browser support we can assume `jQuery.support.opacity` is always true
so refactoring the code to fix alignment issue.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://user-images.githubusercontent.com/64412143/119269839-59b16600-bc17-11eb-8232-c353151f06fb.png)
Now:
![image](https://user-images.githubusercontent.com/64412143/119269825-4acab380-bc17-11eb-9b5e-bea5ec879435.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 