### PR TITLE
Fix bad UI related to increased max-width

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -443,26 +443,26 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
         $ reader_observations = get_observation_metrics(work['key'])
         $:render_template("observations/stats_component", work, edition, reader_observations, work_title, page.key)
     </div>
+  </div>
 
-    <div class="workFooter">
-      $# pages like /books/ia:foo00bar are fake records created from metadata API.
-      $# Adding them to lists doesn't work. Disabling it to avoid any issues.
-      $if "lists" in ctx.features and not page.is_fake_record():
-        <h2 class="home-h2"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
-        <div class="user-book-options">
-          <div class="Tools tools-override">
-            $if work:
-              $ component_times['WorkListTime'] = time()
-              $:render_template("lists/widget", work, include_header=False, include_widget=False)
-              $ component_times['WorkListTime'] = time() - component_times['WorkListTime']
+  <div class="workFooter">
+    $# pages like /books/ia:foo00bar are fake records created from metadata API.
+    $# Adding them to lists doesn't work. Disabling it to avoid any issues.
+    $if "lists" in ctx.features and not page.is_fake_record():
+      <h2 class="home-h2"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
+      <div class="user-book-options">
+        <div class="Tools tools-override">
+          $if work:
+            $ component_times['WorkListTime'] = time()
+            $:render_template("lists/widget", work, include_header=False, include_widget=False)
+            $ component_times['WorkListTime'] = time() - component_times['WorkListTime']
 
-            $if edition:
-              $ component_times['EditionListTime'] = time()
-              $:render_template("lists/widget", edition, include_header=False, include_widget=False)
-              $ component_times['EditionListTime'] = time() - component_times['EditionListTime']
-          </div>
+          $if edition:
+            $ component_times['EditionListTime'] = time()
+            $:render_template("lists/widget", edition, include_header=False, include_widget=False)
+            $ component_times['EditionListTime'] = time() - component_times['EditionListTime']
         </div>
-    </div>
+      </div>
   </div>
 
   $ component_times['RelatedWorksCarousel'] = time()

--- a/static/css/components/iaBar.less
+++ b/static/css/components/iaBar.less
@@ -4,7 +4,7 @@
 
 .iaBar {
   .display-flex();
-  max-width: 960px;
+  max-width: 1060px;
   margin: 0 auto;
   -webkit-box-align: center;
   -ms-flex-align: center;

--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -57,7 +57,7 @@
     margin-bottom: 0;
   }
   li {
-    width: 280px;
+    width: 310px;
     margin-right: 10px;
   }
   span.imageLg {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -51,7 +51,6 @@ div.editionAbout {
 }
 
 .workFooter {
-  clear: both;
   border-top: 1px solid @lighter-grey;
   ul.listLists {
     display: flex;
@@ -202,16 +201,17 @@ div.editionTools {
 }
 
 @media only screen and (min-width: @width-breakpoint-desktop) {
+  .workDetails {
+    display: flex;
+  }  
   div.edition {
     &Cover {
-      float: left;
       width: 225px;
       margin-right: 1.5em;
       margin-bottom: 0;
     }
     &About {
-      float: left;
-      width: 75%;
+      flex: 1;
     }
   }
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -203,7 +203,7 @@ div.editionTools {
 @media only screen and (min-width: @width-breakpoint-desktop) {
   .workDetails {
     display: flex;
-  }  
+  }
   div.edition {
     &Cover {
       width: 225px;

--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -35,7 +35,7 @@ body.full-width #test-body-mobile {
   .content {
     &Quarter {
       float: left;
-      width: 215px;
+      width: 240px;
     }
   }
 }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -2100,12 +2100,12 @@ div#subjectLists {
   .content {
     &Twothird {
       float: left;
-      width: 610px;
+      width: 675px;
       padding-right: 38px;
     }
     &Onethird {
       float: left;
-      width: 270px;
+      width: 305px;
     }
     &Half {
       float: left;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to PR #4926 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes:

1. IA Bar max-width
![image](https://user-images.githubusercontent.com/64412143/120059586-24ba6e80-c070-11eb-8adb-1e044f1a470b.png)
2. Books Page use display: flex; https://github.com/internetarchive/openlibrary/pull/4926#issuecomment-809811187
![image](https://user-images.githubusercontent.com/64412143/120059623-4e739580-c070-11eb-9509-aa971e8aa5f9.png)
3. Fixes Author Page https://github.com/internetarchive/openlibrary/pull/4926#issuecomment-850661580
4. Fixes Subjects Page https://github.com/internetarchive/openlibrary/pull/4926#issuecomment-811632887
5. Fixes My Lists
![image](https://user-images.githubusercontent.com/64412143/120059717-b88c3a80-c070-11eb-8839-f55db80dd036.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 