### PR TITLE
Indicate if note exists in modal link text

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -495,6 +495,15 @@ class Work(Thing):
         edition_id = extract_numeric_id_from_olid(edition_olid) if edition_olid else -1
         return Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)
 
+    
+    def has_book_note(self, username, edition_olid):
+        if not username:
+            return False
+        work_id = extract_numeric_id_from_olid(self.key)
+        edition_id = extract_numeric_id_from_olid(edition_olid)
+        return len(Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)) > 0
+
+
     def get_users_observations(self, username):
         if not username:
             return None

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -501,9 +501,9 @@ class Work(Thing):
         work_id = extract_numeric_id_from_olid(self.key)
         edition_id = extract_numeric_id_from_olid(edition_olid)
         return len(Booknotes.get_patron_booknote(
-                username, work_id,
-                edition_id=edition_id)
-            ) > 0
+            username, work_id,
+            edition_id=edition_id)
+        ) > 0
 
     def get_users_observations(self, username):
         if not username:

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -495,14 +495,15 @@ class Work(Thing):
         edition_id = extract_numeric_id_from_olid(edition_olid) if edition_olid else -1
         return Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)
 
-    
     def has_book_note(self, username, edition_olid):
         if not username:
             return False
         work_id = extract_numeric_id_from_olid(self.key)
         edition_id = extract_numeric_id_from_olid(edition_olid)
-        return len(Booknotes.get_patron_booknote(username, work_id, edition_id=edition_id)) > 0
-
+        return len(Booknotes.get_patron_booknote(
+                username, work_id,
+                edition_id=edition_id)
+            ) > 0
 
     def get_users_observations(self, username):
         if not username:

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -292,7 +292,11 @@ $if include_widget:
 
     $# BookNotes feature:
     $if ctx.user and ctx.user.is_beta_tester():
-      $:macros.NotesModal(work, edition, _("My book notes"), 'cta', 'cta-section patron-metadata')
+      $if work.has_book_note(username, edition.key.split('/')[-1]):
+        $ link_text = _("Update my book note")
+      $else:
+        $ link_text = _("Add a book note")
+      $:macros.NotesModal(work, edition, link_text, 'cta', 'cta-section patron-metadata')
 
 
 $if include_showcase:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
On book pages, the book notes modal link's text will indicate whether or not a patron has created a note for an edition.

### Technical
<!-- What should be noted about the implementation? -->
Text does not update if a new note is added, nor if a note is deleted.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![modal_link_text](https://user-images.githubusercontent.com/28732543/128948324-232f175f-db58-4f31-9026-8a1d7d113a25.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 
