### PR TITLE
Change class of input fields from "required" to "textarea"; Fix apply…

### DIFF
--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -64,20 +64,25 @@ export function initRealTimeValidation() {
         var value2 = document.getElementById('password2').value;
         if (value && value2) {
             if (value2 === value) {
-                $('#password2Message').removeClass().addClass('darkgreen').text('');
-                $('label[for="password2"]').removeClass();
-                $(document.getElementById('password2')).removeClass().addClass('required');
+                $(document.getElementById('password2')).removeClass('required invalid');
+                $('label[for="password2"]').removeClass('invalid');
+                $('#password2Message').removeClass('invalid').addClass('darkgreen').text('');
             }
             else {
-                $(document.getElementById('password2')).removeClass().addClass('required invalid');
-                $('label[for="password2"]').removeClass().addClass('invalid');
-                $('#password2Message').removeClass().addClass('invalid').text('Passwords didnt match');
+                $(document.getElementById('password2')).addClass('required invalid');
+                $('label[for="password2"]').addClass('invalid');
+                $('#password2Message').removeClass('darkgreen').addClass('invalid').text('Passwords do not match');
             }
         }
         else {
-            $('label[for="password2"]').removeClass();
-            $(document.getElementById('password2')).removeClass().addClass('required');
-            $('#password2Message').removeClass().text('');
+            if (!value) {
+                $(document.getElementById('password')).addClass('required');
+                $('label[for="password"]').removeClass('invalid');
+                $('#passwordMessage').removeClass('invalid').text('');
+            }
+            $(document.getElementById('password2')).addClass('required');
+            $('label[for="password2"]').removeClass('invalid');
+            $('#password2Message').removeClass('invalid').text('');
         }
     }
 

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -27,8 +27,8 @@ def find_ia_account(email=None):
 
 
 Login = Form(
-    Textbox('username', description=_('Username'), klass='required'),
-    Password('password', description=_('Password'), klass='required'),
+    Textbox('username', description=_('Username'), klass='textarea'),
+    Password('password', description=_('Password'), klass='textarea'),
     Hidden('redirect'),
 )
 forms.login = Login
