### PR TITLE
updating authors search page

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -964,7 +964,7 @@ class author_search_json(author_search):
 @public
 def random_author_search(limit=10):
     """
-    Returns a JSON string that contains a random list of authors.  Amount of authors
+    Returns a dict that contains a random list of authors.  Amount of authors
     returned is set be the given limit.
     """
     letters_and_digits = string.ascii_letters + string.digits

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -987,7 +987,7 @@ def random_author_search(limit=10):
         # The template still expects the key to be in the old format
         doc['key'] = doc['key'].split("/")[-1]
 
-    return json.dumps(search_results['response'])
+    return search_results['response']
 
 
 def rewrite_list_editions_query(q, page, offset, limit):

--- a/openlibrary/templates/authors/index.html
+++ b/openlibrary/templates/authors/index.html
@@ -27,7 +27,7 @@ $var title: $_('Authors')
             $elif 'date' in doc:
                 $ date = doc['date']
             <li class="sansserif">
-            <a href="/authors/$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
+            <a href="/authors/$doc['key']" class="larger">$name</a>&nbsp;<span class="brown small">$date</span><br />
             <span class="small grey"><b>$wc</b>
             $if 'top_subjects' in doc:
                 $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),

--- a/openlibrary/templates/authors/index.html
+++ b/openlibrary/templates/authors/index.html
@@ -29,9 +29,11 @@ $var title: $_('Authors')
             <li class="sansserif">
             <a href="/authors/$doc['key']" class="larger">$name</a>&nbsp;<span class="brown small">$date</span><br />
             <span class="small grey"><b>$work_count_str</b>
-            $if 'top_subjects' in doc:
-                $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
-            $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
+            $if work_count:
+                $if 'top_subjects' in doc:
+                    $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
+                $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))
+            </span>
             </li>
         </ul>
 </div>

--- a/openlibrary/templates/authors/index.html
+++ b/openlibrary/templates/authors/index.html
@@ -1,5 +1,6 @@
 $def with ()
 
+$ results = random_author_search()
 $var title: $_('Authors')
 
 <div id="contentHead">
@@ -15,36 +16,22 @@ $var title: $_('Authors')
 	        <input type="submit" value="$_('Search')" class="large"/>
 	    </p>
 	</form>
-
-	<h2>$_('Tips for Reconciling Author Records')</h2>
-	<h3>Merging Authors</h3>
-	<p>Open Library holds catalog records from many different libraries around the world, each of which has similar, yet different, cataloging practices. Some libraries will enter an author name like <em>Lastname, Firstname</em> whereas others will enter them <em>Firstname Lastname</em>. Formal titles (such as Sir, Queen etc.) can inhibit Open Library's ability to spot two variations of an author's name as the same author. When adding authors include as little information as possible that identify the author while keeping them distinguishable from other authors.
-	</p>
-	<p>Admins have the ability to join these duplicates together. There's <a href="https://blog.openlibrary.org/2010/08/16/duplicate-authors-wave-your-magic-wand/" rel="nofollow">more info on the Open Library blog</a> about merging authors, and you can explore <a href="/recentchanges/merge-authors" rel="nofollow">recent author merges</a> too. <a href="https://openlibrary.org/contact">Send us an email</a> if you see an author merge that needs doing.
-	</p>
-
-	<h3>Splitting Authors</h3>
-	<p>Sometimes, Open Library thinks that a certain author has written a book or two that was actually written by another author with a similar or identical name. In this case, the books in question need to be split apart. It's a bit fiddly to do this, but it's really useful.
-	</p>
-	<p>Here's how to split an author:
-	</p>
-	<ol>
-	 <li>
-	     <a href="/search/authors" rel="nofollow">Find</a> the author that needs to be split. Click the EDIT button. <br/>
-	 </li>
-	 <li>
-	     Add some more information to that author record that will help you identify it later, like a middle initial or a birth/death date. Leave a note about what you've changed and hit SAVE.<br/>
-	 </li>
-	 <li>
-	     Then, from the author's page, pick the book(s) that need to be split off.<br/>
-	 </li>
-	 <li>
-	     Now comes the tricky part. On the book page(s) you've just opened, you'll need to edit the works to point to the other author. Hit EDIT on those work pages.<br/>
-	 </li>
-	 <li>
-	     Find the Author field. Clear the name in it, and re-enter the author you'd like to connect this book to. There's a chance there'll only be one entry for the author (hence the join you're trying to split), so you may need to choose "Create a New Author Record for..." That will create a new author stub, and you can attach the books to that stub.
-	 </li>
-	</ol>
-	<p>We know this is a bit complicated, but once you've done it a few times, it's not too bad. The key is to make sure there's some distinct metadata between the two author records so you can tell them apart. Good luck!
-	</p>
+	<ul class="authorList">
+        $for doc in results['docs']:
+            $ n = doc['name']
+            $ num = doc['work_count']
+            $ wc = ungettext("1 book", "%(count)d books", num, count=num)
+            $ date = ''
+            $if 'birth_date' in doc or 'death_date' in doc:
+                $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')
+            $elif 'date' in doc:
+                $ date = doc['date']
+            <li class="sansserif">
+            <a href="/authors/$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
+            <span class="small grey"><b>$wc</b>
+            $if 'top_subjects' in doc:
+                $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
+            $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
+            </li>
+        </ul>
 </div>

--- a/openlibrary/templates/authors/index.html
+++ b/openlibrary/templates/authors/index.html
@@ -18,9 +18,9 @@ $var title: $_('Authors')
 	</form>
 	<ul class="authorList">
         $for doc in results['docs']:
-            $ n = doc['name']
-            $ num = doc['work_count']
-            $ wc = ungettext("1 book", "%(count)d books", num, count=num)
+            $ name = doc['name']
+            $ work_count = doc['work_count']
+            $ work_count_str = ungettext("1 book", "%(count)d books", work_count, count=work_count)
             $ date = ''
             $if 'birth_date' in doc or 'death_date' in doc:
                 $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')

--- a/openlibrary/templates/authors/index.html
+++ b/openlibrary/templates/authors/index.html
@@ -28,7 +28,7 @@ $var title: $_('Authors')
                 $ date = doc['date']
             <li class="sansserif">
             <a href="/authors/$doc['key']" class="larger">$name</a>&nbsp;<span class="brown small">$date</span><br />
-            <span class="small grey"><b>$wc</b>
+            <span class="small grey"><b>$work_count_str</b>
             $if 'top_subjects' in doc:
                 $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
             $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3296

What does this PR achieve?  It updates the authors search page from containing instructions that are not required, to displaying a list of 10 random authors.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<img width="1440" alt="Screenshot 2021-08-19 at 1 42 18 AM" src="https://user-images.githubusercontent.com/69111235/129965726-237d3f49-92b8-4636-9c6b-fcf5754f0f9f.png">
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
