### PR TITLE
Add helper eg /data/ol_dump_editions_latest.txt.gz links for ratings/readinglog

### DIFF
--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -28,8 +28,19 @@ def download_url(item, filename):
     return "%s/download/%s/%s" % (IA_BASE_URL, item, filename)
 
 
+DUMP_PREFIXES = (
+    '',
+    '_authors',
+    '_editions',
+    '_works',
+    '_deworks',
+    '_ratings',
+    '_reading-log',
+)
+
+
 class ol_dump_latest(delegate.page):
-    path = "/data/ol_dump(|_authors|_editions|_works|_deworks)_latest.txt.gz"
+    path = f"/data/ol_dump({'|'.join(DUMP_PREFIXES)})_latest.txt.gz"
 
     def GET(self, prefix):
         items = [item for item in get_ol_dumps() if item.startswith("ol_dump")]
@@ -54,7 +65,7 @@ class ol_cdump_latest(delegate.page):
 
 
 class ol_dumps(delegate.page):
-    path = "/data/ol_dump(|_authors|_editions|_works)_(\d\d\d\d-\d\d-\d\d).txt.gz"
+    path = rf"/data/ol_dump({'|'.join(DUMP_PREFIXES)})_(\d\d\d\d-\d\d-\d\d).txt.gz"
 
     def GET(self, prefix, date):
         item = "ol_dump_" + date


### PR DESCRIPTION
Work towards #3989 .

### Technical
<!-- What should be noted about the implementation? -->

### Testing
```
$ curl https://testing.openlibrary.org/data/ol_dump_ratings_latest.txt.gz -s -L -I -o /dev/null -w '%{url_effective}'
https://ia601503.us.archive.org/26/items/ol_dump_2021-08-11/ol_dump_ratings_2021-08-11.txt.gz

$ curl https://testing.openlibrary.org/data/ol_dump_reading-log_latest.txt.gz -s -L -I -o /dev/null -w '%{url_effective}'
https://ia801503.us.archive.org/26/items/ol_dump_2021-08-11/ol_dump_reading-log_2021-08-11.txt.gz

$ curl https://testing.openlibrary.org/data/ol_dump_editions_latest.txt.gz -s -L -I -o /dev/null -w '%{url_effective}'
https://ia801503.us.archive.org/26/items/ol_dump_2021-08-11/ol_dump_editions_2021-08-11.txt.gz

$ curl https://testing.openlibrary.org/data/ol_dump_editions_2021-08-11.txt.gz -s -L -I -o /dev/null -w '%{url_effective}'
https://ia801503.us.archive.org/26/items/ol_dump_2021-08-11/ol_dump_editions_2021-08-11.txt.gz
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
