### PR TITLE
Provide option to (re)import non-monograph MARC records if neccessary

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -271,11 +271,12 @@ class ia_importapi(importapi):
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
             # Don't add the book if the MARC record is a non-monograph item,
-            # unless it is a serial (etc) for a scanning partner.
-            try:
-                raise_non_book_marc(rec, **next_data)
-            except BookImportError as e:
-                if not (local_id and e.error_code == 'item-is-serial'):
+            # unless it is a scanning partner record, or force_import is set.
+            force_import |= local_id is not None
+            if not force_import:
+                try:
+                    raise_non_book_marc(rec, **next_data)
+                except BookImportError as e:
                     return self.error(e.error_code, e.error, **e.kwargs)
             result = add_book.load(edition)
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -261,6 +261,7 @@ class ia_importapi(importapi):
             if local_id:
                 local_id_type = web.ctx.site.get('/local_ids/' + local_id)
                 prefix = local_id_type.urn_prefix
+                force_import = True
                 id_field, id_subfield = local_id_type.id_location.split('$')
                 def get_subfield(field, id_subfield):
                     if isinstance(field, str):
@@ -271,8 +272,7 @@ class ia_importapi(importapi):
                 edition['local_id'] = ['urn:%s:%s' % (prefix, _id) for _id in _ids]
 
             # Don't add the book if the MARC record is a non-monograph item,
-            # unless it is a scanning partner record, or force_import is set.
-            force_import |= local_id is not None
+            # unless it is a scanning partner record and/or force_import is set.
             if not force_import:
                 try:
                     raise_non_book_marc(rec, **next_data)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -176,7 +176,7 @@ class ia_importapi(importapi):
 
         :param str identifier: archive.org ocaid
         :param bool require_marc: require archive.org item have MARC record?
-        :param bool force_import: force the import of this record if it otherwise would be rejected
+        :param bool force_import: force import of this record
         :rtype: dict
         :returns: the data of the imported book or raises  BookImportError
         """
@@ -285,7 +285,9 @@ class ia_importapi(importapi):
             return json.dumps(result)
 
         try:
-            return self.ia_import(identifier, require_marc=require_marc, force_import=force_import)
+            return self.ia_import(identifier,
+                                  require_marc=require_marc,
+                                  force_import=force_import)
         except BookImportError as e:
             return self.error(e.error_code, e.error, **e.kwargs)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Allows some MARC records to be re-imported from IA that are not technically marked as monographs.

This will enable 
* some past orphaned editions records to be repaired (the existing repair process is not triggering because some of these records are being rejected immediately)
* full scanning and metadata retrieval for scanning partners who have had map books, scores, multi-volume monographs, and other items rejected previously.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
