### PR TITLE
Enable ol-covers to use Docker deploy replicas again

### DIFF
--- a/docker-compose.infogami-local.yml
+++ b/docker-compose.infogami-local.yml
@@ -3,7 +3,7 @@
 ## docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.infogami-local.yml up -d
 ##
 
-version: "3.1"
+version: "3.8"
 services:
   web:
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@
 # is used without the -f parameter. It contains local development specific
 # configuration options which we don't want to apply to production/staging
 
-version: "3.1"
+version: "3.8"
 services:
   web:
     build:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,7 +5,7 @@
 ## docker-compose up -d
 ##
 
-version: "3.1"
+version: "3.8"
 services:
   web:
     profiles: ["ol-web1", "ol-web2"]
@@ -54,6 +54,8 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - /1:/1
+    deploy:
+      replicas: 2
 
   covers_nginx:
     profiles: ["ol-covers0"]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -5,7 +5,7 @@
 ## docker-compose up -d
 ##
 
-version: "3.1"
+version: "3.8"
 services:
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "3.8"
 services:
   web:
     image: "${OLIMAGE:-oldev:latest}"

--- a/scripts/deployment/restart_servers.sh
+++ b/scripts/deployment/restart_servers.sh
@@ -24,10 +24,5 @@ fi
 
 for SERVER in $SERVERS; do
     HOSTNAME=$(host $SERVER | cut -d " " -f 1)
-    EXTRA_OPTS=""
-    if [[ $SERVER == ol-covers0* ]]; then
-        EXTRA_OPTS="--scale covers=2"
-    fi
-
-    ssh $SERVER "cd /opt/openlibrary; COMPOSE_FILE=$PRODUCTION HOSTNAME=$HOSTNAME OLIMAGE=$OLIMAGE docker-compose --profile $(echo $SERVER | cut -f1 -d '.') up --no-deps -d $EXTRA_OPTS"
+    ssh $SERVER "cd /opt/openlibrary; COMPOSE_FILE=$PRODUCTION HOSTNAME=$HOSTNAME OLIMAGE=$OLIMAGE docker-compose --profile $(echo $SERVER | cut -f1 -d '.') up --no-deps -d"
 done


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5956 which got in a bad git state with vendor/infogami

<!-- What issue does this PR close? -->
To simplify both configuration and scaling up or down, this pull request enables `ol-covers` to use [Docker compose deploy replicas](https://docs.docker.com/compose/compose-file/compose-file-v3/#replicas) .

This PR also upgrades from Docker compose file v3.1 to v3.8
* https://docs.docker.com/compose/compose-file/compose-versioning/

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested in #5951

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
