### PR TITLE
Create on demand GHA workflow codegen_api_docs.yml

### DIFF
--- a/.github/workflows/codegen_api_docs.yml
+++ b/.github/workflows/codegen_api_docs.yml
@@ -1,0 +1,37 @@
+name: codegen_api_docs
+on: workflow_dispatch
+jobs:
+  codegen_api_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          # https://lxml.de/installation.html#requirements
+          sudo apt-get install libxml2-dev libxslt-dev
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements_test.txt
+          pip list --outdated
+      - run: make git
+      - shell: python
+        run: |
+          import inspect
+          import platform
+
+          for name, value in inspect.getmembers(platform):
+              if name[0] != "_" and callable(value):
+                  try:
+                      value = value()
+                  except (IndexError, TypeError):
+                      continue
+                  if str(value).strip("(),' "):
+                      print("{:>21}() = {}".format(name, value))
+
+          import sys
+          print(sys.platform, sys.version)


### PR DESCRIPTION
Put in place an on-demand GItHub Action that will enable testing of #5910 before it is ready to be merged.

The Python code at the end is from https://github.com/cclauss/Ten-lines-or-less/blob/master/platform_info.py

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
