### PR TITLE
Fix dangling ref to run_solr_search signature breaking /authors and subjects search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -909,7 +909,8 @@ class subject_search(delegate.page):
     def get_results(self, q, offset=0, limit=100):
         valid_fields = ['key', 'name', 'subject_type', 'work_count']
         q = escape_colon(escape_bracket(q), valid_fields)
-        params = {
+
+        results = run_solr_search(solr_select_url, {
             "fq": "type:subject",
             "q.op": "AND",
             "q": q,
@@ -919,10 +920,7 @@ class subject_search(delegate.page):
             "qt": "standard",
             "wt": "json",
             "sort": "work_count desc"
-        }
-
-        solr_select = solr_select_url + "?" + urllib.parse.urlencode(params, 'utf-8')
-        results = run_solr_search(solr_select)
+        })
         response = results['response']
 
         for doc in response['docs']:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1001,11 +1001,13 @@ def random_author_search(limit=10):
     """
     letters_and_digits = string.ascii_letters + string.digits
     seed = ''.join(random.choice(letters_and_digits) for _ in range(10))
-    rows = '&rows=%d' % (limit)
-    sort = '&sort=random_%s+desc' % (seed)
-    solr_select = solr_select_url + "?fq=type:author&q.op=AND&q=*&wt=json" + rows + sort
 
-    search_results = run_solr_search(solr_select)
+    search_results = run_solr_search(solr_select_url, {
+        'q': 'type:author',
+        'rows': limit,
+        'sort': f'random_{seed} desc',
+        'wt': 'json',
+    })
 
     docs = search_results.get('response', {}).get('docs', [])
 


### PR DESCRIPTION
Causing a small error in the latest deploy on http://openlibrary.org/authors

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] https://testing.openlibrary.org/authors works
- [x] https://openlibrary.org/search/subjects?q=horror&mode=everything

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
