### PR TITLE
Replace heavy plus symbol with bullet in book tags component

### DIFF
--- a/openlibrary/components/ObservationForm/components/CategorySelector.vue
+++ b/openlibrary/components/ObservationForm/components/CategorySelector.vue
@@ -104,18 +104,17 @@ export default {
         /**
          * Returns an HTML code denoting what symbol to display in a book tag type chip.
          *
-         * Will return a heavy plus symbol if no book tags of a chip's type have been selected,
+         * Will return a bullet symbol if no book tags of a chip's type have been selected,
          * and a heavy checkmark otherwise.
          *
          * @returns {String} An HTML code representing selections of a type.
          */
         displaySymbol: function(type) {
-            // &#10133; - Heavy plus
-            // &#10004; - Heavy checkmark
             if (this.allSelectedValues[type] && this.allSelectedValues[type].length) {
+                // &#10004; - Heavy checkmark
                 return '&#10004;';
             }
-            return '&#10133;';
+            return '&bull;';
         }
     }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces heavy plus symbol with bullet symbol in book tags component.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-08-17 18-11-13](https://user-images.githubusercontent.com/28732543/129807672-401985da-1902-46f4-9319-37f1e70b996b.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 