### PR TITLE
Correct login, logout, and account creation errors

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -33,7 +33,7 @@ $def field(input, suffix=''):
 $if ctx.user:
     $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
     <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
-    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].trigger('submit')">log out</a> and start the signup process afresh.')</p>
+    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>
 $else:
     <form class="olform create validate" name="signup" method="post" action="">
         $if form.note:

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -129,7 +129,7 @@ $def with (page)
           <li><a href="$homepath()/account">$_("Settings")</a></li>
           <li>
             <form name="logout" action="/account/logout" method="post">
-              <a href="#" onclick="document.forms['logout'].trigger('submit')">$_("Log out")</a>
+              <a href="#" onclick="document.forms['logout'].submit()">$_("Log out")</a>
             </form>
           </li>
         </ul>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -12,7 +12,7 @@ $var title: $("Log In")
 
   $if ctx.user:
       <p>$:_("You are already logged into Open Library as %(user)s.", user='<a href="%s">%s</a>' % (ctx.user.key, ctx.user.displayname))</p>
-      <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].trigger('submit')">log out</a> and start the signup process afresh.')</p>
+      <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>
 
   $else:
       <form id="register" class="login olform" name="register" method="post">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5256

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects login, logout, and account creation errors that are currently present in local development instances.

### Technical
<!-- What should be noted about the implementation? -->
The `jQuery.trigger` function was replaced with vanilla `form.submit` calls in each of the modified files.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Attempt to login with valid credentials.
2. Once logged in, attempt to logout using the "Log out" option in the navigation menu.
3. Once logged out, navigate to the account creation page and attempt to submit the form.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
