### PR TITLE
API to resolve redirects for single work

### DIFF
--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -1,14 +1,16 @@
 from . import db
 
 
-class Booknotes:
+class Booknotes(db.CommonExtras):
 
+    TABLENAME = "booknotes"
+    PRIMARY_KEY = ["username", "work_id", "edition_id"]
     NULL_EDITION_VALUE = -1
 
     @classmethod
     def total_booknotes(cls):
         oldb = db.get_db()
-        query = "SELECT count(*) from booknotes"
+        query = f"SELECT count(*) from {cls.TABLENAME}"
         return oldb.query(query)['count']
 
     @classmethod
@@ -38,6 +40,12 @@ class Booknotes:
             query += " AND created >= $since"
         query += ' group by work_id order by cnt desc limit $limit'
         return list(oldb.query(query, vars={'limit': limit, 'since': since}))
+
+    @classmethod
+    def get_booknotes_for_work(cls, work_id):
+        oldb = db.get_db()
+        query = "SELECT * from booknotes where work_id=$work_id"
+        return list(oldb.query(query, vars={"work_id": work_id}))
 
     @classmethod
     def count_total_booksnotes_by_user(cls, username):
@@ -79,10 +87,8 @@ class Booknotes:
         limit=100,
         page=1,
     ):
-        """
-        By default, get all a patron's booknotes. if work_id, get book note for that work_id and edition_id.
-
-        return:
+        """By default, get all a patron's booknotes. if work_id, get book
+        note for that work_id and edition_id.
         """
         oldb = db.get_db()
         page = int(page) if page else 1

--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -6,6 +6,7 @@ class Booknotes(db.CommonExtras):
     TABLENAME = "booknotes"
     PRIMARY_KEY = ["username", "work_id", "edition_id"]
     NULL_EDITION_VALUE = -1
+    ALLOW_DELETE_ON_CONFLICT = False
 
     @classmethod
     def total_booknotes(cls):

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -12,6 +12,7 @@ class Bookshelves(db.CommonExtras):
     TABLENAME = "bookshelves_books"
     PRIMARY_KEY = ["username", "work_id", "bookshelf_id"]
     PRESET_BOOKSHELVES = {'Want to Read': 1, 'Currently Reading': 2, 'Already Read': 3}
+    ALLOW_DELETE_ON_CONFLICT = True
 
     PRESET_BOOKSHELVES_JSON = {
         'want_to_read': 1,

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -7,8 +7,10 @@ from . import db
 logger = logging.getLogger(__name__)
 
 
-class Bookshelves:
+class Bookshelves(db.CommonExtras):
 
+    TABLENAME = "bookshelves_books"
+    PRIMARY_KEY = ["username", "work_id", "bookshelf_id"]
     PRESET_BOOKSHELVES = {'Want to Read': 1, 'Currently Reading': 2, 'Already Read': 3}
 
     PRESET_BOOKSHELVES_JSON = {
@@ -245,7 +247,7 @@ class Bookshelves:
         users_status = cls.get_users_read_status_of_work(username, work_id)
         if not users_status:
             return oldb.insert(
-                'bookshelves_books',
+                cls.TABLENAME,
                 username=username,
                 bookshelf_id=bookshelf_id,
                 work_id=work_id,
@@ -254,7 +256,7 @@ class Bookshelves:
         else:
             where = "work_id=$work_id AND username=$username"
             return oldb.update(
-                'bookshelves_books',
+                cls.TABLENAME,
                 where=where,
                 bookshelf_id=bookshelf_id,
                 edition_id=edition_id,
@@ -270,7 +272,7 @@ class Bookshelves:
 
         try:
             return oldb.delete(
-                'bookshelves_books',
+                cls.TABLENAME,
                 where=('work_id=$work_id AND username=$username'),
                 vars=where,
             )
@@ -281,9 +283,9 @@ class Bookshelves:
     def get_works_shelves(cls, work_id, lazy=False):
         """Bookshelves this work is on"""
         oldb = db.get_db()
-        query = "SELECT * from bookshelves_books where work_id=$work_id"
+        query = f"SELECT * from {cls.TABLENAME} where work_id=$work_id"
         try:
-            result = oldb.query(query, vars={'work_id': int(work_id)})
+            result = oldb.query(query, vars={'work_id': work_id})
             return result if lazy else list(result)
         except:
             return None

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -50,7 +50,6 @@ class CommonExtras:
                         for k, v in row.items()
                         if k in cls.PRIMARY_KEY
                     ])
-                    web.debug(where)
                     try:
                         # try to update the row to new_work_id
                         oldb.query(f"UPDATE {cls.TABLENAME} set work_id={new_work_id} where {where}")
@@ -65,7 +64,10 @@ class CommonExtras:
         except:
             t.rollback()
             raise
-        t.rollback() if _test else t.commit()
+        if _test:
+            t.rollback()
+        else:
+            t.commit()
         return rows_changed, rows_deleted
 
 

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -1,6 +1,7 @@
 """Interface to access the database of openlibrary.
 """
 import web
+from sqlite3 import IntegrityError
 from psycopg2.errors import UniqueViolation
 from infogami.utils import stats
 
@@ -37,7 +38,7 @@ class CommonExtras:
                 where="work_id=$work_id",
                 work_id=new_work_id,
                 vars={"work_id": current_work_id})
-        except UniqueViolation:
+        except (UniqueViolation, IntegrityError):
             try:
                 # get records with old work_id
                 rows = oldb.select(
@@ -54,7 +55,7 @@ class CommonExtras:
                         # try to update the row to new_work_id
                         oldb.query(f"UPDATE {cls.TABLENAME} set work_id={new_work_id} where {where}")
                         rows_changed += 1
-                    except UniqueViolation:
+                    except (UniqueViolation, IntegrityError):
                         # otherwise, delete row with current_work_id if failed
                         oldb.query(f"DELETE FROM {cls.TABLENAME} WHERE {where}")
                         rows_deleted += 1

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -1,8 +1,8 @@
 """Interface to access the database of openlibrary.
 """
 import web
+from psycopg2.errors import UniqueViolation
 from infogami.utils import stats
-
 
 @web.memoize
 def _get_db():
@@ -15,6 +15,58 @@ def get_db():
     The database object is cached so that one object is used everywhere.
     """
     return _get_db()
