### PR TITLE
Change layout of saved image modal

### DIFF
--- a/openlibrary/templates/covers/saved.html
+++ b/openlibrary/templates/covers/saved.html
@@ -2,30 +2,30 @@ $def with (image, showinfo=True)
 
 $putctx("cssfile", "form")
 
-<div class="imagePost">
-    $if image:
-        <img src="$image.url(size='M')" class="cover" alt="New book cover"/>
-</div>
+<div class="saved-image-container">
+    <div class="imagePost">
+        $if image:
+            <img src="$image.url(size='M')" class="cover" width="200" alt="New book cover"/>
+    </div>
 
-<div class="imageSaved" data-image-id="$(image and image.id)">
-    <div class="saved">$_("Saved!")</div>
-    <div class="meta">
-        $if showinfo:
-            <strong>$_("Notes:")</strong><br/>
-            $ d = image.info()
-            $if d:
-                $if d.author:
-                    Uploaded by <a href="$d.author.key">$d.author.name</a> on $format_date(d.created)<br/>
-                $else:
-                    Uploaded anonymously on $datestr(d.created)<br/>
-                $if d.source_url:
-                    <a href="$d.source_url">$d.source_url</a><br/>
-            <br/>
-        <a href="$changequery()">$_("Add another image")</a>?
+    <div class="imageSaved" data-image-id="$(image and image.id)">
+        <div class="saved">$_("Saved!")</div>
+        <div class="meta">
+            $if showinfo:
+                <strong>$_("Notes:")</strong><br/>
+                $ d = image.info()
+                $if d:
+                    $if d.author:
+                        Uploaded by <a href="$d.author.key">$d.author.name</a> on $format_date(d.created)<br/>
+                    $else:
+                        Uploaded anonymously on $datestr(d.created)<br/>
+                    $if d.source_url:
+                        <a href="$d.source_url">$d.source_url</a><br/>
+                <br/>
+            <a href="$changequery()">$_("Add another image")</a>?
+        </div>
     </div>
 </div>
-
-<div class="clearfix"></div>
 
 <div class="formButtons">
     <button type="button" name="finished" id="popClose" value="Finished" class="largest">$_("Finished")</button>

--- a/static/css/page-form.less
+++ b/static/css/page-form.less
@@ -90,12 +90,10 @@ footer,
   padding: .4em;
 }
 .imagePost {
-  float: left;
   width: 300px;
   text-align: center;
 }
 .imageSaved {
-  float: left;
   width: 300px;
   font-size: .75em;
   color: @grey;
@@ -108,6 +106,9 @@ footer,
   padding: 6px 0 0 40px;
   min-height: 30px;
   margin: 25px 0 15px;
+}
+.saved-image-container {
+  display: flex;
 }
 
 @media all and ( min-width: @width-breakpoint-desktop ) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4889

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects issue in which the "Finished" button overlaps links in the saved image modal.

### Technical
<!-- What should be noted about the implementation? -->
Image div and upload information div were nested within a div having `display: flex`.  Removed floats from both of the nested divs.  The `clearfix` div was removed from the template. A width attribute of `200` was added to the image.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Attempt to upload an image.  Upon success, ensure that none of the modal text is overlapped by any other elements in the view.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![book-saved-flex](https://user-images.githubusercontent.com/28732543/121397929-cf5d4780-c922-11eb-94b0-56d1fae542ee.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
