### PR TITLE
Add want to read button to Search Page

### DIFF
--- a/openlibrary/macros/ReadingLogButton.html
+++ b/openlibrary/macros/ReadingLogButton.html
@@ -1,13 +1,26 @@
-$def with (work, read_status)
+$def with (work, read_status, url=None, searchPage = None)
 
-<form method="POST" action="$(work.key)/bookshelves.json?debug=true" class="reading-log-lite">
-  <select name="bookshelf_id">
-    $ shelf_names = {1: _('Want to Read'), 2: _('Currently Reading'), 3: _('Already Read') }
-    $for shelf_id in [1, 2, 3]:
-      $ is_selected = read_status == shelf_id
-      <option value="$shelf_id" $cond(is_selected, 'selected')>
-        $cond(is_selected, '✓') $shelf_names[shelf_id]
-      </option>
-    <option value="-1">$_('Remove')</option>
-  </select>
-</form>
+$if ctx.user:
+  <form method="POST" action="$(work.key)/bookshelves.json?debug=true" class="reading-log-lite $(searchPage)">
+    <select name="bookshelf_id">
+      $ shelf_names = {1: _('Want to Read'), 2: _('Currently Reading'), 3: _('Already Read') }
+      $for shelf_id in [1, 2, 3]:
+        $ is_selected = read_status == shelf_id
+        <option value="$shelf_id" $cond(is_selected, 'selected')>
+          $cond(is_selected, '✓') $shelf_names[shelf_id]
+        </option>
+      <option value="-1">$_('Remove')</option>
+    </select>
+  </form>
+
+$else:
+  <div class="dropit">
+    <div class="dropper on">
+        <div class="log-work">
+            <button class="unactivated" type="submit">$_('Want to Read')</button>
+            <a href="/account/login?redir=$(url)" class="dropclick-prevent dropclick-unactivated">
+              <div class="arrow arrow-unactivated"></div>
+            </a>
+        </div>
+    </div>
+  </div>

--- a/openlibrary/macros/ReadingLogButton.html
+++ b/openlibrary/macros/ReadingLogButton.html
@@ -1,8 +1,8 @@
-$def with (work, read_status, url=None, searchPage = None)
+$def with (work, read_status, url=None, form_classes="")
 
 $if ctx.user:
-  <form method="POST" action="$(work.key)/bookshelves.json?debug=true" class="reading-log-lite $(searchPage)">
-    <select name="bookshelf_id">
+  <form method="POST" action="$(work.key)/bookshelves.json" class="reading-log-lite $(form_classes)">
+    <select name="bookshelf_id" id="book-shelf">
       $ shelf_names = {1: _('Want to Read'), 2: _('Currently Reading'), 3: _('Already Read') }
       $for shelf_id in [1, 2, 3]:
         $ is_selected = read_status == shelf_id
@@ -17,10 +17,12 @@ $else:
   <div class="dropit">
     <div class="dropper on">
         <div class="log-work">
+          <form method="POST" action="$(work.key)/bookshelves.json">
             <button class="unactivated" type="submit">$_('Want to Read')</button>
