### PR TITLE
Display correct source code for CTA button stories

### DIFF
--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -5,9 +5,9 @@ export default {
     title: 'Legacy/Button'
 };
 
-const ButtonTemplate = (buttonType, text, badgeCount=null) => `<div class="cta-btn ${ButtonTypes[buttonType]}">${text} ${badgeCount ? BadgeTemplate(badgeCount) : ''}</div>`;
+const ButtonTemplate = (buttonType, text, badgeCount=null) => `<div class="cta-btn${ButtonTypes[buttonType]}">${text}${badgeCount ? BadgeTemplate(badgeCount) : ''}</div>`;
 
-const BadgeTemplate = (badgeCount) => `<span class="cta-btn__badge">${badgeCount}</span>`
+const BadgeTemplate = (badgeCount) => ` <span class="cta-btn__badge">${badgeCount}</span>`
 
 const ButtonTypes = {
     default: '',
@@ -17,15 +17,50 @@ const ButtonTypes = {
 }
 
 export const CtaBtn = () => ButtonTemplate('default','Leave waitlist');
+CtaBtn.parameters = {
+    docs: {
+        source: {
+            code: ButtonTemplate('default', 'Leave waitlist')
+        }
+    }
+}
 
 export const CtaBtnUnavailable = () => ButtonTemplate('unavailable','Join waitlist');
+CtaBtnUnavailable.parameters = {
+    docs: {
+        source: {
+            code: ButtonTemplate('unavailable', 'Join waitlist')
+        }
+    }
+}
 
 export const CtaBtnAvailable = () => ButtonTemplate('available','Borrow');
+CtaBtnAvailable.parameters = {
+    docs: {
+        source: {
+            code: ButtonTemplate('available', 'Borrow')
+        }
+    }
+}
 
 export const CtaBtnPreview = () => ButtonTemplate('preview','Preview');
+CtaBtnPreview.parameters = {
+    docs: {
+        source: {
+            code: ButtonTemplate('preview', 'Preview')
+        }
+    }
+}
 
 export const CtaBtnWithBadge = () =>
     ButtonTemplate('unavailable','Join waiting list',4);
+CtaBtnWithBadge.parameters = {
+    docs: {
+        source: {
+            code: ButtonTemplate('unavailable', 'Join waiting list', 4)
+        }
+    }
+}
 
 export const CtaBtnGroup = () => `<div class="cta-button-group">
 <a href="/borrow/ia/sevenhabitsofhi00cove?ref=ol" title="Borrow ebook from Internet Archive" id="borrow_ebook" data-ol-link-track="CTAClick|Borrow" class="cta-btn cta-btn--available">Borrow</a>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates our CTA button stories such that the correct button HTML is displayed in each button's code block.

### Technical
<!-- What should be noted about the implementation? -->
By default, Storybook displays the code used to generate a story as the component's code. For convenience, the HTML for each story is generated using a `ButtonTemplate` function, which does not exist in Open Library.  This PR replaces the incorrect `ButtonTemplate` code with the HTML that a developer would use to create the same button in OL.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Start Storybook and navigate to the Storybook site.
2. Click on the "Docs" nav item:

![Screenshot from 2021-09-29 16-04-55](https://user-images.githubusercontent.com/28732543/135340660-8af1c598-f76f-4ed0-bef5-79f2d6dda890.png)

3. Expand the "Buttons" section in the sidebar.
4. Ensure that the correct HTML is displayed in each component's "Show code" section.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before change:
![storybook_code_before](https://user-images.githubusercontent.com/28732543/135338622-873d9c15-fe28-43f6-a8c9-b0167905d155.png)

After change:
![storybook_code_after](https://user-images.githubusercontent.com/28732543/135338657-45bc6a18-bbb4-4701-9f20-1675c13b1c45.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
