### PR TITLE
Added Lists link to books page navbar

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -16,6 +16,6 @@ $def with (edition_count=1, show_observations=False)
     <a href="#reader-observations">$_("Reviews")</a>
   </li>
   <li>
-    <a href="#lists">$_("Lists")</a>
+    <a href="#lists-section">$_("Lists")</a>
   </li>
 </ul>

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -15,4 +15,7 @@ $def with (edition_count=1, show_observations=False)
   <li>
     <a href="#reader-observations">$_("Reviews")</a>
   </li>
+  <li>
+    <a href="#lists">$_("Lists")</a>
+  </li>
 </ul>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -478,7 +478,7 @@ $if is_privileged_user:
     $# pages like /books/ia:foo00bar are fake records created from metadata API.
     $# Adding them to lists doesn't work. Disabling it to avoid any issues.
     $if "lists" in ctx.features and not page.is_fake_record():
-      <h2 class="home-h2"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
+      <h2 class="home-h2" id="lists"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
       <div class="user-book-options">
         <div class="Tools tools-override">
           $if work:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -478,7 +478,7 @@ $if is_privileged_user:
     $# pages like /books/ia:foo00bar are fake records created from metadata API.
     $# Adding them to lists doesn't work. Disabling it to avoid any issues.
     $if "lists" in ctx.features and not page.is_fake_record():
-      <h2 class="home-h2" id="lists"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
+      <h2 class="home-h2" id="lists-section"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
       <div class="user-book-options">
         <div class="Tools tools-override">
           $if work:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6096

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added `Lists` link to books page navbar after the `Reviews` link.

### Technical
<!-- What should be noted about the implementation? -->
Added the id `lists` to the  [Lists containing this Book](https://openlibrary.org/works/OL16225732W/Life's_Handicap/lists) section.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="811" alt="Screenshot 2022-02-03 at 12 21 47 PM" src="https://user-images.githubusercontent.com/73935799/152295333-ca941efa-f6aa-4f93-8c6d-d5a48fbba773.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp  @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
