### PR TITLE
Only run javascript CI when javascript changed

### DIFF
--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -4,6 +4,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths: [ '**.json', '**.js', '**.vue', '**.less', '**.css', 'vendor/js/**' ]
 jobs:
   javascript_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    paths: [ '**.json', '**.js', '**.vue', '**.less', '**.css', 'vendor/js/**' ]
+    paths: [ '**.json', '**.js', '**.vue', '**.less', '**.css', 'vendor/js/**', '.github/workflows/javascript_tests.yml' ]
 jobs:
   javascript_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -4,7 +4,15 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    paths: [ '**.json', '**.js', '**.vue', '**.less', '**.css', 'vendor/js/**', '.github/workflows/javascript_tests.yml' ]
+    paths:
+      - 'Makefile'
+      - '.github/workflows/javascript_tests.yml'
+      - 'vendor/js/**'
+      - '**.json'
+      - '**.js'
+      - '**.vue'
+      - '**.less'
+      - '**.css'
 jobs:
   javascript_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
These tests are a little slow, and are more often than not, not necessary for a lot of PRs!

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
- Note this is only for PRs ; merging in to master will always run JS tests.

### Testing
- [x] Note JS tests didn't run in first commit
- [x] Ran after adding the workflow file to the path list.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jimchamp @cclauss 
