### PR TITLE
Encode Nothing values for memcache

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -556,8 +556,7 @@ class PrefixKeyFunc:
 
         memcache doesn't like spaces in the key.
         """
-        return json.dumps([] if isinstance(value, Nothing) else value, separators=(",", ":"), sort_keys=True)
-
+        return json.dumps(value, separators=(",", ":"), sort_keys=True)
 
 def method_memoize(f):
     """

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -16,6 +16,7 @@ from infogami.infobase.client import Nothing
 
 from openlibrary.utils import olmemcache
 from openlibrary.utils.dateutil import MINUTE_SECS
+from openlibrary.core.helpers import NothingEncoder
 
 import six
 
@@ -192,7 +193,7 @@ class memcache_memoize:
 
         memcache doesn't like spaces in the key.
         """
-        return json.dumps([] if isinstance(value, Nothing) else value, separators=(",", ":"))
+        return json.dumps([] if isinstance(value, Nothing) else value, separators=(",", ":"), cls=NothingEncoder)
 
     def memcache_set(self, args, kw, value, time):
         """Adds value and time to memcache. Key is computed from the arguments."""

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -12,6 +12,7 @@ import web
 
 from infogami import config
 from infogami.utils import stats
+from infogami.infobase.client import Nothing
 
 from openlibrary.utils import olmemcache
 from openlibrary.utils.dateutil import MINUTE_SECS
@@ -191,7 +192,7 @@ class memcache_memoize:
 
         memcache doesn't like spaces in the key.
         """
-        return json.dumps(value, separators=(",", ":"))
+        return json.dumps([] if isinstance(value, Nothing) else value, separators=(",", ":"))
 
     def memcache_set(self, args, kw, value, time):
         """Adds value and time to memcache. Key is computed from the arguments."""
@@ -554,7 +555,7 @@ class PrefixKeyFunc:
 
         memcache doesn't like spaces in the key.
         """
-        return json.dumps(value, separators=(",", ":"), sort_keys=True)
+        return json.dumps([] if isinstance(value, Nothing) else value, separators=(",", ":"), sort_keys=True)
 
 
 def method_memoize(f):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5753 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
I have added code to check for variables of Nothing type and replace it with an empty array, before that variable gets passed into json.dumps. The change has been made in json_encode functions used while caching.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
