### PR TITLE
Hide private sidebar links in public reading log views

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -123,15 +123,16 @@ $if og_title:
                 <li><a class="list-link" href="$(lst.key)">$lst['name'] ($(len(lst.seeds)))</a></li>
             </div>
           </ul>
-        <ul class="booknotes-list">
-          <li class="subsection">$_('Notes & Observations')</li>
-          <li><a $('class=selected' if key=='notes' else '') href="$urlbase/notes">$_('My notes (%(count)d)', count=booknotes_counts['notes'])</a></li>
-          <li><a $('class=selected' if key=='observations' else '') href="$urlbase/observations">$_('My observations (%(count)d)', count=booknotes_counts['observations'])</a></li>
-        </ul>
-        <ul class="import-export-lists">
-          <li class="subsection">$_("Import / Export")</li>
-          <li><a href="/account/import">$_("Import & Export Options")</a></li>
-        </ul>
+        $if owners_page:
+          <ul class="booknotes-list">
+            <li class="subsection">$_('Notes & Observations')</li>
+            <li><a $('class=selected' if key=='notes' else '') href="$urlbase/notes">$_('My notes (%(count)d)', count=booknotes_counts['notes'])</a></li>
+            <li><a $('class=selected' if key=='observations' else '') href="$urlbase/observations">$_('My observations (%(count)d)', count=booknotes_counts['observations'])</a></li>
+          </ul>
+          <ul class="import-export-lists">
+            <li class="subsection">$_("Import / Export")</li>
+            <li><a href="/account/import">$_("Import & Export Options")</a></li>
+          </ul>
       </div>
       $if key == 'notes':
         $:render_template('account/notes', items, user, booknotes_counts['notes'], page=current_page)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
If you navigate to another patron's public reading log today, you will see links to their book notes and observations (including counts).  The import/export link is present, as well.

Clicking on the notes or observations link will result in an error, as these views are only displayed to the owner.

This PR hides those links to users who are not the page owner.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
