### PR TITLE
Replace !&()./<>\\^|´™ chars in Subjects URLs to prevent 404 errors

### DIFF
--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,7 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_').replace('>' , '1R').replace('<' , '1L').replace('™', '2L')
+        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_').replace('>' , '1R').replace('<' , '1L').replace('™', '2L').replace('´', '3L')
         <li>
             <a href="$key">$n</a>
             $code:

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,7 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F')
+        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '')
 
         <li>
             <a href="$key">$n</a>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,7 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $         $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '')
+        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F')
 
         <li>
             <a href="$key">$n</a>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,7 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_')
+        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_').replace('>' , '1R').replace('<' , '1L')
 
         <li>
             <a href="$key">$n</a>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,8 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_').replace('>' , '1R').replace('<' , '1L')
-
+        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_').replace('>' , '1R').replace('<' , '1L').replace('™', '2L')
         <li>
             <a href="$key">$n</a>
             $code:

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,7 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '')
+        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '').replace('/' , '%2F').replace('(' , '%8C').replace(')' , '%9C').replace('!' , '').replace('.' , '').replace('|' , '').replace('\' , '').replace('&' , '%2A').replace('^' , '_')
 
         <li>
             <a href="$key">$n</a>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -43,7 +43,7 @@ $if q and 'error' not in results:
     <ul class="subjectList">
     $for doc in response['docs']:
         $ n = doc['name']
-        $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '').replace(',', '')
+        $         $ key = '/subjects/' + url_map.get(doc['type'], '') + n.lower().replace(' ', '_').replace('?', '')
 
         <li>
             <a href="$key">$n</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #333

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

A number of Subjects or Publishers have special characters, like slashes "/", in their names which result in link URLs leading to 404s.

e.g. If you do a Subject search for "business economics", the first links are:

https://openlibrary.org/subjects/business_&_economics_/_finance
https://openlibrary.org/subjects/business_&_economics_/_management
These have textual labels of "BUSINESS & ECONOMICS / Finance" and "BUSINESS & ECONOMICS / Management" and lead to 404 pages.

This PR fixes URL encoding for many special characters, as in the examples above.

### Technical
<!-- What should be noted about the implementation? -->

Does not use encoder library, but manually covers a multitude of key edge cases in URL encoding. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Using PR-modified version of openlibrary, attempt to add a book with "10/18" in title, or ">" or "™" or "&", to name a few examples.