### PR TITLE
Fix XSS attack with dev_host url parameter

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -778,6 +778,8 @@ def get_donation_include(include):
     dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
     if dev_host and re.match('^[a-zA-Z0-9-.]+$', dev_host):
         dev_host += "."   # e.g. `www-user.`
+    else:
+        dev_host = ''
     script_src = "https://%sarchive.org/includes/donate.js" % dev_host
     if 'ymd' in web_input:
         script_src += '?ymd=' + web_input.ymd


### PR DESCRIPTION
Hotfix; the dev_host url param was creating an XSS hole.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] https://openlibrary.org/?dev_host=%22%3E%3C/script%3E%3Cscript%3Ealert(%27hi%27);%3C/script%3E doesn't run the JS in the url.
- [x] view-source:https://openlibrary.org/?dev_host=www loads www.archive.org donate.js

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
