### PR TITLE
Fix add some useful components to empty loans pages

### DIFF
--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -55,7 +55,8 @@ window.q.push(function(){
 <div>
   $if len(loans) == 0:
     <div><em>$_("You've not checked out any books at this moment.")</em></div>
-    $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test, compact_mode=True)
+    <div>Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific category:</div>
+     $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, compact_mode=True)
     $:render_template("home/categories", test=test)
     Check out our <a href="/collections">special collections</a>
 $else:

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -55,7 +55,8 @@ window.q.push(function(){
 <div>
   $if len(loans) == 0:
     <div><em>$_("You've not checked out any books at this moment.")</em></div>
-    <div>Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific category:</div>
+    <br>
+    <div>Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific subject:</div>
      $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, compact_mode=True)
     $:render_template("home/categories", test=test)
     Or, check out our <a href="/collections">special collections</a>.

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -58,10 +58,6 @@ window.q.push(function(){
     $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test, compact_mode=True)
     $:render_template("home/categories", test=test)
     Check out our <a href="/collections">special collections</a>
-
-
-
-
 $else:
   $# Have current loans
   <div class="borrow borrow-table collapse">

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -58,7 +58,7 @@ window.q.push(function(){
     <div>Looking for a book to borrow?  Check out our staff picks, or search for a book on a specific category:</div>
      $:render_template("home/custom_ia_carousel", title=_('Books We Love'), key="staff_picks", query='languageSorter:("English")', subject="openlibrary_staff_picks", sorts=["lending___last_browse desc"], limit=18, test=test, compact_mode=True)
     $:render_template("home/categories", test=test)
-    Check out our <a href="/collections">special collections</a>
+    Or, check out our <a href="/collections">special collections</a>.
 $else:
   $# Have current loans
   <div class="borrow borrow-table collapse">

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -1,4 +1,4 @@
-$def with (user, loans)
+$def with (user, loans, test=False)
 
 <style type="text/css">
 .date, .waitrank {
@@ -54,7 +54,13 @@ window.q.push(function(){
 
 <div>
   $if len(loans) == 0:
-    <div><em>$_("You've not checked out any books at this moment.")</em></div>
+    <!-- <div><em>$_("You've not checked out any books at this moment.")</em></div> -->
+
+        $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
+
+        $:render_template("home/categories", test=test) 
+
+
 $else:
   $# Have current loans
   <div class="borrow borrow-table collapse">

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -54,11 +54,12 @@ window.q.push(function(){
 
 <div>
   $if len(loans) == 0:
-    <!-- <div><em>$_("You've not checked out any books at this moment.")</em></div> -->
+    <div><em>$_("You've not checked out any books at this moment.")</em></div>
+    $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test, compact_mode=True)
+    $:render_template("home/categories", test=test)
+    Check out our <a href="/collections">special collections</a>
 
-        $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 
-        $:render_template("home/categories", test=test) 
 
 
 $else:

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,4 +1,4 @@
-$def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False)
+$def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False, compact_mode=False)
 
 $ ctx.setdefault("links", [])
 $# Apparently fonts always need crossorigin for some reason
@@ -72,7 +72,10 @@ $if test or (books and len(books) >= min_books):
           $ }
         $else:
           $ load_more_config = {}
-        $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
+        $if compact_mode:
+          $ config = ['.carousel-' + key, 4, 4, 4, 3, 2, 1, load_more_config ]
+        $else:
+          $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
         <div class="carousel carousel-$key carousel--progressively-enhanced"
           data-config="$json_encode(config)">
           $for index, book in enumerate(books or []):

--- a/openlibrary/templates/home/custom_ia_carousel.html
+++ b/openlibrary/templates/home/custom_ia_carousel.html
@@ -1,7 +1,7 @@
-$def with(title, key, query='', subject='', work_id='', _type='', sorts='', limit=None, min_books=7, test=False)
+$def with(title, key, query='', subject='', work_id='', _type='', sorts='', limit=None, min_books=7, test=False, compact_mode=False)
 
 $ url = compose_ia_url(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit, advanced=False)
 $ books = generic_carousel(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit) if not test else []
 $ sorts = ','.join(sorts) if sorts else ''
 $ load_more_url = '/browse.json?q=%s&subject=%s&work_id=%s&_type=%s&sorts=%s' % (query, subject, work_id, _type, sorts)
-$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more={"url": load_more_url, "mode": "page", "limit": limit}, test=test)
+$:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more={"url": load_more_url, "mode": "page", "limit": limit}, test=test, compact_mode=compact_mode)

--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   margin: 0 auto;
-  width: 100%;
+  width: 75%;
 
   header {
     padding: 8px;
@@ -43,5 +43,13 @@
 @media only screen and (max-width: @width-breakpoint-tablet) {
   .mybooks-details header {
     flex-direction: column-reverse;
+  }
+
+  .mybooks-details {
+    width: 100%;
+  }
+
+  .carousel-container {
+    margin: 0 -18px;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5979

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
#### Enhance user experience/engagement  on `/account/loans` page, 
If a patron has currently has no loans, display the following on the loans page:

- "Books We Love" carousel  [because of failure of creating the book we love carousel, instead I have replace it with 'Classic Books Carousel]
- "Browse by Subject" carousel
- link to our collections page (https://openlibrary.org/collections)

### Technical

<!-- What should be noted about the implementation? -->
1. Add boolean paramater <compact_mode> to custom_ia_carousel, custom_carousel template which will determine the breaking behaviour
1.2 Set breaking [a:f] pareters [4, 4, 4, 3, 2, 1]for the compact design
2. Make css changes in mybooks-details.less to make my loan page's carousel's responsive
3. Add action button to my loan's page which redirects to collections page

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Go to /accounts/loan 
2. DevTools Responsive Breakpoints

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![01](https://user-images.githubusercontent.com/58180803/146615913-69f70e14-822b-42f9-a336-b3be3fc7fb68.png)
![02](https://user-images.githubusercontent.com/58180803/146615917-2e7b4ee3-3b3e-4cc6-b5e7-1b426dc64fd6.png)
![03](https://user-images.githubusercontent.com/58180803/146615918-6f7806b4-dbcf-422e-9d20-7ec0c537d630.png)
![04](https://user-images.githubusercontent.com/58180803/146615923-1dcb73f3-55de-4c46-b1e2-4ef3ff287993.png)
![05](https://user-images.githubusercontent.com/58180803/146615925-7edb6c80-a44e-443d-806e-fd8a24dd6d4d.png)
![06](https://user-images.githubusercontent.com/58180803/146615929-9fede384-8bf9-4e97-9a0a-35b3735e82a9.png)




### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
