### PR TITLE
use isbn:{isbn} as ia_id, faster unique

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -33,56 +33,59 @@ class Batch(web.storage):
         items = [line.strip() for line in open(filename) if line.strip()]
         self.add_items(items)
 
-    def dedupe_ia_items(self, items):
-        already_present = [
+    def dedupe_items(self, items):
+        ia_ids = [item.get('ia_id') for item in items if item.get('ia_id')]
+        already_present = set([
             row.ia_id for row in db.query(
-                "SELECT ia_id FROM import_item WHERE ia_id IN $items",
+                "SELECT ia_id FROM import_item WHERE ia_id IN $ia_ids",
                 vars=locals()
             )
-        ]
+        ])
         # ignore already present
         logger.info(
             "batch %s: %d items are already present, ignoring...",
             self.name,
             len(already_present)
         )
-        return list(set(items) - set(already_present))
+        # Those unique items whose ia_id's aren't already present
+        return [
+            item for item in items
+            if item.get('ia_id') not in already_present
+        ]
 
-    def add_items(self, items, ia_items=True):
+    def normalize_items(self, items):
+        return [{
+            'batch_id': self.id,
+            'ia_id': item.get('ia_id') or item,
+            'data': json.dumps(
+                item.get('data'),
+                sort_keys=True
+            ) if item.get('data') else None
+        } for item in items]
+
+    def add_items(self, items):
         """
-        :param ia_items: True if `items` is a list of IA identifiers, False if
-        book data dicts.
+        :param items: either a list of `ia_id`  (legacy) or a list of dicts
+            containing keys `ia_id` and book `data`. In the case of
+            the latter, `ia_id` will be of form e.g. "isbn:1234567890";
+            i.e. of a format id_type:value which cannot be a valid IA id.
         """
         if not items:
             return
 
         logger.info("batch %s: adding %d items", self.name, len(items))
 
-        if ia_items:
-            items = self.dedupe_ia_items(items)
-
+        items = self.dedupe_items(self.normalize_items(items))
         if items:
-            # Either create a reference to an IA id which will be loaded
-            # from Archive.org metadata, or provide json data book record
-            # which will be loaded directly into the OL catalog
-            values = [
-                {
-                    'batch_id': self.id,
-                    **({'ia_id': item} if ia_items else {
-                        'data': json.dumps(item, sort_keys=True)
-                    })
-                }
-                for item in items
-            ]
             try:
                 # TODO: Upgrade psql and use `INSERT OR IGNORE`
                 # otherwise it will fail on UNIQUE `data`
                 # https://stackoverflow.com/questions/1009584
-                db.get_db().multiple_insert("import_item", values)
+                db.get_db().multiple_insert("import_item", items)
             except UniqueViolation:
-                for value in values:
+                for item in items:
                     try:
-                        db.get_db().insert("import_item", **value)
+                        db.get_db().insert("import_item", **item)
                     except UniqueViolation:
                         pass
             logger.info("batch %s: added %d items", self.name, len(items))

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -38,7 +38,7 @@ class Batch(web.storage):
         already_present = set([
             row.ia_id for row in db.query(
                 "SELECT ia_id FROM import_item WHERE ia_id IN $ia_ids",
-                vars=locals()
+                vars={"ia_ids": ia_ids}
             )
         ])
         # ignore already present

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -26,18 +26,16 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
     """Requests OL to import an item and retries on server errors.
     """
     # logger uses batch_id:id for item.data identifier if no item.ia_id
-    _id = item.ia_id or "%s:%s" % (item.batch_id, item.id)
-    logger.info("importing %s", _id)
+    logger.info("importing %s", item.ia_id)
     for i in range(retries):
         if i != 0:
             logger.info("sleeping for 5 seconds before next attempt.")
             time.sleep(5)
         try:
             ol = get_ol(servername=servername)
-            if item.ia_id:
-                return ol.import_ocaid(item.ia_id, require_marc=require_marc)
-            else:
+            if item.data:
                 return ol.import_data(item.data)
+            return ol.import_ocaid(item.ia_id, require_marc=require_marc)
         except IOError as e:
             logger.warning("Failed to contact OL server. error=%s", e)
         except OLError as e:

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -26,7 +26,8 @@ def ol_import_request(item, retries=5, servername=None, require_marc=True):
     """Requests OL to import an item and retries on server errors.
     """
     # logger uses batch_id:id for item.data identifier if no item.ia_id
-    logger.info("importing %s", item.ia_id)
+    _id = item.ia_id or "%s:%s" % (item.batch_id, item.id)
+    logger.info("importing %s", _id)
     for i in range(retries):
         if i != 0:
             logger.info("sleeping for 5 seconds before next attempt.")


### PR DESCRIPTION
Rather than adding a new column for ID & type (since we have `ia_id` and all the infrastructure around it), I made it a requirement for a record to have an `ia_id` field.

This change makes it so, if you import a book by isbn, the `ia_id` is e.g. `isbn:0123456789` which cannot be a valid internet archive identifier (since it contains a `:`)

This also gets around requiring separate logic to determine which items have or don't have `ia_id`. It can now always do the unique check by the `ia_id` field. The determining factor will be whether a `data` field is present. If it is, the record will be imported as data. Otherwise, imported via `ia_id` which will fail if the ID is invalid.

### Considerations

1. We want the database to be performant. Checking `ia_id` instead of comparing large json strings for uniqueness helps there
2. We don't want to add a ton of new fields to the database
3. It would be great if we don't have to re-write a ton of import code in order to make this change
4. If possible, we also to find unique violations early (rather than having to iterate over every item in a failed batch) and by adding `ia_id` to every record and calling the pre-emptive dedupe checking code, now we get this advantage for everything in the batch, not just ia-imports.

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@cdrini + @jimchamp when convenient & as time permits, please watch https://archive.org/embed/openlibrary-tour-2020/ol_imports_comprehensive.mp4 video for context