### PR TITLE
Fix /account/login.json not working

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -18,9 +18,6 @@ import math
 import infogami
 
 # make sure infogami.config.features is set
-from openlibrary.book_providers import get_book_provider, get_book_provider_by_name, \
-    get_cover_url
-
 if not hasattr(infogami.config, 'features'):
     infogami.config.features = []
 
@@ -931,6 +928,14 @@ def is_bot():
 
 
 def setup_template_globals():
+    # must be imported here, otherwise silently messes up infogami's import execution
+    # order, resulting in random errors like the the /account/login.json endpoint
+    # defined in accounts.py being ignored, and using the infogami endpoint instead.
+    from openlibrary.book_providers import (
+        get_book_provider,
+        get_book_provider_by_name,
+        get_cover_url,
+    )
     web.template.Template.globals.update({
         'next': next,
         'sorted': sorted,


### PR DESCRIPTION
The hypothesis is that because book_providers imports something important at the wrong time, it was causing the OL /account/login.json override to be registered at the wrong time, before infogami had setup its necessary hooks.

<!-- What issue does this PR close? -->
Closes #5815

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
```
curl -XPOST 'localhost:4444/account/login.json' -d '{"access": "***", "secret": "***"}'
```

Should return nothing; replace `localhost:4444` with whatever env you want to test.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
