### PR TITLE
allow deletion of contributors

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -566,6 +566,9 @@ class SaveBookHelper:
                 edition_data.translation_of = None
                 edition_data.translated_from = None
 
+            if 'contributors' not in edition_data:
+                self.edition.contributors = []
+
             self.edition.update(edition_data)
             saveutil.save(self.edition)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #143

Makes it so that contributors can be deleted. 

### Technical
<!-- What should be noted about the implementation? -->

Previously, when you removed all contributors the form didn't send any contributor data. Because no contributor data was sent there was no update to remove all the contributors.

Now, if no contributor data is sent it will remove the contributors. This creates the intended UX


I originally tried `del self.edition.contributors` instead of setting to an empty array.
However that and would give this error:

<details>
  <summary>Spoiler</summary>

Code
```
            if 'contributors' not in edition_data and self.edition.contributors:
                del self.edition.contributors
```

Error
  ```
           | Traceback (most recent call last):
openlibrary-web-1           |   File "/home/openlibrary/.pyenv/versions/3.9.4/lib/python3.9/site-packages/web/application.py", line 280, in process
openlibrary-web-1           |     return self.handle()
openlibrary-web-1           |   File "/home/openlibrary/.pyenv/versions/3.9.4/lib/python3.9/site-packages/web/application.py", line 271, in handle
openlibrary-web-1           |     return self._delegate(fn, self.fvars, args)
openlibrary-web-1           |   File "/home/openlibrary/.pyenv/versions/3.9.4/lib/python3.9/site-packages/web/application.py", line 517, in _delegate
openlibrary-web-1           |     return handle_class(cls)
openlibrary-web-1           |   File "/home/openlibrary/.pyenv/versions/3.9.4/lib/python3.9/site-packages/web/application.py", line 495, in handle_class
openlibrary-web-1           |     return tocall(*args)
openlibrary-web-1           |   File "/openlibrary/infogami/utils/app.py", line 200, in <lambda>
openlibrary-web-1           |     HEAD = GET = POST = PUT = DELETE = lambda self: delegate()
openlibrary-web-1           |   File "/openlibrary/infogami/utils/app.py", line 220, in delegate
openlibrary-web-1           |     return getattr(cls(), method)(*args)
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 797, in POST
openlibrary-web-1           |     helper.save(web.input())
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 570, in save
openlibrary-web-1           |     del self.edition.contributors
openlibrary-web-1           | AttributeError: contributors
openlibrary-web-1           | 

```
  
</details>


NOTE: This is technically a breaking change if anyone was sending automated requests as form data. However, they should be using the json api anyway and this brings the functionality more in line with what a save api should do. 


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Add a contributor to a work
2. Remove a contributor from a work

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->


https://user-images.githubusercontent.com/921217/137983828-5e92a37e-6201-42f0-8651-df0d9921a6e3.mp4



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
