### PR TITLE
Fix QueryCarousels not infinite scrolling

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -14,7 +14,7 @@ const Carousel = {
      * @param {String} loadMore.pageMode of page e.g. `offset`
      */
     add: function(selector, a, b, c, d, e, f, loadMore) {
-        var responsive_settings, availabilityStatuses, addWork, url, default_limit;
+        var responsive_settings, availabilityStatuses, addWork, default_limit;
 
         a = a || 6;
         b = b || 5;
@@ -78,16 +78,14 @@ const Carousel = {
             borrow_available: {cls: 'cta-btn--available', cta: 'Borrow'},
             borrow_unavailable: {cls: 'cta-btn--unavailable', cta: 'Join Waitlist'},
             error: {cls: 'cta-btn--missing', cta: 'Not In Library'},
-            private: {cls: 'cta-btn--available', cta: 'Preview'}
+            // private: {cls: 'cta-btn--available', cta: 'Preview'}
         };
 
         addWork = function(work) {
-            let availability = work.availability || {};
-            let ocaid = availability.identifier ||
+            const availability = work.availability || {};
+            const ocaid = availability.identifier ||
                 work.lending_identifier_s ||
-                work.ia ? work.ia[0] : undefined;
-            let openlibrary_edition = availability.openlibrary_edition ||
-                work.lending_edition_s || undefined;
+                (work.ia ? work.ia[0] : undefined);
             // Use solr data to augment availability API
             if (!availability.status || availability.status === 'error') {
                 if (work.lending_identifier_s) {
@@ -96,69 +94,62 @@ const Carousel = {
                     availability.status = 'private';
                 }
             }
-            let cover = {
+            const cover = {
                 type: 'id',
-                id: work.covers ? work.covers[0] : work.cover_id || work.cover_i
+                id: work.covers ? work.covers[0] : (work.cover_id || work.cover_i)
             };
-            let availabilityStatus = availabilityStatuses[availability.status];
-            let cls = availabilityStatus.cls;
-            let cta = availabilityStatus.cta;
-            let url = (cls == 'cta-btn--available') ?
-                (`/borrow/ia/${ocaid}`) : (cls == 'cta-btn--unavailable') ?
-                    (`/books/${openlibrary_edition}`) : work.key;
-            let isClickable = availability.status == 'error' ? 'disabled' : '';
+            const availabilityStatus = availabilityStatuses[availability.status] || availabilityStatuses.error;
+            const cls = availabilityStatus.cls;
+            const cta = availabilityStatus.cta;
+            const url = cls == 'cta-btn--available' ? `/borrow/ia/${ocaid}` : work.key;
 
             if (!cover.id && ocaid) {
                 cover.type = 'ia';
                 cover.id = ocaid;
             }
 
-            return `${'<div class="book carousel__item slick-slide slick-active" ' +
-                '"aria-hidden="false" role="option">' +
-                '<div class="book-cover">' +
-                  '<a href="'}${work.key}" ${isClickable}>` +
-                    `<img class="bookcover" title="${
-                        work.title}" ` +
-                      `src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg">` +
-                  '</a>' +
-                '</div>' +
-                '<div class="book-cta">' +
-                  `<a class="btn cta-btn ${cls}" href="${url
-                  }" data-ol-link-track="subjects" ` +
-                    `title="${cta}: ${work.title
-                    }" data-key="subjects" data-ocaid="${ocaid}">${cta
-                    }</a>` +
-                '</div>' +
-              '</div>';
+            const $el = $(`
+                <div class="book carousel__item">
+                    <div class="book-cover">
+                        <a href="${work.key}">
+                            <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg">
+                        </a>
+                    </div>
+                    <div class="book-cta">
+                        <a class="btn cta-btn ${cls}"
+                           data-ol-link-track="subjects"
+                           data-key="subjects"
+                       >${cta}</a>
+                    </div>
+                </div>`);
+            $el.find('.bookcover').attr('title', work.title);
+            $el.find('.cta-btn')
+                .attr('title', `${cta}: ${work.title}`)
+                .attr('data-ocaid', ocaid)
+                .attr('href', url);
+            return $el;
         }
 
         // if a loadMore config is provided and it has a (required) url
         if (loadMore && loadMore.url) {
-            url;
-            try {
-                // exception handling needed in case loadMore.url is relative path
-                url = new URL(loadMore.url);
-            } catch (e) {
-                url = new URL(window.location.origin + loadMore.url);
-            }
+            // handle relative path
+            const url = loadMore.url.startsWith('/') ? new URL(location.origin + loadMore.url) : new URL(loadMore.url);
+
             default_limit = 18; // 3 pages of 6 books
             url.searchParams.set('limit', loadMore.limit || default_limit);
             loadMore.pageMode = loadMore.pageMode === 'page' ? 'page' : 'offset'; // verify pagination mode
             loadMore.locked = false; // prevent additional calls when not in critical section
 
             // Bind an action listener to this carousel on resize or advance
-            $(selector).on('afterChange', function() {
-                var totalSlides = $(`${selector}.slick-slider`)
-                    .slick('getSlick').$slides.length;
-                var numActiveSlides = $(`${selector} .slick-active`).length;
-                var currentLastSlide = $(`${selector}.slick-slider`)
-                    .slick('slickCurrentSlide') + numActiveSlides;
+            $(selector).on('afterChange', function(ev, slick, curSlide) {
+                const totalSlides = slick.$slides.length;
+                const numActiveSlides = slick.$slides.filter('.slick-active').length;
                 // this allows us to pre-load before hitting last page
-                var lastSlideOn2ndLastPage = (totalSlides - numActiveSlides);
+                const isOn2ndLastPage = curSlide >= Math.max(0, totalSlides - numActiveSlides * 2);
 
-                if (!loadMore.locked && (currentLastSlide >= lastSlideOn2ndLastPage) && (currentLastSlide < totalSlides)) {
+                if (!loadMore.locked && !loadMore.allDone && isOn2ndLastPage) {
                     loadMore.locked = true; // lock for critical section
-                    document.body.style.cursor='wait'; // change mouse to spin
+                    slick.addSlide('<div class="carousel__item carousel__loading-end">Loading...</div>');
 
                     if (loadMore.pageMode == 'page') {
                         // for first time, we're on page 1 already so initialize as page 2
@@ -171,21 +162,17 @@ const Carousel = {
                     // update the current page or offset within the URL
                     url.searchParams.set(loadMore.pageMode, loadMore.page);
 
-                    $.ajax({
-                        url: url,
-                        type: 'GET',
-                        success: function(results) {
+                    $.ajax({ url: url, type: 'GET' })
+                        .then(function(results) {
                             const works = results.works || results.docs;
-                            $.each(works, function(work_idx) {
-                                var work = works[work_idx];
-                                var lastSlidePos = $(`${selector}.slick-slider`)
-                                    .slick('getSlick').$slides.length - 1;
-                                $(selector).slick('slickAdd', addWork(work), lastSlidePos);
-                            });
-                            document.body.style.cursor='default'; // return cursor to ready
+                            // Remove loading indicator
+                            slick.removeSlide(totalSlides);
+                            works.forEach(work => slick.addSlide(addWork(work)));
+                            if (!works.length) {
+                                loadMore.allDone = true;
+                            }
                             loadMore.locked = false;
-                        }
-                    });
+                        });
                 }
             });
         }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes (Can't find the issue?). Fixes carousel "load more" not working.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ All carousels on homepage (except Classic Books) support scrolling
- ✅ Subjects pages support scrolling: http://testing.openlibrary.org/subjects/magic
- ✅ Publisher pages support scrolling: http://testing.openlibrary.org/publishers/Headline_Publishing_Group
- ✅ Query carousels work: http://testing.openlibrary.org/collections/k-12

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles @jamesachamp @libjenner @seabelis 
