### PR TITLE
Create Standard Ebooks import job

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ beautifulsoup4==4.9.3
 DBUtils==1.3
 Deprecated==1.2.12
 eventer==0.1.1
+feedparser==6.0.8
 flup-py3==1.0.3
 Genshi==0.7.5
 gunicorn==20.1.0

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -1,0 +1,152 @@
+import json
+from typing import Any, Dict, List, Optional
+import requests
+import sys
+import time
+
+import os.path as path
+
+import feedparser
+
+from openlibrary.core.imports import Batch
+
+sys.path.insert(0, path.abspath(path.join(path.sep, 'openlibrary')))
+from openlibrary.config import load_config
+load_config(
+        path.abspath(path.join(
+                    path.sep, 'olsystem', 'etc', 'openlibrary.yml')))
+from openlibrary.core.imports import Batch
+from infogami import config
+
+FEED_URL = 'https://standardebooks.org/opds/all'
+LAST_UPDATED_TIME = './out/standard_ebooks_last_updated.txt'
+
+
+def get_feed():
+    """Fetches and returns Standard Ebook's feed."""
+    r = requests.get(FEED_URL)
+    return feedparser.parse(r.text)
+
+
+def map_data(entry: Dict[str, Any]) -> Dict[str, str]:
+    """Maps Standard Ebooks feed entry to an Open Library import object."""
+    std_ebooks_id = entry.id.replace('https://standardebooks.org/ebooks/', '')
+    mapped_data = {
+        "title": entry.title,
+        "source_records": [f"standardebooks:{std_ebooks_id}"],
+        "publishers": [entry.publisher],
+        "publish_date": entry.dc_issued[0:4],
+        "authors": [{"name": author.name} for author in entry.authors],
+        "description": entry.content[0].value,
+        "subjects": [tag.term for tag in entry.tags],
+        "identifiers": {
+            "standard_ebooks": [std_ebooks_id]
+        }
+    }
+    return mapped_data
+
+
+def create_batch(records: List[Dict[str, str]]) -> None:
+    """Creates Standard Ebook batch import job.
+
+    Attempts to find existing Standard Ebooks import batch.
+    If nothing is found, a new batch is created. All of the 
+    given import records are added to the batch job as JSON strings.
+    """
+    now = time.gmtime(time.time())
+    batch_name = f'standardebooks-{now.tm_year}{now.tm_month}'
+    batch = Batch.find(batch_name) or Batch.new(batch_name)
+    batch.add_items([{'ia_id': r['source_records'][0], 'data': json.dumps(r)} for r in records])
+
+
+def get_last_updated_time() -> Optional[str]:
+    """Gets date of last import job.
+
+    Last updated dates are read from a local file.  If no
+    file exists, None is returned. Last updated date is
+    expected to be in HTTP-date format:
+    https://httpwg.org/specs/rfc7231.html#http.date
+
+    returns last updated date string or None
+    """
+    last_updated = None
+
+    if os.path.exists(LAST_UPDATED_TIME):
+        with open(LAST_UPDATED_TIME, 'r') as f:
+            last_updated = f.readline()
+
+    return last_updated
+
+
+def find_last_updated():
+    """Fetches and returns Standard Ebooks most recent update date.
+
+    Returns None if the last modified date is not included in the 
+    response headers.
+    """
+    r = requests.head(FEED_URL)
+    return r.headers['last-modified'] if r.ok else None
+
+
+def convert_date_string(date_string: str) -> time.struct_time:
+    """date_string will be formatted similarly to this:
+    Fri, 05 Nov 2021 03:50:24 GMT
+
+    returns datetime representation of the given time, or the earliest possible time if no time given.
+    """
+    if not date_string:
+        return time.gmtime(0)
+    return time.strptime(date_string[5:-4], '%d %b %Y %H:%M:%S')
+
+
+def map_entries(entries: List[Dict[str, Any]], modified_since: time.struct_time) -> List[str]:
+    """Returns a list of import objects."""
+    results = []
+    for e in entries:
+        if e.updated_parsed > modified_since:
+            results.append(map_data(e))
+
+    return results
+
+
+def import_job():
+    # Make HEAD request to get last-modified time
+    last_modified = find_last_updated()
+
+    if not last_modified:
+        print(f'HEAD request to {FEED_URL} failed. Not attempting GET request.')
+        return
+
+    print(f'Last-Modified date: {last_modified}')
+
+    updated_on = get_last_updated_time()
+    if last_modified == updated_on:
+        print(f'No new updates since {updated_on}. Processing completed.')
+        return
+
+    print(f'Last import job: {updated_on}')
+    # Get feed:
+    d = get_feed()
+
+    # Create datetime using updated_on:
+    modified_since = convert_date_string(updated_on)
+
+    # Map feed entries to list of import objects:
+    print(f'Importing all entries that have been updated since {modified_since}.')
+    mapped_entries = map_entries(d.entries, modified_since)
+    print(f'{len(mapped_entries)} import objects created.')
+
+    # Import all data:
+    create_batch(mapped_entries)
+    print(f'{len(mapped_entries)} entries added to the batch import job.')
+
+    # Store timestamp for header
+    with open(LAST_UPDATED_TIME, 'w') as f:
+        f.write(last_modified)
+        print(f'Last updated timestamp written to: {LAST_UPDATED_TIME}')
+
+
+if __name__ == '__main__':
+    print("Start: Standard Ebooks import job")
+    import_job()
+    print("End: Standard Ebooks import job")

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
+#! /usr/bin/env python
 import json
 import requests
 import sys
 import time
