### PR TITLE
Add ability to the user to filter lists by date added

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -117,8 +117,9 @@ class Bookshelves(object):
         return dict([(i['bookshelf_id'], i['count']) for i in result]) if result else {}
 
     @classmethod
-    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1, 
-                               sort: Literal['created asc', 'created desc'] = 'created desc'):
+    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1,
+                               sort: Literal['created asc', 'created desc'] =
+                               'created desc'):
         """Returns a list of Reading Log database records for books which
         the user has logged. Records are described in core/schema.py
         and include:
@@ -139,7 +140,7 @@ class Bookshelves(object):
             'offset': limit * (page - 1),
             'bookshelf_id': bookshelf_id
         }
-        if sort =='created desc':
+        if sort == 'created desc':
             query = ("SELECT * from bookshelves_books WHERE "
                      "bookshelf_id=$bookshelf_id AND username=$username "
                      "ORDER BY created DESC "

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -117,7 +117,8 @@ class Bookshelves(object):
         return dict([(i['bookshelf_id'], i['count']) for i in result]) if result else {}
 
     @classmethod
-    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1, sort: Literal['created asc', 'created desc'] = 'created desc'):
+    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1, 
+                               sort: Literal['created asc', 'created desc'] = 'created desc'):
         """Returns a list of Reading Log database records for books which
         the user has logged. Records are described in core/schema.py
         and include:
@@ -138,19 +139,19 @@ class Bookshelves(object):
             'offset': limit * (page - 1),
             'bookshelf_id': bookshelf_id
         }
-        if sort=='created desc':
+        if sort =='created desc':
             query = ("SELECT * from bookshelves_books WHERE "
-                    "bookshelf_id=$bookshelf_id AND username=$username "
-                    "ORDER BY created DESC "
-                    "LIMIT $limit OFFSET $offset")
+                     "bookshelf_id=$bookshelf_id AND username=$username "
+                     "ORDER BY created DESC "
+                     "LIMIT $limit OFFSET $offset")
         else:
             query = ("SELECT * from bookshelves_books WHERE "
-                    "bookshelf_id=$bookshelf_id AND username=$username "
-                    "ORDER BY created ASC "
-                    "LIMIT $limit OFFSET $offset")
+                     "bookshelf_id=$bookshelf_id AND username=$username "
+                     "ORDER BY created ASC "
+                     "LIMIT $limit OFFSET $offset")
         if bookshelf_id is None:
             query = ("SELECT * from bookshelves_books WHERE "
-                "username=$username")
+                     "username=$username")
             # XXX Removing limit, offset, etc from data looks like a bug
             # unrelated / not fixing in this PR.
             data = { 'username': username }

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -129,65 +129,35 @@ class Bookshelves(object):
         created (datetime) - date the book was logged
 
         """
+        oldb = db.get_db()
+        page = int(page) if page else 1
+        data = {
+            'username': username,
+            'limit': limit,
+            'offset': limit * (page - 1),
+            'bookshelf_id': bookshelf_id
+        }
         if date_added is None:
-            oldb = db.get_db()
-            page = int(page) if page else 1
-            data = {
-                'username': username,
-                'limit': limit,
-                'offset': limit * (page - 1),
-                'bookshelf_id': bookshelf_id
-            }
             query = ("SELECT * from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
                     "LIMIT $limit OFFSET $offset")
-            if bookshelf_id is None:
-                query = ("SELECT * from bookshelves_books WHERE "
-                    "username=$username")
-                # XXX Removing limit, offset, etc from data looks like a bug
-                # unrelated / not fixing in this PR.
-                data = { 'username': username }
-            return list(oldb.query(query, vars=data))
         elif date_added=="descending":
-            oldb = db.get_db()
-            page = int(page) if page else 1
-            data = {
-                'username': username,
-                'limit': limit,
-                'offset': limit * (page - 1),
-                'bookshelf_id': bookshelf_id
-            }
             query = ("SELECT * from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
                     "ORDER BY created DESC "
                     "LIMIT $limit OFFSET $offset")
-            if bookshelf_id is None:
-                query = ("SELECT * from bookshelves_books WHERE "
-                    "username=$username")
-                # XXX Removing limit, offset, etc from data looks like a bug
-                # unrelated / not fixing in this PR.
-                data = { 'username': username }
-            return list(oldb.query(query, vars=data))
         else :
-            oldb = db.get_db()
-            page = int(page) if page else 1
-            data = {
-                'username': username,
-                'limit': limit,
-                'offset': limit * (page - 1),
-                'bookshelf_id': bookshelf_id
-            }
             query = ("SELECT * from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
                     "ORDER BY created ASC "
                     "LIMIT $limit OFFSET $offset")
-            if bookshelf_id is None:
-                query = ("SELECT * from bookshelves_books WHERE "
-                    "username=$username")
-                # XXX Removing limit, offset, etc from data looks like a bug
-                # unrelated / not fixing in this PR.
-                data = { 'username': username }
-            return list(oldb.query(query, vars=data))
+        if bookshelf_id is None:
+            query = ("SELECT * from bookshelves_books WHERE "
+                "username=$username")
+            # XXX Removing limit, offset, etc from data looks like a bug
+            # unrelated / not fixing in this PR.
+            data = { 'username': username }
+        return list(oldb.query(query, vars=data))
 
     @classmethod
     def get_users_read_status_of_work(cls, username, work_id):

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
 from . import db
@@ -116,7 +117,7 @@ class Bookshelves(object):
         return dict([(i['bookshelf_id'], i['count']) for i in result]) if result else {}
 
     @classmethod
-    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1, date_added=None):
+    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1, sort: Literal['created asc', 'created desc'] = 'created desc'):
         """Returns a list of Reading Log database records for books which
         the user has logged. Records are described in core/schema.py
         and include:
