### PR TITLE
Fix jQuery deprecated methods

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -1,6 +1,6 @@
 export function initAddBookImport () {
     $('.list-books a').on('click', function() {
-        var li = $(this).parents('li:first');
+        var li = $(this).parents('li').first();
         $('input#work').val(`/works/${li.attr('id')}`);
         $('form#addbook').trigger('submit');
     });

--- a/openlibrary/plugins/openlibrary/js/add_new_field.js
+++ b/openlibrary/plugins/openlibrary/js/add_new_field.js
@@ -41,7 +41,7 @@ export default function($){
                 }
             });
 
-            const $href=$(options.href);
+            const $href = $(options.href);
             // handle cancel
             $href.on('cbox_closed', function() {
 

--- a/openlibrary/plugins/openlibrary/js/add_new_field.js
+++ b/openlibrary/plugins/openlibrary/js/add_new_field.js
@@ -41,8 +41,9 @@ export default function($){
                 }
             });
 
+            const $href=$(options.href);
             // handle cancel
-            $(options.href).on('cbox_closed', function() {
+            $href.on('cbox_closed', function() {
 
                 if ($this.val() == '__add__') {
                     $this.val('');
@@ -54,7 +55,7 @@ export default function($){
             });
 
             // handle submit
-            $('form').first().add($(options.href)).on('submit', function(event) {
+            $('form').first().add($href).on('submit', function(event) {
                 var array, d, i, data;
                 event.preventDefault();
 

--- a/openlibrary/plugins/openlibrary/js/add_new_field.js
+++ b/openlibrary/plugins/openlibrary/js/add_new_field.js
@@ -64,7 +64,7 @@ export default function($){
                 d = {};
 
                 for (i in array) {
-                    d[array[i].name] = (array[i].value).trim();
+                    d[array[i].name] = array[i].value.trim();
                 }
 
                 // validate

--- a/openlibrary/plugins/openlibrary/js/add_new_field.js
+++ b/openlibrary/plugins/openlibrary/js/add_new_field.js
@@ -42,7 +42,7 @@ export default function($){
             });
 
             // handle cancel
-            $(options.href).bind('cbox_closed', function() {
+            $(options.href).on('cbox_closed', function() {
 
                 if ($this.val() == '__add__') {
                     $this.val('');
@@ -54,7 +54,7 @@ export default function($){
             });
 
             // handle submit
-            $('form:first', $(options.href)).on('submit', function(event) {
+            $('form').first().add($(options.href)).on('submit', function(event) {
                 var array, d, i, data;
                 event.preventDefault();
 
@@ -63,7 +63,7 @@ export default function($){
                 d = {};
 
                 for (i in array) {
-                    d[array[i].name] = $.trim(array[i].value);
+                    d[array[i].name] = (array[i].value).trim();
                 }
 
                 // validate
@@ -78,7 +78,7 @@ export default function($){
                 $('<option/>')
                     .html(d.label || d.value)
                     .attr('value', d.value)
-                    .insertBefore($this.find('option:last').prev()) // insert before ---
+                    .insertBefore($this.find('option').last().prev()) // insert before ---
                     .parent().val(d.value);
 
                 // add JSON to hidden field

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -34,7 +34,7 @@ export function initCoversChange() {
 }
 
 function val(selector) {
-    return ($(selector).trim().val());
+    return ($(selector).val()).trim;
 }
 
 function error(message, event) {

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -13,7 +13,7 @@ export function initCoversChange() {
     // Add iframes lazily when the popup is loaded.
     // This avoids fetching the iframes along with main page.
     $('.coverPop')
-        .bind('click', function () {
+        .on('click', function () {
             // clear the content of #imagesAdd and #imagesManage before adding new
             $('#imagesAdd').html('');
             $('#imagesManage').html('');
@@ -27,14 +27,14 @@ export function initCoversChange() {
                 add_iframe('#imagesManage', manage_url);
             }, 0);
         })
-        .bind('cbox_cleanup', function () {
+        .on('cbox_cleanup', function () {
             $('#imagesAdd').html('');
             $('#imagesManage').html('');
         });
 }
 
 function val(selector) {
-    return $.trim($(selector).val());
+    return ($(selector).trim().val());
 }
 
 function error(message, event) {

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -34,7 +34,7 @@ export function initCoversChange() {
 }
 
 function val(selector) {
-    return ($(selector).val()).trim;
+    return $(selector).val().trim();
 }
 
 function error(message, event) {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -170,13 +170,13 @@ export function initEditLinks() {
             prefix: $('#links').data('prefix')
         },
         validate: function(data) {
-            if ((data.url).trim() === '' || (data.url).trim() === 'https://') {
+            if (data.url.trim() === '' || data.url.trim() === 'https://') {
                 $('#link-errors').html('Please provide a URL.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-url').trigger('focus');
                 return false;
             }
-            if ((data.title).trim === '') {
+            if (data.title.trim() === '') {
                 $('#link-errors').html('Please provide a label.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-label').trigger('focus');

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -146,9 +146,9 @@ export function initEdit() {
 
     // update length on add.
     $('#excerpts')
-        .bind('repeat-add', update_len)
-        .bind('repeat-add', show_hide_title)
-        .bind('repeat-remove', show_hide_title);
+        .on('repeat-add', update_len)
+        .on('repeat-add', show_hide_title)
+        .on('repeat-remove', show_hide_title);
 
     // update length on load
     update_len();
@@ -170,13 +170,13 @@ export function initEditLinks() {
             prefix: $('#links').data('prefix')
         },
         validate: function(data) {
-            if ($.trim(data.url) === '' || $.trim(data.url) === 'https://') {
+            if ((data.url).trim() === '' || (data.url).trim() === 'https://') {
                 $('#link-errors').html('Please provide a URL.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-url').trigger('focus');
                 return false;
             }
-            if ($.trim(data.title) === '') {
+            if ((data.title).trim() === '') {
                 $('#link-errors').html('Please provide a label.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-label').trigger('focus');

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -176,7 +176,7 @@ export function initEditLinks() {
                 $('#link-url').trigger('focus');
                 return false;
             }
-            if ((data.title).trim() === '') {
+            if ((data.title).trim === '') {
                 $('#link-errors').html('Please provide a label.');
                 $('#link-errors').removeClass('hidden');
                 $('#link-label').trigger('focus');

--- a/openlibrary/plugins/openlibrary/js/jquery.repeat.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.repeat.js
@@ -94,7 +94,7 @@ export default function($){
         }
         function onRemove(event) {
             event.preventDefault();
-            $(this).parents('.repeat-item:eq(0)').remove();
+            $(this).parents('.repeat-item').eq(0).remove();
             elems._this.trigger('repeat-remove');
         }
         addSelector = `${id} .repeat-add`;

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -8,9 +8,9 @@ export function initAuthorMergePage() {
         }
         return false;
     });
-    $('div.radio:first input[type=radio]').prop('checked', true);
-    $('div.checkbox:first input[type=checkbox]').prop('checked', true);
-    $('div.author:first').addClass('master');
+    $('div.radio').first().find('input[type=radio]').prop('checked', true);
+    $('div.checkbox').first().find('input[type=checkbox]').prop('checked', true);
+    $('div.author').first().addClass('master');
     $('#include input[type=radio]').on('mouseover', function () {
         $(this).parent().parent().addClass('mouseoverHighlight', 300);
     });

--- a/openlibrary/plugins/openlibrary/js/subjects.js
+++ b/openlibrary/plugins/openlibrary/js/subjects.js
@@ -86,7 +86,7 @@ Subject.prototype = {
     },
 
     bind: function(name, callback) {
-        $(this).bind(name, callback);
+        $(this).on(name, callback);
     },
 
     getPageCount: function() {

--- a/openlibrary/plugins/openlibrary/js/tabs.js
+++ b/openlibrary/plugins/openlibrary/js/tabs.js
@@ -2,7 +2,7 @@ const TABS_OPTIONS = { fx: { opacity: 'toggle' } };
 
 export default function initTabs($node) {
     $node.tabs(TABS_OPTIONS);
-    $node.filter('.autohash').bind('tabsselect', function(event, ui) {
+    $node.filter('.autohash').on('tabsselect', function(event, ui) {
         document.location.hash = ui.panel.id;
     });
 }

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -1,7 +1,7 @@
 // http://jqueryminute.com/set-focus-to-the-next-input-field-with-jquery/
 $.fn.focusNextInputField = function() {
     return this.each(function() {
-        var fields = $(this).parents('form:eq(0),body').find(':input:visible');
+        var fields = $(this).parents('form').eq(0).add('body').find(':input:visible');
         var index = fields.index(this);
         if (index > -1 && (index + 1) < fields.length) {
             fields.eq(index + 1).focus();

--- a/vendor/js/jquery-form/jquery.form.js
+++ b/vendor/js/jquery-form/jquery.form.js
@@ -53,7 +53,7 @@ $.fn.ajaxSubmit = function(options) {
 	if (typeof options == 'function')
 		options = { success: options };
 
-	var url = this.attr('action').trim();
+	var url = $.trim(this.attr('action'));
 	if (url) {
 		// clean url (don't include hash vaue)
 		url = (url.match(/^([^#]+)/)||[])[1];

--- a/vendor/js/jquery-form/jquery.form.js
+++ b/vendor/js/jquery-form/jquery.form.js
@@ -53,7 +53,7 @@ $.fn.ajaxSubmit = function(options) {
 	if (typeof options == 'function')
 		options = { success: options };
 
-	var url = $.trim(this.attr('action'));
+	var url = this.attr('action').trim();
 	if (url) {
 		// clean url (don't include hash vaue)
 		url = (url.match(/^([^#]+)/)||[])[1];


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to https://github.com/internetarchive/openlibrary/pull/5201

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

1. :eq has been replaced with .eq()
   Ref: https://api.jquery.com/eq-selector/
2. :first has been replaced to .first()
    Ref: https://api.jquery.com/first-selector/
3. .bind() has been replaced to .on()
    Ref: https://api.jquery.com/bind/
4. $.trim(f) has been replaced with f.trim()

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 