### PR TITLE
Fix uploading covers on local environment

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -16,6 +16,9 @@ dummy_sendmail: True
 debug: True
 
 coverstore_url: http://covers:7075
+# URL to use inside HTML files; must be publicly accessible from
+# a client's browser
+coverstore_public_url: http://localhost:7075
 
 state_dir: var/run
 

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -210,11 +210,6 @@ def _get_safepath_re():
     return re.compile(pattern)
 
 
-def get_coverstore_url():
-    """Returns the base url of coverstore by looking at the config."""
-    return config.get('coverstore_url', 'https://covers.openlibrary.org').rstrip('/')
-
-
 _texsafe_map = {
     '"': r'\textquotedbl{}',
     '#': r'\#',

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -28,7 +28,7 @@ from six.moves import urllib
 from .ia import get_metadata_direct
 from .waitinglist import WaitingLoan
 from ..accounts import OpenLibraryAccount
-from ..plugins.upstream.utils import get_coverstore_url
+from ..plugins.upstream.utils import get_coverstore_url, get_coverstore_public_url
 
 
 def _get_ol_base_url():
@@ -62,7 +62,9 @@ class Image:
             return None
 
     def url(self, size="M"):
-        return f"{get_coverstore_url()}/{self.category}/id/{self.id}-{size.upper()}.jpg"
+        """Get the public URL of the image."""
+        coverstore_url = get_coverstore_public_url()
+        return f"{coverstore_url}/{self.category}/id/{self.id}-{size.upper()}.jpg"
 
     def __repr__(self):
         return "<image: %s/%d>" % (self.category, self.id)

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -28,6 +28,7 @@ from six.moves import urllib
 from .ia import get_metadata_direct
 from .waitinglist import WaitingLoan
 from ..accounts import OpenLibraryAccount
+from ..plugins.upstream.utils import get_coverstore_url
 
 
 def _get_ol_base_url():
@@ -45,7 +46,7 @@ class Image:
         self.id = id
 
     def info(self):
-        url = '%s/%s/id/%s.json' % (h.get_coverstore_url(), self.category, self.id)
+        url = f'{get_coverstore_url()}/{self.category}/id/{self.id}.json'
         if url.startswith("//"):
             url = "http:" + url
         try:
@@ -61,7 +62,7 @@ class Image:
             return None
 
     def url(self, size="M"):
-        return "%s/%s/id/%s-%s.jpg" % (h.get_coverstore_url(), self.category, self.id, size.upper())
+        return f"{get_coverstore_url()}/{self.category}/id/{self.id}-{size.upper()}.jpg"
 
     def __repr__(self):
         return "<image: %s/%d>" % (self.category, self.id)

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -9,13 +9,13 @@ $ cover_ids =  [cover for cover in doc.get('covers', []) if cover != -1]
   <span class="bookcover">
     $if availability:
       $if availability.get('openlibrary_edition'):
-        $ cover = get_coverstore_url() + "/b/olid/%s-M.jpg" % availability.get('openlibrary_edition')
+        $ cover = get_coverstore_public_url() + "/b/olid/%s-M.jpg" % availability.get('openlibrary_edition')
       $elif ocaid:
         $ cover = "//archive.org/download/%s/page/cover_w60_h60.jpg" % ocaid
     $elif doc.get('cover_i') or cover_ids:
-      $ cover = get_coverstore_url() + "/b/id/%s-M.jpg" % (doc.cover_i or cover_ids[0])
+      $ cover = get_coverstore_public_url() + "/b/id/%s-M.jpg" % (doc.cover_i or cover_ids[0])
     $elif doc.get('cover_edition_key'):
-      $ cover = get_coverstore_url() + "/b/olid/%s-M.jpg" % doc.cover_edition_key
+      $ cover = get_coverstore_public_url() + "/b/olid/%s-M.jpg" % doc.cover_edition_key
     $elif doc.get('ocaid'):
       $ cover = "//archive.org/download/%s/page/cover_w60_h60.jpg" % doc.get('ocaid')
     $else:

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -10,11 +10,10 @@ from infogami.utils.view import render_template, public
 from infogami.infobase.client import storify
 from infogami import config
 
-from openlibrary.core import admin, cache, ia, lending, \
-    helpers as h
+from openlibrary.core import admin, cache, ia, lending
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil
-from openlibrary.plugins.upstream.utils import get_blog_feeds
+from openlibrary.plugins.upstream.utils import get_blog_feeds, get_coverstore_url
 from openlibrary.plugins.worksearch import search, subjects
 
 import six
@@ -469,7 +468,8 @@ def format_work_data(work):
                         zip(work['author_key'], work['author_name'])]
 
     if 'cover_edition_key' in work:
-        d['cover_url'] = h.get_coverstore_url() + "/b/olid/%s-M.jpg" % work['cover_edition_key']
+        coverstore_url = get_coverstore_url()
+        d['cover_url'] = f"{coverstore_url}/b/olid/{work['cover_edition_key']}-M.jpg"
 
     d['read_url'] = "//archive.org/stream/" + work['ia'][0]
     return d

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -13,7 +13,7 @@ from infogami import config
 from openlibrary.core import admin, cache, ia, lending
 from openlibrary.i18n import gettext as _
 from openlibrary.utils import dateutil
-from openlibrary.plugins.upstream.utils import get_blog_feeds, get_coverstore_url
+from openlibrary.plugins.upstream.utils import get_blog_feeds, get_coverstore_public_url
 from openlibrary.plugins.worksearch import search, subjects
 
 import six
@@ -468,7 +468,7 @@ def format_work_data(work):
                         zip(work['author_key'], work['author_name'])]
 
     if 'cover_edition_key' in work:
