### PR TITLE
fix(search): Enforce max width on search results container

### DIFF
--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -39,6 +39,7 @@
   }
   .details {
     display: inline;
+    overflow: hidden;
     width: 100%;
     padding: 5px;
     margin: 0;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1083,6 +1083,7 @@ div#searchResults ul {
 // openlibrary/templates/type/author/view.html
 // openlibrary/templates/work_search.html
 div#searchResults {
+  max-width: 100%;
   .SRPCover {
     margin: 0 15px 20px 0;
     vertical-align: middle;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5810

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
Sets max width of search results container and overflow on details container to ensure a string of unbroken characters for the title and/or author will not cause the search results details to exceed its container.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![Screen Shot 2021-11-01 at 8 51 13 PM](https://user-images.githubusercontent.com/39553/139769443-0f489d8e-4f2a-474e-a661-112b920932f6.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
