### PR TITLE
Remove inline JS from templates/history.html

### DIFF
--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -51,7 +51,7 @@ $ rev = page.latest_revision or page.revision
                     <td class="comment">$:render_template("history/comment", v)</td>
                     <td class="compare" style="text-align:center;">
                         <input type="radio" id="a$v.revision" name="a" title="Compare this version..." value="$v.revision"
-                        $if v.revision == rev-1:
+                        $if v.revision == rev - 1:
                             checked
                         $elif v.revision == rev:
                             checked

--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -12,6 +12,8 @@ $else:
 
 $var title: $name
 
+$ rev = page.latest_revision or page.revision
+
 <div id="contentHead">
     $:macros.databarHistory(page)
     <span class="lightgreen smallest sansserif">$_("History of edits to")</span>
@@ -48,9 +50,17 @@ $var title: $name
                         <td class="history" style="vertical-align: top;">$v.ip</td>
                     <td class="comment">$:render_template("history/comment", v)</td>
                     <td class="compare" style="text-align:center;">
-                        <input type="radio" id="a$v.revision" name="a" title="Compare this version..." value="$v.revision"/>
+                        <input type="radio" id="a$v.revision" name="a" title="Compare this version..." value="$v.revision"
+                        $if v.revision == rev-1:
+                            checked
+                        $elif v.revision == rev:
+                            checked
+                        />
                         &nbsp;&nbsp;&nbsp;
-                        <input type="radio" id="b$v.revision" name="b" title="...to this version" value="$v.revision"/>
+                        <input type="radio" id="b$v.revision" name="b" title="...to this version" value="$v.revision"
+                        $if v.revision == rev:
+                            checked
+                        />
                     </td>
                 </tr>
             <tr>
@@ -64,19 +74,6 @@ $var title: $name
         <input type="hidden" name="m" value="diff"/>
 
         </form>
-
-        <script type="text/javascript">
-            $ rev = page.latest_revision or page.revision
-            var a = document.getElementById("a${rev - 1}");
-            var a2 = document.getElementById("a$rev");
-            var b = document.getElementById("b$rev");
-
-            if (a)
-                a.checked = true;
-            else
-                a2.checked = true;
-            b.checked = true;
-        </script>
 
         <div class="sansserif">
         $ page = safeint(query_param("page", "0"))


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #4474 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Use non JS method instead of inline JS
### Technical
<!-- What should be noted about the implementation? -->
It basically selects two latest revision radio inputs (a10 and b11) and if only one revision is present then it selects (a1, b1)
![image](https://user-images.githubusercontent.com/64412143/120500914-d1814c80-c3de-11eb-8638-3603ac89d912.png)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/64412143/120510629-3e004980-c3e7-11eb-9328-d4c0621bf75d.png)
![image](https://user-images.githubusercontent.com/64412143/120510709-51abb000-c3e7-11eb-8c1f-e4c7b90b1201.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 