### PR TITLE
Async star ratings

### DIFF
--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -50,6 +50,8 @@ $ form_id = "ratingsForm%s" % id
         </a>
       </div>
   </div>
-  $if rating:
-      <button type="submit" class="star-messaging">$_("Clear my rating")</button>
+  $ class_list = "star-messaging"
+  $if not rating:
+    $ class_list = "%s hidden" % (class_list)
+  <button type="submit" class="$class_list">$_("Clear my rating")</button>
 </form>

--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -5,7 +5,7 @@ $ rating = work and username and work.get_users_rating(username)
 $ edition_key = edition.key if edition else ""
 $ form_id = "ratingsForm%s" % id
 
-<form id="$form_id" method="POST" action="$(work.key)/ratings.json"
+<form class="star-rating-form" id="$form_id" method="POST" action="$(work.key)/ratings.json"
       property="reviewRating" typeof="Rating" vocab="http://schema.org/">
   <meta property="worstRating" content="1"/>
   <meta property="bestRating" content="5"/>

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -132,7 +132,7 @@ class ratings(delegate.page):
     def POST(self, work_id):
         """Registers new ratings for this work"""
         user = accounts.get_current_user()
-        i = web.input(edition_id=None, rating=None, redir=False, redir_url=None, page=None)
+        i = web.input(edition_id=None, rating=None, redir=False, redir_url=None, page=None, ajax=False)
         key = (i.redir_url if i.redir_url else
             i.edition_id if i.edition_id else
             ('/works/OL%sW' % work_id))
@@ -167,7 +167,7 @@ class ratings(delegate.page):
             )
             r = response('rating added')
 
-        if i.redir:
+        if i.redir and not i.ajax:
             p = h.safeint(i.page, 1)
             query_params = f'?page={p}' if p > 1 else ''
             if i.page:

