### PR TITLE
Create `i18n-messages add` for `.po` file generation

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -5,6 +5,7 @@ from typing import List
 
 import web
 import os
+import shutil
 
 import babel
 from babel._compat import BytesIO
@@ -108,6 +109,30 @@ def update_translations():
             print('updated', po_path)
 
     compile_translations()
+
+
+def generate_po(args):
+    if args:
+        po_dir = os.path.join(root, args[0])
+        pot_src = os.path.join(root, 'messages.pot')
+        po_dest = os.path.join(po_dir, 'messages.po')
+
+        if os.path.exists(po_dir):
+            if os.path.exists(po_dest):
+                print(f"Portable object file already exists at {po_dest}")
+            else:
+                shutil.copy(pot_src, po_dest)
+                os.chmod(po_dest, 0o666)
+                print(f"File created at {po_dest}")
+        else:
+            os.mkdir(po_dir)
+            os.chmod(po_dir, 0o777)
+            shutil.copy(pot_src, po_dest)
+            os.chmod(po_dest, 0o666)
+            print(f"File created at {po_dest}")
+    else:
+        print("Add failed. Missing required locale code.")
+
 
 @web.memoize
 def load_translations(lang):

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -19,7 +19,7 @@ def help():
     print("  update  - update the existing translations by adding newly added string to it.")
     print("  help    - display this help message")
     
-def main(cmd):
+def main(cmd, args):
     if cmd == 'extract':
         message_sources = [
             'openlibrary/templates/',
@@ -33,6 +33,8 @@ def main(cmd):
         i18n.compile_translations()
     elif cmd == 'update':
         i18n.update_translations()
+    elif cmd == 'add':
+        i18n.generate_po(args)
     elif cmd == 'help':
         help()
     else:
@@ -40,8 +42,8 @@ def main(cmd):
         sys.exit(2)
 
 if __name__ == "__main__":
-    if len(sys.argv) == 2:
-        main(sys.argv[1])
+    if len(sys.argv) >= 2:
+        main(sys.argv[1], sys.argv[2:])
     else:
         help()
         sys.exit(1)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `i18n-messages add` utility, which takes a locale code as a parameter and creates a new locale directory containing a `messages.po` file.  The new `messages.po` file is simply a copy of the `messages.pot` template file.

### Technical
<!-- What should be noted about the implementation? -->
New directory and files are created only if they do not already exist.  `root` is the group and owner of new created files and directories in Ubuntu 18.04, and likely many other distros.  Because of this, `os.chmod` was used to relax permissions on the new directories and files.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Execute `i18n-messages add`, passing a new locale code as a parameter.
2. Ensure that the `i18n` directory contains a new directory with the same name as your locale code.
3. Ensure that the new directory contains a `messages.po` file, and that this file is a copy of `i18n/messages.pot`.
4. Ensure that you can modify the new file.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
