### PR TITLE
Migrating partner lib from archive.org to Openlibrary APIs

### DIFF
--- a/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
+++ b/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
@@ -62,7 +62,7 @@ async function addOpenLibraryButtons(options) {
             const e = foundIsbnElementsMap[isbn]
             const buttons = selectorToPlaceBtnIn ? e.querySelector(selectorToPlaceBtnIn) : e;
             const openLibraryBtnLink = document.createElement('a')
-            openLibraryBtnLink.href = `https://openlibrary.org/borrow/ia/${availability.identifier}`
+            openLibraryBtnLink.href = `https://openlibrary.org/works/${availability.openlibrary_work}`
             openLibraryBtnLink.text = textOnBtn || 'Open Library'
             openLibraryBtnLink.classList.add('openlibrary-btn')
             buttons.append(openLibraryBtnLink);

--- a/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
+++ b/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
@@ -20,7 +20,7 @@ function getIsbnToElementMap(container) {
  */
 async function getAvailabilityDataFromOpenLibrary(isbnList) {
     const apiBaseUrl = 'https://openlibrary.org/search.json';
-    const apiUrl = `${apiBaseUrl}?fields=*,availability&q=isbn:${isbnList.join("+OR+")}`;
+    const apiUrl = `${apiBaseUrl}?fields=*,availability&q=isbn:${isbnList.join('+OR+')}`;
     const response = await fetch(apiUrl);
     const jsonResponse = await response.json();
     const olDocs = jsonResponse.docs;
@@ -28,7 +28,7 @@ async function getAvailabilityDataFromOpenLibrary(isbnList) {
     olDocs.forEach((doc) => {
         const isbnList = doc.isbn;
         isbnList.forEach((isbn) => {
-          isbnToAvailabilityDataMap[isbn] = doc?.availability;
+            isbnToAvailabilityDataMap[isbn] = doc?.availability;
         });
     });
     return isbnToAvailabilityDataMap;

--- a/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
+++ b/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
@@ -19,7 +19,7 @@ function getIsbnToElementMap(container) {
  * @returns {Promise<Array>}
  */
 async function getAvailabilityDataFromOpenLibrary(isbnList) {
-    const apiBaseUrl = "https://openlibrary.org/search.json";
+    const apiBaseUrl = 'https://openlibrary.org/search.json';
     const apiUrl = `${apiBaseUrl}?fields=*,availability&q=isbn:${isbnList.join("+OR+")}`;
     const response = await fetch(apiUrl);
     const jsonResponse = await response.json();

--- a/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
+++ b/openlibrary/plugins/openlibrary/js/partner_ol_lib.js
@@ -18,12 +18,20 @@ function getIsbnToElementMap(container) {
  * @param {string[]} isbnList
  * @returns {Promise<Array>}
  */
-async function getAvailabilityDataFromArchiveOrg(isbnList) {
-    const apiBaseUrl = 'https://archive.org/services/availability'
-    const apiUrl = `${apiBaseUrl}?isbn=${isbnList.join(',')}`;
+async function getAvailabilityDataFromOpenLibrary(isbnList) {
+    const apiBaseUrl = "https://openlibrary.org/search.json";
+    const apiUrl = `${apiBaseUrl}?fields=*,availability&q=isbn:${isbnList.join("+OR+")}`;
     const response = await fetch(apiUrl);
     const jsonResponse = await response.json();
-    return jsonResponse.responses;
+    const olDocs = jsonResponse.docs;
+    const isbnToAvailabilityDataMap = {};
+    olDocs.forEach((doc) => {
+        const isbnList = doc.isbn;
+        isbnList.forEach((isbn) => {
+          isbnToAvailabilityDataMap[isbn] = doc?.availability;
+        });
+    });
+    return isbnToAvailabilityDataMap;
 }
 
 /**
@@ -47,7 +55,7 @@ async function addOpenLibraryButtons(options) {
         )
     }
     const foundIsbnElementsMap = getIsbnToElementMap(bookContainer);
-    const availabilityResults = await getAvailabilityDataFromArchiveOrg(Object.keys(foundIsbnElementsMap))
+    const availabilityResults = await getAvailabilityDataFromOpenLibrary(Object.keys(foundIsbnElementsMap))
     Object.keys(foundIsbnElementsMap).map((isbn) => {
         const availability = availabilityResults[isbn]
         if (availability && availability.status !== 'error') {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5586 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Initially we were using archive.org APIs internally. This now switches them to use OpenLibraries APIs. 
- Instead of opening the borrow page of an edition directly like before, this changes it such that it opens the work page instead. From there, the edition to be borrowed can be picked by the patron. 

### Screenshot
Here is a sample from BWB (no styling etc..)
![image](https://user-images.githubusercontent.com/8049414/138546727-c05f9430-2df1-4ccd-8dce-0a524c2fec82.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 