### PR TITLE
Fix lists json export

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -1,5 +1,6 @@
 """Lists implementaion.
 """
+import json
 import random
 import web
 
@@ -473,7 +474,7 @@ class export(delegate.page):
         elif format == "json":
             data = {"editions": self.get_editions(lst, raw=True)}
             web.header("Content-Type", "application/json")
-            return delegate.RawText(formats.dump_json(data))
+            return delegate.RawText(json.dumps(data))
         elif format == "yaml":
             data = {"editions": self.get_editions(lst, raw=True)}
             web.header("Content-Type", "application/yaml")


### PR DESCRIPTION
Closes #5215 . Hotfix ; replace removed function with `json.dumps`.

### Technical
The function was removed in f9de97d  ; you can see that it was just a plain wrapper around simplejson.dumps, so just replacing it with json.dumps .

### Testing
- ✅ Exporting the list now works: https://testing.openlibrary.org/people/dcapillae/lists/OL197248L/Rif_War/export?format=json

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@dherbst @dcapillae 
