### PR TITLE
Display percentages of total responses in review section

### DIFF
--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -586,6 +586,7 @@ def get_observation_metrics(work_olid):
                 'description': 'What is the pace of this book?',
                 'multi_choice': False,
                 'total_respondents_for_type': 10,
+                'total_responses': 10,
                 'values': [
                     {
                         'value': 'fast',
@@ -630,8 +631,12 @@ def get_observation_metrics(work_olid):
             'values': []
         }
 
+        total_responses = 0
+
         for i in observation_totals:
             if i['type_id'] != current_type_id:
+                current_observation['total_responses'] = total_responses
+                total_responses = 0
                 metrics['observations'].append(current_observation)
                 current_type_id = i['type_id']
                 observation_item = next((o for o in OBSERVATIONS['observations'] if current_type_id == o['id']))
@@ -648,7 +653,9 @@ def get_observation_metrics(work_olid):
                         'count': i['total'] 
                     } 
                 )
+            total_responses += i['total']
     
+        current_observation['total_responses'] = total_responses
         metrics['observations'].append(current_observation)
     return metrics
         

--- a/openlibrary/templates/observations/review_component.html
+++ b/openlibrary/templates/observations/review_component.html
@@ -13,10 +13,11 @@ $else:
     <div class="reviews">
     $for o in reader_observations['observations']:
       <span class="review__category">
-      $ total = o['total_respondents_for_type']
-        <span class="reviews__label" title="$o['description']">$o['label'] <span class="reviews__count">$total</span></span>
+      $ total_respondents = o['total_respondents_for_type']
+        <span class="reviews__label" title="$o['description']">$o['label'] <span class="reviews__count">$total_respondents</span></span>
+        $ total_responses = o['total_responses']
         $for v in o['values']:
-          $ percentage = (v['count'] / total) * 100
+          $ percentage = (v['count'] / total_responses) * 100
           <span class="reviews__pill">
             <span class="reviews__value">
               $v['value']


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Pills in review section now show percentages based on the total responses, instead of total respondents.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-08-18 15-40-46](https://user-images.githubusercontent.com/28732543/129961869-1a1a7d91-e066-4c5c-9134-b4c7279f7267.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 