+from typing import Any, Dict, List, Optional
 
 import os.path as path
 
@@ -28,12 +28,12 @@ def get_feed():
     return feedparser.parse(r.text)
 
 
-def map_data(entry) -> dict:
+def map_data(entry) -> Dict[str, Any]:
     """Maps Standard Ebooks feed entry to an Open Library import object."""
     std_ebooks_id = entry.id.replace('https://standardebooks.org/ebooks/', '')
     return {
         "title": entry.title,
-        "source_records": [f"standardebooks:{std_ebooks_id}"],
+        "source_records": [f"standard_ebooks:{std_ebooks_id}"],
         "publishers": [entry.publisher],
         "publish_date": entry.dc_issued[0:4],
         "authors": [{"name": author.name} for author in entry.authors],
@@ -45,7 +45,7 @@ def map_data(entry) -> dict:
     }
 
 
-def create_batch(records: list[dict[str, str]]) -> None:
+def create_batch(records: List[Dict[str, str]]) -> None:
     """Creates Standard Ebook batch import job.
 
     Attempts to find existing Standard Ebooks import batch.
@@ -61,7 +61,7 @@ def create_batch(records: list[dict[str, str]]) -> None:
     )
 
 
-def get_last_updated_time() -> str | None:
+def get_last_updated_time() -> Optional[str]:
     """Gets date of last import job.
 
     Last updated dates are read from a local file.  If no
@@ -78,7 +78,7 @@ def get_last_updated_time() -> str | None:
     return None
 
 
-def find_last_updated() -> str | None:
+def find_last_updated() -> Optional[str]:
     """Fetches and returns Standard Ebooks most recent update date.
 
     Returns None if the last modified date is not included in the
@@ -88,7 +88,7 @@ def find_last_updated() -> str | None:
     return r.headers['last-modified'] if r.ok else None
 
 
-def convert_date_string(date_string: str | None) -> time.struct_time:
+def convert_date_string(date_string: Optional[str]) -> time.struct_time:
     """Converts HTTP-date format string into a struct_time object.
 
     The date_string will be formatted similarly to this:
@@ -118,7 +118,7 @@ def convert_date_string(date_string: str | None) -> time.struct_time:
 def filter_modified_since(
     entries,
     modified_since: time.struct_time
-):
+) -> List[Dict[str, str]]:
     """Returns a list of import objects."""
     return [map_data(e) for e in entries if e.updated_parsed > modified_since]
 

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -2,7 +2,7 @@
 import json
 import requests
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import os.path as path
 
@@ -23,7 +23,7 @@ def get_feed():
     return feedparser.parse(r.text)
 
 
-def map_data(entry) -> Dict[str, Any]:
+def map_data(entry) -> dict[str, Any]:
     """Maps Standard Ebooks feed entry to an Open Library import object."""
     std_ebooks_id = entry.id.replace('https://standardebooks.org/ebooks/', '')
     return {
@@ -40,7 +40,7 @@ def map_data(entry) -> Dict[str, Any]:
     }
 
 
