### PR TITLE
Allow ?limit=0 on author /works.json endpoint

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -362,8 +362,8 @@ class author_works(delegate.page):
             raise web.notfound('')
         else:
             i = web.input(limit=50, offset=0)
-            limit = h.safeint(i.limit) or 50
-            offset = h.safeint(i.offset) or 0
+            limit = h.safeint(i.limit, 50)
+            offset = h.safeint(i.offset, 0)
 
             data = self.get_works_data(doc, limit=limit, offset=offset)
             return delegate.RawText(json.dumps(data), content_type="application/json")


### PR DESCRIPTION
Small hotfix. I often use `?limit=0` as a way to get only the size of the results, as a perf optimization.

### Technical
- This is *technically* a breaking change to a public API, but hopefully no one is depending on it?

### Testing
- ✅ Invalid limit doesn't error http://localhost:8080/authors/OL6848355A/works.json?limit=foo
- ✅ Limit of 0 works http://localhost:8080/authors/OL6848355A/works.json?limit=0

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jimman2003 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
