### PR TITLE
Fixed layout of  `Not in library` button

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -115,7 +115,7 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
   $else:
     <div class="cta-button-group">
       <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
-    </div>  
+    </div>
 
 $else:
   <div class="cta-button-group">

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -113,7 +113,9 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
         <a href="https://openlibrary.org/bookdrive" target="_blank">$_('Learn More')</a>
       </p>
   $else:
-    <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+    <div class="cta-button-group">
+      <a href="$work_key" class="cta-btn cta-btn--missing" data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+    </div>  
 
 $else:
   <div class="cta-button-group">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5942

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I have wrapped the"Not in Library" books within a `cta-button-group` div which solve the extra vertical height that the card was having.

### Technical
<!-- What should be noted about the implementation? -->


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run the local setup on docker go to the main website, inspect the webpage using dev tools and verify.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1440" alt="Screenshot 2021-12-08 at 8 22 04 AM" src="https://user-images.githubusercontent.com/73935799/145139931-031eec42-4d0a-45ec-9c17-ce2539f8b4ac.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 
