### PR TITLE
Switch olbase to use python:3.9.4 image instead of ubuntu:xenial

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -73,8 +73,6 @@ services:
 
   home:
     image: "oldev:${OLDEV_TAG:-latest}"
-    environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -178,7 +178,6 @@ services:
     restart: always
     hostname: "$HOSTNAME"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OL_URL=https://openlibrary.org/
       - STATE_FILE=solr8-update.offset
@@ -202,7 +201,6 @@ services:
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OPENLIBRARY_RCFILE=/olsystem/etc/olrc-importbot
-      - PYENV_VERSION=${PYENV_VERSION:-}
     volumes:
       - ../olsystem:/olsystem
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   web:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 4 --timeout 180}
     command: docker/ol-web-start.sh
@@ -40,7 +39,6 @@ services:
     hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=conf/openlibrary.yml
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_URL=http://web:8080/
       - STATE_FILE=solr-update.offset
     volumes:
@@ -57,7 +55,6 @@ services:
   covers:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --max-requests 250}
     command: docker/ol-covers-start.sh
@@ -74,7 +71,6 @@ services:
   infobase:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}
       - INFOBASE_OPTS=${INFOBASE_OPTS:-}
     command: docker/ol-infobase-start.sh

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM python:3.9.4
 
 ENV LANG en_US.UTF-8
 
@@ -30,38 +30,11 @@ RUN apt-get -qq update && apt-get install -y \
     unzip \
     lftp
 
-# Print gnu parallel citation
-USER openlibrary
-RUN echo 'will cite' | parallel --citation
-USER root
-RUN echo 'will cite' | parallel --citation
-
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs
 
-# Install pyenv
-# Python build deps: https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
-RUN apt-get -qq update && apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
-
-# Install latest pyenv (https://github.com/pyenv/pyenv-installer)
-USER openlibrary
-RUN curl https://pyenv.run | bash && \
-    echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /home/openlibrary/.bashrc
-ENV PYENV_ROOT /home/openlibrary/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-
-# Install wheel before other requirements to reduce Docker build time.
-RUN pyenv update && pyenv install 3.9.4 \
- && pyenv global 3.9.4 \
- && pyenv rehash \
- && python3.9 -m pip install --upgrade pip wheel
-
-USER root
-# Add pyenv to root's bashrc as well
-RUN echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /root/.bashrc
+RUN python -m pip install --upgrade pip wheel
 
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary \
  && mkdir /openlibrary && chown openlibrary:openlibrary /openlibrary \
@@ -73,7 +46,7 @@ WORKDIR /openlibrary
 
 USER openlibrary
 COPY requirements*.txt ./
-RUN python3.9 -m pip install --default-timeout=100 -r requirements.txt
+RUN python -m pip install --default-timeout=100 -r requirements.txt
 
 COPY package*.json ./
 RUN npm ci
@@ -83,6 +56,6 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 # run make to initialize git submodules, build css and js files
 RUN ln -s vendor/infogami/infogami infogami \
  && make \
- && python3.9 -m pip list --outdated
+ && python -m pip list --outdated
 
 ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -57,5 +57,3 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 RUN ln -s vendor/infogami/infogami infogami \
  && make \
  && python -m pip list --outdated
-
-ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -2,7 +2,7 @@ FROM openlibrary/olbase:latest
 WORKDIR /openlibrary
 
 COPY requirements*.txt ./
-RUN python3.9 -m pip install -r requirements_test.txt
+RUN python -m pip install -r requirements_test.txt
 
 COPY package*.json ./
 RUN npm install

--- a/docker/README.md
+++ b/docker/README.md
@@ -161,11 +161,6 @@ docker-compose down && \
 
 # In your browser, navigate to http://localhost:8080
 
-# Test Open Library on another version of Python that is in `.python-version` and ol-dev
-# PYENV_VERSION can currently be set to: 3.9.4
-docker-compose down && \
-    PYENV_VERSION=3.9.4 docker-compose up -d && \
-    docker-compose logs -f --tail=10 web
-
-# In your browser, navigate to http://localhost:8080
+# To test Open Library on another version of Python, modify Dockerfile.olbase and then
+# rebuild olbase (see above) and oldev (`docker-compose build`)
 ```

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# Init PYENV vars
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-
-exec "$@"

--- a/scripts/solr_builder/Dockerfile.olpython
+++ b/scripts/solr_builder/Dockerfile.olpython
@@ -1,7 +1,6 @@
 FROM openlibrary/olbase:latest
 
 ENV PYTHONPATH=/openlibrary:/openlibrary/vendor/infogami
-ENV PYENV_VERSION=3.9.4
 
 USER root
 COPY requirements*.txt ./


### PR DESCRIPTION
Experiment: pyenv is a good chunk of our build time, and a big chunk of the complexity of our container. We needed both python 2 and 3 installed to make the 2 to 3 migration easier; hence pyenv. Since future python migrations are very unlikely to be as complicated, we should just switch to hammering in one version of python. This reduces build times (since pyenv _builds_ python), and greatly reduces complexity: simpler Dockerfile, no more environment variables. It also means updating python is much simpler; change 3.9.4 to whatever, put on testing.openlibrary.org and test.

Note this does mean we're no longer based off ubuntu:xenial ; I can't figure out if python:3.9.4 is ubuntu based, but apt-get works, and creating/managing users works, so... 🤷‍♂️

### Technical
- The resulting image size is about the same (~2.04 GB ungzipped)

### Testing
- [x] Test local environment works
- [ ] Push up image to docker hub with `pybase` label
- [ ] Put it on testing
- [ ] Restart crons on ol-home0 to use the pybase image
- [ ] Update cron scripts to not do any python magic

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles @dhruvmanila @cclauss 
