### PR TITLE
Fix header details tags showing ">" marker on safari!

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -270,6 +270,10 @@
       content: "";
     }
 
+    summary::-webkit-details-marker {
+      display: none;
+    }
+
     label {
       background: transparent;
       border: none;
@@ -605,6 +609,10 @@ div.search-facet:focus-within {
   summary::marker {
     content: "";
   }
+
+  summary::-webkit-details-marker {
+    display: none;
+  }
 }
 
 .hamburger-component,
@@ -630,6 +638,10 @@ div.search-facet:focus-within {
 
   summary::marker {
     content: "";
+  }
+
+  summary::-webkit-details-marker {
+    display: none;
   }
 
   summary {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5520

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Confirmed working on browserstack/iOS 14, FF/Win10, Ch/Win10

### Screenshot
![image](https://user-images.githubusercontent.com/6251786/128555854-75babefa-b8de-44b2-b14d-33ec363afbc7.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
