### PR TITLE
Images refreshes automatically upon addition 

### DIFF
--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -102,7 +102,7 @@ export function initCoversSaved() {
     const doc_type_key = data_config_json['key'];
     const coverstore_url = data_config_json['url'];
     const cover_selector = data_config_json['selector'];
-    const image = parent.$('.imageSaved').data('image-id');
+    const image = $('.imageSaved').data('imageId');
     var cover_url;
 
     $('.formButtons button').on('click', parent.closePopup);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4876

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When a book cover is added, it requires a refresh to show the new cover. This PR removes this issue, now upon addition images appear as soon as the `submit` button is clicked.
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @jamesachamp 