### PR TITLE
Adding trending view

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -167,11 +167,29 @@ class Bookshelves:
                 "LIMIT $limit OFFSET $offset"
             )
         if bookshelf_id is None:
-            query = "SELECT * from bookshelves_books WHERE " "username=$username"
+            query = "SELECT * from bookshelves_books WHERE username=$username"
             # XXX Removing limit, offset, etc from data looks like a bug
             # unrelated / not fixing in this PR.
             data = {'username': username}
         return list(oldb.query(query, vars=data))
+
+
+    @classmethod
+    def get_recently_logged_books(cls, bookshelf_id=None, limit=50, page=1):
+        oldb = db.get_db()
+        page = int(page) if page else 1
+        data = {
+            'bookshelf_id': bookshelf_id,
+            'limit': limit,
+            'offset': limit * (page - 1),
+        }
+        where = "WHERE bookshelf_id=$bookshelf_id " if bookshelf_id else ""
+        query = (
+            f"SELECT * from bookshelves_books {where} "
+            "ORDER BY created DESC LIMIT $limit OFFSET $offset"
+        )
+        return list(oldb.query(query, vars=data))
+
 
     @classmethod
     def get_users_read_status_of_work(cls, username, work_id):

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -1,7 +1,10 @@
 from typing import Literal
 from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
+import logging
 from . import db
+
+logger = logging.getLogger(__name__)
 
 
 class Bookshelves:
@@ -70,22 +73,26 @@ class Bookshelves:
         return results[0] if results else None
 
     @classmethod
-    def most_logged_books(cls, shelf_id, limit=10, since=False):
+    def most_logged_books(cls, shelf_id=None, limit=10, since=False):
         """Returns a ranked list of work OLIDs (in the form of an integer --
         i.e. OL123W would be 123) which have been most logged by
         users. This query is limited to a specific shelf_id (e.g. 1
         for "Want to Read").
         """
         oldb = db.get_db()
-        query = 'select work_id, count(*) as cnt from bookshelves_books WHERE bookshelf_id=$shelf_id '
+        where = 'WHERE bookshelf_id' + ('=$shelf_id' if shelf_id else ' IS NOT NULL ')
         if since:
-            query += " AND created >= $since"
+            where += 'AND created >= $since'
+        query = f'select work_id, count(*) as cnt from bookshelves_books {where}'
         query += ' group by work_id order by cnt desc limit $limit'
