### PR TITLE
Remove book tags feature flags

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -12,8 +12,7 @@ $def with (edition_count=1, show_observations=False)
   <li>
     <a href="#edition-details">$_("This Edition")</a>
   </li>
-  $if show_observations and ctx.user and ctx.user.is_beta_tester():
-      <li>
-        <a href="#reader-observations">$_("Reviews")</a>
-      </li>
+  <li>
+    <a href="#reader-observations">$_("Reviews")</a>
+  </li>
 </ul>

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -838,9 +838,9 @@ class public_my_books(delegate.page):
                         'type': '/type/edition',
                         'isbn_%s' % len(s['isbn']): s['isbn']
                     })[0]) for s in sponsorships)
-            elif key == 'notes' and is_logged_in_user and user.is_beta_tester():
+            elif key == 'notes' and is_logged_in_user:
                 books = PatronBooknotes(user).get_notes(page=int(i.page))
-            elif key == 'observations' and is_logged_in_user and user.is_beta_tester():
+            elif key == 'observations' and is_logged_in_user:
                 books = PatronBooknotes(user).get_observations(page=int(i.page))
             else:
                 books = readlog.get_works(key, page=i.page,

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -123,12 +123,11 @@ $if og_title:
                 <li><a class="list-link" href="$(lst.key)">$lst['name'] ($(len(lst.seeds)))</a></li>
             </div>
           </ul>
-        $if user.is_beta_tester():
-          <ul class="booknotes-list">
-            <li class="subsection">$_('Notes & Observations')</li>
-            <li><a $('class=selected' if key=='notes' else '') href="$urlbase/notes">$_('My notes (%(count)d)', count=booknotes_counts['notes'])</a></li>
-            <li><a $('class=selected' if key=='observations' else '') href="$urlbase/observations">$_('My observations (%(count)d)', count=booknotes_counts['observations'])</a></li>
-          </ul>
+        <ul class="booknotes-list">
+          <li class="subsection">$_('Notes & Observations')</li>
+          <li><a $('class=selected' if key=='notes' else '') href="$urlbase/notes">$_('My notes (%(count)d)', count=booknotes_counts['notes'])</a></li>
+          <li><a $('class=selected' if key=='observations' else '') href="$urlbase/observations">$_('My observations (%(count)d)', count=booknotes_counts['observations'])</a></li>
+        </ul>
       </div>
       $if key == 'notes':
         $:render_template('account/notes', items, user, booknotes_counts['notes'], page=current_page)

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -117,9 +117,8 @@ $def with (page)
         'image-class': 'header-dropdown__icon',
         'links': loginLinks
       }
-    $# Add book notes link between 'My Reading Stats' and 'Settings' for beta testers:
-    $if ctx.user.is_beta_tester():
-      $accountProps['links'].insert(5, { "href": "/account/books/notes", "text": _("My Book Notes") })
+
+    $accountProps['links'].insert(5, { "href": "/account/books/notes", "text": _("My Book Notes") })
     $:render_template("lib/header_dropdown", accountProps )
 
   $:render_template("lib/header_dropdown", hamburgerProps )

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -290,13 +290,11 @@ $if include_widget:
     $if include_rating:
       $:macros.StarRatings(work, edition)
 
-    $# BookNotes feature:
-    $if ctx.user and ctx.user.is_beta_tester():
-      $if work.has_book_note(username, edition.key.split('/')[-1]):
-        $ link_text = _("Update my book note")
-      $else:
-        $ link_text = _("Add a book note")
-      $:macros.NotesModal(work, edition, link_text, 'cta', 'cta-section patron-metadata')
+    $if work.has_book_note(username, edition.key.split('/')[-1]):
+      $ link_text = _("Update my book note")
+    $else:
+      $ link_text = _("Add a book note")
+    $:macros.NotesModal(work, edition, link_text, 'cta', 'cta-section patron-metadata')
 
 
 $if include_showcase:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -452,11 +452,9 @@ $if is_privileged_user:
           </div>
       </div>
 
-      $# BookNotes feature:
-      $if ctx.user and ctx.user.is_beta_tester():
-        $if show_observations:
-          $ reader_observations = get_observation_metrics(work['key'])
-          $:render_template("observations/review_component", work, reader_observations, page.key)
+      $if show_observations:
+        $ reader_observations = get_observation_metrics(work['key'])
+        $:render_template("observations/review_component", work, reader_observations, page.key)
     </div>
   </div>
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Enable book tags features and views for all.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in (preferably _not_ as a beta tester):
1. Navigate to a book page.
2. Attempt to open a book notes modal and leave a note.
3. Ensure that the "Review" tab is present above the edition table.  Click the tab.
4. Ensure that the review component is present.
5. Open the book tags modal and select some tags.
6. Click "My Book Notes" link in the account drop-down menu.
7. Ensure that the notes view has loaded and that your note is present.
8. Click the "My Observations" link in the sidebar. Ensure that the view renders without error and that your review is present.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
