### PR TITLE
Refactor/Move inline js from books/edit template

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -22,6 +22,28 @@ function update_len() {
 }
 
 /**
+ * Gets length of 'textid' section, limit textid value length to input 'limit'
+ * and updates text of 'infodiv' section
+ *
+ * @param {String} textid  text section id name
+ * @param {Number} limit   character number limit
+ * @param {String} infodiv information section id name
+ * @return {boolean} is character number below or equal to limit
+ */
+function limitChars(textid, limit, infodiv) {
+    var text = $(`#${textid}`).val();
+    var textlength = text.length;
+    if (textlength > limit) {
+        $(`#${infodiv}`).html('Maximum length is ' + limit + ' characters');
+        $(`#${textid}`).val(text.substr(0, limit));
+        return false;
+    } else {
+        $(`#${infodiv}`).html('You have ' + (limit - textlength) + ' characters left');
+        return true;
+    }
+}
+
+/**
  * This is needed because jQuery has no forEach equivalent that works with jQuery elements instead of DOM elements
  * @param selector - css selector used by jQuery
  * @returns {*[]} - array of jQuery elements
@@ -184,7 +206,6 @@ function show_hide_title() {
     }
 }
 
-
 export function initEditExcerpts() {
     $('#excerpts').repeat({
         vars: {
@@ -203,7 +224,10 @@ export function initEditExcerpts() {
     });
 
     // update length on every keystroke
-    $('#excerpts-excerpt').on('keyup', update_len);
+    $('#excerpts-excerpt').on('keyup', function() {
+        limitChars('excerpts-excerpt', 2000, 'charLimit');
+        update_len();
+    });
 
     // update length on add.
     $('#excerpts')
@@ -250,22 +274,6 @@ export function initEditLinks() {
 }
 
 /**
- * TODO
- */
-function limitChars(textid, limit, infodiv) {
-    var text = $(`#${textid}`).val();
-    var textlength = text.length;
-    if (textlength > limit) {
-        $(`#${infodiv}`).html('Maximum length is ' + limit + ' characters');
-        $(`#${textid}`).val(text.substr(0, limit));
-        return false;
-    } else {
-        $(`#${infodiv}`).html('You have ' + (limit - textlength) + ' characters left');
-        return true;
-    }
-}
-
-/**
  * Initializes edit page.
  *
  * Assumes presence of elements with id:
@@ -274,7 +282,6 @@ function limitChars(textid, limit, infodiv) {
  *    - '#contentHead'
  */
 export function initEdit() {
-    $('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});
     var hash = document.location.hash || '#edition';
     var tab = hash.split('/')[0];
     var link = `#link_${tab.substr(1)}`;

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -250,6 +250,22 @@ export function initEditLinks() {
 }
 
 /**
+ * TODO
+ */
+function limitChars(textid, limit, infodiv) {
+    var text = $(`#${textid}`).val();
+    var textlength = text.length;
+    if (textlength > limit) {
+        $(`#${infodiv}`).html('Maximum length is ' + limit + ' characters');
+        $(`#${textid}`).val(text.substr(0, limit));
+        return false;
+    } else {
+        $(`#${infodiv}`).html('You have ' + (limit - textlength) + ' characters left');
+        return true;
+    }
+}
+
+/**
  * Initializes edit page.
  *
  * Assumes presence of elements with id:
@@ -258,6 +274,7 @@ export function initEditLinks() {
  *    - '#contentHead'
  */
 export function initEdit() {
+    $('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});
     var hash = document.location.hash || '#edition';
     var tab = hash.split('/')[0];
     var link = `#link_${tab.substr(1)}`;

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -185,8 +185,7 @@ function show_hide_title() {
 }
 
 
-export function initEdit() {
-
+export function initEditExcerpts() {
     $('#excerpts').repeat({
         vars: {
             prefix: 'work--excerpts',
@@ -251,13 +250,18 @@ export function initEditLinks() {
 }
 
 /**
- * TODO
+ * Initializes edit page.
+ *
+ * Assumes presence of elements with id:
+ *    - '#link_edition'
+ *    - '#tabsAddbook'
+ *    - '#contentHead'
  */
-export function initEdit2() {
+export function initEdit() {
     var hash = document.location.hash || '#edition';
     var tab = hash.split('/')[0];
-    var link = '#link_' + tab.substr(1);
-    var fieldname = ':input' + hash.replace('/', '-');
+    var link = `#link_${tab.substr(1)}`;
+    var fieldname = `:input${hash.replace('/', '-')}`;
 
     $(link).click();
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -253,24 +253,7 @@ export function initEditLinks() {
 /**
  * TODO
  */
-function limitChars(textid, limit, infodiv) {
-    var text = $(`#${textid}`).val();
-    var textlength = text.length;
-    if (textlength > limit) {
-        $(`#${infodiv}`).html('Maximum length is ' + limit + ' characters');
-        $(`#${textid}`).val(text.substr(0, limit));
-        return false;
-    } else {
-        $(`#${infodiv}`).html('You have ' + (limit - textlength) + ' characters left');
-        return true;
-    }
-}
-
-/**
- * TODO
- */
 export function initEdit2() {
-    $('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});
     var hash = document.location.hash || '#edition';
     var tab = hash.split('/')[0];
     var link = '#link_' + tab.substr(1);

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -22,23 +22,19 @@ function update_len() {
 }
 
 /**
- * Gets length of 'textid' section, limit textid value length to input 'limit'
- * and updates text of 'infodiv' section
+ * Gets length of 'textid' section and limit textid value length to input 'limit'
  *
  * @param {String} textid  text section id name
  * @param {Number} limit   character number limit
- * @param {String} infodiv information section id name
  * @return {boolean} is character number below or equal to limit
  */
-function limitChars(textid, limit, infodiv) {
+function limitChars(textid, limit) {
     var text = $(`#${textid}`).val();
     var textlength = text.length;
     if (textlength > limit) {
-        $(`#${infodiv}`).html(`Maximum length is ${limit} characters`);
         $(`#${textid}`).val(text.substr(0, limit));
         return false;
     } else {
-        $(`#${infodiv}`).html(`You have ${limit - textlength} characters left`);
         return true;
     }
 }
@@ -225,7 +221,7 @@ export function initEditExcerpts() {
 
     // update length on every keystroke
     $('#excerpts-excerpt').on('keyup', function() {
-        limitChars('excerpts-excerpt', 2000, 'charLimit');
+        limitChars('excerpts-excerpt', 2000);
         update_len();
     });
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -249,3 +249,45 @@ export function initEditLinks() {
         }
     });
 }
+
+/**
+ * TODO
+ */
+function limitChars(textid, limit, infodiv) {
+    var text = $(`#${textid}`).val();
+    var textlength = text.length;
+    if (textlength > limit) {
+        $(`#${infodiv}`).html('Maximum length is ' + limit + ' characters');
+        $(`#${textid}`).val(text.substr(0, limit));
+        return false;
+    } else {
+        $(`#${infodiv}`).html('You have ' + (limit - textlength) + ' characters left');
+        return true;
+    }
+}
+
+/**
+ * TODO
+ */
+export function initEdit2() {
+    $('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});
+    var hash = document.location.hash || '#edition';
+    var tab = hash.split('/')[0];
+    var link = '#link_' + tab.substr(1);
+    var fieldname = ':input' + hash.replace('/', '-');
+
+    $(link).click();
+
+    // input field is enabled only after the tab is selected and that takes some time after clicking the link.
+    // wait for 1 sec after clicking the link and focus the input field
+    setTimeout(function() {
+        // scroll such that top of the content is visible
+        if ($(fieldname).length != 0) {
+            $(fieldname).focus();
+        }
+        else {
+            $('#tabsAddbook > div:visible :input:first').focus();
+        }
+        $(window).scrollTop($('#contentHead').offset().top);
+    }, 1000);
+}

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -34,11 +34,11 @@ function limitChars(textid, limit, infodiv) {
     var text = $(`#${textid}`).val();
     var textlength = text.length;
     if (textlength > limit) {
-        $(`#${infodiv}`).html('Maximum length is ' + limit + ' characters');
+        $(`#${infodiv}`).html(`Maximum length is ${limit} characters`);
         $(`#${textid}`).val(text.substr(0, limit));
         return false;
     } else {
-        $(`#${infodiv}`).html('You have ' + (limit - textlength) + ' characters left');
+        $(`#${infodiv}`).html(`You have ${limit - textlength} characters left`);
         return true;
     }
 }
@@ -287,17 +287,17 @@ export function initEdit() {
     var link = `#link_${tab.substr(1)}`;
     var fieldname = `:input${hash.replace('/', '-')}`;
 
-    $(link).click();
+    $(link).trigger('click');
 
     // input field is enabled only after the tab is selected and that takes some time after clicking the link.
     // wait for 1 sec after clicking the link and focus the input field
     setTimeout(function() {
         // scroll such that top of the content is visible
-        if ($(fieldname).length != 0) {
-            $(fieldname).focus();
+        if ($(fieldname).length !== 0) {
+            $(fieldname).trigger('focus');
         }
         else {
-            $('#tabsAddbook > div:visible :input:first').focus();
+            $('#tabsAddbook > div:visible :input:first').trigger('focus');
         }
         $(window).scrollTop($('#contentHead').offset().top);
     }, 1000);

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -91,6 +91,7 @@ jQuery(function () {
             .then(module => module.initEditionsTable());
     }
 
+    const edition = document.getElementById('tabsAddbook');
     const autocompleteAuthor = document.querySelector('.multi-input-autocomplete--author');
     const addRowButton = document.getElementById('add_row_button');
     const roles = document.querySelector('#roles');
@@ -103,17 +104,20 @@ jQuery(function () {
 
     // conditionally load for user edit page
     if (
+        edition ||
         autocompleteAuthor || addRowButton || roles || identifiers || classifications ||
         autocompleteLanguage || autocompleteWorks || excerpts || links
     ) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => {
+                if (edition) {
+                    module.initEdit();
+                }
                 if (addRowButton) {
                     module.initEditRow();
                 }
                 if (excerpts) {
-                    module.initEdit();
-                    module.initEdit2();
+                    module.initEditExcerpts();
                 }
                 if (links) {
                     module.initEditLinks();

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -113,6 +113,7 @@ jQuery(function () {
                 }
                 if (excerpts) {
                     module.initEdit();
+                    module.initEdit2();
                 }
                 if (links) {
                     module.initEditLinks();

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -5,43 +5,6 @@ $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) e
 $var title: $this_title
 $putctx("robots", "noindex,nofollow")
 
-<script type="text/javascript">
-function limitChars(textid, limit, infodiv) {
-    var text = \$('#'+textid).val();
-    var textlength = text.length;
-    if(textlength > limit) {
-        \$('#'+infodiv).html('Maximum length is '+limit+' characters');
-        \$('#'+textid).val(text.substr(0,limit));
-        return false;
-    } else {
-        \$('#'+infodiv).html('You have '+ (limit - textlength) +' characters left');
-        return true;
-    }
-};
-window.q.push( function(){
-    \$('#excerpt').keyup(function(){limitChars('excerpt', 2000, 'charLimit');});
-    var hash = document.location.hash || "#edition";
-    var tab = hash.split("/")[0]
-    var link = "#" + "link_" + tab.substr(1);
-    var fieldname = ":input" + hash.replace('/', '-');
-
-    \$(link).trigger('click');
-
-    // input field is enabled only after the tab is selected and that takes some time after clicking the link.
-    // wait for 1 sec after clicking the link and focus the input field
-    setTimeout(function() {
-        // scroll such that top of the content is visible
-        if (\$(fieldname).length != 0) {
-            \$(fieldname).focus();
-        }
-        else {
-            \$("#tabsAddbook > div:visible :input:first").focus();
-        }
-        \$(window).scrollTop(\$("#contentHead").offset().top);
-    }, 1000);
-} );
-</script>
-
 <div id="contentHead" class="editFormHead">
     $code:
         def find_mode():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes openlibrary/templates/books/edit.html point from #4474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Move inline JavaScript from books/edit.html template to index.js and edit.js.

### Technical
<!-- What should be noted about the implementation? -->
<del>Dead code removed (`$(#excerpt).keyup()` and associated `limitChars()`)</del>
`$(#excerpt).keyup()` and associated `limitChars()` repaired.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson