### PR TITLE
Show stats component only if work key exists

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,4 +1,4 @@
-$def with (edition_count=1, has_observations=False)
+$def with (edition_count=1, show_observations=False)
 
 <ul class="work-menu sticky">
   <li class="selected">
@@ -12,9 +12,7 @@ $def with (edition_count=1, has_observations=False)
   <li>
     <a href="#edition-details">$_("This Edition")</a>
   </li>
-  $if has_observations:
-    $# BookNotes feature:
-    $if ctx.user and ctx.user.is_beta_tester():
+  $if show_observations and ctx.user and ctx.user.is_beta_tester():
       <li>
         <a href="#reader-observations">$_("Reader Observations")</a>
       </li>

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,4 +1,4 @@
-$def with (edition_count=1)
+$def with (edition_count=1, has_observations=False)
 
 <ul class="work-menu sticky">
   <li class="selected">
@@ -12,9 +12,10 @@ $def with (edition_count=1)
   <li>
     <a href="#edition-details">$_("This Edition")</a>
   </li>
-  $# BookNotes feature:
-  $if ctx.user and ctx.user.is_beta_tester():
-    <li>
-      <a href="#reader-observations">$_("Reader Observations")</a>
-    </li>
+  $if has_observations:
+    $# BookNotes feature:
+    $if ctx.user and ctx.user.is_beta_tester():
+      <li>
+        <a href="#reader-observations">$_("Reader Observations")</a>
+      </li>
 </ul>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -6,7 +6,7 @@ $ component_times['TotalTime'] = time()
 $ tab = input(tab=None).tab
 $ editions = []
 $ page_type = page.key.split('/')[1]
-$ show_stats_component = True
+$ show_observations = True
 
 $if page.key.startswith('/works'):
   $ work = page
@@ -14,7 +14,7 @@ $elif page.works:
   $ work = list(page.works)[0]
 $else:
   $ work = page.make_work_from_orphaned_edition()
-  $ show_stats_component = False
+  $ show_observations = False
 $ edition = storage({})
 
 $ component_times['get_sorted_editions'] = time()
@@ -217,7 +217,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
         </div>
         $:macros.ReadMore("subjects")
     </div>
-      $:macros.EditionNavBar(work.edition_count, show_stats_component)
+      $:macros.EditionNavBar(work.edition_count, show_observations)
 
       <p class="preview-languages">
         $ seen = set()
@@ -450,7 +450,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
 
       $# BookNotes feature:
       $if ctx.user and ctx.user.is_beta_tester():
-        $if show_stats_component:
+        $if show_observations:
           $ reader_observations = get_observation_metrics(work['key'])
           $:render_template("observations/stats_component", work, edition, reader_observations, work_title, page.key)
     </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -6,6 +6,7 @@ $ component_times['TotalTime'] = time()
 $ tab = input(tab=None).tab
 $ editions = []
 $ page_type = page.key.split('/')[1]
+$ show_stats_component = True
 
 $if page.key.startswith('/works'):
   $ work = page
@@ -13,6 +14,7 @@ $elif page.works:
   $ work = list(page.works)[0]
 $else:
   $ work = page.make_work_from_orphaned_edition()
+  $ show_stats_component = False
 $ edition = storage({})
 
 $ component_times['get_sorted_editions'] = time()
@@ -215,8 +217,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
         </div>
         $:macros.ReadMore("subjects")
     </div>
-
-      $:macros.EditionNavBar(work.edition_count)
+      $:macros.EditionNavBar(work.edition_count, show_stats_component)
 
       <p class="preview-languages">
         $ seen = set()
@@ -449,8 +450,9 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
 
       $# BookNotes feature:
       $if ctx.user and ctx.user.is_beta_tester():
-        $ reader_observations = get_observation_metrics(work['key'])
-        $:render_template("observations/stats_component", work, edition, reader_observations, work_title, page.key)
+        $if show_stats_component:
+          $ reader_observations = get_observation_metrics(work['key'])
+          $:render_template("observations/stats_component", work, edition, reader_observations, work_title, page.key)
     </div>
   </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5404

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Does not render the reader observations statistics component on book pages if an edition is orphaned.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:
1. Navigate to a book page of an orphaned edition.
2. Ensure that the page loads without any errors.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
