### PR TITLE
unset font-size for #edithead paragraphs

### DIFF
--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -120,7 +120,6 @@ div#databar {
   }
   p {
     color: @brown;
-    font-size: 14px;
     margin: 0;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5349

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
the size is now 16 px (default in most browsers)
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
check a page mentioned in the above issue
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
can't really find a place in dev container to screenshot
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekapeles @libjenner