### PR TITLE
Add `i18n-messages validate` to check for fuzzy matching in `.po` files

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -21,13 +21,35 @@ def _compile_translation(po, mo):
     try:
         catalog = read_po(open(po, 'rb'))
 
-        f = open(mo, 'wb')
-        write_mo(f, catalog)
-        f.close()
-        print('compiled', po, file=web.debug)
+        if _validate_catalog(catalog):
+            f = open(mo, 'wb')
+            write_mo(f, catalog)
+            f.close()
+            print('compiled', po, file=web.debug)
+        else:
+            print("Failed to compile", po)
+            print()
     except Exception as e:
         print('failed to compile', po, file=web.debug)
         raise e
+
+
+def _validate_catalog(catalog):
+    validation_errors = []
+    for message in catalog:
+        if message.fuzzy:
+            if message.lineno:
+                validation_errors.append(f'  Line {message.lineno}: "{message.string}" is fuzzy.')
+            else:
+                validation_errors.append('  File is fuzzy.  Remove line containing "#, fuzzy" found near the beginning of the file.')
+
+    if validation_errors:
+        print("Validation failed...")
+        print("Please correct the following errors before proceeding:")
+        for e in validation_errors:
+            print(e)
+
+    return len(validation_errors) == 0
 
 
 def get_locales():

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -21,14 +21,10 @@ def _compile_translation(po, mo):
     try:
         catalog = read_po(open(po, 'rb'))
 
-        if _validate_catalog(catalog):
-            f = open(mo, 'wb')
-            write_mo(f, catalog)
-            f.close()
-            print('compiled', po, file=web.debug)
-        else:
-            print("Failed to compile", po)
-            print()
+        f = open(mo, 'wb')
+        write_mo(f, catalog)
+        f.close()
+        print('compiled', po, file=web.debug)
     except Exception as e:
         print('failed to compile', po, file=web.debug)
         raise e
@@ -55,6 +51,26 @@ def _validate_catalog(catalog):
             print(e)
 
     return len(validation_errors) == 0
+
+
+def validate_translations(args):
+    if args:
+        locale = args[0]
+        po_path = os.path.join(root, locale, 'messages.po')
+
+        if os.path.exists(po_path):
+            catalog = read_po(open(po_path, 'rb'))
+            is_valid = _validate_catalog(catalog)
+
+            if is_valid:
+                print(f'Translations for locale "{locale}" are valid!')
+            return is_valid
+        else:
+            print(f'Portable object file for locale "{locale}" does not exist.')
+            return False
+    else:
+        print('Must include locale code when executing validate.')
+        return False
 
 
 def get_locales():

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -36,7 +36,7 @@ def _validate_catalog(catalog):
         if message.fuzzy:
             if message.lineno:
                 validation_errors.append(
-                    f'  Line {message.lineno}: "{message.string}" is fuzzy.'
+                    f'openlibrary/i18n/te/messages.po:{message.lineno}: "{message.string}" is fuzzy.'
                 )
             else:
                 validation_errors.append(

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -39,12 +39,14 @@ def _validate_catalog(catalog):
     for message in catalog:
         if message.fuzzy:
             if message.lineno:
-                validation_errors.append(f'  Line {message.lineno}: "{message.string}" is fuzzy.')
+                validation_errors.append(
+                    f'  Line {message.lineno}: "{message.string}" is fuzzy.'
+                )
             else:
                 validation_errors.append(
-                    '  File is fuzzy.  Remove line containing "#, fuzzy" found near the '
-                    'beginning of the file.'
-                    )
+                    '  File is fuzzy.  Remove line containing "#, fuzzy" found near '
+                    'the beginning of the file.'
+                )
 
     if validation_errors:
         print("Validation failed...")

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -41,7 +41,10 @@ def _validate_catalog(catalog):
             if message.lineno:
                 validation_errors.append(f'  Line {message.lineno}: "{message.string}" is fuzzy.')
             else:
-                validation_errors.append('  File is fuzzy.  Remove line containing "#, fuzzy" found near the beginning of the file.')
+                validation_errors.append(
+                    '  File is fuzzy.  Remove line containing "#, fuzzy" found near the '
+                    'beginning of the file.'
+                    )
 
     if validation_errors:
         print("Validation failed...")

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -30,13 +30,13 @@ def _compile_translation(po, mo):
         raise e
 
 
-def _validate_catalog(catalog):
+def _validate_catalog(catalog, locale):
     validation_errors = []
     for message in catalog:
         if message.fuzzy:
             if message.lineno:
                 validation_errors.append(
-                    f'openlibrary/i18n/te/messages.po:{message.lineno}: "{message.string}" is fuzzy.'
+                    f'openlibrary/i18n/{locale}/messages.po:{message.lineno}: "{message.string}" is fuzzy.'
                 )
             else:
                 validation_errors.append(
@@ -60,7 +60,7 @@ def validate_translations(args):
 
         if os.path.exists(po_path):
             catalog = read_po(open(po_path, 'rb'))
-            is_valid = _validate_catalog(catalog)
+            is_valid = _validate_catalog(catalog, locale)
 
             if is_valid:
                 print(f'Translations for locale "{locale}" are valid!')

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -36,7 +36,8 @@ def _validate_catalog(catalog, locale):
         if message.fuzzy:
             if message.lineno:
                 validation_errors.append(
-                    f'openlibrary/i18n/{locale}/messages.po:{message.lineno}: "{message.string}" is fuzzy.'
+                    f'openlibrary/i18n/{locale}/messages.po:{message.lineno}:'
+                    f' "{message.string}" is fuzzy.'
                 )
             else:
                 validation_errors.append(

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -11,13 +11,14 @@ from openlibrary import i18n
 def help():
     print("utility to manage i18n messages")
     print() 
-    print("USAGE: %s [extract|compile|update]" % sys.argv[0])
+    print("USAGE: %s [extract|compile|update|validate]" % sys.argv[0])
     print() 
     print("Available Commands:")
-    print("  compile - compile the message files (.po) to .mo")
-    print("  extract - extract i18n messages from templates and macros")
-    print("  update  - update the existing translations by adding newly added string to it.")
-    print("  help    - display this help message")
+    print("  compile  - compile the message files (.po) to .mo")
+    print("  extract  - extract i18n messages from templates and macros")
+    print("  update   - update the existing translations by adding newly added string to it.")
+    print("  validate - check message file for errors")
+    print("  help     - display this help message")
     
 def main(cmd, args):
     if cmd == 'extract':
@@ -35,6 +36,8 @@ def main(cmd, args):
         i18n.update_translations()
     elif cmd == 'add':
         i18n.generate_po(args)
+    elif cmd == 'validate':
+        i18n.validate_translations(args)
     elif cmd == 'help':
         help()
     else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5425

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `validate` command to our existing i18n utilities.  `i18n-messages validate` requires a locale code.  If a `.po` file exists for the given locale code, the file is checked for `fuzzy` flags.

If no `fuzzy` flags are found, a success message is printed and the function returns `True`.  Otherwise, messages containing the line number of flagged strings are printed and `False` is returned.  The function will also return `False` if an either an unknown locale code, or no locale code, is passed when the script is executed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Run `i18n-messages validate` with a valid locale code.  Check the accuracy of the messages that are printed to the console.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini
