### PR TITLE
stop search bar from loading insecure content

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -38,7 +38,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
         return `
             <li>
                 <a href="/authors/${author.key}">
-                    <img src="http://covers.openlibrary.org/a/olid/${author.key}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_author-lg.png" alt=""/>
+                    <img src="//covers.openlibrary.org/a/olid/${author.key}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_author-lg.png" alt=""/>
                     <span class="author-desc"><div class="author-name">${author.name}</div></span>
                 </a>
             </li>`;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Loads content over https when on production instead of http.

I noticed that when author images are loaded in the search bar FF gives an insecure content warning because the images are loaded over http. This PR fixes that.

### Technical
<!-- What should be noted about the implementation? -->
This just changes the code to match what already happens for works

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
N/A

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="938" alt="image" src="https://user-images.githubusercontent.com/921217/136712436-29e7c7a1-ba1e-4faf-8ce8-0e88ff5d58f8.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 