### PR TITLE
Remove unneeded catalog-level fuzzy flags from template files

### DIFF
--- a/openlibrary/i18n/cs/messages.po
+++ b/openlibrary/i18n/cs/messages.po
@@ -4,7 +4,6 @@
 # project.
 # Clonewayx <EMAIL@ADDRESS>, 2017.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"

--- a/openlibrary/i18n/ja/messages.po
+++ b/openlibrary/i18n/ja/messages.po
@@ -4,7 +4,6 @@
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4,7 +4,6 @@
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -4,7 +4,6 @@
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -17,6 +17,7 @@ def help():
     print("  compile  - compile the message files (.po) to .mo")
     print("  extract  - extract i18n messages from templates and macros")
     print("  update   - update the existing translations by adding newly added string to it.")
+    print("  add      - create new .po file for the given locale.")
     print("  validate - check message file for errors")
     print("  help     - display this help message")
     


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes useless `fuzzy` flag found in first set of comments in the `.pot` file.  Also removes this flag from three `.po` files.

Adds help text for missing `i18n-messages` command (`add`).

### Technical
<!-- What should be noted about the implementation? -->
`fuzzy` flags are comments placed in `.po` files that denote changes in messages that may require a human to double-check.  These flags should not appear in a `.pot` file, and are being copied over to all `.po` files that are generated by `i18n-messages add`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