@@ -137,16 +138,12 @@ class Bookshelves(object):
             'offset': limit * (page - 1),
             'bookshelf_id': bookshelf_id
         }
-        if date_added is None:
-            query = ("SELECT * from bookshelves_books WHERE "
-                    "bookshelf_id=$bookshelf_id AND username=$username "
-                    "LIMIT $limit OFFSET $offset")
-        elif date_added=="descending":
+        if sort=='created desc':
             query = ("SELECT * from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
                     "ORDER BY created DESC "
                     "LIMIT $limit OFFSET $offset")
-        else :
+        else:
             query = ("SELECT * from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
                     "ORDER BY created ASC "

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -116,7 +116,7 @@ class Bookshelves(object):
         return dict([(i['bookshelf_id'], i['count']) for i in result]) if result else {}
 
     @classmethod
-    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1):
+    def get_users_logged_books(cls, username, bookshelf_id=None, limit=100, page=1, date_added=None):
         """Returns a list of Reading Log database records for books which
         the user has logged. Records are described in core/schema.py
         and include:
@@ -129,24 +129,65 @@ class Bookshelves(object):
         created (datetime) - date the book was logged
 
         """
-        oldb = db.get_db()
-        page = int(page) if page else 1
-        data = {
-            'username': username,
-            'limit': limit,
-            'offset': limit * (page - 1),
-            'bookshelf_id': bookshelf_id
-        }
-        query = ("SELECT * from bookshelves_books WHERE "
-                 "bookshelf_id=$bookshelf_id AND username=$username "
-                 "LIMIT $limit OFFSET $offset")
-        if bookshelf_id is None:
+        if date_added is None:
+            oldb = db.get_db()
+            page = int(page) if page else 1
+            data = {
+                'username': username,
+                'limit': limit,
+                'offset': limit * (page - 1),
+                'bookshelf_id': bookshelf_id
+            }
             query = ("SELECT * from bookshelves_books WHERE "
-                 "username=$username")
-            # XXX Removing limit, offset, etc from data looks like a bug
-            # unrelated / not fixing in this PR.
-            data = { 'username': username }
-        return list(oldb.query(query, vars=data))
+                    "bookshelf_id=$bookshelf_id AND username=$username "
+                    "LIMIT $limit OFFSET $offset")
+            if bookshelf_id is None:
+                query = ("SELECT * from bookshelves_books WHERE "
+                    "username=$username")
+                # XXX Removing limit, offset, etc from data looks like a bug
+                # unrelated / not fixing in this PR.
+                data = { 'username': username }
+            return list(oldb.query(query, vars=data))
+        elif date_added=="descending":
+            oldb = db.get_db()
+            page = int(page) if page else 1
+            data = {
+                'username': username,
+                'limit': limit,
+                'offset': limit * (page - 1),
+                'bookshelf_id': bookshelf_id
+            }
+            query = ("SELECT * from bookshelves_books WHERE "
+                    "bookshelf_id=$bookshelf_id AND username=$username "
+                    "ORDER BY created DESC "
+                    "LIMIT $limit OFFSET $offset")
+            if bookshelf_id is None:
+                query = ("SELECT * from bookshelves_books WHERE "
+                    "username=$username")
+                # XXX Removing limit, offset, etc from data looks like a bug
+                # unrelated / not fixing in this PR.
+                data = { 'username': username }
+            return list(oldb.query(query, vars=data))
+        else :
+            oldb = db.get_db()
+            page = int(page) if page else 1
+            data = {
+                'username': username,
+                'limit': limit,
+                'offset': limit * (page - 1),
+                'bookshelf_id': bookshelf_id
+            }
+            query = ("SELECT * from bookshelves_books WHERE "
+                    "bookshelf_id=$bookshelf_id AND username=$username "
+                    "ORDER BY created ASC "
+                    "LIMIT $limit OFFSET $offset")
+            if bookshelf_id is None:
+                query = ("SELECT * from bookshelves_books WHERE "
+                    "username=$username")
+                # XXX Removing limit, offset, etc from data looks like a bug
+                # unrelated / not fixing in this PR.
+                data = { 'username': username }
+            return list(oldb.query(query, vars=data))
 
     @classmethod
     def get_users_read_status_of_work(cls, username, work_id):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -712,31 +712,33 @@ class ReadingLog(object):
                 if logged_books[i]['edition_id'] else '')
         return works
 
