### PR TITLE
Fix add edition not working due to author_names being disabled

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -138,7 +138,6 @@ export function initWorksMultiInputAutocomplete() {
 }
 
 export function initAuthorMultiInputAutocomplete() {
-    $('.author-autocomplete').prop('disabled', false);
     getJqueryElements('.multi-input-autocomplete--author').forEach(jqueryElement => {
         /* Values in the html passed from Python code */
         const dataConfig = JSON.parse(jqueryElement[0].dataset.config);

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -28,7 +28,7 @@ $var title: $_("Add a book")
         </div>
         <div class="formElement">
             <div class="label"><label for="author">$_("Author")</label> <span class="smaller lighter">$_('Like, "Agatha Christie" or "Jean-Paul Sartre." We\'ll also do a live check to see if we already know the author.')</span></div>
-            $:render_template("books/author-autocomplete", cond(author, [author], []), "author_names", "authors")
+            $:render_template("books/author-autocomplete", cond(author, [author], []), "author_names", "authors", readonly=work is not None)
         </div>
 
         <div class="formElement">

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -31,9 +31,9 @@ $jsdef render_author_autocomplete_item(item):
                 <span class="subject">Subjects: ${', '.join(item.subjects)}</span>
         </div>
 
-$jsdef render_author(name_path, dict_path, disabled, i, author):
+$jsdef render_author(name_path, dict_path, readonly, i, author):
     <div class="input">
-        <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" $cond(disabled, 'disabled', '')>
+        <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" $cond(readonly, 'readonly', '')>
         <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
         <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
         <a href="javascript:;" class="add">$_("Add another author?")</a>

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -1,4 +1,4 @@
-$def with (authors, name_path, dict_path)
+$def with (authors, name_path, dict_path, readonly=False)
 $# :param list[dict] authors: e.g. {name: str, key: str}
 $# :param str name_path: form path for the user-visible author name
 $# :param str dict_path: form path for the author dict
@@ -41,5 +41,5 @@ $jsdef render_author(name_path, dict_path, readonly, i, author):
 $ config = {'name_path': name_path, 'dict_path': dict_path}
 <div class="multi-input-autocomplete--author" data-config="$dumps(config)">
     $for author in (authors or [storage(name="", key="")]):
-        $:render_author(name_path, dict_path, True, loop.index0, author)
+        $:render_author(name_path, dict_path, readonly, loop.index0, author)
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5219. Hotfix. Apparently setting an input field to disabled causes it to not be sent in the POST. We want readonly.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅  Confirmed can add an edition to an existing work.
- ✅ Confirmed can't modify the author when adding an edition to an existing work.
- ✅ Confirmed adding authors when editing work
- ✅ Confirmed adding author to new work/edition

### Screenshot
The UI looks more confusing, but we can fix later.

| Before | After | 
| ------- | ------ | 
| ![image](https://user-images.githubusercontent.com/6251786/120036488-35b2a380-bfce-11eb-9158-b2dcaad1700e.png) |  ![image](https://user-images.githubusercontent.com/6251786/120036438-23d10080-bfce-11eb-839d-c74a1feb4ddb.png) |


### Stakeholders
@seabelis 
