### PR TITLE
Truncate book title when cover is missing

### DIFF
--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -19,7 +19,7 @@ $if size == "M":
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">
-                    <div class="BookTitle">$:macros.TruncateString(title, 70)
+                    <div class="BookTitle">$:macros.TruncateString(title, 30)
                         <div class="Author">$:macros.TruncateString(author_names, 30)</div>
                     </div>
                 </div>

--- a/openlibrary/templates/covers/book_cover.html
+++ b/openlibrary/templates/covers/book_cover.html
@@ -19,7 +19,7 @@ $if size == "M":
             </div>
             <div class="SRPCoverBlank" style="display: $cond(not cover_url, 'block', 'none');">
                 <div class="innerBorder">
-                    <div class="BookTitle">$:macros.TruncateString(title, 30)
+                    <div class="BookTitle">$:macros.TruncateString(title, 45)
                         <div class="Author">$:macros.TruncateString(author_names, 30)</div>
                     </div>
                 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5822

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Truncates the title of a book when the book has no cover image.

### Technical
<!-- What should be noted about the implementation? -->
Reduces the maximum length of a title string from 70 to 30 characters.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![truncated_title](https://user-images.githubusercontent.com/28732543/140423247-ee6193ea-fa05-42e0-8657-743ffdd2efb8.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@JeffKaplan @mekarpeles 
