### PR TITLE
Prevent login from redirecting offsite

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -319,7 +319,7 @@ class account_login(delegate.page):
     def GET(self):
         referer = web.ctx.env.get('HTTP_REFERER', '/')
         # Don't set referer if request is from offsite
-        if not 'openlibrary.org' in referer:
+        if 'openlibrary.org' not in referer:
             referer = None
         i = web.input(redirect=referer)
         f = forms.Login()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5748

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When logging in, patrons will now only be redirected to the referring page if that page is an Open Library page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
**Note:** This should be tested with Chrome

1. Log out of your testing Open Library account.
2. Do a Google search for "Open Library login"
3. Using Chrome's dev tools, change the address of the correct link to `https://testing.openlibrary.org/account/login`.
4. Click the link and log in.
5. Ensure that you are redirected to the testing home page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 