### PR TITLE
Refactor/deploys keys and dockerhub uploads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,9 @@ i18n:
 	$(PYTHON) ./scripts/i18n-messages compile
 
 git:
-#Do not run these on DockerHub since it recursively clones all the repos before build initiates
-ifneq ($(DOCKER_HUB),TRUE)
 	git submodule init
 	git submodule sync
 	git submodule update
-endif
 
 clean:
 	rm -rf $(BUILD)

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,7 +1,5 @@
 FROM ubuntu:xenial
 
-ARG DOCKER_HUB=FALSE
-
 ENV LANG en_US.UTF-8
 
 # required for postgres

--- a/docker/README.md
+++ b/docker/README.md
@@ -120,7 +120,7 @@ If you need to make changes to the dependencies in Dockerfile.olbase, rebuild it
 docker build -t openlibrary/olbase:latest -f docker/Dockerfile.olbase . # 30+ min (Win10Home/Dec 2018)
 ```
 
-This image is automatically rebuilt when master is pushed to at https://hub.docker.com/r/openlibrary/olbase .
+This image is automatically rebuilt on deploy by ol-home0 and is pushed to at https://hub.docker.com/r/openlibrary/olbase.
 
 If you're making changes you think might affect Docker Hub, you can create a branch starting with `docker-test`, e.g. `docker-test-py2py3` (no weird chars), to trigger a build in docker hub at e.g. `openlibrary/olbase:docker-test-py2py3`.
 

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd ../
-docker build -t $IMAGE_NAME --build-arg DOCKER_HUB=TRUE -f "$DOCKERFILE_PATH" .

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -29,11 +29,8 @@ docker build -t openlibrary/olbase:latest -f docker/Dockerfile.olbase .
 docker login
 docker push openlibrary/olbase:latest
 
-# booklending utils requires login
-for SERVER in $SERVERS; do
-  echo -e '\n\n'$SERVER
-  ssh -t $SERVER 'if [ -d /opt/booklending_utils ]; then cd /opt/booklending_utils && sudo git pull origin master; fi'
-done
+# Clone booklending utils
+parallel --quote ssh {1} "echo -e '\n\n{}'; if [ -d /opt/booklending_utils ]; then cd {2} && sudo git pull git@git.archive.org:jake/booklending_utils.git master; fi" ::: $SERVERS ::: /opt/booklending_utils
 
 # Prune old images now ; this should remove any unused images
 parallel --quote ssh {} "echo -e '\n\n{}'; docker image prune -f" ::: $SERVERS
@@ -49,7 +46,7 @@ parallel --quote ssh {} "echo -e '\n\n{}'; echo 'FROM openlibrary/olbase:latest'
 # And tag the deploy!
 DEPLOY_TAG="deploy-$(date +%Y-%m-%d)"
 sudo git tag $DEPLOY_TAG
-sudo git push origin $DEPLOY_TAG
+sudo git push git@github.com:internetarchive/openlibrary.git $DEPLOY_TAG
 
 echo "Finished production deployment at $(date)"
 echo "To reboot the servers, please run scripts/deployments/restart_all_servers.sh"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -22,6 +22,13 @@ echo "Starting production deployment at $(date)"
 # `sudo git pull origin master` the core Open Library repos:
 parallel --quote ssh {1} "echo -e '\n\n{}'; cd {2} && sudo git pull origin master" ::: $SERVERS ::: /opt/olsystem /opt/openlibrary
 
+# Rebuild & upload docker image for olbase
+cd /opt/openlibrary
+make git
+docker build -t openlibrary/olbase:latest -f docker/Dockerfile.olbase .
+docker login
+docker push openlibrary/olbase:latest
+
 # booklending utils requires login
 for SERVER in $SERVERS; do
   echo -e '\n\n'$SERVER


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5462 ; moves olbase dockerhub autobuilds to our deploy.sh in ol-home0 because dockerhub autobuild is now paid only

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

tested upload, login, and push on ol-home0

### Notes

Also, adds keys / specified git ssh cloning to enable keyless pulls during deploys
ectly. 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini @jimchamp 