### PR TITLE
Update modal copy

### DIFF
--- a/openlibrary/macros/NotesModal.html
+++ b/openlibrary/macros/NotesModal.html
@@ -26,7 +26,7 @@ $if reload_id:
         <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
       </div>
       <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
-        <p>$_("My personal notes about this edition:")</p>
+        <p>$_("My private notes about this edition:")</p>
         <div>
           <textarea class="notes-modal-textarea" name="notes" rows="10">$(notes.notes if notes else "")</textarea>
         </div>

--- a/openlibrary/macros/ObservationsModal.html
+++ b/openlibrary/macros/ObservationsModal.html
@@ -23,7 +23,7 @@ $if reload_id:
         <h2>$_("Observations")</h2>
         <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
       </div>
-      <p class="observation-instructions">$_('Additional observations about this work. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.')</p>
+      <p class="observation-instructions">$_('Additional public observations about this work. Each section is optional, but highly recommended.  These anonymous observations will be used to populate the "Reader Observations" section of this page.')</p>
       <form class="floatform" name="$id-user-metadata" id="$id-user-metadata">
         $for o in observations['observations']:
           $ class_name = 'multi-choice' if o['multi_choice'] else 'single-choice'


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the copy of book notes and book tags modals, with the hope that data privacy concerns are more clearly addressed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![modal_notes_privacy](https://user-images.githubusercontent.com/28732543/127407728-4067d7b9-a0b6-4a2b-b82e-7d13c7575203.png)
_New copy for notes modal_

![modal_observations_privacy](https://user-images.githubusercontent.com/28732543/127407745-a7cefea9-d580-4f4b-bd61-b1d6815b4574.png)
_New copy for tags modal_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles
