### PR TITLE
Fix readable edition not selected when visiting work page

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -187,11 +187,12 @@ def get_book_provider_by_name(short_name: str) -> Optional[AbstractBookProvider]
     return next((p for p in PROVIDER_ORDER if p.short_name == short_name), None)
 
 
+ia_provider = cast(InternetArchiveProvider, get_book_provider_by_name('ia'))
+prefer_ia_provider_order = uniq([ia_provider, *PROVIDER_ORDER])
+
+
 def get_provider_order(prefer_ia=False) -> list[AbstractBookProvider]:
-    default_order = PROVIDER_ORDER
-    if prefer_ia:
-        ia_provider = cast(InternetArchiveProvider, get_book_provider_by_name('ia'))
-        default_order = uniq([ia_provider, *PROVIDER_ORDER])
+    default_order = prefer_ia_provider_order if prefer_ia else PROVIDER_ORDER
 
     provider_order = default_order
     provider_overrides = web.input(providerPref=None).providerPref
@@ -225,7 +226,6 @@ def get_book_provider(
     # OCAIDs that look like they're from other providers.
     prefer_ia = not isinstance(ed_or_solr, Edition)
     if prefer_ia:
-        ia_provider = cast(InternetArchiveProvider, get_book_provider_by_name('ia'))
         ia_ocaids = [
             ocaid
             # Subjects/publisher pages have ia set to a specific value :/

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1077,6 +1077,7 @@ def setup_template_globals():
     # order, resulting in random errors like the the /account/login.json endpoint
     # defined in accounts.py being ignored, and using the infogami endpoint instead.
     from openlibrary.book_providers import (
+        get_best_edition,
         get_book_provider,
         get_book_provider_by_name,
         get_cover_url,
@@ -1096,6 +1097,7 @@ def setup_template_globals():
             'random': random.Random(),
             'get_lang': lambda: web.ctx.lang,
             'ceil': math.ceil,
+            'get_best_edition': get_best_edition,
             'get_book_provider': get_book_provider,
             'get_book_provider_by_name': get_book_provider_by_name,
             'get_cover_url': get_cover_url,

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -46,6 +46,8 @@ $elif editions:
       $ [selected_provider, selected_id] = ['ia', query_param('edition')]
     $ provider = get_book_provider_by_name(selected_provider)
     $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), edition)
+  $else:
+    $ edition, provider = get_best_edition(editions)
 
 $ ocaid = edition.get('ocaid')
 $ book_title = edition.get('title', '') or (work.title if work else '')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5802

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
- This approach is a little over-engineered, but I'm hoping it'll let us easily expand to things like preferring english works for english users, once we get that infra.

### Testing

Would recommend pulling down #5907 for testing locally ; simplifies it a ton since that let's you copy an entire work (with editions)!

- Aliens book from issue now selects IA edition:  https://openlibrary.org/works/OL102584W
- providerPref now respected: `/works/OL252350W/The_Cave_in_the_Mountain?providerPref=gutenberg`
- Books with no readable editions not broken
- Books with _many_ editions not too slow
    - There's a lot of sorting-y stuff happening!
    - Imported ~920 editions of hamlet ; added about 0.42 seconds to the load :/ That's non-trivial, but the page already takes ~4s, so considering that ok for now. Will check on testing as well.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
