### PR TITLE
Add i18n validation tests to the makefile

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -32,7 +32,9 @@ jobs:
           pip list --outdated
       - run: make git
       - name: Run make i18n
-        run: make i18n
+        run: /
+          make i18n
+          make test-i18n
       - name: Run tests
         run: |
           git fetch --no-tags --prune --depth=1 origin master

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -32,7 +32,7 @@ jobs:
           pip list --outdated
       - run: make git
       - name: Run make i18n
-        run: /
+        run: |
           make i18n
           make test-i18n
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-py:
 
 test-i18n:
   # Valid locale codes should be added as arguments to validate
-	$(PYTHON) ./scripts/i18n-messages validate
+	$(PYTHON) ./scripts/i18n-messages validate de es fr ja
 
 test:
 	make test-py && npm run test && make test-i18n

--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,4 @@ test-i18n:
 	$(PYTHON) ./scripts/i18n-messages validate_production
 
 test:
-	make test-py && npm run test
+	make test-py && npm run test && make test-i18n

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ test-py:
 	pytest . --ignore=tests/integration --ignore=scripts/2011 --ignore=infogami --ignore=vendor --ignore=node_modules
 
 test-i18n:
-	$(PYTHON) ./scripts/i18n-messages validate_production
+  # Valid locale codes should be added as arguments to validate
+	$(PYTHON) ./scripts/i18n-messages validate
 
 test:
 	make test-py && npm run test && make test-i18n

--- a/Makefile
+++ b/Makefile
@@ -76,5 +76,8 @@ endif
 test-py:
 	pytest . --ignore=tests/integration --ignore=scripts/2011 --ignore=infogami --ignore=vendor --ignore=node_modules
 
+test-i18n:
+	$(PYTHON) ./scripts/i18n-messages validate_production
+
 test:
 	make test-py && npm run test

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -56,38 +56,8 @@ def _validate_catalog(catalog, locale):
 
 
 def validate_translations(args):
-    """Validates the catalog for the given locale code.
-
-    Returns:
-      0 if the catalog is valid
-      -1 if an unknown locale is passed as an argument
-      -2 if no locale was passed as an argument
-      A positive number if there were validation errors
-    """
-    if args:
-        locale = args[0]
-        po_path = os.path.join(root, locale, 'messages.po')
-
-        if os.path.exists(po_path):
-            catalog = read_po(open(po_path, 'rb'))
-            num_errors = _validate_catalog(catalog, locale)
-
-            if num_errors == 0:
-                print(f'Translations for locale "{locale}" are valid!')
-            return num_errors
-        else:
-            print(f'Portable object file for locale "{locale}" does not exist.')
-            return -1
-    else:
-        print('Must include locale code when executing validate.')
-        return -2
-
-
-def validate_vetted_translations():
-    """Validates all locales found in `/openlibrary/i18n/valid.txt`.
-
-    `valid.txt` should contain all valid locale codes, one per line.
-
+    """Validates all locales passed in as arguments.
+    
     Returns a dictionary of locale-exit code key-value pairs.  Non-
     zero exit codes indicate that a locale has failed validation.
     If any locales have a non-zero value, the validation can be
@@ -95,16 +65,24 @@ def validate_vetted_translations():
     """
     results = {}
 
-    try:
-        with open(os.path.join(root, 'valid.txt')) as f:
-            for line in f:
-                locale = line.rstrip()
-                exit_code = validate_translations([locale])
-                results[locale] = exit_code
-    except FileNotFoundError:
-        print('Valid locales file not found...')
-        return results
+    if args:
+        for arg in args:
+            locale = arg
+            po_path = os.path.join(root, locale, 'messages.po')
 
+            if os.path.exists(po_path):
+                catalog = read_po(open(po_path, 'rb'))
+                num_errors = _validate_catalog(catalog, locale)
+
+                if num_errors == 0:
+                    print(f'Translations for locale "{locale}" are valid!')
+                results[arg] = num_errors
+            else:
+                results[arg] = -1
+                print(f'Portable object file for locale "{locale}" does not exist.')
+    else:
+        print('Must include locale code when executing validate.')
+    
     return results
 
 

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -90,7 +90,7 @@ def validate_vetted_translations():
 
     Returns a dictionary of locale-exit code key-value pairs.  Non-
     zero exit codes indicate that a locale has failed validation.
-    If any locales have a non-zero value, the validation can be 
+    If any locales have a non-zero value, the validation can be
     considered a failure.
     """
     results = {}

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -83,6 +83,31 @@ def validate_translations(args):
         return -2
 
 
