### PR TITLE
Improve community book tags stats component

### DIFF
--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -25,7 +25,7 @@ $def with(work, edition, reader_observations, work_title, key)
       </div>
   $else:
     <hr>
-    <div class="no-stats-message">$_('No reader observations have been submitted for this work.')</div>
+    <div class="no-stats-message">$_('No community observations have been submitted for this work.')</div>
     <div class="no-stats-message">$_('Click the link below to share your observations.')</div>
   <hr>
   $if ctx.user:

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -5,7 +5,7 @@ $def with(work, edition, reader_observations, work_title, key)
 <div class="tab-section">
   <h2 class="observation-title">$_('Reader Observations')</h2>
   <div class="work-line">$work_title</div>
-  $if reader_observations['total_respondents'] > 0:
+  $if reader_observations['total_respondents']:
     <h4 class="observer-count">
       $:ungettext('Based on observations from <strong>%(count)s</strong> patron', 'Based on observations from <strong>%(count)s</strong> patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
     </h4>

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -5,7 +5,7 @@ $def with(work, edition, reader_observations, work_title, key)
 <div class="tab-section">
   <h2 class="observation-title">$_('Reader Observations')</h2>
   <div class="work-line">$work_title</div>
-  $if reader_observations['total_respondents'] > 1:
+  $if reader_observations['total_respondents'] > 0:
     <h4 class="observer-count">
       $:ungettext('Based on observations from <strong>%(count)s</strong> patron', 'Based on observations from <strong>%(count)s</strong> patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
     </h4>
@@ -24,7 +24,8 @@ $def with(work, edition, reader_observations, work_title, key)
       </div>
   $else:
     <hr>
-    <div class="no-stats-message">$_('At least two people must submit observations before this information can be displayed.')</div>
+    <div class="no-stats-message">$_('No reader observations have been submitted for this work.')</div>
+    <div class="no-stats-message">$_('Click the link below to share your observations.')</div>
   <hr>
   $if ctx.user:
     $:macros.ObservationsModal(work, _('Add your observations'), 'stats', 'stats-link')

--- a/openlibrary/templates/observations/stats_component.html
+++ b/openlibrary/templates/observations/stats_component.html
@@ -9,16 +9,17 @@ $def with(work, edition, reader_observations, work_title, key)
     <h4 class="observer-count">
       $:ungettext('Based on observations from <strong>%(count)s</strong> patron', 'Based on observations from <strong>%(count)s</strong> patrons', reader_observations['total_respondents'], count=reader_observations['total_respondents'])<span class="adjust">.</span>
     </h4>
-    <hr>
     $for o in reader_observations['observations']:
       $ total = o['total_respondents_for_type']
+      <hr>
       <div class="section">
         <h3 class="observation-header">$o['description']</h3>
+        <p>$:ungettext('One person responded:', '%(count)d people responded:', total, count=total)</p>
         <div>
           <p>
           $for v in o['values']:
             $ percentage = (v['count'] / total) * 100
-            <span class="observation-percentage"><span class="observation-value">$v['value'].capitalize():</span> $int(percentage)%</span>
+            <span class="observation-percentage"><span class="observation-value">$v['value'].capitalize():</span> $v['count'] ($int(percentage)%)</span>
           </p>
         </div>
       </div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Introduces the following improvements to the book tags statistics component, found on book pages:

1. Removes constraint requiring 2 patrons to review a work before statistics are displayed.
2. Lists number of respondents per aspect displayed.
3. Separates aspects with horizontal rules, making the component feel like less of a wall of text.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:

1. Navigate to a book page.
2. Either scroll to the bottom of the page, or click the "Reader Observations" tab found above the editions table.
3. Observe the reader observations component.
4. Make some new observations and refresh the page to see the changes reflected in the component.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![multiple_respondents](https://user-images.githubusercontent.com/28732543/127404058-f726dddd-e9b3-4d76-8233-bf2c1def5506.png)
_Work with multiple respondents_

![no_respondents](https://user-images.githubusercontent.com/28732543/127404095-6eaae833-400d-4cc6-aaf0-af252817f44a.png)
_Work with no respondents_

Suggestions for copy/design improvements are welcome.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 