### PR TITLE
deduplicate authors on import

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -40,6 +40,7 @@ from openlibrary import accounts
 from openlibrary.catalog.merge.merge_marc import build_marc
 from openlibrary.catalog.utils import mk_norm
 from openlibrary.core import lending
+from openlibrary.utils import uniq, dicthash
 from openlibrary.utils.isbn import normalize_isbn
 
 from openlibrary.catalog.add_book.load_book import build_query, east_in_by_statement, import_author, InvalidLanguage
@@ -672,6 +673,8 @@ def load(rec, account_key=None):
     rec = normalize_record_isbns(rec)
 
     edition_pool = build_pool(rec)
+    # deduplicate authors
+    rec['authors'] = uniq(rec.get('authors',[]), dicthash)
     if not edition_pool:
         # No match candidates found, add edition
         return load_data(rec, account_key=account_key)

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -674,7 +674,7 @@ def load(rec, account_key=None):
 
     edition_pool = build_pool(rec)
     # deduplicate authors
-    rec['authors'] = uniq(rec.get('authors',[]), dicthash)
+    rec['authors'] = uniq(rec.get('authors', []), dicthash)
     if not edition_pool:
         # No match candidates found, add edition
         return load_data(rec, account_key=account_key)

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -142,7 +142,7 @@ def test_load_deduplicates_authors(mock_site, add_languages, ia_writeback):
     rec = {
         'ocaid': 'test_item',
         'source_records': ['ia:test_item'],
-        'authors': [{'name': 'John Brown'}, {'name': 'John Brown'}, {'name': 'John Brown'}, {'name': 'John Brown'}],
+        'authors': [{'name': 'John Brown'}, {'name': 'John Brown'}],
         'title': 'Test item',
         'languages': ['eng'],
     }

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -133,6 +133,25 @@ def test_load_test_item(mock_site, add_languages, ia_writeback):
     assert w.type.key == '/type/work'
 
 
+def test_load_deduplicates_authors(mock_site, add_languages, ia_writeback):
+    """
+    Testings that authors are deduplicated before being added
+    This will only work if all the author dicts are identical
+    Not sure if that is the case when we get the data for import
+    """
+    rec = {
+        'ocaid': 'test_item',
+        'source_records': ['ia:test_item'],
+        'authors': [{'name': 'John Brown'}, {'name': 'John Brown'}, {'name': 'John Brown'}, {'name': 'John Brown'}],
+        'title': 'Test item',
+        'languages': ['eng'],
+    }
+
+    reply = load(rec)
+    assert reply['success'] is True
+    assert len(reply['authors']) == 1
+
+
 def test_load_with_subjects(mock_site, ia_writeback):
     rec = {
         'ocaid': 'test_item',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Address part of my of proposal on #5650
Also a rework of #5651

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR will deduplicate authors upon import.

### Technical
<!-- What should be noted about the implementation? -->
I am not confident that when we get author dicts for import if they are duplicate.
If someone could check with something like `OL24626887W` that would be very helpful.

If they aren't identical (like lets say they also have a field for if they were illustrator or not) I'll need some sample data to come up with a specific implementation.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I added an automated test :)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
