### PR TITLE
Make solr-updater --no-solr-next explicit

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -172,9 +172,11 @@ services:
     secrets:
       - ia_db_pw_file
 
-  # This will replace solr-updater once we fully migrate to solr8
+  # solr-updater running for the "next" version of solr we will deploy
   solr-next-updater:
-    profiles: ["ol-home0"]
+    # Set it to something so that it never starts by default ; we have to
+    # explicitly start it (usually only when a solr reindex project is in progress)
+    profiles: ["ol-never"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: unless-stopped
     hostname: "$HOSTNAME"

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -603,10 +603,9 @@ class SolrProcessor:
             add_list('publish_year', pub_years)
             add('first_publish_year', min(int(y) for y in pub_years))
 
-        if get_solr_next():
-            number_of_pages_median = pick_number_of_pages_median(editions)
-            if number_of_pages_median:
-                add('number_of_pages_median', number_of_pages_median)
+        number_of_pages_median = pick_number_of_pages_median(editions)
+        if number_of_pages_median:
+            add('number_of_pages_median', number_of_pages_median)
 
         field_map = [
             ('lccn', 'lccn'),
@@ -1699,7 +1698,7 @@ def main(
     profile=False,
     data_provider: Literal['default', 'legacy', 'external'] = "default",
     solr_base: str = None,
-    solr_next=True,
+    solr_next=False,
     update: Literal['update', 'print'] = 'update',
 ):
     """

--- a/scripts/new-solr-updater.py
+++ b/scripts/new-solr-updater.py
@@ -251,7 +251,7 @@ def main(
     exclude_edits_containing: str = None,
     ol_url='http://openlibrary.org/',
     solr_url: str = None,
-    solr_next=True,
+    solr_next=False,
     socket_timeout=10,
     load_ia_scans=False,
     commit=True,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5502

Now that the next version of solr has been cemented into production, we update solr-next. What was solr-next before, is now just normal solr, and the next solr-next has to be primed :) 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
