### PR TITLE
Solrbuilder/Solrupdater improvements in prep for Solr 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ load_sample_data:
 	curl http://localhost:8080/_dev/process_ebooks # hack to show books in returncart
 
 reindex-solr:
-	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web:8080/ -c conf/openlibrary.yml --data-provider=legacy
-	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py -s http://web:8080/ -c conf/openlibrary.yml --data-provider=legacy
+	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/books/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py --ol-url http://web:8080/ --ol-config conf/openlibrary.yml --data-provider=legacy
+	psql --host db openlibrary -t -c 'select key from thing' | sed 's/ *//' | grep '^/authors/' | PYTHONPATH=$(PWD) xargs python openlibrary/solr/update_work.py --ol-url http://web:8080/ --ol-config conf/openlibrary.yml --data-provider=legacy
 
 lint-diff:
 	git diff "$${BASE_BRANCH:-master}" -U0 | ./scripts/flake8-diff.sh

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -11,7 +11,7 @@ import requests
 import sys
 import time
 
-from httpx import RequestError, HTTPStatusError
+from httpx import RequestError, HTTPStatusError, ReadTimeout
 from six.moves.urllib.parse import urlparse
 from collections import defaultdict
 from unicodedata import normalize
@@ -1174,6 +1174,8 @@ def solr8_update(
             'resp': resp.content,
             'status_code': resp.status_code
         })
