### PR TITLE
Switch to ia cli to upload dumps

### DIFF
--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -103,8 +103,8 @@ function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
     log "ia version is v$(ia --version)"  # ia version is v1.9.0
-    ia upload $dump $dump/ --metadata "collection:ol_exports" #this needs configuration in home folder
-    ia upload $cdump $cdump/ --metadata "collection:ol_exports" #this needs configuration in home folder
+    ia upload $dump $dump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}"#this needs configuration in home folder
+    ia upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}"#this needs configuration in home folder
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -103,7 +103,7 @@ function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
     log "ia version is v$(ia --version)"  # ia version is v1.9.0
-    # Need to pre-generate `${dump}_files.xml` and `${dump}_meta.xml` via a subset of `uploaditeems.py`
+    # Need to pre-generate `${dump}_files.xml` and `${dump}_meta.xml` via a subset of `uploaditem.py`
     ia upload $dump $dump --metadata "uploader:openlibrary@archive.org" --metadata "title:$dump" --metadata "collection:ol_exports"
     ia upload $cdump $cdump --metadata "uploader:openlibrary@archive.org" --metadata "title:$cdump" --metadata "collection:ol_exports"
 }

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -103,9 +103,8 @@ function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
     log "ia version is v$(ia --version)"  # ia version is v1.9.0
-    # Need to pre-generate `${dump}_files.xml` and `${dump}_meta.xml` via a subset of `uploaditem.py`
-    ia upload $dump $dump --metadata "uploader:openlibrary@archive.org" --metadata "title:$dump" --metadata "collection:ol_exports"
-    ia upload $cdump $cdump --metadata "uploader:openlibrary@archive.org" --metadata "title:$cdump" --metadata "collection:ol_exports"
+    ia upload $dump $dump --metadata "collection:ol_exports" #this needs configuration in home folder
+    ia upload $cdump $cdump --metadata "collection:ol_exports" #this needs configuration in home folder
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -103,8 +103,8 @@ function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
     log "ia version is v$(ia --version)"  # ia version is v1.9.0
-    ia upload $dump $dump --metadata "collection:ol_exports" #this needs configuration in home folder
-    ia upload $cdump $cdump --metadata "collection:ol_exports" #this needs configuration in home folder
+    ia upload $dump $dump/ --metadata "collection:ol_exports" #this needs configuration in home folder
+    ia upload $cdump $cdump/ --metadata "collection:ol_exports" #this needs configuration in home folder
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -103,8 +103,8 @@ function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
     log "ia version is v$(ia --version)"  # ia version is v2.2.0
-    ia --config-file=/olsystem/etc/ia.ini upload $dump  $dump/  --metadata "collection:ol_exports" --metadata "year:${date:0:4}" --retries 300
-    ia --config-file=/olsystem/etc/ia.ini upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}" --retries 300
+    ia --config-file=/olsystem/etc/ia.ini upload $dump  $dump/  --metadata "collection:ol_exports" --metadata "year:${date:0:4}" --metadata "format:Data" --retries 300
+    ia --config-file=/olsystem/etc/ia.ini upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}" --metadata "format:Data" --retries 300
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -103,8 +103,8 @@ function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
     log "ia version is v$(ia --version)"  # ia version is v2.2.0
-    ia --config-file=/olsystem/etc/ia.ini upload $dump  $dump/  --metadata "collection:ol_exports" --metadata "year:${date:0:4}"
-    ia --config-file=/olsystem/etc/ia.ini upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}"
+    ia --config-file=/olsystem/etc/ia.ini upload $dump  $dump/  --metadata "collection:ol_exports" --metadata "year:${date:0:4}" --retries 300
+    ia --config-file=/olsystem/etc/ia.ini upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}" --retries 300
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -102,8 +102,9 @@ ls -lhR
 function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
-    python /olsystem/bin/uploaditem.py $dump --nowait --uploader=openlibrary@archive.org
-    python /olsystem/bin/uploaditem.py $cdump --nowait --uploader=openlibrary@archive.org
+     ia $dump $dump.txt.gz --metadata "uploader:openlibrary@archive.org" --metadata "title:$dump" --metadata "collection:ol_exports"
+     ia $cdump $cdump.txt.gz  --metadata "uploader:openlibrary@archive.org" --metadata "title:$cdump" --metadata "collection:ol_exports"
+
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -102,9 +102,10 @@ ls -lhR
 function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
-     ia $dump $dump.txt.gz --metadata "uploader:openlibrary@archive.org" --metadata "title:$dump" --metadata "collection:ol_exports"
-     ia $cdump $cdump.txt.gz  --metadata "uploader:openlibrary@archive.org" --metadata "title:$cdump" --metadata "collection:ol_exports"
-
+    log "ia version is v$(ia --version)"  # ia version is v1.9.0
+    # Need to pre-generate `${dump}_files.xml` and `${dump}_meta.xml` via a subset of `uploaditeems.py`
+    ia upload $dump $dump --metadata "uploader:openlibrary@archive.org" --metadata "title:$dump" --metadata "collection:ol_exports"
+    ia upload $cdump $cdump --metadata "uploader:openlibrary@archive.org" --metadata "title:$cdump" --metadata "collection:ol_exports"
 }
 
 if [ "$archive" == "--archive" ];

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -102,9 +102,9 @@ ls -lhR
 function archive_dumps() {
     # copy stuff to archive.org
     # TODO: Switch to ia client tool. This will only work in production 'til then
-    log "ia version is v$(ia --version)"  # ia version is v1.9.0
-    ia upload $dump $dump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}"#this needs configuration in home folder
-    ia upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}"#this needs configuration in home folder
+    log "ia version is v$(ia --version)"  # ia version is v2.2.0
+    ia --config-file=/olsystem/etc/ia.ini upload $dump  $dump/  --metadata "collection:ol_exports" --metadata "year:${date:0:4}"
+    ia --config-file=/olsystem/etc/ia.ini upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${date:0:4}"
 }
 
 if [ "$archive" == "--archive" ];


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes #5930

https://archive.org/services/docs/api/internetarchive/cli.html#upload
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature
* [x] Use `ia` v2.2.0 the right version to use
* [x] What must be done to ___configure___ ai? @cclauss `ia --config-file /x.y.z` -- Should we use /olsystem?
* [x] What is the right ___upload___ command for `dump`?
* [x] What is the right ___upload___ command for `cdump`?
* ~Should we create `*_files.xml` with code from `uploaditem.py` or with `ia`?~ Auto-created on IA
* ~Should we create `*_meta.xml` with code from `uploaditem.py` or with `ia`?~ Auto-created on IA
* [ ] Currently `uploaditem.py` is run with a `--no-wait` option.  Does `ia` have a async command? No
    * Should we use parallels? 
* [ ] Update https://github.com/internetarchive/openlibrary/wiki/Generating-Data-Dumps

### Technical
<!-- What should be noted about the implementation? -->
I added only the basic metadata
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
verify that the cli does upload the correct files with metadata
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 