### PR TITLE
Remove transform from cover image

### DIFF
--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -13,7 +13,6 @@
   min-height: 10px;
   padding-right: 1.5em;
   .cover-animation {
-    transform: perspective(0) rotateX(0deg);
     transition: transform .8s, opacity .8s;
   }
   .cover-animation:hover {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5658

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes unnecessary transform from `.cover-animation` class, preventing glitch with image hover animation.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![working_book_cover_image](https://user-images.githubusercontent.com/28732543/134103503-fc2a3212-7a3a-4630-99fe-6143ac760bc1.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