+
+
+class CommonExtras:
+    """
+    A set of methods used by bookshelves, booknotes, ratings, and observations tables
+    """
+
+    @classmethod
+    def update_work_id(cls, current_work_id, new_work_id, _test=False):
+        """This method allows all instances of a work_id (such as that of a
+        redirect) to be updated to a new work_id.
+        """
+        oldb = get_db()
+        t = oldb.transaction()
+        rows_changed = 0
+        rows_deleted = 0
+        try:
+            rows_changed = oldb.update(
+                cls.TABLENAME,
+                where="work_id=$work_id",
+                work_id=new_work_id,
+                vars={"work_id": current_work_id})
+        except UniqueViolation:
+            try:
+                # get records with old work_id
+                rows = oldb.select(
+                    cls.TABLENAME,
+                    where="work_id=$work_id",
+                    vars={"work_id": current_work_id})
+                for row in rows:
+                    where = " AND ".join([
+                        f"{k}='{v}'"
+                        for k, v in row.items()
+                        if k in cls.PRIMARY_KEY
+                    ])
+                    web.debug(where)
+                    try:
+                        # try to update the row to new_work_id
+                        oldb.query(f"UPDATE {cls.TABLENAME} set work_id={new_work_id} where {where}")
+                        rows_changed += 1
+                    except UniqueViolation:
+                        # otherwise, delete row with current_work_id if failed
+                        oldb.query(f"DELETE FROM {cls.TABLENAME} WHERE {where}")
+                        rows_deleted += 1
+            except:
+                t.rollback()
+                raise
+        except:
+            t.rollback()
+            raise
+        t.rollback() if _test else t.commit()
+        return rows_changed, rows_deleted
 
 
 def _proxy(method_name):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -636,6 +636,20 @@ class Work(Thing):
             d['ia'] = solrdata.get('ia')
         return d
 
+    @staticmethod
+    def get_redirect_chain(work_key: str) -> list:
+        resolved_key = None
+        redirect_chain = []
+        key = work_key
+        while not resolved_key:
+            thing = web.ctx.site.get(key)
+            redirect_chain.append(thing)
+            if thing.type.key == "/type/redirect":
+                key = thing.location
+            else:
+                resolved_key = thing.key
+        return redirect_chain
+
 
 class Author(Thing):
     """Class to represent /type/author objects in OL."""

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -744,9 +744,11 @@ def get_observation_metrics(work_olid):
     return metrics
 
 
-class Observations:
+class Observations(db.CommonExtras):
 
+    TABLENAME = "observations"
     NULL_EDITION_VALUE = -1
+    PRIMARY_KEY = ["work_id", "edition_id", "username", "observation_value", "observation_type"]
 
     @classmethod
     def summary(cls):
@@ -942,6 +944,12 @@ class Observations:
             query += " AND work_id=$work_id"
 
         return list(oldb.query(query, vars=data))
+
+    @classmethod
+    def get_observations_for_work(cls, work_id):
+        oldb = db.get_db()
+        query = "SELECT * from observations where work_id=$work_id"
+        return list(oldb.query(query, vars={"work_id": work_id}))
 
     @classmethod
     def get_observations_grouped_by_work(cls, username, limit=25, page=1):

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -749,6 +749,7 @@ class Observations(db.CommonExtras):
     TABLENAME = "observations"
     NULL_EDITION_VALUE = -1
     PRIMARY_KEY = ["work_id", "edition_id", "username", "observation_value", "observation_type"]
+    ALLOW_DELETE_ON_CONFLICT = True
 
     @classmethod
     def summary(cls):

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -20,6 +20,7 @@ class Ratings(db.CommonExtras):
     TABLENAME = "ratings"
     VALID_STAR_RATINGS = range(6)  # inclusive: [0 - 5] (0-5 star)
     PRIMARY_KEY = ["username", "work_id"]
+    ALLOW_DELETE_ON_CONFLICT = True
 
     @classmethod
     def summary(cls):

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -15,9 +15,11 @@ class WorkRatingsSummary(TypedDict):
     ratings_count_5: int
 
 
-class Ratings:
+class Ratings(db.CommonExtras):
 
+    TABLENAME = "ratings"
     VALID_STAR_RATINGS = range(6)  # inclusive: [0 - 5] (0-5 star)
+    PRIMARY_KEY = ["username", "work_id"]
 
     @classmethod
     def summary(cls):
@@ -101,7 +103,7 @@ class Ratings:
     def get_all_works_ratings(cls, work_id):
         oldb = db.get_db()
         query = 'select * from ratings where work_id=$work_id'
-        return list(oldb.query(query, vars={'work_id': work_id}))
+        return list(oldb.query(query, vars={'work_id': int(work_id)}))
 
     @classmethod
     def get_users_rating_for_work(cls, username, work_id):

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -208,12 +208,19 @@ class add_work_to_staff_picks:
 
 class resolve_redirects:
     def GET(self):
