### PR TITLE
update onboarding docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ A quick public tour of Open Library to get your familiar with the service and it
 
 ### Onboarding
 
-A comprehensive volunteer orientation video to learn what it means to work on Open Library (1.5h). This video is a companion to our [Orientation Guide](https://docs.google.com/document/d/1fkTDqYFx2asuMWwSIDQRHJlnu-AGWpMrDDd9o5z8Cik/edit#). If you're looking for a good first issue, check out [Menu of Opportunities](https://docs.google.com/document/d/1CgWXIsyn_kTZ_6n3n_zfSDuglj1yLUjVtg1EjL0Bf6E/edit#heading=h.gzsl3sqg0r51).
+A comprehensive volunteer orientation video to learn what it means to work on Open Library (1.5h). This video is a companion to our [Orientation Guide](https://docs.google.com/document/d/1fkTDqYFx2asuMWwSIDQRHJlnu-AGWpMrDDd9o5z8Cik/edit#). 
+If you're looking for a good first issue, check out [Good First Issues](https://github.com/internetarchive/openlibrary/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+First+Issue%22).
 
 [![archive org_details_openlibrary-orientation-2020_start=80](https://user-images.githubusercontent.com/978325/91350387-78272580-e79b-11ea-9e26-85cfd1d38fe1.png)](https://archive.org/details/openlibrary-orientation-2020?start=80)
 
@@ -23,20 +24,14 @@ A deep dive into the technical details, architecture, and code structure behind 
 
 ### Code of Conduct
 
-Before continuing, please familiarize yourself with our [code of conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md). We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place:
-
-https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md
+Before continuing, please familiarize yourself with our [code of conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md). 
+We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place:
 
 ### Join our Community
 
-* The core Open Library team communicates over an invite-only slack channel. You may request an invitation on our [volunteers](https://openlibrary.org/volunteer) page. 
+* The core Open Library team communicates over an invite-only Slack channel. You may request an invitation on our [volunteers](https://openlibrary.org/volunteer) page. 
 * If you have a quick question about getting started, anyone can ask on our [gitter chat](https://gitter.im/theopenlibrary/Lobby).
 * The Open Library hosts a video Community Call every Tuesday @ 10:00am PT, [request an invite](https://openlibrary.org/volunteer) to join us!
-
-Resources for Contributors
-
-Look through our issues related to [`contributing`](https://github.com/internetarchive/openlibrary/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Acontributing).
-
 
 ## Installing Open Library
 For instructions on setting up a local developer's instance of Open Library, please refer to the [Installation Guide](https://github.com/internetarchive/openlibrary#installation). 
@@ -44,7 +39,8 @@ For instructions on setting up a local developer's instance of Open Library, ple
 [![archive org_details_openlibrary-developer-docs_zoom_0 mp4_autoplay=1 start=2](https://user-images.githubusercontent.com/978325/91351305-ef10ee00-e79c-11ea-9bfb-c2733696ec58.png)](https://archive.org/details/openlibrary-developer-docs/zoom_0.mp4)
 
 
-Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/Getting-Started). [Here's a handy cheat sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) if you are new to using Git.
+Also, refer to the [Quickstart Guide](https://github.com/internetarchive/openlibrary/wiki/Getting-Started). 
+[Here's a handy cheat sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) if you are new to using Git.
 
 ## Common Setup Tasks
 
@@ -53,7 +49,7 @@ Our login process on Open Library's dev instance is a bit funky. You need to cor
 - https://github.com/internetarchive/openlibrary/issues/1197#issuecomment-479752932
 
 ### Adding Data to Open Library
-- In case you are looking to add data using MARC and ONIX records, possibly in bulk please do it via at https://github.com/internetarchive/openlibrary-bots (the Open Library Bots).
+- If you are looking to add data using MARC and ONIX records, visit [Open Library Bots](https://github.com/internetarchive/openlibrary-bots).
 
 ## Submitting Issues
 
@@ -76,7 +72,8 @@ We usually discuss weekly goals via our Tuesday Community Call and using slack.
 
 ## Development Practices
 
-Whenever working on a new feature/hotfix/refactor, the first step is to make sure a corresponding issue exists. We then take this issue number and affix it to the branch name which we will use for development.
+Whenever working on a new feature/hotfix/refactor, make sure a corresponding issue exists. 
+We use the issue number in the branch name.
 
 A branch name consists of the: issue number, whether it is a feature/hotfix/refactor, and a human readable slug, e.g:
 
@@ -93,7 +90,7 @@ npm test
 
 If it passes your patch is ready for review!
 
-Note, many issues can be fixed automatically without any manual work from your part using the following command:
+Many issues can be automatically fixed using the following command:
 
 ```
 npm run lint-fix
@@ -101,7 +98,7 @@ npm run lint-fix
 
 ## Submitting Pull Requests
 
-Once you've finished making your changes, submit a pull request (PR) to get your code into Open Library. Please take the time to check whether someone has already raised the issue you are solving. Thank you for your contributions!
+Once you've finished making your changes, submit a pull request (PR). Please take the time to check whether someone has already raised the issue you are solving. Thank you for your contributions!
 
 Follow these rules when creating a PR:
 
@@ -112,7 +109,9 @@ Follow these rules when creating a PR:
 
 ## QA Testing
 
-Once a Pull Request has been submitted, ask an approved member of staff to spin up an isolated kubernetes Open Library pod for the branch that you're working on. They will give you a link which will let you test your branch's current code against a near-production environment. Read more about our [Plans for Kubernetes](https://github.com/internetarchive/openlibrary/wiki/Kubernetes)
+Once a Pull Request has been submitted, ask an approved member of staff to spin up an isolated kubernetes Open Library pod for the branch that you're working on. 
+They will give you a link which will let you test your branch's current code against a near-production environment. 
+Read more about our [Plans for Kubernetes](https://github.com/internetarchive/openlibrary/wiki/Kubernetes)
 
 # Maintainers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ A deep dive into the technical details, architecture, and code structure behind 
 ### Code of Conduct
 
 Before continuing, please familiarize yourself with our [code of conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md). 
-We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place:
+We are a non-profit, open-source, inclusive project, and we believe everyone deserves a safe place to make the world a little better. We're committed to creating this safe place.
 
 ### Join our Community
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,10 @@ Here's a quick public tour of Open Library to get your familiar with the service
 
 ## Installation
 
-The development environment can be set up using the [Docker Instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md). You can also watch the [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4) for a more detailed explanation.
+Run `docker-compose up` and visit http://localhost:8080
+
+Need more details? Checkout the [Docker instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md) 
+or [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4).
 
 ### Developer's Guide
 


### PR DESCRIPTION
Ironically, no associated ticket. I'm just trying to improve our onboarding docs before adding anything about remote development (gitpods / github codespaces).

The improvements are generally:
* Putting linebreaks in long lines. (this has no visual changes)
* Wordsmithing - making descriptions shorter and hopefully clearer
* Removing links that aren't useful
* Add the docker command to the main readme

I try to err on the side of being as clear as possible for new users.

If you think anything should be phrased differently feel free to edit the pr directly, make a comment, or make a PR.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jamesachamp 