-def create_batch(records: List[Dict[str, str]]) -> None:
+def create_batch(records: list[dict[str, str]]) -> None:
     """Creates Standard Ebook batch import job.
 
     Attempts to find existing Standard Ebooks import batch.
@@ -113,7 +113,7 @@ def convert_date_string(date_string: Optional[str]) -> time.struct_time:
 def filter_modified_since(
     entries,
     modified_since: time.struct_time
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Returns a list of import objects."""
     return [map_data(e) for e in entries if e.updated_parsed > modified_since]
 

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 import requests
 import sys
 import time
@@ -11,12 +11,11 @@ import feedparser
 from openlibrary.core.imports import Batch
 
 sys.path.insert(0, path.abspath(path.join(path.sep, 'openlibrary')))
-from openlibrary.config import load_config
+from openlibrary.config import load_config  # noqa: E402
 load_config(
-        path.abspath(path.join(
-                    path.sep, 'olsystem', 'etc', 'openlibrary.yml')))
-from openlibrary.core.imports import Batch
-from infogami import config
+    path.abspath(path.join(
+        path.sep, 'olsystem', 'etc', 'openlibrary.yml')))
+from infogami import config  # noqa: E402,F401
 
 FEED_URL = 'https://standardebooks.org/opds/all'
 LAST_UPDATED_TIME = './out/standard_ebooks_last_updated.txt'
@@ -28,7 +27,7 @@ def get_feed():
     return feedparser.parse(r.text)
 
 
