### PR TITLE
Restore date filtering functionality to publishers and subjects pages.

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -175,6 +175,32 @@ const Carousel = {
                         });
                 }
             });
+
+            document.addEventListener('filter', function(ev) {
+                url.searchParams.set("published_in", ev.detail.yearFrom + "-" + ev.detail.yearTo);
+
+                // Reset the page count - the result set is now 'new'
+                loadMore.page = 2;
+
+                let slick = $(selector).slick('getSlick');
+                const totalSlides = slick.$slides.length;
+
+                // Remove the current slides
+                slick.removeSlide(totalSlides, true, true);
+                slick.addSlide('<div class="carousel__item carousel__loading-end">Loading...</div>');
+
+                $.ajax({ url: url, type: 'GET' })
+                        .then(function(results) {
+                            const works = results.works || results.docs;
+                            // Remove loading indicator
+                            slick.slickRemove(0);
+                            works.forEach(work => slick.addSlide(addWork(work)));
+                            if (!works.length) {
+                                loadMore.allDone = true;
+                            }
+                            loadMore.locked = false;
+                        });
+            });
         }
     }
 };

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -177,12 +177,12 @@ const Carousel = {
             });
 
             document.addEventListener('filter', function(ev) {
-                url.searchParams.set("published_in", ev.detail.yearFrom + "-" + ev.detail.yearTo);
+                url.searchParams.set('published_in', `${ev.detail.yearFrom}-${ev.detail.yearTo}`);
 
                 // Reset the page count - the result set is now 'new'
                 loadMore.page = 2;
 
-                let slick = $(selector).slick('getSlick');
+                const slick = $(selector).slick('getSlick');
                 const totalSlides = slick.$slides.length;
 
                 // Remove the current slides
@@ -190,16 +190,16 @@ const Carousel = {
                 slick.addSlide('<div class="carousel__item carousel__loading-end">Loading...</div>');
 
                 $.ajax({ url: url, type: 'GET' })
-                        .then(function(results) {
-                            const works = results.works || results.docs;
-                            // Remove loading indicator
-                            slick.slickRemove(0);
-                            works.forEach(work => slick.addSlide(addWork(work)));
-                            if (!works.length) {
-                                loadMore.allDone = true;
-                            }
-                            loadMore.locked = false;
-                        });
+                    .then(function(results) {
+                        const works = results.works || results.docs;
+                        // Remove loading indicator
+                        slick.slickRemove(0);
+                        works.forEach(work => slick.addSlide(addWork(work)));
+                        if (!works.length) {
+                            loadMore.allDone = true;
+                        }
+                        loadMore.locked = false;
+                    });
             });
         }
     }

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -93,11 +93,11 @@ export function loadEditionsGraph() {
         }
     });
 
