### PR TITLE
Adding Alt Text to Home Page Images

### DIFF
--- a/openlibrary/templates/home/stats.html
+++ b/openlibrary/templates/home/stats.html
@@ -9,34 +9,34 @@ $if stats:
       <div id="home-stats-charts">
         <div class="statschart">
           <div class="chartShow" onclick="window.location.href='//archive.org/stats';" title="$_('See all visitors to OpenLibrary.org')">
-            <div id="visitors-graph" style="width:150px;height:60px;"></div>
+            <div id="visitors-graph" style="width:150px;height:60px;" title="$_('Area graph of recent unique visitors')"></div>
             <a href="//archive.org/stats" title="$_('See all visitors to OpenLibrary.org')"><span class="ticks">$:commify(stats["visitors"].get_summary(28))</span><span class="label">$_('Unique Visitors')</span></a>
           </div>
         </div>
 
         <div class="statschart">
           <div class="chartShow" onclick="window.location.href='/stats';" title="$_('How many new Open Library members have we welcomed?')">
-            <div id="members-graph" style="width:150px;height:60px;"></div>
+            <div id="members-graph" style="width:150px;height:60px;" title="$_('Area graph of new members')"></div>
             <a href="/stats" title="$_('How many new Open Library members have we welcomed?')"><span class="ticks">$:commify(stats["members"].get_summary(28))</span><span class="label">$_('New Members')</span></a>
           </div>
         </div>
         <div class="statschart">
           <div class="chartShow" onclick="window.location.href='/recentchanges';" title="$_('People are constantly updating the catalog')">
-            <div id="edits-graph" style="width:150px;height:60px;"></div>
+            <div id="edits-graph" style="width:150px;height:60px;" title="$_('Area graph of recent catalog edits')"></div>
             <a href="/recentchanges" title="$_('People are constantly updating the catalog')"><span class="ticks">$:commify(stats["human_edits"].get_summary(28))</span><span class="label">$_('Catalog Edits')</span></a>
           </div>
         </div>
 
         <div class="statschart">
           <div class="chartShow" onclick="window.location.href='/lists';" title="$_('Members can create Lists')">
-            <div id="lists-graph" style="width:150px;height:60px;"></div>
+            <div id="lists-graph" style="width:150px;height:60px;" title="$_('Area graph of lists created recently')"></div>
             <a href="/lists" title="$_('Members can create Lists')"><span class="ticks">$:commify(stats["lists"].get_summary(28))</span><span class="label">$_('Lists Created')</span></a>
           </div>
         </div>
 
         <div class="statschart">
           <div class="chartShow" onclick="window.location.href='/stats';" title="$_('We\'re a library, so we lend books, too')">
-            <div id="ebooks-graph" style="width:150px;height:60px;"></div>
+            <div id="ebooks-graph" style="width:150px;height:60px;" title="$_('Area graph of ebooks borrowed recently')"></div>
             <a href="/borrow" title="$_('We\'re a library, so we lend books, too')"><span class="ticks">$:commify(stats["loans"].get_summary(28))</span><span class="label">$_('eBooks Borrowed')</span></a>
           </div>
         </div>

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -64,7 +64,7 @@ $def with (page)
     </div>
     <hr>
     <div id="footer-details">
-      <img id="archive-logo" src="/static/images/pantheon.png" alt="" aria-hidden="true">
+      <img id="archive-logo" src="/static/images/pantheon.png" alt="$_('Open Library logo')">
       <div id="legal-details" >
         <span>$:_('Open Library is an initiative of the <a href="//archive.org/">Internet Archive</a>, a 501(c)(3) non-profit, building a digital library of Internet sites and other cultural artifacts in  digital form. Other <a href="//archive.org/projects/">projects</a> include the <a href="//archive.org/web/">Wayback Machine</a>, <a href="//archive.org/">archive.org</a> and <a href="//archive-it.org">archive-it.org</a>')</span>
       </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4630 (and I believe #4521)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the accessibility violations on the home page by adding alt text to images missing it

### Technical
<!-- What should be noted about the implementation? -->
I removed the aria hidden attribute from the Open Library logo in the footer to allow the new alt text to show. I also used the title attribute to add the alt text for the 'Around the Library' graphs to avoid messing with their div coding.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to home page and inspect accessibility for 'Around the Library' graphs and the logo in the footer. See new alt text visible. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Screenshots of no UI changes:

![Screenshot 2021-12-01 at 21-17-50 OpenLibrary org](https://user-images.githubusercontent.com/74606164/144241542-5132db53-46d7-4ec6-9ae6-d5caa15858bb.png)
![Screenshot 2021-12-01 at 21-17-40 OpenLibrary org](https://user-images.githubusercontent.com/74606164/144241545-4ddc0d67-4605-4278-a098-a96b0ec4b7d0.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bpmcneilly 