### PR TITLE
fixes /dev subnav + adds i18n

### DIFF
--- a/openlibrary/macros/Subnavigation.html
+++ b/openlibrary/macros/Subnavigation.html
@@ -12,7 +12,7 @@ $     ("/developers/licensing", _("Licensing")),
 $ ]
 
 $ tour_nav = [
-$     ("/tour", "Welcome"),
+$     ("/tour", _("Welcome")),
 $     ("/search/howto", _("Searching Open Library")),
 $     ("/tour/reading", _("Reading Books")),
 $     ("/tour/books", _("Adding & Editing Books")),

--- a/openlibrary/macros/Subnavigation.html
+++ b/openlibrary/macros/Subnavigation.html
@@ -1,32 +1,28 @@
 $def with (page)
 
-$ dev_nav1 = [
-$     ("/developers", "Developers"),
-$     ("/developers/api", "API"),
-$     ("/data", "Data"),
-$     ("/developers/licensing", "Licensing"),
-$ ]
-
-$ dev_nav2 = [
-$   ("http://github.com/internetarchive/openlibrary/issues", "Bugs"),
-$   ("http://github.com/internetarchive/openlibrary", "Source Code"),
-$   ("http://code.openlibrary.org/", "OL Development"),
+$ dev_pages = ["/developers", "/data", "/developers/api", "/developers/licensing"]
+$ dev_nav = [
+$     ("/developers", _("Developer Center (Home)")),
+$     ("/developers/api", _("Web API")),
+$     ("https://github.com/internetarchive/openlibrary-client", _("Client Library")),
+$     ("/data", _("Data Dumps")),
+$     ("https://github.com/internetarchive/openlibrary", _("Source Code")),
+$     ("https://github.com/internetarchive/openlibrary/issues", _("Report an Issue")),
+$     ("/developers/licensing", _("Licensing")),
 $ ]
 
 $ tour_nav = [
 $     ("/tour", "Welcome"),
-$     ("/search/howto", "Searching Open Library"),
-$     ("/tour/reading", "Reading Books"),
-$     ("/tour/books", "Adding & Editing Books"),
-$     ("/tour/subjects", "Using Subjects"),
-$     ("/help/faq", "Open Library F.A.Q."),
+$     ("/search/howto", _("Searching Open Library")),
+$     ("/tour/reading", _("Reading Books")),
+$     ("/tour/books", _("Adding & Editing Books")),
+$     ("/tour/subjects", _("Using Subjects")),
+$     ("/help/faq", _("Open Library F.A.Q.")),
 $ ]
 
-$if page.key in ["/developers","/data","/developers/api","/developers/licensing","/developers/ol","/developers/docs"]:
+$if page.key in dev_pages:
     <div class="subNav sansserif">
-        $:render_template("lib/subnavigation", dev_nav1)
-        <span style="float: left; padding: 0px 10px">&bull;</span>
-        $:render_template("lib/subnavigation", dev_nav2)
+        $:render_template("lib/subnavigation", dev_nav)
     </div>
     <br style="clear: both;"/>
 

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -30,7 +30,7 @@ $def with (page)
       <div>
         <h2>$:_('Develop')</h2>
         <ul>
-          <li><a href="/developers" title="$_('Explore Open Library Development Center')">$_('Development Center')</a></li>
+          <li><a href="/developers" title="$_('Explore Open Library Developer Center')">$_('Developer Center')</a></li>
           <li><a href="/developers/api" title="$_('Explore Open Library APIs')">$_('API Documentation')</a></li>
           <li><a href="/developers/dumps" title="$_('Bulk Open Library data')">$_('Bulk Data Dumps')</a></li>
           <li><a href="https://github.com/internetarchive/openlibrary/wiki/Writing-Bots" title="$_('Write a bot')">$_('Writing Bots')</a></li>


### PR DESCRIPTION
I added `"home"` as one of the i18n nav items in testing on `ol-mek` to verify the i18n was working in e.g. Spanish.

Currently:
![openlibrary org_developers](https://user-images.githubusercontent.com/978325/123680904-0de97200-d7fe-11eb-8206-089588802a92.png)

Will be:
![testing openlibrary org_1337_developers_api](https://user-images.githubusercontent.com/978325/123680756-ea262c00-d7fd-11eb-929b-2263c77ed18a.png)
With i18n:
![testing openlibrary org_1337_developers_api_lang=es](https://user-images.githubusercontent.com/978325/123680751-e98d9580-d7fd-11eb-8d52-8de57e9096a9.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@dcapillae @cdrini @jamesachamp 