### PR TITLE
Fixed padding issue in `Log In` button.

### DIFF
--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -65,7 +65,7 @@ $var title: $("Log In")
 
         <div class="formElement bottom">
             <br/>
-            <input value="$_('Log In')" type="submit" class="login-submit" name="login" title="$_('Log In')"/>
+            <button value="$_('Log In')" type="submit" class="login-submit larger" name="login" title="$_('Log In')">$_('Log In')</button>
         </div>
         <div class="formElement">
             <div class="label"></div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5981 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes padding Issue in the `login` button, now it works just the same as the `Sign Up` button.


### Technical
<!-- What should be noted about the implementation? -->
Instead of using the `<input/>` tag in HTML, I have replaced it with `<button>` tag, this way the code is uniform with the signup page and the padding Issue is also solved.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1439" alt="Screenshot 2021-12-21 at 8 32 56 AM" src="https://user-images.githubusercontent.com/73935799/146863875-d746d8ba-44ae-483a-a438-9ee47bb0e7de.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
