### PR TITLE
add noindex header to anywhere but prd

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -11,7 +11,7 @@ $def with (page)
     <meta name="creator" content="OpenLibrary.org" />
     <meta name="copyright" content="Original content copyright; 2007-2015" />
     <meta name="distribution" content="Global" />
-    $if not request.canonical_url.startswith("https://openlibrary.org/"):
+    $if request.domain != 'openlibrary.org':
         <meta name="robots" content="noindex">
 
     <link rel="canonical" href="$request.canonical_url" />

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -5,12 +5,14 @@ $def with (page)
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="title" content="" />
-    <meta name = "keywords" content = "free books, books to read, free ebooks,audio books,read books for free, read books online, online library">
+    <meta name="keywords" content="free books, books to read, free ebooks, audio books, read books for free, read books online, online library">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="OpenLibrary.org" />
     <meta name="creator" content="OpenLibrary.org" />
     <meta name="copyright" content="Original content copyright; 2007-2015" />
     <meta name="distribution" content="Global" />
+    $if not request.canonical_url.startswith("https://openlibrary.org/"):
+        <meta name="robots" content="noindex">
 
     <link rel="canonical" href="$request.canonical_url" />
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5403 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `noindex` header to testing/stage so we don't have testing/staging results showing up in search engines.

This also fixes some tiny whitespace issues on the `keywords` header. I can remove that if desired.

### Technical
<!-- What should be noted about the implementation? -->
I couldn't figure out a simple way to access web.ctx.host so I just used the `$request.canonical_url` which uses web.ctx.host.

If this is a way we should access web.ctx.host feel free to fix or just let me know.

### Considerations
1. Are any openlibrary.org subdomains we don’t want excluded? (I assume blog.openlibrary.org won't be impacted)
2. Is there any chance someone else is hosting fork this and it will cause their site to stop being indexed?

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I see it working locally by inspecting the html.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 