### PR TITLE
added padding and font issue on submit button related to issue #6003

### DIFF
--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -18,7 +18,7 @@ $if search:
     $if has_fulltext_only:
       <input type="hidden" name="has_fulltext" value="true"/>
     <input type="text" placeholder="Search collection" name="q2"/>
-    <input type="submit"/>
+    <input style="padding: 3px; font-size:medium;" type="submit"/>
   </form>
 
 $code:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6003

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added more padding to the submit button on the collections page search box

### Technical
<!-- What should be noted about the implementation? -->
Adding padding helps to beutify button

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. --> Just check the inline css done on the file https://github.com/internetarchive/openlibrary/blob/master/openlibrary/macros/QueryCarousel.html in this line 21

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
before:
![image](https://user-images.githubusercontent.com/80326954/147734899-467d32af-5744-48e7-b63d-f41dd7fbbce3.png)
after:
![image](https://user-images.githubusercontent.com/80326954/147734956-1dc19887-c5c3-4e3e-aace-78c4bf20bf9e.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
Checked