### PR TITLE
Fix library explorer language filter display

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -455,9 +455,7 @@ export default {
 
     .multiselect__content {
       display: flex !important;
-      // Since this control is always at the bottom for us, have the results in
-      // reverse order, so that the likeliest match is closest to the input field.
-      flex-direction: column-reverse;
+      flex-direction: column;
     }
   }
 
@@ -484,8 +482,6 @@ export default {
     display: flex;
     flex-direction: column-reverse;
     border-radius: 4px 4px 0 0;
-    overflow: hidden;
-    overflow: clip;
     box-shadow: 0 0 5px rgba(0, 0, 0, .2);
     background: linear-gradient(to bottom, #fff, #ebdfc5 150%);
     max-width: 100%;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5042

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix the language drop-down list filter not displaying correctly and behaving strangely when navigating with up/down arrow keys in the Library Explorer

### Technical
<!-- What should be noted about the implementation? -->
Likeliest match is not near the input field anymore (as per comment in code), however likeliest match is still selected first.

Tested on FF95 only.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to `/explore`, open `Filter` in the control panel and open the list at `Other...`.

Navigate with up/down arrow keys in the drop-down list.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/73437497/145731431-b9511398-9b4e-405b-89ed-950d1e97d5cc.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
