### PR TITLE
Fix translatable string 'Add another edition' on work page

### DIFF
--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -4014,7 +4014,7 @@ msgid "Availability"
 msgstr "Disponibilidad"
 
 #: type/work/editions_datatable.html:37
-msgid "Add another edition"
+msgid "Add another edition?"
 msgstr "¿Añadir otra edición?"
 
 #: AffiliateLinks.html:15

--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -4015,7 +4015,7 @@ msgstr "Disponibilidad"
 
 #: type/work/editions_datatable.html:37
 msgid "Add another edition"
-msgstr "Añadir otra edición"
+msgstr "¿Añadir otra edición?"
 
 #: AffiliateLinks.html:15
 msgid "Better World Books"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4210,7 +4210,7 @@ msgid "Availability"
 msgstr ""
 
 #: type/work/editions_datatable.html:37
-msgid "Add another edition"
+msgid "Add another edition?"
 msgstr ""
 
 #: AffiliateLinks.html:15

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -30,7 +30,7 @@ $ book_keys = []
     </tbody>
 </table>
 <p class="small sansserif edition-adder">
-  <a href="/books/add?work=$work.key" title="$_('Add another edition of %(work)s', work=work.title)">$_("Add another edition")</a>?
+  <a href="/books/add?work=$work.key" title="$_('Add another edition of %(work)s', work=work.title)">$_("Add another edition?")</a>
 </p>
 
 <!-- Admin only text doesn't need to be translated -->


### PR DESCRIPTION
A small correction to include the "?" sign as part of the translatable string.

I have modified the string in the messages.pot file and in the Spanish translation. I have not modified the other languages in order to avoid mistranslations.

### Screenshot
A screenshot of the site page showing the only modified string.
![add-another-edition-screenshot](https://user-images.githubusercontent.com/7125952/127029839-89835e5a-30bc-4114-8207-c05f56681870.jpg)


### Stakeholders
Open Library translators team.