### PR TITLE
Improve notes modal size and style

### DIFF
--- a/openlibrary/plugins/openlibrary/js/modals/index.js
+++ b/openlibrary/plugins/openlibrary/js/modals/index.js
@@ -345,7 +345,8 @@ function displayModal(modalId, reloadId) {
         inline: true,
         opacity: '0.5',
         href: `#${modalId}-metadata-form`,
-        width: '60%',
+        width: '100%',
+        maxWidth: '640px',
         onClosed: function() {
             if (reloadId) {
                 $(`#${reloadId}`).trigger('contentReload');

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -3,8 +3,8 @@
 @import (reference) "./buttonBtn.less";
 
 .book-notes-form {
-  width: 75%;
   margin: 1em auto;
+  padding: 0 20px;
 
   p {
     font-size: 16px;
@@ -49,9 +49,20 @@
 }
 
 @media screen and (max-width: @width-breakpoint-tablet) {
+  .note-form-buttons {
+    flex-direction: column-reverse;
+    
+    .update-note-button {
+      margin-bottom: 1em;
+    }
+  }
   .book-notes-form {
-    button {
+    button, a {
       width: 100%;
+    }
+
+    a {
+      text-align: center;
     }
   }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Increases width of notes modal textarea.  Increases width of modal to 100% on small screens.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![fullscreen_notes_modal](https://user-images.githubusercontent.com/28732543/129259585-7380ee63-7d56-4666-bbc9-5762aa9a3bd4.png)
_Notes modal on a large screen_

![small_screen_notes_modal](https://user-images.githubusercontent.com/28732543/129259643-76cd0a78-bb4c-4aaa-af0c-3f05657b1eea.png)
_Notes modal on a small screen_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@mekarpeles 