### PR TITLE
Handle Nothing type when exporting lists

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -274,7 +274,7 @@ class list_seeds(delegate.page):
             "entries": seeds
         }
 
-        text = formats.dump(data, self.encoding)
+        text = h.json_encode(data)
         return delegate.RawText(text)
 
     def POST(self, key):


### PR DESCRIPTION
Closes #5415
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Uses JSON encoder with Nothing serializer for list exports.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
