### PR TITLE
Librarian tools permission group

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -77,9 +77,6 @@ features:
     support: admin
     undo: enabled
     upstream: enabled
-    user_metadata:
-        filter: usergroup
-        usergroup: /usergroup/beta-testers
 
 upstream_to_www_migration: true
 default_template_root: /upstream

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -712,6 +712,9 @@ class User(Thing):
     def is_beta_tester(self):
         return self.is_usergroup_member('/usergroup/beta-testers')
 
+    def has_librarian_tools(self):
+        return self.is_usergroup_member('/usergroup/librarian-tools')
+
     def get_lists(self, seed=None, limit=100, offset=0, sort=True):
         """Returns all the lists of this user.
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5721

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates a usergroup intended for librarians that are permitted to use newly developed librarian tools that may be somewhat risky to use carelessly.

### Technical
<!-- What should be noted about the implementation? -->
Usergroup `/usergroup/librarian-tools` has been created in production.

**Note:** Nothing special was needed in my dev instance to support this update.  I did find that if usergroups are used in the application's openlibrary.yml configs, the usergroup must exist on the local instance first.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Testing locally:
1. Call `User.has_librarian_tools()`.  This should return True only if you are a member of `/usergroup/librarian-tools`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini