### PR TITLE
Auto-restart memcached on staging

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -31,6 +31,9 @@ services:
       # does not clobber the data generated inside the image / container
       - .:/openlibrary
 
+  memcached:
+    restart: unless-stopped
+
 volumes:
   ol-vendor:
   ol-build:


### PR DESCRIPTION
Noticed that after an outage, memcached is not auto-restarting on testing.openlbirary.org, causing the site to be slow until it is manually restarted.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Not tested; Small change, I think it should be unlikely to cause an issue.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
