### PR TITLE
Include works in ListCarousel

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -119,6 +119,20 @@ class ListMixin:
         # Might be an issue of the total number of editions is too big, but
         # that isn't the case for most lists.
 
+    def get_works(self, limit=50, offset=0, _raw=False):
+        work_keys = {
+            seed.key for seed in self.seeds if seed and seed.type.key == '/type/work'
+        }
+
+        works = web.ctx.site.get_many(list(work_keys))
+
+        return {
+            "count": len(works),
+            "offset": offset,
+            "limit": limit,
+            "works": works,
+        }
+
     def get_all_editions(self):
         """Returns all the editions of this list in arbitrary order.
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -344,6 +344,22 @@ def get_list_editions(key, offset=0, limit=50, api=False):
             )
         return editions
 
+def get_list_works(key, offset=0, limit=50, api=False):
+    lst = web.ctx.site.get(key)
+    if lst:
+        offset = offset or 0
+        all_works = lst.get_works(limit=limit, offset=offset, _raw=True)
+        works = all_works['works'][offset : offset + limit]
+        if api:
+            entries = [e.dict() for e in works if e.pop("seeds") or e]
+            return make_collection(
+                size=all_works['count'],
+                entries=entries,
+                limit=limit,
+                offset=offset,
+                key=key,
+            )
+        return works
 
 class list_editions_json(delegate.page):
     path = r"(/people/[^/]+/lists/OL\d+L)/editions"

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1200,9 +1200,10 @@ def rewrite_list_editions_query(q, page, offset, limit):
     if '/lists/' in q:
         editions = get_list_editions(q, offset=offset, limit=limit)
         works = get_list_works(q, offset=offset, limit=limit)
-        finalList = editions + works
-        work_ids = [lt.get('works')[0]['key'] for lt in finalList]
-        q = 'key:(' + ' OR '.join(work_ids) + ')'
+        editions_ids = [lt.get('works')[0]['key'] for lt in editions]
+        works_ids = [lt.get('key') for lt in works]
+        final_ids = editions_ids + works_ids
+        q = 'key:(' + ' OR '.join(final_ids) + ')'
         # We've applied the offset to fetching get_list_editions to
         # produce the right set of discrete work IDs. We don't want
         # it applied to paginate our resulting solr query.

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -20,7 +20,7 @@ from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core.lending import add_availability, get_availability_of_ocaids
 from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.plugins.inside.code import fulltext_search
-from openlibrary.plugins.openlibrary.lists import get_list_editions
+from openlibrary.plugins.openlibrary.lists import get_list_editions, get_list_works
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.upstream.utils import urlencode
 from openlibrary.utils import escape_bracket
@@ -1192,14 +1192,16 @@ def rewrite_list_editions_query(q, page, offset, limit):
     return the query, unchanged, exactly as it entered the
     function. If it does contain a lists key, then use the pagination
     information to fetch the right block of keys from the
-    lists_editions API and then feed these editions resulting work
+    lists_editions and lists_works API and then feed these editions resulting work
     keys into solr with the form key:(OL123W, OL234W). This way, we
     can use the solr API to fetch list works and render them in
     carousels in the right format.
     """
     if '/lists/' in q:
         editions = get_list_editions(q, offset=offset, limit=limit)
-        work_ids = [ed.get('works')[0]['key'] for ed in editions]
+        works = get_list_works(q, offset=offset, limit=limit)
+        finalList = editions + works
+        work_ids = [lt.get('works')[0]['key'] for lt in finalList]
         q = 'key:(' + ' OR '.join(work_ids) + ')'
         # We've applied the offset to fetching get_list_editions to
         # produce the right set of discrete work IDs. We don't want


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6130 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Fetching works ids for the works present in the list separately and merging them with the edition ids.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Use the List Description to add a listCarousel containing only works.
Observe - No error popping up.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