-            <a href="/account/login?redir=$(url)" class="dropclick-prevent dropclick-unactivated">
-              <div class="arrow arrow-unactivated"></div>
-            </a>
+          </form>
+          <a href="/account/login?redir=$(url)" class="dropclick-prevent dropclick-unactivated">
+            <div class="arrow arrow-unactivated"></div>
+          </a>
         </div>
     </div>
   </div>

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -96,6 +96,7 @@ export function initReadingListFeature() {
         // new shelf to the server and removing the associated item.
         // Note that any change to this select will result in the book changing
         // shelf.
+        const $searchPage = $('.searchPage')[0] || null
         $.ajax({
             url: $self.closest('form').attr('action'),
             type: 'POST',
@@ -104,7 +105,9 @@ export function initReadingListFeature() {
             },
             datatype: 'json',
             success: function() {
-                $self.closest('.searchResultItem').remove();
+                if ($searchPage===null) {
+                    $self.closest('.searchResultItem').remove();
+                }
             }
         });
         e.preventDefault();

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -96,7 +96,7 @@ export function initReadingListFeature() {
         // new shelf to the server and removing the associated item.
         // Note that any change to this select will result in the book changing
         // shelf.
-        const $searchPage = $('.searchPage')[0] || null
+        const $searchPage = $('.search-page')[0] || null
         $.ajax({
             url: $self.closest('form').attr('action'),
             type: 'POST',
@@ -105,8 +105,11 @@ export function initReadingListFeature() {
             },
             datatype: 'json',
             success: function() {
-                if ($searchPage===null) {
+                if (!$searchPage) {
                     $self.closest('.searchResultItem').remove();
+                }
+                else {
+                    $('.search-page').load(' #book-shelf');
                 }
             }
         });

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -18,7 +18,7 @@ from infogami import config
 from infogami.utils import delegate, stats
 from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core.lending import add_availability, get_availability_of_ocaids
-from openlibrary.core.models import Edition  # noqa: E402
+from openlibrary.core.models import Edition, Work  # noqa: E402
 from openlibrary.plugins.inside.code import fulltext_search
 from openlibrary.plugins.openlibrary.lists import get_list_editions
 from openlibrary.plugins.openlibrary.processors import urlsafe
@@ -807,6 +807,8 @@ class search(delegate.page):
             get_availability_of_ocaids,
             fulltext_search,
             FACET_FIELDS,
+            Work.get_users_read_status,
+            url=web.ctx.fullpath
         )
 
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -167,7 +167,7 @@ $ )
                 $ ocaid = work.ia[0] if work.ia else None
                 $ availability = (work.get('availability') or {}).get('status')
                 $ users_work_read_status = get_users_read_status(work, username) if work and username else None
-                $ decorations = macros.ReadingLogButton(work, read_status=users_work_read_status, url=url, searchPage="searchPage")
+                $ decorations = macros.ReadingLogButton(work, read_status=users_work_read_status, url=url, form_classes="search-page")
                 $# if we're explicitly showing *everything*...
                 $# or if we're showing only things with ocaids which are available...
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,6 +1,7 @@
-$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields)
+$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields, get_users_read_status, url)
 
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
+$ username = ctx.user and ctx.user.key.split('/')[-1]
 
 $def add_facet_url(k, v):
     $if k != 'has_fulltext':
@@ -165,10 +166,12 @@ $ )
             $for work in works:
                 $ ocaid = work.ia[0] if work.ia else None
                 $ availability = (work.get('availability') or {}).get('status')
+                $ users_work_read_status = get_users_read_status(work, username) if work and username else None
+                $ decorations = macros.ReadingLogButton(work, read_status=users_work_read_status, url=url, searchPage="searchPage")
                 $# if we're explicitly showing *everything*...
                 $# or if we're showing only things with ocaids which are available...
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):
-                    $:macros.SearchResultsWork(work)
+                    $:macros.SearchResultsWork(work, decorations = decorations)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5501

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds Want to Read Button to search results page.
### Technical
<!-- What should be noted about the implementation? -->
- The reading log dropdown present in the reading logs page has been used again to implement this.
- When a user is not logged in, the green Want to Read button appears in the search result.
  - This button is disabled, and when the dropdown is clicked, the user is sent to the login page and after login redirected back to  the search results page  
- When a user is logged in, the dropdown from the reading log page appears, and user can choose from the four options.
  - The reading log lite button, upon selection removes the item from the list, but for search results, we might want to keep the book present in the result, so I have disabled this behaviour for search results page by applying following condition in `ol.js`:
  
 ```success: function() {
                if($searchPage==null) {
                    $self.closest('.searchResultItem').remove();
                }
```
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
User is not logged in:
![image](https://user-images.githubusercontent.com/53360510/144724740-302f9856-5101-4c3a-88b8-30a2686de4ad.png)

User is logged in:
![image](https://user-images.githubusercontent.com/53360510/144724753-e590da55-3579-449f-b8e1-b819698e2a20.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jimchamp 