### PR TITLE
fix Match color of page-banner and footer-icons

### DIFF
--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -60,7 +60,7 @@ footer {
     width: 35px;
     height: 35px;
     cursor: pointer;
-    background-color: @grey;
+    background-color: @dark-grey;
     border-radius: 3px;
     font-size: 20px;
     color: @white;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5986 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix color of footer-icons 

### Technical
<!-- What should be noted about the implementation? -->
Changes the css property from grey to dark-grey

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/58180803/147128195-318de42a-0651-41c1-ae94-fa22ca4b2fd2.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
