### PR TITLE
replacing civicrm call with elastic

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -36,7 +36,7 @@ PAGE_COST_CENTS = 12
 def get_sponsored_editions_civi(user):
     """
     Deprecated by get_sponsored_editions but worth maintaining as we
-    may periodicaly have to programatically access data from civi
+    may periodically have to programmatically access data from civi
     since it is the ground-truth of this data.
 
     Gets a list of books from the civi API which internet archive
@@ -54,9 +54,9 @@ def get_sponsored_editions_civi(user):
     return {}
 
 
-def get_sponsored_editions(user, page=1, civi=False):
+def get_sponsored_editions(user, page=1):
     """
-    Gets a list of books from the civi API which internet archive
+    Gets a list of books from archive.org elasticsearch
     @archive_username has sponsored
 
     :param user user: infogami user

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -51,7 +51,7 @@ def get_sponsored_editions_civi(user):
     if archive_id:
         contact_id = get_contact_id_by_username(archive_id) if archive_id else None
         return get_sponsorships_by_contact_id(contact_id) if contact_id else []
-    return {}
+    return []
 
 
 def get_sponsored_editions(user, page=1):

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -77,7 +77,7 @@ def get_sponsored_editions(user, page=1):
         r = requests.get(f'{url}?{params}')
         # e.g. [{'openlibrary_edition': 'OL24896084M', 'identifier': 'isbn_9780691160191'}]
         return r.json()['response'].get('docs')
-    return {}
+    return []
 
 
 def do_we_want_it(isbn):

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -193,7 +193,12 @@ class MyBooksTemplate:
             self.counts['sponsorships'] = len(sponsorships)
 
             if self.key == 'sponsorships':
-                data = self._prepare_data(logged_in_user, sponsorships=sponsorships)
+                data = add_availability(
+                    web.ctx.site.get_many([
+                        '/books/%s' % doc['openlibrary_edition']
+                        for doc in sponsorships
+                    ])
+                )
             elif self.key in self.READING_LOG_KEYS:
                 data = add_availability(
                     self.readlog.get_works(
@@ -235,16 +240,6 @@ class MyBooksTemplate:
         page=1,
         username=None,
     ):
-        if sponsorships:
-            return (
-                web.ctx.site.get(
-                    web.ctx.site.things(
-                        {'type': '/type/edition', 'isbn_%s' % len(s['isbn']): s['isbn']}
-                    )[0]
-                )
-                for s in sponsorships
-            )
-
         if self.key == 'loans':
             logged_in_user.update_loan_status()
             return borrow.get_loans(logged_in_user)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -236,7 +236,6 @@ class MyBooksTemplate:
     def _prepare_data(
         self,
         logged_in_user,
-        sponsorships=None,
         page=1,
         username=None,
     ):

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -198,7 +198,7 @@ class MyBooksTemplate:
                         '/books/%s' % doc['openlibrary_edition']
                         for doc in sponsorships
                     ])
-                )
+                ) if sponsorships else None
             elif self.key in self.READING_LOG_KEYS:
                 data = add_availability(
                     self.readlog.get_works(

--- a/openlibrary/tests/core/test_sponsors.py
+++ b/openlibrary/tests/core/test_sponsors.py
@@ -4,7 +4,31 @@ from openlibrary.core.sponsorships import do_we_want_it
 
 
 class TestSponsorship:
+
     def test_get_sponsored_editions(self, monkeypatch):
+        user = storage(key='/person/mekBot')
+
+        monkeypatch.setattr(
+            sponsorships, 'get_internet_archive_id', lambda user_key: '@username'
+        )
+        assert sponsorships.get_internet_archive_id(user) == '@username'
+
+        class RequestMock(dict):
+            def __init__(self, *arg):
+                super().__init__(*arg)
+
+            def json(self):
+                return self
+
+        monkeypatch.setattr(
+            sponsorships.requests, 'get', lambda url, **kwargs:
+            RequestMock({'response': {'docs': []}})
+        )
+
+        assert sponsorships.get_sponsored_editions(user) == []
+
+
+    def test_get_sponsored_editions_civi(self, monkeypatch):
         user = storage(key='/person/mekBot')
 
         monkeypatch.setattr(
@@ -15,7 +39,7 @@ class TestSponsorship:
             sponsorships, 'get_contact_id_by_username', lambda archive_id: None
         )
         assert sponsorships.get_contact_id_by_username('@username') is None
-        assert sponsorships.get_sponsored_editions(user) == []
+        assert sponsorships.get_sponsored_editions_civi(user) == []
 
         monkeypatch.setattr(
             sponsorships, 'get_contact_id_by_username', lambda archive_id: '123'
@@ -26,7 +50,7 @@ class TestSponsorship:
             'get_sponsorships_by_contact_id',
             lambda contact_id: ['fake_data'],
         )
-        assert sponsorships.get_sponsored_editions(user) == ['fake_data']
+        assert sponsorships.get_sponsored_editions_civi(user) == ['fake_data']
 
     def test_do_we_want_it(self, monkeypatch, mock_site):
         isbn = '0123456789'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5801

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces CiviCRM call w/ Archive.org ElasticSearch queries (less reliance on additional services)

### Technical
<!-- What should be noted about the implementation? -->

**NOTE:**
On staging, notes seems to be broken (but is working in production)
https://staging.openlibrary.org/people/mekBot/books/notes?debug=true

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

http://ol-dev1.us.archive.org:1337/people/mekBot/books/sponsorships

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

**When  on `sponsorships` tab**
![ol-dev1 us archive org_1337_people_mekBot_books_sponsorships](https://user-images.githubusercontent.com/978325/147395635-7bde3591-d4ce-4b5a-8499-6bcb98b04799.png)

**When not on `sponsorships` tab**
![ol-dev1 us archive org_1337_people_mekBot_books_currently-reading](https://user-images.githubusercontent.com/978325/147395634-9ac17ed2-5e1c-407a-a0a8-c1cff78b49bb.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @jimchamp @bfalling 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
