### PR TITLE
Pre-commit: Add end_of_file_fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v4.0.1
     hooks:
       - id: check-yaml
-      # - id: end-of-file-fixer
+      - id: end-of-file-fixer
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         args:
@@ -38,7 +38,7 @@ repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
-      - id: codespell  # See setup.cfg for args
+      - id: codespell  # See setup.cfg for arguments.
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.910-1'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Subtask of #5843

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Pre-commit: Add [end_of_file_fixer](https://github.com/pre-commit/pre-commit-hooks#end-of-file-fixer) to ensure that files end with one and only one carriage return (\n).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
