### PR TITLE
Use appropriately sized cover images in add covers modal

### DIFF
--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -34,7 +34,7 @@ $if status:
                         <div class="carousel-section">
                             <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
                                 <div id="popcovers" class="carousel carousel--progressively-enhanced"
-                                    data-config="$json_encode(['#popcovers', 4, 4, 4, 3, 2, 1])">
+                                    data-config="$json_encode(['#popcovers', 3, 3, 3, 3, 2, 1])">
                                 $for cover in doc.get_edition_covers():
                                     <div class="book carousel__item" data-id="$cover.id">
                                         <div class="book-cover">

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -34,7 +34,7 @@ $if status:
                         <div class="carousel-section">
                             <div id="covers" class="carousel-container carousel-container-decorated carousel--minimal">
                                 <div id="popcovers" class="carousel carousel--progressively-enhanced"
-                                    data-config="$json_encode(['#popcovers'])">
+                                    data-config="$json_encode(['#popcovers', 4, 4, 4, 3, 2, 1])">
                                 $for cover in doc.get_edition_covers():
                                     <div class="book carousel__item" data-id="$cover.id">
                                         <div class="book-cover">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5217

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sets the maximum number of covers displayed at once in the add covers modal carousel to three.

### Technical
<!-- What should be noted about the implementation? -->
Explicitly passes number of books to be displayed to Carousel initialization function.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![add-cover-3-max](https://user-images.githubusercontent.com/28732543/121442030-cd15e000-c958-11eb-9540-347b6a7bbf83.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 