### PR TITLE
Display random category on component load

### DIFF
--- a/openlibrary/components/ObservationForm.vue
+++ b/openlibrary/components/ObservationForm.vue
@@ -10,6 +10,7 @@
       ref="categories"
       :observations-array="observationsArray"
       :all-selected-values="allSelectedValues"
+      :initial-selected-id="getSelectedId"
       @update-selected="updateSelected"
       />
     <ValueCard
@@ -120,11 +121,32 @@ export default {
          */
         updateSelected: function(observation) {
             this.selectedObservation = observation
+        },
+        /**
+         * Randomly sets a selected observation.
+         */
+        selectRandomObservation: function() {
+            const randomNumber = Math.floor(Math.random() * 100000);
+            this.selectedObservation = this.observationsArray[randomNumber % this.observationsArray.length];
+        }
+    },
+    computed: {
+        /**
+         * Return the selected observation's ID, or null if no observation is selected.
+         *
+         * @returns {Number|null} The ID of the selected observation, if one exists.
+         */
+        getSelectedId: function() {
+            if (this.selectedObservation) {
+                return this.selectedObservation.id;
+            }
+            return null
         }
     },
     created: function() {
         this.observationsArray = decodeAndParseJSON(this.schema)['observations'];
         this.allSelectedValues = decodeAndParseJSON(this.observations);
+        this.selectRandomObservation();
     },
     mounted: function() {
         this.observer = new ResizeObserver(() => {

--- a/openlibrary/components/ObservationForm/components/CategorySelector.vue
+++ b/openlibrary/components/ObservationForm/components/CategorySelector.vue
@@ -58,6 +58,14 @@ export default {
         allSelectedValues: {
             type: Object,
             required: true
+        },
+        /**
+         * The ID of the initially selected observation.
+         */
+        initialSelectedId: {
+            type: Number,
+            required: false,
+            default: 0
         }
     },
     data: function() {
@@ -67,7 +75,7 @@ export default {
              *
              * @type {number | null}
              */
-            selectedId: null,
+            selectedId: this.initialSelectedId,
         }
     },
     methods: {
@@ -87,7 +95,7 @@ export default {
                     }
                 }
             } else {
-                this.selected = null;
+                this.selectedId = null;
 
                 // Set ObservationForm's selected observation to null
                 this.$emit('update-selected', null)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When book tags component is open, a random category is now initially selected.

### Technical
<!-- What should be noted about the implementation? -->
Page must be refreshed in order for new random category to be selected.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![random_category](https://user-images.githubusercontent.com/28732543/129811035-5ad72a0d-1b21-4edd-8077-8b12681b2168.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 
