### PR TITLE
Cleanup data after a successful import in the import_item table

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -111,6 +111,8 @@ class ImportItem(web.storage):
             error=error,
             ol_key=ol_key,
             import_time=datetime.datetime.utcnow())
+        if status != 'failed':
+            d = dict(**d, data=None)
         db.update("import_item", where="id=$id", vars=self, **d)
         self.update(d)
 


### PR DESCRIPTION
### Technical
Every import queued by the patner bots will queue up the import with corresponding data of the book/edition in the `import_item` table. This will cause the size of the table to increase with every import. This change will clean up the data column once the import is succesful.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 