### PR TITLE
Add preview buttons to search results

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -105,6 +105,9 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
   $else:
     <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
 
+$elif ocaid:
+  $:macros.BookPreview(ocaid)
+
 $else:
   <div class="cta-button-group">
     <a href="$work_key" class="cta-btn cta-btn--missing"

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -105,7 +105,7 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
   $else:
     <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
 
-$elif ocaid:
+$elif ocaid and not (secondary_action and availability.get('is_printdisabled')):
   $:macros.BookPreview(ocaid)
 
 $else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Displays a preview button if a book has an OCAID, but is not lendable nor readable.  Preview button is displayed even if patron is logged out.

### Technical
<!-- What should be noted about the implementation? -->
Check for OCAID is placed after the donate button eligibility check.  By this point in the checks it has been established that the book is neither readable nor lendable.

A second preview button may be displayed in the databar.  If this occurs, we may have to add an additional `not secondary_action` check to the new edition.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
