### PR TITLE
hotfix get_availability for key types != archive.org 'identifier'

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -336,8 +336,9 @@ def get_availability(key, ids):
         response = requests.get(url, timeout=config_http_request_timeout)
         items = response.json().get('responses', {})
         for pkey in items:
-            ocaid = items[pkey].get('identifier', key == 'identifier' and pkey)                             
+            ocaid = items[pkey].get('identifier', key == 'identifier' and pkey)
             items[pkey] = update_availability_schema_to_v2(items[pkey], ocaid)
+        return items
     except Exception as e:  # TODO: Narrow exception scope
         logger.exception("get_availability(%s)" % url)
         items = { 'error': 'request_timeout', 'details': str(e) }

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -344,7 +344,7 @@ def get_availability(key, ids):
         items = { 'error': 'request_timeout', 'details': str(e) }
 
         for pkey in ids:
-            # key could be isbn, ocaid, or openlibrary_[work|edition]                                          
+            # key could be isbn, ocaid, or openlibrary_[work|edition]
             ocaid = pkey if key == 'identifier' else None
             items[pkey] = update_availability_schema_to_v2(
                 {'status': 'error'}, ocaid)

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -336,7 +336,7 @@ def get_availability(key, ids):
         response = requests.get(url, timeout=config_http_request_timeout)
         items = response.json().get('responses', {})
         for pkey in items:
-            ocaid = items[pkey].get('identifier', key == 'identifier' and pkey)
+            ocaid = pkey if key == 'identifier' else items[pkey].get('identifier')
             items[pkey] = update_availability_schema_to_v2(items[pkey], ocaid)
         return items
     except Exception as e:  # TODO: Narrow exception scope

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -335,15 +335,17 @@ def get_availability(key, ids):
     try:
         response = requests.get(url, timeout=config_http_request_timeout)
         items = response.json().get('responses', {})
-        for ocaid in items:
-            items[ocaid] = update_availability_schema_to_v2(items[ocaid], ocaid)
-        return items
+        for pkey in items:
+            ocaid = items[pkey].get('identifier', key == 'identifier' and pkey)                             
+            items[pkey] = update_availability_schema_to_v2(items[pkey], ocaid)
     except Exception as e:  # TODO: Narrow exception scope
         logger.exception("get_availability(%s)" % url)
         items = { 'error': 'request_timeout', 'details': str(e) }
 
-        for ocaid in ids:
-            items[ocaid] = update_availability_schema_to_v2(
+        for pkey in ids:
+            # key could be isbn, ocaid, or openlibrary_[work|edition]                                          
+            ocaid = pkey if key == 'identifier' else None
+            items[pkey] = update_availability_schema_to_v2(
                 {'status': 'error'}, ocaid)
         return items
 


### PR DESCRIPTION
OL's get_availability call to Archive.org/services/availability bulk API was incorrectly assuming the json items returned would always be primary keyed by Archive.org ID (i.e. `ocaid` / `identifier`).

In most cases, we call this API with `identifier` (e.g. to add availability to our carousels and search results). However, this API can also be used to lookup `isbn`s, `openlibrary_work`s and `openlibrary_edition`s and when these IDs are provided, the Archive.org API keys the results according to the id-type specified (e.g. using `isbn` as the key will return results whose primary key is `isbn`, not archive.org `identifier`).

When a key other than `identifier` is used, the `ocaid` value must be extracted from the results, rather than the primary index key returned by the API.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

`get_availability("openlibrary_work", ["OL529092W"])` should not return  have an `ocaid` of `OL529092W`

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jamesachamp 