### PR TITLE
Refactor button story to use string literals

### DIFF
--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -5,20 +5,21 @@ export default {
     title: 'Legacy/Button'
 };
 
-export const CtaBtn = () => '<div class="cta-btn">Leave waitlist</div>';
+const ButtonTemplate = (classes,innerHtml) => `<div class="${classes}">${innerHtml}</div>`;
 
-export const CtaBtnUnavailable = () => '<div class="cta-btn cta-btn--unavailable">Join waitlist</div>';
+export const CtaBtn = () => ButtonTemplate('cta-btn','Leave waitlist');
 
-export const CtaBtnAvailable = () => '<div class="cta-btn cta-btn--available">Borrow</div>';
+export const CtaBtnUnavailable = () => ButtonTemplate('cta-btn cta-btn--unavailable','Join waitlist');
 
-export const CtaBtnPreview = () => '<div class="cta-btn cta-btn--preview">Preview</div>';
+export const CtaBtnAvailable = () => ButtonTemplate('cta-btn cta-btn--available','Borrow');
 
-export const CtaBtnWithBadge = () => `
-<div class="cta-btn cta-btn--unavailable">
-  Join waiting list
-  <span class="cta-btn__badge">4</span>
-</div>
-`;
+export const CtaBtnPreview = () => ButtonTemplate('cta-btn cta-btn--preview','Preview');
+
+export const CtaBtnWithBadge = () =>
+    ButtonTemplate('cta-btn cta-btn--unavailable',
+        `Join waiting list
+    <span class="cta-btn__badge">4</span>`)
+;
 
 export const CtaBtnGroup = () => `<div class="cta-button-group">
 <a href="/borrow/ia/sevenhabitsofhi00cove?ref=ol" title="Borrow ebook from Internet Archive" id="borrow_ebook" data-ol-link-track="CTAClick|Borrow" class="cta-btn cta-btn--available">Borrow</a>

--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -5,21 +5,27 @@ export default {
     title: 'Legacy/Button'
 };
 
-const ButtonTemplate = (classes,innerHtml) => `<div class="${classes}">${innerHtml}</div>`;
+const ButtonTemplate = (buttonType, text, badgeCount=null) => `<div class="cta-btn ${ButtonTypes[buttonType]}">${text} ${badgeCount ? BadgeTemplate(badgeCount) : ''}</div>`;
 
-export const CtaBtn = () => ButtonTemplate('cta-btn','Leave waitlist');
+const BadgeTemplate = (badgeCount) => `<span class="cta-btn__badge">${badgeCount}</span>`
 
-export const CtaBtnUnavailable = () => ButtonTemplate('cta-btn cta-btn--unavailable','Join waitlist');
+const ButtonTypes = {
+    default: '',
+    unavailable: ' cta-btn--unavailable',
+    available: ' cta-btn--available',
+    preview: ' cta-btn--shell cta-btn--preview'
+}
 
-export const CtaBtnAvailable = () => ButtonTemplate('cta-btn cta-btn--available','Borrow');
+export const CtaBtn = () => ButtonTemplate('default','Leave waitlist');
 
-export const CtaBtnPreview = () => ButtonTemplate('cta-btn cta-btn--preview','Preview');
+export const CtaBtnUnavailable = () => ButtonTemplate('unavailable','Join waitlist');
+
+export const CtaBtnAvailable = () => ButtonTemplate('available','Borrow');
+
+export const CtaBtnPreview = () => ButtonTemplate('preview','Preview');
 
 export const CtaBtnWithBadge = () =>
-    ButtonTemplate('cta-btn cta-btn--unavailable',
-        `Join waiting list
-    <span class="cta-btn__badge">4</span>`)
-;
+    ButtonTemplate('unavailable','Join waiting list',4);
 
 export const CtaBtnGroup = () => `<div class="cta-button-group">
 <a href="/borrow/ia/sevenhabitsofhi00cove?ref=ol" title="Borrow ebook from Internet Archive" id="borrow_ebook" data-ol-link-track="CTAClick|Borrow" class="cta-btn cta-btn--available">Borrow</a>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor
### Technical
<!-- What should be noted about the implementation? -->
uses string literals , as a crude way to recreate in plain html https://storybook.js.org/docs/vue/get-started/setup
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jdlrobson 