### PR TITLE
Prevent duplicate default carousel keys

### DIFF
--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -28,4 +28,7 @@ $code:
   books = [storage(b) for b in (results.get('docs', []))]
   load_more = {"url": "/search.json?" + urlencode(params), "limit": limit }
 
+  if key is '':
+    key = str(abs(hash(query)))
+
 $:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -873,6 +873,7 @@ def setup():
         'sum': sum,
         'get_donation_include': get_donation_include,
         'websafe': web.websafe,
+        'hash': hash
     })
 
     from openlibrary.core import helpers as h


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When multiple carousels on a single page share the same key, they tend to be buggy in different ways.  The most visible bug causes a carousel to render without its "next" and "previous" buttons.  In some cases, carousels with the same key will fetch more books using another carousel's query string.

This PR seeks to avoid these bugs by attempting to create a unique key for all carousels created without a key.  It doesn't absolutely prevent duplicate keys on a single page, but should greatly reduce the amount that can occur.

### Technical
<!-- What should be noted about the implementation? -->
In cases where carousels are created without a key, the absolute value of the carousel's hashed query string is used as the key.  This approach has some limitations:
1. Multiple carousels using the same query will have the same generated key.
2. My understanding is that keys are used for site analytics.  Randomly generated keys provide little insight into what carousels are receiving attention from patrons.
3. By default, Python's `hash` function will return different values for strings between sessions.  This further complicates the analytics issue as the same carousel will have different default keys over time.
4. While highly unlikely, two different query strings can produce the same hashed value.  The odds are higher in this case as the absolute value of the hash is being used as the key.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Add two or more carousels to a single page using the QueryCarousel macro.  Ensure that each carousel is created with no key and different query strings.
2. Inspect the carousel elements, specifically the divs with class `carousel`.  These will also have a class name that contains the key (`carousel-${key}`). Ensure that the keys are different for each carousel.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@libjenner 
@mekarpeles 