-    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE, 
+    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE,
                          sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Want to Read'],
             page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE, 
+    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE,
                               sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Currently Reading'],
             page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE, 
+    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE,
                          sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
             page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_works(self, key, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
+    def get_works(self, key, page=1, limit=RESULTS_PER_PAGE,
+                  sort='created', sort_order='desc'):
         """
         :rtype: list of openlibrary.plugins.upstream.models.Work
         """
         key = key.lower()
         if key in self.KEYS:
-            return self.KEYS[key](page=page, limit=limit, sort=sort, sort_order=sort_order)
+            return self.KEYS[key](page=page, limit=limit,
+                                  sort=sort, sort_order=sort_order)
         else: # must be a list or invalid page!
             #works = web.ctx.site.get_many([ ... ])
             raise
@@ -770,11 +772,13 @@ class public_my_books(delegate.page):
                         'isbn_%s' % len(s['isbn']): s['isbn']
                     })[0]) for s in sponsorships)
             else:
-                books = readlog.get_works(key, page=i.page, sort='created', sort_order=i.sort)
+                books = readlog.get_works(key, page=i.page,
+                                          sort='created', sort_order=i.sort)
             return render['account/books'](
                 books, key, sponsorship_count=len(sponsorships),
                 reading_log_counts=readlog.reading_log_counts, lists=readlog.lists,
-                user=user, logged_in_user=logged_in_user, public=is_public, sort_order=str(i.sort)
+                user=user, logged_in_user=logged_in_user, public=is_public,
+                sort_order=str(i.sort)
             )
         raise web.seeother(user.key)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -712,20 +712,20 @@ class ReadingLog(object):
                 if logged_books[i]['edition_id'] else '')
         return works
 
