### PR TITLE
Avoid XSS attacks by escaping HTML string

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -2,6 +2,7 @@ import { debounce } from './nonjquery_utils.js';
 import * as SearchUtils from './SearchUtils';
 import { PersistentValue } from './SearchUtils';
 import $ from 'jquery';
+import { websafe } from './jsdef'
 
 /** Mapping of search bar facets to search endpoints */
 const FACET_TO_ENDPOINT = {
@@ -29,7 +30,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
                 <a href="${work.key}">
                     <img src="//covers.openlibrary.org/b/id/${work.cover_i}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_book-sm.png" alt=""/>
                     <span class="book-desc">
-                        <div class="book-title">${work.title}</div> by <span class="book-author">${author_name}</span>
+                        <div class="book-title">${websafe(work.title)}</div> by <span class="book-author">${websafe(author_name)}</span>
                     </span>
                 </a>
             </li>`;
@@ -39,7 +40,7 @@ const RENDER_AUTOCOMPLETE_RESULT = {
             <li>
                 <a href="/authors/${author.key}">
                     <img src="//covers.openlibrary.org/a/olid/${author.key}-S.jpg?default=https://openlibrary.org/static/images/icons/avatar_author-lg.png" alt=""/>
-                    <span class="author-desc"><div class="author-name">${author.name}</div></span>
+                    <span class="author-desc"><div class="author-name">${websafe(author.name)}</div></span>
                 </a>
             </li>`;
     }

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -40,8 +40,8 @@ $code:
         return {
             "seed": seed,
             "type": seed_type,
-            "title": title,
-            "remove_dialog_html": _('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=title)
+            "title": websafe(title),
+            "remove_dialog_html": _('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=websafe(title))
         }
 
     def get_list_data(list, seed, include_cover_url=True):


### PR DESCRIPTION

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents some XSS attacks on search autocomplete and books pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
