### PR TITLE
Redesign Mobile Header Bar

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -102,7 +102,7 @@
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "21KB"
+      "maxSize": "22KB"
     }
   ]
 }

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -74,7 +74,7 @@
     },
     {
       "path": "static/build/page-admin.css",
-      "maxSize": "21KB"
+      "maxSize": "22KB"
     },
     {
       "path": "static/build/page-book.css",
@@ -98,7 +98,7 @@
     },
     {
       "path": "static/build/page-subject.css",
-      "maxSize": "8KB"
+      "maxSize": "9KB"
     },
     {
       "path": "static/build/page-user.css",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -78,7 +78,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "10KB"
+      "maxSize": "11KB"
     },
     {
       "path": "static/build/page-edit.css",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -90,7 +90,7 @@
     },
     {
       "path": "static/build/page-home.css",
-      "maxSize": "6KB"
+      "maxSize": "7KB"
     },
     {
       "path": "static/build/page-plain.css",

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -132,6 +132,13 @@ export class SearchBar {
                 this.$input.trigger('focus');
             }
         });
+        $(document).on('click', event => {
+            if ($(event.target).closest('.search-component').length === 0) {
+                if (!(this.collapsed)) {
+                    this.toggleCollapse();
+                }
+            }
+        });
     }
 
     /**

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -132,9 +132,10 @@ export class SearchBar {
                 this.$input.trigger('focus');
             }
         });
+        // Collapse search bar when clicking outside of search bar
         $(document).on('click', event => {
             if ($(event.target).closest('.search-component').length === 0) {
-                if (!(this.collapsed)) {
+                if (!this.collapsed) {
                     this.toggleCollapse();
                 }
             }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -287,6 +287,10 @@ jQuery(function () {
 
     $('#wikiselect').on('focus', function(){$(this).trigger('select');})
 
+    $('.hamburger-component .mask-menu').on('click', function () {
+        $('details[open]').not(this).removeAttr('open');
+    });
+
     // Open one dropdown at a time.
     $(document).on('click', function (event) {
         const $openMenus = $('.header-dropdown details[open]').parents('.header-dropdown');

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -14,7 +14,7 @@ $# @param {DropdownLink[]} props.links
       <summary>
         $if 'mask' in props and ctx.user:
             <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
-            <img class="header-dropdown__icon" src="$(props['image'])" alt="$(props['label'])"/>
+            <img class="header-dropdown__icon logged" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'image' in props:
             <img class="header-dropdown__icon" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'label' in props:
@@ -37,12 +37,12 @@ $# @param {DropdownLink[]} props.links
               <li class="subsection">
                 $(link['subsection'])
                 $if link['subsection'] == 'My Open Library' and ctx.user:
-                  <img class="header-dropdown__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
+                  <img class="app-drawer__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
               </li>
             $elif 'loginClass' in link:
               <li class="$(link['loginClass'])">
-                <a href="/account/login">$_('Log in')</a>
-                <a href="/account/create">$_('Sign up')</a>
+                <a href="/account/login">$_('Log In')</a>
+                <a href="/account/create">$_('Sign Up')</a>
               </li>
             $else:
               <li>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -25,7 +25,12 @@ $# @param {DropdownLink[]} props.links
       </summary>
       $if 'mask' in props:
         <div class="mask-menu"></div>
-      <div class="$(props['name'])-dropdown-component navigation-dropdown-component">
+      <div 
+      $if 'mask' in props:
+        class="app-drawer"
+      $else:
+        class="$(props['name'])-dropdown-component navigation-dropdown-component"
+      >
         <ul class="dropdown-menu $(props['name'])-dropdown-menu">
           $for link in props['links']:
             $if 'subsection' in link:
@@ -34,11 +39,13 @@ $# @param {DropdownLink[]} props.links
                 $if link['subsection'] == 'My Open Library' and ctx.user:
                   <img class="header-dropdown__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
               </li>
+            $elif 'loginClass' in link:
+              <li class="$(link['loginClass'])">
+                <a href="/account/login">$_('Log in')</a>
+                <a href="/account/create">$_('Sign up')</a>
+              </li>
             $else:
-              <li
-              $if 'loginClass' in link:
-                class="$(link['loginClass'])"
-              >
+              <li>
               $if 'post' in link:
                 <form action="$(link['post'])" method="post">
                   <button>$(link["text"])</button>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -12,7 +12,10 @@ $# @param {DropdownLink[]} props.links
 <div class="$(props['name'])-component header-dropdown">
     <details>
       <summary>
-        $if 'image' in props:
+        $if 'mask' in props and ctx.user:
+            <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
+            <img class="header-dropdown__icon" src="$(props['image'])" alt="$(props['label'])"/>
+        $elif 'image' in props:
             <img class="header-dropdown__icon" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'label' in props:
             $(props['label'])
@@ -20,17 +23,34 @@ $# @param {DropdownLink[]} props.links
 
         <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
       </summary>
+      $if 'mask' in props:
+        <div class="mask-menu"></div>
       <div class="$(props['name'])-dropdown-component navigation-dropdown-component">
         <ul class="dropdown-menu $(props['name'])-dropdown-menu">
           $for link in props['links']:
-            <li>
-            $if 'post' in link:
-              <form action="$(link['post'])" method="post">
-                <button>$(link["text"])</button>
-              </form>
+            $if 'subsection' in link:
+              <li class="subsection">
+                $(link['subsection'])
+                $if link['subsection'] == 'My Open Library' and ctx.user:
+                  <img class="header-dropdown__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
+              </li>
             $else:
-              <a href="$(link['href'])">$(link['text'])</a>
-            </li>
+              <li
+              $if 'loginClass' in link:
+                class="$(link['loginClass'])"
+              >
+              $if 'post' in link:
+                <form action="$(link['post'])" method="post">
+                  <button>$(link["text"])</button>
+                </form>
+              $else:
+                <a href="$(link['href'])">
+                  $if 'new' in link and props['name'] == 'hamburger':
+                    <span>$(link['text'])</span><span class="badge">NEW!</span>
+                  $else:
+                    $(link['text'])
+                </a>
+              </li>
         </ul>
       </div>
     </details>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -12,21 +12,21 @@ $# @param {DropdownLink[]} props.links
 <div class="$(props['name'])-component header-dropdown">
     <details>
       <summary>
-        $if 'mask' in props and ctx.user:
-            <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
-            <img class="header-dropdown__icon logged" src="$(props['image'])" alt="$(props['label'])"/>
+        $if props['name'] == 'hamburger' and ctx.user:
+            <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')">
+            <img class="$(props['image-class']) logged" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'image' in props:
-            <img class="header-dropdown__icon" src="$(props['image'])" alt="$(props['label'])"/>
+            <img class="$(props['image-class'])" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'label' in props:
             $(props['label'])
             <span class="shift">$_('Menu')</span>
 
         <img class="down-arrow" aria-hidden="true" src="/static/images/down-arrow.png" alt="" role="presentation" width="7" height="4">
       </summary>
-      $if 'mask' in props:
+      $if 'show_mask' in props:
         <div class="mask-menu"></div>
       <div 
-      $if 'mask' in props:
+      $if props['name'] == 'hamburger':
         class="app-drawer"
       $else:
         class="$(props['name'])-dropdown-component navigation-dropdown-component"
@@ -36,13 +36,11 @@ $# @param {DropdownLink[]} props.links
             $if 'subsection' in link:
               <li class="subsection">
                 $(link['subsection'])
-                $if link['subsection'] == 'My Open Library' and ctx.user:
-                  <img class="app-drawer__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
               </li>
             $elif 'loginClass' in link:
               <li class="$(link['loginClass'])">
-                <a href="/account/login">$_('Log In')</a>
-                <a href="/account/create">$_('Sign Up')</a>
+                <a class="login-links__secondary" href="/account/login">$_('Log In')</a>
+                <a class="login-links__primary" href="/account/create">$_('Sign Up')</a>
               </li>
             $else:
               <li>
@@ -53,7 +51,7 @@ $# @param {DropdownLink[]} props.links
               $else:
                 <a href="$(link['href'])">
                   $if 'new' in link and props['name'] == 'hamburger':
-                    <span>$(link['text'])</span><span class="badge">NEW!</span>
+                    <span>$(link['text'])</span><span class="app-drawer__badge">$_('New!')</span>
                   $else:
                     $(link['text'])
                 </a>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -11,7 +11,7 @@ $# @param {string|null} props.image URL for image (optional)
 $# @param {DropdownLink[]} props.links
 <div class="$(props['name'])-component header-dropdown">
     <details>
-      <summary>
+      <summary $:cond(props['name'] == 'hamburger', 'data-ol-link-track="HeaderBar|Hamburger"')>
         $if props['name'] == 'hamburger' and ctx.user:
             <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')">
             <img class="$(props['image-class']) logged" src="$(props['image'])" alt="$(props['label'])"/>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -21,7 +21,6 @@ $def with (page)
   $  'image': '/static/images/menu.png',
   $  'label': 'additional options menu'
   $ }
-  $:render_template("lib/header_dropdown", hamburgerProps )
 
   <div class="logo-component">
     <a href="/" title="$_('The Internet Archive\'s Open Library: One page for every book')">
@@ -117,4 +116,59 @@ $def with (page)
     $if ctx.user.is_beta_tester():
       $accountProps['links'].insert(5, { "href": "/account/books/notes", "text": _("My Book Notes") })
     $:render_template("lib/header_dropdown", accountProps )
+
+    <div class="header-dropdown account_icon">
+      <img class="header-dropdown__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
+    </div>
+
+  <div class="hamburger-component header-dropdown">
+
+    <details>
+      <summary>
+        <img src="/static/images/menu.png" alt="additional options menu"/>
+      </summary>
+      <div class="mask-menu"></div>
+      <div class="hamburger-dropdown-component navigation-dropdown-component">
+        <ul class="dropdown-menu hamburger-dropdown-menu">
+          <li class="subsection">My Open Library</li>
+          $if not ctx.user:
+            <li class="login-links"><a class="login" href="/account/login">$_("Log in")</a></li>
+            <li class="login-links"><a href="/account/create">$_("Sign up")</a></li>
+          $if ctx.user:
+            <li><a href="$ctx.user.key">$_("My Profile")</a></li>
+            <li><a href="$homepath()/account/loans">$_("My Loans")</a></li>
+            <li><a href="$ctx.user.key/lists">$_("My Lists")</a></li>
+            <li><a href="/account/books">$_("My Reading Log")</a></li>
+            <li><a href="/account/books/already-read/stats">$_("My Reading Stats")</a></li>
+            <li><a href="$homepath()/account">$_("Settings")</a></li>
+            <li>
+              <form name="logout" action="/account/logout" method="post">
+                <a href="#" onclick="document.forms['logout'].submit()">$_("Log out")</a>
+              </form>
+            </li>
+
+          <li class="subsection">Browse</li>
+          <li><a href="/subjects">$_("Subjects")</a></li>
+          <li><a href="/explore">$_("Library Explorer")</a></li>
+          <li><a href="/lists">$_("Lists")</a></li>
+          <li><a href="/collections">$_("Collections")</a></li>
+          <li><a href="/k-12">$_("K-12 Student Library")</a></li>
+          <li><a href="/random">$_("Random Book")</a></li>
+          <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
+          <li class="subsection">Others</li>
+          <li><a href="/books/add">$_("Add a Book")</a></li>
+          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
+          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
+          <li><a href="/developers">$_("Developer Center")</a></li>
+          <li><a href="/help">$_("Help & Support")</a></li>
+        </ul>
+      </div>
+    </details>
+  </div>
 </header>
+<div class="header-bar mobile">
+  <ul class="navigation-component mobile">
+    <li>$:render_template("lib/header_dropdown", browseProps )</li>
+    <li>$:render_template("lib/header_dropdown", moreProps )</li>
+  </ul>
+</div>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -2,11 +2,19 @@ $def with (page)
 
 <header id="header-bar" class="header-bar">
   $if ctx.user:
-    $ loginLinks = []
+    $ loginLinks = [
+    $     { "href": ctx.user.key, "text": _("My Profile") },
+    $     { "href": homepath() + "/account/loans", "text": _("My Loans") },
+    $     { "href": ctx.user.key + "/lists", "text": _("My Lists") },
+    $     { "href": "/account/books", "text": _("My Reading Log") },
+    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats") },
+    $     { "href": homepath() + "/account", "text": _("Settings") },
+    $     { "post": "/account/logout", "text": _("Log out") },
+    $ ]
   $else:
     $ loginLinks = [
-    $     { "href": "/account/login", "text": _("Log in") },
-    $     { "href": "/account/create", "text": _("Sign up") }
+    $     { "loginClass": "login-links", "href": "/account/login", "text": _("Log in") },
+    $     { "loginClass": "login-links", "href": "/account/create", "text": _("Sign up") }
     $ ]
   $ moreLinks = [
   $     { "href": "/books/add", "text": _("Add a Book") },
@@ -15,11 +23,22 @@ $def with (page)
   $     { "href": "/developers", "text": _("Developer Center") },
   $     { "href": "/help", "text": _("Help & Support") }
   $ ]
+  $ browseLinks = [
+  $     { "href": "/subjects", "text": _("Subjects") },
+  $     { "new": "", "href": "/explore", "text": _("Library Explorer") },
+  $     { "href": "/lists", "text": _("Lists") },
+  $     { "new": "", "href": "/collections", "text": _("Collections") },
+  $     { "href": "/k-12", "text": _("K-12 Student Library") },
+  $     { "href": "/random", "text": _("Random Book") },
+  $     { "href": "/advancedsearch", "text": _("Advanced Search") }
+  $ ]
   $ hamburgerProps = {
   $  'name': 'hamburger',
-  $  'links': loginLinks + moreLinks,
+  $  'links': [ { "subsection": _("My Open Library") } ] + loginLinks +
+  $     [ { "subsection": _("Browse") } ] + browseLinks + [ { "subsection": _("More") } ] + moreLinks,
   $  'image': '/static/images/menu.png',
-  $  'label': 'additional options menu'
+  $  'label': 'additional options menu',
+  $  'mask' : ''
   $ }
 
   <div class="logo-component">
@@ -35,14 +54,7 @@ $def with (page)
   $ browseProps = {
   $   'name': 'browse',
   $   'label': _('Browse'),
-  $   'links': [
-  $     { "href": "/subjects", "text": _("Subjects") },
-  $     { "href": "/lists", "text": _("Lists") },
-  $     { "href": "/collections", "text": _("Collections") },
-  $     { "href": "/k-12", "text": _("K-12 Student Library") },
-  $     { "href": "/random", "text": _("Random Book") },
-  $     { "href": "/advancedsearch", "text": _("Advanced Search") }
-  $   ]
+  $   'links': browseLinks
   $ }
 
   $ moreProps = {
@@ -102,69 +114,15 @@ $def with (page)
         # dev environment), this get_internet_archive_id returns None. Setting it to an
         # empty string returns a valid image ¯\_(ツ)_/¯
         'image': 'https://archive.org/services/img/' + (get_internet_archive_id(ctx.user.key) or ''),
-        'links': [
-          { "href": ctx.user.key, "text": _("My Profile") },
-          { "href": homepath() + "/account/loans", "text": _("My Loans") },
-          { "href": ctx.user.key + "/lists", "text": _("My Lists") },
-          { "href": "/account/books", "text": _("My Reading Log") },
-          { "href": "/account/books/already-read/stats", "text": _("My Reading Stats") },
-          { "href": homepath() + "/account", "text": _("Settings") },
-          { "post": "/account/logout", "text": _("Log out") }
-        ]
+        'links': loginLinks
       }
     $# Add book notes link between 'My Reading Stats' and 'Settings' for beta testers:
     $if ctx.user.is_beta_tester():
       $accountProps['links'].insert(5, { "href": "/account/books/notes", "text": _("My Book Notes") })
     $:render_template("lib/header_dropdown", accountProps )
 
-    <div class="header-dropdown account_icon">
-      <img class="header-dropdown__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="My account">
-    </div>
+  $:render_template("lib/header_dropdown", hamburgerProps )
 
-  <div class="hamburger-component header-dropdown">
-
-    <details>
-      <summary>
-        <img src="/static/images/menu.png" alt="additional options menu"/>
-      </summary>
-      <div class="mask-menu"></div>
-      <div class="hamburger-dropdown-component navigation-dropdown-component">
-        <ul class="dropdown-menu hamburger-dropdown-menu">
-          <li class="subsection">My Open Library</li>
-          $if not ctx.user:
-            <li class="login-links"><a class="login" href="/account/login">$_("Log in")</a></li>
-            <li class="login-links"><a href="/account/create">$_("Sign up")</a></li>
-          $if ctx.user:
-            <li><a href="$ctx.user.key">$_("My Profile")</a></li>
-            <li><a href="$homepath()/account/loans">$_("My Loans")</a></li>
-            <li><a href="$ctx.user.key/lists">$_("My Lists")</a></li>
-            <li><a href="/account/books">$_("My Reading Log")</a></li>
-            <li><a href="/account/books/already-read/stats">$_("My Reading Stats")</a></li>
-            <li><a href="$homepath()/account">$_("Settings")</a></li>
-            <li>
-              <form name="logout" action="/account/logout" method="post">
-                <a href="#" onclick="document.forms['logout'].submit()">$_("Log out")</a>
-              </form>
-            </li>
-
-          <li class="subsection">Browse</li>
-          <li><a href="/subjects">$_("Subjects")</a></li>
-          <li><a href="/explore"><span>$_("Library Explorer")</span><span class="badge">NEW!</span></a></li>
-          <li><a href="/lists">$_("Lists")</a></li>
-          <li><a href="/collections"><span>$_("Collections")</span><span class="badge">NEW!</span></a></li>
-          <li><a href="/k-12">$_("K-12 Student Library")</a></li>
-          <li><a href="/random">$_("Random Book")</a></li>
-          <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
-          <li class="subsection">Other</li>
-          <li><a href="/books/add">$_("Add a Book")</a></li>
-          <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
-          <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>
-          <li><a href="/developers">$_("Developer Center")</a></li>
-          <li><a href="/help">$_("Help & Support")</a></li>
-        </ul>
-      </div>
-    </details>
-  </div>
 </header>
 <div class="header-bar mobile">
   <ul class="navigation-component mobile">

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -149,9 +149,9 @@ $def with (page)
 
           <li class="subsection">Browse</li>
           <li><a href="/subjects">$_("Subjects")</a></li>
-          <li class="new"><a href="/explore">$_("Library Explorer")</a><span class="badge">NEW!</span></li>
+          <li><a href="/explore"><span>$_("Library Explorer")</span><span class="badge">NEW!</span></a></li>
           <li><a href="/lists">$_("Lists")</a></li>
-          <li class="new"><a href="/collections">$_("Collections")</a><span class="badge">NEW!</span></li>
+          <li><a href="/collections"><span>$_("Collections")</span><span class="badge">NEW!</span></a></li>
           <li><a href="/k-12">$_("K-12 Student Library")</a></li>
           <li><a href="/random">$_("Random Book")</a></li>
           <li><a href="/advancedsearch">$_("Advanced Search")</a></li>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -13,8 +13,7 @@ $def with (page)
     $ ]
   $else:
     $ loginLinks = [
-    $     { "loginClass": "login-links", "href": "/account/login", "text": _("Log in") },
-    $     { "loginClass": "login-links", "href": "/account/create", "text": _("Sign up") }
+    $     { "loginClass": "login-links" }
     $ ]
   $ moreLinks = [
   $     { "href": "/books/add", "text": _("Add a Book") },

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -35,9 +35,10 @@ $def with (page)
   $  'name': 'hamburger',
   $  'links': [ { "subsection": _("My Open Library") } ] + loginLinks +
   $     [ { "subsection": _("Browse") } ] + browseLinks + [ { "subsection": _("More") } ] + moreLinks,
-  $  'image': '/static/images/menu.png',
+  $  'image': '/static/images/hamburger-icon.svg',
+  $  'image-class': 'hamburger__icon',
   $  'label': 'additional options menu',
-  $  'mask' : ''
+  $  'show_mask': True
   $ }
 
   <div class="logo-component">
@@ -113,6 +114,7 @@ $def with (page)
         # dev environment), this get_internet_archive_id returns None. Setting it to an
         # empty string returns a valid image ¯\_(ツ)_/¯
         'image': 'https://archive.org/services/img/' + (get_internet_archive_id(ctx.user.key) or ''),
+        'image-class': 'header-dropdown__icon',
         'links': loginLinks
       }
     $# Add book notes link between 'My Reading Stats' and 'Settings' for beta testers:

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -125,9 +125,9 @@ $def with (page)
   $:render_template("lib/header_dropdown", hamburgerProps )
 
 </header>
-<div class="header-bar mobile">
+<header class="header-bar mobile">
   <ul class="navigation-component mobile">
     <li>$:render_template("lib/header_dropdown", browseProps )</li>
     <li>$:render_template("lib/header_dropdown", moreProps )</li>
   </ul>
-</div>
+</header>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -149,13 +149,13 @@ $def with (page)
 
           <li class="subsection">Browse</li>
           <li><a href="/subjects">$_("Subjects")</a></li>
-          <li><a href="/explore">$_("Library Explorer")</a></li>
+          <li class="new"><a href="/explore">$_("Library Explorer")</a><span class="badge">NEW!</span></li>
           <li><a href="/lists">$_("Lists")</a></li>
-          <li><a href="/collections">$_("Collections")</a></li>
+          <li class="new"><a href="/collections">$_("Collections")</a><span class="badge">NEW!</span></li>
           <li><a href="/k-12">$_("K-12 Student Library")</a></li>
           <li><a href="/random">$_("Random Book")</a></li>
           <li><a href="/advancedsearch">$_("Advanced Search")</a></li>
-          <li class="subsection">Others</li>
+          <li class="subsection">Other</li>
           <li><a href="/books/add">$_("Add a Book")</a></li>
           <li><a href="/sponsorship">$_("Sponsor a Book")</a></li>
           <li><a href="/recentchanges">$_("Recent Community Edits")</a></li>

--- a/static/css/components/header-bar--desktop.less
+++ b/static/css/components/header-bar--desktop.less
@@ -21,10 +21,6 @@
     order: 6;
   }
 
-  .hamburger-component {
-    display: none;
-  }
-
   .logo-component {
     /* border-right: 1px solid @dark-beige; */
     padding-right: 15px;

