### PR TITLE
run pyenv install in background for gitpod

### DIFF
--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -2,11 +2,14 @@
 # This script does the setup needed for gitpod
 
 # Setup pre-commit hooks
-pyenv install
-pip install pre-commit
-# PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
-env PIP_USER=false pre-commit install
-env PIP_USER=false pre-commit run
+# This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
+{
+    pyenv install
+    pip install pre-commit
+    # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
+    env PIP_USER=false pre-commit install
+    env PIP_USER=false pre-commit run
+} &
 
 # Builds the docker images so when user opens env this step is cached.
 # We do this last because it occasionally fails on gitpod

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -3,6 +3,7 @@
 
 # Setup pre-commit hooks
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
+# A downside is that progress messages from docker and pre-commit may be mixed together.
 {
     pyenv install
     pip install pre-commit


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It takes over 1 minute for `pyenv install` to run on gitpod.

This change will make it so the pyenv install can happen in the background while docker starts building images.

This will cut ~1 minute off the init time for gitpod.

### Technical
<!-- What should be noted about the implementation? -->
The syntax used is explained [here](https://stackoverflow.com/a/14612605/620699).

The downside to this is that the print statements for docker and the pre-commit stuff will be mixed together. Don't think it's worth trying to fix that.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Open this PR in gitpod and see it start in background and finish successfully. 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
