### PR TITLE
Tweaks to solr index schema

### DIFF
--- a/conf/solr/conf/managed-schema
+++ b/conf/solr/conf/managed-schema
@@ -191,7 +191,7 @@
     <field name="time_facet" type="string" stored="false" multiValued="true"/>
     <field name="time_key" type="string" stored="false" multiValued="true"/>
 
-    <field name="text" type="text_en_splitting" multiValued="true"/>
+    <field name="text" type="text_en_splitting" stored="false" multiValued="true"/>
 
     <field name="seed" type="string" multiValued="true"/>
 

--- a/conf/solr/conf/managed-schema
+++ b/conf/solr/conf/managed-schema
@@ -156,7 +156,7 @@
     <field name="first_edition" type="string" indexed="false"/>
     <field name="first_publisher" type="string" indexed="false"/>
     <field name="language" type="string" multiValued="true"/>
-    <field name="number_of_pages" type="pint" multiValued="true"/>
+    <field name="number_of_pages_median" type="pint" />
     <field name="lccn" type="text_general" multiValued="true"/>
     <field name="ia" type="string" multiValued="true"/>
     <field name="ia_count" type="pint"/>

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -4,7 +4,9 @@ import itertools
 import logging
 import os
 import re
-from typing import Literal, List, Union
+from math import ceil
+from statistics import median
+from typing import Literal, List, Union, Optional, cast
 
 import httpx
 import requests
@@ -195,6 +197,19 @@ def pick_cover_edition(editions, work_cover_id):
         # The default: None
         [None],
     ))
+
+
+def pick_number_of_pages_median(editions: List[dict]) -> Optional[int]:
+    number_of_pages = [
+        cast(int, e.get('number_of_pages'))
+        for e in editions
+        if e.get('number_of_pages') and type(e.get('number_of_pages')) == int
+    ]
+
+    if number_of_pages:
+        return ceil(median(number_of_pages))
+    else:
+        return None
 
 
 def get_work_subjects(w):
@@ -548,6 +563,10 @@ class SolrProcessor:
         if pub_years:
             add_list('publish_year', pub_years)
             add('first_publish_year', min(int(y) for y in pub_years))
+
+        number_of_pages_median = pick_number_of_pages_median(editions)
+        if number_of_pages_median:
+            add('number_of_pages_median', number_of_pages_median)
 
         field_map = [
             ('lccn', 'lccn'),

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -2,7 +2,11 @@ import pytest
 
 from openlibrary.solr import update_work
 from openlibrary.solr.data_provider import DataProvider
-from openlibrary.solr.update_work import build_data, pick_cover_edition
+from openlibrary.solr.update_work import (
+    build_data,
+    pick_cover_edition,
+    pick_number_of_pages_median,
+)
 
 author_counter = 0
 edition_counter = 0
@@ -578,3 +582,20 @@ class Test_pick_cover_edition:
     def test_prefers_anything(self):
         ed = {'covers': [123]}
         assert pick_cover_edition([ed], 456) == ed
+
+
+class Test_pick_number_of_pages_median:
+    def test_no_editions(self):
+        assert pick_number_of_pages_median([]) is None
+
+    def test_invalid_type(self):
+        ed = {'number_of_pages': 'spam'}
+        assert pick_number_of_pages_median([ed]) is None
+        eds = [{'number_of_pages': n} for n in [123, 122, 'spam']]
+        assert pick_number_of_pages_median(eds) == 123
+
+    def test_normal_case(self):
+        eds = [{'number_of_pages': n} for n in [123, 122, 1]]
+        assert pick_number_of_pages_median(eds) == 122
+        eds = [{}, {}] + [{'number_of_pages': n} for n in [123, 122, 1]]
+        assert pick_number_of_pages_median(eds) == 122

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -228,6 +228,7 @@ def main(
         exclude_edits_containing: str = None,
         ol_url='http://openlibrary.org/',
         solr_url: str = None,
+        solr_next=False,
         socket_timeout=10,
         load_ia_scans=False,
         commit=True,
@@ -237,6 +238,7 @@ def main(
     :param debugger: Wait for a debugger to attach before beginning
     :param exclude_edits_containing: Don't index matching edits
     :param solr_url: If wanting to override what's in the config file
+    :param solr_next: Whether to assume new schema/etc are used
     :param initial_state: State to use if state file doesn't exist. Defaults to today.
     """
     FORMAT = "%(asctime)-15s %(levelname)s %(message)s"
@@ -263,6 +265,8 @@ def main(
 
     if solr_url:
         update_work.set_solr_base_url(solr_url)
+
+    update_work.set_solr_next(solr_next)
 
     logger.info("loading config from %s", ol_config)
     load_config(ol_config)


### PR DESCRIPTION
- Remove `text` field -- BREAKING CHANGE
- Add `number_of_pages_median` field

### Technical
<!-- What should be noted about the implementation? -->

### Testing
1.  docker-compose down
2. docker volume rm openlibrary_solr-data openlibrary_solr-updater-data
3.  docker-compose up -d
4. [x] http://localhost:8080/search.json?q=the&mode=everything does not have `text`, and _does_ have `number_of_pages_median` (might take a moment to not be empty though)
5. Edit http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain (to kick off solr-updater)
6. [x] http://localhost:8080/search.json?q=the&mode=everything does not have `text`, and does _not_ have `number_of_pages_median`

---

1. docker-compose down
2. docker volume rm openlibrary_solr-data openlibrary_solr-updater-data
3. Update docker-compose.override.yml to have `environment: [EXTRA_OPTS=--solr-next]` for solr-updater
4. docker-compose up -d
5. [x] http://localhost:8080/search.json?q=the&mode=everything does not have `text`, and _does not_ have `number_of_pages_median`
5. Edit http://localhost:8080/books/OL2058361M/The_wit_wisdom_of_Mark_Twain (to kick off solr-updater)
6. [x] http://localhost:8080/search.json?q=the&mode=everything does not have `text`, and _does_ have `number_of_pages_median`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
