### PR TITLE
fix(SearchResultsWork): Limit displayed authors to 9

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -34,10 +34,11 @@ $ max_rendered_authors = 9
         $else:
           $ remaining_authors = len(doc.authors) - max_rendered_authors
           $for a in doc.authors[:max_rendered_authors]:
+            $ separator = ',' if not loop.last or remaining_authors > 0 else ''
             $if not (hasattr(a, 'name') and a.name) and not (hasattr(a, 'author') and hasattr(a.author, 'name') and a.author.name):
-              <em>$_('Unknown author')</em>$(',' if not loop.last or remaining_authors else '')
+              <em>$_('Unknown author')</em>$(separator)
               $continue
-            <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last or remaining_authors else '')
+            <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(separator)
           $if remaining_authors > 0:
             <small><em><a itemprop="url" href="$work_edition_url"
                                          class="results">$ungettext('and 1 other', 'and %(n)s others', remaining_authors, n=remaining_authors)</a></em></small>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -8,6 +8,7 @@ $if book_provider:
 $else:
   $ work_edition_url = book_url
 
+$ max_rendered_authors = 9
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book">
   <span class="bookcover">
     $ cover = get_cover_url(doc) or "/images/icons/avatar_book-sm.png"
@@ -31,11 +32,14 @@ $else:
         $if not doc.authors:
           <em>$_('Unknown author')</em>
         $else:
-          $for a in doc.authors:
+          $for a in doc.authors[:max_rendered_authors]:
             $if not (hasattr(a, 'name') and a.name) and not (hasattr(a, 'author') and hasattr(a.author, 'name') and a.author.name):
               <em>$_('Unknown author')</em>$(',' if not loop.last else '')
               $continue
             <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
+          $if len(doc.authors) > max_rendered_authors:
+            <small><em><a itemprop="url" href="$(book_url)?edition=$(ocaid)"
+                                         class="results">$_('view all authors')</a></em></small>
       </span>
       <span class="resultPublisher">
         $if doc.get('first_publish_year'):

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -32,14 +32,14 @@ $ max_rendered_authors = 9
         $if not doc.authors:
           <em>$_('Unknown author')</em>
         $else:
+          $ remaining_authors = len(doc.authors) - max_rendered_authors
           $for a in doc.authors[:max_rendered_authors]:
             $if not (hasattr(a, 'name') and a.name) and not (hasattr(a, 'author') and hasattr(a.author, 'name') and a.author.name):
-              <em>$_('Unknown author')</em>$(',' if not loop.last else '')
+              <em>$_('Unknown author')</em>$(',' if not loop.last or remaining_authors else '')
               $continue
-            <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
-          $ remaining_authors = len(doc.authors) - max_rendered_authors
+            <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last or remaining_authors else '')
           $if remaining_authors > 0:
-            , <small><em><a itemprop="url" href="$(book_url)?edition=$(ocaid)"
+            <small><em><a itemprop="url" href="$work_edition_url"
                                          class="results">$ungettext('and 1 other', 'and %(n)s others', remaining_authors, n=remaining_authors)</a></em></small>
       </span>
       <span class="resultPublisher">

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -37,9 +37,10 @@ $ max_rendered_authors = 9
               <em>$_('Unknown author')</em>$(',' if not loop.last else '')
               $continue
             <a itemprop="url" href="$(a.get('url') or a.get('key') or a.author.get('url') or a.author.key)" class="results">$(a.name or a.author.name)</a>$(',' if not loop.last else '')
-          $if len(doc.authors) > max_rendered_authors:
-            <small><em><a itemprop="url" href="$(book_url)?edition=$(ocaid)"
-                                         class="results">$_('view all authors')</a></em></small>
+          $ remaining_authors = len(doc.authors) - max_rendered_authors
+          $if remaining_authors > 0:
+            , <small><em><a itemprop="url" href="$(book_url)?edition=$(ocaid)"
+                                         class="results">$ungettext('and 1 other', 'and %(n)s others', remaining_authors, n=remaining_authors)</a></em></small>
       </span>
       <span class="resultPublisher">
         $if doc.get('first_publish_year'):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5630 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes long lists of authors for SearchResultsWork by slicing first 9 authors off authors array and rendering a small "view all authors" message when the authors array exceeds 9.

### Technical
<!-- What should be noted about the implementation? -->
The `max_rendered_authors` is defined at the beginning of the template partial, in the event we feel the max should be changed.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Search for a work title whose author list exceeds 9 (you may need to edit a work locally and add authors in order to achieve this)
2. The search result for the work should show the first 9 authors and a "view all authors" link to the work's show page
3. Click the "view all authors" link
4. From the work show page, click the first author in the list
5. The author show page should display the work with the author list truncated to 9 and the same "view all authors" link should be rendered.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![localhost_8080_search_q=blackout mode=everything](https://user-images.githubusercontent.com/39553/135729628-a0834d55-9be0-4139-bab0-d0778a7c3426.png)

![localhost_8080_authors_OL7531052A_Dhonielle_Clayton](https://user-images.githubusercontent.com/39553/135729632-fdc28761-3c5f-4365-a789-4d38a33281ad.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 