### PR TITLE
Run pyupgrade --keep-runtime-typing in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,9 +51,9 @@ repos:
           - types-all
 
   - repo: https://github.com/asottile/pyupgrade
-     rev: v2.29.0
-     hooks:
-       - id: pyupgrade
-         args:
-         - --py39-plus
-         - --keep-runtime-typing
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py39-plus
+          - --keep-runtime-typing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,11 @@ repos:
           - --scripts-are-modules
         additional_dependencies:
           - types-all
+
+  - repo: https://github.com/asottile/pyupgrade
+     rev: v2.29.0
+     hooks:
+       - id: pyupgrade
+         args:
+         - --py39-plus
+         - --keep-runtime-typing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,10 +49,3 @@ repos:
           - --scripts-are-modules
         additional_dependencies:
           - types-all
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
-    hooks:
-      - id: pyupgrade
-        args:
-        - --py39-plus


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
New type annotations will not be added until Python 3.11.  Importing annotations from `__future__` can sometimes cause other issues, as per @cdrini.  We use `pyupgrade` specifically to replace old-style type annotations.  Removing `pyupgrade` enforces our typing standards and prevents our checks from failing in GitHub.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@cclauss 
