### PR TITLE
adding UNIQUE data str col to import_item table

### DIFF
--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -93,7 +93,6 @@ def get_schema():
         ol_key text,
         comments text,
         UNIQUE (batch_id, ia_id)
-        
     );
     CREATE INDEX import_item_batch_id ON import_item(batch_id);
     CREATE INDEX import_item_import_time ON import_item(import_time);

--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -89,14 +89,17 @@ def get_schema():
         status text default 'pending',
         error text,
         ia_id text,
+        data text UNIQUE,
         ol_key text,
         comments text,
         UNIQUE (batch_id, ia_id)
+        
     );
     CREATE INDEX import_item_batch_id ON import_item(batch_id);
     CREATE INDEX import_item_import_time ON import_item(import_time);
     CREATE INDEX import_item_status ON import_item(status);
     CREATE INDEX import_item_ia_id ON import_item(ia_id);
+    CREATE INDEX import_item_data ON import_item(data);
     """
 
     # monkey patch schema.sql to include the custom functions


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Adds a new indexed UNIQUE str db column called `data` to our `import_item` table schema so that our (currently IA-specific) import batch system can queue up and import [work with] arbitrary OL JSON book records

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
