### PR TITLE
Make category images on homepage lazy

### DIFF
--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -18,6 +18,7 @@ $if subjects:
               <div class="category-icon">
                 <img class="category-img" src="/static/images/categories/$(icon).svg"
                     width="30" height="30"
+                    loading="lazy"
                     alt="$_('browse %(subject)s books', subject=presentable_subject_name)"/>
               </div>
               <p class="category-title">$presentable_subject_name</p>


### PR DESCRIPTION
These are loading really early in the page, despite being at the bottom!

![image](https://user-images.githubusercontent.com/6251786/141217798-d6f1d5b1-b614-4fb2-aef9-14e3de2a651c.png)


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Don't appear in networks panel anymore on first load!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
