### PR TITLE
Increasing limit for work deletion and use can_write instead of checking perms manually

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -493,7 +493,8 @@ class patron_observations(delegate.page):
 class work_delete(delegate.page):
     path = r"/works/(OL\d+W)/[^/]+/delete"
 
-    def get_editions_of_work(self, work: Work, limit: int = 10_000) -> list[dict]:
+    def get_editions_of_work(self, work: Work) -> list[dict]:
+        limit = 1_000  # This is the max limit of the things function
         keys: list = web.ctx.site.things({
             "type": "/type/edition",
             "works": work.key,

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -493,12 +493,20 @@ class patron_observations(delegate.page):
 class work_delete(delegate.page):
     path = r"/works/(OL\d+W)/[^/]+/delete"
 
-    def get_editions_of_work(self, work: Work, limit: int = 10000) -> list[dict]:
+    def get_editions_of_work(self, work: Work, limit: int = 10_000) -> list[dict]:
         keys: list = web.ctx.site.things({
             "type": "/type/edition",
             "works": work.key,
             "limit": limit
         })
+        if len(keys) == limit:
+            raise web.HTTPError(
+                '400 Bad Request',
+                data=json.dumps({
+                    'error': f'API can only delete {limit} editions per work',
+                }),
+                headers={"Content-Type": "application/json"},
+            )
         return web.ctx.site.get_many(keys, raw=True)
 
     def POST(self, work_id: str):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5820 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes sure the delete work endpoint deletes all the ediitons of the work

### Technical
<!-- What should be noted about the implementation? -->
One small technical note, the limit is arbitarily at 10000. I'm just trying to make sure we cover all editions.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 