### PR TITLE
Fix analytics pageview event being sent with wrong service

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -63,6 +63,10 @@ window.$ = jQuery;
 
 window.Promise = Promise;
 
+// This to the best of our knowledge needs to be run synchronously,
+// because it sends the initial pageview to analytics.
+initAnalytics();
+
 // Initialise some things
 jQuery(function () {
     const $markdownTextAreas = $('textarea.markdown');
@@ -83,7 +87,6 @@ jQuery(function () {
     }
     bookReaderInit($);
     jQueryRepeat($);
-    initAnalytics($);
     init($);
     // conditionally load functionality based on what's in the page
     if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {

--- a/openlibrary/plugins/openlibrary/js/ol.analytics.js
+++ b/openlibrary/plugins/openlibrary/js/ol.analytics.js
@@ -3,9 +3,6 @@
 *
 * Depends on Archive.org analytics.js function archive_analytics.send_ping()
 *
-* Usage:
-*     $("select#role").add_new_field({href: "#role-popup"});
-*
 */
 
 export default function initAnalytics() {
@@ -44,4 +41,9 @@ export default function initAnalytics() {
         });
     }
     window.vs = vs;
+
+    // NOTE: This might cause issues if this script is made async #4474
+    window.addEventListener('DOMContentLoaded', function send_analytics_pageview() {
+        window.archive_analytics.send_pageview({});
+    });
 }

--- a/openlibrary/templates/site/footer.html
+++ b/openlibrary/templates/site/footer.html
@@ -17,18 +17,10 @@ $if cssfile == 'user' or 'admin':
         $:render_template("site/stats")
     $:render_template("lib/nav_foot", page)
 
-    <script src="$static_url('build/all.js')" type="text/javascript"></script>
-    <!-- Must be loaded after jquery -->
     <script src="//archive.org/includes/analytics.js?v=0c15bbe" type="text/javascript"></script>
+    <script src="$static_url('build/all.js')" type="text/javascript"></script>
     <!-- Passes total_time for analytics to ol.analytics.js -->
     <div class="analytics-stats-time-calculator" data-time="$total_time"></div>
-
-    <script>
-    //anonymized analytics
-    window.addEventListener('DOMContentLoaded', function send_analytics_pageview() {
-        archive_analytics.send_pageview({});
-    });
-    </script>
 
     $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books', '/contact']]):
         <!-- Must be loaded in Sign Up and Add new Books page -->


### PR DESCRIPTION
Closes #5255 

Fix; ensure sendpageview sent after archive_analytics properly configured by ol.analytics.js. Note this might result in some of our server time metrics being a little longer.

### Technical
- It looks like analytics.js no longer uses jquery! So don't need to order those in that way.

### Testing
- ✅ Locally, pageview event fires with service=ol
- ✅ On testing, pageview event fires with service=ol

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jdlrobson 
