### PR TITLE
Change old publish year sort request

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -116,7 +116,7 @@ FIELD_NAME_MAP = {
 }
 SORTS = {
     'editions': 'edition_count desc',
-    'old': 'first_publish_year asc',
+    'old': 'def(first_publish_year, 9999) asc',
     'new': 'first_publish_year desc',
     'scans': 'ia_count desc',
     # Classifications


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4673

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix book search sort. When work has no publish date and search result sorted by first published, work is sorted last.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Load books with and without publish date.
Search for these books and osrt by `First Published`.
Books without publish date should be displayed as last results.

I've used these OL books with no publish date for my testing:
- /books/OL13633902M
- /books/OL17326159M
- /books/OL17193542M

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