--- a/openlibrary/plugins/openlibrary/js/Toast.js
+++ b/openlibrary/plugins/openlibrary/js/Toast.js
@@ -53,14 +53,18 @@ export class FadingToast extends Toast {
      * @param {number} [timeout] Amount of time, in milliseconds, that the component will be visible
      */
     constructor(message, $parent=null, timeout=DEFAULT_TIMEOUT) {
-        super(
-            // TODO(i18n-js)
-            $(`<div class="toast">
-                <span class="toast__body">${message}</span>
-                <a class="toast__close">&times;<span class="shift">Close</span></a>
-            </div>`),
-            $parent
-        );
+        // TODO(i18n-js)
+        const $toast = $(`<div class="toast">
+            <span class="toast__body">${message}</span>
+            <a class="toast__close">&times;<span class="shift">Close</span></a>
+        </div>`)
+
+        // Prevent sending null parent:
+        if ($parent) {
+            super($toast, $parent);
+        } else {
+            super($toast);
+        }
         this.timeout = timeout;
     }
 

--- a/openlibrary/plugins/openlibrary/js/handlers/index.js
+++ b/openlibrary/plugins/openlibrary/js/handlers/index.js
@@ -8,28 +8,51 @@ export function initRatingHandlers(ratingForms) {
 
 function handleRatingSubmission(event, form) {
     event.preventDefault();
+    // Continue only if selected star is different from previous rating
+    if (!event.submitter.classList.contains('star-selected')) {
 
-    // Construct form data object:
-    const formData = new FormData(form);
-    if (event.submitter.value) {
-        formData.append('rating', event.submitter.value)
+        // Construct form data object:
+        const formData = new FormData(form);
+        let rating;
+        if (event.submitter.value) {
+            rating = Number(event.submitter.value)
+            formData.append('rating', event.submitter.value)
+        }
+        formData.append('ajax', true);
+
+        // Make AJAX call
+        fetch(form.action, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/x-www-form-urlencoded'
+            },
+            body: new URLSearchParams(formData)
+        })
+            .then(function() {
+                // Repaint stars
+                form.querySelectorAll('.star-selected').forEach((elem) => {
+                    elem.classList.remove('star-selected');
+                    if (elem.hasAttribute('property')) {
+                        elem.removeAttribute('property');
+                    }
+                })
+
+                const clearButton = form.querySelector('.star-messaging');
+                if (rating) {
+                    clearButton.classList.remove('hidden');
+                    form.querySelectorAll(`.star-${rating}`).forEach((elem) => {
+                        elem.classList.add('star-selected');
+                        if (elem.tagName === 'LABEL') {
+                            elem.setAttribute('property', 'ratingValue')
+                        }
+                    })
+                } else {
+                    clearButton.classList.add('hidden');
+                }
+            })
+            .catch((error) => {
+                // TODO: Display failure toast
+                console.log(error)
+            })
     }
-    formData.append('ajax', true);
-
-    // Make AJAX call
-    fetch(form.action, {
-        method: 'POST',
-        headers: {
-            'content-type': 'application/x-www-form-urlencoded'
-        },
-        body: new URLSearchParams(formData)
-    })
-        .then((response) => {
-            // TODO: Repaint stars
-            console.log(response)
-        })
-        .catch((error) => {
-            // TODO: Display failure toast
-            console.log(error)
-        })
 }

--- a/openlibrary/plugins/openlibrary/js/handlers/index.js
+++ b/openlibrary/plugins/openlibrary/js/handlers/index.js
@@ -1,3 +1,5 @@
+import { FadingToast } from '../Toast.js';
+
 export function initRatingHandlers(ratingForms) {
     for (const form of ratingForms) {
         form.addEventListener('submit', function(e) {
@@ -28,7 +30,10 @@ function handleRatingSubmission(event, form) {
             },
             body: new URLSearchParams(formData)
         })
-            .then(function() {
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Ratings update failed')
+                }
                 // Repaint stars
                 form.querySelectorAll('.star-selected').forEach((elem) => {
                     elem.classList.remove('star-selected');
@@ -51,8 +56,7 @@ function handleRatingSubmission(event, form) {
                 }
             })
             .catch((error) => {
-                // TODO: Display failure toast
-                console.log(error)
+                new FadingToast(error.message).show();
             })
     }
 }

--- a/openlibrary/plugins/openlibrary/js/handlers/index.js
+++ b/openlibrary/plugins/openlibrary/js/handlers/index.js
@@ -1,0 +1,35 @@
+export function initRatingHandlers(ratingForms) {
+    for (const form of ratingForms) {
+        form.addEventListener('submit', function(e) {
+            handleRatingSubmission(e, form);
+        })
+    }
+}
+
+function handleRatingSubmission(event, form) {
+    event.preventDefault();
+
+    // Construct form data object:
+    const formData = new FormData(form);
+    if (event.submitter.value) {
+        formData.append('rating', event.submitter.value)
+    }
+    formData.append('ajax', true);
+
+    // Make AJAX call
+    fetch(form.action, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/x-www-form-urlencoded'
+        },
+        body: new URLSearchParams(formData)
+    })
+        .then((response) => {
+            // TODO: Repaint stars
+            console.log(response)
+        })
+        .catch((error) => {
+            // TODO: Display failure toast
+            console.log(error)
+        })
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -320,7 +320,7 @@ jQuery(function () {
     // Prevent default star rating behavior:
     const ratingForms = document.querySelectorAll('.star-rating-form')
     if (ratingForms) {
-        import('./handlers')
+        import(/* webpackChunkName: "star-ratings" */'./handlers')
             .then((module) => module.initRatingHandlers(ratingForms));
     }
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -316,4 +316,11 @@ jQuery(function () {
             .find('details')
             .removeAttr('open');
     });
+
+    // Prevent default star rating behavior:
+    const ratingForms = document.querySelectorAll('.star-rating-form')
+    if (ratingForms) {
+        import('./handlers')
+            .then((module) => module.initRatingHandlers(ratingForms));
+    }
 });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Attaches on submit listeners to all star ratings forms on a page.  On submit, the default page refresh is prevented and the ratings are submitted via JS.

If a submission fails, the rater is notified via toast message.

### Technical
<!-- What should be noted about the implementation? -->
Replaced conditional rendering of "Clear my rating" button in template with conditional addition of `hidden` class, allowing the button's visibility to be toggled.
`FadingToast` constructor has been updated to prevent a `null` parent container being passed to the superclass Toast's constructor.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in, do the following:

1. Navigate to a book page.
2. Leave a star rating.  Ensure that the "Clear my rating" button appears, the correct stars are filled,  and that the page does not refresh.
3. Refresh the page.  Ensure that the rating is as expected.
4. Clear the rating.  Ensure that filled stars are removed and that the button does not vanish.
5. Refresh the page and ensure that no stars are filled.
6. Navigate to your "Already read" log.
7. Leave ratings for multiple books on this page. When you submit a rating, ensure that the rating applies only to the intended book.  

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![star_rating](https://user-images.githubusercontent.com/28732543/145318897-06a4bc64-6b70-41f6-bdb4-06c4d6743369.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
