### PR TITLE
Footer redesign for better mobile UX

### DIFF
--- a/openlibrary/templates/lib/links.html
+++ b/openlibrary/templates/lib/links.html
@@ -1,0 +1,18 @@
+$def with (props)
+<details>
+    <summary>
+    $if 'label' in props:
+        $(props['label'])
+    </summary>
+    <ul>
+        $for link in props['links']:
+        <li>
+            <a href="$(link['href'])" title="$(link['title'])">$(link['text'])</a>
+        </li>
+    </ul>
+    $if props['label'] == 'Help' :
+            <aside id="footer-icons">
+                <a class="footer-icons__twitter" href="https://twitter.com/OpenLibrary">twitter</a>
+                <a class="footer-icons__github" href="https://github.com/internetarchive/openlibrary">github</a>
+            </aside>
+</details>

--- a/openlibrary/templates/lib/links.html
+++ b/openlibrary/templates/lib/links.html
@@ -1,13 +1,22 @@
 $def with (props)
-<details>
+<details
+$if 'detailsID' in props:
+    id="$(props['detailsID'])"
+>
     <summary>
     $if 'label' in props:
         $(props['label'])
     </summary>
-    <ul>
+    <ul
+    $if 'localID' in props:
+        id="$(props['localID'])"
+    >
         $for link in props['links']:
         <li>
-            <a href="$(link['href'])" title="$(link['title'])">$(link['text'])</a>
+            $if 'lang' in link:
+                <a href="$(link['href'])" lang="$(link['lang'])" data-lang-id="$(link['data-lang-id'])" title="$(link['title'])">$(link['text'])</a>
+            $else:
+                <a href="$(link['href'])" title="$(link['title'])">$(link['text'])</a>
         </li>
     </ul>
     $if props['label'] == 'Help' :

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -47,6 +47,21 @@ $code:
     ]
   }
 
+  languageProps = {
+    'label': _('Language'),
+    'detailsID': 'footer-locale-menu',
+    'localID': 'locale-options',
+    'links': [
+      { "href": "#", "text": "Čeština (cs)", "title": "_('Czech')", "lang": "cs", "data-lang-id": "cs" },
+      { "href": "#", "text": "Deutsch (de)", "title": "_('German')", "lang": "de", "data-lang-id": "de" },
+      { "href": "#", "text": "English (en)", "title": "_('English')", "lang": "en", "data-lang-id": "en" },
+      { "href": "#", "text": "Español (es)", "title": "_('Spanish')", "lang": "es", "data-lang-id": "es" },
+      { "href": "#", "text": "Français (fr)", "title": "_('French')", "lang": "fr", "data-lang-id": "fr" },
+      { "href": "#", "text": "Hrvatski (hr)", "title": "_('Croatian')", "lang": "hr", "data-lang-id": "hr" },
+      { "href": "#", "text": "తెలుగు (te)", "title": "_('Telugu')", "lang": "te", "data-lang-id": "te" }
+    ]
+  }
+
 <footer>
   <div id="footer-content" >
     <div id="footer-links">
@@ -114,18 +129,7 @@ $code:
       $:render_template("lib/links", discoverProps )
       $:render_template("lib/links", developProps )
       $:render_template("lib/links", helpProps )
-      <div id="footer-locale-menu">
-        <h2>$_('Change Website Language')</h2>
-        <ul id="locale-options">
-          <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a> </li>
-          <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a> </li>
-          <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li>
-          <li><a href="#" lang="es" data-lang-id="es" title="$_('Spanish')">Español (es)</a></li>
-          <li><a href="#" lang="fr" data-lang-id="fr" title="$_('French')">Français (fr)</a></li>
-          <li><a href="#" lang="hr" data-lang-id="hr" title="$_('Croatian')">Hrvatski (hr)</a></li>
-          <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li>
-        </ul>
-      </div>
+      $:render_template("lib/links", languageProps )
     </div>
     <hr>
     <div id="footer-details">

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -1,5 +1,52 @@
 $def with (page)
 