-        return list(
+        logger.info("Query: %s", query)
+        logged_books = list(
             oldb.query(
                 query, vars={'shelf_id': shelf_id, 'limit': limit, 'since': since}
             )
         )
+        logger.info("Results: %s", logged_books)
+        return logged_books
 
     @classmethod
     def count_total_books_logged_by_user(cls, username, bookshelf_ids=None):

--- a/openlibrary/templates/stats/readinglog.html
+++ b/openlibrary/templates/stats/readinglog.html
@@ -59,18 +59,19 @@ $def with (stats)
   </div>
 
   <div class="admin-section">
-    <h3>$_('Most Wanted Books (All Time)')</h3>
+
+    <h3>$_('Most Wanted Books (This Month)')</h3>
     <div class="mybooks-list">
-      <ul class="list-books">
-        $for book in stats['leaderboard']['most_wanted_all']:
+     <ul class="list-books">
+        $for book in stats['leaderboard']['most_wanted_month']:
             $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
       </ul>
     </div>
 
-    <h3>$_('Most Wanted Books (This Month)')</h3>
+    <h3>$_('Most Wanted Books (All Time)')</h3>
     <div class="mybooks-list">
       <ul class="list-books">
-        $for book in stats['leaderboard']['most_wanted_month']:
+        $for book in stats['leaderboard']['most_wanted_all']:
             $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
       </ul>
     </div>

--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -1,0 +1,15 @@
+$def with (logged_books=None)
+
+<div id="contentBody">
+  <h1>$_('Activity Stream')</h1>
+
+  <div class="mybooks-list">
+    <ul class="list-books">
+      $if logged_books:
+        $for entry in logged_books:
+          $ shelf = {1: "Want to Read", 2: "Currently Reading", 3: "Read"}[entry['bookshelf_id']]
+          $:macros.SearchResultsWork(entry['work'], extra="Anonymous " + "marked as " + shelf + " at " + entry['created'].strftime("%m/%d/%Y at %H:%M:%S"), availability=entry['work'].get('availability'))
+    </ul>
+  </div>
+
+</div>

--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -1,15 +1,24 @@
-$def with (logged_books=None)
+$def with (logged_books=None, mode='now')
 
 <div id="contentBody">
-  <h1>$_('Activity Stream')</h1>
+  $ pages = {'now': 'Now', 'daily': 'Today', 'weekly': 'This Week', 'monthly': 'This Month', 'yearly': 'This Year', 'forever': 'All Time'}
+  <h1>$_('Trending Books'): $_(pages[mode])</h1>
+  <p>Books patrons in the community have added to their shelves</p>
+  <p>
+    $for p in pages:
+      <a style="$('font-weight: bold;' if p==mode else '')" href="/trending/$(p)">$pages[p]</a>
+  </p>
 
   <div class="mybooks-list">
     <ul class="list-books">
       $if logged_books:
         $for entry in logged_books:
-          $ shelf = {1: "Want to Read", 2: "Currently Reading", 3: "Read"}[entry['bookshelf_id']]
-          $:macros.SearchResultsWork(entry['work'], extra="Anonymous " + "marked as " + shelf + " at " + entry['created'].strftime("%m/%d/%Y at %H:%M:%S"), availability=entry['work'].get('availability'))
+          $if 'bookshelf_id' in entry:
+            $ shelf = {1: "Want to Read", 2: "Currently Reading", 3: "Read"}[entry['bookshelf_id']]
+            $ extra = "Anonymous " + "marked as " + shelf + " at " + entry['created'].strftime("%m/%d/%Y at %H:%M:%S")
+          $else:
+            $ extra = 'Logged %i times %s' % (entry['cnt'], pages[mode])
+          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'))
     </ul>
   </div>
-
 </div>

--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -3,7 +3,7 @@ $def with (logged_books=None, mode='now')
 <div id="contentBody">
   $ pages = {'now': 'Now', 'daily': 'Today', 'weekly': 'This Week', 'monthly': 'This Month', 'yearly': 'This Year', 'forever': 'All Time'}
   <h1>$_('Trending Books'): $_(pages[mode])</h1>
-  <p>Books patrons in the community have added to their shelves</p>
+  <p>$_("See what readers from the community are adding to their bookshelves")</p>
   <p>
     $for p in pages:
       <a style="$('font-weight: bold;' if p==mode else '')" href="/trending/$(p)">$pages[p]</a>
@@ -15,10 +15,11 @@ $def with (logged_books=None, mode='now')
         $for entry in logged_books:
           $if 'bookshelf_id' in entry:
             $ shelf = {1: "Want to Read", 2: "Currently Reading", 3: "Read"}[entry['bookshelf_id']]
-            $ extra = "Anonymous " + "marked as " + shelf + " at " + entry['created'].strftime("%m/%d/%Y at %H:%M:%S")
+            $ extra = "Someone marked as " + shelf + ", " + entry['created'].strftime("%m/%d/%Y at %H:%M:%S")
           $else:
             $ extra = 'Logged %i times %s' % (entry['cnt'], pages[mode])
-          $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'))
+          $if entry.get('work'):
+            $:macros.SearchResultsWork(entry['work'], extra=extra, availability=entry['work'].get('availability'))
     </ul>
   </div>
 </div>

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -30,8 +30,10 @@ def date_n_days_ago(n=None, start=None):
     return (_start - datetime.timedelta(days=n)) if n else None
 
 
+DATE_ONE_YEAR_AGO = date_n_days_ago(n=365)
 DATE_ONE_MONTH_AGO = date_n_days_ago(n=days_in_current_month())
 DATE_ONE_WEEK_AGO = date_n_days_ago(n=7)
+DATE_ONE_DAY_AGO = date_n_days_ago(n=1)
 
 
 def parse_date(datestr):

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -28,7 +28,7 @@ td {
   padding: 0;
 }
 h1 {
-  margin: 20px;
+  margin: 20px 0;
 }
 button {
   outline: none;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
From 2022 Roadmap: build on https://openlibrary.org/stats/readinglog (prereq for following patrons #739 + #1964 #857 #3449)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Shows a ~realtime list of books being logged by patrons

### Proposal

**This should definitely be a homepage carousel, cached every 5 minutes!**

### Technical
<!-- What should be noted about the implementation? -->

* [x] On https://openlibrary.org/stats/readinglog we have trending all time & this month
* [x] Next up is adding a view for today, this week
* [x] And combining these all into a usable interface (rather than all squished on one page)
* [x] ~Before we show usernames, the privacy setting need to be tweaked to only include those with public reading logs~ mark as anonymous for now

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Try it here: http://ol-dev1.us.archive.org:1337/trending

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ol-dev1 us archive org_1337_trending](https://user-images.githubusercontent.com/978325/147403678-5ee9c314-b6cb-47c8-bcc9-a22354c8907d.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