@@ -76,7 +76,7 @@ class RegisterForm(Form):
         Textbox(
             'email',
             description=_('Your email address'),
-            klass='required',
+            klass='textarea',
             id='emailAddr',
             validators=[
                 vemail,
@@ -88,7 +88,7 @@ class RegisterForm(Form):
         Textbox(
             'username',
             description=_('Choose a screen name'),
-            klass='required',
+            klass='textarea',
             help=_("Letters and numbers only please, and at least 3 characters."),
             autocapitalize="off",
             validators=[vlogin, username_validator],
@@ -96,13 +96,13 @@ class RegisterForm(Form):
         Password(
             'password',
             description=_('Choose a password'),
-            klass='required',
+            klass='textarea',
             validators=[vpass],
         ),
         Password(
             'password2',
             description=_('Confirm password'),
-            klass='required',
+            klass='textarea',
             validators=[
                 vpass,
                 EqualToValidator('password', _("Passwords didn't match.")),

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -23,7 +23,7 @@ $var title: $_("Add a book")
                     <input type="text" id="title" disabled="disabled" value="$work.title"/>
                     <input type="hidden" name="title" value="$work.title"/>
                 $else:
-                    <input type="text" name="title" id="title" class="required title" style="width:630px;" value="$(work and work.title)" $cond(work, 'readonly="readonly"')/>
+                    <input type="text" name="title" id="title" class="textarea title" style="width:630px;" value="$(work and work.title)" $cond(work, 'readonly="readonly"')/>
             </div>
         </div>
         <div class="formElement">
@@ -34,14 +34,14 @@ $var title: $_("Add a book")
         <div class="formElement">
             <div class="label"><label for="publisher">$_("Who is the publisher?")</label></div>
             <div class="input">
-                <input type="text" name="publisher" class="required" id="publisher"/>
+                <input type="text" name="publisher" class="textarea" id="publisher"/>
             </div>
         </div>
 
         <div class="formElement">
             <div class="label"><label for="publish_date">$_("When was it published?")</label> <span class="smaller lighter">$_("The year it was published is plenty.")</span></div>
             <div class="input">
-                <input type="text" name="publish_date" class="required publish-date" id="publish_date"/>
+                <input type="text" name="publish_date" class="textarea publish-date" id="publish_date"/>
             </div>
         </div>
 

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -38,7 +38,7 @@ $var title: $("Log In")
             </div>
 
             <div class="input">
-              <input type="email" class="required" id="username" name="username" value="$(form.username.value or query_param('username'))" placeholder="Email" autocapitalize="off" autocorrect="off"/>
+              <input type="email" class="textarea" id="username" name="username" value="$(form.username.value or query_param('username'))" placeholder="Email" autocapitalize="off" autocorrect="off"/>
               <span class="invalid clearfix" htmlfor="username">$form.username.note</span>
             </div>
         </div>
@@ -46,7 +46,7 @@ $var title: $("Log In")
         <div class="formElement">
             <div class="label"><label for="password">$_("Password")</label> <span class="smaller lighter"></span></div>
             <div class="input">
-                <input type="password" class="required" placeholder="Password" id="password" name="password" value="$form.password.value" />
+                <input type="password" class="textarea" placeholder="Password" id="password" name="password" value="$form.password.value" />
                 <span class="invalid clearfix" htmlfor="password">$form.password.note</span>
             </div>
         </div>

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -21,14 +21,14 @@ $var title: $_('How can we help?')
 
  <div class="formElement">
  <div class="label"><label for="email">$_("Your Email Address")</label></div>
- <div class="input"><input type="email" class="email required" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
+ <div class="input"><input type="email" class="email textarea" name="email" id="email" value="$email"/> ($_('We\'ll need this if you want a reply'))</div>
  <p>$_('If you wish to be contacted by other means, please add your contact preference and details to your question.')</p>
  </div>
 
  <div class="formElement">
    <div class="label"><label for="topic">$_("Topic")</label></div>
    <div class="input">
-     <select class="required" name="topic" id="topic">
+     <select name="topic" id="topic">
        <option value="">$_('Select...')</option>
        <option value="Borrowing Books">$_('Borrowing Help')</option>
        <option value="Developer/Code">$_('Developer/Code Question')</option>
@@ -45,7 +45,7 @@ $var title: $_('How can we help?')
    <div class="label"><label for="question">$_("Your Question")</label></div>
    <p><strong>$_('Note: our staff will likely only be able respond in English.')</strong></p>
    <div class="input">
-     <textarea id="question" name="question" class="required" cols="40" rows="5"></textarea>
+     <textarea id="question" name="question" class="textarea" cols="40" rows="5"></textarea>
    </div>
    <p>$_('If you encounter an error message, please include it. For questions about our books, please provide the title/author or Open Library ID.')</p>
  </div>

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -26,7 +26,7 @@ $putctx("robots", "noindex,nofollow")
                 </span>
             </div>
             <div class="input">
-                <input type="text" name="author--name" id="name" value="$page.name" class="required"/>
+                <input type="text" name="author--name" id="name" value="$page.name" class="textarea"/>
             </div>
         </div>
     </div>

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -48,10 +48,11 @@
     width: 4em;
   }
 
-  input[type=email],
-  input[type=password],
   .required {
-    padding: 8px;
+    border-style: solid;
+    border-width: 2px;
+    border-color: red;
+    border-radius: 2px;
   }
 
   select {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6011

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix & refactor

### Technical
<!-- What should be noted about the implementation? -->
The cause of the issue is closely tied with the usage of the "required" CSS class. That's why this PR also contains a little refactor beyond fixing the format issue.

The "required" CSS class seems to be used with 2 different purposes:
1. To highlight an input field which is left empty after the user left that input field ("Sign Up" page)
2. To mark an input field as an input field which must not be empty ("Log In", "Add a Book", contact form, "Edit Author" pages)

The class only has a "padding" property, which seems insufficient for any of the purposes mentioned above. 

The solution proposed by this PR:
- Change the "required" CSS class so it means a highlight calling the user's attention to the fact that they left the given input field empty after entering that field (mentioned as purpose 2) above)
- Change the CSS class from "required" to "textarea", of those input fields where the usage of the "required" CSS class is used with purpose 2) (mentioned above)
- Remove those CSS properties from "input[type=email]" and "input[type=password]" which are the same as for the "required" CSS class
- (For pages other than the "Sign Up" page this PR does not implement that the input fields get highlighted when being left empty after being entered by the user, as this would be a feature outside the scope of the issue which is targeted by this PR.)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit the [Sign Up](https://openlibrary.org/account/create) page. 
1.1. Check that the height of the signup form's input fields are identical.
1.2. Check that initially the input fields are not highlighted for being empty. For each input field of the signup form, click in the field and click outside the field without entering anything in the field. Check that the field gets highlighted for being left empty.
2. Visit the [Log In](https://openlibrary.org/account/login) page. Check that the input fields are not highlighted initially for being empty.
3. Visit the [contact form](https://openlibrary.org/contact). Check that the input fields are not highlighted initially for being empty.
4. Visit the ["Add a book"](https://openlibrary.org/books/add) page. Check that the input fields are not highlighted initially for being empty.
5. Visit the [Edit Author](https://openlibrary.org/authors/OL586013A/Larry_Long/edit) page of an author. Check that the input fields are not highlighted initially for being empty.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![1 1](https://user-images.githubusercontent.com/15958029/152678907-478f3e1c-baab-42ce-a3a0-314eeab1dedd.png)
![1 2](https://user-images.githubusercontent.com/15958029/152678910-3a5b8b9c-6470-41a9-9444-c0d3d7c0b828.png)
![2](https://user-images.githubusercontent.com/15958029/152678915-a6e62247-6167-4985-9b80-6705494cefb9.png)
![3](https://user-images.githubusercontent.com/15958029/152678916-e0164940-0723-4a45-af8f-133cd8952061.png)
![4](https://user-images.githubusercontent.com/15958029/152678917-12b97303-a8a6-41ba-9979-a9116f78ec9d.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
