### PR TITLE
Draft: http2 for public facing infobase nginx

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -125,7 +125,7 @@ services:
       - infobase
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./docker/infobase_nginx.conf:/etc/nginx/sites-enabled/infobase_nginx.conf:ro
+      - ./docker/infobase_nginx.conf:/etc/nginx/sites-available/public_nginx.conf:ro
       # Needs olsystem for black-listed IPs
       - ../olsystem:/olsystem
     ports:
@@ -134,6 +134,9 @@ services:
       - webnet
     secrets:
       - petabox_seed
+      # Needed by public_nginx.conf
+      - ssl_certificate
+      - ssl_certificate_key
 
   affiliate-server:
     profiles: ["ol-home0"]

--- a/docker/infobase_nginx.conf
+++ b/docker/infobase_nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen       7000;
+    include /etc/nginx/sites-available/public_nginx.conf;
 
     # Allow GET requests with large query strings.
     # Required when querying for multiple infobase documents at once.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
### DRAFT: Do not merge.

Like #5854 but for infobase-nginx instead of covers-nginx

I actually do not believe that this is needed because infobase-nginx does not talk with the outside world.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
