### PR TITLE
Add a cover picture to 'Work Details'

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -94,6 +94,13 @@ $putctx("robots", "noindex,nofollow")
                             </div>
                             $:render_template("books/edit/about", work)
                         </div>
+
+                        <div class="formBackRight">
+                            <div class="illustration">
+                                $:render_template("covers/book_cover", edition)
+                                $:render_template("covers/change", edition)
+                            </div>
+                        </div>
                     </div>
                 </fieldset>
                 <fieldset class="major">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4992 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature

### Technical
<!-- What should be noted about the implementation? -->
Copied over similar code snippet for cover image from books/edit/editions.html into books/edit.html

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Navigate to the 'Edit' page of any book. Click in the work details and should be able to see the cover image displayed. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/71855709/144726184-8b12791b-4656-4fb2-9cfd-124eacd75baf.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
