### PR TITLE
adds privacy column to bookshelves_books

### DIFF
--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE bookshelves_books (
     work_id integer NOT NULL,
     bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
     edition_id integer default null,
+    private BOOLEAN,
     updated timestamp without time zone default (current_timestamp at time zone 'utc'),
     created timestamp without time zone default (current_timestamp at time zone 'utc'),
     primary key (username, work_id, bookshelf_id)


### PR DESCRIPTION
Change has been made on prod, shouldn't affect any existing code. Will be used for trending books, etc. next step is to loop over patrons w/ private reading logs and set books to be private, e.g. `http://openlibrary.org/query.json?type=/type/object&notifications.public_readlog=no`

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