+    except ReadTimeout:
+        logger.warning('ReadTimeout during solr8 POST update')
 
 
 def process_edition_data(edition_data):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -929,7 +929,7 @@ async def solr_insert_documents(
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             f'{solr_base_url}/update',
-            timeout=30,  # The default timeout is silly short
+            timeout=30,  # seconds; the default timeout is silly short
             params=params,
             headers={'Content-Type': 'application/json'},
             content=json.dumps(documents)
@@ -1148,7 +1148,11 @@ def solr8_update(
         skip_id_check=False,
         solr_base_url: str = None,
 ) -> None:
-    """This will replace solr_update once we're fully on Solr 8.7+"""
+    """
+    This will replace solr_update once we're fully on Solr 8.7+
+
+    :param commit_within: milliseconds
+    """
     req_strs = (r if type(r) == str else r.toxml() for r in reqs if r)  # type: ignore
     # .toxml() can return None :/
     content = f"<update>{''.join(s for s in req_strs if s)}</update>"  # type: ignore
@@ -1540,6 +1544,8 @@ def update_keys(keys,
                     print(ET.tostring(root, encoding='unicode'))
                 else:
                     print(str(xml_str)[:100])
+        elif update == 'quiet':
+            pass
 
     global data_provider
     global _ia_db

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1602,7 +1602,7 @@ def update_keys(keys,
     data_provider.preload_editions_of_works(wkeys)
 
     # update works
-    requests = []
+    requests = []  # type: list[Union[UpdateRequest, DeleteRequest, str]]
     requests += [DeleteRequest(deletes)]
     for k in wkeys:
         logger.debug("updating work %s", k)

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1677,8 +1677,6 @@ def update_keys(keys,
             requests += ['<commit />']
         _solr_update(requests, debug=True)
 
-    # Caches should not persist between different calls to update_keys!
-    data_provider.clear_cache()
     logger.debug("END update_keys")
 
 

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -11,7 +11,7 @@ import requests
 import sys
 import time
 
-from httpx import RequestError, HTTPStatusError, ReadTimeout
+from httpx import HTTPError
 from six.moves.urllib.parse import urlparse
 from collections import defaultdict
 from unicodedata import normalize
@@ -1168,14 +1168,8 @@ def solr8_update(
             headers={'Content-Type': 'application/xml'},
             content=content)
         resp.raise_for_status()
-    except (RequestError, HTTPStatusError):
-        logger.error('Error with solr8 POST update', extra={
-            'content': content,
-            'resp': resp.content,
-            'status_code': resp.status_code
-        })
-    except ReadTimeout:
-        logger.warning('ReadTimeout during solr8 POST update')
+    except HTTPError:
+        logger.error('Error with solr8 POST update')
 
 
 def process_edition_data(edition_data):

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -181,6 +181,9 @@ def update_keys(keys):
         count += len(chunk)
         update_work.do_updates(chunk)
 
+        # Caches should not persist between different calls to update_keys!
+        update_work.data_provider.clear_cache()
+
     if count:
         logger.info("updated %d documents", count)
 

--- a/scripts/solr_builder/Jenkinsfile
+++ b/scripts/solr_builder/Jenkinsfile
@@ -200,7 +200,7 @@ pipeline {
                   when { expression { return params.INDEX_WORKS } }
                   steps {
                     dir(env.HOST_SOLR_BUILDER_DIR) {
-                      sh "./index-type.sh work ${params.MAX_CORES} works"
+                      sh "CHUNK_ETA=70 ./index-type.sh work ${params.MAX_CORES} works"
                       solr_commit('solr')
                     }
                   }

--- a/scripts/solr_builder/Jenkinsfile
+++ b/scripts/solr_builder/Jenkinsfile
@@ -200,7 +200,7 @@ pipeline {
                   when { expression { return params.INDEX_WORKS } }
                   steps {
                     dir(env.HOST_SOLR_BUILDER_DIR) {
-                      sh "CHUNK_ETA=70 ./index-type.sh work ${params.MAX_CORES} works"
+                      sh "CHUNK_ETA=70 docker-compose run --name ol_run_works --rm -T ol ./index-type.sh work ${params.MAX_CORES} works"
                       solr_commit('solr')
                     }
                   }
@@ -211,7 +211,7 @@ pipeline {
                         sh '''tail --quiet -n1 $(ls -tr progress/works/*) | gzip > progress/works-progress.txt.gz'''
                         archiveArtifacts artifacts: "progress/works-progress.txt.gz"
                         // Save Log Files
-                        sh '''for name in $(ls logs/works); do docker logs ${name/.txt/} 2>&1; done | gzip > logs/works-indexing.log.gz'''
+                        sh '''cat $(ls -tr logs/works/*) | gzip > logs/works-indexing.log.gz'''
                         archiveArtifacts artifacts: "logs/works-indexing.log.gz"
                       }
                     }
@@ -221,7 +221,7 @@ pipeline {
                   when { expression { return params.INDEX_ORPHANS } }
                   steps {
                     dir(env.HOST_SOLR_BUILDER_DIR) {
-                      sh "CHUNK_ETA=35 ./index-type.sh orphan ${params.MAX_CORES} orphans"
+                      sh "CHUNK_ETA=35 docker-compose run --name ol_run_orphans --rm -T ol ./index-type.sh orphan ${params.MAX_CORES} orphans"
                       solr_commit('solr')
                     }
                   }
@@ -232,7 +232,7 @@ pipeline {
                         sh '''tail --quiet -n1 $(ls -tr progress/orphans/*) | gzip > progress/orphans-progress.txt.gz'''
                         archiveArtifacts artifacts: "progress/orphans-progress.txt.gz"
                         // Save Log Files
-                        sh '''for name in $(ls logs/orphans); do docker logs ${name/.txt/} 2>&1; done | gzip > logs/orphans-indexing.log.gz'''
+                        sh '''cat $(ls -tr logs/orphans/*) | gzip > logs/orphans-indexing.log.gz'''
                         archiveArtifacts artifacts: "logs/orphans-indexing.log.gz"
                       }
                     }
@@ -244,7 +244,7 @@ pipeline {
                     dir(env.HOST_SOLR_BUILDER_DIR) {
                       sh """
                       for subject_type in subject person place time; do
-                        docker-compose run --name ol_run_subjects_\$subject_type -T ol \
+                        docker-compose run --name ol_run_subjects_\$subject_type --rm -T ol \
                           python ./solr_builder/index_subjects.py \
                             \$subject_type \
                             --chunk-size 10000 \
@@ -261,7 +261,7 @@ pipeline {
                   when { expression { return params.INDEX_AUTHORS } }
                   steps {
                     dir(env.HOST_SOLR_BUILDER_DIR) {
-                      sh "./index-type.sh author ${params.MAX_CORES} authors"
+                      sh "docker-compose run --name ol_run_authors --rm -T ol ./index-type.sh author ${params.MAX_CORES} authors"
                       solr_commit('solr')
                     }
                   }
@@ -271,8 +271,8 @@ pipeline {
                         // Save Progress Files
                         sh '''tail --quiet -n1 $(ls -tr progress/authors/*) | gzip > progress/authors-progress.txt.gz'''
                         archiveArtifacts artifacts: "progress/authors-progress.txt.gz"
-                        // Save Logs Files
-                        sh '''for name in $(ls logs/authors); do docker logs ${name/.txt/} 2>&1; done | gzip > logs/authors-indexing.log.gz'''
+                        // Save Log Files
+                        sh '''cat $(ls -tr logs/authors/*) | gzip > logs/authors-indexing.log.gz'''
                         archiveArtifacts artifacts: "logs/authors-indexing.log.gz"
                       }
                     }

--- a/scripts/solr_builder/index-type.sh
+++ b/scripts/solr_builder/index-type.sh
@@ -20,19 +20,22 @@ next_start="//"
 runner_id=0
 
 while [ $done != "true" ]; do
-  runners=$(docker container ls -q -f "name=ol_run" | wc -l)
+  # Need to also exclude the grep command; that's what the -v is for.
+  runners=$(ps aux | grep -F 'solr_builder.py index' | grep -v grep | wc -l)
   while [ $((runners < INSTANCES)) = "1" ] && [ $done != "true" ]; do
     # Actually start the job
     RUN_SIG="ol_run_${TYPE}s_${runner_id}"
     ((runner_id++))
     mkdir -p {logs,progress}/$LOG_DIR
     touch {logs,progress}/$LOG_DIR/$RUN_SIG.txt
-    DOCKER_IMAGE_NAME=$RUN_SIG docker_solr_builder index "${TYPE}s" \
+    # Run in parallel in a subshell
+    (&>"logs/$LOG_DIR/$RUN_SIG.txt" python solr_builder/solr_builder.py index "${TYPE}s" \
       --start-at "/$next_start" \
       --limit $CHUNK_SIZE \
-      --progress "progress/$LOG_DIR/$RUN_SIG.txt"
+      --progress "progress/$LOG_DIR/$RUN_SIG.txt" \
+    &)
 
-    next_start=$(docker-compose run --rm ol python solr_builder/solr_builder.py fetch-end "${TYPE}s" --start-at "/$next_start" --limit $CHUNK_SIZE)
+    next_start=$(python solr_builder/solr_builder.py fetch-end "${TYPE}s" --start-at "/$next_start" --limit $CHUNK_SIZE)
     if [ "$next_start" = "" ]; then done="true"; fi
 
     # Stagger starting of the runners so they don't all request a lot of
@@ -42,15 +45,15 @@ while [ $done != "true" ]; do
     # number of desired instances. Otherwise we'll have fewer running.
     if [ $done != "true" ]; then sleep $((CHUNK_ETA / INSTANCES)); fi
 
-    runners=$(docker container ls -q -f "name=ol_run" | wc -l)
+    runners=$(ps aux | grep -F 'solr_builder.py index' | grep -v grep | wc -l)
   done;
 
   if [ $done != "true" ]; then sleep 30; fi
 done
 
 # Now that we're done, wait for any trailing runners to finish up.
-runners=$(docker container ls -q -f "name=ol_run" | wc -l)
+runners=$(ps aux | grep -F 'solr_builder.py index' | grep -v grep | wc -l)
 while [ $((runners > 0)) = "1" ]; do
   sleep 30
-  runners=$(docker container ls -q -f "name=ol_run" | wc -l)
+  runners=$(ps aux | grep -F 'solr_builder.py index' | grep -v grep | wc -l)
 done

--- a/scripts/solr_builder/solr_builder/fn_to_cli.py
+++ b/scripts/solr_builder/solr_builder/fn_to_cli.py
@@ -85,7 +85,7 @@ class FnToCLI:
 
     @staticmethod
     def parse_docs(docs):
-        params = docs.strip().split(':param ')
+        params = docs.strip().split(':param ')[1:]
         params = [p.strip() for p in params]
         params = [p.split(':', 1) for p in params if p]
         return {
@@ -100,6 +100,8 @@ class FnToCLI:
             return {'type': typ, 'action': BooleanOptionalAction}
         if typ in (int, str, float):
             return {'type': typ}
+        if typ == list[str]:
+            return {'nargs': '*'}
         if not hasattr(typ, '__origin__'):
             raise ValueError(f'Cannot determine type of {typ}')
         if typ.__origin__ == typing.Literal:

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -666,7 +666,8 @@ async def main(
                 db.ia_cache.update(db2.ia_cache)
                 db.cached_work_editions_ranges += db2.cached_work_editions_ranges
 
-            update_keys(keys, commit=False, commit_way_later=True)
+            update_keys(keys, commit=False, commit_way_later=True, solr8=True,
+                        skip_id_check=True)
 
             seen += len(keys)
             plog.update(


### PR DESCRIPTION
Extracted from #4337 . Various improvments to perf / error handling to solrbuilder and friends. Solr builder at this point should be considered Solr 8 only. I recommend reviewing commit by commit; easier that way.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
The most recent full solr reindex was run with this code -- excluding last commit, and the fact that it was run on an older master.

Otherwise:
- ✅ Tested solr updater works correctly in local env with Solr 3
- ✅ Tested solr updater does not cache between update_keys calls (last commit)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
