### PR TITLE
Always render add edition link

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -244,8 +244,7 @@ $if is_privileged_user:
 
       <a name="editions-list" class="section-anchor"></a>
       $ component_times['EditionsTable'] = time()
-      $if editions:
-        $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition)
+      $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition)
       $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
 
       <a name="work-details" class="section-anchor"></a>

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -1,34 +1,38 @@
 $def with (work, editions=None, edition=None)
 
 $ book_keys = []
+$ edition_list_start = time()
 
+$if editions and len(editions):
+  <table id="editions" class="editions-table editions-table--progressively-enhanced">
+      <thead>
+      <tr>
+          <th class="title" title=""><a href="javascript:;">$_('Edition')<span></span></a></th>
+          <th class="read" title=""><a href="javascript:;">$_('Availability')<span></span></a></th>
+      </tr>
+      </thead>
+      <tbody>
+          $ editions = editions or work.get_sorted_editions()
+          $ index_padding = len(str(len(editions)))
+          $for book in editions:
+              $ book_keys.append(book['key'].replace('/books/', ''))
+              $ edition_sort_key = str(loop.index0+1).zfill(index_padding)
+              $if book.key == edition.key:
+                <tr class="highlight">
+                  $# This enables us to always render a select edition first in the table (default)
+                  $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
+                </tr>
+              $else:
+                <tr>
+                  $:render_template("books/edition-sort", book, edition_sort_key)
+                </tr>
+      </tbody>
+  </table>
+$else:
+  <p>$_('No editions available')</p>
 
-<table id="editions" class="editions-table editions-table--progressively-enhanced">
-    <thead>
-    <tr>
-        <th class="title" title=""><a href="javascript:;">$_('Edition')<span></span></a></th>
-        <th class="read" title=""><a href="javascript:;">$_('Availability')<span></span></a></th>
-    </tr>
-    </thead>
-    <tbody>
-        $ edition_list_start = time()
-        $ editions = editions or work.get_sorted_editions()
-        $ index_padding = len(str(len(editions)))
-        $for book in editions:
-            $ book_keys.append(book['key'].replace('/books/', ''))
-            $ edition_sort_key = str(loop.index0+1).zfill(index_padding)
-            $if book.key == edition.key:
-              <tr class="highlight">
-                $# This enables us to always render a select edition first in the table (default)
-                $:render_template("books/edition-sort", book, edition_sort_key, render_first=True)
-              </tr>
-            $else:
-              <tr>
-                $:render_template("books/edition-sort", book, edition_sort_key)
-              </tr>
-        $ edition_list_secs = time() - edition_list_start
-    </tbody>
-</table>
+$ edition_list_secs = time() - edition_list_start
+
 <p class="small sansserif edition-adder">
   <a href="/books/add?work=$work.key" title="$_('Add another edition of %(work)s', work=work.title)">$_("Add another edition?")</a>
 </p>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6133

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that the "Add another edition?" link is present, even if there are no editions.

### Technical
<!-- What should be noted about the implementation? -->
Replaced `editions` check in `editions/view.html` with an `editions` check inside of the `editions_datatable.html` template.  Table in the template now only renders if there are editions present.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![add-another-edition](https://user-images.githubusercontent.com/28732543/153466638-b6fd34e9-cfc8-4b79-8c34-5e3844c5cce6.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
