### PR TITLE
Stop MARC counting as mIRC script on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,6 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Linguist
+*.mrc	-linguist-detectable


### PR DESCRIPTION
This PR should prevent MARC data (*.mrc) being counted as mIRC script by Github's [linguist](https://github.com/github/linguist) stats.

Documentation: https://github.com/github/linguist/blob/master/docs/overrides.md

Does not affect Open Library site behaviour.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![linguist](https://user-images.githubusercontent.com/905545/131424244-34771bef-c73e-4b37-b9ce-e840216fc064.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
