### PR TITLE
Check for work and edition before rendering notes modal link

### DIFF
--- a/openlibrary/macros/NotesModal.html
+++ b/openlibrary/macros/NotesModal.html
@@ -1,42 +1,43 @@
 $def with (work, edition, link_text, id, class_list='', reload_id=None)
 
-$ username = ctx.user and ctx.user.key.split('/')[-1]
-$ notes = work.get_users_notes(username, edition.key.split('/')[-1])
-$ work_key = work.key
+$if work and edition:
+  $ username = ctx.user and ctx.user.key.split('/')[-1]
+  $ notes = work.get_users_notes(username, edition.key.split('/')[-1])
+  $ work_key = work.key
 
-$if notes and len(notes.notes) > 0:
-  $ display_delete_button = True
-$else:
-  $ display_delete_button = False
+  $if notes and len(notes.notes) > 0:
+    $ display_delete_button = True
+  $else:
+    $ display_delete_button = False
 
-$ context = {
-  $ "id": id
-  $ }
+  $ context = {
+    $ "id": id
+    $ }
 
-$if reload_id:
-  $ context['reloadId'] = reload_id
+  $if reload_id:
+    $ context['reloadId'] = reload_id
 
-<div class="$class_list">
-  <a class="notes-modal-link" href="javascript:;" data-context="$json_encode(context)">$link_text</a>
+  <div class="$class_list">
+    <a class="notes-modal-link" href="javascript:;" data-context="$json_encode(context)">$link_text</a>
 
-  <div class="hidden">
-    <div id="$id-metadata-form" class="floaterAdd metadata-form">
-      <div class="floaterHead">
-        <h2>$_("My Book Notes")</h2>
-        <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
+    <div class="hidden">
+      <div id="$id-metadata-form" class="floaterAdd metadata-form">
+        <div class="floaterHead">
+          <h2>$_("My Book Notes")</h2>
+          <a class="dialog--close">&times;<span class="shift">$_("Close")</span></a>
+        </div>
+        <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
+          <p>$_("My private notes about this edition:")</p>
+          <div>
+            <textarea class="notes-modal-textarea" name="notes" rows="10">$(notes.notes if notes else "")</textarea>
+          </div>
+          <input type="hidden" name="work_id" value="$work_key.split('/')[-1]" />
+          <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
+          <div class="note-form-buttons">
+            <button class="delete-note-button cta-btn cta-btn--shell $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
+            <button class="update-note-button">$_("Save Note")</button>
+          </div>
+        </form>
       </div>
-      <form class="book-notes-form" method="POST" action="$(work.key)/notes.json">
-        <p>$_("My private notes about this edition:")</p>
-        <div>
-          <textarea class="notes-modal-textarea" name="notes" rows="10">$(notes.notes if notes else "")</textarea>
-        </div>
-        <input type="hidden" name="work_id" value="$work_key.split('/')[-1]" />
-        <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
-        <div class="note-form-buttons">
-          <button class="delete-note-button cta-btn cta-btn--shell $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
-          <button class="update-note-button">$_("Save Note")</button>
-        </div>
-      </form>
     </div>
   </div>
-</div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Orphaned editions/works are causing lists/widgets.html rendering to fail on book pages.  NotesModal.html is the root cause of this, as it expects both edition and work to not be null when passed as parameters.

NotesModal.html now only returns HTML when both work and edition exist.

### Technical
<!-- What should be noted about the implementation? -->
This solution essentially disables notes for books that are orphaned.  Book notes are recorded at the edition level, and both work and edition OLIDs are required to persist a book note.  Removing the option to create a note for orphaned books seems like the cleanest solution to this issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
