### PR TITLE
Add Excluded Works & Authors to List Exports

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -18,6 +18,7 @@ from openlibrary.plugins.worksearch.search import get_solr
 import six
 from six.moves import urllib
 
+from typing import Dict
 
 logger = logging.getLogger("openlibrary.lists.model")
 
@@ -162,7 +163,7 @@ class ListMixin:
             for k in doc['edition_key']:
                 yield "/books/" + k
 
-    def get_export_list(self):
+    def get_export_list(self)  -> Dict[str, list]:
         """Returns all the editions, works and authors of this list in arbitrary order.
 
         The return value is an iterator over all the entries. Each entry is a dictionary.

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -162,6 +162,37 @@ class ListMixin:
             for k in doc['edition_key']:
                 yield "/books/" + k
 
+    def get_export_list(self):
+        """Returns all the editions, works and authors of this list in arbitrary order.
+
+        The return value is an iterator over all the entries. Each entry is a dictionary.
+
+        This works even for lists with too many seeds as it doesn't try to
+        return entries in the order of last-modified.
+        """
+
+        # Separate by type each of the keys
+        edition_keys = {
+            seed.key for seed in self.seeds if seed and seed.type.key == '/type/edition'
+        }
+        work_keys = {
+            "/works/%s" % seed.key.split("/")[-1] for seed in self.seeds if seed and seed.type.key == '/type/work'
+        }
+        author_keys = {
+            "/authors/%s" % seed.key.split("/")[-1] for seed in self.seeds if seed and seed.type.key == '/type/author'
+        }
+
+        # Create the return dictionary
+        export_list = {}
+        if edition_keys:
+            export_list["editions"] = [doc.dict() for doc in web.ctx.site.get_many(list(edition_keys))]
+        if work_keys:
+            export_list["works"] = [doc.dict() for doc in web.ctx.site.get_many(list(work_keys))]
+        if author_keys:
+            export_list["authors"] = [doc.dict() for doc in web.ctx.site.get_many(list(author_keys))]
+
+        return export_list
+
     def _preload(self, keys):
         keys = list(set(keys))
         return self._site.get_many(keys)

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -18,8 +18,6 @@ from openlibrary.plugins.worksearch.search import get_solr
 import six
 from six.moves import urllib
 
-from typing import Dict
-
 logger = logging.getLogger("openlibrary.lists.model")
 
 # this will be imported on demand to avoid circular dependency
@@ -163,7 +161,7 @@ class ListMixin:
             for k in doc['edition_key']:
                 yield "/books/" + k
 
-    def get_export_list(self)  -> Dict[str, list]:
+    def get_export_list(self)  -> dict[str, list]:
         """Returns all the editions, works and authors of this list in arbitrary order.
 
         The return value is an iterator over all the entries. Each entry is a dictionary.

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -471,8 +471,7 @@ class export(delegate.page):
         else:
             raise web.notfound()
     
