### PR TITLE
Remove badge from availability.js button

### DIFF
--- a/openlibrary/plugins/openlibrary/js/availability.js
+++ b/openlibrary/plugins/openlibrary/js/availability.js
@@ -243,9 +243,7 @@ function initAvailability() {
                                                   'class="join-waitlist waitinglist-form">' +
                                                   '<input type="hidden" name="action" value="join-waitinglist">' +
                                                   '<button type="submit" class="cta-btn cta-btn--unavailable" data-ol-link-track="CTAClick|JoinWaitlist">' +
-                                                  `Join Waitlist${
-                                                      work.num_waitlist !== '0' ? ` <span class="cta-btn__badge">${work.num_waitlist}</span>` : ''
-                                                  }</button></form>${
+                                                  `Join Waitlist</button></form>${
                                                       work.num_waitlist === '0' ? '<div class="waitlist-msg">You will be first in line!</div>' : ''}`);
                                 }
                             }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5537

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes badge count from join waiting list button.

Since `availability.js` will likely be replaced in the future (see #5419), I chose to remove badge rather than debug and fix null wait list count.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
On testing:
1. Navigate to a list that contains a book that has a waiting list.
2. Ensure that the button does not have a badge.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-08-20 17-27-33](https://user-images.githubusercontent.com/28732543/130295101-1a63be67-775d-415c-b4da-200c8ce54b85.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 
