### PR TITLE
Switch production services to restart: unless-stopped

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -10,7 +10,7 @@ services:
   web:
     profiles: ["ol-web1", "ol-web2"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
@@ -26,12 +26,12 @@ services:
     environment:
       # More memory for production
       - SOLR_JAVA_MEM=-Xms10g -Xmx10g
-    restart: always
+    restart: unless-stopped
 
   solr_haproxy:
     profiles: ["ol-solr0"]
     image: haproxy:2.3.5
-    restart: always
+    restart: unless-stopped
     networks:
       - webnet
     volumes:
@@ -46,7 +46,7 @@ services:
   covers:
     profiles: ["ol-covers0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 30 --max-requests 500
@@ -58,7 +58,7 @@ services:
   covers_nginx:
     profiles: ["ol-covers0"]
     image: nginx:1.19.4
-    restart: always
+    restart: unless-stopped
     depends_on:
       - covers
     volumes:
@@ -93,7 +93,7 @@ services:
     hostname: "$HOSTNAME"
     user: root
     command: docker/ol-cron-start.sh
-    restart: always
+    restart: unless-stopped
     volumes:
       - ../olsystem/etc/cron.d/openlibrary.ol_home0:/etc/cron.d/openlibrary.ol_home0:ro
       - ../olsystem:/olsystem
@@ -107,7 +107,7 @@ services:
   infobase:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - INFOBASE_OPTS= fastcgi
@@ -120,7 +120,7 @@ services:
   infobase_nginx:
     profiles: ["ol-home0"]
     image: nginx:1.19.4
-    restart: always
+    restart: unless-stopped
     depends_on:
       - infobase
     volumes:
@@ -138,7 +138,7 @@ services:
   affiliate-server:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - AFFILIATE_CONFIG=/openlibrary.yml
@@ -157,7 +157,7 @@ services:
   solr-updater:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
@@ -175,7 +175,7 @@ services:
   solr8-updater:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - PYENV_VERSION=${PYENV_VERSION:-}
@@ -197,7 +197,7 @@ services:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     command: docker/ol-importbot-start.sh
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
-    restart: always
+    restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
   solr-updater:
     image: "${OLIMAGE:-oldev:latest}"
     command: docker/ol-solr-updater-start.sh
-    restart: always
     hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=conf/openlibrary.yml

--- a/scripts/solr_builder/docker-compose.yml
+++ b/scripts/solr_builder/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
   db:
     image: postgres
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_PASSWORD: example
     working_dir: "/solr_builder"
@@ -16,7 +16,7 @@ services:
 
   adminer:
     image: adminer
-    restart: always
+    restart: unless-stopped
     ports:
       - 8087:8080
     networks:


### PR DESCRIPTION
Useful for #5493 . Fix. This lets us stop the containers, and not have them auto-restart eg when the host machine reboots. 

### Technical
Note the containers will auto-restart if they are not manually stopped. Also note they will still restart-loop if they hit an error or something.

### Testing
Tested:

1. Set `restart: unless-stopped` for solr in docker-compose.yml
2. `docker-compose up -d`
3. Restart docker daemon
4. ✅ Confirm solr is still running
5. Manually stop solr `docker stop openlibrary_solr_1`
6. Restart docker daemon
7. ✅ Confirm solr is not restarted
8. Start solr again `docker start openlibrary_solr_1`
9. Restart docker daemon
10. ✅ Confirm solr is still running

Tested:

1. Set `solr-updater` to `restart: unless-stopped, `command: echo blue`
2. `docker-compose up -d solr-updater`
3. ✅ Confirm restart loop

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
