### PR TITLE
add setup_gitpod.sh to prepare for pre-commit hooks

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,6 @@ tasks:
   # run chown because https://github.com/gitpod-io/gitpod/issues/4851
   before: sudo chown -R gitpod:999 /workspace/openlibrary/
   # init runs once for each commit to the default branch
-  init: docker-compose up --no-start && pyenv install && pip install pre-commit && pre-commit install
+  init: ./scripts/setup_gitpod.sh
   # command runs each time a user starts their workspace
   command: docker-compose up

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -9,3 +9,4 @@ pyenv install
 pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
 env PIP_USER=false pre-commit install
+env PIP_USER=false pre-commit run

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script does the setup needed for gitpod
+
+# Builds the docker images so when user opens env this step is cached
+docker-compose up --no-start
+
+# Setup pre-commit hooks
+pyenv install
+pip install pre-commit
+# PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
+env PIP_USER=false pre-commit install

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # This script does the setup needed for gitpod
 
-# Builds the docker images so when user opens env this step is cached
-docker-compose up --no-start
-
 # Setup pre-commit hooks
 pyenv install
 pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
 env PIP_USER=false pre-commit install
 env PIP_USER=false pre-commit run
+
+# Builds the docker images so when user opens env this step is cached.
+# We do this last because it occasionally fails on gitpod
+docker-compose up --no-start


### PR DESCRIPTION
In testing https://github.com/internetarchive/openlibrary/pull/5849 I realized that we needed to make some changes to the gitpod init step so that it will work with pre-commit hooks that require external libraries.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
I decided to make it into a `.sh` file now to not have to worry about having the yaml formatted just right and have nice comments and ide linting for the script. 

I expect this script to grow as do do things like fix https://github.com/internetarchive/openlibrary/issues/5834

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
There isn't much to test here other then that pre-commit hooks still work. This is mostly important for #5849 which not work in gitpod until this is added.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss @cdrini 