### PR TITLE
Fixed the issue of title going out of bounds

### DIFF
--- a/static/css/components/illustration.less
+++ b/static/css/components/illustration.less
@@ -51,6 +51,7 @@
     height: 100px;
     margin-top: -50px;
     color: @dark-grey;
+    overflow-wrap: break-word;
   }
   .author {
     .BookTitle {


### PR DESCRIPTION
Signed-off-by: Hitansh Shah <shah.hitanshsanjay.mat20@itbhu.ac.in>

<!-- What issue does this PR close? -->
Closes #5976 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
I added a css property of `overflow-wrap: break-word;` under `.BookTitle` in static/css/components/illustration.less

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to "https://openlibrary.org/works/OL25750067W/%C2%98Die%C2%9C_Hauptaufgaben_des_Volkswirtschaftsplanes_%C2%981974_%C2%9C_neunzehnhundertvierundsiebzig_und_der_Weg_zu_" and check the cover image of the book

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/76250591/146939813-c978ce0c-9cc1-4707-941d-672a9831dda1.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
