### PR TITLE
fix books page get_sorted_editions w/o solr

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -728,15 +728,19 @@ class Work(models.Work):
         db_query = {"type": "/type/edition", "works": self.key, "limit": limit}
 
         if ebooks_only:
-            from openlibrary.book_providers import get_book_providers
             edition_keys = []
-            # Always use solr data whether it's up to date or not
-            # to determine which providers this book has
-            # We only make additional queries when a
-            # trusted book provider identifier is present
-            for provider in get_book_providers(self._solr_data):
-                query = {**db_query, **provider.editions_query}
-                edition_keys += web.ctx.site.things(query)
+            if self._solr_data:
+                from openlibrary.book_providers import get_book_providers
+                # Always use solr data whether it's up to date or not
+                # to determine which providers this book has
+                # We only make additional queries when a
+                # trusted book provider identifier is present
+                for provider in get_book_providers(self._solr_data):
+                    query = {**db_query, **provider.editions_query}
+                    edition_keys += web.ctx.site.things(query)
+            else:
+                db_query["ocaid~"] = "*"
+
         else:
             solr_is_up_to_date = (
                 self._solr_data


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6134 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

If no solr data for edition, bypass get data provider and instead use infogami

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

ol-dev1.us.archive.org:1337](http://ol-dev1.us.archive.org:1337/books/OL35552510M/Community-Based_Monitoring_in_the_Arctic?debug=true?

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@jimchamp @seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
