### PR TITLE
add olid to author page

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -193,6 +193,11 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     </ul>
                 </div>
 
+        <div class="section">
+            <h3>Open Library ID</h3>
+            <p>$olid</p>
+        </div>
+
     </div>
 
     $:render_template("lib/history", page)

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -163,7 +163,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             </div>
 
         <div class="section">
-            <h3>$:_('ID Numbers')</h3>
+            <h3>$_('ID Numbers')</h3>
             <ul class="booklinks sansserif">
                 <li>$_('OLID'): $olid</li>
                 $if page.remote_ids:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -165,7 +165,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
         <div class="section">
             <h3>$:_('ID Numbers')</h3>
             <ul class="booklinks sansserif">
-                <li>$olid</li>
+                <li>$_('OLID'): $olid</li>
                 $if page.remote_ids:
                     $ configured_ids = get_author_config()['identifiers']
                     $for id in configured_ids:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -163,16 +163,23 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             </div>
 
         <div class="section">
-            <h3>$:_('Links <span class="gray small sansserif">(outside Open Library)')</span></h3>
-
-            $if page.links or page.remote_ids or (page.wikipedia and page.wikipedia.startswith("http")):
-                <ul class="booklinks sansserif">
+            <h3>$:_('ID Numbers')</h3>
+            <ul class="booklinks sansserif">
+                <li>$olid</li>
                 $if page.remote_ids:
                     $ configured_ids = get_author_config()['identifiers']
                     $for id in configured_ids:
                         $if id.name in page.remote_ids:
                             $ href = id.url.replace('@@@', page.remote_ids[id.name])
                             <li>$id.label: <a itemprop="sameAs" href="$href">$page.remote_ids[id.name]</a></li>
+            </ul>
+        </div>
+
+        <div class="section">
+            <h3>$:_('Links <span class="gray small sansserif">(outside Open Library)')</span></h3>
+
+            $if page.links or (page.wikipedia and page.wikipedia.startswith("http")):
+                <ul class="booklinks sansserif">
                 $if page.wikipedia and page.wikipedia.startswith("http"):
                     <li><a itemprop="sameAs" href="$page.wikipedia">Wikipedia</a></li>
                 $for link in page.links:
@@ -192,11 +199,6 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                             <li itemprop="alternateName">$alternate_name</li>
                     </ul>
                 </div>
-
-        <div class="section">
-            <h3>Open Library ID</h3>
-            <p>$olid</p>
-        </div>
 
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5435

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Tiny feature request to add olid to author pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Hop on an author page, like http://0.0.0.0:8080/authors/OL18319A/Mark_Twain and check out olid at the bottom of the sidebar.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/3520671/129407625-8302a19b-e919-4e44-8a3e-27cdeaac68f8.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


Let me know if we'd rather have the olid in a different part of the sidebar.
