### PR TITLE
fix pre-commit hook for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
-# To enable this pre-commit hook (in this case, pre-push hook), run:
+# To enable this pre-commit hook run:
 # `python3 -m pip install pre-commit` or `brew install pre-commit`
+# Then run `pre-commit install`
 
 # Learn more about this config here: https://pre-commit.com/
 default_language_version:
   python: python3.9
-default_stages: [push]
+
 repos:
   - repo: local
     hooks:
@@ -12,5 +13,5 @@ repos:
         name: make lint-diff
         # Running git inside docker is slow for some reason, so do that outside and pipe
         # the results into docker.
-        entry: git diff master -U0 | docker-compose run --rm home ./scripts/flake8-diff.sh
-        language: script
+        entry: bash -c 'git diff master -U0 | docker-compose run --rm home ./scripts/flake8-diff.sh'
+        language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # To enable this pre-commit hook run:
-# `python3 -m pip install pre-commit` or `brew install pre-commit`
+# `pip install pre-commit` or `brew install pre-commit`
 # Then run `pre-commit install`
 
 # Learn more about this config here: https://pre-commit.com/


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Relates to #5843 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Before this, the pre-commit hook was setup to only run on push and when it did run it gave the following error:
```Executable `/Users/ray/workspace/openlibrary/git` not found```

### Technical
<!-- What should be noted about the implementation? -->
I changed the language to `system` because that's what worked. There may be a case to use `script` language but it was giving me problems  so if you can fix it please do.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try running `pre-commt install` and committing code with extra spaces or something.


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @cclauss @jimman2003 