+def validate_vetted_translations():
+    """Validates all locales found in `/openlibrary/i18n/valid.txt`.
+
+    `valid.txt` should contain all valid locale codes, one per line.
+
+    Returns a dictionary of locale-exit code key-value pairs.  Non-
+    zero exit codes indicate that a locale has failed validation.
+    If any locales have a non-zero value, the validation can be 
+    considered a failure.
+    """
+    results = {}
+
+    try:
+        with open(os.path.join(root, 'valid.txt')) as f:
+            for line in f:
+                locale = line.rstrip()
+                exit_code = validate_translations([locale])
+                results[locale] = exit_code
+    except FileNotFoundError:
+        print('Valid locales file not found...')
+        return results
+
+    return results
+
+
 def get_locales():
     return [
         d

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -55,34 +55,30 @@ def _validate_catalog(catalog, locale):
     return len(validation_errors)
 
 
-def validate_translations(args):
+def validate_translations(args: List[str]):
     """Validates all locales passed in as arguments.
-    
-    Returns a dictionary of locale-exit code key-value pairs.  Non-
-    zero exit codes indicate that a locale has failed validation.
-    If any locales have a non-zero value, the validation can be
-    considered a failure.
+
+    If no arguments are passed, all locales will be validated.
+
+    Returns a dictionary of locale-validation error count
+    key-value pairs.
     """
+    locales = args or get_locales()
     results = {}
 
-    if args:
-        for arg in args:
-            locale = arg
-            po_path = os.path.join(root, locale, 'messages.po')
+    for locale in locales:
+        po_path = os.path.join(root, locale, 'messages.po')
 
-            if os.path.exists(po_path):
-                catalog = read_po(open(po_path, 'rb'))
-                num_errors = _validate_catalog(catalog, locale)
+        if os.path.exists(po_path):
+            catalog = read_po(open(po_path, 'rb'))
+            num_errors = _validate_catalog(catalog, locale)
 
-                if num_errors == 0:
-                    print(f'Translations for locale "{locale}" are valid!')
-                results[arg] = num_errors
-            else:
-                results[arg] = -1
-                print(f'Portable object file for locale "{locale}" does not exist.')
-    else:
-        print('Must include locale code when executing validate.')
-    
+            if num_errors == 0:
+                print(f'Translations for locale "{locale}" are valid!')
+            results[locale] = num_errors
+        else:
+            print(f'Portable object file for locale "{locale}" does not exist.')
+
     return results
 
 

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -40,18 +40,14 @@ def main(cmd, args):
         results = i18n.validate_translations(args)
 
         num_errors = 0
-        for k, v in results.items():
-            if v < 0: # Locale files did not exist
-                print(f'Unknown locale: {k}')
-                sys.exit(1)
-            else:
-                num_errors = num_errors + v
+        for error_count in results.values():
+            num_errors = num_errors + error_count
 
         if num_errors == 0:
             print("Validation passed!")
         else:
             print(f'Validation failed.\n{num_errors} errors found...')
-            sys.exit(2)
+            sys.exit(1)
 
         sys.exit(0)
     elif cmd == 'help':

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -37,14 +37,12 @@ def main(cmd, args):
     elif cmd == 'add':
         i18n.generate_po(args)
     elif cmd == 'validate':
-        i18n.validate_translations(args)
-    elif cmd == 'validate_production':
-        results = i18n.validate_vetted_translations()
+        results = i18n.validate_translations(args)
 
         num_errors = 0
         for k, v in results.items():
-            if v < 0: # Locale file did not exist
-                print(f'Unknown locale file: {k}')
+            if v < 0: # Locale files did not exist
+                print(f'Unknown locale: {k}')
                 sys.exit(1)
             else:
                 num_errors = num_errors + v

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -41,19 +41,21 @@ def main(cmd, args):
     elif cmd == 'validate_production':
         results = i18n.validate_vetted_translations()
 
-        exit_code = 0
+        num_errors = 0
         for k, v in results.items():
             if v < 0: # Locale file did not exist
                 print(f'Unknown locale file: {k}')
-                sys.exit(-1)
+                sys.exit(1)
             else:
-                exit_code = exit_code + v
+                num_errors = num_errors + v
 
-        if exit_code == 0:
+        if num_errors == 0:
             print("Validation passed!")
         else:
-            print("Validation failed...")
-        sys.exit(exit_code)
+            print(f'Validation failed.\n{num_errors} errors found...')
+            sys.exit(2)
+
+        sys.exit(0)
     elif cmd == 'help':
         help()
     else:

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -38,6 +38,22 @@ def main(cmd, args):
         i18n.generate_po(args)
     elif cmd == 'validate':
         i18n.validate_translations(args)
+    elif cmd == 'validate_production':
+        results = i18n.validate_vetted_translations()
+
+        exit_code = 0
+        for k, v in results.items():
+            if v < 0: # Locale file did not exist
+                print(f'Unknown locale file: {k}')
+                sys.exit(-1)
+            else:
+                exit_code = exit_code + v
+
+        if exit_code == 0:
+            print("Validation passed!")
+        else:
+            print("Validation failed...")
+        sys.exit(exit_code)
     elif cmd == 'help':
         help()
     else:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `test-i18n` rule to the makefile.  `test-i18n` does the following:
1. Reads in a list of valid locales from `/openlibrary/i18n/valid.txt`.
2. Runs `validate_translations()` for each locale, storing number of errors found.
3. Prints results and exits.

### Technical
<!-- What should be noted about the implementation? -->
`valid.txt` is expected to contain one locale code per line (no commas or other special characters).  If `valid.txt` contains no locales, validation will pass (All zero locales listed passed validation).  Similarly, if `valid.txt` does not exist, validation is considered successful.

Exit Code Meanings:
0: All locales have passed validation.
1: Some locale files were not found.
2: At least one locale contains one or more invalid translations.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Add some valid locales to `/openlibrary/i18n/valid.txt`
- 'es', 'fr', and 'de' are valid on this branch (and probably some others)
2. Run `make test-i18n` and confirm that validation is passing.
3. Add an invalid locale to `valid.txt` (I've been using 'cs').
4. Confirm that validations fail after running `make test-i18n`.
5. Confirm that validation fails for an unknown locale code.
6. Confirm that `make test` now executes i18n validation.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini
