### PR TITLE
Use SolrProcessor.get_pub_year to get edition years

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -595,8 +595,9 @@ class SolrProcessor:
         pub_dates = {e[k] for e in editions if e.get(k)}
         add_list(k, pub_dates)
         pub_years = {
-            m.group(1) for m in (re_year.search(date) for date in pub_dates) if m
+            self.get_pub_year(e) for e in editions
         }
+        pub_years = pub_years - {None,}
         if pub_years:
             add_list('publish_year', pub_years)
             add('first_publish_year', min(int(y) for y in pub_years))

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -43,9 +43,8 @@ re_lang_key = re.compile(r'^/(?:l|languages)/([a-z]{3})$')
 re_author_key = re.compile(r'^/(?:a|authors)/(OL\d+A)')
 re_bad_char = re.compile('[\x01\x0b\x1a-\x1e]')
 re_edition_key = re.compile(r"/books/([^/]+)")
-re_iso_date = re.compile(r'^(\d{4})-\d\d-\d\d$')
 re_solr_field = re.compile(r'^[-\w]+$', re.U)
-re_year = re.compile(r'(\d{4})$')
+re_year = re.compile(r'\b(\d{4})\b')
 
 # This will be set to a data provider; have faith, mypy!
 data_provider = cast(DataProvider, None)
@@ -491,9 +490,6 @@ class SolrProcessor:
         """
         pub_date = e.get('publish_date', None)
         if pub_date:
-            m = re_iso_date.match(pub_date)
-            if m:
-                return m.group(1)
             m = re_year.search(pub_date)
             if m:
                 return m.group(1)

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -164,7 +164,7 @@ class Test_build_data:
         test_dates = [
             "2000",
             "Another 2000",
-            "2001-01-02",  # Doesn't seems to be handling this case
+            "2001-01-02",  # ISO 8601 formatted dates now supported
             "01-02-2003",
             "Jan 2002",
             "Bad date 12",
@@ -175,7 +175,7 @@ class Test_build_data:
         )
 
         d = build_data(work)
-        assert sorted(d['publish_year']) == ["2000", "2002", "2003"]
+        assert sorted(d['publish_year']) == ["2000", "2001", "2002", "2003"]
         assert d["first_publish_year"] == 2000
 
     def test_isbns(self):

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -166,8 +166,10 @@ class Test_build_data:
             "Another 2000",
             "2001-01-02",  # ISO 8601 formatted dates now supported
             "01-02-2003",
+            "2004 May 23",
             "Jan 2002",
             "Bad date 12",
+            "Bad date 123412314",
         ]
         work = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -175,7 +177,7 @@ class Test_build_data:
         )
 
         d = build_data(work)
-        assert sorted(d['publish_year']) == ["2000", "2001", "2002", "2003"]
+        assert sorted(d['publish_year']) == ["2000", "2001", "2002", "2003", "2004"]
         assert d["first_publish_year"] == 2000
 
     def test_isbns(self):


### PR DESCRIPTION
get_pub_year already supports ISO dates, as well as simple year strings, so it is an easy fix for the issue described in #6021. I don't believe this can have any negative side effects, it will simply extend support to ISO 8601 formatted dates without affecting dates currently indexed normally as get_pub_year falls back to re_year.search if re_iso_date doesn't match.

<!-- What issue does this PR close? -->
Closes #6021

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
This is a fix as currently the document indexed by SOLR for works with only ISO dates doesn't have the "first_published_year" attribute, causing the UI issue described in #6021.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Add a work and edition with an ISO 8601 format date and look at the SOLR index for that work, you should notice the lack of "publish_year" and "first_publish_year" attributes. This affects worksearch, and the UI as described in #6021. After checking out the changes in this PR please reindex `docker-compose exec web make reindex-solr` and you should now see the aforementioned attributes for the respective work in SOLR. 

### Screenshot
Example of record with ISO 8601 formatted publish date.

<!--If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![example-record](https://user-images.githubusercontent.com/722096/148450380-39a90356-1a0c-4bf3-a3af-00ee0f2e2279.png)

SearchResultsWork macro displaying the year correctly.

![example-searchresultswork-macro](https://user-images.githubusercontent.com/722096/148450449-11f56ae1-7faa-4fb6-9273-2899b1ad5200.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
