### PR TITLE
Adding community edits queue

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -1,0 +1,128 @@
+import datetime
+from . import db
+
+
+class CommunityEditsQueue:
+
+    """Schema
+    id: Primary identifier
+    submitter: username of person that made the request
+    reviewer: The username of the person who reviewed the request
+    url: URL of the merge request
+    status: Either "Pending", "Merged", or "Rejected"
+    comment: Short note from reviewer (json blobs (can store timestamps, etc))
+    created: created timestamp
+    updated: update timestamp
+    """
+
+    @classmethod
+    def get_requests(cls, limit: int = 50, page: int = 1, **kwargs):
+        oldb = db.get_db()
+        wheres = []
+        if kwargs.get("status"):
+            wheres.append("status=$status")
+        if "reviewer" in kwargs:
+            wheres.append("reviewer='$reviewer'")
+        if "submitter" in kwargs:
+            if kwargs.get("submitter") is None:
+                wheres.append("submitter IS NOT NULL")
+            else:
+                wheres.append("submitter=$submitter")
+        query_kwargs = {
+            "limit": limit,
+            "offset": limit * (page - 1),
+            "vars": kwargs
+        }
+        if wheres:
+            query_kwargs['where'] = " AND ".join(wheres)
+        return oldb.select("community_edits_queue", **query_kwargs)
+
+    @classmethod
+    def submit_work_merge_request(cls, work_ids, submitter, comment=None):
+        if not comment:
+            # some default note from submitter
+            pass
+        # XXX IDs should be santiized & normalized
+        # e.g. /works/OL123W -> OL123W
+        url = f"/works/merge?records={','.join(work_ids)}"
+        cls.submit_request(url, submitter=submitter, comment=comment)
+
+    @classmethod
+    def submit_author_merge_request(cls, author_ids, submitter, comment=None):
+        if not comment:
+            # some default note from submitter
+            pass
+        # XXX IDs should be santiized & normalized
+        url = "/authors/merge?key={'&key='.join(author_ids)}"
+        cls.submit_request(url, submitter=submitter, comment=comment)
+
+    @classmethod
+    def submit_delete_request(cls, olid, submitter, comment=None):
+        if not comment:
+            # some default note from submitter
+            pass
+        url = f"{olid}/-/edit?m=delete"
+        cls.submit_request(cls, url, submitter=submitter, comment=comment)
+
+    @classmethod
+    def submit_request(cls, url, submitter, reviewer=None, status=1, comment=None):
+        oldb = db.get_db()
+
+        # XXX should there be any validation of the url?
+        # i.e. does this represent a valid merge/delete request?
+        
+        return oldb.insert(
+            "community_edits_queue",
+            submitter=submitter,
+            reviewer=reviewer,
+            url=url,
+            status=status,
+            # XXX comments? TODO
+        )
+
+    @classmethod
+    def assign_request(cls, rid, reviewer):
+        oldb = db.get_db()
+        oldb.update(
+            "community_edits_queue",
+            where="rid=$rid",
+            reviewer=reviewer,
+            vars={"rid": rid}
+        )
+    
+    @classmethod
+    def close_request(cls, rid, comment=None):
+        oldb = db.get_db()
+        oldb.update(
+            "community_edits_queue",
+            where="rid=$rid",
+            status=0,
+            vars={"rid": rid}
+        )
+
+    @classmethod
+    def approve_request(cls, rid, comment=None):
+        oldb = db.get_db()
+        oldb.update(
+            "community_edits_queue",
+            where="rid=$rid",
+            status=2,
+            vars={"rid": rid}
+        )
+
+    @classmethod
+    def comment_request(cls, rid, username, comment):
+        oldb = db.get_db()
+        comments.setdefault("comments", [])
+        # isoformat to avoid to-json issues
+        comments["comments"].append({
+            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "username": username,
+            "message": comment
+        })
+        return oldb.update(
+            "community_edits_queue",
+            where="rid=$rid",
+            vars={"rid": rid, "comments": comment}
+        )
+        

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -1,4 +1,5 @@
 
+
 CREATE TABLE ratings (
     username text NOT NULL,
     work_id integer NOT NULL,
@@ -59,4 +60,15 @@ CREATE TABLE observations (
     observation_value INTEGER not null,
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (work_id, edition_id, username, observation_value, observation_type)
+);
+
+CREATE TABLE community_edits_queue (
+    id serial not null primary key,
+    submitter text not null,
+    reviewer text default null,
+    url text not null,
+    status int not null default 1,
+    comments json,
+    created timestamp without time zone default (current_timestamp at time zone 'utc'),
+    updated timestamp without time zone default (current_timestamp at time zone 'utc')
 );

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -18,8 +18,10 @@ from infogami.utils.context import context
 
 from openlibrary import accounts
 
-from openlibrary.plugins.upstream import addbook, covers, merge_authors, models, utils
+from openlibrary.plugins.upstream import addbook, covers, models, utils
 from openlibrary.plugins.upstream import spamcheck
+from openlibrary.plugins.upstream import merge_authors
+from openlibrary.plugins.upstream import edits
 from openlibrary.plugins.upstream import borrow, recentchanges  # TODO: unused imports?
 from openlibrary.plugins.upstream.utils import render_component
 
@@ -340,6 +342,8 @@ def setup():
     addbook.setup()
     covers.setup()
     merge_authors.setup()
+    #merge_works.setup() # ILE code
+    edits.setup()
 
     from openlibrary.plugins.upstream import data, jsdef
 

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -1,0 +1,40 @@
+"""Librarian Edits
+"""
+
+import re
+import json
+import web
+
+from openlibrary import accounts
+from openlibrary.core.edits import CommunityEditsQueue
+from infogami.utils import delegate
+from infogami.utils.view import render_template
+
+
+class community_edits_queue(delegate.page):
+    path = '/pendingchanges'
+
+    def POST(self):
+        i = web.input(work_ids="", rtype="merge-works", comment=None)
+        user = accounts.get_current_user()
+        username = user['key'].split('/')[-1]
+        if i.rtype == "merge-works":
+            # normalization
+            work_ids = [w for w in re.split("[ ,]", i.work_ids.replace("/works/", "")) if w]
+            result = CommunityEditsQueue.submit_work_merge_request(
+                work_ids,
+                submitter=username,
+                comment=i.comment
+            )
+            return delegate.RawText(json.dumps(result), content_type="application/json")        
+    
+    def GET(self):
+        i = web.input(page=1)
+        user = web.ctx.site.get_user()
+        if user:
+            requests = CommunityEditsQueue.get_requests(page=i.page)
+            return render_template('pendingchanges', requests=requests)
+
+
+def setup():
+    pass

--- a/openlibrary/templates/pendingchanges.html
+++ b/openlibrary/templates/pendingchanges.html
@@ -1,0 +1,17 @@
+$def with(requests=None)
+
+<form method="POST">
+  <p>Submit Work Merge Request (test)</p>
+  <input name="work_ids" placeholder="work_ids csv (e.g. OL123W,OL234W,OL345W)">
+  <input type="submit">
+</form>
+
+<h1>Community Edit Requests</h1>
+
+$if requests:
+  <table>
+    $for r in requests:
+      <tr>
+	<td>$r</td>
+      </tr>
+  </table>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Supports #5421 - generic community edit queue for proposing deletions and merges of works, authors.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
