### PR TITLE
Remove unused docker images during deploy

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -33,7 +33,7 @@ docker push openlibrary/olbase:latest
 parallel --quote ssh {1} "echo -e '\n\n{}'; if [ -d /opt/booklending_utils ]; then cd {2} && sudo git pull git@git.archive.org:jake/booklending_utils.git master; fi" ::: $SERVERS ::: /opt/booklending_utils
 
 # Prune old images now ; this should remove any unused images
-parallel --quote ssh {} "echo -e '\n\n{}'; docker image prune -f" ::: $SERVERS
+parallel --quote ssh {} "echo -e '\n\n{}'; docker image prune --all --force" ::: $SERVERS
 
 # Pull the latest docker images
 parallel --quote ssh {} "echo -e '\n\n{}'; cd /opt/openlibrary && COMPOSE_FILE=\"$COMPOSE_FILE\" docker-compose --profile {} pull --quiet" ::: $SERVERS


### PR DESCRIPTION
Production only needs the images attached to running containers, so we should use docker image prune --all

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
