### PR TITLE
Add ISO 639-1 in language.page

### DIFF
--- a/scripts/ISO_639-1.py
+++ b/scripts/ISO_639-1.py
@@ -1,0 +1,39 @@
+import json 
+import requests 
+from bs4 import BeautifulSoup # library to parse HTML documents
+import pandas as pd # library for data analysis
+
+#GET INFORMATION FROM List_of_ISO_639-1_codes
+wikiurl="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes"
+table_class="wikitable sortable jquery-tablesorter"
+response=requests.get(wikiurl)
+
+# parse data from the html into a beautifulsoup object
+soup = BeautifulSoup(response.text, 'html.parser')
+indiatable=soup.find('table',{'class':"wikitable"})
+
+df=pd.read_html(str(indiatable))
+df=pd.DataFrame(df[0])
+
+columns = df[["639-1", "639-2/B"]]
+
+ISO = {row['639-2/B']:row['639-1'] for index, row in df.iterrows()}
+
+#GET DATA FROM Languages.page
+with open ("openlibrary/plugins/openlibrary/pages/languages.page", "r") as languages :
+  data=json.load(languages)
+  for line in data:
+    code=line["code"]
+    if code in ISO:
+     ISO_1=ISO[code]
+     line["iso_639_1"] = ISO_1
+  
+  render_languagues=json.dumps(data, indent = 2)
+
+with open("openlibrary/plugins/openlibrary/pages/new_languages.page","w") as file:
+  file.write(render_languagues)
+  
+    
+
+
+

--- a/scripts/ISO_639-1.py
+++ b/scripts/ISO_639-1.py
@@ -32,8 +32,3 @@ with open ("openlibrary/plugins/openlibrary/pages/languages.page", "r") as langu
 
 with open("openlibrary/plugins/openlibrary/pages/new_languages.page","w") as file:
   file.write(render_languagues)
-  
-    
-
-
-


### PR DESCRIPTION
Add ISO 639-1 language codes to OL language records

<!-- What issue does this PR close? -->
Closes #5997

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature:Create a script to copy data from https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes , take information from the column 639-1 and add a new field in the language.page. 

### Technical
<!-- What should be noted about the implementation? -->
The script is generating a new file with the additional information, however for a better implementation one could look to overwrite the document .

<img width="258" alt="Screen Shot 2022-01-06 at 12 54 02 AM" src="https://user-images.githubusercontent.com/70716664/148341643-a57a4c93-c617-42a6-bb24-9ceb09657007.png">

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
At the moment there is no component of the List that display the information of 639-1

<img width="496" alt="Screen Shot 2022-01-06 at 12 59 22 AM" src="https://user-images.githubusercontent.com/70716664/148342178-3f438be9-a200-498c-8c61-c9977f0e819f.png">


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Adding information of 639-1
<img width="703" alt="Screen Shot 2022-01-06 at 1 00 32 AM" src="https://user-images.githubusercontent.com/70716664/148342363-67d543da-d5cd-4759-996c-2ac010a1dcf6.png">
 **https://gist.github.com/ejgonzalez17/e8389ea0d632ad05e78a3abce61f26f3.js**

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
