### PR TITLE
Truncate long list entry descriptions

### DIFF
--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -119,14 +119,19 @@ def test_get_coverstore_url(monkeypatch):
 
 
 def test_reformat_html():
+    f = utils.reformat_html
+
     input_string = '<p>This sentence has 32 characters.</p>'
-    assert utils.reformat_html(input_string, 10) == 'This sente...'
-    assert utils.reformat_html(input_string) == 'This sentence has 32 characters.'
-    assert utils.reformat_html(input_string, 5000) == 'This sentence has 32 characters.'
+    assert f(input_string, 10) == 'This sente...'
+    assert f(input_string) == 'This sentence has 32 characters.'
+    assert f(input_string, 5000) == 'This sentence has 32 characters.'
 
     multi_line_string = """<p>This sentence has 32 characters.</p>
                            <p>This new sentence has 36 characters.</p>"""
-    assert utils.reformat_html(multi_line_string) == 'This sentence has 32 ' \
+    assert f(multi_line_string) == 'This sentence has 32 ' \
         'characters.<br>This new sentence has 36 characters.'
-    assert utils.reformat_html(multi_line_string, 34) == 'This sentence has 32 ' \
+    assert f(multi_line_string, 34) == 'This sentence has 32 ' \
         'characters.<br>T...'
+
+    assert f("<script>alert('hello')</script>", 34) == "alert('hello')"
+    assert f("&lt;script&gt;") == "&lt;script&gt;"

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -133,5 +133,5 @@ def test_reformat_html():
     assert f(multi_line_string, 34) == 'This sentence has 32 ' \
         'characters.<br>T...'
 
-    assert f("<script>alert('hello')</script>", 34) == "alert('hello')"
+    assert f("<script>alert('hello')</script>", 34) == "alert(&#39;hello&#39;)"
     assert f("<div>&lt;script&gt;</div>") == "&lt;script&gt;"

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -134,4 +134,4 @@ def test_reformat_html():
         'characters.<br>T...'
 
     assert f("<script>alert('hello')</script>", 34) == "alert(&#39;hello&#39;)"
-    assert f("<div>&lt;script&gt;</div>") == "&lt;script&gt;"
+    assert f("&lt;script&gt;") == "&lt;script&gt;"

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -134,4 +134,4 @@ def test_reformat_html():
         'characters.<br>T...'
 
     assert f("<script>alert('hello')</script>", 34) == "alert('hello')"
-    assert f("&lt;script&gt;") == "&lt;script&gt;"
+    assert f("<div>&lt;script&gt;</div>") == "&lt;script&gt;"

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -124,7 +124,9 @@ def test_reformat_html():
     assert utils.reformat_html(input_string) == 'This sentence has 32 characters.'
     assert utils.reformat_html(input_string, 5000) == 'This sentence has 32 characters.'
 
-    multi_line_input_string = """<p>This sentence has 32 characters.</p>
-                                 <p>This new sentence has 36 characters.</p>"""
-    assert utils.reformat_html(multi_line_input_string) == 'This sentence has 32 characters.<br>This new sentence has 36 characters.'
-    assert utils.reformat_html(multi_line_input_string, 34) == 'This sentence has 32 characters.<br>T...'
+    multi_line_string = """<p>This sentence has 32 characters.</p>
+                           <p>This new sentence has 36 characters.</p>"""
+    assert utils.reformat_html(multi_line_string) == 'This sentence has 32 ' \
+        'characters.<br>This new sentence has 36 characters.'
+    assert utils.reformat_html(multi_line_string, 34) == 'This sentence has 32 ' \
+        'characters.<br>T...'

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -116,3 +116,15 @@ def test_get_coverstore_url(monkeypatch):
     # make sure trailing / is always stripped
     monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:80/", raising=False)
     assert utils.get_coverstore_url() == "https://0.0.0.0:80"
+
+
+def test_reformat_html():
+    input_string = '<p>This sentence has 32 characters.</p>'
+    assert utils.reformat_html(input_string, 10) == 'This sente...'
+    assert utils.reformat_html(input_string) == 'This sentence has 32 characters.'
+    assert utils.reformat_html(input_string, 5000) == 'This sentence has 32 characters.'
+
+    multi_line_input_string = """<p>This sentence has 32 characters.</p>
+                                 <p>This new sentence has 36 characters.</p>"""
+    assert utils.reformat_html(multi_line_input_string) == 'This sentence has 32 characters.<br>This new sentence has 36 characters.'
+    assert utils.reformat_html(multi_line_input_string, 34) == 'This sentence has 32 characters.<br>T...'

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -871,7 +871,10 @@ class HTMLTagRemover(HTMLParser):
         self.data = []
 
     def handle_data(self, data):
-        self.data.append(data)
+        self.data.append(data.strip())
+
+    def handle_endtag(self, tag):
+        self.data.append('\n' if tag in ('p', 'li') else ' ')
 
 
 @public
@@ -886,13 +889,12 @@ def reformat_html(html_str: str, max_length: Optional[int] = None) -> str:
     parser = HTMLTagRemover()
     # Must have a root node, otherwise the parser will fail
     parser.feed(f'<div>{html_str}</div>')
-
-    content = [web.websafe(s.strip()) for s in parser.data if len(s.strip())]
+    content = [web.websafe(s) for s in parser.data if s]
 
     if max_length:
-        return truncate('\n'.join(content), max_length).replace('\n', '<br>')
+        return truncate(''.join(content), max_length).strip().replace('\n', '<br>')
     else:
-        return '\n'.join(content).replace('\n', '<br>')
+        return ''.join(content).strip().replace('\n', '<br>')
 
 
 def setup():

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -874,11 +874,10 @@ class HTMLTagRemover(HTMLParser):
 
 
 @public
-def reformat_html(html_str, max_length=None, root_element=None):
+def reformat_html(html_str, max_length=None):
     """
     Reformats an HTML string, removing all opening and closing tags.
     Adds a line break element between each set of text content.
-    Optionally nests the formatted HTML inside of the given root element.
     Optionally truncates contents that exceeds the given max length.
 
     returns: A reformatted HTML string
@@ -905,12 +904,7 @@ def reformat_html(html_str, max_length=None, root_element=None):
     else:
         end_index = len(content) + 1
 
-    results = '<br>'.join(content[:end_index])
-
-    if root_element:
-        results = f'<{root_element}>{results}</{root_element}>'
-
-    return results
+    return '<br>'.join(content[:end_index])
 
 
 def setup():

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -881,6 +881,10 @@ def reformat_html(html_str: str, max_length: Optional[int] = None) -> str:
     Adds a line break element between each set of text content.
     Optionally truncates contents that exceeds the given max length.
 
+    All text nodes in the HTML string are expected to be enclosed
+    within an HTML tag (i.e. <div>content</div>' would be a valid HTML
+    string, but 'content' would be invalid).
+
     returns: A reformatted HTML string
     """
     parser = HTMLTagRemover()

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -881,14 +881,11 @@ def reformat_html(html_str: str, max_length: Optional[int] = None) -> str:
     Adds a line break element between each set of text content.
     Optionally truncates contents that exceeds the given max length.
 
-    All text nodes in the HTML string are expected to be enclosed
-    within an HTML tag (i.e. <div>content</div>' would be a valid HTML
-    string, but 'content' would be invalid).
-
     returns: A reformatted HTML string
     """
     parser = HTMLTagRemover()
-    parser.feed(html_str)
+    # Must have a root node, otherwise the parser will fail
+    parser.feed(f'<div>{html_str}</div>')
 
     content = [web.websafe(s.strip()) for s in parser.data if len(s.strip())]
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -888,7 +888,10 @@ def reformat_html(html_str: str, max_length: Optional[int]=None) -> str:
 
     content = [s.strip() for s in parser.data if len(s.strip())]
 
-    return truncate('\n'.join(content), max_length).replace('\n', '<br>')
+    if max_length:
+        return truncate('\n'.join(content), max_length).replace('\n', '<br>')
+    else:
+        return '\n'.join(content).replace('\n', '<br>')
 
 
 def setup():

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -890,7 +890,7 @@ def reformat_html(html_str: str, max_length: Optional[int] = None) -> str:
     parser = HTMLTagRemover()
     parser.feed(html_str)
 
-    content = [s.strip() for s in parser.data if len(s.strip())]
+    content = [web.websafe(s.strip()) for s in parser.data if len(s.strip())]
 
     if max_length:
         return truncate('\n'.join(content), max_length).replace('\n', '<br>')

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -875,7 +875,7 @@ class HTMLTagRemover(HTMLParser):
 
 
 @public
-def reformat_html(html_str: str, max_length: Optional[int]=None) -> str:
+def reformat_html(html_str: str, max_length: Optional[int] = None) -> str:
     """
     Reformats an HTML string, removing all opening and closing tags.
     Adds a line break element between each set of text content.

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree as etree
 import datetime
 import logging
 from html.parser import HTMLParser
+from typing import Optional
 
 import requests
 
@@ -874,7 +875,7 @@ class HTMLTagRemover(HTMLParser):
 
 
 @public
-def reformat_html(html_str, max_length=None):
+def reformat_html(html_str: str, max_length: Optional[int]=None) -> str:
     """
     Reformats an HTML string, removing all opening and closing tags.
     Adds a line break element between each set of text content.
@@ -887,24 +888,7 @@ def reformat_html(html_str, max_length=None):
 
     content = [s.strip() for s in parser.data if len(s.strip())]
 
-    if max_length:
-        str_lengths = [len(s) for s in content]
-        end_index = 0
-        for i in str_lengths:
-            end_index += 1
-            if max_length - i == 0:
-                break
-            elif max_length - i < 0:
-                content[end_index - 1] = truncate(
-                    content[end_index - 1],
-                    max_length
-                )
-                break
-            max_length -= i
-    else:
-        end_index = len(content) + 1
-
-    return '<br>'.join(content[:end_index])
+    return truncate('\n'.join(content), max_length).replace('\n', '<br>')
 
 
 def setup():

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -50,7 +50,7 @@ $var title: $_('Lists')
                 </div>
                 <div class="description no-img">
                 $if list.description:
-                    $:reformat_html(format(list.description), max_length=250, root_element='p')
+                    <p>$:reformat_html(format(list.description), max_length=250)</p>
                 $else:
                     <p><em class="grey">$_('No description.')</em></p>
                 </div>

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -50,7 +50,7 @@ $var title: $_('Lists')
                 </div>
                 <div class="description no-img">
                 $if list.description:
-                    $:format(list.description)
+                    $:reformat_html(format(list.description), max_length=250, root_element='p')
                 $else:
                     <p><em class="grey">$_('No description.')</em></p>
                 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5341

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes all HTML tags from list descriptions and truncates the results to 250 characters.  Truncated results are nested within a single `<p>` element.


### Technical
<!-- What should be noted about the implementation? -->
This solution occurs server-side, and only affects list descriptions on the `/lists` page.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This one is tricky to test locally, but the code is live on testing.

1. Navigate to http://testing.openlibrary.org/lists
2. Ensure that any long list descriptions that may appear are truncated
3. Ensure that long list descriptions on list search and my list pages are not truncated

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-07-07 23-39-58](https://user-images.githubusercontent.com/28732543/124858808-bfb23c80-df7c-11eb-8367-e7100dfe8b35.png)

Full list can be found [here](http://testing.openlibrary.org/people/stillme/lists/OL193888L/Not_available_%E3%80%8A_UATF_%E3%80%8B).

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 