### PR TITLE
P1 book page performance fix

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, cast
+from typing import Optional, Union, Literal, Iterator, cast
 
 import web
 from web import uniq
@@ -232,7 +232,7 @@ def get_provider_order(prefer_ia=False) -> list[AbstractBookProvider]:
 
 def get_book_providers(
     ed_or_solr: Union[Edition, dict]
-) -> Optional[AbstractBookProvider]:
+) -> Iterator[AbstractBookProvider]:
 
     # On search results, we want to display IA copies first.
     # Issue is that an edition can be provided by multiple providers; we can easily

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -22,6 +22,10 @@ class AbstractBookProvider:
     def editions_query(self):
         return {f"identifiers.{self.identifier_key}~": "*"}
 
+    @property
+    def solr_key(self):
+        return f"id_{self.identifier_key}"
+
     def get_identifiers(self, ed_or_solr: Union[Edition, dict]) -> list[str]:
         return (
             # If it's an edition
@@ -70,6 +74,10 @@ class InternetArchiveProvider(AbstractBookProvider):
     @property
     def editions_query(self):
         return {f"{self.identifier_key}~": "*"}
+
+    @property
+    def solr_key(self):
+        return f"ia"
 
     def get_identifiers(self, ed_or_solr: Union[Edition, dict]) -> list[str]:
         # Solr work record augmented with availability
@@ -280,6 +288,10 @@ def get_best_edition(
     ])
 
     return best if best else (None, None)
+
+
+def get_solr_keys():
+    return [p.solr_key for p in PROVIDER_ORDER]
 
 
 setattr(get_book_provider, 'ia', get_book_provider_by_name('ia'))

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -719,9 +719,10 @@ class Work(models.Work):
             if 'openlibrary_edition' in availability[work_id]:
                 return '/books/%s' % availability[work_id]['openlibrary_edition']
 
-    def get_sorted_editions(self):
+    def get_sorted_editions(self, ebooks_only=False, limit=10000):
         """
         Get this work's editions sorted by publication year
+        :param bool ocaid_only:
         :rtype: list[Edition]
         """
         use_solr_data = (
@@ -735,7 +736,9 @@ class Work(models.Work):
                 "/books/" + olid for olid in self._solr_data.get('edition_key')
             ]
         else:
-            db_query = {"type": "/type/edition", "works": self.key, "limit": 10000}
+            db_query = {"type": "/type/edition", "works": self.key, "limit": limit}
+            if ebooks_only:
+                db_query["ocaid~"] = "*"
             edition_keys = web.ctx.site.things(db_query)
 
         editions = web.ctx.site.get_many(edition_keys)

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -722,7 +722,7 @@ class Work(models.Work):
     def get_sorted_editions(self, ebooks_only=False, limit=10000):
         """
         Get this work's editions sorted by publication year
-        :param bool ocaid_only:
+        :param bool ebooks_only:
         :rtype: list[Edition]
         """
         use_solr_data = (

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -25,6 +25,9 @@ $# Used for loading the editions table
 $# Book availability of editions injected by bulk get_availability API
 $ ebooks_only = query_param('mode') != 'all'
 $ editions = work.get_sorted_editions(ebooks_only=ebooks_only)
+$if not editions:
+  $ ebooks_only = False
+  $ editions = work.get_sorted_editions()
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']
 
 $# This collects which books are previewable in any manner
@@ -224,7 +227,7 @@ $if is_privileged_user:
         </div>
         $:macros.ReadMore("subjects")
     </div>
-      $:macros.EditionNavBar(len(editions), show_observations)
+      $:macros.EditionNavBar(work.edition_count, show_observations)
 
       $if ebooks_only:
         <p>
@@ -243,7 +246,8 @@ $if is_privileged_user:
 
       <a name="editions-list" class="section-anchor"></a>
       $ component_times['EditionsTable'] = time()
-      $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition)
+      $if editions:
+        $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition)
       $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
 
       <a name="work-details" class="section-anchor"></a>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -232,7 +232,6 @@ $if is_privileged_user:
       $if ebooks_only:
         <p>
           $ungettext("Showing one ebook only.", "Showing %(count)d ebooks only", len(editions), count=len(editions)) <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>
-         
         </p>
 
       <p class="preview-languages">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -23,7 +23,11 @@ $ component_times['get_sorted_editions'] = time()
 $# Fetch a work's editions
 $# Used for loading the editions table
 $# Book availability of editions injected by bulk get_availability API
-$ editions = work.get_sorted_editions()
+$ ebooks_only = query_param('mode') != 'all'
+$ editions = work.get_sorted_editions(ebooks_only=ebooks_only)
+$if ebooks_only and len(editions) < 2:
+  $ editions = work.get_sorted_editions(limit=3)
+  $ ebooks_only = False
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']
 
 $# This collects which books are previewable in any manner
@@ -223,7 +227,12 @@ $if is_privileged_user:
         </div>
         $:macros.ReadMore("subjects")
     </div>
-      $:macros.EditionNavBar(work.edition_count, show_observations)
+      $:macros.EditionNavBar(len(editions), show_observations)
+
+      $if ebooks_only:
+        <p>
+          Showing ebooks only. <a href="?mode=all">View all $(work.edition_count) editions?</a>
+        </p>
 
       <p class="preview-languages">
         $ seen = set()
