### PR TITLE
primes Carousel.js to work w/ Lists + fixes existing bugs

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -175,7 +175,7 @@ const Carousel = {
                         url: url,
                         type: 'GET',
                         success: function(results) {
-                            var works = results.works || results.docs;
+                            const works = results.works || results.docs;
                             $.each(works, function(work_idx) {
                                 var work = works[work_idx];
                                 var lastSlidePos = $(`${selector}.slick-slider`)

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -77,22 +77,36 @@ const Carousel = {
             open: {cls: 'cta-btn--available', cta: 'Read'},
             borrow_available: {cls: 'cta-btn--available', cta: 'Borrow'},
             borrow_unavailable: {cls: 'cta-btn--unavailable', cta: 'Join Waitlist'},
-            error: {cls: 'cta-btn--missing', cta: 'Not In Library'}
+            error: {cls: 'cta-btn--missing', cta: 'Not In Library'},
+            private: {cls: 'cta-btn--available', cta: 'Preview'}
         };
 
         addWork = function(work) {
-            var availability = work.availability.status;
-            var ocaid = work.availability.identifier;
-            var cover = {
+            let availability = work.availability || {};
+            let ocaid = availability.identifier ||
+                work.lending_identifier_s ||
+                work.ia ? work.ia[0] : undefined;
+            let openlibrary_edition = availability.openlibrary_edition ||
+                work.lending_edition_s || undefined;
+            // Use solr data to augment availability API
+            if (!availability.status || availability.status === 'error') {
+                if (work.lending_identifier_s) {
+                    availability.status = 'borrow_available';
+                } else if (ocaid) {
+                    availability.status = 'private';
+                }
+            }
+            let cover = {
                 type: 'id',
                 id: work.covers ? work.covers[0] : work.cover_id || work.cover_i
             };
-            var cls = availabilityStatuses[availability].cls;
-            var url = (cls == 'cta-btn--available') ?
+            let availabilityStatus = availabilityStatuses[availability.status];
+            let cls = availabilityStatus.cls;
+            let cta = availabilityStatus.cta;
+            let url = (cls == 'cta-btn--available') ?
                 (`/borrow/ia/${ocaid}`) : (cls == 'cta-btn--unavailable') ?
-                    (`/books/${work.availability.openlibrary_edition}`) : work.key;
-            var cta = availabilityStatuses[availability].cta;
-            var isClickable = availability == 'error' ? 'disabled' : '';
+                    (`/books/${openlibrary_edition}`) : work.key;
+            let isClickable = availability.status == 'error' ? 'disabled' : '';
 
             if (!cover.id && ocaid) {
                 cover.type = 'ia';
@@ -160,11 +174,8 @@ const Carousel = {
                     $.ajax({
                         url: url,
                         type: 'GET',
-                        success: function(subject_results) {
-                            var works = subject_results.works;
-                            if (!works) {
-                                works = subject_results.docs;
-                            }
+                        success: function(results) {
+                            var works = results.works || results.docs;
                             $.each(works, function(work_idx) {
                                 var work = works[work_idx];
                                 var lastSlidePos = $(`${selector}.slick-slider`)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Upgrades our Carousel.js loadmore functionality to be more robust to values returned by API.

### Technical
<!-- What should be noted about the implementation? -->

This fixes cases where:

1. our availability API returns `status: private` e.g. https://archive.org/services/availability?identifier=Hello.
2. prevents breakage when `book` doesn't have an `identifier` / `ocaid`
3. improves availability accuracy by looking for additional fields for availability options

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Existing carousels should work without much change. @seabelis may have noticed some carousels which **don't** have `ocaid`s (e.g. Not In Library) likely break existing carousels when we try to Load More pages via ajax. This should be solved.

This PR is also a pre-requisite for passing list keys to `QueryCarousels`

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @jamesachamp 