--- a/static/css/components/header-bar--desktop.less
+++ b/static/css/components/header-bar--desktop.less
@@ -1,5 +1,6 @@
 .header-bar {
   margin: 20px auto;
+  padding-top: 0;
   -webkit-box-orient: horizontal;
   -webkit-box-direction: normal;
   -ms-flex-direction: row;

--- a/static/css/components/header-bar--tablet.less
+++ b/static/css/components/header-bar--tablet.less
@@ -5,12 +5,25 @@
     }
   }
 
+  .account-component {
+    display: block;
+  }
+
+  .account_icon {
+    display: none;
+  }
+
   .navigation-component {
+    .display-flex();
     .dropdown-menu {
       border-top: none;
       border-top-right-radius: 0;
       border-top-left-radius: 0;
     }
+  }
+
+  .hamburger-component {
+    display: none;
   }
 
   .search-component {
@@ -28,5 +41,9 @@
       width: auto;
       max-width: 310px;
     }
+  }
+
+  &.mobile {
+    display: none;
   }
 }

--- a/static/css/components/header-bar--tablet.less
+++ b/static/css/components/header-bar--tablet.less
@@ -1,4 +1,15 @@
 .header-bar {
+  padding-top: 5px;
+
+  .logo-component {
+    // The width and height attributes of logo-icon should be equal to
+    // dimensions of /static/images/openlibrary-logo-tighter.svg
+    .logo-icon {
+      height: 47px;
+      width: 189px;
+    }
+  }
+
   .auth-component {
     .hide-me {
       display: inline;
@@ -7,10 +18,6 @@
 
   .account-component {
     display: block;
-  }
-
-  .account_icon {
-    display: none;
   }
 
   .navigation-component {

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -142,6 +142,16 @@
       border: none;
     }
 
+    .app-drawer__badge {
+      color: @white;
+      background-color: @primary-blue;
+      font-size: .9em;
+      padding: 2px 6px 1px;
+      border-radius: 4px;
+      float: right;
+      text-transform: uppercase;
+    }
+
     // stylelint-disable max-nesting-depth, selector-max-specificity
     .subsection {
       font-weight: bold;
@@ -160,36 +170,23 @@
       margin: 0 8px;
     }
 
-    li a {
+    li a, li button, .login-links {
       padding: 10px 8px;
     }
 
     li button {
-      padding: 10px 8px;
       width: 100%;
       font-family: @bahnschrift;
       text-align: left;
       cursor: pointer;
     }
 
-    li .app-drawer__icon {
-      position: absolute;
-      top: 10px;
-      right: 18px;
-      width: 48px;
-      height: 48px;
-      border: 2px solid @border-color;
-      border-radius: 3px;
-    }
-
     .subsection:first-child {
       border-top: 1px solid @dark-beige;
-      position: relative;
     }
 
     .login-links {
       display: flex;
-      padding: 10px 8px;
       border-bottom: none;
       justify-content: space-evenly;
       column-gap: 16px;
@@ -203,22 +200,24 @@
       display: flex;
       justify-content: center;
       align-items: center;
-      color: @primary-blue;
       border-radius: 6px;
       padding: 6px;
-      border: 2px solid @primary-blue;
       transition: .3s;
+    }
+
+    .login-links .login-links__primary {
+      background: @primary-blue;
+      color: @white;
       &:hover {
-        background-color: @white;
+        background-color: @link-blue;
       }
     }
 
-    .login-links a:nth-of-type(2) {
-      background: @primary-blue;
-      color: @white;
-      border: none;
+    .login-links .login-links__secondary {
+      color: @primary-blue;
+      border: 2px solid @primary-blue;
       &:hover {
-        background-color: @link-blue;
+        background-color: @white;
       }
     }
     // stylelint-enable max-nesting-depth, selector-max-specificity
@@ -230,15 +229,6 @@
     order: 4;
     margin-right: 5px;
 
-    .badge {
-      color: @white;
-      background-color: @primary-blue;
-      font-size: .9em;
-      padding: 2px 6px 1px;
-      border-radius: 4px;
-      float: right;
-    }
-
     // stylelint-disable max-nesting-depth, selector-max-specificity
     details[open] {
       .mask-menu{
@@ -249,13 +239,20 @@
       summary ~ * {
         animation: sweep .2s ease-in-out;
       }
-      .header-dropdown__icon {
+      .hamburger__icon {
         background-color: @account-icon-background;
       }
     }
 
-    .header-dropdown__icon.logged {
-      padding-left: 8px;
+    .hamburger__icon {
+      width: 24px;
+      padding: 6px;
+      border-radius: 3px;
+      box-sizing: content-box;
+    }
+
+    .hamburger__icon.logged {
+      padding-left: 20px;
     }
 
     @keyframes sweep {
@@ -317,12 +314,12 @@
     }
 
     .account__icon {
-      border: 2px solid @border-color;
+      border: 2px solid @account-icon-border;
       border-radius: 4px;
       width: 30px;
       height: 30px;
       position: absolute;
-      right: 24px;
+      right: 20px;
     }
 
     button,
@@ -467,7 +464,7 @@
     }
 
     .search-bar-submit {
-      background: url(/static/images/search-lens.png) center no-repeat;
+      background: url(/static/images/search-icon.svg) center no-repeat;
       width: 45px;
       height: 45px;
       border-top-left-radius: .3em;
@@ -863,7 +860,7 @@ div.search-facet:focus-within {
   #header-bar {
     position: sticky;
     top: 0;
-    background: linear-gradient(to bottom, @header-1 50px, @header-2 218px) !important;
+    background: linear-gradient(to bottom, @gradient-start 50px, @gradient-end 218px) !important;
     padding: 3px 0;
     box-shadow: 0 1px 2px rgb(0 0 0 / 15%);
     z-index: @z-index-level-3;
@@ -882,6 +879,9 @@ div.search-facet:focus-within {
       .search-facet-selector {
         margin-top: 1px;
       }
+    }
+    &.mobile {
+      padding: 10px 0;
     }
   }
 }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -134,7 +134,7 @@
     z-index: @z-index-level-2;
     overflow-y: auto;
     overscroll-behavior: contain;
-    font-family: Bahnschrift;
+    font-family: @bahnschrift;
     background-color: @light-beige;
     box-shadow: -10px 0 10px -6px rgb(0 0 0 / 25%);
 
@@ -142,10 +142,11 @@
       border: none;
     }
 
+    // stylelint-disable max-nesting-depth, selector-max-specificity
     .subsection {
       font-weight: bold;
       border-bottom: 2px solid @dark-beige;
-      padding: 16px 10px 1px 10px;
+      padding: 16px 10px 1px;
       &:hover {
         background-color: transparent;
       }
@@ -159,7 +160,6 @@
       padding: 10px 10px 10px 20px;
     }
 
-    // stylelint-disable-next-line selector-max-specificity
     li .header-dropdown__icon {
       position: absolute;
       top: 10px;
@@ -168,7 +168,6 @@
       border-radius: 3px;
     }
 
-    // stylelint-disable-next-line selector-max-specificity
     .subsection:first-child {
       border-top: 1px solid @dark-beige;
       position: relative;
@@ -185,7 +184,6 @@
       }
     }
 
-    // stylelint-disable-next-line selector-max-specificity
     .login-links a {
       flex: 1;
       background: @primary-blue;
@@ -194,13 +192,12 @@
       border-radius: 6px;
       padding: 6px;
       border: 1px solid @primary-blue;
-      transition: 0.3s;
+      transition: .3s;
       &:hover {
         background-color: @link-blue;
       }
     }
 
-    // stylelint-disable-next-line selector-max-specificity
     .login-links a:nth-of-type(2) {
       background: @light-beige;
       color: @primary-blue;
@@ -208,6 +205,7 @@
         background-color: @white;
       }
     }
+    // stylelint-enable max-nesting-depth, selector-max-specificity
   }
 
   .hamburger-component {
@@ -228,7 +226,7 @@
     details[open] {
       .mask-menu{
         visibility: visible;
-        opacity: 0.6;
+        opacity: .6;
         animation: fadeIn .2s ease-in-out;
       }
       summary ~ * {
@@ -243,7 +241,7 @@
 
     @keyframes fadeIn {
       0% {opacity: 0;}
-      100% {opacity: 0.6;}
+      100% {opacity: .6;}
     }
     // stylelint-enable max-nesting-depth, selector-max-specificity
 
@@ -321,10 +319,6 @@
     -ms-flex-order: 1;
     order: 1;
     z-index: @z-index-level-negative;
-
-    .logo-txt:after {
-      content: "";
-    }
 
     .logo-icon {
       position: relative;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -123,61 +123,90 @@
     }
   }
 
-  .hamburger-dropdown-component {
-    @topHeight: 53px;
+  .app-drawer {
+    @topHeight: 50px;
     position: fixed;
+    width: 300px;
+    max-width: 100vw;
     right: 0;
     top: @topHeight;
     height: calc(100% - @topHeight);
     z-index: @z-index-level-2;
     overflow-y: auto;
     overscroll-behavior: contain;
+    font-family: Bahnschrift;
     background-color: @light-beige;
     box-shadow: -10px 0 10px -6px rgb(0 0 0 / 25%);
+
+    ul {
+      border: none;
+    }
+
     .subsection {
       font-weight: bold;
-      border-bottom: 3px solid @dark-beige;
-      padding: 10px;
+      border-bottom: 2px solid @dark-beige;
+      padding: 16px 10px 1px 10px;
+      &:hover {
+        background-color: transparent;
+      }
+    }
+
+    li:not(.subsection) {
+      margin: 0 8px;
     }
 
     li a, li button {
-      padding: 10px 30px 10px 20px;
+      padding: 10px 10px 10px 20px;
     }
 
     // stylelint-disable-next-line selector-max-specificity
     li .header-dropdown__icon {
-      float: right;
-      position: relative;
-      bottom: 15px;
+      position: absolute;
+      top: 10px;
+      right: 18px;
+      border: 1px solid @border-color;
       border-radius: 3px;
     }
 
     // stylelint-disable-next-line selector-max-specificity
     .subsection:first-child {
-      padding-top: 20px;
+      border-top: 1px solid @dark-beige;
+      position: relative;
     }
 
     .login-links {
-      width: 50%;
-      float: left;
+      display: flex;
       padding: 10px;
       border-bottom: none;
+      justify-content: space-evenly;
+      column-gap: 16px;
+      &:hover {
+        background-color: transparent;
+      }
     }
 
     // stylelint-disable-next-line selector-max-specificity
     .login-links a {
+      flex: 1;
       background: @primary-blue;
       text-align: center;
       color: @white;
       border-radius: 6px;
       padding: 6px;
       border: 1px solid @primary-blue;
+      transition: 0.3s;
+      &:hover {
+        background-color: @link-blue;
+      }
     }
 
     // stylelint-disable-next-line selector-max-specificity
-    .login-links:nth-of-type(2) a {
+    .login-links a:nth-of-type(2) {
       background: @light-beige;
       color: @primary-blue;
+      &:hover {
+        background-color: @white;
+      }
     }
   }
 
@@ -199,7 +228,7 @@
     details[open] {
       .mask-menu{
         visibility: visible;
-        opacity: 1;
+        opacity: 0.6;
         animation: fadeIn .2s ease-in-out;
       }
       summary ~ * {
@@ -214,7 +243,7 @@
 
     @keyframes fadeIn {
       0% {opacity: 0;}
-      100% {opacity: 1;}
+      100% {opacity: 0.6;}
     }
     // stylelint-enable max-nesting-depth, selector-max-specificity
 
@@ -244,12 +273,12 @@
 
   .mask-menu {
     position: fixed;
-    top: 53px;
+    top: 50px;
     left: 0;
     right: 0;
     opacity: 0;
     bottom: 0;
-    background: rgba(0,0,0,.5);
+    background: linear-gradient(to right, transparent -30px, @black);
     z-index: @z-index-level-1;
     visibility: hidden;
   }
@@ -266,6 +295,7 @@
     }
 
     .account__icon {
+      border: 1px solid @border-color;
       border-radius: 4px;
       width: 30px;
       height: 30px;
@@ -292,13 +322,16 @@
     order: 1;
     z-index: @z-index-level-negative;
 
+    .logo-txt:after {
+      content: "";
+    }
+
     .logo-icon {
       position: relative;
       top: -1px;
-      height: 40px;
+      height: 32px;
       width: auto;
       margin-right: 5px;
-      padding-right: 5px;
       -ms-flex-item-align: center;
       align-self: center;
     }
@@ -377,7 +410,6 @@
       margin-right: 15px;
       -ms-flex-item-align: center;
       align-self: center;
-      // height: 54px;
 
       .search-bar-component {
         width: 95%;
@@ -660,6 +692,7 @@ div.search-facet:focus-within {
     }
     input[type=submit] {
       border: none;
+      cursor: pointer;
       -webkit-appearance: none;
       -moz-appearance: none;
       appearance: none;
@@ -816,5 +849,21 @@ div.search-facet:focus-within {
     padding: 3px 0;
     box-shadow: 0 1px 2px rgb(0 0 0 / 15%);
     z-index: @z-index-level-3;
+  }
+
+  .header-bar {
+    .logo-component .logo-icon {
+      margin-top: 5px;
+      margin-left: 8px;
+    }
+    .search-component {
+      height: 44px;
+      .search-bar-submit {
+        height: 42px;
+      }
+      .search-facet-selector {
+        margin-top: 1px;
+      }
+    }
   }
 }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -252,7 +252,7 @@
     }
 
     .hamburger__icon.logged {
-      padding-left: 20px;
+      padding-left: 26px;
     }
 
     @keyframes sweep {
@@ -319,7 +319,7 @@
       width: 30px;
       height: 30px;
       position: absolute;
-      right: 24px;
+      right: 28px;
     }
 
     button,

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -99,7 +99,6 @@
     border-radius: 3px;
 
     li {
-      padding: 0 20px 0 10px;
       border-bottom: 1px solid @beige-two;
 
       // stylelint-disable max-nesting-depth, selector-max-specificity
@@ -138,6 +137,10 @@
       font-weight: bold;
       border-bottom: 3px solid @beige-two;
       padding: 10px;
+    }
+
+    li a {
+      padding: 10px 30px 10px 20px;
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -180,17 +183,12 @@
       z-index: @z-index-level-5;
     }
 
-    .new {
-      display: flex;
-      justify-content: space-between;
-    }
-
     .badge {
       color: @white;
       background-color: @primary-blue;
       padding: 1px 3px;
       border-radius: 4px;
-      margin: 8px 0;
+      float: right;
     }
 
     // stylelint-disable max-nesting-depth, selector-max-specificity

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -178,6 +178,19 @@
       z-index: @z-index-level-5;
     }
 
+    .new {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .badge {
+      color: @white;
+      background-color: @primary-blue;
+      padding: 1px 3px;
+      border-radius: 4px;
+      margin: 8px 0;
+    }
+
     // stylelint-disable max-nesting-depth, selector-max-specificity
     details[open] {
       .mask-menu{

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -282,9 +282,9 @@
     -webkit-box-flex: 1;
     -ms-flex: 1;
     flex: 1;
-    -webkit-box-ordinal-group: 1;
-    -ms-flex-order: 0;
-    order: 0;
+    -webkit-box-ordinal-group: 2;
+    -ms-flex-order: 1;
+    order: 1;
     z-index: @z-index-level-negative;
 
     .logo-icon {
@@ -353,9 +353,9 @@
 
   .search-component {
     width: 45px;
-    -webkit-box-ordinal-group: 2;
-    -ms-flex-order: 1;
-    order: 1;
+    -webkit-box-ordinal-group: 3;
+    -ms-flex-order: 2;
+    order: 2;
     height: 47px;
     margin-right: 5px;
     text-align: right;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -245,8 +245,8 @@
     }
 
     .hamburger__icon {
-      width: 24px;
-      padding: 6px;
+      width: 22px;
+      padding: 10px 12px;
       border-radius: 3px;
       box-sizing: content-box;
     }
@@ -319,7 +319,7 @@
       width: 30px;
       height: 30px;
       position: absolute;
-      right: 20px;
+      right: 24px;
     }
 
     button,
@@ -410,7 +410,7 @@
     -ms-flex-order: 2;
     order: 2;
     height: 47px;
-    margin-right: 5px;
+    margin-right: -5px;
     text-align: right;
     -webkit-box-flex: 1;
     -ms-flex: 1;
@@ -860,7 +860,7 @@ div.search-facet:focus-within {
   #header-bar {
     position: sticky;
     top: 0;
-    background: linear-gradient(to bottom, @gradient-start 50px, @gradient-end 218px) !important;
+    background: linear-gradient(to bottom, @header-bar-gradient-start, @header-bar-gradient-end);
     padding: 3px 0;
     box-shadow: 0 1px 2px rgb(0 0 0 / 15%);
     z-index: @z-index-level-3;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -124,23 +124,32 @@
   }
 
   .hamburger-dropdown-component {
+    @topHeight: 58px;
     position: fixed;
     right: 0;
-    top: 0;
-    height: 100vh;
+    top: @topHeight;
+    height: calc(100% - @topHeight);
     z-index: @z-index-level-2;
     overflow-y: auto;
     overscroll-behavior: contain;
     background-color: @light-beige;
-    box-shadow: 0 1px 20px rgba(0,0,0,.25);
+    box-shadow: -10px 0 10px -6px rgb(0 0 0 / 25%);
     .subsection {
       font-weight: bold;
-      border-bottom: 3px solid @beige-two;
+      border-bottom: 3px solid @dark-beige;
       padding: 10px;
     }
 
-    li a {
+    li a, li button {
       padding: 10px 30px 10px 20px;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    li .header-dropdown__icon {
+      float: right;
+      position: relative;
+      bottom: 15px;
+      border-radius: 3px;
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -166,7 +175,7 @@
     }
 
     // stylelint-disable-next-line selector-max-specificity
-    .login-links .login {
+    .login-links:nth-of-type(2) a {
       background: @light-beige;
       color: @primary-blue;
     }
@@ -177,11 +186,6 @@
     -ms-flex-order: 4;
     order: 4;
     margin-right: 5px;
-
-    summary {
-      position: relative;
-      z-index: @z-index-level-5;
-    }
 
     .badge {
       color: @white;
@@ -240,7 +244,7 @@
 
   .mask-menu {
     position: fixed;
-    top: 0;
+    top: 58px;
     left: 0;
     right: 0;
     opacity: 0;
@@ -256,21 +260,17 @@
       content: "" !important;
     }
 
-    // stylelint-disable max-nesting-depth, selector-max-specificity
-    &.account_icon {
-      order: 3;
-      margin-left: 10px;
-
-      img {
-        border: 1px solid @dark-beige;
-        border-radius: .3em;
-      }
-    }
-    // stylelint-enable max-nesting-depth, selector-max-specificity
-
     .header-dropdown__icon {
-      width: 45px;
-      height: 45px;
+      width: 40px;
+      height: 40px;
+    }
+
+    .account__icon {
+      border-radius: 4px;
+      width: 30px;
+      height: 30px;
+      position: absolute;
+      right: 24px;
     }
 
     button,
@@ -295,7 +295,7 @@
     .logo-icon {
       position: relative;
       top: -1px;
-      height: 30px;
+      height: 40px;
       width: auto;
       margin-right: 5px;
       padding-right: 5px;
@@ -374,13 +374,15 @@
       -webkit-box-flex: 1;
       -ms-flex: 1;
       flex: 1;
-      margin-top: 8px;
+      margin-right: 15px;
       -ms-flex-item-align: center;
       align-self: center;
-      height: 54px;
+      // height: 54px;
 
       .search-bar-component {
         width: 95%;
+        background-color: @grey-fafafa;
+        border: 1px solid @dark-beige;
       }
 
       .search-bar {
@@ -424,9 +426,7 @@
 
     .search-bar-component {
       display: inline-block;
-      border: 1px solid @dark-beige;
       border-radius: .3em;
-      background-color: @grey-fafafa;
       position: relative;
     }
 
@@ -628,7 +628,6 @@ div.search-facet:focus-within {
     -webkit-transition: all .2s;
     -o-transition: all .2s;
     transition: all .2s;
-    background: @grey-fafafa;
     border-radius: .3em;
     -webkit-box-flex: 1;
     -ms-flex: 1 0 0%;
@@ -672,14 +671,6 @@ div.search-facet:focus-within {
 // We should review this media query to determine if it is in fact needed.
 @media only screen and (min-width: 25em) {
   .header-bar {
-    .logo-component {
-      // The width and height attributes of logo-icon should be equal to
-      // dimensions of /static/images/openlibrary-logo-tighter.svg
-      .logo-icon {
-        height: 47px;
-        width: 189px;
-      }
-    }
 
     .navigation-component {
       .dropdown-menu {
@@ -724,6 +715,10 @@ div.search-facet:focus-within {
 
     .search-component {
       margin-right: 0;
+    }
+
+    .hamburger-component summary {
+      margin-left: 15px;
     }
   }
 }
@@ -786,6 +781,8 @@ div.search-facet:focus-within {
         display: block;
       }
       .search-bar-component {
+        background-color: @grey-fafafa;
+        border: 1px solid @dark-beige;
         width: 207px;
       }
       .search-bar-input {

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -124,7 +124,7 @@
   }
 
   .hamburger-dropdown-component {
-    @topHeight: 58px;
+    @topHeight: 53px;
     position: fixed;
     right: 0;
     top: @topHeight;
@@ -244,7 +244,7 @@
 
   .mask-menu {
     position: fixed;
-    top: 58px;
+    top: 53px;
     left: 0;
     right: 0;
     opacity: 0;
@@ -596,7 +596,7 @@ div.search-facet:focus-within {
 }
 
 .logo-component {
-  margin: 0 0 5px 5px;
+  margin-left: 5px;
 
   a {
     color: @black;
@@ -813,8 +813,8 @@ div.search-facet:focus-within {
     position: sticky;
     top: 0;
     background: linear-gradient(to bottom, @header-1 50px, @header-2 218px) !important;
-    padding: 5px 0;
-    border-radius: 0 0 4px 4px;
+    padding: 3px 0;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 15%);
     z-index: @z-index-level-3;
   }
 }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -131,12 +131,13 @@
     height: 100vh;
     z-index: @z-index-level-2;
     overflow-y: auto;
+    overscroll-behavior: contain;
     background-color: @light-beige;
     box-shadow: 0 1px 20px rgba(0,0,0,.25);
     .subsection {
       font-weight: bold;
       border-bottom: 3px solid @beige-two;
-      padding: 7px;
+      padding: 10px;
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -147,7 +148,8 @@
     .login-links {
       width: 50%;
       float: left;
-      padding: 5px 10px;
+      padding: 10px;
+      border-bottom: none;
     }
 
     // stylelint-disable-next-line selector-max-specificity
@@ -195,8 +197,8 @@
     details[open] {
       .mask-menu{
         visibility: visible;
-        opacity: .5;
-        animation: none !important;
+        opacity: 1;
+        animation: fadeIn .2s ease-in-out;
       }
       summary ~ * {
         animation: sweep .2s ease-in-out;
@@ -206,6 +208,11 @@
     @keyframes sweep {
       0%    {opacity: 0; transform: translateX(50px)}
       100%  {opacity: 1; transform: translateX(0)}
+    }
+
+    @keyframes fadeIn {
+      0% {opacity: 0;}
+      100% {opacity: 1;}
     }
     // stylelint-enable max-nesting-depth, selector-max-specificity
 
@@ -240,7 +247,7 @@
     right: 0;
     opacity: 0;
     bottom: 0;
-    background: rgba(0,0,0,.8);
+    background: rgba(0,0,0,.5);
     z-index: @z-index-level-1;
     visibility: hidden;
   }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -145,26 +145,40 @@
     // stylelint-disable max-nesting-depth, selector-max-specificity
     .subsection {
       font-weight: bold;
-      border-bottom: 2px solid @dark-beige;
-      padding: 16px 10px 1px;
+      border-bottom: 2px solid hsl(32.7,14.7%,70.6%);
+      padding: 16px 16px 3px;
       &:hover {
         background-color: transparent;
       }
+    }
+
+    li {
+      border-bottom: 1px solid hsla(33.6, 10%, 49.2%, .25);
     }
 
     li:not(.subsection) {
       margin: 0 8px;
     }
 
-    li a, li button {
-      padding: 10px 10px 10px 20px;
+    li a {
+      padding: 10px 8px;
     }
 
-    li .header-dropdown__icon {
+    li button {
+      padding: 10px 8px;
+      width: 100%;
+      font-family: @bahnschrift;
+      text-align: left;
+      cursor: pointer;
+    }
+
+    li .app-drawer__icon {
       position: absolute;
       top: 10px;
       right: 18px;
-      border: 1px solid @border-color;
+      width: 48px;
+      height: 48px;
+      border: 2px solid @border-color;
       border-radius: 3px;
     }
 
@@ -175,7 +189,7 @@
 
     .login-links {
       display: flex;
-      padding: 10px;
+      padding: 10px 8px;
       border-bottom: none;
       justify-content: space-evenly;
       column-gap: 16px;
@@ -186,23 +200,25 @@
 
     .login-links a {
       flex: 1;
-      background: @primary-blue;
-      text-align: center;
-      color: @white;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      color: @primary-blue;
       border-radius: 6px;
       padding: 6px;
-      border: 1px solid @primary-blue;
+      border: 2px solid @primary-blue;
       transition: .3s;
       &:hover {
-        background-color: @link-blue;
+        background-color: @white;
       }
     }
 
     .login-links a:nth-of-type(2) {
-      background: @light-beige;
-      color: @primary-blue;
+      background: @primary-blue;
+      color: @white;
+      border: none;
       &:hover {
-        background-color: @white;
+        background-color: @link-blue;
       }
     }
     // stylelint-enable max-nesting-depth, selector-max-specificity
@@ -217,7 +233,8 @@
     .badge {
       color: @white;
       background-color: @primary-blue;
-      padding: 1px 3px;
+      font-size: .9em;
+      padding: 2px 6px 1px;
       border-radius: 4px;
       float: right;
     }
@@ -232,6 +249,13 @@
       summary ~ * {
         animation: sweep .2s ease-in-out;
       }
+      .header-dropdown__icon {
+        background-color: @account-icon-background;
+      }
+    }
+
+    .header-dropdown__icon.logged {
+      padding-left: 8px;
     }
 
     @keyframes sweep {
@@ -293,7 +317,7 @@
     }
 
     .account__icon {
-      border: 1px solid @border-color;
+      border: 2px solid @border-color;
       border-radius: 4px;
       width: 30px;
       height: 30px;
@@ -745,7 +769,7 @@ div.search-facet:focus-within {
     }
 
     .hamburger-component summary {
-      margin-left: 15px;
+      margin-left: 10px;
     }
   }
 }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -26,6 +26,7 @@
   position: relative;
 
   .account-component {
+    display: none;
     -webkit-box-flex: 0;
     -ms-flex: none;
     flex: none;
@@ -38,6 +39,11 @@
 
     .down-arrow {
       margin-top: 1px;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    .dropdown-menu li {
+      padding: 10px 20px 10px 10px;
     }
 
     .account-dropdown-component {
@@ -62,9 +68,9 @@
     display: none;
     padding: 5px;
     padding-right: 0;
-    -webkit-box-ordinal-group: 5;
-    -ms-flex-order: 4;
-    order: 4;
+    -webkit-box-ordinal-group: 4;
+    -ms-flex-order: 3;
+    order: 3;
 
     li {
       text-align: left;
@@ -91,12 +97,10 @@
     background-color: @light-beige;
     border: 1px solid @dark-beige;
     border-radius: 3px;
-    cursor: pointer;
 
     li {
-      padding: 10px;
+      padding: 0 20px 0 10px;
       border-bottom: 1px solid @beige-two;
-      padding-right: 20px;
 
       // stylelint-disable max-nesting-depth, selector-max-specificity
       &:last-child {
@@ -121,14 +125,76 @@
   }
 
   .hamburger-dropdown-component {
-    position: absolute;
+    position: fixed;
+    right: 0;
+    top: 0;
+    height: 100vh;
+    z-index: @z-index-level-2;
+    overflow-y: auto;
+    background-color: @light-beige;
+    box-shadow: 0 1px 20px rgba(0,0,0,.25);
+    .subsection {
+      font-weight: bold;
+      border-bottom: 3px solid @beige-two;
+      padding: 7px;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    .subsection:first-child {
+      padding-top: 20px;
+    }
+
+    .login-links {
+      width: 50%;
+      float: left;
+      padding: 5px 10px;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    .login-links a {
+      background: @primary-blue;
+      text-align: center;
+      color: @white;
+      border-radius: 6px;
+      padding: 6px;
+      border: 1px solid @primary-blue;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    .login-links .login {
+      background: @light-beige;
+      color: @primary-blue;
+    }
   }
 
   .hamburger-component {
-    -webkit-box-ordinal-group: 1;
-    -ms-flex-order: 0;
-    order: 0;
+    -webkit-box-ordinal-group: 5;
+    -ms-flex-order: 4;
+    order: 4;
     margin-right: 5px;
+
+    summary {
+      position: relative;
+      z-index: @z-index-level-5;
+    }
+
+    // stylelint-disable max-nesting-depth, selector-max-specificity
+    details[open] {
+      .mask-menu{
+        visibility: visible;
+        opacity: .5;
+        animation: none !important;
+      }
+      summary ~ * {
+        animation: sweep .2s ease-in-out;
+      }
+    }
+
+    @keyframes sweep {
+      0%    {opacity: 0; transform: translateX(50px)}
+      100%  {opacity: 1; transform: translateX(0)}
+    }
+    // stylelint-enable max-nesting-depth, selector-max-specificity
 
     summary::marker {
       content: "";
@@ -154,16 +220,39 @@
     }
   }
 
+  .mask-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    opacity: 0;
+    bottom: 0;
+    background: rgba(0,0,0,.8);
+    z-index: @z-index-level-1;
+    visibility: hidden;
+  }
+
   .header-dropdown {
     // For the <details> polyfill used for IE11
     summary::before {
       content: "" !important;
     }
 
+    // stylelint-disable max-nesting-depth, selector-max-specificity
+    &.account_icon {
+      order: 3;
+      margin-left: 10px;
+
+      img {
+        border: 1px solid @dark-beige;
+        border-radius: .3em;
+      }
+    }
+    // stylelint-enable max-nesting-depth, selector-max-specificity
+
     .header-dropdown__icon {
       width: 45px;
       height: 45px;
-      padding: 0 3px;
     }
 
     button,
@@ -180,9 +269,9 @@
     -webkit-box-flex: 1;
     -ms-flex: 1;
     flex: 1;
-    -webkit-box-ordinal-group: 2;
-    -ms-flex-order: 1;
-    order: 1;
+    -webkit-box-ordinal-group: 1;
+    -ms-flex-order: 0;
+    order: 0;
     z-index: @z-index-level-negative;
 
     .logo-icon {
@@ -197,8 +286,12 @@
     }
   }
 
-  .navigation-component {
+  .navigation-component.mobile {
     .display-flex();
+  }
+
+  .navigation-component {
+    display: none;
     -ms-flex-preferred-size: 100%;
     flex-basis: 100%;
     -webkit-box-ordinal-group: 6;
@@ -247,9 +340,9 @@
 
   .search-component {
     width: 45px;
-    -webkit-box-ordinal-group: 3;
-    -ms-flex-order: 2;
-    order: 2;
+    -webkit-box-ordinal-group: 2;
+    -ms-flex-order: 1;
+    order: 1;
     height: 47px;
     margin-right: 5px;
     text-align: right;
@@ -269,7 +362,7 @@
       height: 54px;
 
       .search-bar-component {
-        width: 100%;
+        width: 95%;
       }
 
       .search-bar {
@@ -485,7 +578,7 @@ div.search-facet:focus-within {
 }
 
 .logo-component {
-  margin: 0 0 5px;
+  margin: 0 0 5px 5px;
 
   a {
     color: @black;
@@ -637,9 +730,9 @@ div.search-facet:focus-within {
       -webkit-box-flex: 0;
       -ms-flex: none;
       flex: none;
-      -webkit-box-ordinal-group: 4;
-      -ms-flex-order: 3;
-      order: 3;
+      -webkit-box-ordinal-group: 5;
+      -ms-flex-order: 4;
+      order: 4;
     }
 
     .logo-component {
@@ -649,7 +742,6 @@ div.search-facet:focus-within {
     }
 
     .navigation-component {
-      .display-flex();
       -webkit-box-ordinal-group: 7;
       -ms-flex-order: 6;
       order: 6;
@@ -697,5 +789,17 @@ div.search-facet:focus-within {
         display: block;
       }
     }
+  }
+}
+
+@media only screen and (max-width: @width-breakpoint-tablet) {
+  // stylelint-disable-next-line selector-max-specificity
+  #header-bar {
+    position: sticky;
+    top: 0;
+    background: linear-gradient(to bottom, @header-1 50px, @header-2 218px) !important;
+    padding: 5px 0;
+    border-radius: 0 0 4px 4px;
+    z-index: @z-index-level-3;
   }
 }

--- a/static/css/components/iaBar.less
+++ b/static/css/components/iaBar.less
@@ -29,7 +29,6 @@
 #topNotice {
   font-weight: 100;
   font-size: .9em;
-  margin-bottom: 5px;
   .topNotice-container {
     margin: 0 auto;
     width: 958px;

--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -10,13 +10,6 @@
   position: relative;
 }
 
-// For pages without a header we don't want a margin.
-// This might be better placed in the header component in future
-// but is kept here for backwards compatibility with v1 pages
-header + #test-body-mobile {
-  margin-top: 20px;
-}
-
 // stylelint-disable-next-line no-descending-specificity
 body.full-width #test-body-mobile {
   max-width: initial;

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -100,8 +100,8 @@
 @heart-color: hsl(358, 100%, 74%);
 @blue: hsl(240, 100%, 50%);
 @purple: hsl(283, 97%, 61%);
-@gradient-start: hsl(41, 47%, 93%);
-@gradient-end: hsl(41, 49%, 85%);
+@header-bar-gradient-start: hsl(41.2, 47.1%, 93.3%);
+@header-bar-gradient-end: hsl(41.5, 48.1%, 89.4%);
 @account-icon-background: hsla(37, 24%, 79%, .761);
 
 // book cover carousel component

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -99,6 +99,8 @@
 @heart-color: hsl(358, 100%, 74%);
 @blue: hsl(240, 100%, 50%);
 @purple: hsl(283, 97%, 61%);
+@header-1: hsl(41, 47%, 93%);
+@header-2: hsl(41, 49%, 85%);
 
 // book cover carousel component
 @book-cover-carousel-background: hsl(47, 54%, 90%);

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -102,6 +102,7 @@
 @purple: hsl(283, 97%, 61%);
 @header-1: hsl(41, 47%, 93%);
 @header-2: hsl(41, 49%, 85%);
+@account-icon-background: hsla(37, 24%, 79%, .761);
 
 // book cover carousel component
 @book-cover-carousel-background: hsl(47, 54%, 90%);

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -62,6 +62,7 @@
 @beige: hsl(48, 33%, 83%);
 @brown: hsl(40, 32%, 29%);
 @brown-3a301e: hsl(39, 32%, 17%); // this color is only used once
+@border-color: hsl(45, 7%, 79%); //used twice
 @light-yellow: hsl(58, 100%, 90%);
 @lighter-yellow: hsl(58, 92%, 95%);
 @dark-beige:hsl(64, 9%, 71%);

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -62,7 +62,7 @@
 @beige: hsl(48, 33%, 83%);
 @brown: hsl(40, 32%, 29%);
 @brown-3a301e: hsl(39, 32%, 17%); // this color is only used once
-@border-color: hsl(45, 7%, 79%); //used twice
+@account-icon-border: hsl(45, 7%, 79%); // this color is only used once
 @light-yellow: hsl(58, 100%, 90%);
 @lighter-yellow: hsl(58, 92%, 95%);
 @dark-beige:hsl(64, 9%, 71%);
@@ -100,8 +100,8 @@
 @heart-color: hsl(358, 100%, 74%);
 @blue: hsl(240, 100%, 50%);
 @purple: hsl(283, 97%, 61%);
-@header-1: hsl(41, 47%, 93%);
-@header-2: hsl(41, 49%, 85%);
+@gradient-start: hsl(41, 47%, 93%);
+@gradient-end: hsl(41, 49%, 85%);
 @account-icon-background: hsla(37, 24%, 79%, .761);
 
 // book cover carousel component

--- a/static/css/less/font-families.less
+++ b/static/css/less/font-families.less
@@ -19,3 +19,4 @@
 @monospace: monospace;
 @verdana: verdana, sans-serif;
 @ichonochive: "Iconochive-Regular", sans-serif;
+@bahnschrift: Bahnschrift, sans-serif;

--- a/static/images/hamburger-icon.svg
+++ b/static/images/hamburger-icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="18"
+   height="18"
+   viewBox="0 0 4.7624999 4.7625001"
+   version="1.1"
+>
+   <path
+      style="fill:none;stroke:#8a7f71;stroke-width:0.513296;stroke-linecap:round;"
+      d="M 0.25664798,4.078872 H 4.505852 M 0.25664798,2.3812494 H 4.505852 M 0.25664798,0.683628 H 4.505852" />
+</svg>

--- a/static/images/search-icon.svg
+++ b/static/images/search-icon.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="18"
+   height="18"
+   viewBox="0 0 4.7624999 4.7625001"
+   version="1.1"
+>
+   <g style="fill:none;stroke:#8a7f71;stroke-linecap:round;stroke-linejoin:round" transform="matrix(0.73953016,0,0,0.73953016,-37.846719,-8.8081817)">
+      <circle style="stroke-width:0.8" cx="53.773613" cy="14.629464" r="2.1969051" />
+      <path style="stroke-width:0.9" d="m 55.579954,16.191707 1.586654,1.586654" />
+   </g>
+</svg>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5423; Closes #5212

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Redesigned the Mobile Header Bar.
We want to make the header bar feel more like a native app's header.
### Technical
<!-- What should be noted about the implementation? -->

- [X] The buttons in the toolbar should have padding; the toolbar itself should not have much (any?) padding. (This makes the click regions larger)
- [X] The click region of each list item needs to be taller. Make sure this is easy to change. The list item <a tags should have most of the padding.
- [X] Clicking anywhere outside the drawer will close the drawer
- [X] Clicking on the hamburger icon while the drawer is open will close the drawer
- [Pending] Optional: swiping from the right edge from anywhere will open the drawer
- [X] The header bar should be sticky
- [X] You should not be able to scroll the document body while the header bar is open (see overscroll-behavior)
Discussion: Do we want to lock the body scroll (shadow area)?
- [X] You should be able to scroll the hamburger drawer
- [X] The drawer should animate in.
- [X] The "shadow" should animate in.
- [X] Font on Windows should be Bahnschrift (pre-installed on windows devices)
- [X] The Browse/More menus should still be there, but won't be sticky. (Longer term, might want to remove these)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Logged out users**
![out-final](https://user-images.githubusercontent.com/64412143/128026617-5f08c2dc-9aee-46d1-b7f5-17834ea7dff1.png)

**Logged in users**
![in-final](https://user-images.githubusercontent.com/64412143/128026641-6926ae0a-2338-4f6f-9db5-4ba08c851013.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @jdlrobson 