### PR TITLE
Show page banner on mobile

### DIFF
--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -6,16 +6,12 @@
 @import "less/breakpoints.less";
 
 .page-banner {
-  display: none;
+  display: block;
   color: @white;
   font-family: @lucida_sans_serif-1;
   background: @black;
   padding: 15px;
   border-bottom: 1px solid @beige;
-
-  @media screen and (min-width: @width-breakpoint-tablet) {
-    display: block;
-  }
 
   &-black {
     background-color: @dark-grey;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5799

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that page banners are displayed on smaller screens.

### Technical
<!-- What should be noted about the implementation? -->
Removed media query used to set the banner's `display`.  Banner display now always set to `block`, as banner is conditionally rendered in body.html.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Download this branch, and enable to banner by setting `announcement` equal to a string [here](https://github.com/internetarchive/openlibrary/blob/5f2bdefcd383b05444cc89d312632484ad04f78e/openlibrary/templates/site/body.html#L30).
2. Start the application and open localhost:8080
3. Ensure that the banner is present in desktop mode.
4. Switch to responsive design mode.
5. Ensure that the banner is still present.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![mobile_banner](https://user-images.githubusercontent.com/28732543/139133737-460588e5-2f9d-49d4-8b92-7c6456b81978.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
