### PR TITLE
Add more profiling to book page components

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -44,28 +44,28 @@ $if isbn_10 and not asin:
           $if not page.is_fake_record():
               $:render_template('covers/change', page, ".edition-cover .bookCover img")
         </div>
-        $ render_times['Sidebar: DonateModal'] = time()
+        $ render_times['databarWork: DonateModal'] = time()
         $:macros.DonateModal(page, ids={'isbn': isbn_13, 'asin': asin, 'prices': True})
-        $ render_times['Sidebar: DonateModal'] = time() - render_times['Sidebar: DonateModal']
+        $ render_times['databarWork: DonateModal'] = time() - render_times['databarWork: DonateModal']
 
         $ work = (page.works and page.works[0]) or page
         $ edition = page.works and page
 
-        $ render_times['Sidebar: List widget'] = time()
+        $ render_times['databarWork: List widget'] = time()
         $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False, user_lists_only=False)
-        $ render_times['Sidebar: List widget'] = time() - render_times['Sidebar: List widget']
+        $ render_times['databarWork: List widget'] = time() - render_times['databarWork: List widget']
 
         $# For the Works & Editions page, always use ground_truth_availability API for selected Edition
-        $ render_times['Sidebar: LoanStatus'] = time()
+        $ render_times['databarWork: LoanStatus'] = time()
         $:macros.LoanStatus(page, allow_expensive_availability_check=True, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page, post=lists_widget)
-        $ render_times['Sidebar: LoanStatus'] = time() - render_times['Sidebar: LoanStatus']
+        $ render_times['databarWork: LoanStatus'] = time() - render_times['databarWork: LoanStatus']
 
         $if editions_page:
-          $ render_times['Sidebar: Book provider'] = time()
+          $ render_times['databarWork: Book provider'] = time()
           $ book_provider = get_book_provider(page)
           $if book_provider:
             $:book_provider.render_download_options(page)
-          $ render_times['Sidebar: Book provider'] = time() - render_times['Sidebar: Book provider']
+          $ render_times['databarWork: Book provider'] = time() - render_times['databarWork: Book provider']
       </div>
     </div>
 
@@ -88,9 +88,9 @@ $if isbn_10 and not asin:
 
         <div class="cta-section">
           <p class="cta-section-title">$_('Buy this book')</p>
-          $ render_times['AffiliateLinks'] = time()
+          $ render_times['databarWork: AffiliateLinks'] = time()
           $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
-          $ render_times['AffiliateLinks'] = time() - render_times['AffiliateLinks']
+          $ render_times['databarWork: AffiliateLinks'] = time() - render_times['databarWork: AffiliateLinks']
         </div>
       </div>
     </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -1,4 +1,4 @@
-$def with (page, editions_page=False)
+$def with (page, editions_page=False, render_times={})
 
 $if page.type.key == '/type/work' and page.edition_count == 1:
     $ edit_url = page.editions[0].key + '?m=edit'
@@ -44,20 +44,28 @@ $if isbn_10 and not asin:
           $if not page.is_fake_record():
               $:render_template('covers/change', page, ".edition-cover .bookCover img")
         </div>
-
+        $ render_times['Sidebar: DonateModal'] = time()
         $:macros.DonateModal(page, ids={'isbn': isbn_13, 'asin': asin, 'prices': True})
+        $ render_times['Sidebar: DonateModal'] = time() - render_times['Sidebar: DonateModal']
 
         $ work = (page.works and page.works[0]) or page
         $ edition = page.works and page
+
+        $ render_times['Sidebar: List widget'] = time()
         $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False, user_lists_only=False)
+        $ render_times['Sidebar: List widget'] = time() - render_times['Sidebar: List widget']
 
         $# For the Works & Editions page, always use ground_truth_availability API for selected Edition
+        $ render_times['Sidebar: LoanStatus'] = time()
         $:macros.LoanStatus(page, allow_expensive_availability_check=True, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page, post=lists_widget)
+        $ render_times['Sidebar: LoanStatus'] = time() - render_times['Sidebar: LoanStatus']
 
         $if editions_page:
+          $ render_times['Sidebar: Book provider'] = time()
           $ book_provider = get_book_provider(page)
           $if book_provider:
             $:book_provider.render_download_options(page)
+          $ render_times['Sidebar: Book provider'] = time() - render_times['Sidebar: Book provider']
       </div>
     </div>
 
@@ -80,7 +88,9 @@ $if isbn_10 and not asin:
 
         <div class="cta-section">
           <p class="cta-section-title">$_('Buy this book')</p>
+          $ render_times['AffiliateLinks'] = time()
           $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+          $ render_times['AffiliateLinks'] = time() - render_times['AffiliateLinks']
         </div>
       </div>
     </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -154,9 +154,7 @@ $if is_privileged_user:
         <link itemprop="exampleOfWork" href="$work.key">
 
     <div class="editionCover">
-      $ component_times['databarWork'] = time()
       $:macros.databarWork(edition or work, editions_page=True, render_times=component_times)
-      $ component_times['databarWork'] = time() - component_times['databarWork']
     </div>
 
     <div class="editionAbout">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -155,7 +155,7 @@ $if is_privileged_user:
 
     <div class="editionCover">
       $ component_times['databarWork'] = time()
-      $:macros.databarWork(edition or work, editions_page=True)
+      $:macros.databarWork(edition or work, editions_page=True, render_times=component_times)
       $ component_times['databarWork'] = time() - component_times['databarWork']
     </div>
 
@@ -457,8 +457,13 @@ $if is_privileged_user:
       </div>
 
       $if show_observations:
+        $ component_times['get_observation_metrics'] = time()
         $ reader_observations = get_observation_metrics(work['key'])
+        $ component_times['get_observation_metrics'] = time() - component_times['get_observation_metrics']
+
+        $ component_times['Review component'] = time()
         $:render_template("observations/review_component", work, reader_observations, page.key)
+        $ component_times['Review component'] = time() - component_times['Review component']
     </div>
   </div>
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds additional profiling to the following book page components and functions.  Executions times for book page components can be found at the bottom of book pages that are served in debug mode.

| New Key | Description |
| --- | --- |
| databarWork: AffiliateLinks | Sidebar vendor links and prices |
| get_observation_metrics | Function for getching data that belongs in the review component |
| Review component | Component that displays review statistics for a work |
| databarWork: DonateModal | The sidebar DonateModal macro |
| databarWork: List widget | The sidebar lists/widget template |
| databarWork: LoanStatus | The sidebar LoanStatus macro |
| databarWork: Book provider | Time taken to fetch book provider and render download options |

### Technical
<!-- What should be noted about the implementation? -->
In order to profile sidebar items, `component_times` is passed from the book page template to the `databarWork` template as `render_times`.

The `databarWork` entry has been replaced by the new entries that are prefixed with `databarWork: `

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a book page.
2. Add `debug=true` to the URL's query string, and refresh the page.
3. Check the times in the profile table at the bottom of the page. Ensure that nothing is amiss.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![profile](https://user-images.githubusercontent.com/28732543/150617945-691ac463-531c-4d55-85bf-f5058eb3d6d2.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
