### PR TITLE
Fixed admin only feature showing on edit page

### DIFF
--- a/openlibrary/macros/TypeChanger.html
+++ b/openlibrary/macros/TypeChanger.html
@@ -1,8 +1,8 @@
 $def with (type, usetable=0)
 $# Used on http://localhost:8080/about?m=edit for blank page
 $# and any generic page in the admin UI; e.g. creating a page.
-<div class="formElement pagetype collapse adminOnly" id="pageType">
-    $if ctx.user and ctx.user.is_admin():
+$if ctx.user and ctx.user.is_admin():
+    <div class="formElement pagetype collapse adminOnly" id="pageType">
         <script>
         function changeTemplate() {
             var t = document.edit['type.key'].value;
@@ -20,6 +20,8 @@ $# and any generic page in the admin UI; e.g. creating a page.
         <div class="input">
             $:thinginput(type, name="type.key", id="type.key", expected_type="/type/type", kind="regular",  onchange="changeTemplate();")
         </div>
-    $else:
+    </div>
+$else:
+    <div class="formElement pagetype collapse" id="pageType">
         <input type="hidden" name="type.key" value="$type"/>
-</div>
+    </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4581

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Resolves the Issue of a `pageType` block showing in non admin mode

### Technical
<!-- What should be noted about the implementation? -->
Instead of conditionally rendering the contents of `pageType` block I have rendered the entire pageType block conditionally. In case the user is not an admin I have removed the class `adminOnly` from the` pageType` div which makes it's `display:none` automatically.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
User login: 
<img width="1439" alt="Screenshot 2021-12-17 at 9 10 56 AM" src="https://user-images.githubusercontent.com/73935799/146486194-5cd3c959-d07b-45c3-801d-83417cefdf45.png">

Admin login:
<img width="1438" alt="Screenshot 2021-12-17 at 9 13 42 AM" src="https://user-images.githubusercontent.com/73935799/146486220-2aa80dac-8c03-4203-9aa1-2cbcba775b11.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 
