### PR TITLE
[libraryexplorer] Remove individual page count fetches; now in solr!

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
+++ b/openlibrary/components/LibraryExplorer/components/BookCover3D.vue
@@ -22,7 +22,6 @@
 </template>
 
 <script>
-import CONFIGS from '../configs';
 import CSSBox from './CSSBox';
 import FlatBookCover from './FlatBookCover';
 import { hashCode } from '../utils.js';
@@ -43,8 +42,6 @@ export default {
             default: 50
         },
         book: Object,
-        fetchCoordinator: Object,
-        containerIntersectionRatio: Number,
         /** @type {'image' | 'text'} */
         cover: String,
     },
@@ -53,40 +50,13 @@ export default {
         return {
             finalWidth: this.width,
             finalHeight: this.height,
-            finalThickness: this.thickness
+            finalThickness: this.book.number_of_pages_median ? Math.min(50, this.book.number_of_pages_median / 10) : this.thickness,
         };
     },
     methods: {
         updateWithImageMetadata(e) {
             this.finalHeight = e.target.height;
         },
-        async fetchBookLength(work_key) {
-            const url = `${CONFIGS.OL_BASE_SEARCH}/query.json?${new URLSearchParams({
-                type: '/type/edition',
-                works: work_key,
-                number_of_pages: '',
-                limit: 5
-            })}`;
-            const fetch = this.fetchCoordinator ?
-                this.fetchCoordinator.fetch.bind(this.fetchCoordinator, {priority: () => this.containerIntersectionRatio, name: `cover ${work_key}`}) :
-                fetch;
-            const results = await fetch(url, { cache: 'force-cache' }).then(r =>
-                r.json()
-            );
-            const lengths = results
-                .filter(ed => ed.number_of_pages)
-                .map(ed => ed.number_of_pages);
-            if (lengths.length) {
-                return lengths[0];
-            }
-        }
-    },
-
-    async mounted() {
-        const length = await this.fetchBookLength(this.book.key);
-        if (length) {
-            this.finalThickness = Math.min(50, length / 10);
-        }
     },
 
     computed: {

--- a/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
+++ b/openlibrary/components/LibraryExplorer/components/OLCarousel.vue
@@ -205,7 +205,7 @@ export default {
                 offset,
                 limit: this.limit,
                 sort: this.sort,
-                fields: 'key,title,author_name,cover_i,ddc,lcc,lending_edition_s,first_publish_year,edition_count',
+                fields: 'key,title,author_name,cover_i,ddc,lcc,lending_edition_s,first_publish_year,edition_count,number_of_pages_median',
             });
 
             const url = `${CONFIGS.OL_BASE_SEARCH}/search.json?${params.toString()}`;

--- a/openlibrary/components/LibraryExplorer/components/Shelf.vue
+++ b/openlibrary/components/LibraryExplorer/components/Shelf.vue
@@ -29,7 +29,6 @@
 
     <OLCarousel
       class="shelf-carousel"
-      ref="olCarousel"
       :data-short="
         node.children && node.position != 'root'
           ? node.children[node.position].short
@@ -64,8 +63,6 @@
         <BookCover3D
             v-if="features.book3d"
             :width="150" :height="200" :thickness="50" :book="book"
-            :fetchCoordinator="fetchCoordinator"
-            :containerIntersectionRatio="$refs.olCarousel.intersectionRatio"
             :cover="features.cover"
         />
         <FlatBookCover v-else :book="book" :cover="features.cover" />


### PR DESCRIPTION
This removes a ton of fetches and complexity!

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] https://testing.openlibrary.org/explore Ensure books still show thickness when (settings > 3d), but now it no longer takes time to come in! Also no `query.json` requests in the networks panel.

### Screenshot
Here's how many requests we made in books 3d to get this information _before_...
![image](https://user-images.githubusercontent.com/6251786/141393036-83598c18-064c-4eb8-909d-b8467d80f9eb.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
