### PR TITLE
Change header bar font size on reading log stats pages

### DIFF
--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -36,10 +36,6 @@ $jsdef render_excluded_works_list(works, total):
       margin: 0;
     }
 
-    details > summary {
-      font-size: 0.75em;
-    }
-
     .selected-works {
         position: sticky;
         bottom: 0;


### PR DESCRIPTION
…log_stats.html file which was causing the decrease in font size of the navbar items on the stats page

<!-- What issue does this PR close? -->
Closes #5766 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
NA

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Open the following page
http://localhost:8080/people/openlibrary/books/already-read/stats

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-10-19 23-07-48](https://user-images.githubusercontent.com/52305879/137963167-08c39091-1f51-44a0-b795-8f1948f3bec2.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 