### PR TITLE
Serve archive.org JS files from openlibrary.org

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -354,6 +354,19 @@ class robotstxt(delegate.page):
             raise web.notfound()
 
 
+@web.memoize
+def fetch_ia_js(filename: str) -> str:
+    return requests.get(f'https://archive.org/includes/{filename}').text
+
+
+class ia_js_cdn(delegate.page):
+    path = r'/cdn/archive.org/(donate\.js|analytics\.js)'
+
+    def GET(self, filename):
+        web.header('Content-Type', 'text/javascript')
+        raise web.HTTPError('200 OK', {}, fetch_ia_js(filename))
+
+
 class serviceworker(delegate.page):
     path = '/sw.js'
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -777,10 +777,10 @@ def get_donation_include(include):
     # needing to reload openlibrary services:
     dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
     if dev_host and re.match('^[a-zA-Z0-9-.]+$', dev_host):
-        dev_host += "."   # e.g. `www-user.`
+        script_src = "https://%s.archive.org/includes/donate.js" % dev_host
     else:
-        dev_host = ''
-    script_src = "https://%sarchive.org/includes/donate.js" % dev_host
+        script_src = "/cdn/archive.org/donate.js"
+
     if 'ymd' in web_input:
         script_src += '?ymd=' + web_input.ymd
 

--- a/openlibrary/templates/site/footer.html
+++ b/openlibrary/templates/site/footer.html
@@ -38,7 +38,7 @@ $if cssfile == 'user' or 'admin':
     </script>
 
     <!-- Must be loaded after jquery -->
-    <script src="//archive.org/includes/analytics.js?v=0c15bbe" type="text/javascript"></script>
+    <script src="/cdn/archive.org/analytics.js" type="text/javascript"></script>
     <script src="$static_url('build/all.js')" type="text/javascript"></script>
     <!-- Passes total_time for analytics to ol.analytics.js -->
     <div class="analytics-stats-time-calculator" data-time="$total_time"></div>


### PR DESCRIPTION
This should improve our score here for subresource integrity: https://observatory.mozilla.org/analyze/openlibrary.org ; and potentially give us a speed boost, since not connecting to archive.org for these scripts.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] Locally, http://localhost:8080/cdn/archive.org/analytics.js serves the right file + caches
- [x] Test on testing.openlibrary.org

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
