### PR TITLE
Handle Nothing type when exporting lists

### DIFF
--- a/openlibrary/core/formats.py
+++ b/openlibrary/core/formats.py
@@ -3,6 +3,8 @@
 import json
 import yaml
 
+from openlibrary.core.helpers import json_encode
+
 __all__ = ["load_yaml", "dump_yaml"]
 
 
@@ -25,7 +27,7 @@ def load(text, format):
 
 def dump(data, format):
     if format == "json":
-        return json.dumps(data)
+        return json_encode(data)
     elif format == "yml":
         return dump_yaml(data)
     else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5415

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Uses JSON encoder with Nothing serializer for list exports.

### Technical
<!-- What should be noted about the implementation? -->
Call to standard `json.dumps` in `formats.dump` has been replaced with `helpers.json_encode` call.

`format.dump` appears to only be used in `lists.py` to return data related to lists.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
