### PR TITLE
Precommit hooks for gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,6 @@ tasks:
   # run chown because https://github.com/gitpod-io/gitpod/issues/4851
   before: sudo chown -R gitpod:999 /workspace/openlibrary/
   # init runs once for each commit to the default branch
-  init: docker-compose up --no-start
+  init: docker-compose up --no-start && pyenv install && pip install pre-commit && pre-commit install
   # command runs each time a user starts their workspace
   command: docker-compose up


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #5843

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Precommit hooks will be setup automatically for gitpod environments.

This is ONLY to get precommit hooks setup. Autoformatting code on save will be a different PR.

### Technical
<!-- What should be noted about the implementation? -->
* `pyenv install` installs the version in `.python-version` as that's what's needed.
* `pip install pre-commit` will install precommit to the local environment (since it doesn't run from inside docker).
* `pre-commit install` actually installs the hooks.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
You can test it out here: https://gitpod.io/#https://github.com/internetarchive/openlibrary/pull/5851

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @cdrini 