-        params = web.input(key='', test=False)
-        summary = {
-            'key': params.key,
-            'redirect_chain': [],
-            'resolved_key': None
-        }
+        return self.main(test=True)
+
+    def POST(self):
+        return self.main(test=False)
+
+    def main(self, test=False):
+        params = web.input(key='', test='')
+
+        # Provide an escape hatch to let POST requests preview
+        if test is False and params.test:
+            test = True
+
+        summary = {'key': params.key, 'redirect_chain': [], 'resolved_key': None}
         if params.key:
             redirect_chain = Work.get_redirect_chain(params.key)
             summary['redirect_chain'] = [
@@ -241,16 +248,16 @@ class resolve_redirects:
 
                 # track updates
                 r['updates']['readinglog'] = Bookshelves.update_work_id(
-                    olid, new_olid, _test=params.test
+                    olid, new_olid, _test=test
                 )
                 r['updates']['ratings'] = Ratings.update_work_id(
-                    olid, new_olid, _test=params.test
+                    olid, new_olid, _test=test
                 )
                 r['updates']['booknotes'] = Booknotes.update_work_id(
-                    olid, new_olid, _test=params.test
+                    olid, new_olid, _test=test
                 )
                 r['updates']['observations'] = Observations.update_work_id(
-                    olid, new_olid, _test=params.test
+                    olid, new_olid, _test=test
                 )
 
         return delegate.RawText(

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -225,8 +225,7 @@ class resolve_redirects:
             ]
             summary['resolved_key'] = redirect_chain[-1].key
 
-            for i, _ in enumerate(summary['redirect_chain']):
-                r = summary['redirect_chain'][i]
+            for r in summary['redirect_chain']:
                 olid = r['key'].split('/')[-1][2:-1]
                 new_olid = summary['resolved_key'].split('/')[-1][2:-1]
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -240,14 +240,18 @@ class resolve_redirects:
                     Observations.get_observations_for_work(olid))
 
                 # track updates
-                r['updates']['readinglog'] = list(
-                    Bookshelves.update_work_id(olid, new_olid, _test=params.test))
-                r['updates']['ratings'] = list(
-                    Ratings.update_work_id(olid, new_olid, _test=params.test))
-                r['updates']['booknotes'] = list(
-                    Booknotes.update_work_id(olid, new_olid, _test=params.test))
-                r['updates']['observations'] = list(
-                    Observations.update_work_id(olid, new_olid, _test=params.test))
+                r['updates']['readinglog'] = Bookshelves.update_work_id(
+                    olid, new_olid, _test=params.test
+                )
+                r['updates']['ratings'] = Ratings.update_work_id(
+                    olid, new_olid, _test=params.test
+                )
+                r['updates']['booknotes'] = Booknotes.update_work_id(
+                    olid, new_olid, _test=params.test
+                )
+                r['updates']['observations'] = Observations.update_work_id(
+                    olid, new_olid, _test=params.test
+                )
 
         return delegate.RawText(
             json.dumps(summary), content_type="application/json")

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -34,6 +34,7 @@ from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.ratings import Ratings
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.observations import Observations
+from openlibrary.core.models import Work
 
 from openlibrary.plugins.upstream import forms, spamcheck
 from openlibrary.plugins.upstream.account import send_forgot_password_email
@@ -214,18 +215,15 @@ class resolve_redirects:
             'resolved_key': None
         }
         if params.key:
-            key = params.key
-            while not summary['resolved_key']:
-                thing = web.ctx.site.get(key)
-                if thing.type.key == "/type/redirect":
-                    summary['redirect_chain'].append({
-                        "key": thing.key,
-                        "occurrences": {},
-                        "updates": {},
-                    })
-                    key = thing.location
-                else:
-                    summary['resolved_key'] = thing.key
+            redirect_chain = Work.get_redirect_chain(params.key)
+            summary['redirect_chain'] = [
+                {
+                    "key": thing.key,
+                    "occurrences": {},
+                    "updates": {}
+                } for thing in redirect_chain
+            ]
+            summary['resolved_key'] = redirect_chain[-1].key
 
             for i, _ in enumerate(summary['redirect_chain']):
                 r = summary['redirect_chain'][i]

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -1,12 +1,14 @@
 import web
-from openlibrary.core.db import CommonExtras, get_db
+from openlibrary.core.db import get_db
+from openlibrary.core.bookshelves import Bookshelves
 
 class TestUpdateWorkID:
 
