### PR TITLE
Use template partial for dropdown menus

### DIFF
--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -3,11 +3,11 @@
 # @property {string|null} href of link for HTTP get request
 # @property {string|null} post when set will be used instead of href and should use HTTP POST request.
 #
-# @param Object props template properties
-# @param string props.name unique identifying name for dropdown and distinguishing it from other dropdowns
-# @param string props.label for menu, also used as alt text for dropdown icon when props.image is set
-# @param string|null props.image URL for image (optional)
-# @param DropdownLink[] props.links
+# @param {Object} props template properties
+# @param {string} props.name unique identifying name for dropdown and distinguishing it from other dropdowns
+# @param {string} props.label for menu, also used as alt text for dropdown icon when props.image is set
+# @param {string|null} props.image URL for image (optional)
+# @param {DropdownLink[]} props.links
 $def with (props)
 <div class="$(props['name'])-component header-dropdown">
     <details>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -9,6 +9,16 @@
 # @param {string|null} props.image URL for image (optional)
 # @param {DropdownLink[]} props.links
 $def with (props)
+$# @typedef {Object} DropdownLink
+$# @property {string} text of link
+$# @property {string|null} href of link for HTTP get request
+$# @property {string|null} post when set will be used instead of href and should use HTTP POST request.
+$#
+$# @param {Object} props template properties
+$# @param {string} props.name unique identifying name for dropdown and distinguishing it from other dropdowns
+$# @param {string} props.label for menu, also used as alt text for dropdown icon when props.image is set
+$# @param {string|null} props.image URL for image (optional)
+$# @param {DropdownLink[]} props.links
 <div class="$(props['name'])-component header-dropdown">
     <details>
       <summary>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -1,3 +1,13 @@
+# @typedef {Object} DropdownLink
+# @property {string} text of link
+# @property {string|null} href of link for HTTP get request
+# @property {string|null} post when set will be used instead of href and should use HTTP POST request.
+#
+# @param Object props template properties
+# @param string props.name unique identifying name for dropdown and distinguishing it from other dropdowns
+# @param string props.label for menu, also used as alt text for dropdown icon when props.image is set
+# @param string|null props.image URL for image (optional)
+# @param DropdownLink[] props.links
 $def with (props)
 <div class="$(props['name'])-component header-dropdown">
     <details>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -1,13 +1,3 @@
-# @typedef {Object} DropdownLink
-# @property {string} text of link
-# @property {string|null} href of link for HTTP get request
-# @property {string|null} post when set will be used instead of href and should use HTTP POST request.
-#
-# @param {Object} props template properties
-# @param {string} props.name unique identifying name for dropdown and distinguishing it from other dropdowns
-# @param {string} props.label for menu, also used as alt text for dropdown icon when props.image is set
-# @param {string|null} props.image URL for image (optional)
-# @param {DropdownLink[]} props.links
 $def with (props)
 $# @typedef {Object} DropdownLink
 $# @property {string} text of link

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -1,0 +1,27 @@
+$def with (props)
+<div class="$(props['name'])-component header-dropdown">
+    <details>
+      <summary>
+        $if 'image' in props:
+            <img class="header-dropdown__icon" src="$(props['image'])" alt="$(props['label'])"/>
+        $elif 'label' in props:
+            $(props['label'])
+            <span class="shift">$_('Menu')</span>
+
+        <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
+      </summary>
+      <div class="$(props['name'])-dropdown-component navigation-dropdown-component">
+        <ul class="dropdown-menu $(props['name'])-dropdown-menu">
+          $for link in props['links']:
+            <li>
+            $if 'post' in link:
+              <form action="$(link['post'])" method="post">
+                <button>$(link["text"])</button>
+              </form>
+            $else:
+              <a href="$(link['href'])">$(link['text'])</a>
+            </li>
+        </ul>
+      </div>
+    </details>
+</div>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,27 +1,28 @@
 $def with (page)
 
 <header id="header-bar" class="header-bar">
-  <div class="hamburger-component header-dropdown">
-
-    <details>
-      <summary>
-        <img src="/static/images/menu.png" alt="additional options menu"/>
-      </summary>
-      <div class="hamburger-dropdown-component navigation-dropdown-component">
-        <ul class="dropdown-menu hamburger-dropdown-menu">
-          $if not ctx.user:
-            <li><a href="/account/login">$_("Log in")</a></li>
-            <li><a href="/account/create">$_("Sign up")</a></li>
-
-          <li><a href="/books/add">$_("Add a Book")</a></li>
-          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
-          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
-          <li><a href="/developers">$_("Developer Center")</a></li>
-          <li><a href="/help">$_("Help & Support")</a></li>
-        </ul>
-      </div>
-    </details>
-  </div>
+  $if not ctx.user:
+    $ loginLinks = []
+  $else:
+    $ loginLinks = [
+    $     { "href": "/account/login", "text": _("Log in") },
+    $     { "href": "/account/create", "text": _("Sign up") }
+    $ ]
+  $ moreLinks = [
+  $     { "href": "/books/add", "text": _("Add a Book") },
+  $     { "href": "/sponsorship", "text": _("Sponsor a Book") },
+  $     { "href": "/collections", "text": _("Collections") },
+  $     { "href": "/recentchanges", "text": _("Recent Community Edits") },
+  $     { "href": "/developers", "text": _("Developer Center") },
+  $     { "href": "/help", "text": _("Help & Support") }
+  $ ]
+  $ hamburgerProps = {
+  $  'name': 'hamburger',
+  $   'links': loginLinks + moreLinks, # todo add links
+  $  'image': '/static/images/menu.png',
+  $  'label': 'additional options menu'
+  $ }
+  $:render_template("lib/header_dropdown", hamburgerProps )
 
   <div class="logo-component">
     <a href="/" title="$_('The Internet Archive\'s Open Library: One page for every book')">
