### PR TITLE
Expose endpoint for works' observations

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -454,10 +454,10 @@ class price_api(delegate.page):
 
 
 class patrons_observations(delegate.page):
-    """"
+    """
     Fetches a patron's observations for a work, requires auth, intended
     to be used internally to power the My Books Page & books pages modal
-    """"
+    """
     path = r"/works/OL(\d+)W/observations"
     encoding = "json"
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -519,7 +519,7 @@ class patrons_observations(delegate.page):
 class public_observations(delegate.page):
     """
     Public observations fetches anonymized community reviews
-    for a list of works. Useful for decorating search results. 
+    for a list of works. Useful for decorating search results.
     """
     path = '/observations'
     encoding = 'json'

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -513,6 +513,10 @@ class internal_observations(delegate.page):
 
 
 class public_observations(delegate.page):
+    """"
+    Public observations fetches anonymized community reviews
+    for a list of works. Useful for decorating search results. 
+    """"
     path = '/observations'
     encoding = 'json'
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -453,7 +453,11 @@ class price_api(delegate.page):
         return json.dumps(metadata)
 
 
-class internal_observations(delegate.page):
+class patrons_observations(delegate.page):
+    """"
+    Fetches a patron's observations for a work, requires auth, intended
+    to be used internally to power the My Books Page & books pages modal
+    """"
     path = r"/works/OL(\d+)W/observations"
     encoding = "json"
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -21,7 +21,7 @@ from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.core import ia, db, models, lending, helpers as h
-from openlibrary.core.observations import Observations
+from openlibrary.core.observations import Observations, get_observation_metrics
 from openlibrary.core.models import Booknotes, Work
 from openlibrary.core.sponsorships import qualifies_for_sponsorship
 from openlibrary.core.vendors import (
@@ -453,7 +453,7 @@ class price_api(delegate.page):
         return json.dumps(metadata)
 
 
-class patron_observations(delegate.page):
+class internal_observations(delegate.page):
     path = r"/works/OL(\d+)W/observations"
     encoding = "json"
 
@@ -510,6 +510,21 @@ class patron_observations(delegate.page):
             )
 
         return response('Observations removed')
+
+
+class public_observations(delegate.page):
+    path = '/observations'
+    encoding = 'json'
+
+    def GET(self):
+        i = web.input(olid=[])
+        works = i.olid
+        metrics = {w: get_observation_metrics(w) for w in works}
+
+        return delegate.RawText(
+            json.dumps({'observations': metrics}),
+            content_type='application/json'
+        )
 
 
 class work_delete(delegate.page):

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -517,10 +517,10 @@ class patrons_observations(delegate.page):
 
 
 class public_observations(delegate.page):
-    """"
+    """
     Public observations fetches anonymized community reviews
     for a list of works. Useful for decorating search results. 
-    """"
+    """
     path = '/observations'
     encoding = 'json'
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In support of The Best Book On, this PR creates a `/observations` GET endpoint which can be used to fetch observation data for a list of works.

### Technical
<!-- What should be noted about the implementation? -->
Work OLIDs are expected to be sent via query string.  `openlibrary.org/observations?olid=OL123W&olid=OL456W` would fetch observation data for works OL123W and OL456W.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This can be tested by making GET requests to `/observations`.  Ensure that the `Accept` header is set to `application/json` when making the requests.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 