### PR TITLE
Fix reading list flash on book page load

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -232,7 +232,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
       </div>
     </div>
     <ul id="already-lists" class="listLists">
-        $:render_already_lists(lists, user_key)
+      $:render_already_lists(lists, user_key)
     </ul>
 
 $jsdef render_widget_display(lists, limit, user_key):

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -231,7 +231,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
       </div>
     </div>
     <ul id="already-lists" class="listLists">
-      $:render_already_lists(lists, user_key)
+      
     </ul>
 
 $jsdef render_widget_display(lists, limit, user_key):

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -106,7 +106,8 @@ $jsdef render_my_lists(lists, property):
            
 $jsdef render_already_lists(lists, user_key):
     $for list in lists:
-        $:show_list(list, user_key)
+        $if list['active']:
+            $:show_list(list, user_key)
 
 $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, username, pageurl, readinglogonly, use_work, user_key):
     <div class="dropit">
@@ -231,7 +232,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
       </div>
     </div>
     <ul id="already-lists" class="listLists">
-      
+        $:render_already_lists(lists, user_key)
     </ul>
 
 $jsdef render_widget_display(lists, limit, user_key):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5108

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects issue in which all of a patron's lists are briefly displayed under the reading log button on book page load.

### Technical
<!-- What should be noted about the implementation? -->
All lists are briefly displayed due to a call to `render_already_lists` in the template.  This function is later called via Javascript, rendering only lists containing the page's book, which replaced the list.

Removing the initial `render_already_lists` call prevents the flash, and likely improves page performance.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a patron with multiple reading lists:
1. Find a book that is in at least on of your reading lists, but not in all of the lists.
2. Navigate to that book's page.
3. Verify that all of the lists are not briefly displayed on page load.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Page refresh before code change:**
![flash-before](https://user-images.githubusercontent.com/28732543/120552572-6aa36980-c3c5-11eb-9472-419abfa147f3.gif)

**Page refresh after code change:**
![flash-after](https://user-images.githubusercontent.com/28732543/120552660-83138400-c3c5-11eb-8f43-c25dc626d7ee.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 