### PR TITLE
add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,20 @@
+ports:
+- port: 8080
+# ignore these ports by default to avoid extra notifications
+- port: 8983
+  onOpen: ignore
+- port: 7075
+  onOpen: ignore
+- port: 7000
+  onOpen: ignore
+- port: 3000
+  onOpen: ignore
+tasks:
+- name: Start App
+  # run chown because https://github.com/gitpod-io/gitpod/issues/4851
+  before: sudo chown -R gitpod:999 /workspace/openlibrary/
+  # init runs once for each commit to the default branch
+  init: docker-compose up --no-start
+  # command runs each time a user starts their workspace
+  command: docker-compose up
+  

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,4 +17,3 @@ tasks:
   init: docker-compose up --no-start
   # command runs each time a user starts their workspace
   command: docker-compose up
-  

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 # Open Library
 
-[![Build Status](https://travis-ci.org/internetarchive/openlibrary.svg?branch=master)](https://travis-ci.org/internetarchive/openlibrary) [![Join the chat at https://gitter.im/theopenlibrary/Lobby](https://badges.gitter.im/theopenlibrary/Lobby.svg)](https://gitter.im/theopenlibrary/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/internetarchive/openlibrary.svg?branch=master)](https://travis-ci.org/internetarchive/openlibrary)
+[![Join the chat at https://gitter.im/theopenlibrary/Lobby](https://badges.gitter.im/theopenlibrary/Lobby.svg)](https://gitter.im/theopenlibrary/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
 
 [Open Library](https://openlibrary.org) is an open, editable library catalog, building towards a web page for every book ever published.
 

--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,6 @@ This lets you work on Open Library entirely in your browser without having to in
 Warning: This integration is still experimental.
 [![Open In Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
 
-
 ### Developer's Guide
 
 For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide. 

--- a/Readme.md
+++ b/Readme.md
@@ -39,8 +39,8 @@ Run `docker-compose up` and visit http://localhost:8080
 Need more details? Checkout the [Docker instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md) 
 or [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4).
 
-***Alternatively***, if you do not want to set up Open Library on your local computer, try Gitpod! 
-This lets you work on Open Library entirely in your browser without having to install anything on your personal computer. 
+***Alternatively***, if you do not want to set up Open Library on your local computer, try Gitpod!
+This lets you work on Open Library entirely in your browser without having to install anything on your personal computer.
 Warning: This integration is still experimental.
 [![Open In Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
 

--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,12 @@ Run `docker-compose up` and visit http://localhost:8080
 Need more details? Checkout the [Docker instructions](https://github.com/internetarchive/openlibrary/blob/master/docker/README.md) 
 or [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlibrary-docker-set-up.mp4).
 
+***Alternatively***, if you do not want to set up Open Library on your local computer, try Gitpod! 
+This lets you work on Open Library entirely in your browser without having to install anything on your personal computer. 
+Warning: This integration is still experimental.
+[![Open In Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
+
+
 ### Developer's Guide
 
 For instructions on administrating your Open Library instance, refer to the Developer's [Quickstart](https://github.com/internetarchive/openlibrary/wiki/Getting-Started) Guide. 


### PR DESCRIPTION
In efforts to get GitHub Codespaces to work (#5438) I discovered gitpod.io and got it working.

In short, gitpod is an IDE that runs in the cloud and has a generous free plan. It has the major benefit of requiring zero setup for users to get started making small fixes.

As Mek [mentioned](https://internetarchive.slack.com/archives/C0ETZV72L/p1626992054477300), Open Library generally tries to avoid having tool specific files to the repo. However, adding this file will make it significantly easier for new users to start developing.

Right now, gitpod has a pretty generous free plan of 50 hours a month (or 100 hours for students). While we don't want to depend on that I'd say we should utilize it while we can. They also are an open source project so I'm hopeful they'll keep something nice going for the open source community.

- [ ] Open ticket with https://contribute.dev/ to add Open Library to projects using gitpod (for me to do)
- [x] @cdrini can you authorize gitpod for prebuilds? [Instructions](https://www.gitpod.io/docs/prebuilds#on-github)

PS: I plan to make a short video showing how to get started with gitpods but to do that I'd like to have this working on the main repo not just my fork :)

### Technical

#### chown
The most important thing to discuss here is that we run the command `sudo chown -R gitpod:999 /workspace/openlibrary/`

You can see an explanation for why here - https://github.com/gitpod-io/gitpod/issues/4851

In short it just has to do with the fact that we use the `/openlibrary` folder for docker. But gitpods by default uses that path already for the cloned repo. There seems to be a small risk that files could conflict but unless we want to change the folder we mount to there isn't much else we can do.

#### Tasks
You can read more about tasks [here](https://www.gitpod.io/docs/config-start-tasks) but in short the things in the `init` step only run once and then are cached for all users. 

The `command` is the part that runs as soon as a user starts the app.

#### Ports
We ignore all but the 8080 port. All this does it prevent small popups for each port. It's still quite easy to see what's going on with the other ports.

### Testing
I guess the easiest way is to test with my branch.

I also posted a video in slack [here](https://internetarchive.slack.com/archives/C0ETZV72L/p1626992054477300).

### Screenshot
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/921217/127071654-57c416c1-c516-497b-a70c-ad51beed1d1c.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
