### PR TITLE
Performance improvement for account.py public_my_books_json()

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -802,8 +802,9 @@ class public_my_books_json(delegate.page):
                     {
                         'title': w.get('title'),
                         'key': w.key,
-                        'author_keys': [a.key for a in w.get_authors()],
-                        'author_names': w.get_author_names() or None,
+                        'author_keys': [a.author.key for a in w.get('authors', [])],
+                        'author_names': [str(a.author.name) for a
+                                         in w.get('authors', [])],
                         'first_publish_year': w.first_publish_year or None,
                         'lending_edition_s': (w._solr_data and
                                               w._solr_data.get('lending_edition_s') or


### PR DESCRIPTION
### Technical
Rather than using get_authors() and get_author_names(), which generate a lot of server calls and are bad for performance, use the raw author keys but explicitly convert the author name into a string. The Nothing object which is causing serialization problems in this field should return an empty string.

### Testing
http://testing.openlibrary.org/people/seabelis/books/already-read.json?limit=1&page=62&debug=true

should continue to load after applying the change (just faster)

### Stakeholders
@mheiman @mekarpeles 
