### PR TITLE
fix search bar image distortion

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -522,6 +522,7 @@
               min-height: 60px;
               background-color: @lightest-grey;
               margin-right: 10px;
+              object-fit: cover;
             }
 
             .book-desc {


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Before this PR, author images in search bar often were badly distorted. This fixes that.

### Technical
<!-- What should be noted about the implementation? -->

This solution clips the image rather than distorting it which makes a much nicer UX.

How does `object-fit: cover` work?
> The replaced content is sized to maintain its aspect ratio while filling the element’s entire content box. If the object's aspect ratio does not match the aspect ratio of its box, then the object will be clipped to fit.

[Source](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before ----------------------------------------------- after
<img width="345" alt="Screen Shot 2021-10-10 at 4 31 47 PM" src="https://user-images.githubusercontent.com/921217/136712253-d00bd416-aa67-4583-801d-25170bed907e.png"> <img width="345" alt="Screen Shot 2021-10-10 at 4 32 06 PM" src="https://user-images.githubusercontent.com/921217/136712255-8b83757c-bf69-46cf-8c16-e5226e7236ee.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 