+$code:
+  openlibraryProps = {
+    'label': _('Open Library'),
+    'links': [
+      { "href": "/about/vision", "text": _("Vision"), "title": _("") },
+      { "href": "/volunteer", "text": _("Volunteer"), "title": _("") },
+      { "href": "/partner-with-us", "text": _("Partner With Us"), "title": _("") },
+      { "href": "https://archive.org/about/jobs.php", "text": _("Careers"), "title": _("") },
+      { "href": "https://blog.openlibrary.org/", "text": _("Blog"), "title": _("") },
+      { "href": "https://archive.org/about/terms.php", "text": _("Terms of Service"), "title": _("") },
+      { "href": "https://archive.org/donate/?platform=ol", "text": _("Donate"), "title": _("") }
+    ]
+  }
+
+  discoverProps = {
+    'label': _('Discover'),
+    'links': [
+      { "href": "/", "text": _("Home"), "title": _("'Go home'") },
+      { "href": "/search", "text": _("Books"), "title": _("Explore Books") },
+      { "href": "/search/authors", "text": _("Authors"), "title": _("Explore authors") },
+      { "href": "/subjects", "text": _("Subjects"), "title": _("Explore subjects") },
+      { "href": "/collections", "text": _("Collections"), "title": _("Explore collections") },
+      { "href": "/advancedsearch", "text": _("Advanced Search"), "title": _("Advanced Search") },
+      { "href": "#top", "text": _("Return to Top"), "title": _("Navigate to top of this page") }
+    ]
+  }
+
+  developProps = {
+    'label': _('Develop'),
+    'links': [
+      { "href": "/developers", "text": _("Development Center"), "title": _("Explore Open Library Development Center") },
+      { "href": "/developers/api", "text": _("API Documentation"), "title": _("Explore Open Library APIs") },
+      { "href": "/developers/dumps", "text": _("Bulk Data Dumps"), "title": _("Bulk Open Library data") },
+      { "href": "https://github.com/internetarchive/openlibrary/wiki/Writing-Bots", "text": _("Writing Bots"), "title": _("Write a Bot") },
+      { "href": "/books/add", "text": _("Add a Book"), "title": _("Add a new book to Open Library") }
+    ]
+  }
+
+  helpProps = {
+    'label': _('Help'),
+    'links': [
+      { "href": "/help", "text": _("Help Center"), "title": _("Help Center") },
+      { "href": "/contact?path=$request.path", "text": _("Report A Problem"), "title": _("Problems") },
+      { "href": "/help/faq/editing", "text": _("Suggesting Edits"), "title": _("Suggest Edits") }
+    ]
+  }
+
 <footer>
   <div id="footer-content" >
     <div id="footer-links">
@@ -51,6 +98,24 @@ $def with (page)
       </div>
       <div id="footer-locale-menu">
         <h2>$_('Change Website Language')</h2> 
+        <ul id="locale-options">
+          <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a> </li>
+          <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a> </li>
+          <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li>
+          <li><a href="#" lang="es" data-lang-id="es" title="$_('Spanish')">Español (es)</a></li>
+          <li><a href="#" lang="fr" data-lang-id="fr" title="$_('French')">Français (fr)</a></li>
+          <li><a href="#" lang="hr" data-lang-id="hr" title="$_('Croatian')">Hrvatski (hr)</a></li>
+          <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li>
+        </ul>
+      </div>
+    </div>
+    <div id="footer-links-mobile">
+      $:render_template("lib/links", openlibraryProps )
+      $:render_template("lib/links", discoverProps )
+      $:render_template("lib/links", developProps )
+      $:render_template("lib/links", helpProps )
+      <div id="footer-locale-menu">
+        <h2>$_('Change Website Language')</h2>
         <ul id="locale-options">
           <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a> </li>
           <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a> </li>

--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -11,7 +11,7 @@ div#footer-content {
   display: none;
 }
 
-@media only screen and (max-width: 650px) {
+@media only screen and (max-width: @width-breakpoint-tablet) {
   #footer-links {
     display: none !important;
   }
@@ -19,20 +19,31 @@ div#footer-content {
     display: block;
     summary {
       font-weight: 700;
+      cursor: pointer;
+      padding: 5px 0;
     }
     summary::marker {
       content: "";
     }
     summary::after {
-      content: "\002B";
-      font-size: 1.1em;
+      content: "\003E";
       float: right;
+      transform: rotate(90deg);
     }
-    details[open] summary:after {
-      content: "\002D";
+    details[open] {
+      summary:after {
+        content: "\003C";
+      }
+      summary ~ * {
+        animation: sweepDown .5s ease-in-out;
+      }
     }
     details {
       margin: 20px 0;
+    }
+    @keyframes sweepDown {
+      0%    {opacity: 0; max-height: 0px; }
+      100%  {opacity: 1; max-height: 500px; }
     }
   }
 }

--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -42,7 +42,7 @@ div#footer-content {
       margin: 20px 0;
     }
     @keyframes sweepDown {
-      0%    {opacity: 0; max-height: 0px; }
+      0%    {opacity: 0; max-height: 0; }
       100%  {opacity: 1; max-height: 500px; }
     }
   }

--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -7,6 +7,36 @@ div#footer-content {
   padding: 20px;
 }
 
+#footer-links-mobile {
+  display: none;
+}
+
+@media only screen and (max-width: 650px) {
+  #footer-links {
+    display: none !important;
+  }
+  #footer-links-mobile {
+    display: block;
+    summary {
+      font-weight: 700;
+    }
+    summary::marker {
+      content: "";
+    }
+    summary::after {
+      content: "\002B";
+      font-size: 1.1em;
+      float: right;
+    }
+    details[open] summary:after {
+      content: "\002D";
+    }
+    details {
+      margin: 20px 0;
+    }
+  }
+}
+
 div#footer-links {
   .display-flex();
   margin-left: 10px;
@@ -85,9 +115,11 @@ footer {
   }
 }
 
-#footer-links {
+#footer-links,
+#footer-links-mobile {
   ul li a {
-    color: @dark-blue;
+    text-decoration: none;
+    color: @dark-grey;
   }
   div {
     margin: 20px 0;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Redesigned Mobile Footer.

Instead of  `V` and  `Ʌ` we can also use `+` and `-`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![footer](https://user-images.githubusercontent.com/64412143/126452150-928649e1-a5b5-4a17-a696-8e613304e957.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 