### PR TITLE
Link to author identifier docs from reading stats page #5437

### DIFF
--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -118,7 +118,7 @@ $jsdef render_excluded_works_list(works, total):
             </section>
     </section>
 
-    <small>$:_('Demographic statistics powered by <a href="https://www.wikidata.org/">Wikidata</a>. Here\'s a <a id="wd-query-sample" href="">sample</a> of the query used.')</small>
+    <small>$:_('Demographic statistics powered by <a href="https://www.wikidata.org/">Wikidata</a>. Here\'s a <a id="wd-query-sample" href="">sample</a> of the query used.') <br>Improve these stats by adding the Wikidata author identifier following <a href="https://openlibrary.org/help/faq/editing.en#author-identifiers-purpose"> these instructions</a>.</small>
 
     <h2>$_('Work Stats')</h2>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5437

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Link to author identifier docs from reading stats page
### Technical
<!-- What should be noted about the implementation? -->
changed
Demographic statistics powered by Wikidata. Here's a sample of the query used.
To

Demographic statistics powered by Wikidata. Here's a sample of the query used.
Improve these stats by adding the Wikidata author identifier following (these instructions {link}).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
