### PR TITLE
Add missing text_international to solr types generator

### DIFF
--- a/openlibrary/solr/types_generator.py
+++ b/openlibrary/solr/types_generator.py
@@ -28,6 +28,7 @@ def generate():
             'string': 'str',
             'text_en_splitting': 'str',
             'text_general': 'str',
+            'text_international': 'str',
             'boolean': 'bool',
         }
 


### PR DESCRIPTION
Looks like #5568 was slightly out of date.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