-        coverstore_url = get_coverstore_url()
+        coverstore_url = get_coverstore_public_url()
         d['cover_url'] = f"{coverstore_url}/b/olid/{work['cover_edition_key']}-M.jpg"
 
     d['read_url'] = "//archive.org/stream/" + work['ia'][0]

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -18,7 +18,7 @@ from openlibrary.core import models, ia
 from openlibrary.core.models import Image
 from openlibrary.core import lending
 
-from openlibrary.plugins.upstream.utils import get_coverstore_url, MultiDict, parse_toc, get_edition_config
+from openlibrary.plugins.upstream.utils import MultiDict, parse_toc, get_edition_config
 from openlibrary.plugins.upstream import account
 from openlibrary.plugins.upstream import borrow
 from openlibrary.plugins.worksearch.code import works_by_author, sorted_work_editions

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -102,3 +102,17 @@ def test_canonical_url():
     web.ctx.query = '?sort=new&mode=2'
     url = 'https://www.openlibrary.org/authors/Ayn_Rand'
     assert request.canonical_url == url
+
+
+def test_get_coverstore_url(monkeypatch):
+    from infogami import config
+
+    monkeypatch.delattr(config, "coverstore_url", raising=False)
+    assert utils.get_coverstore_url() == "https://covers.openlibrary.org"
+
+    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:8090", raising=False)
+    assert utils.get_coverstore_url() == "https://0.0.0.0:8090"
+
+    # make sure trailing / is always stripped
+    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:8090/", raising=False)
+    assert utils.get_coverstore_url() == "https://0.0.0.0:8090"

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -110,9 +110,9 @@ def test_get_coverstore_url(monkeypatch):
     monkeypatch.delattr(config, "coverstore_url", raising=False)
     assert utils.get_coverstore_url() == "https://covers.openlibrary.org"
 
-    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:8090", raising=False)
-    assert utils.get_coverstore_url() == "https://0.0.0.0:8090"
+    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:80", raising=False)
+    assert utils.get_coverstore_url() == "https://0.0.0.0:80"
 
     # make sure trailing / is always stripped
-    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:8090/", raising=False)
-    assert utils.get_coverstore_url() == "https://0.0.0.0:8090"
+    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:80/", raising=False)
+    assert utils.get_coverstore_url() == "https://0.0.0.0:80"

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -285,9 +285,13 @@ def radio_list(name, args, value):
         html.append(radio_input())
 
 
-@public
 def get_coverstore_url() -> str:
     return config.get('coverstore_url', 'https://covers.openlibrary.org').rstrip('/')
+
+
+@public
+def get_coverstore_public_url() -> str:
+    return config.get('coverstore_public_url', get_coverstore_url()).rstrip('/')
 
 
 def _get_changes_v1_raw(query, revision=None):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -284,8 +284,9 @@ def radio_list(name, args, value):
             label = arg
         html.append(radio_input())
 
+
 @public
-def get_coverstore_url():
+def get_coverstore_url() -> str:
     return config.get('coverstore_url', 'https://covers.openlibrary.org').rstrip('/')
 
 

--- a/openlibrary/templates/covers/change.html
+++ b/openlibrary/templates/covers/change.html
@@ -29,7 +29,7 @@ $else:
 
 <div class="$size sansserif manageCoversContainer hidden--nojs">
   <a aria-controls="addImage" class="coverPop dialog--open">
-    <div class="manageCovers" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
+    <div class="manageCovers" data-config="$dumps({'key': doc.type.key, 'url': get_coverstore_public_url(), 'selector': cover_selector, 'add_url': add_url, 'manage_url': manage_url})">$change</div>
   </a>
 </div>
 

--- a/openlibrary/templates/diff.html
+++ b/openlibrary/templates/diff.html
@@ -44,11 +44,11 @@ $def diff_covers(p, a, b):
             <td class="diff-header-side">$p</td>
             <td class="diff-body">
                 $for img in a[p]:
-                    <img src="$get_coverstore_url()/b/id/$img-M.jpg"/>
+                    <img src="$get_coverstore_public_url()/b/id/$img-M.jpg"/>
             </td>
             <td class="diff-body">
                 $for img in b[p]:
-                    <img src="$get_coverstore_url()/b/id/$img-M.jpg"/>
+                    <img src="$get_coverstore_public_url()/b/id/$img-M.jpg"/>
             </td>
         </tr>
 

--- a/openlibrary/tests/core/test_helpers.py
+++ b/openlibrary/tests/core/test_helpers.py
@@ -104,18 +104,6 @@ def test_urlsafe():
     assert h.urlsafe("?a") == "a"
     assert h.urlsafe("a?") == "a"
 
-def test_get_coverstore_url(monkeypatch):
-    from infogami import config
-
-    monkeypatch.delattr(config, "coverstore_url", raising=False)
-    assert h.get_coverstore_url() == "https://covers.openlibrary.org"
-
-    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:8090", raising=False)
-    assert h.get_coverstore_url() == "https://0.0.0.0:8090"
-
-    # make sure trailing / is always stripped
-    monkeypatch.setattr(config, "coverstore_url", "https://0.0.0.0:8090/", raising=False)
-    assert h.get_coverstore_url() == "https://0.0.0.0:8090"
 
 def test_texsafe():
     assert h.texsafe("hello") == r"hello"


### PR DESCRIPTION
Uploading covers locally doesn't work because in the local environment, the server needs to hit covers:7075, but the user's browser doesn't have access to that host. So we need a separate, public resource URL for that. In the local dev environment it's localhost:7075.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] Tested uploading a cover works locally
- [ ] Test on testing that uploading/viewing covers works

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
