### PR TITLE
jQuery 3 follow ups: fix merge page and subjects error

### DIFF
--- a/openlibrary/plugins/openlibrary/js/jquery.customFade.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.customFade.js
@@ -4,8 +4,6 @@ export default function addFadeInFunctionsTojQuery($) {
     // books/edit/edition.html, publishers/view.html and subjects.html
     $.fn.customFadeIn = function(speed, callback) {
         $(this).fadeIn(speed, function() {
-            if (jQuery.browser.msie)
-                $(this).get(0).style.removeAttribute('filter');
             if (callback != undefined)
                 callback();
         });
@@ -14,8 +12,6 @@ export default function addFadeInFunctionsTojQuery($) {
     // covers/change.html
     $.fn.customFadeOut = function(speed, callback) {
         $(this).fadeOut(speed, function() {
-            if (jQuery.browser.msie)
-                $(this).get(0).style.removeAttribute('filter');
             if (callback != undefined)
                 callback();
         });

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -4,7 +4,8 @@ $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and qu
     // <!--
     window.q.push(function() {
         if ("$query_param('merge', 'false')" == "true") {
-            \$("#preMerge").parent().andSelf().show();
+            \$("#preMerge").show();
+            \$("#preMerge").parent().show();
 
             $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]
             var data = {


### PR DESCRIPTION
Since upgrading to jQuery 3 feature, the browser detection is no
longer available. Given we support IE >=11 which supports opacity (filter was used < IE11 to do that)

this code is redundant and can be removed.

I get a JS error `Uncaught TypeError: t.browser is undefined` on http://localhost:8080/subjects/mathematics
The error resolves with this patch.

### Technical

Missed in the jQuery 3 upgrade.

### Testing
* Make sure no JavaScript errors on  http://localhost:8080/subjects/mathematics
* Create a new author Mark Twain 2 while logged in as an admin. Go to http://localhost:8080/search/authors?q=Mark+Twain and click merge authors. Click "Merge authors".  Make sure no javaScript error displays.
* 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles @cdrini  - deploy blocker I suspect.
