### PR TITLE
Add submodule initialization commands to docs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Before attempting to build openlibrary using the Docker instructions below, plea
 
 - Install `docker-ce`: https://docs.docker.com/get-docker/ (tested with version 19.*)
 - Install `docker-compose`: https://docs.docker.com/compose/install/
-- Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. Running  should get rid of the issue if it persists. You can modify an existing openlibrary repository using `git remote rm origin` and then `git remote add origin git@github.com:internetarchive/openlibrary.git`
+- Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. You can modify an existing openlibrary repository using `git remote rm origin` and then `git remote add origin git@github.com:internetarchive/openlibrary.git`. Then run `git submodule init; git submodule sync; git submodule update` to get rid of the issue.
 
 ## Setup/Teardown Commands
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ Before attempting to build openlibrary using the Docker instructions below, plea
 
 - Install `docker-ce`: https://docs.docker.com/get-docker/ (tested with version 19.*)
 - Install `docker-compose`: https://docs.docker.com/compose/install/
-- Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. You can modify an existing openlibrary repository using `git remote rm origin` and then `git remote add origin git@github.com:internetarchive/openlibrary.git`
+- Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. Running  should get rid of the issue if it persists. You can modify an existing openlibrary repository using `git remote rm origin` and then `git remote add origin git@github.com:internetarchive/openlibrary.git`
 
 ## Setup/Teardown Commands
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
No issues exists around this issue as far as I can tell, it may relate to the work done in https://github.com/internetarchive/openlibrary/pull/5455 so reasonably it could be added to that PR. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This is a slight addition to the documentation when downloading and initializing git submodules if they are not setup when first pulled there are some commands which can be ran to help the user install them. 

specifically `git submodule init && git submodule update`

### Technical
<!-- What should be noted about the implementation? -->

No technical changes, just some documentation updates for getting started. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Clone the repository using HTTP, run  `git submodule init` and then `git submodule update` from the root of the repository

The following should appear: 

```
Cloning into '/Users/$user/git/external/openlibrary/vendor/infogami'...
Cloning into '/Users/$user/git/external/openlibrary/vendor/js/wmd'...
Submodule path 'vendor/infogami': checked out '0b05f20b0323a3078fddc8a9cfd4455cc68faa3a'
Submodule path 'vendor/js/wmd': checked out '7d7b5287bed949eee809182c07c4170309ddbf06'
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No UI changes for this PR

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@RayBB I see that you have another Docs related ticket, I am not sure who the correct stakeholders are for this as it is my first PR. 

@jamesachamp
