### PR TITLE
fix(#5982) - Fixes pointer and width for the logout button

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -119,6 +119,16 @@
         padding: 10px;
         display: block;
       }
+
+      form {
+        cursor: pointer;
+      }
+
+      button {
+        cursor: pointer;
+        text-align: start;
+        width: 100%;
+      }
       // stylelint-enable max-nesting-depth, selector-max-specificity
     }
   }

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -120,10 +120,6 @@
         display: block;
       }
 
-      form {
-        cursor: pointer;
-      }
-
       button {
         cursor: pointer;
         text-align: start;


### PR DESCRIPTION
- Will be able to logout properly after clicking

Closes #5982 

Fixes the logout button on the dropdown menu: makes the pointer cursor on hover and increases the width of the button
to actually logout on click.

### Technical
Gave the form and button cursor: pointer; attributes and increased the width of the button to 100% of its parent (form).

### Testing
Test by logging into openlibrary and hovering on the logout button/clicking it to make sure it logs out.

### Screenshot
<img width="1205" alt="proof" src="https://user-images.githubusercontent.com/36729591/146458827-f3fc1cd0-d882-4dd0-a9a7-d022e15de26a.png">


### Stakeholders
