### PR TITLE
Fix local Solr reindexer

### DIFF
--- a/scripts/solr_builder/solr_builder/fn_to_cli.py
+++ b/scripts/solr_builder/solr_builder/fn_to_cli.py
@@ -100,7 +100,7 @@ class FnToCLI:
             return {'type': typ, 'action': BooleanOptionalAction}
         if typ in (int, str, float):
             return {'type': typ}
-        if typ == list[str]:
+        if typ == typing.List[str]:
             return {'nargs': '*'}
         if not hasattr(typ, '__origin__'):
             raise ValueError(f'Cannot determine type of {typ}')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes bug in which `reindex-solr` call was failing after new Solr8 updates.

### Technical
<!-- What should be noted about the implementation? -->
Incorrect type was being checked in `type_to_argparse` function, resulting in a `ValueError`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
