### PR TITLE
Create custom JSON encoder for Nothing values

### DIFF
--- a/openlibrary/core/formats.py
+++ b/openlibrary/core/formats.py
@@ -3,6 +3,8 @@
 import json
 import yaml
 
+from openlibrary.core.helpers import NothingEncoder
+
 __all__ = ["load_yaml", "dump_yaml"]
 
 
@@ -25,7 +27,7 @@ def load(text, format):
 
 def dump(data, format):
     if format == "json":
-        return json.dumps(data)
+        return json.dumps(data, cls=NothingEncoder)
     elif format == "yml":
         return dump_yaml(data)
     else:

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -107,8 +107,24 @@ def sanitize(html, encoding='utf8'):
     return stream.render()
 
 
+class NothingEncoder(json.JSONEncoder):
+    def default(self, obj):
+        """Custom JSON encoder for handling Nothing values.
+
+        Returns None if a value is a Nothing object. Otherwise,
+        encode values using the default JSON encoder.
+        """
+        if isinstance(obj, Nothing):
+            return None
+        return super().default(obj)
+
+
 def json_encode(d, **kw):
-    """Same as json.dumps."""
+    """Calls json.dumps on the given data d.
+    If d is a Nothing object, passes an empty list to json.dumps.
+
+    Returns the json.dumps results.
+    """
     return json.dumps([] if isinstance(d, Nothing) else d, **kw)
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5415

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates custom JSON encoder which converts `Nothing` objects into `None`.  Adds encoder to `helpers.dump`.

### Technical
<!-- What should be noted about the implementation? -->
`format.dump` appears to only be used in lists.py to return data related to lists.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This code is on testing now.  Compare the following list data in production and testing:

http://openlibrary.org/people/tmanarl/lists/OL197952L/seeds.json?debug=true
http://testing.openlibrary.org/people/tmanarl/lists/OL197952L/seeds.json?debug=true

The production link errors out, while the `Nothing` values have been replaced with `null` in the JSON string returned in testing.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
