### PR TITLE
Fix broken graph on `/admin/imports`

### DIFF
--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -227,7 +227,7 @@ export function loadGraph(id, options = {}, tooltip_message = '', color = null) 
         if (tooltip_message) {
             return plot_tooltip_graph($(node), data, tooltip_message, color);
         } else {
-            return $.plot($(node), data, options);
+            return $.plot($(node), [{data: data}], options);
         }
     }
 }

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -8,6 +8,7 @@ import 'flot/jquery.flot.selection.js';
 import 'flot/jquery.flot.crosshair.js';
 import 'flot/jquery.flot.stack.js';
 import 'flot/jquery.flot.pie.js';
+import 'flot/jquery.flot.time.js';
 
 /**
  * A special graph loaded on the following URLs:

--- a/openlibrary/templates/admin/imports.html
+++ b/openlibrary/templates/admin/imports.html
@@ -81,7 +81,7 @@ $var title: Imports
             </tr>
     </table>
 </div>
-<script type="text/json+graph" id="json-books-imported-daily">$:json_encode(stats.get_books_imported_per_day())</script>
+<script type="text/json+graph" id="graph-json-books-added-per-day">$:json_encode(stats.get_books_imported_per_day())</script>
 
 <style type="text/css">
 div.graph, div.chart{


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes broken import graph found in the admin imports dashboard.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as an admin:
1. Navigate to https://testing.openlibrary.org/admin/imports
2. Ensure that the graph is present.

### Screenshot
<!-- If this PR touches UI, please post evidence of it behaving correctly. -->
![Screenshot from 2021-09-17 18-25-49](https://user-images.githubusercontent.com/28732543/133860411-8faa73a1-f61f-46b1-8460-a5480f92144b.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
