### PR TITLE
minimal attempt to avoid importing non-books

### DIFF
--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -55,11 +55,14 @@ class Biblio:
     ]
     REQUIRED_FIELDS = requests.get(SCHEMA_URL).json()['required']
 
+    NONBOOK = ['A2', 'AA', 'AB', 'AJ', 'AVI', 'AZ', 'BK', 'BM', 'C3', 'CD', 'CE', 'CF', 'CR', 'CRM', 'CRW', 'CX', 'D3', 'DA', 'DD', 'DF', 'DI', 'DL', 'DO', 'DR', 'DRM', 'DRW', 'DS', 'DV', 'EC', 'FC', 'FI', 'FM', 'FR', 'FZ', 'GB', 'GC', 'GM', 'GR', 'H3', 'H5', 'L3', 'L5', 'LP', 'MAC', 'MC', 'MF', 'MG', 'MH', 'ML', 'MS', 'MSX', 'MZ', 'N64', 'NGA', 'NGB', 'NGC', 'NGE', 'NT', 'OR', 'OS', 'PC', 'PP', 'PRP', 'PS', 'PSC', 'PY', 'QU', 'RE', 'RV', 'SA', 'SD', 'SG', 'SH', 'SK', 'SL', 'SMD', 'SN', 'SO', 'SO1', 'SO2', 'SR', 'SU', 'TA', 'TB', 'TR', 'TS', 'TY', 'UX', 'V35', 'V8', 'VC', 'VD', 'VE', 'VF', 'VK', 'VM', 'VN', 'VO', 'VP', 'VS', 'VU', 'VY', 'VZ', 'WA', 'WC', 'WI', 'WL', 'WM', 'WP', 'WT', 'WX', 'XL', 'XZ', 'ZF', 'ZZ']
+
     def __init__(self, data):
         self.isbn = data[124]
         self.source_id = 'bwb:%s' % self.isbn
         self.isbn_13 = [self.isbn]
         self.title = data[10]
+        self.primary_format = data[6]
         self.publish_date = data[20][:4]  # YYYY, YYYYMMDD
         self.publishers = [data[135]]
         self.weight = data[39]
@@ -88,6 +91,7 @@ class Biblio:
 
         # Assert importable
         assert self.isbn_13
+        assert self.primary_format not in self.NONBOOK
         for field in self.REQUIRED_FIELDS:
             assert getattr(self, field)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Attempts to address  #4151

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Many of the notebooks in the data are hard to distinguish from real books -- there are many metadata fields available, but they are not used consistently, (many are left blank), there is a `primary format` field which does appear to be mandatory, and that contains one of 206(?) possible values. That looks like the best way of filtering non-books available in the source data.

This PR add a blacklist of the most non-bookish. A whitelist might be better, where we only allow certain kinds of best-book like types.

This is a start for a whitelist, which I could implement, if the community discussion mentioned on #4151 leans towards selective importing:

```
AP	UK- A Format Paperback
BD	Children's Board Books
BG	Big Book
BP	UK-B Format Paperback
BZ	Book, Other
DP	Digest Paperback
EB	E-Book
LB	Library Binding
LE	Leather
MM	Mass Market
NV	Novelty Book
PB	Picture Book
PF	Perfect
PR	Prebound
TC	Trade Cloth
TP	Trade Paper
TUK	UK-Trade Paper
```


### Technical
<!-- What should be noted about the implementation? -->

I'm following what looks like existing 'reject for import' path in this code -- raise an exception by failing an `assert` -- I don't see that it is handled anywhere though. Is this correct? I half suspect that the current asserts never trigger because I'm pretty sure all of these input have ISBNs.
 
This import script still looks unfinished, there are fields like dimensions and LCCN which could be used, but they don't seem to be sent to the importer.


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
