### PR TITLE
make fuzzy msgs warnings not exceptions

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -37,14 +37,20 @@ def _validate_catalog(catalog, locale):
     for message in catalog:
         message_errors = validate(message, catalog)
 
-        if message_errors:
-            if message.lineno:
+        if message.lineno:
+            if message.fuzzy:
+                print(
+                    f'openlibrary/i18n/{locale}/messages.po:'
+                    f'{message.lineno}: {message.string}'
+                )
+            if message_errors:
                 validation_errors.append(
                     f'openlibrary/i18n/{locale}/messages.po:'
                     f'{message.lineno}: {message.string}'
                 )
+            
             for e in message_errors:
-                validation_errors.append(e)
+                validation_errors.append(e)  
 
     if validation_errors:
         print("Validation failed...")

--- a/openlibrary/i18n/validators.py
+++ b/openlibrary/i18n/validators.py
@@ -7,24 +7,9 @@ from babel.messages.checkers import python_format
 
 
 def validate(message: Message, catalog: Catalog) -> List[str]:
-    errors = _validate_fuzzy(message)
-    errors.extend([f'    {str(err)}' for err in message.check(catalog)])
+    errors = [f'    {str(err)}' for err in message.check(catalog)]
     if message.python_format and not message.pluralizable and message.string:
         errors.extend(_validate_cfmt(message.id, message.string))
-
-    return errors
-
-
-def _validate_fuzzy(message: Message) -> List[str]:
-    """Returns an error list if the message is fuzzy.
-
-    If a fuzzy flag is found above the header of a `.po`
-    file, the message will have `None` as its line number.
-    """
-    errors = []
-    if message.fuzzy:
-        if message.lineno:
-            errors.append('    Is fuzzy')
 
     return errors
 


### PR DESCRIPTION
@cdrini + @jimchamp worked on this so that when we generate new .po files for all the languages in i18n when there are website changes, then the fuzzy matches will not cause exceptions (since they won't render on the live website) and instead will appear to future translator-reviewers as warnings.