### PR TITLE
List + Solr work_key powered QueryCarousel

### DIFF
--- a/openlibrary/macros/ListCarousel.html
+++ b/openlibrary/macros/ListCarousel.html
@@ -1,0 +1,11 @@
+$def with (list_key, title=None, key='', limit=20, has_fulltext_only=True, url=None)
+
+$# Takes following parameters
+$# * list_key (str) -- A list key e.g. /people/mekBot/lists/OL104041L
+$# * title (str) -- A title to show above the carousel (links to /search?q=query)
+$# * key (str) -- unique name of the carousel in analytics
+$# * limit (int) -- initial number of books to pull
+$# * has_fulltext_only (bool) -- only include readable titles
+$# * url (str) -- whether to make title a link to url
+
+$:macros.QueryCarousel(query=list_key, title=title, key=key, limit=limit, has_fulltext_only=has_fulltext_only, url=url)

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -19,7 +19,7 @@ $if search:
   </form>
 
 $code:
-  params = { 'q': query }
+  params = { 'q': query, 'fields': '*,availability' }
   url = url or "/search?" + urlencode(params)
   if has_fulltext_only:
     params['has_fulltext'] = 'true'

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -245,7 +245,7 @@ class list_view_json(delegate.page):
         i = web.input()
         raw = i.get("_raw") == "true"
         lst = get_list(key, raw=raw)
-        if not lst or lst.type.key == '/type/delete':
+        if not lst or lst['type']['key'] == '/type/delete':
             raise web.notfound()
         web.header("Content-Type", self.content_type)
         return delegate.RawText(formats.dump(lst, self.encoding))

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -207,24 +207,11 @@ class lists_yaml(lists_json):
     encoding = "yml"
     content_type = "text/yaml"
 
-class list_view_json(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)"
-    encoding = "json"
-    content_type = "application/json"
-
-    def GET(self, key):
-        lst = web.ctx.site.get(key)
-        if not lst or lst.type.key == '/type/delete':
-            raise web.notfound()
-
-        i = web.input()
-        if i.get("_raw") == "true":
-            return delegate.RawText(self.dumps(lst.dict()))
-
-        data = self.get_list_data(lst)
-        return delegate.RawText(self.dumps(data))
-
-    def get_list_data(self, lst):
+def get_list(key, raw=False):
+    lst = web.ctx.site.get(key)
+    if lst:
+        if raw:
+            return lst.dict()
         return {
             "links": {
                 "self": lst.key,
@@ -233,7 +220,10 @@ class list_view_json(delegate.page):
                 "editions": lst.key + "/editions",
             },
             "name": lst.name or None,
-            "description": lst.description and six.text_type(lst.description) or None,
+            "description": (
+                lst.description and six.text_type(lst.description)
+                or None
+            ),
             "seed_count": len(lst.seeds),
             "edition_count": lst.edition_count,
 
@@ -244,28 +234,30 @@ class list_view_json(delegate.page):
             }
         }
 
-    def dumps(self, data):
+class list_view_json(delegate.page):
+    path = r"(/people/[^/]+/lists/OL\d+L)"
+    encoding = "json"
+    content_type = "application/json"
+
+    def GET(self, key):
+        i = web.input()
+        raw = i.get("_raw") == "true"
+        lst = get_list(key, raw=raw)
+        if not lst or lst.type.key == '/type/delete':
+            raise web.notfound()
         web.header("Content-Type", self.content_type)
-        return formats.dump(data, self.encoding)
+        return delegate.RawText(formats.dump(lst, self.encoding))
 
 class list_view_yaml(list_view_json):
     encoding = "yml"
     content_type = "text/yaml"
 
-class list_seeds(delegate.page):
-    path = r"(/people/\w+/lists/OL\d+L)/seeds"
-    encoding = "json"
-
-    content_type = "application/json"
-
-    def GET(self, key):
-        lst = web.ctx.site.get(key)
-        if not lst:
-            raise web.notfound()
-
+@public
+def get_list_seeds(key):
+    lst = web.ctx.site.get(key)
+    if lst:
         seeds = [seed.dict() for seed in lst.get_seeds()]
