### PR TITLE
Refactor/Move inline js from type/author/view template

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -148,6 +148,13 @@ jQuery(function () {
         import('./merge')
             .then(module => module.initAuthorMergePage());
     }
+
+    // conditionally load for author view page
+    if (document.getElementById('preMerge')) {
+        import(/* webpackChunkName: "merge" */ './merge')
+            .then((module) => module.initAuthorView());
+    }
+
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
         import('./realtime_account_validation.js')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -150,10 +150,10 @@ jQuery(function () {
         import(/* webpackChunkName: "merge" */ './merge')
             .then(module => {
                 if (mergePageElement) {
-                    module.initAuthorMergePage()
+                    module.initAuthorMergePage();
                 }
                 if (preMergePageElement) {
-                    module.initAuthorView())
+                    module.initAuthorView();
                 }
             });
     }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -144,15 +144,18 @@ jQuery(function () {
     }
 
     // conditionally load for author merge page
-    if (document.querySelector('#author-merge-page')) {
-        import('./merge')
-            .then(module => module.initAuthorMergePage());
-    }
-
-    // conditionally load for author view page
-    if (document.getElementById('preMerge')) {
+    const mergePageElement = document.querySelector('#author-merge-page');
+    const preMergePageElement = document.getElementById('preMerge');
+    if (mergePageElement || preMergePageElement) {
         import(/* webpackChunkName: "merge" */ './merge')
-            .then((module) => module.initAuthorView());
+            .then(module => {
+                if (mergePageElement) {
+                    module.initAuthorMergePage()
+                }
+                if (preMergePageElement) {
+                    module.initAuthorView())
+                }
+            });
     }
 
     // conditionally load real time signup functionality based on class in the page

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -43,19 +43,13 @@ export function initAuthorMergePage() {
  */
 export function initAuthorView() {
     const dataKeysJSON = $('#preMerge').data('keys');
-    const masterKey = dataKeysJSON['master'];
-    const duplicateKeys = dataKeysJSON['duplicates'];
 
     $('#preMerge').show();
     $('#preMerge').parent().show();
 
-    let duplicates = [];
-    for (let key of duplicateKeys.split(',')) {
-        duplicates.push(`/authors/${key}`);
-    }
     let data = {
-        master: masterKey,
-        duplicates: duplicates
+        master: dataKeysJSON['master'],
+        duplicates: dataKeysJSON['duplicates']
     };
 
     $.ajax({

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -34,3 +34,41 @@ export function initAuthorMergePage() {
         }
     });
 }
+
+/**
+ * Initializes preMerge element on author page.
+ *
+ * Show 'preMerge' element and launch author merge of duplicate keys into master key.
+ * Assumes presence of element with '#preMerge' id and 'data-keys' attribute.
+ */
+export function initAuthorView() {
+    const dataKeysJSON = $('#preMerge').data('keys');
+    const masterKey = dataKeysJSON['master'];
+    const duplicateKeys = dataKeysJSON['duplicates'];
+
+    $('#preMerge').show();
+    $('#preMerge').parent().show();
+
+    let duplicates = [];
+    for (let key of duplicateKeys.split(',')) {
+        duplicates.push(`/authors/${key}`);
+    }
+    let data = {
+        master: masterKey,
+        duplicates: duplicates
+    };
+
+    $.ajax({
+        url: '/authors/merge.json',
+        type: 'POST',
+        data: JSON.stringify(data),
+        success: function() {
+            $('#preMerge').fadeOut();
+            $('#postMerge').fadeIn();
+        },
+        error: function() {
+            $('#preMerge').fadeOut();
+            $('#errorMerge').fadeIn();
+        }
+    });
+}

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -1,43 +1,4 @@
 $def with (page)
-$if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
-    <script type="text/javascript">
-    // <!--
-    window.q.push(function() {
-        if ("$query_param('merge', 'false')" == "true") {
-            \$("#preMerge").show();
-            \$("#preMerge").parent().show();
-
-            $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]
-            var data = {
-                "master": "$page.key",
-                "duplicates": $:json_encode(duplicates)
-            };
-            /*
-            \$.post("/authors/merge.json", JSON.stringify(data),
-                function(result, status, req) {
-                    \$("#preMerge").fadeOut(); \$("#postMerge").fadeIn();
-                },
-                "json"
-            );
-            */
-
-            \$.ajax({
-                url: "/authors/merge.json",
-                type: "POST",
-                data: JSON.stringify(data),
-                success: function(data, textStatus, XMLHttpRequest) {
-                    \$("#preMerge").fadeOut();
-                    \$("#postMerge").fadeIn();
-                },
-                error: function(XMLHttpRequest, textStatus, errorThrown) {
-                    \$("#preMerge").fadeOut();
-                    \$("#errorMerge").fadeIn();
-                }
-            });
-        }
-    });
-    //-->
-    </script>
 
 $# Most authors are people, so only use org in the exceptional case that
 $# the record explicitly is labelled as such.
@@ -95,7 +56,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
     $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
        <div class="message" style="display: none;">
-            <div id="preMerge" style="display: none;">
+            <div id="preMerge" style="display: none;" data-keys="$dumps({'master': page.key, 'duplicates': query_param('duplicates', '')})">
                 <p class="larger collapse"><strong>$_('Merging Authors...')</strong></p>
                 <p class="collapse adjust"><img src="/images/ajax-loader-bar.gif" width="220" height="19" alt="$_('In progress...')"/></p>
                 <p class="smaller lightgreen collapse">$_('Duplicates')</p>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -55,14 +55,14 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 <div id="contentBody">
 
     $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
-       <div class="message" style="display: none;">
-            <div id="preMerge" style="display: none;" data-keys="$dumps({'master': page.key, 'duplicates': query_param('duplicates', '')})">
+        $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]
+        <div class="message" style="display: none;">
+            <div id="preMerge" style="display: none;" data-keys="$dumps({'master': page.key, 'duplicates': duplicates})">
                 <p class="larger collapse"><strong>$_('Merging Authors...')</strong></p>
                 <p class="collapse adjust"><img src="/images/ajax-loader-bar.gif" width="220" height="19" alt="$_('In progress...')"/></p>
                 <p class="smaller lightgreen collapse">$_('Duplicates')</p>
                 <p class="small collapse">
                     <ul>
-                        $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]
                         $for key in duplicates:
                              $ doc = get_document(key)
                              $if doc:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes openlibrary/templates/type/author/view.html point from #4474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Move inline JavaScript from type/author/view.html template to index.js and merge.js.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 