### PR TITLE
Create aggregate book notes and observations views

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "static/build/modal-links.*.js",
-      "maxSize": "5KB"
+      "maxSize": "5.3KB"
     },
     {
       "path": "static/build/user-website.*.js",

--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -52,8 +52,22 @@ class Booknotes(object):
         oldb = db.get_db()
         data = {'username': username}
         query = "SELECT count(*) from booknotes WHERE username=$username"
-        return oldb.query(query, vars=data)['count']
+        return oldb.query(query, vars=data)[0]['count']
 
+    @classmethod
+    def count_works_with_notes_by_user(cls, username):
+        """
+        Counts the total number of works logged by this 'username'
+        """
+        oldb = db.get_db()
+        data = {'username': username}
+        query = """
+            SELECT 
+                COUNT(DISTINCT(work_id))
+            FROM booknotes
+            WHERE username=$username
+        """
+        return oldb.query(query, vars=data)[0]['count']
 
     @classmethod
     def get_patron_booknote(cls, username, work_id, edition_id=NULL_EDITION_VALUE):

--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -99,6 +99,35 @@ class Booknotes(object):
         query += "LIMIT $limit OFFSET $offset"
         return list(oldb.query(query, vars=data))
 
+    @classmethod
+    def get_notes_grouped_by_work(cls, username, limit=25, page=1):
+        """
+        Returns a list of book notes records, which are grouped by work_id.
+        The 'notes' field contains a JSON string consisting of 'edition_id'/
+        book note key-value pairs.
+
+        return: List of records grouped by works.
+        """
+        oldb = db.get_db()
+        data = {
+            'username': username,
+            'limit': limit,
+            'offset': limit * (page - 1)
+        }
+        query = """
+            SELECT
+                work_id,
+                json_agg(row_to_json(
+                    (SELECT r FROM (SELECT edition_id, notes) r)
+                    )
+                ) AS notes
+            FROM booknotes
+            WHERE username=$username
+            GROUP BY work_id
+            LIMIT $limit OFFSET $offset
+        """
+
+        return list(oldb.query(query, vars=data))
 
     @classmethod
     def add(cls, username, work_id, notes, edition_id=NULL_EDITION_VALUE):

--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -62,7 +62,7 @@ class Booknotes(object):
         oldb = db.get_db()
         data = {'username': username}
         query = """
-            SELECT 
+            SELECT
                 COUNT(DISTINCT(work_id))
             FROM booknotes
             WHERE username=$username

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -508,19 +508,6 @@ class Work(Thing):
 
         return formatted_observations
 
-    def get_users_observations(self, username):
-        if not username:
-            return None
-        work_id = extract_numeric_id_from_olid(self.key)
-        raw_observations = Observations.get_patron_observations(username, work_id)
-        formatted_observations = defaultdict(list)
-
-        for r in raw_observations:
-            kv_pair = Observations.get_key_value_pair(r['type'], r['value'])
-            formatted_observations[kv_pair.key].append(kv_pair.value)
-
-        return formatted_observations
-
     def get_num_users_by_bookshelf(self):
         if not self.key:  # a dummy work
             return {'want-to-read': 0, 'currently-reading': 0, 'already-read': 0}

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -494,6 +494,19 @@ class Work(Thing):
         work_id = extract_numeric_id_from_olid(self.key)
         edition_id = extract_numeric_id_from_olid(edition_olid) if edition_olid else -1
         return Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)
+    
+    def get_users_observations(self, username):
+        if not username:
+            return None
+        work_id = extract_numeric_id_from_olid(self.key)
+        raw_observations = Observations.get_patron_observations(username, work_id)
+        formatted_observations = defaultdict(list)
+
+        for r in raw_observations:
+            kv_pair = Observations.get_key_value_pair(r['type'], r['value'])
+            formatted_observations[kv_pair.key].append(kv_pair.value)
+
+        return formatted_observations
 
     def get_users_observations(self, username):
         if not username:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -494,7 +494,7 @@ class Work(Thing):
         work_id = extract_numeric_id_from_olid(self.key)
         edition_id = extract_numeric_id_from_olid(edition_olid) if edition_olid else -1
         return Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)
-    
+
     def get_users_observations(self, username):
         if not username:
             return None

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -504,7 +504,10 @@ class Observations(object):
 
         query += 'GROUP BY type'
 
-        return { i['type']: i['total_respondents'] for i in list(oldb.query(query, vars=data)) }
+        return {
+            i['type']: i['total_respondents']
+            for i in list(oldb.query(query, vars=data))
+        }
 
     @classmethod
     def count_observations(cls, work_id):
@@ -546,17 +549,19 @@ class Observations(object):
     @classmethod
     def count_distinct_observations(cls, username):
         """
-        Fetches the number of works in which the given user has made at least one observation.
+        Fetches the number of works in which the given user has made at least
+        one observation.
 
-        return: The number of works for which the given user has made at least one observation
+        return: The number of works for which the given user has made at least
+        one observation
         """
         oldb = db.get_db()
         data = {
             'username': username
         }
         query = """
-            SELECT 
-              COUNT(DISTINCT(work_id)) 
+            SELECT
+              COUNT(DISTINCT(work_id))
             FROM observations
             WHERE observations.username = $username
         """
@@ -615,12 +620,12 @@ class Observations(object):
             'offset': limit * (page - 1)
         }
         query = """
-            SELECT 
-                work_id, 
+            SELECT
+                work_id,
                 JSON_AGG(ROW_TO_JSON(
-	                (SELECT r FROM
-		                (SELECT observation_type, observation_values) r)
-	                )
+                    (SELECT r FROM
+                        (SELECT observation_type, observation_values) r)
+                    )
                 ) AS observations
             FROM (
                 SELECT

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -465,7 +465,7 @@ class Observations(object):
 
         query += 'GROUP BY type'
 
-        return { i['type']: i['total_respondents'] for i in list(db.query(query, vars=data)) }
+        return { i['type']: i['total_respondents'] for i in list(oldb.query(query, vars=data)) }
 
     @classmethod
     def count_observations(cls, work_id):
@@ -503,6 +503,26 @@ class Observations(object):
             ORDER BY type_id, total DESC"""
 
         return list(oldb.query(query, vars=data))
+
+    @classmethod
+    def count_distinct_observations(cls, username):
+        """
+        Fetches the number of works in which the given user has made at least one observation.
+
+        return: The number of works for which the given user has made at least one observation
+        """
+        oldb = db.get_db()
+        data = {
+            'username': username
+        }
+        query = """
+            SELECT 
+              COUNT(DISTINCT(work_id)) 
+            FROM observations
+            WHERE observations.username = $username
+        """
+
+        return oldb.query(query, vars=data)[0]['count']
 
     @classmethod
     def get_key_value_pair(cls, type_id, value_id):

--- a/openlibrary/macros/NotesModal.html
+++ b/openlibrary/macros/NotesModal.html
@@ -1,12 +1,20 @@
-$def with (work, edition, link_text, id, class_list='')
+$def with (work, edition, link_text, id, class_list='', reload_id=None)
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ notes = work.get_users_notes(username, edition.key.split('/')[-1])
 $ work_key = work.key
 
+$if notes and len(notes.notes) > 0:
+  $ display_delete_button = True
+$else:
+  $ display_delete_button = False
+
 $ context = {
   $ "id": id
   $ }
+
+$if reload_id:
+  $ context['reloadId'] = reload_id
 
 <div class="$class_list">
   <a class="notes-modal-link" href="javascript:;" data-context="$json_encode(context)">$link_text</a>
@@ -20,11 +28,14 @@ $ context = {
       <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
         <p>$_("My personal notes about this edition:")</p>
         <div>
-          <textarea name="notes" rows="10">$(notes.notes if notes else "")</textarea>
+          <textarea class="notes-modal-textarea" name="notes" rows="10">$(notes.notes if notes else "")</textarea>
         </div>
         <input type="hidden" name="work_id" value="$work_key.split('/')[-1]" />
         <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
-        <button class="update-note-button cta-btn"type="button">$_("Save Note")</button>
+        <div class="note-form-buttons">
+          <button class="delete-note-button cta-btn $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
+          <button class="update-note-button cta-btn"type="button">$_("Save Note")</button>
+        </div>
       </form>
     </div>
   </div>

--- a/openlibrary/macros/ObservationsModal.html
+++ b/openlibrary/macros/ObservationsModal.html
@@ -1,4 +1,4 @@
-$def with (work, link_text, id, classes='')
+$def with (work, link_text, id, classes='', reload_id=None)
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 
@@ -10,6 +10,9 @@ $ context = {
   $ "work": work.key,
   $ "id": id
   $ }
+
+$if reload_id:
+  $ context['reloadId'] = reload_id
 
 <div class="$classes">
   <a class="observations-modal-link" href="javascript:;" data-context="$json_encode(context)">$link_text</a>

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -426,14 +426,6 @@ class price_api(delegate.page):
         return json.dumps(metadata)
 
 
-class observations(delegate.page):
-    path = "/observations"
-    encoding = "json"
-
-    def GET(self):
-        return delegate.RawText(json.dumps(get_observations()), content_type="application/json")
-
-
 class patron_observations(delegate.page):
     path = r"/works/OL(\d+)W/observations"
     encoding = "json"

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -444,8 +444,11 @@ class patron_observations(delegate.page):
         for r in existing_records:
             kv_pair = Observations.get_key_value_pair(r['type'], r['value'])
             patron_observations[kv_pair.key].append(kv_pair.value)
-            
-        return delegate.RawText(json.dumps(patron_observations), content_type="application/json")
+
+        return delegate.RawText(
+                json.dumps(patron_observations), 
+                content_type="application/json"
+            )
 
     def POST(self, work_id):
         user = accounts.get_current_user()

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -430,6 +430,23 @@ class patron_observations(delegate.page):
     path = r"/works/OL(\d+)W/observations"
     encoding = "json"
 
+    def GET(self, work_id):
+        user = accounts.get_current_user()
+
+        if not user:
+            raise web.seeother('/account/login')
+
+        username = user.key.split('/')[2]
+        existing_records = Observations.get_patron_observations(username, work_id)
+
+        patron_observations = defaultdict(list)
+
+        for r in existing_records:
+            kv_pair = Observations.get_key_value_pair(r['type'], r['value'])
+            patron_observations[kv_pair.key].append(kv_pair.value)
+            
+        return delegate.RawText(json.dumps(patron_observations), content_type="application/json")
+
     def POST(self, work_id):
         user = accounts.get_current_user()
 
@@ -451,3 +468,19 @@ class patron_observations(delegate.page):
             }), content_type="application/json")
 
         return response('Observations added')
+
+    def DELETE(self, work_id):
+        user = accounts.get_current_user()
+        username = user.key.split('/')[2]
+
+        if not user:
+            raise web.seeother('/account/login')
+
+        Observations.remove_observations(username, work_id)
+
+        def response(msg, status="success"):
+            return delegate.RawText(json.dumps({
+                status: msg
+            }), content_type="application/json")
+
+        return response('Observations removed')

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -446,9 +446,9 @@ class patron_observations(delegate.page):
             patron_observations[kv_pair.key].append(kv_pair.value)
 
         return delegate.RawText(
-                json.dumps(patron_observations), 
-                content_type="application/json"
-            )
+            json.dumps(patron_observations),
+            content_type="application/json"
+        )
 
     def POST(self, work_id):
         user = accounts.get_current_user()

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -218,10 +218,18 @@ jQuery(function () {
             .then((module) => module.init());
     }
 
-    if (document.getElementsByClassName('observations-modal-link').length ||
-        document.getElementsByClassName('notes-modal-link').length) {
-        import(/* webpackChunkName: "patron_metadata" */ './patron-metadata')
-            .then((module) => module.initPatronMetadata());
+    const $observationModalLinks = $('.observations-modal-link');
+    const $notesModalLinks = $('.notes-modal-link');
+    if ($observationModalLinks.length || $notesModalLinks.length) {
+        import(/* webpackChunkName: "modal-links" */ './modals')
+            .then(module => {
+                if ($observationModalLinks.length) {
+                    module.initObservationsModal($observationModalLinks);
+                }
+                if ($notesModalLinks.length) {
+                    module.initNotesModal($notesModalLinks);
+                }
+            });
     }
 
     if (document.getElementsByClassName('manageCovers').length) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -218,18 +218,15 @@ jQuery(function () {
             .then((module) => module.init());
     }
 
-    const $observationModalLinks = $('.observations-modal-link');
-    const $notesModalLinks = $('.notes-modal-link');
-    if ($observationModalLinks.length || $notesModalLinks.length) {
-        import(/* webpackChunkName: "modal-links" */ './modals')
-            .then(module => {
-                if ($observationModalLinks.length) {
-                    module.initObservationsModal($observationModalLinks);
-                }
-                if ($notesModalLinks.length) {
-                    module.initNotesModal($notesModalLinks);
-                }
-            });
+    if (document.getElementsByClassName('observations-modal-link').length ||
+        document.getElementsByClassName('notes-modal-link').length) {
+        import(/* webpackChunkName: "patron_metadata" */ './patron-metadata')
+            .then((module) => module.initPatronMetadata());
+    }
+
+    if (document.getElementsByClassName('manageCovers').length) {
+        import(/* webpackChunkName: "covers" */ './covers')
+            .then((module) => module.initCoversChange());
     }
 
     const manageCoversElement = document.getElementsByClassName('manageCovers').length;

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -122,10 +122,10 @@ export function initObservationsModal($modalLinks) {
 
 /**
  * Add on click listeners to a collection of modal links.
- * 
+ *
  * When any of the links are clicked, it's corresponding modal
  * will be displayed.
- * 
+ *
  * @param {JQuery} $modalLinks  A collection of modal links.
  */
 function addClickListeners($modalLinks) {
@@ -174,20 +174,20 @@ function addObservationReloadListeners($observationLists) {
                         observations = observations.charAt(0).toUpperCase() + observations.slice(1);
 
                         listItems += `
-                        <li>
-                            <span class="observation-category">${category.charAt(0).toUpperCase() + category.slice(1)}:</span> ${observations}
-                        </li>
-                    `;
+                    <li>
+                        <span class="observation-category">${category.charAt(0).toUpperCase() + category.slice(1)}:</span> ${observations}
+                    </li>
+                `;
                     }
 
                     $list.empty();
 
                     if (listItems.length === 0) {
                         listItems = `
-                        <li>
-                            No observations for this work.
-                        </li>
-                    `;
+                    <li>
+                        No observations for this work.
+                    </li>
+                `;
                         $list.addClass('no-content');
                         $buttonsDiv.removeClass('observation-buttons');
                         $buttonsDiv.addClass('no-content');
@@ -203,7 +203,6 @@ function addObservationReloadListeners($observationLists) {
                 })
         })
     })
-  })
 }
 
 /**
@@ -298,31 +297,31 @@ function displayModal(modalId, reloadId) {
  * @param {JQuery}  $parent  Object that contains the observations form.
  * @param {Object}  context  An object containing the patron's username and the work's OLID.
  */
- function addObservationChangeListeners($parent, context) {
-  const $questionSections = $parent.find('.aspect-section');
-  const username = context.username;
-  const workOlid = context.work.split('/')[2];
+function addObservationChangeListeners($parent, context) {
+    const $questionSections = $parent.find('.aspect-section');
+    const username = context.username;
+    const workOlid = context.work.split('/')[2];
 
-  $questionSections.each(function() {
-      const $inputs = $(this).find('input')
+    $questionSections.each(function() {
+        const $inputs = $(this).find('input')
 
-      $inputs.each(function() {
-          $(this).on('change', function() {
-              const type = $(this).attr('name');
-              const value = $(this).attr('value');
-              const observation = {};
-              observation[type] = value;
+        $inputs.each(function() {
+            $(this).on('change', function() {
+                const type = $(this).attr('name');
+                const value = $(this).attr('value');
+                const observation = {};
+                observation[type] = value;
 
-              const data = {
-                  username: username,
-                  action: `${$(this).prop('checked') ? 'add': 'delete'}`,
-                  observation: observation
-              }
+                const data = {
+                    username: username,
+                    action: `${$(this).prop('checked') ? 'add': 'delete'}`,
+                    observation: observation
+                }
 
-              submitObservation($(this), workOlid, data, type);
-          });
-      })
-  });
+                submitObservation($(this), workOlid, data, type);
+            });
+        })
+    });
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -16,12 +16,7 @@ export function initNotesModal($modalLinks) {
  * Adds click listeners to buttons in all notes forms on a page.
  */
 function addNotesButtonListeners() {
-    let toast;
-
     $('.update-note-button').on('click', function(){
-    // If button is inside of metadata form, set toast's parent element to the form:
-        const $parent = $(this).closest('.metadata-form');
-
         // Get form data
         const formData = new FormData($(this).prop('form'));
 
@@ -36,15 +31,21 @@ function addNotesButtonListeners() {
             contentType: false,
             processData: false,
             success: function() {
-                // Display success message
-                if (toast) {
-                    toast.close();
-                }
-                toast = new Toast($parent, 'Update successful!');
-                toast.show();
+                showToast($('body'), 'Update successful!')
+                $.colorbox.close();
             }
         });
     });
+}
+
+/**
+ * Creates and displays a toast component.
+ * 
+ * @param {JQuery} $parent Mount point for toast component
+ * @param {String} message Message displayed in toast component
+ */
+function showToast($parent, message) {
+    new Toast($parent, message).show();
 }
 
 /**
@@ -57,6 +58,8 @@ function addNotesButtonListeners() {
  */
 export function initObservationsModal($modalLinks) {
     addClickListeners($modalLinks);
+    addReloadListeners($('.observations-list'))
+    addDeleteObservationsListeners($('.delete-observations-button'));
 
     $modalLinks.each(function(_i, modalLinkElement) {
         const $element = $(modalLinkElement);
@@ -75,27 +78,164 @@ export function initObservationsModal($modalLinks) {
  * @param {JQuery} $modalLinks  A collection of modal links.
  */
 function addClickListeners($modalLinks) {
-  $modalLinks.each(function(_i, modalLinkElement) {
-    $(modalLinkElement).on('click', function() {
-      const context = $(this).data('context');
-      displayModal(context.id);
+    $modalLinks.each(function(_i, modalLinkElement) {
+        $(modalLinkElement).on('click', function() {
+            const context = $(this).data('context');
+            displayModal(context.id, context.reloadId);
+        })
+    })
+}
+
+// TODO: document this function
+/**
+ * Adds listeners to all observation lists on a page.
+ * 
+ * Observation lists are found in the aggregate observations
+ * view, and display all observations that were submitted for
+ * a work. If new observations are submitted, an 'observationReload'
+ * event is fired, triggering an update of the observations list.
+ * 
+ * @param {JQuery} $observationLists All of the observations lists on a page
+ */
+function addReloadListeners($observationLists) {
+    $observationLists.each(function(_i, list) {
+        $(list).on('observationReload', function() {
+            const $list = $(this);
+            const $buttonsDiv = $list.siblings('div').first();
+            const id = $list.attr('id');
+            const workOlid = `OL${id.split('-')[0]}W`;
+    
+            $list.empty();
+            $list.append(`
+                <li class="throbber-li">
+                    <div class="throbber"><h3>Updating observations</h3></div>
+                </li>
+            `)
+    
+            $.ajax({
+                type: 'GET',
+                url: `/works/${workOlid}/observations`,
+                dataType: 'json'
+            })
+            .done(function(data) {
+                let listItems = '';
+                for (const [category, values] of Object.entries(data)) {
+                    let observations = values.join(', ');
+                    observations = observations.charAt(0).toUpperCase() + observations.slice(1);
+
+                    listItems += `
+                        <li>
+                            <span class="observation-category">${category.charAt(0).toUpperCase() + category.slice(1)}:</span> ${observations}
+                        </li>
+                    `;
+                }
+
+                $list.empty();
+
+                if (listItems.length === 0) {
+                    listItems = `
+                        <li>
+                            No observations for this work.
+                        </li>
+                    `;
+                    $list.addClass('no-content');
+                    $buttonsDiv.removeClass('observation-buttons');
+                    $buttonsDiv.addClass('no-content');
+                    $buttonsDiv.children().first().addClass('hidden');
+                } else {
+                    $list.removeClass('no-content');
+                    $buttonsDiv.removeClass('no-content');
+                    $buttonsDiv.addClass('observation-buttons');
+                    $buttonsDiv.children().first().removeClass('hidden');
+                }
+
+                $list.append(listItems);
+            })
+        })
     })
   })
 }
 
 /**
+ * Deletes all of a work's observations and refreshes observations view.
+ * 
+ * Delete observation buttons are only available on the aggregate
+ * observations view, beneath a list of previously submitted observations.
+ * Clicking the delete button will delete all of the observations for a 
+ * work and update the view.
+ * 
+ * @param {JQuery} $deleteButtons All observation delete buttons found on a page.
+ */
+function addDeleteObservationsListeners($deleteButtons) {
+    $deleteButtons.each(function(_i, deleteButton) {
+        const $button = $(deleteButton);
+
+        $button.on('click', function() {
+            const workOlid = `OL${$button.prop('id').split('-')[0]}W`;
+        
+            $.ajax({
+                url: `/works/${workOlid}/observations`,
+                type: 'DELETE',
+                contentType: 'application/json',
+                success: function() {
+                    // Remove observations in view
+                    const $observationsView = $button.closest('.observation-view');
+                    const $list = $observationsView.find('ul');
+    
+                    $list.empty();
+                    $list.append(`
+                        <li>
+                            No observations for this work.
+                        </li>
+                    `)
+                    $list.addClass('no-content');
+    
+                    $button.parent().removeClass('observation-buttons');
+                    $button.parent().addClass('no-content');
+                    $button.addClass('hidden');
+
+                    // find and clear modal selections
+                    clearForm($button.siblings().find('form'));
+                }
+            });
+        })
+    });
+}
+
+/**
+ * Unchecks all inputs in an observations modal form.
+ * 
+ * @param {JQuery} $form An observations modal form
+ */
+function clearForm($form) {
+    $form.find('input').each(function(_i, input) {
+        if (input.checked) {
+            input.checked = false;
+        }
+    });
+}
+
+/**
  * Displays a model identified by the given identifier.
  * 
+ * Optionally fires a reload event to a list with the given ID.
+ *
  * @param {String} modalId  A string that uniquely identifies a modal.
+ * @param {String} [reloadId]   ID of list receiving a reload event   
  */
-function displayModal(modalId) {
-  $.colorbox({
-    inline: true,
-    opacity: '0.5',
-    href: `#${modalId}-metadata-form`,
-    width: '60%',
-  });
-};
+function displayModal(modalId, reloadId) {
+    $.colorbox({
+        inline: true,
+        opacity: '0.5',
+        href: `#${modalId}-metadata-form`,
+        width: '60%',
+        onClosed: function() {
+            if (reloadId) {
+                $(`#${reloadId}`).trigger('observationReload');
+            }
+        }
+    });
+}
 
 /**
  * Adds change listeners to each input in the observations section of the modal.
@@ -142,21 +282,22 @@ function displayModal(modalId) {
  * @param {Object}  data        Payload that will be sent to the back-end server.
  * @param {String}  sectionType Name of the input's section.
  */
- function submitObservation(workOlid, data, sectionType) {
-   console.log("in submitObservations");
-   console.log(sectionType);
-
-  // Make AJAX call
-  $.ajax({
-      type: 'POST',
-      url: `/works/${workOlid}/observations`,
-      contentType: 'application/json',
-      data: JSON.stringify(data)
-  })
-      .done(function() {
-          // Show success message:
-      })
-      .fail(function() {
-          // Show failure message:
-      });
+function submitObservation($input, workOlid, data, sectionType) {
+    let toastMessage;
+    // Make AJAX call
+    $.ajax({
+        type: 'POST',
+        url: `/works/${workOlid}/observations`,
+        contentType: 'application/json',
+        data: JSON.stringify(data)
+    })
+    .done(function() {
+        toastMessage = `${sectionType} saved!`;
+    })
+    .fail(function() {
+        toastMessage = `${sectionType} save failed...`;
+    })
+    .always(function() {
+        showToast($input.closest('.metadata-form'), toastMessage);
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -68,95 +68,95 @@ export function initObservationsModal($modalLinks) {
 
 /**
  * Add on click listeners to a collection of modal links.
- *
+ * 
  * When any of the links are clicked, it's corresponding modal
  * will be displayed.
- *
+ * 
  * @param {JQuery} $modalLinks  A collection of modal links.
  */
 function addClickListeners($modalLinks) {
-    $modalLinks.each(function(_i, modalLinkElement) {
-        $(modalLinkElement).on('click', function() {
-            const context = $(this).data('context');
-            displayModal(context.id);
-        })
+  $modalLinks.each(function(_i, modalLinkElement) {
+    $(modalLinkElement).on('click', function() {
+      const context = $(this).data('context');
+      displayModal(context.id);
     })
+  })
 }
 
 /**
  * Displays a model identified by the given identifier.
- *
+ * 
  * @param {String} modalId  A string that uniquely identifies a modal.
  */
 function displayModal(modalId) {
-    $.colorbox({
-        inline: true,
-        opacity: '0.5',
-        href: `#${modalId}-metadata-form`,
-        width: '60%',
-    });
-}
+  $.colorbox({
+    inline: true,
+    opacity: '0.5',
+    href: `#${modalId}-metadata-form`,
+    width: '60%',
+  });
+};
 
 /**
-* Adds change listeners to each input in the observations section of the modal.
-*
-* For each checkbox and radio button in the observations form, a change listener
-* that triggers observation submissions is added.  On change, a payload containing
-* the username, action type ('add' when an input is checked, 'delete' when unchecked),
-* and observation type and value are sent to the back-end server.
-*
-* @param {JQuery}  $parent  Object that contains the observations form.
-* @param {Object}  context  An object containing the patron's username and the work's OLID.
-*/
-function addObservationChangeListeners($parent, context) {
-    const $questionSections = $parent.find('.aspect-section');
-    const username = context.username;
-    const workOlid = context.work.split('/')[2];
+ * Adds change listeners to each input in the observations section of the modal.
+ *
+ * For each checkbox and radio button in the observations form, a change listener
+ * that triggers observation submissions is added.  On change, a payload containing
+ * the username, action type ('add' when an input is checked, 'delete' when unchecked),
+ * and observation type and value are sent to the back-end server.
+ *
+ * @param {JQuery}  $parent  Object that contains the observations form.
+ * @param {Object}  context  An object containing the patron's username and the work's OLID.
+ */
+ function addObservationChangeListeners($parent, context) {
+  const $questionSections = $parent.find('.aspect-section');
+  const username = context.username;
+  const workOlid = context.work.split('/')[2];
 
-    $questionSections.each(function() {
-        const $inputs = $(this).find('input')
+  $questionSections.each(function() {
+      const $inputs = $(this).find('input')
 
-        $inputs.each(function() {
-            $(this).on('change', function() {
-                const type = $(this).attr('name');
-                const upperCaseType = type[0].toUpperCase() + type.slice(1);
-                const value = $(this).attr('value');
-                const observation = {};
-                observation[type] = value;
+      $inputs.each(function() {
+          $(this).on('change', function() {
+              const type = $(this).attr('name');
+              const value = $(this).attr('value');
+              const observation = {};
+              observation[type] = value;
 
-                const data = {
-                    username: username,
-                    action: `${$(this).prop('checked') ? 'add': 'delete'}`,
-                    observation: observation
-                }
+              const data = {
+                  username: username,
+                  action: `${$(this).prop('checked') ? 'add': 'delete'}`,
+                  observation: observation
+              }
 
-                submitObservation($(this), workOlid, data, upperCaseType);
-            });
-        })
-    });
+              submitObservation($(this), workOlid, data, type);
+          });
+      })
+  });
 }
 
 /**
  * Submits an observation to the server.
  *
- * @param {JQuery}  $input      The checkbox or radio button that is firing the change event.
  * @param {String}  workOlid    The OLID for the work being observed.
  * @param {Object}  data        Payload that will be sent to the back-end server.
  * @param {String}  sectionType Name of the input's section.
  */
-function submitObservation($input, workOlid, data, sectionType) {
-    const $parent = $input.closest('.metadata-form');
-    // Make AJAX call
-    $.ajax({
-        type: 'POST',
-        url: `/works/${workOlid}/observations`,
-        contentType: 'application/json',
-        data: JSON.stringify(data)
-    })
-        .done(function() {
-            new Toast($parent, `${sectionType} saved!`).show();
-        })
-        .fail(function() {
-            new Toast($parent, `${sectionType} save failed...`).show();
-        });
+ function submitObservation(workOlid, data, sectionType) {
+   console.log("in submitObservations");
+   console.log(sectionType);
+
+  // Make AJAX call
+  $.ajax({
+      type: 'POST',
+      url: `/works/${workOlid}/observations`,
+      contentType: 'application/json',
+      data: JSON.stringify(data)
+  })
+      .done(function() {
+          // Show success message:
+      })
+      .fail(function() {
+          // Show failure message:
+      });
 }

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -20,14 +20,14 @@ function addNotesButtonListeners() {
     $('.update-note-button').on('click', function(){
         // Get form data
         const formData = new FormData($(this).prop('form'));
-        
+
         if (formData.get('notes')) {
             const $deleteButton = $($(this).siblings()[0]);
 
             // Post data
             const workOlid = formData.get('work_id');
             formData.delete('work_id');
-    
+
             $.ajax({
                 url: `/works/${workOlid}/notes.json`,
                 data: formData,
@@ -72,16 +72,16 @@ function addNotesButtonListeners() {
 
 /**
  * Adds listeners for content reload events on a page's notes textareas
- * 
+ *
  * When a registered textarea receives a content reload event, it's text
  * is updated with the most recently submitted note.
- * 
- * @param {JQuery} $notesTextareas  All notes text areas on a page. 
+ *
+ * @param {JQuery} $notesTextareas  All notes text areas on a page.
  */
 function addNotesReloadListeners($notesTextareas) {
     $notesTextareas.each(function(_i, textarea) {
         const $textarea = $(textarea);
-        
+
         $textarea.on('contentReload', function() {
             const newValue = $textarea.parent().find('.notes-modal-textarea')[0].value;
             $textarea.val(newValue);
@@ -91,7 +91,7 @@ function addNotesReloadListeners($notesTextareas) {
 
 /**
  * Creates and displays a toast component.
- * 
+ *
  * @param {JQuery} $parent Mount point for toast component
  * @param {String} message Message displayed in toast component
  */
@@ -139,12 +139,12 @@ function addClickListeners($modalLinks) {
 
 /**
  * Adds listeners to all observation lists on a page.
- * 
+ *
  * Observation lists are found in the aggregate observations
  * view, and display all observations that were submitted for
  * a work. If new observations are submitted, an 'observationReload'
  * event is fired, triggering an update of the observations list.
- * 
+ *
  * @param {JQuery} $observationLists All of the observations lists on a page
  */
 function addObservationReloadListeners($observationLists) {
@@ -154,53 +154,53 @@ function addObservationReloadListeners($observationLists) {
             const $buttonsDiv = $list.siblings('div').first();
             const id = $list.attr('id');
             const workOlid = `OL${id.split('-')[0]}W`;
-    
+
             $list.empty();
             $list.append(`
                 <li class="throbber-li">
                     <div class="throbber"><h3>Updating observations</h3></div>
                 </li>
             `)
-    
+
             $.ajax({
                 type: 'GET',
                 url: `/works/${workOlid}/observations`,
                 dataType: 'json'
             })
-            .done(function(data) {
-                let listItems = '';
-                for (const [category, values] of Object.entries(data)) {
-                    let observations = values.join(', ');
-                    observations = observations.charAt(0).toUpperCase() + observations.slice(1);
+                .done(function(data) {
+                    let listItems = '';
+                    for (const [category, values] of Object.entries(data)) {
+                        let observations = values.join(', ');
+                        observations = observations.charAt(0).toUpperCase() + observations.slice(1);
 
-                    listItems += `
+                        listItems += `
                         <li>
                             <span class="observation-category">${category.charAt(0).toUpperCase() + category.slice(1)}:</span> ${observations}
                         </li>
                     `;
-                }
+                    }
 
-                $list.empty();
+                    $list.empty();
 
-                if (listItems.length === 0) {
-                    listItems = `
+                    if (listItems.length === 0) {
+                        listItems = `
                         <li>
                             No observations for this work.
                         </li>
                     `;
-                    $list.addClass('no-content');
-                    $buttonsDiv.removeClass('observation-buttons');
-                    $buttonsDiv.addClass('no-content');
-                    $buttonsDiv.children().first().addClass('hidden');
-                } else {
-                    $list.removeClass('no-content');
-                    $buttonsDiv.removeClass('no-content');
-                    $buttonsDiv.addClass('observation-buttons');
-                    $buttonsDiv.children().first().removeClass('hidden');
-                }
+                        $list.addClass('no-content');
+                        $buttonsDiv.removeClass('observation-buttons');
+                        $buttonsDiv.addClass('no-content');
+                        $buttonsDiv.children().first().addClass('hidden');
+                    } else {
+                        $list.removeClass('no-content');
+                        $buttonsDiv.removeClass('no-content');
+                        $buttonsDiv.addClass('observation-buttons');
+                        $buttonsDiv.children().first().removeClass('hidden');
+                    }
 
-                $list.append(listItems);
-            })
+                    $list.append(listItems);
+                })
         })
     })
   })
@@ -208,12 +208,12 @@ function addObservationReloadListeners($observationLists) {
 
 /**
  * Deletes all of a work's observations and refreshes observations view.
- * 
+ *
  * Delete observation buttons are only available on the aggregate
  * observations view, beneath a list of previously submitted observations.
- * Clicking the delete button will delete all of the observations for a 
+ * Clicking the delete button will delete all of the observations for a
  * work and update the view.
- * 
+ *
  * @param {JQuery} $deleteButtons All observation delete buttons found on a page.
  */
 function addDeleteObservationsListeners($deleteButtons) {
@@ -222,7 +222,7 @@ function addDeleteObservationsListeners($deleteButtons) {
 
         $button.on('click', function() {
             const workOlid = `OL${$button.prop('id').split('-')[0]}W`;
-        
+
             $.ajax({
                 url: `/works/${workOlid}/observations`,
                 type: 'DELETE',
@@ -231,7 +231,7 @@ function addDeleteObservationsListeners($deleteButtons) {
                     // Remove observations in view
                     const $observationsView = $button.closest('.observation-view');
                     const $list = $observationsView.find('ul');
-    
+
                     $list.empty();
                     $list.append(`
                         <li>
@@ -239,7 +239,7 @@ function addDeleteObservationsListeners($deleteButtons) {
                         </li>
                     `)
                     $list.addClass('no-content');
-    
+
                     $button.parent().removeClass('observation-buttons');
                     $button.parent().addClass('no-content');
                     $button.addClass('hidden');
@@ -254,7 +254,7 @@ function addDeleteObservationsListeners($deleteButtons) {
 
 /**
  * Unchecks all inputs in an observations modal form.
- * 
+ *
  * @param {JQuery} $form An observations modal form
  */
 function clearForm($form) {
@@ -267,11 +267,11 @@ function clearForm($form) {
 
 /**
  * Displays a model identified by the given identifier.
- * 
+ *
  * Optionally fires a reload event to a list with the given ID.
  *
  * @param {String} modalId  A string that uniquely identifies a modal.
- * @param {String} [reloadId]   ID of list receiving a reload event   
+ * @param {String} [reloadId]   ID of list receiving a reload event
  */
 function displayModal(modalId, reloadId) {
     $.colorbox({
@@ -341,13 +341,13 @@ function submitObservation($input, workOlid, data, sectionType) {
         contentType: 'application/json',
         data: JSON.stringify(data)
     })
-    .done(function() {
-        toastMessage = `${sectionType} saved!`;
-    })
-    .fail(function() {
-        toastMessage = `${sectionType} save failed...`;
-    })
-    .always(function() {
-        showToast($input.closest('.metadata-form'), toastMessage);
-    });
+        .done(function() {
+            toastMessage = `${sectionType} saved!`;
+        })
+        .fail(function() {
+            toastMessage = `${sectionType} save failed...`;
+        })
+        .always(function() {
+            showToast($input.closest('.metadata-form'), toastMessage);
+        });
 }

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -847,7 +847,7 @@ class public_my_books(delegate.page):
                                           sort='created', sort_order=i.sort)
 
             booknotes_counts = PatronBooknotes.get_counts(username)
-            
+
             return render['account/books'](
                 books, key, sponsorship_count=len(sponsorships),
                 reading_log_counts=readlog.reading_log_counts, lists=readlog.lists,

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -1,4 +1,5 @@
-$def with (items, key, sponsorship_count=None, reading_log_counts=None, lists=None, user=None, logged_in_user=None, public=False, sort_order='desc')
+$def with (items, key, sponsorship_count=None, reading_log_counts=None, lists=None, user=None, logged_in_user=None, public=False, sort_order='desc', booknotes_counts=None)
+
 $# Displays a user's reading log
 $# :param list items:
 $# :param Literal['currently-reading', 'want-to-read', 'already-read', 'sponsorships', 'loans', 'waitlist'] key:
@@ -7,6 +8,7 @@ $# :param Dict[Literal['currently-reading', 'want-to-read', 'already-read'], int
 $# :param list? lists:
 $# :param user:
 $# :param bool public:
+$# :param Dict[Literal['notes', 'observations'], int] booknotes_counts: Number of notes and observations left by patron
 
 $ title = _('My Books')
 $ urlbase = ctx.path.rsplit('/', 1)[0]
@@ -14,14 +16,19 @@ $ username = user.key.split('/')[-1]
 $ owners_page = logged_in_user and urlbase.startswith('/people/'+logged_in_user.key.split('/')[-1])
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
 
-$ sort_order = sort_order
-
 $ current_page = int(input(page=1).page)
-$ total_items = sponsorship_count if key == 'sponsorships' else int(reading_log_counts[key])
+$if key == 'sponsorships':
+  $ total_items = sponsorship_count
+$elif key == 'notes' or key == 'observations':
+  $ total_items = int(booknotes_counts[key])
+$else:
+  $ total_items = int(reading_log_counts[key])
+
 $ userDisplayName = user.displayname or ctx.user.displayname
 $ userKey = user.key or ctx.user.key
 
 $ header_title = unicode(render_template('account/readinglog_shelf_name', key)).strip()
+$ breadcrumb = _("Reading Log")
 $if key == 'currently-reading':
   $ og_title = _("Books %(username)s is reading", username=userDisplayName)
   $ og_description = _("%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading.", username=userDisplayName, total=total_items)
@@ -33,8 +40,17 @@ $elif key == 'already-read':
   $ og_description = _("%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about.", username=userDisplayName, total=total_items)
 $elif key == 'sponsorships':
   $ header_title = _("Sponsorships")
+  $ breadcrumb = header_title
   $ og_title = _("Books %(userdisplayname)s is sponsoring", userdisplayname=userDisplayName)
   $ og_description = "{username} is sponsoring {total} books. Join {username} on OpenLibrary.org and share the books that you'll soon be reading!".format(username=userDisplayName, total=total_items)
+$elif key == 'notes':
+  $ header_title = _("Book Notes")
+  $ breadcrumb = header_title
+  $ og_title = None
+$elif key == 'observations':
+  $ header_title = _("Observations")
+  $ breadcrumb = header_title
+  $ og_title = None
 
 $if owners_page:
   $var title: $header_title
@@ -52,7 +68,7 @@ $if og_title:
 <div id="contentHead">
   <div id="mybooks">
     <div class="small sansserif grey account-settings-menu">
-      <a href="$userKey">$userDisplayName</a> &raquo; $_("Reading Log")
+      <a href="$userKey">$userDisplayName</a> &raquo; $breadcrumb
     </div>
     <div>
 
@@ -65,19 +81,25 @@ $if og_title:
           $header_title
       </h1>
 
-      $if owners_page:
+      $if owners_page and key not in ['notes', 'observations']:
         <a href="$ctx.path/stats" title="$('View stats about this shelf')">$_('Stats')</a>
     </div>
 
     $if owners_page:
       <h3>
-        $if public:
-          $_('Your reading log is currently set to public')
-          <button onclick="prompt('Copy share link to clipboard:', window.location.protocol + '//' + window.location.hostname + '/people/$(username)/books/$(key)');">Share</button> or
+        $if key == 'notes':
+          $_('Your private book notes cannot be viewed by other patrons')
+        $elif key == 'observations':
+          $# TODO: Fix this awful copy:
+          $_('Your observations will be anonymously shared with other patrons')
         $else:
-          $_('Your reading log is currently set to private')
-        &mdash;
-        <a href="/account/privacy">$_('Manage your privacy settings')</a>
+          $if public:
+            $_('Your reading log is currently set to public')
+            <button onclick="prompt('Copy share link to clipboard:', window.location.protocol + '//' + window.location.hostname + '/people/$(username)/books/$(key)');">Share</button> or
+          $else:
+            $_('Your reading log is currently set to private')
+          &mdash;
+          <a href="/account/privacy">$_('Manage your privacy settings')</a>
       </h3>
 
     <div class="mybooks">
@@ -102,47 +124,57 @@ $if og_title:
                 <li><a class="list-link" href="$(lst.key)">$lst['name'] ($(len(lst.seeds)))</a></li>
             </div>
           </ul>
-        <ul class="import-export-lists">
-          <li class="subsection">$_("Import / Export")</li>
-          <li><a href="/account/import">$_("Import & Export Options")</a></li>
-        </ul>
+        $if user.is_beta_tester():
+          <ul class="booknotes-list">
+            <li class="subsection">$_('Notes & Observations')</li>
+            <li><a $('class=selected' if key=='notes' else '') href="$urlbase/notes">$_('My notes (%(count)d)', count=booknotes_counts['notes'])</a></li>
+            <li><a $('class=selected' if key=='observations' else '') href="$urlbase/observations">$_('My observations (%(count)d)', count=booknotes_counts['observations'])</a></li>
+          </ul>
       </div>
-      <div class="mybooks-list">
+      $if key == 'notes':
+        <div>
+          Notes view
+        </div>
+      $elif key == 'observations':
+        <div>
+          Observations view
+        </div>
+      $else:
+        <div class="mybooks-list">
+          <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
+            $if sort_order == 'desc':
+              <strong class="lightgreen">$_("Date Added (newest)")</strong>
+              |
+              <a href="$ctx.path?sort=asc">$_("Date Added (oldest)")</a>
+            $else:
+              <a href="$ctx.path?sort=desc">$_("Date Added (newest)")</a>
+              |
+              <strong class="lightgreen">$_("Date Added (oldest)")</strong>
+          </span>
 
-        <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
-          $if sort_order == 'desc':
-            <strong class="lightgreen">$_("Date Added (newest)")</strong>
-            |
-            <a href="$ctx.path?sort=asc">$_("Date Added (oldest)")</a>
-          $else:
-            <a href="$ctx.path?sort=desc">$_("Date Added (newest)")</a>
-            |
-            <strong class="lightgreen">$_("Date Added (oldest)")</strong>
-        </span>
-
-        $:macros.Pager(current_page, total_items, results_per_page=25)
-        <ul class="list-books">
-          $if items:
-            $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
-            $for item in items:
-              $if key == 'loans':
-                $ edition = get_document(item['book'])
-                $ work = get_document(edition.works[0]) if (edition.get('type', {}).get('key') == '/type/work' and edition.works and edition.works[0]) else None
-                $ decorations = owners_page and macros.ManageLoansButtons(item, edition) or ''
-                $:macros.SearchResultsWork(work or edition, decorations=decorations, cta=False)
-              $elif key == 'waitlists':
-                $ edition = item
-                $ decorations = owners_page and macros.ManageWaitlistButton(edition) or ''
-                $:macros.SearchResultsWork(edition, decorations=decorations, cta=False)
-              $else:
-                $ work = item
-                $ decorations = (bookshelf_id and owners_page) and macros.ReadingLogButton(work, read_status=bookshelf_id)
-                $:macros.SearchResultsWork(work, decorations=decorations, cta=False)
-          $else:
-            <li>$_('No books are on this shelf')</li>
-        </ul>
-        $:macros.Pager(current_page, total_items, results_per_page=25)
-      </div>
+          $:macros.Pager(current_page, total_items, results_per_page=25)
+          <ul class="list-books">
+            $if items:
+              $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
+              $for item in items:
+                $if key == 'loans':
+                  $ edition = get_document(item['book'])
+                  $ work = get_document(edition.works[0]) if (edition.get('type', {}).get('key') == '/type/work' and edition.works and edition.works[0]) else None
+                  $ decorations = owners_page and macros.ManageLoansButtons(item, edition) or ''
+                  $:macros.SearchResultsWork(work or edition, decorations=decorations, cta=False)
+                $elif key == 'waitlists':
+                  $ edition = item
+                  $ decorations = owners_page and macros.ManageWaitlistButton(edition) or ''
+                  $:macros.SearchResultsWork(edition, decorations=decorations, cta=False)
+                $else:
+                  $ work = item
+                  $ decorations = (bookshelf_id and owners_page) and macros.ReadingLogButton(work, read_status=bookshelf_id)
+                  $:macros.SearchResultsWork(work, decorations=decorations, cta=False)
+            $else:
+              <li>$_('No books are on this shelf')</li>
+          </ul>
+          $:macros.Pager(current_page, total_items, results_per_page=25)
+        </div>
     </div>
   </div>
 </div>

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -132,13 +132,9 @@ $if og_title:
           </ul>
       </div>
       $if key == 'notes':
-        <div>
-          Notes view
-        </div>
+        $:render_template('account/notes', items, user, booknotes_counts['notes'], page=current_page)
       $elif key == 'observations':
-        <div>
-          Observations view
-        </div>
+        $:render_template('account/observations', items, user, booknotes_counts['observations'], page=current_page)
       $else:
         <div class="mybooks-list">
           <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">

--- a/openlibrary/templates/account/notes.html
+++ b/openlibrary/templates/account/notes.html
@@ -54,9 +54,10 @@ $def with (notes, user, num_found, page=1, results_per_page=25)
                     </div>
                   </div>
                   <div class="book-note">
-                    <textarea rows="10" readonly>$i['notes'][k]</textarea>
+                    $ textarea_id = str(k) + "-notes-textarea"
+                    <textarea class="notes-textarea" id="$textarea_id" rows="10" readonly>$i['notes'][k]</textarea>
                     $ id = str(k) + "edition-modal-link"
-                    $:macros.NotesModal(i.work, edition, _('View or update note'), id, 'notes-view-modal-link')
+                    $:macros.NotesModal(i.work, edition, _('View or update note'), id, 'notes-view-modal-link', reload_id=textarea_id)
                   </div>
                 </li>
             </ul>

--- a/openlibrary/templates/account/notes.html
+++ b/openlibrary/templates/account/notes.html
@@ -1,0 +1,68 @@
+$def with (notes, user, num_found, page=1, results_per_page=25)
+
+<div class="my-observations">
+  <div class="list-container">
+    $if notes:
+      $for i in notes:
+        $ work_id = i.work_id
+        $ work_cover_url = i.work_details['cover_url']
+        <li class="main-list-item">
+          <div class="work-section">
+            <span class="imageLg">
+              <a href="$i.work_key"><img src="$work_cover_url"></a>
+            </span>
+            <span>
+              <h3 itemprop="name" class="booktitle">
+                <a itemprop="url" href="$i.work_key" class="results">$i.work_details['title']</a>
+              </h3>
+              $if i.work_details['authors']:
+                By: $', '.join(i.work_details['authors'])
+              $else:
+                $_('Unknown author')
+            </span>
+          </div>
+          <div id="$work_id-notes">
+            <ul class="notes-list">
+              $for k in sorted(i['notes']):
+                <li class="notes-list-item">
+                  $ edition = i['editions'][k]
+                  <div class="book-info">
+                    <div class="title">
+                      $_('My notes for an edition of ')
+                      $if edition.title:
+                        <a href="$edition.url()">$edition.title</a><br>
+                      $else:
+                        <a href="$edition.url()"><em>$_('Title Missing')</em></a>
+                      <div class="published">
+                        $if edition.publishers and edition.publish_date:
+                          $edition.publish_date, $(', '.join(edition.publishers))
+                        $elif edition.publish_date:
+                          $edition.publish_date
+                        $elif edition.publishers:
+                          <em>$_('Publish date unknown')</em>, $(', '.join(edition.publishers))
+                        $else:
+                          <em>$_('Publisher unknown')</em>
+                      </div>
+                      <div>
+                        $edition.physical_format.replace('[', '').replace(']','')
+                        $if edition.languages:
+                          $_('in %(language)s', language=', '.join(l.name for l in edition.languages))
+                        $if edition.edition_name:
+                          -
+                          $edition.edition_name
+                      </div>
+                    </div>
+                  </div>
+                  $ id = str(k) + "edition-modal-link"
+                  $:macros.NotesModal(i.work, edition, _('View or update note'), id)
+                </li>
+            </ul>
+          </div>
+        </li>
+    $else:
+      $_("No notes found.")<br>
+  </div>
+  <div class="pager">
+    $:macros.Pager(page, num_found, results_per_page)
+  </div>
+</div>

--- a/openlibrary/templates/account/notes.html
+++ b/openlibrary/templates/account/notes.html
@@ -53,8 +53,11 @@ $def with (notes, user, num_found, page=1, results_per_page=25)
                       </div>
                     </div>
                   </div>
-                  $ id = str(k) + "edition-modal-link"
-                  $:macros.NotesModal(i.work, edition, _('View or update note'), id)
+                  <div class="book-note">
+                    <textarea rows="10" readonly>$i['notes'][k]</textarea>
+                    $ id = str(k) + "edition-modal-link"
+                    $:macros.NotesModal(i.work, edition, _('View or update note'), id, 'notes-view-modal-link')
+                  </div>
                 </li>
             </ul>
           </div>

--- a/openlibrary/templates/account/observations.html
+++ b/openlibrary/templates/account/observations.html
@@ -1,0 +1,50 @@
+$def with (observations, user, num_found, page=1, results_per_page=25)
+
+<div class="my-observations">
+  <div class="list-container">
+    $if observations:
+      <ul>
+        $for i in observations:
+          $ work_id = i.work_id
+          $ work_cover_url = i.work_details['cover_url']
+          <li class="main-list-item">
+            <div class="work-section">
+              <span class="imageLg">
+                <a href="$i.work_key"><img src="$work_cover_url"></a>
+              </span>
+              <span>
+                <h3 itemprop="name" class="booktitle">
+                  <a itemprop="url" href="$i.work_key" class="results">$i.work_details['title']</a>
+                </h3>
+                $if i.work_details['authors']:
+                  By: $', '.join(i.work_details['authors'])
+                $else:
+                  $_('Unknown author')
+              </span>
+            </div>
+            <div class="observation-view" id="$work_id-observations">
+              $ modal_id = str(work_id) + "-observations-modal"
+              $ list_id = str(work_id) + "-observations-list"
+
+              <ul class="observations-list" id="$list_id">
+                $for k in sorted(i['observations']):
+                  $ category = k.capitalize()
+                  $ formatted_observations = ', '.join(i['observations'][k]).capitalize()
+                  <li>
+                    <span class="observation-category">$category:</span> $formatted_observations
+                  </li>
+              </ul>
+              <div class="observation-buttons">
+                <button class="delete-observations-button cta-btn" id="$work_id-observation-delete">$_('Delete')</button>
+                $:macros.ObservationsModal(i.work, _('Update Observations'), modal_id, classes="observations-update-link", reload_id=list_id)
+              </div>
+            </div>
+          </li>
+      </ul>
+    $else:
+      $_("No observations found.")<br>
+  </div>
+  <div class="pager">
+    $:macros.Pager(page, num_found, results_per_page)
+  </div>
+</div>

--- a/openlibrary/templates/account/observations.html
+++ b/openlibrary/templates/account/observations.html
@@ -26,6 +26,7 @@ $def with (observations, user, num_found, page=1, results_per_page=25)
               $ modal_id = str(work_id) + "-observations-modal"
               $ list_id = str(work_id) + "-observations-list"
 
+              <h3 class="observations-header">Observations</h3>
               <ul class="observations-list" id="$list_id">
                 $for k in sorted(i['observations']):
                   $ category = k.capitalize()

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -113,5 +113,8 @@ $def with (page)
           { "post": "/account/logout", "text": _("Log out") }
         ]
       }
+    $# Add book notes link between 'My Reading Stats' and 'Settings' for beta testers:
+    $if ctx.user.is_beta_tester():
+      $accountProps['links'].insert(5, { "href": "/account/books/notes", "text": _("My Book Notes") })
     $:render_template("lib/header_dropdown", accountProps )
 </header>

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -105,14 +105,30 @@
     }
   }
 
-  button {
-    font-size: 1.2em;
-    background-color: @green;
-    width: unset;
-    margin-left: auto;
+  .note-form-buttons {
+    display: flex;
+    justify-content: space-between;
 
-    &:hover { 
-      background-color: darken(@green, 10%); 
+    button {
+      font-size: 1.2em;
+      width: unset;
+    }
+
+    .delete-note-button {
+      background-color: @red;
+  
+      &:hover { 
+        background-color: darken(@red, 10%); 
+      }
+    }
+
+    .update-note-button {
+      background-color: @green;
+      margin-left: auto;
+      
+      &:hover { 
+        background-color: darken(@green, 10%); 
+      }
     }
   }
 }

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -104,31 +104,31 @@
       padding: .25em;
     }
   }
+}
 
-  .note-form-buttons {
-    display: flex;
-    justify-content: space-between;
+.note-form-buttons {
+  display: flex;
+  justify-content: space-between;
 
-    button {
-      font-size: 1.2em;
-      width: unset;
+  button {
+    font-size: 1.2em;
+    width: unset;
+  }
+
+  .delete-note-button {
+    background-color: @red;
+
+    &:hover {
+      background-color: darken(@red, 10%);
     }
+  }
 
-    .delete-note-button {
-      background-color: @red;
-  
-      &:hover { 
-        background-color: darken(@red, 10%); 
-      }
-    }
+  .update-note-button {
+    background-color: @green;
+    margin-left: auto;
 
-    .update-note-button {
-      background-color: @green;
-      margin-left: auto;
-      
-      &:hover { 
-        background-color: darken(@green, 10%); 
-      }
+    &:hover {
+      background-color: darken(@green, 10%);
     }
   }
 }

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -2,40 +2,6 @@
 @import (reference) "../less/colors.less";
 @import (reference) "./buttonBtn.less";
 
-.failure-indicator {
-  color: @red;
-}
-
-.success-indicator {
-  color: @green;
-}
-
-.pending-indicator{
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-}
-
-.pending-indicator:after {
-  content: " ";
-  display: block;
-  width: 1em;
-  height: 1em;
-  border-radius: 50%;
-  border: 1px solid @black;
-  border-color: @black transparent;
-  animation: pending-indicator 1.2s linear infinite;
-}
-
-@keyframes pending-indicator {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
 .single-choice {
   display: flex;
   margin-bottom: .5em;
@@ -135,6 +101,7 @@
 
     textarea {
       width: 100%;
+      padding: .25em;
     }
   }
 
@@ -143,6 +110,10 @@
     background-color: @green;
     width: unset;
     margin-left: auto;
+
+    &:hover { 
+      background-color: darken(@green, 10%); 
+    }
   }
 }
 
@@ -193,12 +164,5 @@
       margin-right: unset;
       display: block;
     }
-  }
-
-  .pending-indicator,
-  .success-indicator,
-  .failure-indicator {
-    display: block;
-    height: 1em;
   }
 }

--- a/static/css/components/notes-view.less
+++ b/static/css/components/notes-view.less
@@ -1,0 +1,130 @@
+@import (reference) "../less/colors.less";
+
+/* Common styling */
+.my-observations,
+.my-notes {
+  flex: 1;
+  padding: 10px;
+}
+
+.list-container {
+  margin-top: 1em;
+}
+
+.main-list-item {
+  border-bottom: 1px solid @cream;
+  margin-bottom: 1em;
+  background-color: @grey-fafafa;
+}
+
+.work-section {
+  display: flex;
+  padding: 1em;
+
+  .imageLg {
+    padding-right: 1em;
+  }
+}
+
+.no-content {
+  padding: 1em;
+  text-align: center;
+}
+
+.pager {
+  .pagination {
+    justify-content: center;
+  }
+}
+
+/* Notes view */
+.notes-list {
+  .notes-list-item {
+    border-top: 2px solid @lightest-grey;
+  }
+}
+
+.book-info {
+  padding: 1em;
+}
+
+.book-note {
+  padding: 1em;
+
+  textarea {
+    width: 100%;
+    resize: none;
+    padding: 0.25em;
+  }
+
+  .notes-view-modal-link {
+    margin-top: 1em;
+    text-align: center;
+  }
+}
+
+
+/* Observations view */
+.observations-header {
+  color: @dark-grey;
+  padding: 1em 1em 0;
+  text-decoration: underline;
+}
+
+.observations-list {
+  padding: 0 1em 0;
+}
+
+.observations-modal-link {
+  margin-top: 1em;
+  font-size: 1.2em;
+}
+
+.observation-category {
+  font-weight: bold;
+}
+
+.observation-buttons {
+  display: flex;
+  justify-content: space-between;
+  padding: 1em;
+
+  .delete-observations-button {
+    background-color: @red;
+    width: unset;
+    font-size: 1.2em;
+
+    &:hover { 
+      background-color: darken(@red, 20%); 
+    }
+  }
+}
+
+.throbber-li {
+  .throbber {
+    position: relative;
+    top: unset;
+    left: unset;
+    height: unset;
+    margin: 1em auto;
+
+    h3 {
+      padding-top: 1.5em;
+      margin-top: unset;
+    }
+  }
+}
+
+@media screen and (max-width: @width-breakpoint-tablet) {
+  .observation-buttons {
+    flex-direction: column-reverse;
+  }
+
+  .observation-buttons {
+    text-align: center;
+
+    .delete-observations-button {
+      margin-top: 1em;
+    }
+  }
+}

--- a/static/css/components/notes-view.less
+++ b/static/css/components/notes-view.less
@@ -54,7 +54,7 @@
   textarea {
     width: 100%;
     resize: none;
-    padding: 0.25em;
+    padding: .25em;
   }
 
   .notes-view-modal-link {
@@ -62,7 +62,6 @@
     text-align: center;
   }
 }
-
 
 /* Observations view */
 .observations-header {
@@ -72,7 +71,7 @@
 }
 
 .observations-list {
-  padding: 0 1em 0;
+  padding: 0 1em;
 }
 
 .observations-modal-link {
@@ -94,8 +93,8 @@
     width: unset;
     font-size: 1.2em;
 
-    &:hover { 
-      background-color: darken(@red, 20%); 
+    &:hover {
+      background-color: darken(@red, 20%);
     }
   }
 }
@@ -118,9 +117,6 @@
 @media screen and (max-width: @width-breakpoint-tablet) {
   .observation-buttons {
     flex-direction: column-reverse;
-  }
-
-  .observation-buttons {
     text-align: center;
 
     .delete-observations-button {

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -7,6 +7,8 @@
  * - /about/vision
  * - /account
  * - /account/books/want-to-read
+ * - /account/books/notes
+ * - /account/books/observations
  * - /account/email/forgot-ia
  * - /account/login
  * - /account/loans
@@ -210,3 +212,5 @@ tr.table-row.selected{
 @import (less) "legacy.less";
 // Import styles specific to the BorrowTable for user pages
 @import (less) "legacy-borrowTable-adminUser.less";
+// Import styles for notes and observations views
+@import (less) "components/notes-view.less";


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4868

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows patrons to view all of the book notes and observations that they have submitted.  Aggregate notes and observations views are displayed on the logged in patron's `/books` page.

Patrons are also given the ability to delete notes (using the notes modal), and observations (from the observations view).

### Technical
<!-- What should be noted about the implementation? -->
This PR builds upon the work done in #5342.  It will likely need to be rebased once that PR is merged.  Leaving this as a draft until that happens.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Note_update](https://user-images.githubusercontent.com/28732543/123499229-322d2f00-d603-11eb-9cf7-1c1d2e26cc90.gif)
*Updating a note in the new notes view*

![Observation_update](https://user-images.githubusercontent.com/28732543/123499244-51c45780-d603-11eb-9b06-342166701894.gif)
*Deleting and updating observations in the new view*

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 