### PR TITLE
select identifier type based on value

### DIFF
--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -95,6 +95,16 @@ export default {
                 .map(([name, value]) => `<input type="hidden" name="author--remote_ids--${name}" value="${value}"/>`)
                 .join('');
             document.querySelector(this.output_selector).innerHTML = html;
+        },
+        selectIdentifierByInputValue: function() {
+            // Selects the dropdown identifier based on the input value
+            // Only supports wikidata and isni because the other identifiers are just numbers
+            const wikiDatas = this.inputValue.match(/Q\d+/i);
+            if (wikiDatas?.length > 0){
+                this.selectedIdentifier = 'wikidata';
+            } else if (this.inputValue.length === 16){
+                this.selectedIdentifier = 'isni';
+            }
         }
     },
     created: function(){
@@ -105,7 +115,11 @@ export default {
             {
                 handler: function(){this.createHiddenInputs()},
                 deep: true
-            }
+            },
+        inputValue:
+            {
+                handler: function(){this.selectIdentifierByInputValue()},
+            },
     }
 }
 </script>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When you paste a wikidata ID or isni the appropriate type will automatically be selected.

### Technical
<!-- What should be noted about the implementation? -->
This doesn't validate, just makes the lives of editors a bit easier.

Validation can be a separate ticket.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Testing locally requires you to add the config yaml or wait until #5742 is resolved.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/136449094-a1108bb2-abb3-4cb5-8fbe-10c7d0d1c673.mp4


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@libjenner @jimchamp 
