### PR TITLE
Add Rosetta 2 information to Docker README

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,6 +17,15 @@ git config core.symlinks true
 git reset --hard HEAD
 ```
 
+### For Users of Macs Containing an M1 Chip
+
+You will likely need to install Rosetta 2 in order to run Docker on your machine.  This can be manually installed by running the following in your command line:
+
+```
+softwareupdate --install-rosetta
+```
+More detailed information about this can be found in the [Docker Desktop for Apple silicon documention](https://docs.docker.com/docker-for-mac/apple-silicon/).
+
 ### Prerequisites & Troubleshooting
 
 Before attempting to build openlibrary using the docker instructions below, please follow this checklist. If you encounter an error, this section may serve as a troubleshooting guide:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates Docker README to include information about Rosetta 2 installation, which is currently needed in order to run Docker on machines with an M1 chip.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