-    def setup_method(self, method):
+    @classmethod
+    def setup_class(cls):
         web.config.db_parameters = dict(dbn="sqlite", db=":memory:")
-        self.db = get_db()
-        self.db.query("""
+        db = get_db()
+        db.query("""
         CREATE TABLE bookshelves_books (
         username text NOT NULL,
         work_id integer NOT NULL,
@@ -16,22 +18,45 @@ class TestUpdateWorkID:
         );
         """)
 
-    def test_update(self):
-        CommonExtras.TABLENAME = "bookshelves_books"
-        book1 = {
+    def setup_method(self, method):
+        self.db = get_db()
+        self.source_book = {
             "username": "@cdrini",
             "work_id": "1",
             "edition_id": "1",
             "bookshelf_id": "1"
         }
-        assert not len(list(self.db.select("bookshelves_books", where=book1)))
-        self.db.insert("bookshelves_books", **book1)
-        assert len(list(self.db.select("bookshelves_books", where=book1))) == 1
+        assert not len(list(self.db.select("bookshelves_books")))
+        self.db.insert("bookshelves_books", **self.source_book)
 
-        # [x] 1 -> 2 (no 2 exists in db) + many case
-        #     1 -> 2 (2 does exist in db) + many case
-        #        1 -> 2 (2 has different edition than 1)
-        CommonExtras.update_work_id("1", "2")
+    def teardown_method(self):
+        self.db.query("delete from bookshelves_books;")
+
+    def test_update_collision(self):
+        existing_book = {
+            "username": "@cdrini",
+            "work_id": "2",
+            "edition_id": "2",
+            "bookshelf_id": "1"
+        }
+        self.db.insert("bookshelves_books", **existing_book)
+        assert len(list(self.db.select("bookshelves_books"))) == 2
+        Bookshelves.update_work_id(self.source_book['work_id'], existing_book['work_id'])
+        assert len(list(self.db.select("bookshelves_books", where={
+            "username": "@cdrini",
+            "work_id": "2",
+            "edition_id": "2"
+        }))), "failed to update 1 to 2"
+        assert not len(list(self.db.select("bookshelves_books", where={
+            "username": "@cdrini",
+            "work_id": "1",
+            "edition_id": "1"
+        }))), "old work_id 1 present"
+
+
+    def test_update_simple(self):
+        assert len(list(self.db.select("bookshelves_books"))) == 1
+        Bookshelves.update_work_id(self.source_book['work_id'], "2")
         assert len(list(self.db.select("bookshelves_books", where={
             "username": "@cdrini",
             "work_id": "2",

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -1,0 +1,44 @@
+import web
+from openlibrary.core.db import CommonExtras, get_db
+
+class TestUpdateWorkID:
+
+    def setup_method(self, method):
+        web.config.db_parameters = dict(dbn="sqlite", db=":memory:")
+        self.db = get_db()
+        self.db.query("""
+        CREATE TABLE bookshelves_books (
+        username text NOT NULL,
+        work_id integer NOT NULL,
+        bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
+        edition_id integer default null,
+        primary key (username, work_id, bookshelf_id)
+        );
+        """)
+
+    def test_update(self):
+        CommonExtras.TABLENAME = "bookshelves_books"
+        book1 = {
+            "username": "@cdrini",
+            "work_id": "1",
+            "edition_id": "1",
+            "bookshelf_id": "1"
+        }
+        assert not len(list(self.db.select("bookshelves_books", where=book1)))
+        self.db.insert("bookshelves_books", **book1)
+        assert len(list(self.db.select("bookshelves_books", where=book1))) == 1
+
+        # [x] 1 -> 2 (no 2 exists in db) + many case
+        #     1 -> 2 (2 does exist in db) + many case
+        #        1 -> 2 (2 has different edition than 1)
+        CommonExtras.update_work_id("1", "2")
+        assert len(list(self.db.select("bookshelves_books", where={
+            "username": "@cdrini",
+            "work_id": "2",
+            "edition_id": "1"
+        }))), "failed to update 1 to 2"
+        assert not len(list(self.db.select("bookshelves_books", where={
+            "username": "@cdrini",
+            "work_id": "1",
+            "edition_id": "1"
+        }))), "old value 1 present"

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -1,6 +1,7 @@
 import web
 from openlibrary.core.db import get_db
 from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.booknotes import Booknotes
 
 class TestUpdateWorkID:
 
@@ -15,8 +16,19 @@ class TestUpdateWorkID:
         bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
         edition_id integer default null,
         primary key (username, work_id, bookshelf_id)
-        );
-        """)
+        );""")
+
+        db.query(
+            """
+            CREATE TABLE booknotes (
+                username text NOT NULL,
+                work_id integer NOT NULL,
+                edition_id integer NOT NULL default -1,
+                notes text NOT NULL,
+                primary key (username, work_id, edition_id)
+            );
+            """
+        )
 
     def setup_method(self, method):
         self.db = get_db()
@@ -57,13 +69,13 @@ class TestUpdateWorkID:
     def test_update_simple(self):
         assert len(list(self.db.select("bookshelves_books"))) == 1
         Bookshelves.update_work_id(self.source_book['work_id'], "2")
-        assert len(list(self.db.select("bookshelves_books", where={
-            "username": "@cdrini",
-            "work_id": "2",
-            "edition_id": "1"
-        }))), "failed to update 1 to 2"
-        assert not len(list(self.db.select("bookshelves_books", where={
-            "username": "@cdrini",
-            "work_id": "1",
-            "edition_id": "1"
-        }))), "old value 1 present"
+
+    def test_no_allow_delete_on_conflict(self):
+        rows = [
+            {"username": "@mek", "work_id": 1, "edition_id": 1, "notes": "Jimmeny"},
+            {"username": "@mek", "work_id": 2, "edition_id": 1, "notes": "Cricket"},
+        ]
+        self.db.multiple_insert("booknotes", rows)
+        resp = Booknotes.update_work_id("1", "2")
+        assert resp == {'rows_changed': 0, 'rows_deleted': 0, 'failed_deletes': 1}
+        assert [dict(row) for row in self.db.select("booknotes")] == rows


### PR DESCRIPTION
- Each feature type (i.e. bookshelves, ratings, observations, booknotes) inherits from db.CommonExtras
- Result shows occurrences of redirect works per type (bookshelves, ratings, observations, booknotes)
- Handles chains of redirects
- _test=True / ?test=true flag to db rollback/abort transaction

<!-- What issue does this PR close? -->
Closes #5999 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

**NB** For any given category (e.g. ratings, booknotes, bookshelves, observations -- let's pick ratings), there is an edge case that a work of type redirect (e.g. work OL123W) will need to resolve to its active work (e.g. OL234W) but this active work already has a db entry in the db (e.g. if the patron has a rating in the db for both OL123W and OL234W). In this case, the transaction of updating the redirect work (e.g. OL123W) to the active work (e.g. OL234W) will fail because of a `UniqueConstraint`. Therefore, in the case where this happens, we must fetch all of the rows where the redirect work (e.g. OL123W) appears in the table (e.g. ratings) and attempt to update them one at a time. If/when the `UniqueConstraint` is encountered, we may then simply delete the row for the redirect work because it has already been accounted for by the existence of the (conflicting) active work.

`db.CommonExtras` parent class was added to core/db so that the behavior for syncing/updating a work_id in any of the tables is the same. Each child class (i.e. ratings, observations, booknotes, bookshelves) now defines two new class constants: `TABLENAME` and `PRIMARY_KEY` (i.e. the key names consisting of the primary key in the db). These two new fields let us make the functions within the `db.CommonExtras` class generic.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

http://ol-dev1.us.archive.org:1337/admin/resolve_redirects?key=/works/OL5976342W&debug=true&test=true

remove `test=true` to commit the db transaction

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
