### PR TITLE
Add entire work with copydocs.py

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -112,10 +112,10 @@ class OpenLibrary:
         response = self._request(key + '.json', params={'v': v} if v else {})
         return unmarshal(response.json())
 
-    def get_many(self, keys, max_length = 500):
+    def get_many(self, keys):
         """Get multiple documents in a single request as a dictionary.
         """
-        if len(keys) > max_length:
+        if len(keys) > 100:
             # Process in batches to avoid crossing the URL length limit.
             d = {}
             for chunk in web.group(keys, 100):

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -247,7 +247,7 @@ def copy(
         cache = {}
 
     def get_many(keys):
-        docs = marshal(src.get_many(keys, max_length = 100).values())
+        docs = marshal(src.get_many(keys).values())
         # work records may contain excerpts, which reference the author of the excerpt.
         # Deleting them to prevent loading the users.
         for doc in docs:


### PR DESCRIPTION
Makes it so that by default, when a work ID is specified, all its editions are also copied over.

### Technical
- Also made it more resilient to partial errors, so one bad apple doesn't spoil the batch. We should create a new issue to discover why some of the batches are failing -- and maybe to make infobase give a better error than "Unable to connect to infobase server" :/

### Testing
```sh
./scripts/copydocs.py /works/OL102584W
# All 10 editions copied

./scripts/copydocs.py /works/OL9170454W
# Most of the 1000 editions copied ; some errored, but the whole batch wasn't abandoned.
```

TODO: Test some non-work things ; maybe also test `--no-editions` ? Does OptionParse define that?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jimchamp 
