### PR TITLE
Autofill login for dev instances

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -887,16 +887,6 @@ class Partials(delegate.page):
         )
 
 
-@public
-def is_openlibrary_host():
-    """
-    To see if we are running in a "local" instance or not
-    In this case local is defined as NOT openlibrary.org hosted
-    such as: openlibrary.org, testing.library.org, or staging.openlibrary.org
-    Why not look for localhost? Gitpod and GitHub codespaces have different hosts
-    """
-    return "openlibrary.org" in os.environ.get("HTTP_HOST", "")
-
 def is_bot():
     r"""Generated on ol-www1 within /var/log/nginx with:
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -887,6 +887,16 @@ class Partials(delegate.page):
         )
 
 
+@public
+def is_openlibrary_host():
+    """
+    To see if we are running in a "local" instance or not
+    In this case local is defined as NOT openlibrary.org hosted
+    such as: openlibrary.org, testing.library.org, or staging.openlibrary.org
+    Why not look for localhost? Gitpod and GitHub codespaces have different hosts
+    """
+    return "openlibrary.org" in os.environ.get("HTTP_HOST", "")
+
 def is_bot():
     r"""Generated on ol-www1 within /var/log/nginx with:
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -261,9 +261,9 @@ jQuery(function () {
     }
 
     if (document.getElementById('autofill-dev-credentials')) {
-        document.getElementById("username").value = "openlibrary@example.com"
-        document.getElementById("password").value = "admin123"
-        document.getElementById("remember").checked = true
+        document.getElementById('username').value = 'openlibrary@example.com'
+        document.getElementById('password').value = 'admin123'
+        document.getElementById('remember').checked = true
     }
     if (document.getElementById('adminLinks')) {
         import(/* webpackChunkName: "admin" */ './admin')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -260,6 +260,11 @@ jQuery(function () {
             .then(module => module.initAddBookImport());
     }
 
+    if (document.getElementById('autofill-dev-credentials')) {
+        document.getElementById("username").value = "openlibrary@example.com"
+        document.getElementById("password").value = "admin123"
+        document.getElementById("remember").checked = true
+    }
     if (document.getElementById('adminLinks')) {
         import(/* webpackChunkName: "admin" */ './admin')
             .then((module) => module.initAdmin());

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -16,6 +16,16 @@ $var title: $("Log In")
 
   $else:
       <form id="register" class="login olform" name="register" method="post">
+          <div class="flash-messages" id="autofill-dev-credentials">
+              <div class="info">
+                  <span>
+                      This is a development instance, the default credentials are automatically filled.
+                      <br>
+                      email: openlibrary@example.com password: admin123
+                      $page
+                  </span>
+              </div>
+          </div>
 
         $if form.note:
             <div class="note">$form.note</div>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -16,7 +16,7 @@ $var title: $("Log In")
 
   $else:
       <form id="register" class="login olform" name="register" method="post">
-          $if not is_openlibrary_host():
+          $if "dev" in ctx.features:
               <div class="flash-messages" id="autofill-dev-credentials">
                   <div class="info">
                       <span>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -16,16 +16,16 @@ $var title: $("Log In")
 
   $else:
       <form id="register" class="login olform" name="register" method="post">
-          <div class="flash-messages" id="autofill-dev-credentials">
-              <div class="info">
-                  <span>
-                      This is a development instance, the default credentials are automatically filled.
-                      <br>
-                      email: openlibrary@example.com password: admin123
-                      $page
-                  </span>
+          $if not is_openlibrary_host():
+              <div class="flash-messages" id="autofill-dev-credentials">
+                  <div class="info">
+                      <span>
+                          This is a development instance, the default credentials are automatically filled.
+                          <br>
+                          email: openlibrary@example.com password: admin123
+                      </span>
+                  </div>
               </div>
-          </div>
 
         $if form.note:
             <div class="note">$form.note</div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes  #5440

Feature to autofill credentials for local development.

### Technical
I decided to do the python/js hybrid approach because:
1. It will leave a trace in the html (the element id) to search for about autofill
2. In my opinion, it would be more messy and error prone to add the name/password in python

However, if someone wants to make a PR showing that the python only solution is cleaner I welcome it :)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Spin up a dev instance (you'll have to run `make js`) and see it auto fill on the login page.

Will need someone to test that this doesn't show up on testing/staging.

### Screenshot

https://user-images.githubusercontent.com/921217/133849145-368ff9cb-9b6c-4ccb-8182-eddb43bc3196.mp4

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 