### PR TITLE
DRAFT: Test http2 on Docker-base covers_nginx

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -67,8 +67,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
-    ports:
-      - 7000:7000
+    #ports:
+    #  - 7000:7000
     volumes:
       - ol-vendor:/openlibrary/vendor
       - .:/openlibrary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,34 @@ services:
         max-size: "512m"
         max-file: "4"
 
+  covers_nginx:
+    image: "${OLIMAGE:-oldev:latest}"
+    restart: unless-stopped
+    depends_on:
+      - covers
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
+      # Needed for HTTPS, since this is a public server
+#      - ../olsystem/etc/nginx/sites-available/default-docker.conf:/etc/nginx/sites-enabled/default:ro
+#      # Needs access to openlibrary for static files
+#      - ../olsystem:/olsystem
+#      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
+    ports:
+#     - 80:80
+      - 1234:443
+    networks:
+      - webnet
+    logging:
+      options:
+        max-size: "512m"
+        max-file: "4"
+#    secrets:
+#      - petabox_seed
+      # Needed by default-docker.conf
+#      - ssl_certificate
+#      - ssl_certificate_key
+
   infobase:
     image: "${OLIMAGE:-oldev:latest}"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
       # Needed for HTTPS, since this is a public server
-      - ./docker/default_nginx.conf:/etc/nginx/sites-enabled/default:ro
+      - ./docker/default_nginx.conf:/etc/nginx/sites-available/default:ro
 #      # Needs access to openlibrary for static files
 #      - ../olsystem:/olsystem
 #      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
         max-file: "4"
 
   covers_nginx:
-    image: "${OLIMAGE:-oldev:latest}"
+    image: nginx:1.19.4
     restart: unless-stopped
     depends_on:
       - covers
@@ -79,7 +79,7 @@ services:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
       # Needed for HTTPS, since this is a public server
-#      - ../olsystem/etc/nginx/sites-available/default-docker.conf:/etc/nginx/sites-enabled/default:ro
+      - ./docker/default_nginx.conf:/etc/nginx/sites-enabled/default:ro
 #      # Needs access to openlibrary for static files
 #      - ../olsystem:/olsystem
 #      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
@@ -92,11 +92,11 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
-#    secrets:
+    secrets:
 #      - petabox_seed
       # Needed by default-docker.conf
-#      - ssl_certificate
-#      - ssl_certificate_key
+      - ssl_certificate
+      - ssl_certificate_key
 
   infobase:
     image: "${OLIMAGE:-oldev:latest}"
@@ -114,6 +114,13 @@ services:
       options:
         max-size: "512m"
         max-file: "4"
+
+secrets:
+    # SSL-related secrets
+    ssl_certificate:
+      file: ./example.crt
+    ssl_certificate_key:
+      file: ./example.key
 
 networks:
   webnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
 #      - ../olsystem:/olsystem
 #      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
     ports:
-#     - 80:80
+      - 80:80
       - 1234:443
     networks:
       - webnet

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,9 +1,10 @@
 server {
+      include /etc/nginx/sites-available/default;
       #listen 80;
       #listen 443;
       #listen [::]:443 ssl http2 ipv6only=on;
       #listen 443 ssl http2;
-      server_name  covers.openlibrary.org;
+      server_name  x-covers.openlibrary.org;
 
       #include /run/secrets/petabox_seed;
       root /openlibrary;

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,5 +1,5 @@
 server {
-      #listen 80;
+      listen 80;
       #listen 443;
       listen [::]:443 ssl http2 ipv6only=on;
       listen 443 ssl http2;

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,9 +1,11 @@
 server {
-      listen 80;
-      listen 443;
+      #listen 80;
+      #listen 443;
+      listen [::]:443 ssl http2 ipv6only=on;
+      listen 443 ssl http2;
       server_name  covers.openlibrary.org;
 
-      include /run/secrets/petabox_seed;
+      #include /run/secrets/petabox_seed;
       root /openlibrary;
 
       keepalive_timeout 5;

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -10,6 +10,8 @@ server {
 
       keepalive_timeout 5;
 
+      ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+
       location / {
         proxy_pass http://covers:7075;
         proxy_set_header Host $http_host;

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,8 +1,8 @@
 server {
-      listen 80;
+      #listen 80;
       #listen 443;
-      listen [::]:443 ssl http2 ipv6only=on;
-      listen 443 ssl http2;
+      #listen [::]:443 ssl http2 ipv6only=on;
+      #listen 443 ssl http2;
       server_name  covers.openlibrary.org;
 
       #include /run/secrets/petabox_seed;
@@ -10,7 +10,7 @@ server {
 
       keepalive_timeout 5;
 
-      ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+      #ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
 
       location / {
         proxy_pass http://covers:7075;

--- a/docker/default_nginx.conf
+++ b/docker/default_nginx.conf
@@ -4,12 +4,12 @@
 # In the meantime, keeping here because if someone tries to make an improvements on
 # the openlibrary repo, we wouldn't be able to deploy it!
 
-server {
-    listen 80 default;
+#server {
+    #listen 80 default;
     listen [::]:443 ssl http2 ipv6only=on;
     listen 443 ssl http2;
 
-    server_name localhost;
+    #server_name localhost;
     # root /olsystem/www;
 
     ssl_certificate /run/secrets/ssl_certificate;
@@ -20,4 +20,4 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
     ssl_prefer_server_ciphers on;
-}
+#}

--- a/docker/default_nginx.conf
+++ b/docker/default_nginx.conf
@@ -1,0 +1,23 @@
+# TODO: Keep in sync with ./default until we're fully onto docker
+
+# TODO: Once this is used on all our prod infra, move this to the openlibrary repo.
+# In the meantime, keeping here because if someone tries to make an improvements on
+# the openlibrary repo, we wouldn't be able to deploy it!
+
+server {
+    listen 80 default;
+    listen [::]:443 ssl http2 ipv6only=on;
+    listen 443 ssl http2;
+
+    server_name localhost;
+    # root /olsystem/www;
+
+    ssl_certificate /run/secrets/ssl_certificate;
+    ssl_certificate_key /run/secrets/ssl_certificate_key;
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    # ssl_dhparam /olsystem/etc/nginx/dhparam-2048.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+    ssl_prefer_server_ciphers on;
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -25,8 +25,8 @@ http {
     server_names_hash_bucket_size   64;
     types_hash_bucket_size 64;
 
-    log_format iacombined '$seed$remote_addr $host $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_time';
-    access_log    /var/log/nginx/access.log iacombined;
+#    log_format iacombined '$seed$remote_addr $host $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_time';
+#    access_log    /var/log/nginx/access.log iacombined;
 
     client_max_body_size 50m;
 
@@ -42,7 +42,7 @@ http {
     gzip_types       text/plain text/css application/x-javascript application/xml;
 
     # Black-listed IPs
-    include /olsystem/etc/nginx/deny.conf;
+    # include /olsystem/etc/nginx/deny.conf;
 
     # Things are mounted into here by the docker-compose file
     include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #5418 
Blocked by #5840

Test http2 in Docker using covers_nginx.  This should allow FireFox to access `localhost:1234` and enable `curl -I -L localhost:1234` as discussed in https://www.digitalocean.com/community/tutorials/how-to-set-up-nginx-with-http-2-support-on-ubuntu-18-04

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->



### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
* Use FireFox to access `localhost:1234`
* Do `curl -I -L localhost:1234`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
