### PR TITLE
Given the long run times, make ol-dumps easier to test

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -107,9 +107,12 @@ def generate_cdump(data_file, date=None):
     #   False
     #   >>> "2010-05-17T10:20:30" < "2010-05-17Z"
     #   True
+    #
+    # If scripts/oldump.sh has exported $OLDUMP_TESTING then save a lot of time by only
+    # processing a subset of the lines in data_file.
+    max_lines = 1_000_000 if os.getenv("OLDUMP_TESTING") else 0  # 0 means unlimited.
     filter = date and (lambda doc: doc["last_modified"]["value"] < date + "Z")
-
-    print_dump(read_data_file(data_file), filter=filter)
+    print_dump(read_data_file(data_file, max_lines), filter=filter)
 
 
 def sort_dump(dump_file=None, tmpdir="/tmp/", buffer_size="1G"):

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -40,9 +40,6 @@ SCRIPTS=/openlibrary/scripts
 PSQL_PARAMS=${PSQL_PARAMS:-"-h db openlibrary"}
 TMPDIR=${TMPDIR:-/openlibrary/dumps}
 
-mkdir -p $TMPDIR
-cd $TMPDIR
-
 date=$1
 archive=$2
 
@@ -52,6 +49,10 @@ dump=ol_dump_$date
 function log() {
     echo "* $@" 1>&2
 }
+
+MSG="$USER has started $0 $1 $2 in $TMPDIR on ${HOSTNAME:-$HOST} at $(date)"
+log $MSG
+logger $MSG
 
 # create a clean directory
 log "clean directory: $TMPDIR/dumps"
@@ -134,5 +135,9 @@ mkdir -p $TMPDIR/sitemaps
 cd $TMPDIR/sitemaps
 time python $SCRIPTS/sitemaps/sitemap.py $TMPDIR/dumps/$dump/$dump.txt.gz > sitemaps.log
 ls -lh
+
+MSG="$USER has completed $0 $1 $2 in $TMPDIR on ${HOSTNAME:-$HOST} at $(date)"
+echo $MSG
+logger $MSG
 
 echo "done"

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -25,6 +25,9 @@
 # 110 minutes to extract the 29GB of data from the database so it is highly
 # recommended to save a copy of data.txt.gz in another directory to accelerate the
 # testing of subsequent job steps.  See `TESTING:` comments below.
+# 
+# Successful data dumps are transferred to:
+#     https://archive.org/details/ol_exports?sort=-publicdate
 
 set -e
 
@@ -113,7 +116,8 @@ ls -lhR
 
 
 function archive_dumps() {
-    # Copy stuff to archive.org.  For progress on transfers, see:
+    # Copy data dumps to https://archive.org/details/ol_exports?sort=-publicdate
+    # For progress on transfers, see:
     # https://catalogd.archive.org/catalog.php?checked=1&all=1&banner=rsync%20timeout
     # TODO: Switch to ia client tool. This will only work in production 'til then
     python /olsystem/bin/uploaditem.py $dump --nowait --uploader=openlibrary@archive.org

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -113,15 +113,15 @@ ls -lhR
 
 
 function archive_dumps() {
-    # copy stuff to archive.org
+    # Copy stuff to archive.org.  For progress on transfers, see:
+    # https://catalogd.archive.org/catalog.php?checked=1&all=1&banner=rsync%20timeout
     # TODO: Switch to ia client tool. This will only work in production 'til then
     python /olsystem/bin/uploaditem.py $dump --nowait --uploader=openlibrary@archive.org
     python /olsystem/bin/uploaditem.py $cdump --nowait --uploader=openlibrary@archive.org
 }
 
 # Only archive if that caller has requested it and we are not testing.
-if [ "$archive" == "--archive" ];
-then
+if [ "$archive" == "--archive" ]; then
     if [[ -z $OLDUMP_TESTING ]]; then
         archive_dumps
     fi

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -25,7 +25,7 @@
 # 110 minutes to extract the 29GB of data from the database so it is highly
 # recommended to save a copy of data.txt.gz in another directory to accelerate the
 # testing of subsequent job steps.  See `TESTING:` comments below.
-# 
+#
 # Successful data dumps are transferred to:
 #     https://archive.org/details/ol_exports?sort=-publicdate
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5893

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Testing (stats as of November 2021):
The oldump cron job on `ol-home0` takes 18+ hours to process 192,000,000+ records in 29GB of data!!

These changes enable `scripts/oldump.sh` to `OLDUMP_TESTING=true` which will allow the script and `openlibrary/data/dump.py` to only process the first 1 million lines of the file instead of 192+ million lines. The first step of this script will still take 110 minutes to extract the 29GB of data from our database so it is ___highly recommended___ to save a copy of `data.txt.gz` to skip that step and accelerate the testing of subsequent job steps.

### Technical
<!-- What should be noted about the implementation? -->
```
Call flow:
docker-compose.production.yml defines `cron-jobs` Docker container.
--> docker/ol-cron-start.sh sets up the cron tasks.
    --> olsystem: /etc/cron.d/openlibrary.ol_home0 defines the actual job
        --> scripts/oldump.sh
            --> scripts/oldump.py
                --> openlibrary/data/dump.py
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