-    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE, date_added=None):
+    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Want to Read'],
-            page=page, limit=limit, date_added=date_added))
+            page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE, date_added=None):
+    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Currently Reading'],
-            page=page, limit=limit, date_added=None))
+            page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE, date_added=None):
+    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
-            page=page, limit=limit, date_added=None))
+            page=page, limit=limit, sort=sort + ' ' + sort_order))
 
     def get_works(self, key, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
         """

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -727,13 +727,13 @@ class ReadingLog(object):
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
             page=page, limit=limit, date_added=None))
 
-    def get_works(self, key, page=1, limit=RESULTS_PER_PAGE):
+    def get_works(self, key, page=1, limit=RESULTS_PER_PAGE, date_added=None):
         """
         :rtype: list of openlibrary.plugins.upstream.models.Work
         """
         key = key.lower()
         if key in self.KEYS:
-            return self.KEYS[key](page=page, limit=limit)
+            return self.KEYS[key](page=page, limit=limit, date_added=date_added)
         else: # must be a list or invalid page!
             #works = web.ctx.site.get_many([ ... ])
             raise
@@ -751,7 +751,8 @@ class public_my_books(delegate.page):
 
     def GET(self, username, key='loans'):
         """check if user's reading log is public"""
-        i = web.input(page=1)
+        i = web.input(page=1, sort=None)
+        date_added=i.sort
         user = web.ctx.site.get('/people/%s' % username)
         if not user:
             return render.notfound("User %s"  % username, create=False)
@@ -767,11 +768,11 @@ class public_my_books(delegate.page):
                         'isbn_%s' % len(s['isbn']): s['isbn']
                     })[0]) for s in sponsorships)
             else:
-                books = readlog.get_works(key, page=i.page)
+                books = readlog.get_works(key, page=i.page, date_added=i.sort)
             return render['account/books'](
                 books, key, sponsorship_count=len(sponsorships),
                 reading_log_counts=readlog.reading_log_counts, lists=readlog.lists,
-                user=user, logged_in_user=logged_in_user, public=is_public
+                user=user, logged_in_user=logged_in_user, public=is_public, date_added=str(date_added)
             )
         raise web.seeother(user.key)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -712,17 +712,20 @@ class ReadingLog(object):
                 if logged_books[i]['edition_id'] else '')
         return works
 
-    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
+    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE, 
+                         sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Want to Read'],
             page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
+    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE, 
+                              sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Currently Reading'],
             page=page, limit=limit, sort=sort + ' ' + sort_order))
 
-    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
+    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE, 
+                         sort='created', sort_order='desc'):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
             page=page, limit=limit, sort=sort + ' ' + sort_order))

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -712,20 +712,20 @@ class ReadingLog(object):
                 if logged_books[i]['edition_id'] else '')
         return works
 
-    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE):
+    def get_want_to_read(self, page=1, limit=RESULTS_PER_PAGE, date_added=None):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Want to Read'],
-            page=page, limit=limit))
+            page=page, limit=limit, date_added=date_added))
 
-    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE):
+    def get_currently_reading(self, page=1, limit=RESULTS_PER_PAGE, date_added=None):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Currently Reading'],
-            page=page, limit=limit))
+            page=page, limit=limit, date_added=None))
 
-    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE):
+    def get_already_read(self, page=1, limit=RESULTS_PER_PAGE, date_added=None):
         return self.process_logged_books(Bookshelves.get_users_logged_books(
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
-            page=page, limit=limit))
+            page=page, limit=limit, date_added=None))
 
     def get_works(self, key, page=1, limit=RESULTS_PER_PAGE):
         """

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -727,13 +727,13 @@ class ReadingLog(object):
             self.user.get_username(), bookshelf_id=Bookshelves.PRESET_BOOKSHELVES['Already Read'],
             page=page, limit=limit, date_added=None))
 
-    def get_works(self, key, page=1, limit=RESULTS_PER_PAGE, date_added=None):
+    def get_works(self, key, page=1, limit=RESULTS_PER_PAGE, sort='created', sort_order='desc'):
         """
         :rtype: list of openlibrary.plugins.upstream.models.Work
         """
         key = key.lower()
         if key in self.KEYS:
-            return self.KEYS[key](page=page, limit=limit, date_added=date_added)
+            return self.KEYS[key](page=page, limit=limit, sort=sort, sort_order=sort_order)
         else: # must be a list or invalid page!
             #works = web.ctx.site.get_many([ ... ])
             raise
@@ -751,8 +751,7 @@ class public_my_books(delegate.page):
 
     def GET(self, username, key='loans'):
         """check if user's reading log is public"""
