### PR TITLE
Remove notes modals from notes list page

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "static/build/modal-links.*.js",
-      "maxSize": "5.3KB"
+      "maxSize": "5.5KB"
     },
     {
       "path": "static/build/user-website.*.js",

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -220,7 +220,8 @@ jQuery(function () {
 
     const $observationModalLinks = $('.observations-modal-link');
     const $notesModalLinks = $('.notes-modal-link');
-    if ($observationModalLinks.length || $notesModalLinks.length) {
+    const $notesPageButtons = $('.note-page-buttons')
+    if ($observationModalLinks.length || $notesModalLinks.length || $notesPageButtons.length) {
         import(/* webpackChunkName: "modal-links" */ './modals')
             .then(module => {
                 if ($observationModalLinks.length) {
@@ -228,6 +229,9 @@ jQuery(function () {
                 }
                 if ($notesModalLinks.length) {
                     module.initNotesModal($notesModalLinks);
+                }
+                if ($notesPageButtons.length) {
+                    module.addNotesPageButtonListeners();
                 }
             });
     }

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -99,39 +99,41 @@ export function addNotesPageButtonListeners() {
     });
 
     $('.delete-note-button').on('click', function() {
-        const $parent = $(this).parent();
+        if (confirm('Really delete this book note?')) {
+            const $parent = $(this).parent();
 
-        const workId = $(this).parent().siblings('input')[0].value;
-        const editionId = $(this).parent().attr('id').split('-')[0];
+            const workId = $(this).parent().siblings('input')[0].value;
+            const editionId = $(this).parent().attr('id').split('-')[0];
 
-        const formData = new FormData();
-        formData.append('edition_id', `OL${editionId}M`);
+            const formData = new FormData();
+            formData.append('edition_id', `OL${editionId}M`);
 
-        $.ajax({
-            url: `/works/OL${workId}W/notes.json`,
-            data: formData,
-            type: 'POST',
-            contentType: false,
-            processData: false,
-            success: function() {
-                showToast($('body'), 'Note deleted.');
+            $.ajax({
+                url: `/works/OL${workId}W/notes.json`,
+                data: formData,
+                type: 'POST',
+                contentType: false,
+                processData: false,
+                success: function() {
+                    showToast($('body'), 'Note deleted.');
 
-                // Remove list element from UI:
-                if ($parent.closest('.notes-list').children().length === 1) {
-                    // This is the last edition for a set of notes on a work.
-                    // Remove the work element:
-                    $parent.closest('.main-list-item').remove();
+                    // Remove list element from UI:
+                    if ($parent.closest('.notes-list').children().length === 1) {
+                        // This is the last edition for a set of notes on a work.
+                        // Remove the work element:
+                        $parent.closest('.main-list-item').remove();
 
-                    if (!$('.main-list-item').length) {
-                        $('.list-container')[0].innerText = 'No notes found.';
+                        if (!$('.main-list-item').length) {
+                            $('.list-container')[0].innerText = 'No notes found.';
+                        }
+                    } else {
+                        // Notes for other editions of the work exist
+                        // Remove the edition's notes list item:
+                        $parent.closest('.notes-list-item').remove();
                     }
-                } else {
-                    // Notes for other editions of the work exist
-                    // Remove the edition's notes list item:
-                    $parent.closest('.notes-list-item').remove();
                 }
-            }
-        });
+            });
+        }
     });
 }
 

--- a/openlibrary/templates/account/notes.html
+++ b/openlibrary/templates/account/notes.html
@@ -55,9 +55,13 @@ $def with (notes, user, num_found, page=1, results_per_page=25)
                   </div>
                   <div class="book-note">
                     $ textarea_id = str(k) + "-notes-textarea"
-                    <textarea class="notes-textarea" id="$textarea_id" rows="10" readonly>$i['notes'][k]</textarea>
-                    $ id = str(k) + "edition-modal-link"
-                    $:macros.NotesModal(i.work, edition, _('View or update note'), id, 'notes-view-modal-link', reload_id=textarea_id)
+                    $ button_div_id = str(k) + "-note-form-buttons"
+                    <textarea class="notes-textarea" id="$textarea_id" rows="10">$i['notes'][k]</textarea>
+                    <input type="hidden" name="workId" value="$work_id" />
+                    <div class="note-page-buttons" id="$button_div_id">
+                      <button class="delete-note-button cta-btn" type="button">$_("Delete Note")</button>
+                      <button class="update-note-button cta-btn" type="button">$_("Save Note")</button>
+                    </div>
                   </div>
                 </li>
             </ul>

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -106,8 +106,7 @@
   }
 }
 
-.note-form-buttons,
-.note-page-buttons {
+.note-form-buttons {
   display: flex;
   justify-content: space-between;
 

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -106,7 +106,8 @@
   }
 }
 
-.note-form-buttons {
+.note-form-buttons,
+.note-page-buttons {
   display: flex;
   justify-content: space-between;
 

--- a/static/css/components/notes-view.less
+++ b/static/css/components/notes-view.less
@@ -63,6 +63,33 @@
   }
 }
 
+.note-page-buttons {
+  display: flex;
+  justify-content: space-between;
+
+  button {
+    font-size: 1.2em;
+    width: unset;
+  }
+
+  .delete-note-button {
+    background-color: @red;
+
+    &:hover {
+      background-color: darken(@red, 10%);
+    }
+  }
+
+  .update-note-button {
+    background-color: @green;
+    margin-left: auto;
+
+    &:hover {
+      background-color: darken(@green, 10%);
+    }
+  }
+}
+
 /* Observations view */
 .observations-header {
   color: @dark-grey;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes notes modals from the notes list page, and places update and delete buttons under each note textarea.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:

1. Navigate to the notes list page.
2. Attempt to update a note.  Refresh the page to check if the note was persisted.
3. Delete a note. Ensure that the expected elements are removed from the UI. Refresh the page to ensure that the note was deleted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 