### PR TITLE
pre-commit: Run flake8-diff.sh outside of Docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,9 @@ repos:
     hooks:
       - id: make-lint-diff
         name: make lint-diff
-        # Running git inside docker is slow for some reason, so do that outside and pipe
-        # the results into docker.
-        entry: bash -c 'git diff master -U0 | docker-compose run --rm home ./scripts/flake8-diff.sh'
+        entry: bash -c 'git diff master -U0 | ./scripts/flake8-diff.sh'
         language: system
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
       - id: make-lint-diff
         name: make lint-diff
         entry: bash -c 'git diff master -U0 | ./scripts/flake8-diff.sh'
-        language: system
+        language: python
+        additional_dependencies:
+          - flake8
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Let's speed up our pre-commit jobs.  As discussed at https://github.com/internetarchive/openlibrary/pull/5849#issuecomment-968516899 running flake8 inside Docker is way too slow for a pre-commit job.  This PR enables pre-commit to run `scripts/flake8-diff.sh` in the local directory which completes quickly and finds all the same issues.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
Edit any Python file in the repo and create an _undefined name_ (`test = this_thing_that_does_not_exist`) and commit that change.  Pre-commit should fail on a flake8 `F821 undefined name`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