@@ -33,44 +34,27 @@ $def with (page)
     </a>
   </div>
 
+  $ browseProps = {
+  $   'name': 'browse',
+  $   'label': _('Browse'),
+  $   'links': [
+  $     { "href": "/subjects", "text": _("Subjects") },
+  $     { "href": "/lists", "text": _("Lists") },
+  $     { "href": "/collections", "text": _("Collections") },
+  $     { "href": "/k-12", "text": _("K-12 Student Library") },
+  $     { "href": "/random", "text": _("Random Book") },
+  $     { "href": "/advancedsearch", "text": _("Advanced Search") }
+  $   ]
+  $ }
+
+  $ moreProps = {
+  $   'name': 'more',
+  $   'label': _('More'),
+  $   'links': moreLinks
+  $ }
   <ul class="navigation-component">
-    <li class="browse-menu header-dropdown">
-      <details>
-        <summary>
-          $_('Browse') 
-          <span class="shift">$_('Menu')</span>
-          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
-        </summary>
-        <div class="navigation-dropdown-component">
-          <ul class="dropdown-menu browse-menu-options">
-            <li><a href="/subjects">$_("Subjects")</a></li>
-            <li><a href="/lists">$_("Lists")</a></li>
-            <li><a href="/collections">$_("Collections")</a></li>
-            <li><a href="/k-12">$_("K-12 Student Library")</a></li>
-            <li><a href="/random">$_("Random Book")</a></li>
-            <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
-          </ul>
-        </div>
-      </details>
-    </li>
-    <li class="more-menu header-dropdown">
-      <details>
-        <summary>
-          $_('More') 
-          <span class="shift">$_('Menu')</span>
-          <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
-        </summary>
-        <div class="navigation-dropdown-component">
-          <ul class="dropdown-menu more-menu-options">
-            <li><a href="/books/add">$_("Add a Book")</a></li>
-            <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
-            <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
-            <li><a href="/developers">$_("Developer Center")</a></li>
-            <li><a href="/help">$_("Help & Support")</a></li>
-          </ul>
-        </div>
-      </details>
-    </li>
+    <li>$:render_template("lib/header_dropdown", browseProps )</li>
+    <li>$:render_template("lib/header_dropdown", moreProps )</li>
   </ul>
 
   <div class="search-component">
@@ -112,29 +96,19 @@ $def with (page)
     </ul>
 
   $if ctx.user:
-    <div class="account-component header-dropdown">
-      <details>
-        <summary>
-          <div class="dropdown-avatar">        
-            <div class="avatar dropdown-button" id="userToggle" aria-expanded="false" aria-label="My account" style="background-image: url('https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))');"></div>
-            <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" role="presentation" alt=""/>
-          </div>
-        </summary>
-        <div class="account-dropdown navigation-dropdown-component" id="main-account-dropdown">
-          <ul class="dropdown-menu">
-            <li><a href="$ctx.user.key">$_("My Profile")</a></li>
-            <li><a href="$homepath()/account/loans">$_("My Loans")</a></li>
-            <li><a href="$ctx.user.key/lists">$_("My Lists")</a></li>
-            <li><a href="/account/books">$_("My Reading Log")</a></li>
-            <li><a href="/account/books/already-read/stats">$_("My Reading Stats")</a></li>
-            <li><a href="$homepath()/account">$_("Settings")</a></li>
-            <li>
-              <form name="logout" action="/account/logout" method="post">
-                <a href="#" onclick="document.forms['logout'].submit()">$_("Log out")</a>
-              </form>
-            </li>
-          </ul>
-        </div>
-      </details>
-    </div>
+    $ accountProps = {
+    $   'name': 'account',
+    $   'label': 'My account',
+    $   'image': 'https://archive.org/services/img/' + get_internet_archive_id(ctx.user.key),
+    $   'links': [
+    $     { "href": ctx.user.key, "text": _("My Profile") },
+    $     { "href": homepath() + "/account/loans", "text": _("My Loans") },
+    $     { "href": ctx.user.key + "/lists", "text": _("My Lists") },
+    $     { "href": "/account/books", "text": _("My Reading Log") },
+    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats") },
+    $     { "href": homepath() + "/account", "text": _("Settings") },
+    $     { "post": "/account/logout", "text": _("Log out") }
+    $   ]
+    $ }
+    $:render_template("lib/header_dropdown", accountProps )</li>
 </header>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 <header id="header-bar" class="header-bar">
