### PR TITLE
deduplicate authors on work save

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -699,8 +699,21 @@ class SaveBookHelper:
 
         # ignore empty authors
         work.authors = [a for a in work.get('authors', []) if a.get('author', {}).get('key', '').strip()]
+        work.authors = self.deduplicate_authors(work.get('authors', []))
 
         return trim_doc(work)
+
+    @staticmethod
+    def deduplicate_authors(authors):
+        # make sure that no authors are listed twice
+        seen_authors = set()
+        deduplicated_authors = []
+        for a in authors:
+            author_key = a.get('author', {}).get('key', '')
+            if author_key not in seen_authors:
+                deduplicated_authors.append(a)
+                seen_authors.add(author_key)
+        return deduplicated_authors
 
     def _prevent_ocaid_deletion(self, edition):
         # Allow admins to modify ocaid


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Address part of my of proposal on #5650 

### Technical
<!-- What should be noted about the implementation? -->
I am not entirely sure if this is the best place to do de-duplication. Would be happy to move it somewhere more appropriate if such a place exists.

I'm also not tied to this approach. But I figured it would be easier to discuss if we had a proposed change in front of us :)

In my opinion, it is okay not to warn/validate this client side because it was likely an unintentional change anyway.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to a work
2. Try to add an author two times
3. When you save it will only have added it once

### Screenshot

https://user-images.githubusercontent.com/921217/133018602-6e5802a6-dca5-47db-b2e1-6b182c42a9c0.mp4




### Stakeholders
<!-- @ tag stakeholders of this bug -->

