### PR TITLE
Enable GitHub Action javascript_tests to be manually run

### DIFF
--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -13,6 +13,7 @@ on:
       - '**.vue'
       - '**.less'
       - '**.css'
+  workflow_dispatch:
 jobs:
   javascript_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Our JavaScript tests are automatically run only when certain files are modified.  However, sometimes it would be useful to run these tests on demand.  Adding GitHub Actions `workflow_dispatch` enables manually triggered tests of our JavaScript code.  https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
