### PR TITLE
Update nginx SSL protocols

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -16,7 +16,7 @@ events {
 }
 
 http {
-    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_session_cache   shared:SSL:50m;
     ssl_session_timeout 10m;
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5653

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Didn't test, but confirmed that TLSv1.3 has been supported in nginx since 1.13 (we have 1.19)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
