### PR TITLE
Fix login redirect issues

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -360,9 +360,10 @@ class account_login(delegate.page):
         return render.login(f)
 
     def GET(self):
-        referer = web.ctx.env.get('HTTP_REFERER', '/')
+        referer = web.ctx.env.get('HTTP_REFERER', '')
         # Don't set referer if request is from offsite
-        if 'openlibrary.org' not in referer:
+        if ('openlibrary.org' not in referer
+            or referer.endswith('openlibrary.org/')):
             referer = None
         i = web.input(redirect=referer)
         f = forms.Login()
@@ -400,8 +401,6 @@ class account_login(delegate.page):
         )
         blacklist = [
             "/account/login",
-            "/account/password",
-            "/account/email",
             "/account/create",
         ]
         if i.redirect == "" or any([path in i.redirect for path in blacklist]):

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -225,7 +225,7 @@ $jsdef render_widget_add(lists, work_key, edition_key, users_work_read_status, u
                 </div>
 
               $else:
-                <a href="/account/login?redir=$pageurl" class="dropclick plain">
+                <a href="/account/login?redirect=$pageurl" class="dropclick plain">
                   <h3>$('Add to List')</h3>
                   <div class="arrow"></div>
                 </a>
@@ -280,7 +280,7 @@ $if include_widget:
 
                   <button class="unactivated" type="submit">$_('Want to Read')</button>
                 </form>
-                <a href="/account/login?redir=$(page_url)" class="dropclick-prevent dropclick-unactivated">
+                <a href="/account/login?redirect=$(page_url)" class="dropclick-prevent dropclick-unactivated">
                   <div class="arrow arrow-unactivated"></div>
                 </a>
             </div>
@@ -289,7 +289,7 @@ $if include_widget:
   $if work:
     $if include_rating:
       $:macros.StarRatings(work, edition)
-    $if edition:
+    $if ctx.user and edition:
       $if work.has_book_note(username, edition.key.split('/')[-1]):
         $ link_text = _("Update my book note")
       $else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This contains a few login-related bug fixes:
1. By default, patrons will be redirected to their loans page if no other redirect URL is POSTed.
2. Replaced incorrect `redir` query parameter used by the book page reading log dropper.
3. Do not render book note link if patron is not logged in (the link doesn't function for logged-out patrons).

### Technical
<!-- What should be noted about the implementation? -->
We failed to account for the hidden `redirect` input in the login template in #5774.  This was populated by default with the `HTTP_REFERER` by the `/login` GET method.  `/account/loans` now replaces `HTTP_REFERER` as the default redirect value.

The main issue with this approach is that using the navbar login link on a book page will result in a redirect to the loans page.  Some may consider this behavior to be unexpected/undesired.  To remedy this, we could chose a sensible default based on the referer's path in the login `GET` method if no redirects are given.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged out:
1. Navigate to a book page.
2. Ensure that the book note link is not visible below the star rating component.
3. Click on the reading log dropper.  This will load the login page.
4. Log into the site, ensuring that you have been redirected to the book page.
5. Ensure that the book note link is present.
6. Log out and log back in while in different contexts (from Google search, from the homepage, etc.).  Ensure that the redirect behavior is as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 