### PR TITLE
Hoist image on authors page above the editions list on mobile view

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -81,14 +81,8 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 <p class="small collapse">$_("That merge didn't work. It's our fault, and we've made a note of it.")</p>
             </div>
         </div>
-
-    <div class="contentTwothird" style="margin-bottom:0;">
-
-        <div class="illustration author-image">
-            $:render_template("covers/author_photo", page)
-            $:render_template("covers/change", page, ".bookCover img")
-        </div>
-
+    <div class="authorContent">
+    <div class="contentTwothird author-description">
         <div itemprop="description">
             $:format(page.get('bio', ''))
         </div>
@@ -104,8 +98,10 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 <h6 class="collapse black uppercase">$_("Location")</h6>
                 $page.location
             </div>
+    </div>    
 
-        <div class="clearfix"></div>
+    <div class="contentTwothird" style="margin-bottom:0;">
+        
         <div id="works" class="section">
                 <h2 class="collapse">
                     $ungettext("1 work", "%(count)d works", books.num_found, count=books.num_found)
@@ -140,11 +136,13 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
         </div>
     </div>
+
+    <div class="illustration author-image">
+        $:render_template("covers/author_photo", page)
+        $:render_template("covers/change", page, ".bookCover img")
+    </div>
+
     <div class="contentOnethird">
-        <div class="illustration author-image-desktop">
-            $:render_template("covers/author_photo", page)
-            $:render_template("covers/change", page, ".bookCover img")
-        </div>
 
         $def render_subjects(label, subjects, prefix):
             $if subjects:
@@ -201,6 +199,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     </ul>
                 </div>
 
+    </div>
     </div>
 
     $:render_template("lib/history", page)

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -84,6 +84,11 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
     <div class="contentTwothird" style="margin-bottom:0;">
 
+        <div class="illustration author-image">
+            $:render_template("covers/author_photo", page)
+            $:render_template("covers/change", page, ".bookCover img")
+        </div>
+
         <div itemprop="description">
             $:format(page.get('bio', ''))
         </div>
@@ -136,7 +141,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
         </div>
     </div>
     <div class="contentOnethird">
-        <div class="illustration">
+        <div class="illustration author-image-desktop">
             $:render_template("covers/author_photo", page)
             $:render_template("covers/change", page, ".bookCover img")
         </div>

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -205,6 +205,17 @@ tr.table-row.selected{
   padding: 20px;
   border-radius: 5px;
 }
+.author-image {
+  display: none;
+}
+@media only screen and (max-width: @width-breakpoint-desktop) {
+  .author-image {
+    display: block;
+  }
+  .author-image-desktop {
+    display: none;
+  }
+}
 
 // Import all common components
 @import (less) "legacy.less";

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -205,15 +205,16 @@ tr.table-row.selected{
   padding: 20px;
   border-radius: 5px;
 }
-.author-image {
-  display: none;
-}
 @media only screen and (max-width: @width-breakpoint-desktop) {
-  .author-image {
-    display: block;
+  .authorContent {
+    display: flex;
+    flex-direction: column;
   }
-  .author-image-desktop {
-    display: none;
+  .author-description {
+    order: -2;
+  }
+  .author-image {
+    order: -1;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The image being part of `contentOnethird` was placed below the works section for width<960px
### Technical
<!-- What should be noted about the implementation? -->
Issue: Authors Page (mobile view)
![image](https://user-images.githubusercontent.com/64412143/120798185-9c016e00-c55a-11eb-89d4-c19445bc686f.png)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Solution:
Mobile View:
![image](https://user-images.githubusercontent.com/64412143/120880976-56d94c80-c5eb-11eb-9d88-9f1a342322cb.png)
Desktop View:
![image](https://user-images.githubusercontent.com/64412143/120881209-33170600-c5ed-11eb-80e9-5182a2cb49fe.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