-    placeholder.bind("plotclick", function (event, pos, item) {
+    placeholder.bind('plotclick', function (event, pos, item) {
 
         if (item) {
             plot.unhighlight();
-            let yearFrom = item.datapoint[0].toFixed(0);
+            const yearFrom = item.datapoint[0].toFixed(0);
             applyDateFilter(yearFrom, yearFrom);
 
             plot.highlight(item.series,item.datapoint);
@@ -107,7 +107,7 @@ export function loadEditionsGraph() {
         }
     });
 
-    placeholder.bind("plotselected", function (event, ranges) {
+    placeholder.bind('plotselected', function (event, ranges) {
         plot = $.plot(placeholder, data,
             $.extend(true, {}, options, {
                 xaxis: { min: ranges.xaxis.from, max: ranges.xaxis.to },
@@ -115,13 +115,13 @@ export function loadEditionsGraph() {
             })
         );
 
-        let yearFrom = ranges.xaxis.from.toFixed(0);
-        let yearTo = ranges.xaxis.to.toFixed(0);
+        const yearFrom = ranges.xaxis.from.toFixed(0);
+        const yearTo = ranges.xaxis.to.toFixed(0);
         applyDateFilter(yearFrom, yearTo);
     });
 
-    function applyDateFilter(yearFrom, yearTo, hideSelector=".chartUnzoom", showSelector=".chartZoom") {
-        document.dispatchEvent(new CustomEvent('filter', { "detail": { "yearFrom": yearFrom, "yearTo": yearTo } }));
+    function applyDateFilter(yearFrom, yearTo, hideSelector='.chartUnzoom', showSelector='.chartZoom') {
+        document.dispatchEvent(new CustomEvent('filter', { detail: { yearFrom: yearFrom, yearTo: yearTo } }));
         $(hideSelector).hide();
         $(showSelector).removeClass('hidden').show();
     }
@@ -130,12 +130,12 @@ export function loadEditionsGraph() {
     dateFrom = plot.getAxes().xaxis.min.toFixed(0);
     dateTo = plot.getAxes().xaxis.max.toFixed(0);
 
-    $(".resetSelection").click(function() {
+    $('.resetSelection').on('click', function() {
         plot = $.plot(placeholder, data, options);
 
-        let yearFrom = plot.getAxes().xaxis.min.toFixed(0);
-        let yearTo = plot.getAxes().xaxis.max.toFixed(0);
-        applyDateFilter(yearFrom, yearTo, ".chartZoom", ".chartUnzoom");
+        const yearFrom = plot.getAxes().xaxis.min.toFixed(0);
+        const yearTo = plot.getAxes().xaxis.max.toFixed(0);
+        applyDateFilter(yearFrom, yearTo, '.chartZoom', '.chartUnzoom');
     });
 
     $('.chartYaxis').css({top: '60px', left: '-60px'});

--- a/openlibrary/plugins/openlibrary/js/graphs/plot.js
+++ b/openlibrary/plugins/openlibrary/js/graphs/plot.js
@@ -92,9 +92,51 @@ export function loadEditionsGraph() {
             previousPoint = null;
         }
     });
+
+    placeholder.bind("plotclick", function (event, pos, item) {
+
+        if (item) {
+            plot.unhighlight();
+            let yearFrom = item.datapoint[0].toFixed(0);
+            applyDateFilter(yearFrom, yearFrom);
+
+            plot.highlight(item.series,item.datapoint);
+        }
+        else {
+            plot.unhighlight();
+        }
+    });
+
+    placeholder.bind("plotselected", function (event, ranges) {
+        plot = $.plot(placeholder, data,
+            $.extend(true, {}, options, {
+                xaxis: { min: ranges.xaxis.from, max: ranges.xaxis.to },
+                yaxis: { min: ranges.yaxis.from, max: ranges.yaxis.to }
+            })
+        );
+
+        let yearFrom = ranges.xaxis.from.toFixed(0);
+        let yearTo = ranges.xaxis.to.toFixed(0);
+        applyDateFilter(yearFrom, yearTo);
+    });
+
+    function applyDateFilter(yearFrom, yearTo, hideSelector=".chartUnzoom", showSelector=".chartZoom") {
+        document.dispatchEvent(new CustomEvent('filter', { "detail": { "yearFrom": yearFrom, "yearTo": yearTo } }));
+        $(hideSelector).hide();
+        $(showSelector).removeClass('hidden').show();
+    }
+
     plot = $.plot(placeholder, data, options);
     dateFrom = plot.getAxes().xaxis.min.toFixed(0);
     dateTo = plot.getAxes().xaxis.max.toFixed(0);
+
+    $(".resetSelection").click(function() {
+        plot = $.plot(placeholder, data, options);
+
+        let yearFrom = plot.getAxes().xaxis.min.toFixed(0);
+        let yearTo = plot.getAxes().xaxis.max.toFixed(0);
+        applyDateFilter(yearFrom, yearTo, ".chartZoom", ".chartUnzoom");
+    });
 
     $('.chartYaxis').css({top: '60px', left: '-60px'});
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5955

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix for UI regression

### Technical
<!-- What should be noted about the implementation? -->
Largely inspired by the original functionality that got lost at some point, this restores the `plotselected` and `plotclick` event handlers but this uses events for communication between the graph module and the Carousel as the latter module has changed significantly since this functionality last existed in the codebase. The changes to Carousel should only come into effect when used on a publisher or subject page and should not affect it in any other way.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Fixes the UI regression described in #5955. Test filtering by clicking a year or dragging across a range of years, the Carousel should update with a suitable list of works from the selected date range or year.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![filtered-1900-to-1910](https://user-images.githubusercontent.com/722096/146283364-f0751f3f-6461-4a46-b06e-8342da503603.png)
![filtered-2000-to-2010](https://user-images.githubusercontent.com/722096/146283365-8c87520e-3a14-440f-b0a9-df99dd70392d.png)
![unfiltered](https://user-images.githubusercontent.com/722096/146283368-80075449-18ef-4621-ba3a-01d061fa4cdd.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
