### PR TITLE
Fix duplicate manage cover template in modal

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -232,11 +232,6 @@ jQuery(function () {
             });
     }
 
-    if (document.getElementsByClassName('manageCovers').length) {
-        import(/* webpackChunkName: "covers" */ './covers')
-            .then((module) => module.initCoversChange());
-    }
-
     const manageCoversElement = document.getElementsByClassName('manageCovers').length;
     const addCoversElement = document.getElementsByClassName('imageIntro').length;
     const saveCoversElement = document.getElementsByClassName('imageSaved').length;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5504

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes duplicate add and manage covers templates from the covers modal.

### Technical
<!-- What should be noted about the implementation? -->
The covers initialization JS function was being called twice.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a book page and click the manage cover link.
2. Ensure that there is only one template displayed.
3. Click the "Manage" tab, and ensure that only one template is displayed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 