@@ -236,7 +245,6 @@ $if is_privileged_user:
       </p>
 
       <a name="editions-list" class="section-anchor"></a>
-
       $ component_times['EditionsTable'] = time()
       $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition)
       $ component_times['EditionsTable'] = time() - component_times['EditionsTable']

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -231,7 +231,8 @@ $if is_privileged_user:
 
       $if ebooks_only:
         <p>
-          Showing ebooks only. <a href="?mode=all">View all $(work.edition_count) editions?</a>
+          $ungettext("Showing one ebook only.", "Showing %(count)d ebooks only", len(editions), count=len(editions)) <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>
+         
         </p>
 
       <p class="preview-languages">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -25,9 +25,6 @@ $# Used for loading the editions table
 $# Book availability of editions injected by bulk get_availability API
 $ ebooks_only = query_param('mode') != 'all'
 $ editions = work.get_sorted_editions(ebooks_only=ebooks_only)
-$if ebooks_only and len(editions) < 2:
-  $ editions = work.get_sorted_editions(limit=3)
-  $ ebooks_only = False
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']
 
 $# This collects which books are previewable in any manner

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -17,12 +17,7 @@ $ book_keys = []
         $for book in editions:
             $ book_keys.append(book['key'].replace('/books/', ''))
             $ edition_sort_key = str(loop.index0+1).zfill(index_padding)
-            $if book.key == edition.key:
-              <tr class="highlight">
-                $# This enables us to always render a select edition first in the table (default)
-                $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
-              </tr>
-            $else:
+            $if book.key != edition.key:
               <tr>
                 $:render_template("books/edition-sort", book, edition_sort_key)
               </tr>

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -17,7 +17,12 @@ $ book_keys = []
         $for book in editions:
             $ book_keys.append(book['key'].replace('/books/', ''))
             $ edition_sort_key = str(loop.index0+1).zfill(index_padding)
-            $if book.key != edition.key:
+            $if book.key == edition.key:
+              <tr class="highlight">
+                $# This enables us to always render a select edition first in the table (default)
+                $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
+              </tr>
+            $else:
               <tr>
                 $:render_template("books/edition-sort", book, edition_sort_key)
               </tr>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Temporary shim for #4485 (to be replaced with a better solution (e.g. async editions table or iframe) later this quarter.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

See performance plan notes:
https://docs.google.com/document/d/1buJASy3MbxQPYstoUGW_tAwC7UYTKfcejUm8xXsfAIc/edit#heading=h.doeu99u9fz8e

### Justification

Some works on Open Library have 500+ editions, all of which get loaded in order to:

1. choose the best edition &
2. populate the editions table. 

This results in load times of up to 10 seconds. Halving this number would be a significant victory.

### Hypothesis

My experiences speaking to patrons and @JeffKaplan has given me some confidence that:

1. The average Open Library patron cares primarily about discovering readable books
2. The average patron uses the default editions table setting of "View 3" & won't notice any difference
3. Because of [1] Patrons often report being confused when seeing "Not In Library"
4. This approach still lets patrons still able to search/filter through all previewable books

### Approach

Instead of loading every book, by default we only load editions with ebooks, e.g. for [Ulysses](http://ol-dev1.us.archive.org:1337/works/OL86344W/Ulysses), 29 instead of all 271.

A patron can "break out of the box" by clicking "View all editions"
![ol-dev1 us archive org_1337_works_OL86344W_Ulysses](https://user-images.githubusercontent.com/978325/149454505-460173f5-0602-4cdf-ac0e-b8a17fdc54c3.png)

### Possible Issues

:warning: It looks like our `ebooks_only` code is not always getting run (likely has to do w/ infogami v. solr in https://github.com/internetarchive/openlibrary/pull/6049/files#diff-3930c9567d998a2acedfcbbf7ade4a5351307a33fe0d4b3ede449a6382be5237R722).

For instance, http://ol-dev1.us.archive.org:1337/works/OL86344W/Ulysses does load in `ebook_only` mode but this other title doesn't: http://ol-dev1.us.archive.org:1337/books/OL24375285M/Because_of_Mr._Terupt


### UI Considerations

The UI may be annoying for patrons who **do** want to see the full editions table. In order to do this, the patron first has to load the ebooks-only view and after, then click "View All" (i.e. then load a more expensive page) which is worse even than just showing the expensive page to begin with. I think we could improve this experience further to work better for all patrons by having a `checkbox` which remembers patrons' preferences, which can be used to select/unselect "Ebooks Only", instead of having a link.

This way...

* The average patron has a faster experience & sees ebooks...
* Librarians can enjoy a faster experience when they don't need a full editions table...
* And if Librarians need a faster editions table, they just need to click a checkbox which will remember their settings.

### Technical
<!-- What should be noted about the implementation? -->

Uses `{"type": "/type/edition", "works": self.key, "limit": limit, "ocaid~": "*"}` to only find editions of a work with `ocaid` values.

This change modifies the editions table so that the edition we're currently on will not be added to the edition table (as @mheiman and others suggested this was confusing + redundant). As a result, if we're in `ebooks_only` mode, we require that at least 2 editions are present (which helps guarantee the editions table will always contain at least 1 ebook in addition to the edition ebook we may be currently on): 

```
$ editions = work.get_sorted_editions(ebooks_only=ebooks_only)
$if ebooks_only and len(editions) < 2:
$ editions = work.get_sorted_editions(limit=3)
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->