### PR TITLE
Fix eligibility_check having wrong signature

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     BLOCKED_PATRONS = []
 
-    def eligibility_check(edition):
+    def eligibility_check(edition, patron=None):
         """For testing if Internet Archive book sponsorship check unavailable"""
         return False
 


### PR DESCRIPTION
This was causing errors on the site for most books, because it's missing a parameter.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Already patch deployed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 
