### PR TITLE
i18n `update` accepts optional parameters

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -91,11 +91,15 @@ def compile_translations():
         if os.path.exists(po_path):
             _compile_translation(po_path, mo_path)
 
-def update_translations():
+
+def update_translations(locales):
+    locales_to_update = locales or get_locales()
+    print(f"Updating {locales_to_update}")
+
     pot_path = os.path.join(root, 'messages.pot')
     template = read_po(open(pot_path, 'rb'))
 
-    for locale in get_locales():
+    for locale in locales_to_update:
         po_path = os.path.join(root, locale, 'messages.po')
         mo_path = os.path.join(root, locale, 'messages.mo')
 
@@ -107,6 +111,8 @@ def update_translations():
             write_po(f, catalog)
             f.close()
             print('updated', po_path)
+        else:
+            print(f"ERROR: {po_path} does not exist...")
 
     compile_translations()
 

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -83,8 +83,11 @@ def extract_messages(dirs: List[str]):
 
     print('wrote template to', path)
 
-def compile_translations():
-    for locale in get_locales():
+
+def compile_translations(locales: List[str]):
+    locales_to_update = locales or get_locales()
+
+    for locale in locales_to_update:
         po_path = os.path.join(root, locale, 'messages.po')
         mo_path = os.path.join(root, locale, 'messages.mo')
 
@@ -92,7 +95,7 @@ def compile_translations():
             _compile_translation(po_path, mo_path)
 
 
-def update_translations(locales):
+def update_translations(locales: List[str]):
     locales_to_update = locales or get_locales()
     print(f"Updating {locales_to_update}")
 
@@ -114,7 +117,7 @@ def update_translations(locales):
         else:
             print(f"ERROR: {po_path} does not exist...")
 
-    compile_translations()
+    compile_translations(locales_to_update)
 
 
 def generate_po(args):

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -32,7 +32,7 @@ def main(cmd, args):
     elif cmd == 'compile':
         i18n.compile_translations()
     elif cmd == 'update':
-        i18n.update_translations()
+        i18n.update_translations(args)
     elif cmd == 'add':
         i18n.generate_po(args)
     elif cmd == 'help':

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -30,7 +30,7 @@ def main(cmd, args):
         ]
         i18n.extract_messages(message_sources)
     elif cmd == 'compile':
-        i18n.compile_translations()
+        i18n.compile_translations(args)
     elif cmd == 'update':
         i18n.update_translations(args)
     elif cmd == 'add':


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5416

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Multiple locale codes can optionally be added to the `i18n-messages update` command.  If codes are added, only the corresponding `.po` files will be updated.

Locale codes should be delimited by spaces.  For example, `i18n-messages update es de` will update the Spanish and German `.po` files.

Running `i18n-messages update` without any locale codes will update all `.po` files in the `i18n` directory, as per usual.

### Technical
<!-- What should be noted about the implementation? -->
Any amount of locale codes can be included with an `update` call.  If there is not a corresponding `.po` file for a locale code, and error message is displayed and execution will continue normally.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run `i18n-messages update` and ensure that all `.po` files are updated.
2. Run `i18n-messages update` with a single locale code.  Ensure that only the corresponding `.po` file is updated.
3. Repeat step two with multiple local codes. Ensure that only the expected files are updated.
4. Repeat step two with a non-existent locale code.  Ensure that nothing is updated.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 