### PR TITLE
Fix list delete icon disappears on hover

### DIFF
--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -117,7 +117,7 @@
     }
   }
   a:hover span {
-    background-position: right 0px;
+    background-position: right 0;
   }
 }
 

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -117,7 +117,7 @@
     }
   }
   a:hover span {
-    background-position: right 0;
+    background-position: -21px 0;
   }
 }
 

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -117,7 +117,7 @@
     }
   }
   a:hover span {
-    background-position: 21px 0;
+    background-position: right 0px;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5959

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixs List delete icon disappears on hover

### Technical
<!-- What should be noted about the implementation? -->
Changed `background-position` value

### Testing
All lists: `/account/lists`
List pages: `/people/{username}/lists/{list_olid}`

<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to either of the above listed pages.
Locate a green trash bin icon and hover over it.
Actual: The green trash bin icon disappears.
Expected: The red open trash bin icon is displayed.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2021-12-10 22-09-53](https://user-images.githubusercontent.com/58180803/145610818-52f33723-478f-44d0-9a3a-c7e70a1e904b.png)

![Screenshot from 2021-12-10 22-19-47](https://user-images.githubusercontent.com/58180803/145610924-8721bda7-ca12-4067-9562-c438bfd3ae3e.png)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 
