### PR TITLE
Fixed editions table on books pages contains link to current page

### DIFF
--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -14,7 +14,6 @@ $ book_keys = []
         $ edition_list_start = time()
         $ editions = editions or work.get_sorted_editions()
         $ index_padding = len(str(len(editions)))
-        $ render_first_flag = 1
         $for book in editions:
             $ book_keys.append(book['key'].replace('/books/', ''))
             $ edition_sort_key = str(loop.index0+1).zfill(index_padding)

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -14,18 +14,20 @@ $ book_keys = []
         $ edition_list_start = time()
         $ editions = editions or work.get_sorted_editions()
         $ index_padding = len(str(len(editions)))
+        $ render_first_flag = 1
         $for book in editions:
             $ book_keys.append(book['key'].replace('/books/', ''))
             $ edition_sort_key = str(loop.index0+1).zfill(index_padding)
-            $if book.key == edition.key:
-              <tr class="highlight">
-                $# This enables us to always render a select edition first in the table (default)
-                $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
-              </tr>
-            $else:
-              <tr>
-                $:render_template("books/edition-sort", book, edition_sort_key)
-              </tr>
+            $if book.key != edition.key:
+              $if render_first_flag == 1:
+                <tr class="highlight">
+                  $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
+                </tr>
+                $ render_first_flag = 0
+              $else:
+                <tr>
+                  $:render_template("books/edition-sort", book, edition_sort_key)
+                </tr>
         $ edition_list_secs = time() - edition_list_start
     </tbody>
 </table>

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -19,15 +19,9 @@ $ book_keys = []
             $ book_keys.append(book['key'].replace('/books/', ''))
             $ edition_sort_key = str(loop.index0+1).zfill(index_padding)
             $if book.key != edition.key:
-              $if render_first_flag == 1:
-                <tr class="highlight">
-                  $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
-                </tr>
-                $ render_first_flag = 0
-              $else:
-                <tr>
-                  $:render_template("books/edition-sort", book, edition_sort_key)
-                </tr>
+              <tr>
+                $:render_template("books/edition-sort", book, edition_sort_key)
+              </tr>
         $ edition_list_secs = time() - edition_list_start
     </tbody>
 </table>


### PR DESCRIPTION
Signed-off-by: Hitansh Shah <shah.hitanshsanjay.mat20@itbhu.ac.in>

<!-- What issue does this PR close? -->
Closes #6040 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
On books page it removes the link of the current page from editions table

### Technical
<!-- What should be noted about the implementation? -->
The changes were made solely in [editions_datatable.html](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/type/work/editions_datatable.html). I changed the conditional statements inside the for loop for rendering template. I also declared a new variable `render_first_flag` with default value of `1` which decides when to render with `render_first=True` argument in `render_template` function. The variable helps to differentiate between the case where the already displayed edition appears in first iteration of for loop and the case where it does not.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to https://openlibrary.org/books/OL7824010M/Where_the_Red_Fern_Grows or any other book (with multiple editions) page.
2. Check that the editions table does not contain the editions which is already displayed

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Before:** 
![image](https://user-images.githubusercontent.com/76250591/148735711-51898cac-16c6-40e4-a11e-f13602ad64b3.png)

**After:**
![image](https://user-images.githubusercontent.com/76250591/148735825-63a70ea9-7b35-4162-9591-571e6506f399.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
