### PR TITLE
Various toast component bug fixes

### DIFF
--- a/openlibrary/plugins/openlibrary/js/Toast.js
+++ b/openlibrary/plugins/openlibrary/js/Toast.js
@@ -10,7 +10,7 @@ const DEFAULT_TIMEOUT = 2500;
  */
 export class Toast {
 
-  /**
+    /**
    * Creates a new toast component, adds a close listener to the component, and adds the component
    * as the first child of the given parent element.
    *
@@ -18,41 +18,41 @@ export class Toast {
    * @param {string} message Message that will be displayed in the toast component
    * @param {number} timeout Amount of time, in milliseconds, that the component will be visible
    */
-  constructor($parent, message, timeout=DEFAULT_TIMEOUT) {
-      if (!$parent.has('.toast-container').length) {
-          $parent.prepend('<div class="toast-container"></div>')
-      }
-      const $toastContainer = $parent.children('.toast-container').first();
+    constructor($parent, message, timeout=DEFAULT_TIMEOUT) {
+        if (!$parent.has('.toast-container').length) {
+            $parent.prepend('<div class="toast-container"></div>')
+        }
+        const $toastContainer = $parent.children('.toast-container').first();
 
-      this.timeout = timeout;
-      this.$toast = $(`<div class="toast">
+        this.timeout = timeout;
+        this.$toast = $(`<div class="toast">
         <span class="toast-message">${message}</span>
         <a class="toast--close">&times;<span class="shift">$_("Close")</span></a>
       </div>
     `);
 
-      this.$toast.find('.toast--close').on('click', () => {
-          this.close();
-      });
+        this.$toast.find('.toast--close').on('click', () => {
+            this.close();
+        });
 
-      $toastContainer.append(this.$toast);
-  }
+        $toastContainer.append(this.$toast);
+    }
 
-  /**
+    /**
    * Displays the toast component on the page.
    */
-  show() {
-      this.$toast.addClass('show');
+    show() {
+        this.$toast.addClass('show');
 
-      setTimeout(() => {
-          this.close();
-      }, this.timeout);
-  }
+        setTimeout(() => {
+            this.close();
+        }, this.timeout);
+    }
 
-  /**
+    /**
    * Hides the toast component and removes it from the DOM.
    */
-  close() {
-      this.$toast.fadeOut('slow', function() { $(this).remove() });
-  }
+    close() {
+        this.$toast.fadeOut('slow', function() { $(this).remove() });
+    }
 }

--- a/openlibrary/plugins/openlibrary/js/Toast.js
+++ b/openlibrary/plugins/openlibrary/js/Toast.js
@@ -9,7 +9,6 @@ const DEFAULT_TIMEOUT = 2500;
  * @class Toast creates a small pop-up message that closes after some amount of time.
  */
 export class Toast {
-  static $toastContainer;
 
   /**
    * Creates a new toast component, adds a close listener to the component, and adds the component
@@ -20,12 +19,10 @@ export class Toast {
    * @param {number} timeout Amount of time, in milliseconds, that the component will be visible
    */
   constructor($parent, message, timeout=DEFAULT_TIMEOUT) {
-      if (!Toast.$toastContainer) {
-          Toast.$toastContainer = $('<div class="toast-container"></div>');
+      if (!$parent.has('.toast-container').length) {
+          $parent.prepend('<div class="toast-container"></div>')
       }
-      if ($parent.has(Toast.$toastContainer).length === 0) {
-          $parent.prepend(Toast.$toastContainer);
-      }
+      const $toastContainer = $parent.children('.toast-container').first();
 
       this.timeout = timeout;
       this.$toast = $(`<div class="toast">
@@ -38,7 +35,7 @@ export class Toast {
           this.close();
       });
 
-      Toast.$toastContainer.append(this.$toast);
+      $toastContainer.append(this.$toast);
   }
 
   /**

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -333,6 +333,8 @@ function addObservationChangeListeners($parent, context) {
  */
 function submitObservation($input, workOlid, data, sectionType) {
     let toastMessage;
+    const capitalizedType = sectionType[0].toUpperCase() + sectionType.substring(1);
+
     // Make AJAX call
     $.ajax({
         type: 'POST',
@@ -341,10 +343,10 @@ function submitObservation($input, workOlid, data, sectionType) {
         data: JSON.stringify(data)
     })
         .done(function() {
-            toastMessage = `${sectionType} saved!`;
+            toastMessage = `${capitalizedType} saved!`;
         })
         .fail(function() {
-            toastMessage = `${sectionType} save failed...`;
+            toastMessage = `${capitalizedType} save failed...`;
         })
         .always(function() {
             showToast($input.closest('.metadata-form'), toastMessage);

--- a/static/css/components/toast.less
+++ b/static/css/components/toast.less
@@ -16,6 +16,8 @@
   width: max-content;
   margin: 0 auto 20px;
   padding: 1em;
+  display: flex;
+  justify-content: space-between;
 
   background-color: @light-beige;
   border: 1px solid @mid-grey;

--- a/static/css/components/toast.less
+++ b/static/css/components/toast.less
@@ -19,6 +19,7 @@
   padding: 1em;
   display: flex;
   justify-content: space-between;
+  pointer-events: auto;
 
   background-color: @light-beige;
   border: 1px solid @mid-grey;
@@ -28,7 +29,6 @@
 
   .toast--close {
     padding-left: .75em;
-    pointer-events: auto;
   }
 
   .toast--close:hover {

--- a/static/css/components/toast.less
+++ b/static/css/components/toast.less
@@ -8,6 +8,7 @@
   left: 0;
   right: 0;
   z-index: @z-index-level-17;
+  pointer-events: none;
 }
 
 .toast {
@@ -27,6 +28,7 @@
 
   .toast--close {
     padding-left: .75em;
+    pointer-events: auto;
   }
 
   .toast--close:hover {


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes a number of issues with the toast component:
1. Keeps close icon from appearing close to the center of the component when a short toast message is displayed.
2. Allows multiple toast containers to exist on a page at a single time, preventing toast messages from being displayed on a hidden component (like a modal).
3. Allows a modal to be closed by the 'X' icon if it is overlapped by a toast container.

This PR also ensures that toast messages for observation type updates are capitalized.

### Technical
<!-- What should be noted about the implementation? -->
Some background: Individual toast components are appended to an invisible toast container.  The container stretches the width of the page and allows multiple toast components to be displayed in a column.  The container itself is appended to a parent element, which is passed to the Toast constructor.

Initially, a static toast container was being used.  This caused issues when toast messages with different parent elements were being displayed on a single page.  Containers are now appended to a parent element in the Toast constructor only if the parent does not already have a toast container as a child.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:
1. Navigate to a book page.
2. Click the link on the Reader Observation component to open the observations modal.
3. Submit an observation by clicking any radio button or checkbox. Observe the toast message that appears.
4. While the toast message is visible, click the modal's 'X' icon.  The modal should close.
5. Repeat steps 2 and 3.  Click the 'X' icon on the toast component.  The component should close.
6. Open the book notes modal by clicking the "My book notes" link located below the star rating component.
7. Submit a note.  The book notes modal will close, and a toast message should be visible.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![toast_update](https://user-images.githubusercontent.com/28732543/127567766-7240e1fe-d3f6-404b-9cef-3bac11ab6344.png)
_Updated toast component with observation type capitalized and 'X' in a reasonable position_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles, as this affects the book tags project