### PR TITLE
Update Git submodule protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/infogami"]
 	path = vendor/infogami
-	url = git://github.com/internetarchive/infogami.git
+	url = https://github.com/internetarchive/infogami.git
 [submodule "vendor/js/wmd"]
 	path = vendor/js/wmd
-	url = git://github.com/internetarchive/wmd.git
+	url = https://github.com/internetarchive/wmd.git


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Our GitHub actions are failing on the `make git` step, due to the use of `git://` protocol in our submodules.  GitHub suggests using ssh or https in the future: https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting

### Technical
<!-- What should be noted about the implementation? -->
After this change, ol_home began throwing errors on start.  Rebuilding Docker corrected this issue, but there is probably a less extreme solution (maybe a recursive sync would work: `git submodule sync --recursive`).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
