### PR TITLE
 Fix header bar missing for local dev env when logged in 

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -100,7 +100,10 @@ $def with (page)
       accountProps = {
         'name': 'account',
         'label': 'My account',
-        'image': 'https://archive.org/services/img/' + get_internet_archive_id(ctx.user.key),
+        # It seems like in the local dev environment (and presumably _only_ in the local
+        # dev environment), this get_internet_archive_id returns None. Setting it to an
+        # empty string returns a valid image ¯\_(ツ)_/¯
+        'image': 'https://archive.org/services/img/' + (get_internet_archive_id(ctx.user.key) or ''),
         'links': [
           { "href": ctx.user.key, "text": _("My Profile") },
           { "href": homepath() + "/account/loans", "text": _("My Loans") },

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -96,19 +96,20 @@ $def with (page)
     </ul>
 
   $if ctx.user:
-    $ accountProps = {
-    $   'name': 'account',
-    $   'label': 'My account',
-    $   'image': 'https://archive.org/services/img/' + get_internet_archive_id(ctx.user.key),
-    $   'links': [
-    $     { "href": ctx.user.key, "text": _("My Profile") },
-    $     { "href": homepath() + "/account/loans", "text": _("My Loans") },
-    $     { "href": ctx.user.key + "/lists", "text": _("My Lists") },
-    $     { "href": "/account/books", "text": _("My Reading Log") },
-    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats") },
-    $     { "href": homepath() + "/account", "text": _("Settings") },
-    $     { "post": "/account/logout", "text": _("Log out") }
-    $   ]
-    $ }
-    $:render_template("lib/header_dropdown", accountProps )</li>
+    $code:
+      accountProps = {
+        'name': 'account',
+        'label': 'My account',
+        'image': 'https://archive.org/services/img/' + get_internet_archive_id(ctx.user.key),
+        'links': [
+          { "href": ctx.user.key, "text": _("My Profile") },
+          { "href": homepath() + "/account/loans", "text": _("My Loans") },
+          { "href": ctx.user.key + "/lists", "text": _("My Lists") },
+          { "href": "/account/books", "text": _("My Reading Log") },
+          { "href": "/account/books/already-read/stats", "text": _("My Reading Stats") },
+          { "href": homepath() + "/account", "text": _("Settings") },
+          { "post": "/account/logout", "text": _("Log out") }
+        ]
+      }
+    $:render_template("lib/header_dropdown", accountProps )
 </header>


### PR DESCRIPTION
Hotfix extension of #5287 . Looks like get_internet_archive_id can return `None` in local dev! 🙃 

### Technical
- Recommend going commit by commit; the first commit is just a formatting change.

### Testing
- Tested locally; header bar appears :+1:

### Screenshot
![image](https://user-images.githubusercontent.com/6251786/122592674-9c0d6d80-d032-11eb-8ed9-9535027c8d34.png)


### Stakeholders
@jdlrobson @jamesachamp 
