### PR TITLE
Bug Fix account.py public_my_books_json to handle bad author data

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -802,8 +802,8 @@ class public_my_books_json(delegate.page):
                     {
                         'title': w.get('title'),
                         'key': w.key,
-                        'author_keys': [a.author.key for a in w.get('authors', [])],
-                        'author_names': [a.author.name for a in w.get('authors', [])],
+                        'author_keys': [a.key for a in w.get_authors()],
+                        'author_names': w.get_author_names() or None,
                         'first_publish_year': w.first_publish_year or None,
                         'lending_edition_s': (w._solr_data and
                                               w._solr_data.get('lending_edition_s') or


### PR DESCRIPTION
hotfix

### Technical
Now uses get_authors() and get_author_names() methods on Work to get cleaner author data and avoid serialization errors.

### Testing
Load http://testing.openlibrary.org/people/seabelis/books/already-read.json?limit=1&page=62&debug=true

### Stakeholders
@mheiman @mekarpeles 
