### PR TITLE
Require confirmation before note deletion

### DIFF
--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -44,29 +44,31 @@ function addNotesModalButtonListeners() {
     });
 
     $('.delete-note-button').on('click', function() {
-        const $button = $(this);
+        if (confirm('Really delete this book note?')) {
+            const $button = $(this);
 
-        // Get form data
-        const formData = new FormData($button.prop('form'));
+            // Get form data
+            const formData = new FormData($button.prop('form'));
 
-        // Post data
-        const workOlid = formData.get('work_id');
-        formData.delete('work_id');
-        formData.delete('notes');
+            // Post data
+            const workOlid = formData.get('work_id');
+            formData.delete('work_id');
+            formData.delete('notes');
 
-        $.ajax({
-            url: `/works/${workOlid}/notes.json`,
-            data: formData,
-            type: 'POST',
-            contentType: false,
-            processData: false,
-            success: function() {
-                showToast($('body'), 'Note deleted.');
-                $.colorbox.close();
-                $button.toggleClass('hidden');
-                $button.closest('form').find('textarea').val('');
-            }
-        });
+            $.ajax({
+                url: `/works/${workOlid}/notes.json`,
+                data: formData,
+                type: 'POST',
+                contentType: false,
+                processData: false,
+                success: function() {
+                    showToast($('body'), 'Note deleted.');
+                    $.colorbox.close();
+                    $button.toggleClass('hidden');
+                    $button.closest('form').find('textarea').val('');
+                }
+            });
+        }
     });
 }
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Displays a confirmation dialog when a patron attempts to delete a book note.  Note will only be deleted if patron confirms.

### Technical
<!-- What should be noted about the implementation? -->
This PR only affects notes modal on a book page.  Notes page delete confirmations are handled in #5481.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta tester:
1. Navigate to a book page.
2. If you haven't already submitted a note for the book, submit one.
3. Open the notes modal and click the delete button.
4. Confirm that the confirmation dialog appears.
5. Click "Confirm" to delete the note.  Ensure that the note is deleted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![confirm_delete](https://user-images.githubusercontent.com/28732543/128944213-bf484dca-06dd-4ba2-a8d0-0ba5ce8e3405.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@mekarpeles 
