### PR TITLE
Fixed the overflow issue of the edit button.

### DIFF
--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -20,7 +20,7 @@ div.editButton {
 
 div#editInfo {
   float: right;
-  white-space: nowrap;
+  white-space: normal;
   text-align: right;
   > div {
     font-size: 11px;

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -9,10 +9,6 @@ div#editHistory {
   width: auto;
 }
 
-div#editTools {
-  margin-right: 10%;
-}
-
 div.editButton {
   width: auto;
   display: inline-block;

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -9,6 +9,10 @@ div#editHistory {
   width: auto;
 }
 
+div#editTools {
+  margin-right: 10%;
+}
+
 div.editButton {
   width: auto;
   display: inline-block;


### PR DESCRIPTION
Fixed the overflow issue of the edit button

<!-- What issue does this PR close? -->
Closes #5439

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix. This PR fixes the issue of the overflow of the edit button.

### Technical
<!-- What should be noted about the implementation? -->
Though the most obvious thing on my mind was to limit the length of the text near it to a fixed limit and show ellipsis(...) after it.
But going through the CSS in the browser's dev tools, I found that the issue was that we didn't specify any specific bounds from the right which was an obvious thing to do since the container in which it's supposed to have some margin in the x-axis. So just adding some right margin was the solution. This may sound quite trivial but please refer to the screenshots where I have shown the effect of that.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Just run it :)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2021-07-29 000817_LI](https://user-images.githubusercontent.com/55590289/127526572-d409d7cc-8e01-447a-89b9-19e03fbcee6a.jpg)
![Screenshot 2021-07-29 000749](https://user-images.githubusercontent.com/55590289/127523581-8a2df9c2-56c7-41c9-b3b8-abaf6f90fb32.jpg)
![Screenshot 2021-07-29 000850](https://user-images.githubusercontent.com/55590289/127609199-b03af144-2fcf-46b9-a1b8-a07b2afd492e.jpg)
![Screenshot 2021-07-29 000942](https://user-images.githubusercontent.com/55590289/127609218-9eab6614-5a79-4f1c-bc97-ce1b30f63d6c.jpg)





### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB @jimchamp 
