### PR TITLE
unbreaks ia imports (items submitted as ia_id)

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -58,6 +58,7 @@ class Batch(web.storage):
             'ia_id': item
         } if type(item) is str else {
             'batch_id': self.id,
+            # Partner bots set ia_id to eg "partner:978..."
             'ia_id': item.get('ia_id'),
             'data': json.dumps(
                 item.get('data'),

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -55,8 +55,10 @@ class Batch(web.storage):
 
     def normalize_items(self, items):
         return [{
+            'ia_id': item
+        } if type(item) is str else {
             'batch_id': self.id,
-            'ia_id': item.get('ia_id') or item,
+            'ia_id': item.get('ia_id'),
             'data': json.dumps(
                 item.get('data'),
                 sort_keys=True


### PR DESCRIPTION
hotfix for ia imports. Tested on cron server

normalize_items was not working correctly when `item` was a string (instead of a dict)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