-  $if not ctx.user:
+  $if ctx.user:
     $ loginLinks = []
   $else:
     $ loginLinks = [
@@ -18,7 +18,7 @@ $def with (page)
   $ ]
   $ hamburgerProps = {
   $  'name': 'hamburger',
-  $   'links': loginLinks + moreLinks, # todo add links
+  $  'links': loginLinks + moreLinks,
   $  'image': '/static/images/menu.png',
   $  'label': 'additional options menu'
   $ }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -139,13 +139,16 @@
       border: none;
     }
 
-    /*  Technical/design debt: For unknown historic reasons the hamburger button does not have an arrow to the right of the icon,
-    but the profile icon does. This is likely an accessibility or UX problem.
-    
-    There's an argument to be made that this should be visible for consistency with other dropdown menus and to better
-    meet user expectations which might expect the hamburger to load a menu overlaying the screen as is consistent with other designs.
+    /*  Technical/design debt: For unknown historic reasons the hamburger button does not have an
+    arrow to the right of the icon, but the profile icon does. This is likely an accessibility
+    or UX problem.
 
-    When OpenLibrary has a design lead, this should be understood and either reviewed or better documented. */
+    There's an argument to be made that this should be visible for consistency with other dropdown
+    menus and to better meet user expectations which might expect the hamburger to load a menu
+    overlaying the screen as is consistent with other designs.
+
+    When OpenLibrary has a design lead, this should be understood and either reviewed or better
+    documented. */
     .down-arrow {
         display: none;
     }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -150,7 +150,7 @@
     When OpenLibrary has a design lead, this should be understood and either reviewed or better
     documented. */
     .down-arrow {
-        display: none;
+      display: none;
     }
   }
 

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -138,6 +138,17 @@
       background: transparent;
       border: none;
     }
+
+    /*  Technical/design debt: For unknown historic reasons the hamburger button does not have an arrow to the right of the icon,
+    but the profile icon does. This is likely an accessibility or UX problem.
+    
+    There's an argument to be made that this should be visible for consistency with other dropdown menus and to better
+    meet user expectations which might expect the hamburger to load a menu overlaying the screen as is consistent with other designs.
+
+    When OpenLibrary has a design lead, this should be understood and either reviewed or better documented. */
+    .down-arrow {
+        display: none;
+    }
   }
 
   .header-dropdown {

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -36,17 +36,11 @@
     -ms-flex-order: 3;
     order: 3;
 
-    a {
-      color: @white;
-      text-decoration: none;
-      display: block;
-    }
-
     .down-arrow {
       margin-top: 1px;
     }
 
-    .account-dropdown {
+    .account-dropdown-component {
       position: absolute;
       text-align: right;
       // Note, it must be padding so that the gap between the icon and
@@ -81,6 +75,7 @@
       // stylelint-enable declaration-block-no-duplicate-properties
 
       // stylelint-disable-next-line max-nesting-depth
+      button,
       a {
         color: @dark-grey;
       }
@@ -112,6 +107,7 @@
         background-color: @white;
       }
 
+      button,
       a {
         text-decoration: none;
         color: @dark-grey;
@@ -142,11 +138,22 @@
       background: transparent;
       border: none;
     }
+  }
 
-    img {
-      width: 44px;
-      height: 44px;
+  .header-dropdown {
+    .header-dropdown__icon {
+      width: 45px;
+      height: 45px;
       padding: 0 3px;
+    }
+
+    button,
+    a {
+      color: @white;
+      text-decoration: none;
+      display: block;
+      border: 0;
+      background: none;
     }
   }
 
@@ -190,6 +197,7 @@
       font-size: 1em;
 
       // stylelint-disable max-nesting-depth, selector-max-specificity
+      button,
       a {
         color: @dark-grey;
         text-decoration: none;
@@ -422,21 +430,20 @@ div.search-facet:focus-within {
   summary::marker {
     content: "";
   }
+}
 
-  .dropdown-avatar {
+.hamburger-component,
+.account-component {
+  summary {
     .display-flex();
     -webkit-box-align: center;
     -ms-flex-align: center;
     align-items: center;
-    .avatar {
+    .header-dropdown__icon {
       border: none;
       margin-right: 5px;
-      background-size: cover;
-      background-position: center;
-      width: 45px;
-      height: 45px;
-      background-color: @mid-grey;
       border-radius: 3px;
+      box-sizing: content-box;
     }
   }
 }


### PR DESCRIPTION
Fixes: #5248

### Technical

Follow up to #5181, makes dropdown component a template partial. This will allow us to experiment with using Vue.js in a follow up, and results in more standardized HTML between the different menus.

### Testing
* Should be no noticeable UI regression between this patch and the last
* Notice the arrow to the right of the hamburger which adds consistency with the other menus and their functions.

### Screenshot
<img width="952" alt="Screen Shot 2021-06-08 at 7 50 56 PM" src="https://user-images.githubusercontent.com/148752/121285223-d9d00080-c892-11eb-9e3b-a2858c048bdc.png">

### Stakeholders
@cdrini @Yashs911 