-        i = web.input(page=1, sort=None)
-        date_added=i.sort
+        i = web.input(page=1, sort='desc')
         user = web.ctx.site.get('/people/%s' % username)
         if not user:
             return render.notfound("User %s"  % username, create=False)
@@ -768,11 +767,11 @@ class public_my_books(delegate.page):
                         'isbn_%s' % len(s['isbn']): s['isbn']
                     })[0]) for s in sponsorships)
             else:
-                books = readlog.get_works(key, page=i.page, date_added=i.sort)
+                books = readlog.get_works(key, page=i.page, sort='created', sort_order=i.sort)
             return render['account/books'](
                 books, key, sponsorship_count=len(sponsorships),
                 reading_log_counts=readlog.reading_log_counts, lists=readlog.lists,
-                user=user, logged_in_user=logged_in_user, public=is_public, date_added=str(date_added)
+                user=user, logged_in_user=logged_in_user, public=is_public, sort_order=str(i.sort)
             )
         raise web.seeother(user.key)
 

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -1,4 +1,4 @@
-$def with (items, key, sponsorship_count=None, reading_log_counts=None, lists=None, user=None, logged_in_user=None, public=False, date_added=None)
+$def with (items, key, sponsorship_count=None, reading_log_counts=None, lists=None, user=None, logged_in_user=None, public=False, sort_order='desc')
 $# Displays a user's reading log
 $# :param list items:
 $# :param Literal['currently-reading', 'want-to-read', 'already-read', 'sponsorships', 'loans', 'waitlist'] key:
@@ -14,7 +14,7 @@ $ username = user.key.split('/')[-1]
 $ owners_page = logged_in_user and urlbase.startswith('/people/'+logged_in_user.key.split('/')[-1])
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
 
-$ date_added = date_added
+$ sort_order = sort_order
 
 $ current_page = int(input(page=1).page)
 $ total_items = sponsorship_count if key == 'sponsorships' else int(reading_log_counts[key])
@@ -67,6 +67,17 @@ $if og_title:
 
       $if owners_page:
         <a href="$ctx.path/stats" title="$('View stats about this shelf')">$_('Stats')</a>
+      
+      <span class="mytools-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
+        $if sort_order == 'desc':
+          <strong class="lightgreen">$_("Date Added (newest)")</strong>
+          |
+          <a href="$ctx.path?sort=asc">$_("Date Added (oldest)")</a>
+        $else:
+          <a href="$ctx.path?sort=desc">$_("Date Added (newest)")</a>
+          |
+          <strong class="lightgreen">$_("Date Added (oldest)")</strong>
+      </span>
     </div>
 
     $if owners_page:
@@ -101,12 +112,6 @@ $if og_title:
               $for lst in lists:
                 <li><a class="list-link" href="$(lst.key)">$lst['name'] ($(len(lst.seeds)))</a></li>
             </div>
-          </ul>
-        $if key == 'want-to-read':
-          <ul class="preset-lists">
-            <li class="subsection">$_('Sort Filters')</li>
-            <li><a href="$ctx.path?sort=descending" $('class=selected' if date_added == 'descending' else '')>$_('Newest to Oldest')</a></li>
-            <li><a href="$ctx.path?sort=ascending" $('class=selected' if date_added == 'ascending' else '')>$_('Oldest to Newest')</a></li>
           </ul>
       </div>
       <div class="mybooks-list">

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -1,4 +1,4 @@
-$def with (items, key, sponsorship_count=None, reading_log_counts=None, lists=None, user=None, logged_in_user=None, public=False)
+$def with (items, key, sponsorship_count=None, reading_log_counts=None, lists=None, user=None, logged_in_user=None, public=False, date_added=None)
 $# Displays a user's reading log
 $# :param list items:
 $# :param Literal['currently-reading', 'want-to-read', 'already-read', 'sponsorships', 'loans', 'waitlist'] key:
@@ -13,6 +13,8 @@ $ urlbase = ctx.path.rsplit('/', 1)[0]
 $ username = user.key.split('/')[-1]
 $ owners_page = logged_in_user and urlbase.startswith('/people/'+logged_in_user.key.split('/')[-1])
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
+
+$ date_added = date_added
 
 $ current_page = int(input(page=1).page)
 $ total_items = sponsorship_count if key == 'sponsorships' else int(reading_log_counts[key])
