### PR TITLE
Expand subject/people/places fields in edit

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,4 +16,4 @@ tasks:
   # init runs once for each commit to the default branch
   init: ./scripts/setup_gitpod.sh
   # command runs each time a user starts their workspace
-  command: docker-compose run --rm home npm run-script watch-css
+  command: docker-compose up

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,4 +16,4 @@ tasks:
   # init runs once for each commit to the default branch
   init: ./scripts/setup_gitpod.sh
   # command runs each time a user starts their workspace
-  command: docker-compose up
+  command: docker-compose run --rm home npm run-script watch-css

--- a/openlibrary/templates/books/edit/about.html
+++ b/openlibrary/templates/books/edit/about.html
@@ -21,7 +21,8 @@ $def with (work)
             $for s in work.get_subjects():
                 $ s = s.replace('"', '""')
                 $subjects.append('"' + s + '"' if ',' in s else s)
-            <input type="text" name="work--subjects" id="about-subjects" value="$', '.join(subjects)" tabindex="0"/>
+            <textarea name="work--subjects" id="about-subjects" cols="55" rows="1" wrap="soft"
+            onkeyup="this.style.height = 'auto'; this.style.height = (3 + this.scrollHeight)+'px';" tabindex="0">$', '.join(subjects)</textarea>
         </div>
     </div>
 
@@ -35,7 +36,8 @@ $def with (work)
             $for s in work.subject_people:
                 $ s = s.replace('"', '""')
                 $subjects.append('"' + s + '"' if ',' in s else s)
-            <input type="text" name="work--subject_people" id="about-people" value="$', '.join(subjects)" tabindex="0"/>
+            <textarea name="work--subject_people" id="about-people" cols="55" rows="1" wrap="soft"
+            onkeyup="this.style.height = 'auto'; this.style.height = (3 + this.scrollHeight)+'px';" tabindex="0">$', '.join(subjects)</textarea>
         </div>
     </div>
 
@@ -49,7 +51,8 @@ $def with (work)
             $for s in work.subject_places:
                 $ s = s.replace('"', '""')
                 $subjects.append('"' + s + '"' if ',' in s else s)
-            <input type="text" name="work--subject_places" id="about-places" value="$', '.join(subjects)" tabindex="0"/>
+            <textarea name="work--subject_places" id="about-places" cols="55" rows="1" wrap="soft"
+            onkeyup="this.style.height = 'auto'; this.style.height = (3 + this.scrollHeight)+'px';" tabindex="0">$', '.join(subjects)</textarea>
         </div>
     </div>
 

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -48,7 +48,7 @@
     width: 4em;
   }
 
-  input[type=email],
+  input[type=text],
   input[type=password],
   .required {
     padding: 8px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6074

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create a book record, then edit the book record and type in the subject, people, and places fields.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/46527761/153471430-e0093cf1-3727-4626-8638-37a50256f7d1.png)
![image](https://user-images.githubusercontent.com/46527761/153471502-ff12a6bf-16a1-4a32-9161-a1ddd38bc453.png)
![image](https://user-images.githubusercontent.com/46527761/153471545-969e53c5-5013-4c50-a189-0b8627fd0f77.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
