### PR TITLE
Closes Remove repeated edition description from book pages

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -365,7 +365,6 @@ $if is_privileged_user:
             <h3 class="edition-header">$_("First Sentence")</h3>
             <p>"$(edition.first_sentence)"</p>
             </div>
-            
 
         $if edition:
           $ component_times['TableOfContents'] = time()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -365,16 +365,7 @@ $if is_privileged_user:
             <h3 class="edition-header">$_("First Sentence")</h3>
             <p>"$(edition.first_sentence)"</p>
             </div>
-
-          $if edition.description:
-            <div class="section">
-              <h3 class="edition-header">$_("Edition Description")</h3>
-              <div class="edition-description">
-                <div class="addReadMore showlesscontent">
-                  $:sanitize(format(edition.description))
-                </div>
-              </div>
-            </div>
+            
 
         $if edition:
           $ component_times['TableOfContents'] = time()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6107

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the edition description from the #edition-details component.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/58180803/152604686-478707db-095e-4076-8d40-fb9a8948201d.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/58180803/152604807-09e3c886-c322-4826-bfba-9c3d1d503d4f.png">



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
