### PR TITLE
Update notes form styling

### DIFF
--- a/openlibrary/macros/NotesModal.html
+++ b/openlibrary/macros/NotesModal.html
@@ -33,8 +33,8 @@ $if reload_id:
         <input type="hidden" name="work_id" value="$work_key.split('/')[-1]" />
         <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
         <div class="note-form-buttons">
-          <button class="delete-note-button cta-btn $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
-          <button class="update-note-button cta-btn"type="button">$_("Save Note")</button>
+          <button class="delete-note-button cta-btn cta-btn--shell $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
+          <a class="update-note-button linkButton" href="javascript;">$_("Save Note")</a>
         </div>
       </form>
     </div>

--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -17,10 +17,10 @@ export function initNotesModal($modalLinks) {
  * Adds click listeners to buttons in all notes modals on a page.
  */
 function addNotesModalButtonListeners() {
-    $('.update-note-button').on('click', function(){
+    $('.update-note-button').on('click', function(event){
+        event.preventDefault();
         // Get form data
-        const formData = new FormData($(this).prop('form'));
-
+        const formData = new FormData($(this).closest('form')[0]);
         if (formData.get('notes')) {
             const $deleteButton = $($(this).siblings()[0]);
 
@@ -77,7 +77,8 @@ function addNotesModalButtonListeners() {
 * from the view.
 */
 export function addNotesPageButtonListeners() {
-    $('.update-note-button').on('click', function() {
+    $('.update-note-link-button').on('click', function(event) {
+        event.preventDefault();
         const workId = $(this).parent().siblings('input')[0].value;
         const editionId = $(this).parent().attr('id').split('-')[0];
         const note = $(this).parent().siblings('textarea')[0].value;

--- a/openlibrary/templates/account/notes.html
+++ b/openlibrary/templates/account/notes.html
@@ -59,8 +59,8 @@ $def with (notes, user, num_found, page=1, results_per_page=25)
                     <textarea class="notes-textarea" id="$textarea_id" rows="10">$i['notes'][k]</textarea>
                     <input type="hidden" name="workId" value="$work_id" />
                     <div class="note-page-buttons" id="$button_div_id">
-                      <button class="delete-note-button cta-btn" type="button">$_("Delete Note")</button>
-                      <button class="update-note-button cta-btn" type="button">$_("Save Note")</button>
+                      <button class="delete-note-button cta-btn cta-btn--shell" type="button">$_("Delete Note")</button>
+                      <a href="javascript;" class="update-note-link-button linkButton">$_("Save Note")</a>
                     </div>
                   </div>
                 </li>

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -2,98 +2,13 @@
 @import (reference) "../less/colors.less";
 @import (reference) "./buttonBtn.less";
 
-.single-choice {
-  display: flex;
-  margin-bottom: .5em;
-
-  &-label {
-    display: inline-block;
-    width: 16%;
-    text-align: center;
-    text-transform: capitalize;
-
-    input {
-      display: block;
-      margin: 0 auto 5px;
-    }
-  }
-}
-
-.multi-choice {
-  display: flex;
-  flex-wrap: wrap;
-  margin-bottom: .5em;
-
-  &-label {
-    flex: 0 0 25%;
-    margin: .5em 0;
-    text-transform: capitalize;
-  }
-
-  input[type="checkbox"] {
-    margin-right: .3em;
-  }
-}
-
-.form-buttons {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-
-  .submit-btn {
-    font-size: 1.2em;
-    width: auto;
-    background-color: @green;
-    margin-top: unset;
-    margin-left: 1.5em;
-    display: unset;
-  }
-}
-
-.aspect-section {
-  summary {
-    cursor: pointer;
-    text-transform: capitalize;
-    font-size: 1em;
-    font-weight: 600;
-    color: @grey;
-    margin: .5em 0;
-    padding: .5em;
-  }
-
-  &[open] summary {
-    background-color: @blue-204764;
-  }
-
-  summary:hover {
-    background-color: @blue-204764;
-  }
-
-  div {
-    padding-left: .5em;
-    padding-bottom: .5em;
-  }
-
-  h3 {
-    display: inline-block;
-    margin: 0;
-    margin-right: .5em;
-  }
-
-  fieldset {
-    border: none;
-
-    legend {
-      margin: 1em 0;
-      color: @grey;
-      font-weight: 600;
-    }
-  }
-}
-
 .book-notes-form {
   width: 75%;
   margin: 1em auto;
+
+  p {
+    font-size: 16px;
+  }
 
   div {
     width: 100%;
@@ -102,6 +17,7 @@
     textarea {
       width: 100%;
       padding: .25em;
+      font-size: 16px;
     }
   }
 }
@@ -116,20 +32,15 @@
   }
 
   .delete-note-button {
-    background-color: @red;
-
-    &:hover {
-      background-color: darken(@red, 10%);
-    }
+    border-color: @red;
+    color: @red;
   }
 
   .update-note-button {
-    background-color: @green;
     margin-left: auto;
-
-    &:hover {
-      background-color: darken(@green, 10%);
-    }
+    margin-top: 5px;
+    border-width: 2px;
+    font-size: 1.2em;
   }
 }
 
@@ -138,47 +49,9 @@
 }
 
 @media screen and (max-width: @width-breakpoint-tablet) {
-  .single-choice {
-    display: inline-block;
-
-    &-label {
-      display: flex;
-      width: 100%;
-      margin: 1em 0;
-      text-align: left;
-
-      input {
-        margin: auto 1em auto 0;
-      }
-    }
-  }
-
-  .multi-choice-label {
-    flex: 0 0 50%;
-  }
-
   .book-notes-form {
     button {
       width: 100%;
-    }
-  }
-
-  .form-buttons {
-    flex-direction: column;
-
-    .submit-btn {
-      order: -1;
-      width: 100%;
-      margin-left: unset;
-      margin-bottom: 1.5em;
-      margin-top: .5em;
-    }
-  }
-
-  .aspect-section {
-    h3 {
-      margin-right: unset;
-      display: block;
     }
   }
 }

--- a/static/css/components/notes-view.less
+++ b/static/css/components/notes-view.less
@@ -55,6 +55,7 @@
     width: 100%;
     resize: none;
     padding: .25em;
+    font-size: 16px;
   }
 
   .notes-view-modal-link {
@@ -73,20 +74,15 @@
   }
 
   .delete-note-button {
-    background-color: @red;
-
-    &:hover {
-      background-color: darken(@red, 10%);
-    }
+    border-color: @red;
+    color: @red;
   }
 
-  .update-note-button {
-    background-color: @green;
+  .update-note-link-button {
     margin-left: auto;
-
-    &:hover {
-      background-color: darken(@green, 10%);
-    }
+    margin-top: 5px;
+    border-width: 2px;
+    font-size: 1.2em;
   }
 }
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates styling of buttons and textareas in notes view and notes modals.  Dead CSS was also removed.

### Technical
<!-- What should be noted about the implementation? -->
Save notes buttons are now anchor elements styled to look like buttons.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshots
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![notes_modal](https://user-images.githubusercontent.com/28732543/129116698-1ff422c7-6d97-4666-90c0-9b011d950c2f.png)
_Notes modal_

![notes_page_update](https://user-images.githubusercontent.com/28732543/129116703-ee8a1173-32c2-4749-a5fd-558cba0f5b87.png)
_Notes page_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 
