### PR TITLE
Fix image uploads

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -54,7 +54,7 @@ class add_cover(delegate.page):
         else:
             data = None
 
-        if i.url and i.url.strip() == "http://":
+        if i.url and i.url.strip() == "https://":
             i.url = ""
 
         user = accounts.get_current_user()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5637

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects issue where book covers can not be uploaded to Open Library.

### Technical
<!-- What should be noted about the implementation? -->
The server checks for a default URL values and replaces it with an empty string.  The default URL in the covers modal was changed to in #5569, but the server was checking for the previous default URL.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open the add covers modal for a book.
2. Attempt to upload a new book cover.  Ensure that this works without error.
3. Open another add covers modal.
4. Attempt to add a cover via URL to test for regressions.
5. Delete any cover images that were used for testing (unless they were the correct cover images).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 