@@ -103,8 +105,8 @@ $if og_title:
         $if key == 'want-to-read':
           <ul class="preset-lists">
             <li class="subsection">$_('Sort Filters')</li>
-            <li><a href="$ctx.path/descending" $('class=selected' if key == 'descending' else '')>$_('Newest to Oldest')</a></li>
-            <li><a href="$ctx.path/ascending" $('class=selected' if key == 'ascending' else '')>$_('Oldest to Newest')</a></li>
+            <li><a href="$ctx.path?sort=descending" $('class=selected' if date_added == 'descending' else '')>$_('Newest to Oldest')</a></li>
+            <li><a href="$ctx.path?sort=ascending" $('class=selected' if date_added == 'ascending' else '')>$_('Oldest to Newest')</a></li>
           </ul>
       </div>
       <div class="mybooks-list">

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -100,6 +100,12 @@ $if og_title:
                 <li><a class="list-link" href="$(lst.key)">$lst['name'] ($(len(lst.seeds)))</a></li>
             </div>
           </ul>
+        $if key == 'want-to-read':
+          <ul class="preset-lists">
+            <li class="subsection">$_('Sort Filters')</li>
+            <li><a href="$ctx.path/descending" $('class=selected' if key == 'descending' else '')>$_('Newest to Oldest')</a></li>
+            <li><a href="$ctx.path/ascending" $('class=selected' if key == 'ascending' else '')>$_('Oldest to Newest')</a></li>
+          </ul>
       </div>
       <div class="mybooks-list">
         $:macros.Pager(current_page, total_items, results_per_page=25)

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -67,17 +67,6 @@ $if og_title:
 
       $if owners_page:
         <a href="$ctx.path/stats" title="$('View stats about this shelf')">$_('Stats')</a>
-      
-      <span class="mytools-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
-        $if sort_order == 'desc':
-          <strong class="lightgreen">$_("Date Added (newest)")</strong>
-          |
-          <a href="$ctx.path?sort=asc">$_("Date Added (oldest)")</a>
-        $else:
-          <a href="$ctx.path?sort=desc">$_("Date Added (newest)")</a>
-          |
-          <strong class="lightgreen">$_("Date Added (oldest)")</strong>
-      </span>
     </div>
 
     $if owners_page:
@@ -115,6 +104,18 @@ $if og_title:
           </ul>
       </div>
       <div class="mybooks-list">
+
+        <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
+          $if sort_order == 'desc':
+            <strong class="lightgreen">$_("Date Added (newest)")</strong>
+            |
+            <a href="$ctx.path?sort=asc">$_("Date Added (oldest)")</a>
+          $else:
+            <a href="$ctx.path?sort=desc">$_("Date Added (newest)")</a>
+            |
+            <strong class="lightgreen">$_("Date Added (oldest)")</strong>
+        </span>
+
         $:macros.Pager(current_page, total_items, results_per_page=25)
         <ul class="list-books">
           $if items:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4267

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> 
Adding a new feature for sorting the Reading Log "Want to read" list of users by the date they have added their books.

### Technical
<!-- What should be noted about the implementation? -->
Two filters added when being in the "Want to read" list, one for descending order and one for ascending.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit the Reading Log "Want to read" list
2. Two filters should appear, "Newest to Oldest" and "Oldest to Newest".
3. By clicking "Newest to Oldest" the books on the right should be sorted by the date the user has logged them in his list from newest logged to oldest logged. 
4. By clicking "Oldest to Newest" the books on the right should be sorted by the date the user has logged them in his list from oldest logged to newest logged. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/56540005/122667403-795a9080-d1bb-11eb-86cb-48243180b95b.png)

![image](https://user-images.githubusercontent.com/56540005/122667429-8d9e8d80-d1bb-11eb-8f48-0aeb03d64134.png)

![image](https://user-images.githubusercontent.com/56540005/122667458-a313b780-d1bb-11eb-987c-a899f95bb7ba.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles, @jamesachamp 