### PR TITLE
Fixes width of password input fields on signup page

### DIFF
--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -15,7 +15,7 @@
     padding: 10px 0 2px;
 
     label {
-      font-size: 1.0em;
+      font-size: 1em;
       font-family: @lucida_sans_serif-5;
       font-weight: 700;
     }
@@ -28,30 +28,30 @@
     width: 100%;
   }
 
-  input[type=number],
-  input[type=text] {
+  input[type="number"],
+  input[type="text"] {
     margin: 0 10px 5px 0;
   }
 
-  input[type=number],
-  input[type=text],
-  input[type=email],
-  input[type=password],
+  input[type="number"],
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
   textarea {
-    font-size: 1.0em;
+    font-size: 1em;
     font-family: @lucida_sans_serif-5;
     padding: 3px;
     max-width: 100%;
   }
 
-  input[type=number] {
-    width: 4em;
+  input[type="email"],
+  input[type="password"],
+  .required {
+    padding: 0px;
   }
 
-  input[type=email],
-  input[type=password],
-  .required {
-    // padding: 8px;
+  input[type="number"] {
+    width: 4em;
   }
 
   select {
@@ -70,11 +70,11 @@
     /* stylelint-disable selector-max-specificity */
     .major {
       // stylelint-disable-next-line max-nesting-depth
-      input[type=text],
-      input[type=email],
-      input[type=password],
+      input[type="text"],
+      input[type="email"],
+      input[type="password"],
       textarea {
-        font-size: .875em;
+        font-size: 0.875em;
         width: 100%;
       }
     }
@@ -118,7 +118,7 @@
   height: 265px;
 }
 
-@media all and ( min-width: @width-breakpoint-desktop ) {
+@media all and (min-width: @width-breakpoint-desktop) {
   .olform {
     // formBackLeft and formBackRight are presently only used in
     // openlibrary/templates/books/edit/edition.html (edit form)
@@ -138,12 +138,12 @@
   }
 }
 
-@media all and ( min-width: @width-breakpoint-desktop ) {
+@media all and (min-width: @width-breakpoint-desktop) {
   /* stylelint-disable selector-max-specificity */
   .olform {
-    input[type=text],
-    input[type=email],
-    input[type=password],
+    input[type="text"],
+    input[type="email"],
+    input[type="password"],
     textarea {
       width: 475px;
     }

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -44,11 +44,6 @@
     max-width: 100%;
   }
 
-  input[type="email"],
-  input[type="password"],
-  .required {
-    padding: 0px;
-  }
 
   input[type="number"] {
     width: 4em;

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -51,7 +51,7 @@
   input[type=email],
   input[type=password],
   .required {
-    padding: 8px;
+    // padding: 8px;
   }
 
   select {


### PR DESCRIPTION
### What issue does this PR close?
Closes #6011 

### What does this PR achieve?
This PR fixes the variation and unevenness of the sign up page's password field along with other input fields.

### Technical
<!-- What should be noted about the implementation? -->
Unnecessary padding was provided in the  ``/openlibrary/static/css/components/form.olform.less`` file which was overlapping with the default padding on the input fields.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Running ``docker-compose run web make test`` gave all green flags. All the pages are working perfectly fine including the SignUp page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
#### Before
<img width="1645" alt="SignUpLayoutBefore" src="https://user-images.githubusercontent.com/76054330/151633623-e8b876aa-f49c-4aba-80b8-0db16c07f4db.png">

#### After
<img width="1645" alt="SignUpLayoutCheck" src="https://user-images.githubusercontent.com/76054330/151633244-8606c419-ed4f-4e5c-b730-adde2e2633f1.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
--


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
