### PR TITLE
Make standard ebooks importer include language field + fix som errors

### DIFF
--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -89,7 +89,7 @@ def get_schema():
         status text default 'pending',
         error text,
         ia_id text,
-        data text UNIQUE,
+        data text,
         ol_key text,
         comments text,
         UNIQUE (batch_id, ia_id)
@@ -98,7 +98,6 @@ def get_schema():
     CREATE INDEX import_item_import_time ON import_item(import_time);
     CREATE INDEX import_item_status ON import_item(status);
     CREATE INDEX import_item_ia_id ON import_item(ia_id);
-    CREATE INDEX import_item_data ON import_item(data);
     """
 
     # monkey patch schema.sql to include the custom functions

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -66,10 +66,10 @@ def create_batch(records: list[dict[str, str]]) -> None:
     now = time.gmtime(time.time())
     batch_name = f'standardebooks-{now.tm_year}{now.tm_mon}'
     batch = Batch.find(batch_name) or Batch.new(batch_name)
-    batch.add_items([{
-        'ia_id': r['source_records'][0],
-        'data': json.dumps(r)} for r in records]
-    )
+    batch.add_items([
+        {'ia_id': r['source_records'][0], 'data': r}
+        for r in records
+    ])
 
 
 def get_last_updated_time() -> Optional[str]:

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -29,7 +29,14 @@ def map_data(entry) -> dict[str, Any]:
     std_ebooks_id = entry.id.replace('https://standardebooks.org/ebooks/', '')
     image_uris = filter(lambda link: link.rel == IMAGE_REL, entry.links)
 
-    import_record =  {
+    # Standard ebooks only has English works at this time ; because we don't have an
+    # easy way to translate the language codes they store in the feed to the MARC
+    # language codes, we're just gonna handle English for now, and have it error
+    # if Standard Ebooks ever adds non-English works.
+    marc_lang_code = 'eng' if entry.language.startswith('en-') else None
+    if not marc_lang_code:
+        raise ValueError(f'Feed entry language {entry.language} is not supported.')
+    import_record = {
         "title": entry.title,
         "source_records": [f"standard_ebooks:{std_ebooks_id}"],
         "publishers": [entry.publisher],
@@ -39,7 +46,8 @@ def map_data(entry) -> dict[str, Any]:
         "subjects": [tag.term for tag in entry.tags],
         "identifiers": {
             "standard_ebooks": [std_ebooks_id]
-        }
+        },
+        "languages": [marc_lang_code]
     }
 
     if image_uris:


### PR DESCRIPTION
Include languages in the import item from standard ebooks feed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
