### PR TITLE
Fix CI failing due to PPA 404 & various JS lint failures

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,6 +24,7 @@ jobs:
           key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
       - name: Install dependencies
         run: |
+          sudo apt-get update
           # https://lxml.de/installation.html#requirements
           sudo apt-get install libxml2-dev libxslt-dev
           pip install --upgrade pip setuptools wheel

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "123KB"
+      "maxSize": "124KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -292,7 +292,7 @@ export function initEdit() {
             $(fieldname).trigger('focus');
         }
         else {
-            $('#tabsAddbook > div:visible :input:first').trigger('focus');
+            $('#tabsAddbook > div:visible :input').first().trigger('focus');
         }
         $(window).scrollTop($('#contentHead').offset().top);
     }, 1000);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5278

### Technical
PPAs are often outdated as a result of not running apt-get update; not sure why this randomly started breaking though :/

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
