### PR TITLE
Use correct media query for my books page

### DIFF
--- a/static/css/components/mybooks.less
+++ b/static/css/components/mybooks.less
@@ -8,14 +8,14 @@
 // Layout
 .mybooks {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   border-top: 0;
   margin-top: 0;
   font-size: .9em;
 }
-@media only screen and (min-width: @width-breakpoint-tablet) {
+@media only screen and (max-width: @width-breakpoint-tablet) {
   .mybooks {
-    flex-direction: row;
+    flex-direction: column;
   }
 }
 @import (less) "components/mybooks-list.less";


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5876

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that my books page renders properly on iPad Minis.

### Technical
<!-- What should be noted about the implementation? -->
Media query for changing flow direction was different than the query for adjusting the sidebar's width, causing issues when the screen is exactly 768px wide.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ipad_mini](https://user-images.githubusercontent.com/28732543/142321967-ae804672-049b-4f7c-b20f-c3715de169f1.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
