### PR TITLE
Delete unused read api call

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -214,12 +214,7 @@ jQuery(function () {
 
     if (document.getElementById('searchFacets')) {
         import(/* webpackChunkName: "search" */ './search')
-            .then((module) => {
-                module.initSearchFacets();
-                if (document.getElementById('adminTiming')) {
-                    module.initAdminTiming();
-                }
-            });
+            .then((module) => module.initSearchFacets());
     }
 
     if ($('#cboxPrevious').length) {

--- a/openlibrary/plugins/openlibrary/js/search.js
+++ b/openlibrary/plugins/openlibrary/js/search.js
@@ -68,34 +68,3 @@ export function initSearchFacets() {
         less($(this).data('header'), start_facet_count, facet_inc);
     });
 }
-
-let readapi_starttime = 0;
-
-/**
- * Displays difference between readapi_starttime and now in '#adminTiming' element.
- */
-function readapi_callback() {
-    const endtime = Date.now();
-    const duration = (endtime - readapi_starttime) / 1000;
-    const disp = document.getElementById('adminTiming');
-    if (disp) {
-        disp.innerHTML += `<br/><br/><span class="adminOnly">Read API call took ${duration} seconds</span>`;
-    }
-}
-
-/**
- * Initializes adminTiming element.
- *
- * Calls read_multiget API for a list of works.
- * Assumes presence of element with '#adminTiming' id and 'data-wks' attribute.
- */
-export function initAdminTiming() {
-    // ALL admin views are sampled.
-    readapi_starttime = Date.now();
-    const wks = $('#adminTiming').data('wks');
-    $.ajax({
-        url: `https://openlibrary.org/api/volumes/brief/json/${wks}?listofworks=True&no_details=True&stats=True`,
-        dataType: 'jsonp',
-        success: readapi_callback
-    });
-}

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -229,9 +229,8 @@ $elif param and len(docs):
     </div>
 
     $if param and not error and len(docs):
-        $ wks = '|'.join([w.key for w in works])
         $if ctx.user and ctx.user.is_admin():
-            <div id="adminTiming" class="small sansserif clearfix" data-wks="$wks">
+            <div id="adminTiming" class="small sansserif clearfix">
                 <br/><span class="adminOnly">Searching solr took $("%.2f" % search_secs) seconds</span>
             </div>
   </div>


### PR DESCRIPTION
Refactor. As far as I can tell, this wasn't used for anything? Likely a residual from when we checked availability client side?

### Technical
- Here's a sample request: https://openlibrary.org/api/volumes/brief/json/works/OL46125W|/works/OL46309W|/works/OL46390W|/works/OL46326W|/works/OL46224W|/works/OL1993999W|/works/OL46347W|/works/OL16063849W|/works/OL46369W|/works/OL46172W|/works/OL8004422W|/works/OL1001044W|/works/OL14854175W|/works/OL2633238W|/works/OL518262W|/works/OL5608342W|/works/OL5608343W|/works/OL158967W|/works/OL565229W|/works/OL1261147W?listofworks=True&no_details=True&stats=True

### Testing
- [x] Test search results look as expected
- [x] Test lists still have availability

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