-
-        data = {
+        return {
             "links": {
                 "self": key + "/seeds",
                 "list": key
@@ -274,8 +266,17 @@ class list_seeds(delegate.page):
             "entries": seeds
         }
 
-        text = formats.dump(data, self.encoding)
-        return delegate.RawText(text)
+class list_seeds(delegate.page):
+    path = r"(/people/\w+/lists/OL\d+L)/seeds"
+    encoding = "json"
+
+    content_type = "application/json"
+
+    def GET(self, key):
+        lst = get_list_seeds(key)
+        if not lst:
+            raise web.notfound()
+        return delegate.RawText(formats.dump(lst, self.encoding))
 
     def POST(self, key):
         site = web.ctx.site
@@ -323,31 +324,23 @@ class list_seed_yaml(list_seeds):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'
 
-
-class list_editions(delegate.page):
-    """Controller for displaying lists of a seed or lists of a person.
-    """
-    path = r"(/people/\w+/lists/OL\d+L)/editions"
-
-    def is_enabled(self):
-        return "lists" in web.ctx.features
-
-    def GET(self, path):
-        lst = web.ctx.site.get(path)
-        if not lst:
-            raise web.notfound()
-
-        i = web.input(limit=50, page=1)
-        limit = h.safeint(i.limit, 50)
-        page = h.safeint(i.page, 1) - 1
-        offset = page * limit
-
-        editions = lst.get_editions(limit=limit, offset=offset)
-
-        lst.preload_authors(editions['editions'])
-        lst.load_changesets(editions['editions'])
-
-        return render_template("type/list/editions.html", lst, editions)
+@public
+def get_list_editions(key, offset=0, limit=50, api=False):
+    lst = web.ctx.site.get(key)
+    if lst:
+        offset = offset or 0  # enforce sane int defaults
+        all_editions = lst.get_editions(limit=limit, offset=offset, _raw=True)
+        editions = all_editions['editions'][offset:offset+limit]
+        if api:
+            entries = [e.dict() for e in editions if e.pop("seeds") or e]
+            return make_collection(
+                size=all_editions['count'],
+                entries=entries,
+                limit=limit,
+                offset=offset,
+                key=key
+            )
+        return editions
 
 class list_editions_json(delegate.page):
     path = r"(/people/\w+/lists/OL\d+L)/editions"
@@ -356,38 +349,26 @@ class list_editions_json(delegate.page):
     content_type = "application/json"
 
     def GET(self, key):
-        lst = web.ctx.site.get(key)
-        if not lst:
-            raise web.notfound()
-
         i = web.input(limit=50, offset=0)
-
         limit = h.safeint(i.limit, 50)
         offset = h.safeint(i.offset, 0)
-
-        editions = lst.get_editions(limit=limit, offset=offset, _raw=True)
-
-        data = make_collection(
-            size=editions['count'],
-            entries=[self.process_edition(e) for e in editions['editions']],
-            limit=limit,
-            offset=offset
+        editions = get_list_editions(key, offset=offset, limit=limit, api=True)
+        if not editions:
+            raise web.notfound()
+        return delegate.RawText(
+            formats.dump(editions, self.encoding),
+            content_type=self.content_type
         )
-        data['links']['list'] = key
-        text = formats.dump(data, self.encoding)
-        return delegate.RawText(text, content_type=self.content_type)
-
-    def process_edition(self, e):
-        e.pop("seeds", None)
-        return e
 
 class list_editions_yaml(list_editions_json):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'
 
-def make_collection(size, entries, limit, offset):
+def make_collection(size, entries, limit, offset, key=None):
     d = {
         "size": size,
+        "start": offset,
+        "end": offset + limit,
         "entries": entries,
         "links": {
             "self": web.changequery(),
@@ -399,6 +380,9 @@ def make_collection(size, entries, limit, offset):
 
     if offset:
         d['links']['prev'] = web.changequery(limit=limit, offset=max(0, offset-limit))
+
+    if key:
+        d['links']['list'] = key
 
     return d
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -203,9 +203,11 @@ class lists_json(delegate.page):
     def loads(self, text):
         return formats.load(text, self.encoding)
 
+
 class lists_yaml(lists_json):
     encoding = "yml"
     content_type = "text/yaml"
+
 
 def get_list(key, raw=False):
     lst = web.ctx.site.get(key)
@@ -221,8 +223,7 @@ def get_list(key, raw=False):
             },
             "name": lst.name or None,
             "description": (
-                lst.description and six.text_type(lst.description)
-                or None
+                lst.description and six.text_type(lst.description) or None
             ),
             "seed_count": len(lst.seeds),
             "edition_count": lst.edition_count,
@@ -233,6 +234,7 @@ def get_list(key, raw=False):
                 "last_modified": lst.last_modified.isoformat(),
             }
         }
+
 
 class list_view_json(delegate.page):
     path = r"(/people/[^/]+/lists/OL\d+L)"
@@ -248,9 +250,11 @@ class list_view_json(delegate.page):
         web.header("Content-Type", self.content_type)
         return delegate.RawText(formats.dump(lst, self.encoding))
 
+
 class list_view_yaml(list_view_json):
     encoding = "yml"
     content_type = "text/yaml"
+
 
 @public
 def get_list_seeds(key):
@@ -265,6 +269,7 @@ def get_list_seeds(key):
             "size": len(seeds),
             "entries": seeds
         }
+
 
 class list_seeds(delegate.page):
     path = r"(/people/\w+/lists/OL\d+L)/seeds"
@@ -320,9 +325,11 @@ class list_seeds(delegate.page):
         web.header("Content-Type", self.content_type)
         return delegate.RawText(formats.dump(d, self.encoding))
 
+
 class list_seed_yaml(list_seeds):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'
+
 
 @public
 def get_list_editions(key, offset=0, limit=50, api=False):
@@ -342,6 +349,7 @@ def get_list_editions(key, offset=0, limit=50, api=False):
             )
         return editions
 
