### PR TITLE
Disable ground-truth availability checks

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -16,7 +16,9 @@ $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0].key)
 $ no_index = hasattr(doc, 'get_ia_meta_fields') and doc.get_ia_meta_fields().get('noindex', False)
 
+$ waiting_loan_start_time = time()
 $ waiting_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_waiting_loan_for(ocaid)
+$ waiting_loan_total_time = time() - waiting_loan_start_time
 $ my_turn_to_borrow = waiting_loan and waiting_loan['status'] == 'available' and waiting_loan['position'] == 1
 
 
@@ -31,7 +33,9 @@ $if allow_expensive_availability_check and ocaid:
 
 $ borrow_link = '/borrow/ia/%s' % ocaid
 
+$ get_loan_for_start_time = time()
 $ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
+$ get_loan_for_total_time = time() - get_loan_for_start_time
 $if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
@@ -135,5 +139,7 @@ $if ocaid and daisy and book_provider.short_name == 'ia':
 
 $if query_param('debug'):
   $ loanstatus_end_time = time() - loanstatus_start_time
+  <p>get_waiting_loan_for(ocaid) took $("%.2f" % waiting_loan_total_time) seconds</p>
+  <p>get_loan_for(ocaid) took $("%.2f" % get_loan_for_total_time) seconds</p>
   <p>LoanStatus took $("%.2f" % loanstatus_end_time) seconds</p>
   <p>$availability</p>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -51,8 +51,7 @@ $if isbn_10 and not asin:
         $ edition = page.works and page
         $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False, user_lists_only=False)
 
-        $# For the Works & Editions page, always use ground_truth_availability API for selected Edition
-        $:macros.LoanStatus(page, allow_expensive_availability_check=True, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page, post=lists_widget)
+        $:macros.LoanStatus(page, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page, post=lists_widget)
 
         $if editions_page:
           $ book_provider = get_book_provider(page)

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -56,7 +56,7 @@ $if isbn_10 and not asin:
         $ render_times['databarWork: List widget'] = time() - render_times['databarWork: List widget']
 
         $# For the Works & Editions page, only use ground_truth_availability API for selected Edition
-        $# if edition availability status is private or error 
+        $# if edition availability status is private or error
         $ render_times['databarWork: LoanStatus'] = time()
         $ expensive_check = page.get('availability', {}).get('status') in ['private', 'error']
         $:macros.LoanStatus(page, allow_expensive_availability_check=expensive_check, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page, post=lists_widget)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -24,6 +24,7 @@ $# Fetch a work's editions
 $# Used for loading the editions table
 $# Book availability of editions injected by bulk get_availability API
 $ editions = work.get_sorted_editions()
+$ availabilities = {e.availability.get('identifier'): e.availability for e in editions}
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']
 
 $# This collects which books are previewable in any manner
@@ -32,8 +33,8 @@ $ previews = [e for e in editions if e.get('ocaid')]
 $# Choose an edition to render
 $if page.key.startswith('/books'):
   $# We are on an editions page: an edition has been explicitly selected
-  $# NOTE: Editions use the ground_truth_availability API
   $ edition = page
+  $ edition['availability'] = edition.get('ocaid') and availabilities.get(edition['ocaid']) or {}
 $elif editions:
   $# We're presumably on a work url
   $# Set a dummy default editions
@@ -48,6 +49,7 @@ $elif editions:
     $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), edition)
   $else:
     $ edition, provider = get_best_edition(editions)
+    $ edition['availability'] = edition.get('ocaid') and availabilities.get(edition['ocaid']) or {}
 
 $ ocaid = edition.get('ocaid')
 $ book_title = edition.get('title', '') or (work.title if work else '')


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Disables ground-truth availability calls for book page main borrow buttons.  Adds additional profiling to LoanStatus.html.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
