### PR TITLE
17313/return loans

### DIFF
--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -151,6 +151,8 @@ class borrow(delegate.page):
         if action == 'return':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='return_loan')
             stats.increment('ol.loans.return')
+            edition.update_loan_status()
+            user.update_loan_status()
             raise web.seeother('/account/loans')
         elif action == 'join-waitinglist':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='join_waitlist')

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -151,7 +151,7 @@ class borrow(delegate.page):
         if action == 'return':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='return_loan')
             stats.increment('ol.loans.return')
-            raise web.seeother(edition_redirect)
+            raise web.seeother('/account/loans')
         elif action == 'join-waitinglist':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='join_waitlist')
             stats.increment('ol.loans.joinWaitlist')


### PR DESCRIPTION
Closes #2777 

feature

### Technical
For redirecting after a book is returned, the route used is exactly the same as a different page that also redirects to loans. After returning a book, a function is called to update and remove the book from the loan list.

### Testing
To test, return a book and ensure redirection to the original loans page. In addition, make sure the returned book is not on the list anymore (without having to refresh).

### Screenshot
This feature does not directly touch UI, but we included a screenshot to display an empty loans page.
<img width="1197" alt="Screen Shot 2021-12-04 at 7 40 30 PM" src="https://user-images.githubusercontent.com/70723676/144729079-124cc5e7-15f8-4fe2-942c-2c98f923786d.png">

### Stakeholders
N/A
