### PR TITLE
Add prefer-const eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "no-useless-escape": "error",
     "space-in-parens": "error",
     "vars-on-top": "error",
+    "prefer-const": "error",
     "template-curly-spacing": "error",
     "quote-props": ["error", "as-needed"],
     "keyword-spacing": ["error", { "before": true, "after": true } ],

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -258,7 +258,7 @@ export class SearchBar {
             const renderer = RENDER_AUTOCOMPLETE_RESULT[this.facetEndpoint];
             this.$results.css('opacity', 1);
             this.clearAutocompletionResults();
-            for (let d in data.docs) {
+            for (const d in data.docs) {
                 this.$results.append(renderer(data.docs[d]));
             }
         });

--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -4,7 +4,7 @@ import Carousel from './carousel/Carousel';
 
 export function initCarouselsPartials() {
 
-    let fetchRelatedWorks = function() {
+    const fetchRelatedWorks = function() {
         $.ajax({
             url: '/partials',
             type: 'GET',

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -47,7 +47,7 @@ export function initAuthorView() {
     $('#preMerge').show();
     $('#preMerge').parent().show();
 
-    let data = {
+    const data = {
         master: dataKeysJSON['master'],
         duplicates: dataKeysJSON['duplicates']
     };

--- a/openlibrary/plugins/openlibrary/js/page-barcodescanner/LazyBookCard.js
+++ b/openlibrary/plugins/openlibrary/js/page-barcodescanner/LazyBookCard.js
@@ -58,14 +58,14 @@ export default class LazyBookCard {
             }
 
             const textFields = ['title', 'byline', 'identifier'];
-            for (let field of textFields) {
+            for (const field of textFields) {
                 if (oldState[field] != newState[field]) {
                     this.ui.find(`.${field}`).text(newState[field]);
                 }
             }
 
             const classFields = ['loading', 'errored'];
-            for (let field of classFields) {
+            for (const field of classFields) {
                 if (oldState[field] != newState[field]) {
                     this.ui.toggleClass(field, newState[field]);
                 }

--- a/tests/unit/js/test.SearchBar.js
+++ b/tests/unit/js/test.SearchBar.js
@@ -149,7 +149,7 @@ describe('SearchBar', () => {
             expect(navigateToStub.args[0]).toEqual(['/advancedsearch']);
         });
 
-        for (let facet of ['title', 'author', 'all']) {
+        for (const facet of ['title', 'author', 'all']) {
             test(`Facet "${facet}" searches tigger autocomplete`, () => {
                 // Stub debounce to avoid have to manipulate time (!)
                 sandbox.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
@@ -182,7 +182,7 @@ describe('SearchBar', () => {
             expect(getJSONStub.callCount).toBe(0);
         });
 
-        for (let facet of ['lists', 'subject', 'text']) {
+        for (const facet of ['lists', 'subject', 'text']) {
             test(`Facet "${facet}" does not tigger autocomplete`, () => {
                 // Stub debounce to avoid have to manipulate time (!)
                 sandbox.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);

--- a/tests/unit/js/test.search.js
+++ b/tests/unit/js/test.search.js
@@ -20,7 +20,7 @@ function createSearchFacets(totalFacet = 2, visibleFacet = 2, minVisibleFacet = 
 
     const divTestFacet = divSearchFacets.querySelector('div.test');
     for (let i = 0; i < totalFacet; i++) {
-        let facetNb = i + 1;
+        const facetNb = i + 1;
         divTestFacet.innerHTML += `
             <div class="facetEntry">
                 <span><a>facet_${facetNb}</a></span>
@@ -120,10 +120,10 @@ function checkFacetMoreLessVisibility(totalFacet, minVisibleFacet, expectedVisib
     }
 }
 
-let _originalGetClientRects = window.Element.prototype.getClientRects;
+const _originalGetClientRects = window.Element.prototype.getClientRects;
 
 // Stubbed getClientRects to enable jQuery ':hidden' selector used by 'more' and 'less' functions
-let _stubbedGetClientRects = function() {
+const _stubbedGetClientRects = function() {
     let node = this;
     while (node) {
         if (node === document) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5307

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
Added prefer-const rule:
This rule is aimed at flagging variables that are declared using let keyword, but never reassigned after the initial assignment.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
npm run lint
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson 