### PR TITLE
Added google analytics to subject clicks on book page

### DIFF
--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -1,22 +1,25 @@
-$def with(work, tags=[])
+$def with(work,location,tags=[])
 
-$def render_subjects(label, subjects, prefix=""):
+$def render_subjects(label, subjects, track-value, prefix=""):
   $if subjects:
     <div class="section link-box">
       <h6>$label</h6>
       <span>
         $for subject in subjects:
-          <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))">$subject</a>$cond(not loop.last, ",", "")
+          <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track-value">$subject</a>$cond(not loop.last, ",", "")
       </span>
     </div>
 
 $if work:
   $for tag in tags:
     $if tag=="Subjects":
-      $:render_subjects(_("Subjects"), work.get_subjects())
+      $if location=="work":
+        $:render_subjects(_("Subjects"), work.get_subjects(),"WorkSection|SubjectClick")
+      $else:
+        $:render_subjects(_("Subjects"), work.get_subjects(),"BookOverview|SubjectClick")
     $elif tag=="People":
-      $:render_subjects(_("People"), work.subject_people, prefix="person:")
+      $:render_subjects(_("People"), work.subject_people,"WorkSection|SubjectPeopleClick", prefix="person:")
     $elif tag=="Places":
-      $:render_subjects(_("Places"), work.subject_places, prefix="place:")
+      $:render_subjects(_("Places"), work.subject_places,"WorkSection|SubjectPlacesClick", prefix="place:")
     $elif tag=="Times":
-      $:render_subjects(_("Times"), work.subject_times, prefix="time:")
+      $:render_subjects(_("Times"), work.subject_times,"WorkSection|SubjectTimesClick", prefix="time:")

--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -1,12 +1,12 @@
 $def with(work,location,tags=[])
 
-$def render_subjects(label, subjects, track-value, prefix=""):
+$def render_subjects(label, subjects, track_value, prefix=""):
   $if subjects:
     <div class="section link-box">
       <h6>$label</h6>
       <span>
         $for subject in subjects:
-          <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track-value">$subject</a>$cond(not loop.last, ",", "")
+          <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track_value">$subject</a>$cond(not loop.last, ",", "")
       </span>
     </div>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -221,7 +221,7 @@ $if is_privileged_user:
 
     <div class="subjects">
         <div class="subjects-content restricted-view">
-        $:macros.SubjectTags(work, ["Subjects"])
+        $:macros.SubjectTags(work,"overview", ["Subjects"])
         </div>
         $:macros.ReadMore("subjects")
     </div>
@@ -262,7 +262,7 @@ $if is_privileged_user:
         <hr>
 
         $ component_times['SubjectsTags'] = time()
-        $:macros.SubjectTags(work, ["Subjects", "People", "Places", "Times"])
+        $:macros.SubjectTags(work,"work", ["Subjects", "People", "Places", "Times"])
         $ component_times['SubjectsTags'] = time() - component_times['SubjectsTags']
 
         <hr>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6106

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In order to help guide our book page redesign, we would like to understand how patrons are interacting with our book page subject links. More specifically, we'd like to know how often the subject links in the overview are clicked vs. the subject links in the work component, which is located below the fold.

### Technical
<!-- What should be noted about the implementation? -->
Added the different tags through parameter in the `render_subjects` function in the SubjectsTags.html file. Also in order to find if the link is in the  **work** section or the **overview** section, an additional parameter named `location` is used in order to figure out where the link is.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
