### PR TITLE
Allow bot changes to be indexed

### DIFF
--- a/docker/ol-solr-updater-start.sh
+++ b/docker/ol-solr-updater-start.sh
@@ -4,6 +4,5 @@ python --version
 python scripts/new-solr-updater.py $OL_CONFIG \
     --state-file /solr-updater-data/$STATE_FILE \
     --ol-url "$OL_URL" \
-    --exclude-edits-containing 'Bot' \
     --socket-timeout 1800 \
     $EXTRA_OPTS


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5700

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Currently bot edits are being excluded from the regular ongoing Solr index updates. This PR removes the deliberate bot exclusion.

Bots are the main source of new imports into Open Library by a long way. Being excluded from index means that any newly added works or editions are not discoverable, and every new author added is created with an empty 0 works page 

e.g. https://openlibrary.org/authors/OL9405192A/Edward_L._Parker (which my bot recently added from an achive.org record)

It should list the work https://openlibrary.org/works/OL24955945W , instead the author page looks like a junk, unlinked record. This appears to be the default behaviour of newly imported authors, and won't be resolved without manual reindexing.  I though there have been issues raised about 0 work authors in the past, but I can't located one right now. 

This is just one example of many, and this appears to be the current standard behaviour with the exculde bots flag set.

### Technical
<!-- What should be noted about the implementation? -->

Since the Solr 8 update I have noticed manual edits being reflected pretty promptly (less than the previously stated 15mins, although I wasn't timing accurately) -- it seems noticeably faster and better than the past, so Solr 8 has been a very good improvement. I _hope_ the load from bot edits won't cause a preformance problem. OL needs to keep current with more books though, so it needs to be able to index its content, which the bots are providing.

There are also multiple clean up and fix tasks performed by bots that aren't being reflected in the search index (I noticed this problem after merging 10K editions and works from a librarian request bot task) -- the changes were written but there was no obvious effect.

As far as performance goes, I manually added the 10k to reindex in successive batches of 1000 to the admin interface (copy and pasting through the web UI) and the whole lot were picked up successfully and the expect index update occurred promptly, so I think solr can handle large batches like this as they happen.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@mekarpeles 