### PR TITLE
Make staging/testing serve norobots.txt!

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -345,7 +345,9 @@ class robotstxt(delegate.page):
     def GET(self):
         web.header('Content-Type', 'text/plain')
         try:
-            robots_file = 'norobots.txt' if 'dev' in infogami.config.features else 'robots.txt'
+            is_dev = ('dev' in infogami.config.features or
+                      web.ctx.host != 'openlibrary.org')
+            robots_file = 'norobots.txt' if is_dev else 'robots.txt'
             data = open('static/' + robots_file).read()
             raise web.HTTPError('200 OK', {}, data)
         except IOError:


### PR DESCRIPTION
Closes #5403

Saw a staging.openlibrary.org URL in Google search 🤕 . Hotfix.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ http://localhost:8080/robots.txt serves norobots.txt
- ✅ http://testing.openlibrary.org/robots.txt serves norobots.txt
- ✅ https://openlibrary.org/search?debug=true&title=() lists host as `openlibrary.org` (scroll to bottom)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