+
 class list_editions_json(delegate.page):
     path = r"(/people/\w+/lists/OL\d+L)/editions"
     encoding = "json"
@@ -360,9 +368,11 @@ class list_editions_json(delegate.page):
             content_type=self.content_type
         )
 
+
 class list_editions_yaml(list_editions_json):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'
+
 
 def make_collection(size, entries, limit, offset, key=None):
     d = {
@@ -385,6 +395,7 @@ def make_collection(size, entries, limit, offset, key=None):
         d['links']['list'] = key
 
     return d
+
 
 class list_subjects_json(delegate.page):
     path = r"(/people/\w+/lists/OL\d+L)/subjects"
@@ -426,9 +437,11 @@ class list_subjects_json(delegate.page):
             "url": key
         }
 
+
 class list_editions_yaml(list_subjects_json):
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'
+
 
 class lists_embed(delegate.page):
     path = r"(/people/\w+/lists/OL\d+L)/embed"
@@ -438,6 +451,7 @@ class lists_embed(delegate.page):
         if doc is None or doc.type.key != '/type/list':
             raise web.notfound()
         return render_template("type/list/embed", doc)
+
 
 class export(delegate.page):
     path = r"(/people/\w+/lists/OL\d+L)/export"

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -222,6 +222,7 @@ def get_list(key, raw=False):
                 "editions": lst.key + "/editions",
             },
             "name": lst.name or None,
+            "type": { "key": lst.key },
             "description": (
                 lst.description and six.text_type(lst.description) or None
             ),

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -222,7 +222,7 @@ def get_list(key, raw=False):
                 "editions": lst.key + "/editions",
             },
             "name": lst.name or None,
-            "type": { "key": lst.key },
+            "type": {"key": lst.key},
             "description": (
                 lst.description and six.text_type(lst.description) or None
             ),

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -657,7 +657,7 @@ class Work(models.Work):
                     is_ascii(subject))) and
                 all([char not in subject for char in blacklist_chars])):
                 ok_subjects.append(subject)
-        return ok_subjects        
+        return ok_subjects
 
     def get_related_books_subjects(self, filter_unicode=True):
         return self.filter_problematic_subjects(self.get_subjects(), filter_unicode)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1008,6 +1008,7 @@ def random_author_search(limit=10):
 
     return json.dumps(search_results['response'])
 
+
 def rewrite_list_editions_query(q, page, offset, limit):
     """Takes a solr query. If it doesn't contain a /lists/ key, then
     return the query, unchanged, exactly as it entered the
@@ -1045,7 +1046,12 @@ def work_search(query, sort=None, page=1, offset=0, limit=100, fields='*', facet
         sort = process_sort(sort)
 
     # deal with special /lists/ key queries
-    query['q'], page, offset, limit = rewrite_list_editions_query(query['q'], page, offset, limit)
+    query['q'], page, offset, limit = rewrite_list_editions_query(
+        query['q'],
+        page,
+        offset,
+        limit
+    )
     try:
         (reply, solr_select, q_list) = run_solr_query(
             query,
@@ -1106,14 +1112,25 @@ class search_json(delegate.page):
 
         # If the query is a /list/ key, create custom list_editions_query
         q = query['q']
-        query['q'], page, offset, limit = rewrite_list_editions_query(q, page, offset, limit)
-
-        response = work_search(query, sort=sort, page=page, offset=offset, limit=limit,
-                               fields=fields, facet=facet,
-                               spellcheck_count=spellcheck_count)
+        query['q'], page, offset, limit = rewrite_list_editions_query(
+            q,
+            page,
+            offset,
+            limit
+        )
+        response = work_search(
+            query,
+            sort=sort,
+            page=page,
+            offset=offset,
+            limit=limit,
+            fields=fields,
+            facet=facet,
+            spellcheck_count=spellcheck_count
+        )
         response['q'] = q
         response['offset'] = offset
-        response['docs'] = add_availability(response['docs'])
+        response['docs'] = response['docs']
         web.header('Content-Type', 'application/json')
         return delegate.RawText(json.dumps(response, indent=4))
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows List keys to be passed to `QueryCarousel` macro to power carousels

### Technical
<!-- What should be noted about the implementation? -->

This PR extends `QueryCarousel` so a list key may be provided, such as `/people/mekBot/lists/OL104041L/` and the when https://github.com/internetarchive/openlibrary/compare/master...list-querycarousel#diff-a6072af04af429689c35331c2a4a35fa2c23317099533cc2161ef6d8ba79df90R1034 is called, the list will be expanded into a set of work_keys which are *then* passed through to solr.

Note: The limit and offset are necessarily for paging through the List, but we **don't** want the limit and offset to be applied to solr because solr is going to receive a discrete list of work_ids (from the already paginated/offset List) and we want to return all of these works from solr. 

Will likely be unnecessary once/if Lists are in solr

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Adding a `{{ QueryParam("/people/mekBot/lists/OL104041L/") }}` (please check syntax) macro somewhere not too public (e.g. user profile page) should do the trick once this code is on testing. 
 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Will add once it's on testing

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @seabelis 
