### PR TITLE
GitHub Action to run pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,13 @@
+# https://github.com/pre-commit/action
+name: pre-commit
+on:
+  pull_request:
+  push:
+    branches: [master]
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,4 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - uses: pre-commit/action@v2.0.3


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #5843
Blocked by #5870
Now that we have a pre-commit that runs fast, let's add a GitHub Action that runs it in parallel with our existing JavaScript and Python GitHub Actions.  Running this action assures that PRs that are created via the GitHub web UI or other means are tested with the same test that command-line developers use.  This could either be a standalone file (this PR) or these commands could be added as a parallel job in the Python Action.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
___Fails___ because running flake8 inside a Docker container has its downsides.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