-    def get_exports(self, lst: list, raw: bool = False) -> d
-    ict[str, list]:
+    def get_exports(self, lst: list, raw: bool = False) -> dict[str, list]:
         export_data = lst.get_export_list()
         if "editions" in export_data:
             export_data["editions"] = sorted(

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -18,7 +18,6 @@ from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.upstream.account import MyBooksTemplate
 from openlibrary.plugins.worksearch import subjects
 
-from typing import Dict
 
 class lists_home(delegate.page):
     path = "/lists"

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -465,7 +465,7 @@ class export(delegate.page):
             data = self.get_exports(lst, raw=True)
             web.header("Content-Type", "application/json")
             return delegate.RawText(json.dumps(data))
-        elif format == "yaml": 
+        elif format == "yaml":
             data = self.get_exports(lst, raw=True)
             web.header("Content-Type", "application/yaml")
             return delegate.RawText(formats.dump_yaml(data))

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -470,7 +470,7 @@ class export(delegate.page):
             return delegate.RawText(formats.dump_yaml(data))
         else:
             raise web.notfound()
-    
+
     def get_exports(self, lst: list, raw: bool = False) -> dict[str, list]:
         export_data = lst.get_export_list()
         if "editions" in export_data:

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -471,7 +471,8 @@ class export(delegate.page):
         else:
             raise web.notfound()
     
-    def get_exports(self, lst: list, raw: bool = False) -> Dict[str, list]:
+    def get_exports(self, lst: list, raw: bool = False) -> d
+    ict[str, list]:
         export_data = lst.get_export_list()
         if "editions" in export_data:
             export_data["editions"] = sorted(

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -18,6 +18,7 @@ from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.upstream.account import MyBooksTemplate
 from openlibrary.plugins.worksearch import subjects
 
+from typing import Dict
 
 class lists_home(delegate.page):
     path = "/lists"
@@ -471,7 +472,7 @@ class export(delegate.page):
         else:
             raise web.notfound()
     
-    def get_exports(self, lst, raw=False):
+    def get_exports(self, lst: list, raw: bool = False) -> Dict[str, list]:
         export_data = lst.get_export_list()
         if "editions" in export_data:
             export_data["editions"] = sorted(

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -451,23 +451,64 @@ class export(delegate.page):
         format = web.input(format="html").format
 
         if format == "html":
-            html = render_template("lists/export_as_html", lst, self.get_editions(lst))
+            data = self.get_exports(lst)
+            html = render_template("lists/export_as_html", lst, data["editions"], data["works"], data["authors"])
             return delegate.RawText(html)
         elif format == "bibtex":
+            data = self.get_exports(lst)
             html = render_template(
-                "lists/export_as_bibtex", lst, self.get_editions(lst)
+                "lists/export_as_bibtex", lst, data["editions"], data["works"], data["authors"]
             )
             return delegate.RawText(html)
         elif format == "json":
-            data = {"editions": self.get_editions(lst, raw=True)}
+            data = self.get_exports(lst, raw=True)
             web.header("Content-Type", "application/json")
             return delegate.RawText(json.dumps(data))
-        elif format == "yaml":
-            data = {"editions": self.get_editions(lst, raw=True)}
+        elif format == "yaml": 
+            data = self.get_exports(lst, raw=True)
             web.header("Content-Type", "application/yaml")
             return delegate.RawText(formats.dump_yaml(data))
         else:
             raise web.notfound()
+    
+    def get_exports(self, lst, raw=False):
+        export_data = lst.get_export_list()
+        if "editions" in export_data:
+            export_data["editions"] = sorted(
+                export_data["editions"],
+                key=lambda doc: doc['last_modified']['value'],
+                reverse=True,
+            )
+        if "works" in export_data:
+            export_data["works"] = sorted(
+                export_data["works"],
+                key=lambda doc: doc['last_modified']['value'],
+                reverse=True,
+            )
+        if "authors" in export_data:
+            export_data["authors"] = sorted(
+                export_data["authors"],
+                key=lambda doc: doc['last_modified']['value'],
+                reverse=True,
+            )
+
+        if not raw:
+            if "editions" in export_data:
+                export_data["editions"] = [self.make_doc(e) for e in export_data["editions"]]
+                lst.preload_authors(export_data["editions"])
+            else:
+                export_data["editions"] = []
+            if "works" in export_data:
+                export_data["works"] = [self.make_doc(e) for e in export_data["works"]]
+                lst.preload_authors(export_data["works"])
+            else:
+                export_data["works"] = []
+            if "authors" in export_data:
+                export_data["authors"] = [self.make_doc(e) for e in export_data["authors"]]
+                lst.preload_authors(export_data["authors"])
+            else:
+                export_data["authors"] = []
+        return export_data
 
     def get_editions(self, lst, raw=False):
         editions = sorted(

--- a/openlibrary/templates/lists/export_as_bibtex.html
+++ b/openlibrary/templates/lists/export_as_bibtex.html
@@ -1,4 +1,4 @@
-$def with (list, editions)
+$def with (list, editions, works, authors)
 
 $var content_type = "application/x-bibtex"
 
@@ -18,4 +18,31 @@ $for e in editions:
             year: {$:texsafe(str(year))},
         $if e.publish_places:
             place: {$:texsafe(e.publish_places[0])},
+    }
+
+$for e in works:
+    @Work{$e.key.split("/")[-1],
+        title: {$:texsafe(e.title)},
+        $if e.works:
+            $ authors = e.works[0].get_authors()
+        $else:
+            $ authors = e.get_authors()
+        $if authors:
+            author: {$" and ".join(texsafe(a.name or "unnamed") for a in authors)},
+        $if e.publishers:
+            publisher: {$:texsafe(e.publishers[0])},
+        $ year = e.first_publish_year
+        $if year:
+            first_publish_year: {$:texsafe(str(year))}
+    }
+
+$for e in authors:
+    @Author{$e.key.split("/")[-1],
+        name: {$:texsafe(e.name)},
+        $ birth_date = e.birth_date
+        $if birth_date:
+            birth_date: {$:texsafe(str(birth_date))}
+        $ death_date = e.death_date
+        $if death_date:
+            , death_date: {$:texsafe(str(death_date))}
     }

--- a/openlibrary/templates/lists/export_as_html.html
+++ b/openlibrary/templates/lists/export_as_html.html
@@ -1,4 +1,4 @@
-$def with (list, editions)
+$def with (list, editions, works, authors)
 <html>
 <head>
     <title>$list.name - Editions</title>
@@ -29,17 +29,50 @@ $def with (list, editions)
                 <a href="$request.home$book.url()">$book.get('title', 'Title unknown')</a>
             </h3>
             by $:render_authors(book)
-
             <div class="published">
                 $if book.publishers and book.publish_date:
                     $book.publish_date, $(', '.join(book.publishers))
-                $elif book.publish_date:
+                $elif book.first_publish_date:
                     $book.publish_date
                 $elif book.publishers:
                     <em>Publish date unknown</em>, $(', '.join(book.publishers))
                 $else:
                     <em>Publisher unknown</em>
             </div>
+            <br/>
+        </li>
+    </ul>
+    <ul>
+    $for book in works:
+        <li>
+            <h3 class="title">
+                <a href="$request.home$book.url()">$book.get('title', 'Title unknown')</a>
+            </h3>
+            by $:render_authors(book)
+
+            <div class="published">
+                $if book.first_publish_year:
+                    $book.first_publish_year
+                $else:
+                    <em>First publish date unknown</em>
+            </div>
+            <br/>
+        </li>
+    </ul>
+    <ul>
+    $for author in authors:
+        <li>
+            <h3 class="title">
+                <a href="$request.home$author.url()">$author.get('name', 'Name unknown')</a>
+            </h3>
+            $if author.birth_date:
+                ( $author.birth_date
+            $else:
+                <em>( - </em>
+            $if author.death_date:
+                - $author.death_date )
+            $else:
+                <em> )</em>
             <br/>
         </li>
     </ul>


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #5868 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Modifies the current implementation for exporting lists, in which only **Edition** elements work as expected, as **Works* * and **Authors** don't work and give different results than expected respectively. This PR makes the export functionality follow the same behavior as the API.

### Technical
<!-- What should be noted about the implementation? -->
From what I've gathered, the current implementation of the export functionality uses the following method:

https://github.com/internetarchive/openlibrary/blob/c63d733da0e1c9f294caa4eb3cbe341d1f3a4541/openlibrary/core/lists/model.py#L123

The way this method works, it searches for all of the editions related to a given author and work, which explains the reason that when exporting authors a complete list of all of their books is given. The reference for *works* is currently broken, that's why it gives an empty list as a result.

This PR adds another method especifically designed for exporting lists, in which the information of each of the 3 possible types of entries is separated and sent with the structure defined by the API.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Export each of the 3 following lists, their behavior should be:
* [Edition](https://openlibrary.org/people/al_0/lists/OL204223L/test_edition): Working as expected.
* [Work](https://openlibrary.org/people/al_0/lists/OL204222L/test_work): *Not Working*, exports an empty list.
* [Author](https://openlibrary.org/people/al_0/lists/OL204221L/test_author): *Not Working*, provides a complete list of all the author's books.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
The following list is created:
<img width="821" alt="Screen Shot 2022-01-05 at 1 44 09" src="https://user-images.githubusercontent.com/55642668/148179332-d8551fd3-4cc2-4f9f-ac86-fc29df1e5385.png">

When exporting as JSON:
<img width="1439" alt="Screen Shot 2022-01-05 at 1 46 04" src="https://user-images.githubusercontent.com/55642668/148179747-a160813d-7eab-4b34-883c-692c40caea62.png">
[Link to the JSON](https://gist.github.com/Al-0/743e476e161d299384e53f6b0b7b780d)

When exporting as HTML:
<img width="798" alt="Screen Shot 2022-01-05 at 1 48 17" src="https://user-images.githubusercontent.com/55642668/148179998-d5c0081c-3879-4f57-93ea-b22c66170ecc.png">

When exporting as BibTex:
<img width="1432" alt="Screen Shot 2022-01-05 at 1 48 45" src="https://user-images.githubusercontent.com/55642668/148180050-8d168e9b-afcd-4731-af44-53d539d71d5a.png">

When exporting as Yaml:
<img width="1440" alt="Screen Shot 2022-01-05 at 1 49 41" src="https://user-images.githubusercontent.com/55642668/148180182-73ad598c-625c-4b87-88f3-cf145879f976.png">
[Link to the Yaml file](https://gist.github.com/Al-0/b3895152e6346dcb9e0a105f0f273753)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@dcapillae @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
