### PR TITLE
hotfix for accessing `q` for ListQuery

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1111,7 +1111,7 @@ class search_json(delegate.page):
             default=default_spellcheck_count)
 
         # If the query is a /list/ key, create custom list_editions_query
-        q = query['q']
+        q = query.get('q', '')
         query['q'], page, offset, limit = rewrite_list_editions_query(
             q,
             page,


### PR DESCRIPTION
Fixes a flood of errors causing all our metrics to break and our alerts to go haywire.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
