### PR TITLE
[solr8] Tweak dismax params for all search

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -46,6 +46,7 @@ plugin_modules:
 
 plugin_worksearch:
     solr_base_url: http://solr:8983/solr
+    solr8: false
     spellcheck_count: 3
     ebook_count_db_parameters:
         db: openlibrary_ebook_count

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -431,8 +431,8 @@ def run_solr_query(param=None, rows=100, page=1, sort=None, spellcheck_count=Non
         if use_dismax:
             params.append(('q', ' '.join(q_list)))
             params.append(('defType', 'dismax'))
-            params.append(('qf', 'text title^10 author_name^10'))
-            params.append(('bf', 'sqrt(edition_count)'))
+            params.append(('qf', 'text title^20 author_name^20'))
+            params.append(('bf', 'min(100,edition_count)'))
         else:
             params.append(('q', ' '.join(q_list + ['_val_:"sqrt(edition_count)"^10'])))
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -431,8 +431,8 @@ def run_solr_query(param=None, rows=100, page=1, sort=None, spellcheck_count=Non
         if use_dismax:
             params.append(('q', ' '.join(q_list)))
             params.append(('defType', 'dismax'))
-            params.append(('qf', 'text title^5 author_name^5'))
-            params.append(('bf', 'sqrt(edition_count)^10'))
+            params.append(('qf', 'text title^10 author_name^10'))
+            params.append(('bf', 'sqrt(edition_count)'))
         else:
             params.append(('q', ' '.join(q_list + ['_val_:"sqrt(edition_count)"^10'])))
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -431,8 +431,12 @@ def run_solr_query(param=None, rows=100, page=1, sort=None, spellcheck_count=Non
         if use_dismax:
             params.append(('q', ' '.join(q_list)))
             params.append(('defType', 'dismax'))
-            params.append(('qf', 'text title^20 author_name^20'))
-            params.append(('bf', 'min(100,edition_count)'))
+            if config.plugin_worksearch.get('solr8'):
+                params.append(('qf', 'text title^20 author_name^20'))
+                params.append(('bf', 'min(100,edition_count)'))
+            else:
+                params.append(('qf', 'text title^5 author_name^5'))
+                params.append(('bf', 'sqrt(edition_count)^10'))
         else:
             params.append(('q', ' '.join(q_list + ['_val_:"sqrt(edition_count)"^10'])))
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Here's a useful comparison place: https://codepen.io/cdrini/full/wvJqzaK (I needed https on testing to make this work :P )
- ✅ Results are better for popular books https://docs.google.com/spreadsheets/d/1BN5I7-OkTPaoTr2Es6jQ4O9ICWFmH0q9CP6kEgolCgg (books taken from Wikipedia's list of best selling books)
- ✅ Results are about the same for things like subjects.
- ✅ When no `solr8` in config, old weights applied
- ✅ When `solr8: false` in config, old weight applied
- ✅ When `solr8: true` in config, new weight applied

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
