### PR TITLE
Fix standard ebooks download links

### DIFF
--- a/openlibrary/templates/book_providers/standard_ebooks_download_options.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_download_options.html
@@ -1,16 +1,17 @@
 $def with(standard_ebooks_id)
 
 $ base_url = 'https://standardebooks.org/ebooks/' + standard_ebooks_id
+$ flat_id = standard_ebooks_id.replace('/', '_')
 
 <hr>
 <div class="cta-section">
 <p class="cta-section-title">$_('Download Options')</p>
 <ul class="ebook-download-options">
   <li><a href="$base_url/text/single-page" title="$_('Download an HTML from Standard Ebooks')">$_('HTML')</a></li>
-  <li><a href="$base_url/downloads/william-shakespeare_as-you-like-it.epub" title="$_('Download an ePub from Standard Ebook.')">$_('ePub')</a></li>
-  <li><a href="$base_url/downloads/william-shakespeare_as-you-like-it.azw3" title="$_('Download a Kindle file from Standard Ebooks')">$_('Kindle (azw3)')</a></li>
-  <li><a href="$base_url/downloads/william-shakespeare_as-you-like-it.kepub.epub" title="$_('Download a Kobo file from Standard Ebooks')">$_('Kobo (kepub)')</a></li>
-  <li><a href="https://github.com/standardebooks/$standard_ebooks_id.replace('/', '_')" title="$_('View the source code for this Standard Ebook at GitHub')">$_('Source Code')</a></li>
+  <li><a href="$base_url/downloads/$flat_id.epub" title="$_('Download an ePub from Standard Ebook.')">$_('ePub')</a></li>
+  <li><a href="$base_url/downloads/$flat_id.azw3" title="$_('Download a Kindle file from Standard Ebooks')">$_('Kindle (azw3)')</a></li>
+  <li><a href="$base_url/downloads/$flat_id.kepub.epub" title="$_('Download a Kobo file from Standard Ebooks')">$_('Kobo (kepub)')</a></li>
+  <li><a href="https://github.com/standardebooks/$flat_id" title="$_('View the source code for this Standard Ebook at GitHub')">$_('Source Code')</a></li>
   <li><a href="$base_url">$_('More at Standard Ebooks')</a></li>
 </ul>
 </div>

--- a/openlibrary/templates/book_providers/standard_ebooks_download_options.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_download_options.html
@@ -8,9 +8,9 @@ $ flat_id = standard_ebooks_id.replace('/', '_')
 <p class="cta-section-title">$_('Download Options')</p>
 <ul class="ebook-download-options">
   <li><a href="$base_url/text/single-page" title="$_('Download an HTML from Standard Ebooks')">$_('HTML')</a></li>
-  <li><a href="$base_url/downloads/$flat_id.epub" title="$_('Download an ePub from Standard Ebook.')">$_('ePub')</a></li>
-  <li><a href="$base_url/downloads/$flat_id.azw3" title="$_('Download a Kindle file from Standard Ebooks')">$_('Kindle (azw3)')</a></li>
-  <li><a href="$base_url/downloads/$flat_id.kepub.epub" title="$_('Download a Kobo file from Standard Ebooks')">$_('Kobo (kepub)')</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).epub" title="$_('Download an ePub from Standard Ebook.')">$_('ePub')</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).azw3" title="$_('Download a Kindle file from Standard Ebooks')">$_('Kindle (azw3)')</a></li>
+  <li><a href="$base_url/downloads/$(flat_id).kepub.epub" title="$_('Download a Kobo file from Standard Ebooks')">$_('Kobo (kepub)')</a></li>
   <li><a href="https://github.com/standardebooks/$flat_id" title="$_('View the source code for this Standard Ebook at GitHub')">$_('Source Code')</a></li>
   <li><a href="$base_url">$_('More at Standard Ebooks')</a></li>
 </ul>


### PR DESCRIPTION
This just in: Not all books are _As You Like It_ by William Shakespeare.


### Technical
- Please squash these commits when merging.

### Testing
- Try clicking on the Kobo link https://openlibrary.org/books/OL37044422M/The_Time_Traders  and on testing.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
