### PR TITLE
remove extra parenthesis from edition excerpts

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -283,7 +283,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
                               $_("Page %(page)s", page=excerpt.pages),
                           $if excerpt.author:
                               $def excerpt_author_link(): <a href="$excerpt.author.key">$excerpt.author.displayname</a>
-                              $:_("added by %(authorlink)s.", authorlink=str(excerpt_author_link()).strip()))
+                              $:_("added by %(authorlink)s.", authorlink=str(excerpt_author_link()).strip())
                           $else:
                               $_("added anonymously.")
                           $if excerpt.comment:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5410

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the extra parenthesis that was showing up for user.

### Technical
<!-- What should be noted about the implementation? -->
Parenthesis matching is hard to do by hand.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to edition page
2. Add excerpt
3. Check that no extra paren is showing.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