-def map_data(entry: Dict[str, Any]) -> Dict[str, str]:
+def map_data(entry):
     """Maps Standard Ebooks feed entry to an Open Library import object."""
     std_ebooks_id = entry.id.replace('https://standardebooks.org/ebooks/', '')
     mapped_data = {
@@ -50,13 +49,16 @@ def create_batch(records: List[Dict[str, str]]) -> None:
     """Creates Standard Ebook batch import job.
 
     Attempts to find existing Standard Ebooks import batch.
-    If nothing is found, a new batch is created. All of the 
+    If nothing is found, a new batch is created. All of the
     given import records are added to the batch job as JSON strings.
     """
     now = time.gmtime(time.time())
-    batch_name = f'standardebooks-{now.tm_year}{now.tm_month}'
+    batch_name = f'standardebooks-{now.tm_year}{now.tm_mon}'
     batch = Batch.find(batch_name) or Batch.new(batch_name)
-    batch.add_items([{'ia_id': r['source_records'][0], 'data': json.dumps(r)} for r in records])
+    batch.add_items([{
+        'ia_id': r['source_records'][0],
+        'data': json.dumps(r)} for r in records]
+    )
 
 
 def get_last_updated_time() -> Optional[str]:
@@ -71,7 +73,7 @@ def get_last_updated_time() -> Optional[str]:
     """
     last_updated = None
 
-    if os.path.exists(LAST_UPDATED_TIME):
+    if path.exists(LAST_UPDATED_TIME):
         with open(LAST_UPDATED_TIME, 'r') as f:
             last_updated = f.readline()
 
@@ -81,7 +83,7 @@ def get_last_updated_time() -> Optional[str]:
 def find_last_updated():
     """Fetches and returns Standard Ebooks most recent update date.
 
-    Returns None if the last modified date is not included in the 
+    Returns None if the last modified date is not included in the
     response headers.
     """
     r = requests.head(FEED_URL)
@@ -92,14 +94,18 @@ def convert_date_string(date_string: str) -> time.struct_time:
     """date_string will be formatted similarly to this:
     Fri, 05 Nov 2021 03:50:24 GMT
 
-    returns datetime representation of the given time, or the earliest possible time if no time given.
+    returns datetime representation of the given time, or the earliest
+    possible time if no time given.
     """
     if not date_string:
         return time.gmtime(0)
     return time.strptime(date_string[5:-4], '%d %b %Y %H:%M:%S')
 
 
-def map_entries(entries: List[Dict[str, Any]], modified_since: time.struct_time) -> List[str]:
+def map_entries(
+    entries,
+    modified_since: time.struct_time
+):
     """Returns a list of import objects."""
     results = []
     for e in entries:

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -19,7 +19,7 @@ load_config(
 from infogami import config  # noqa: E402,F401
 
 FEED_URL = 'https://standardebooks.org/opds/all'
-LAST_UPDATED_TIME = './out/standard_ebooks_last_updated.txt'
+LAST_UPDATED_TIME = './standard_ebooks_last_updated.txt'
 
 
 def get_feed():
@@ -155,7 +155,7 @@ def import_job() -> None:
     print(f'{len(modified_entries)} entries added to the batch import job.')
 
     # Store timestamp for header
-    with open(LAST_UPDATED_TIME, 'w') as f:
+    with open(LAST_UPDATED_TIME, 'w+') as f:
         f.write(last_modified)
         print(f'Last updated timestamp written to: {LAST_UPDATED_TIME}')
 

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -96,6 +96,19 @@ def convert_date_string(date_string: str | None) -> time.struct_time:
 
     returns struct_time representation of the given time, or the
     epoch if no time given.
+
+    >>> str(convert_date_string(None)) # doctest: +NORMALIZE_WHITESPACE
+    'time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0,
+        tm_min=0, tm_sec=0, tm_wday=3, tm_yday=1, tm_isdst=0)'
+    
+    >>> convert_date_string("") # doctest: +ELLIPSIS
+    time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0, ...
+    
+    >>> convert_date_string(0) # doctest: +ELLIPSIS
+    time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0, ...
+    
+    >>> convert_date_string("Fri, 05 Nov 2021 03:50:24 GMT") # doctest: +ELLIPSIS
+    time.struct_time(tm_year=2021, tm_mon=11, tm_mday=5, tm_hour=3, tm_min=50, ...
     """
     if not date_string:
         return time.gmtime(0)

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -72,7 +72,7 @@ def get_last_updated_time() -> str | None:
     returns last updated date string or None
     """
     if path.exists(LAST_UPDATED_TIME):
-        with open(LAST_UPDATED_TIME, 'r') as f:
+        with open(LAST_UPDATED_TIME) as f:
             return f.readline()
 
     return None
@@ -100,13 +100,13 @@ def convert_date_string(date_string: str | None) -> time.struct_time:
     >>> str(convert_date_string(None)) # doctest: +NORMALIZE_WHITESPACE
     'time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0,
         tm_min=0, tm_sec=0, tm_wday=3, tm_yday=1, tm_isdst=0)'
-    
+
     >>> convert_date_string("") # doctest: +ELLIPSIS
     time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0, ...
-    
+
     >>> convert_date_string(0) # doctest: +ELLIPSIS
     time.struct_time(tm_year=1970, tm_mon=1, tm_mday=1, tm_hour=0, ...
-    
+
     >>> convert_date_string("Fri, 05 Nov 2021 03:50:24 GMT") # doctest: +ELLIPSIS
     time.struct_time(tm_year=2021, tm_mon=11, tm_mday=5, tm_hour=3, tm_min=50, ...
     """

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -115,7 +115,7 @@ def convert_date_string(date_string: str | None) -> time.struct_time:
     return time.strptime(date_string[5:-4], '%d %b %Y %H:%M:%S')
 
 
-def map_entries(
+def filter_modified_since(
     entries,
     modified_since: time.struct_time
 ):
@@ -147,12 +147,12 @@ def import_job() -> None:
 
     # Map feed entries to list of import objects:
     print(f'Importing all entries that have been updated since {modified_since}.')
-    mapped_entries = map_entries(d.entries, modified_since)
-    print(f'{len(mapped_entries)} import objects created.')
+    modified_entries = filter_modified_since(d.entries, modified_since)
+    print(f'{len(modified_entries)} import objects created.')
 
     # Import all data:
-    create_batch(mapped_entries)
-    print(f'{len(mapped_entries)} entries added to the batch import job.')
+    create_batch(modified_entries)
+    print(f'{len(modified_entries)} entries added to the batch import job.')
 
     # Store timestamp for header
     with open(LAST_UPDATED_TIME, 'w') as f:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3982

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates a Standard Ebooks (SE) import flow.  Flow is as follows:

1. Make HEAD request to SE, capturing the last modified date.
2. Read time that job was last executed from local file.
3. If SE feed was modified after the last import job was executed, make GET request for SE feed.
4. For each feed entry that was updated after that last import job, map entry to OL import object.
5. Add JSON string representations of import objects to a new batch job.

### Technical
<!-- What should be noted about the implementation? -->
This solution has a dependency on [feedparser](https://pypi.org/project/feedparser/).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini 
