### PR TITLE
Author names should ignore diacritics in solr

### DIFF
--- a/conf/solr/conf/managed-schema
+++ b/conf/solr/conf/managed-schema
@@ -175,8 +175,8 @@
     <field name="publisher_facet" type="string" stored="false" multiValued="true"/>
     <field name="first_sentence" type="text_en_splitting" multiValued="true"/>
     <field name="author_key" type="string" multiValued="true"/>
-    <field name="author_name" type="text_general" multiValued="true"/>
-    <field name="author_alternative_name" type="text_general" multiValued="true"/>
+    <field name="author_name" type="text_international" multiValued="true"/>
+    <field name="author_alternative_name" type="text_international" multiValued="true"/>
     <field name="author_facet" type="string" stored="false" multiValued="true"/>
     <field name="subject" type="text_en_splitting" multiValued="true"/>
     <field name="subject_facet" type="string" stored="false" multiValued="true"/>

--- a/conf/solr/conf/managed-schema
+++ b/conf/solr/conf/managed-schema
@@ -197,9 +197,9 @@
 
 
    <!-- fields used by documents of type author -->
-   <field name="name" type="text_general" indexed="true" stored="true" multiValued="false"/>
+   <field name="name" type="text_international" indexed="true" stored="true" multiValued="false"/>
    <field name="name_str" type="string" indexed="true" stored="false"/>
-   <field name="alternate_names" type="text_general" indexed="true" stored="true" multiValued="true"/>
+   <field name="alternate_names" type="text_international" indexed="true" stored="true" multiValued="true"/>
    <field name="birth_date" type="string" indexed="true" stored="true"/>
    <field name="death_date" type="string" indexed="true" stored="true"/>
    <field name="date" type="string" indexed="true" stored="true"/>
@@ -432,6 +432,31 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    
+    <!-- A text field with better cross-language defaults: 
+               it tokenizes with StandardTokenizer,
+	       removes stop words from case-insensitive "stopwords.txt"
+	       (empty by default), and down cases.  At query time only, it
+	       also applies synonyms.
+	  -->
+    <fieldType name="text_international" class="solr.TextField" positionIncrementGap="100" multiValued="true">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <!-- in this example, we will only use synonyms at query time
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+        -->
+	      <filter class="solr.ICUFoldingFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+	      <filter class="solr.ICUFoldingFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/conf/solr/conf/solrconfig.xml
+++ b/conf/solr/conf/solrconfig.xml
@@ -85,6 +85,9 @@
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-velocity-\d.*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" />
 
+  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs/" regex="lucene-analyzers-icu-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib/" regex="icu4j-\d.*\.jar" />
+
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged
        if it can't be loaded.

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1,3 +1,5 @@
+from typing import List, Union, Tuple, Any
+
 import web
 import json
 import babel
@@ -458,12 +460,10 @@ def url_quote(text):
 
 
 @public
-def urlencode(dict_or_list_of_tuples):
+def urlencode(dict_or_list_of_tuples: Union[dict, List[Tuple[str, Any]]]) -> str:
     """
     You probably want to use this, if you're looking to urlencode parameters. This will
     encode things to utf8 that would otherwise cause urlencode to error.
-    :param dict or list dict_or_list_of_tuples:
-    :rtype: basestring
     """
     from six.moves.urllib.parse import urlencode as og_urlencode
     tuples = dict_or_list_of_tuples

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -953,6 +953,7 @@ class author_search(delegate.page):
     def get_results(self, q, offset=0, limit=100):
         valid_fields = ['key', 'name', 'alternate_names', 'birth_date', 'death_date', 'date', 'work_count']
         q = escape_colon(escape_bracket(q), valid_fields)
+        q_has_fields = ':' in q.replace(r'\:', '')
 
         d = run_solr_search(solr_select_url, {
             'fq': 'type:author',
@@ -964,6 +965,10 @@ class author_search(delegate.page):
             'qt': 'standard',
             'sort': 'work_count desc',
             'wt': 'json',
+            **({} if q_has_fields else {
+                'defType': 'dismax',
+                'qf': 'name alternate_names'
+            })
         })
 
         docs = d.get('response', {}).get('docs', [])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #178.

Closes #714.

Fix. **NOTE** this won't make a difference in production until the next full solr reindex (#5502 ), so all testing must be done in local env for now.

### Technical
- includes a refactor of worksearch/code.py to allow for params to be used in solr request more easily.
- Change to /search/authors to search `name alternate_names` instead of `text` when no other fields are specified. Needed since only those fields have ICUFolding.

### Testing

First reset the local solr env:
1. `docker rm -f openlibrary_solr_1`
2. `docker rm openlibrary_solr-data`

Then start it up and do a local reindex:

1. `docker-compose up -d`
2. `docker-compose exec web bash`
3. (inside container) `make reindex-solr`


Actual tests:

- ✅ http://localhost:8080/search?q=ghatti&mode=everything returns results
- ✅ http://localhost:8080/search?mode=everything&q=Gha%E1%B9%AD%E1%B9%ADi
- ✅ autocomplete returns results when searching for "ghatti"
- ✅ http://localhost:8080/search?mode=everything&q=Gha%E1%B9%AD%E1%B9%ADi has results
- ✅ http://localhost:8080/search?mode=everything&q=ghatti has same results

- ✅ Non-ascii-able characters are not converted to ascii
    - There are some funny looking transforms, but going to trust Solr knows what it's doing. <details>
        ![circle911](https://user-images.githubusercontent.com/6251786/131537145-d1894515-f9c0-414a-b881-79b73e8b141e.png)
</details>

### Screenshot
![diacritic author names](https://user-images.githubusercontent.com/6251786/131537625-71cec652-a53b-4212-b96f-a39f3d781da4.gif)


### Stakeholders
@tfmorris 
