### PR TITLE
remove border radius from page banner

### DIFF
--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -11,8 +11,6 @@
   font-family: @lucida_sans_serif-1;
   background: @black;
   padding: 15px;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
   border-bottom: 1px solid @beige;
 
   @media screen and (min-width: @width-breakpoint-tablet) {


### PR DESCRIPTION
Fixes a small annoyance. There is a small bit of beige at the top corners of the site due to border radius. I don't think it looks good against the black top bar.

Video shows the difference best.

Hope this change is welcome. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Spin up an instance and see for yourself. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/133894648-28fae26f-51d5-46ba-9677-bf06f4f69345.mp4

### Stakeholders
@jdlrobson @jimchamp (I see you both listed as frontend leads)
