### PR TITLE
Add new remote ID links to author pages

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -179,6 +179,10 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                         <li>VIAF: <a itemprop="sameAs" href="https://viaf.org/viaf/$viaf">$viaf</a></li>
                     $if page.remote_ids.wikidata:
                         <li>Wikidata: <a itemprop="sameAs" href="https://tools.wmflabs.org/reasonator/?q=$page.remote_ids.wikidata">$page.remote_ids.wikidata</a></li>
+                    $if page.remote_ids.project_gutenberg:
+                        <li><a href="https://www.gutenberg.org/ebooks/author/$page.remote_ids.project_gutenberg">Project Gutenberg</a></li>
+                    $if page.remote_ids.librivox:
+                        <li><a href="https://librivox.org/author/$page.remote_ids.librivox">LibriVox</a></li>
                 $if page.wikipedia and page.wikipedia.startswith("http"):
                     <li><a itemprop="sameAs" href="$page.wikipedia">Wikipedia</a></li>
                 $for link in page.links:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -171,18 +171,11 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             $if page.links or page.remote_ids or (page.wikipedia and page.wikipedia.startswith("http")):
                 <ul class="booklinks sansserif">
                 $if page.remote_ids:
-                    $if page.remote_ids.isni:
-                       $ isni = page.remote_ids.isni
-                       <li>ISNI: <a itemprop="sameAs" href="http://www.isni.org/$isni">$' '.join([isni[i:i+4] for i in range(0, 16, 4)])</a></li>
-                    $if page.remote_ids.viaf:
-                        $ viaf = page.remote_ids.viaf
-                        <li>VIAF: <a itemprop="sameAs" href="https://viaf.org/viaf/$viaf">$viaf</a></li>
-                    $if page.remote_ids.wikidata:
-                        <li>Wikidata: <a itemprop="sameAs" href="https://tools.wmflabs.org/reasonator/?q=$page.remote_ids.wikidata">$page.remote_ids.wikidata</a></li>
-                    $if page.remote_ids.project_gutenberg:
-                        <li><a href="https://www.gutenberg.org/ebooks/author/$page.remote_ids.project_gutenberg">Project Gutenberg</a></li>
-                    $if page.remote_ids.librivox:
-                        <li><a href="https://librivox.org/author/$page.remote_ids.librivox">LibriVox</a></li>
+                    $ configured_ids = get_author_config()['identifiers']
+                    $for id in configured_ids:
+                        $if id.name in page.remote_ids:
+                            $ href = id.url.replace('@@@', page.remote_ids[id.name])
+                            <li>$id.label: <a itemprop="sameAs" href="$href">$page.remote_ids[id.name]</a></li>
                 $if page.wikipedia and page.wikipedia.startswith("http"):
                     <li><a itemprop="sameAs" href="$page.wikipedia">Wikipedia</a></li>
                 $for link in page.links:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5284

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds LibriVox and Project Gutenberg links to author pages if a corresponding `remote_id` is present.

### Technical
<!-- What should be noted about the implementation? -->
In addition to the `/config/author.yml` configurations outlined in #5093, two new identifiers must be added:
```
-   label: Project Gutenberg
    name: project_gutenberg
    notes: ''
    url: https://www.gutenberg.org/ebooks/author/@@@
-   label: LibriVox
    name: librivox
    notes: ''
    url: https://librivox.org/author/@@@
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Add the correct LibriVox and Project Gutenberg IDs to an author's identifiers.
2. Confirm that the links are present in the "Links (outside Open Library)" section of the author page.
3. Confirm that the links navigate to the correct Project Gutenberg and LibriVox pages.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![remote_ids](https://user-images.githubusercontent.com/28732543/123681348-b821c380-d817-11eb-8e29-941e995d2af0.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB @cdrini 
