### PR TITLE
http2 for public facing nginx

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -65,7 +65,7 @@ services:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./docker/covers_nginx.conf:/etc/nginx/sites-enabled/covers_nginx.conf:ro
       # Needed for HTTPS, since this is a public server
-      - ../olsystem/etc/nginx/sites-available/default-docker.conf:/etc/nginx/sites-enabled/default:ro
+      - ./docker/public_nginx.conf:/etc/nginx/sites-available/public_nginx.conf:ro
       # Needs access to openlibrary for static files
       - ../olsystem:/olsystem
       - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
@@ -80,7 +80,7 @@ services:
         max-file: "4"
     secrets:
       - petabox_seed
-      # Needed by default-docker.conf
+      # Needed by public_nginx.conf
       - ssl_certificate
       - ssl_certificate_key
 

--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,6 +1,5 @@
 server {
-      listen 80;
-      listen 443;
+      include /etc/nginx/sites-available/public_nginx.conf;
       server_name  covers.openlibrary.org;
 
       include /run/secrets/petabox_seed;

--- a/docker/public_nginx.conf
+++ b/docker/public_nginx.conf
@@ -1,0 +1,19 @@
+# TODO: Keep in ~ sync with olsystem/etc/nginx/sites-available/defaults until we're fully onto Docker
+
+# Sets up HTTP2 listening on 443 with ssl_protocols and ssl_ciphers.
+# Should be used for all public facing Nginx instances.
+
+#server {
+    listen 80 default;
+    listen [::]:443 ssl http2 ipv6only=on;
+    listen 443 ssl http2;
+
+    ssl_certificate /run/secrets/ssl_certificate;
+    ssl_certificate_key /run/secrets/ssl_certificate_key;
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    ssl_dhparam /olsystem/etc/nginx/dhparam-2048.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+    ssl_prefer_server_ciphers on;
+#}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5789 with a more slimmed-down version.

Blocked by #5840
* `public_nginx.conf` is configuration for public-facing Docker-based Nginx nodes.  Content was formerly in OLSystem.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
