### PR TITLE
query parameters are included in the url returned by report a problem

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -24,7 +24,6 @@ from six.moves.urllib.parse import (
     urlencode as parse_urlencode,
     urlparse,
     urlunparse,
-    quote
 )
 
 from infogami import config
@@ -938,7 +937,7 @@ class Request:
     path = property(lambda self: web.ctx.path)
     home = property(lambda self: web.ctx.home)
     domain = property(lambda self: web.ctx.host)
-    fullpath = property(lambda self: quote(web.ctx.fullpath))
+    fullpath = property(lambda self: web.ctx.fullpath)
 
     @property
     def canonical_url(self):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -13,7 +13,6 @@ import datetime
 import logging
 from html.parser import HTMLParser
 from typing import Optional
-from urllib.parse import quote
 
 import requests
 
@@ -935,7 +934,7 @@ def get_blog_feeds():
 
 
 class Request:
-    path = property(lambda self: web.ctx.path + quote(web.ctx.query))
+    path = property(lambda self: web.ctx.path)
     home = property(lambda self: web.ctx.home)
     domain = property(lambda self: web.ctx.host)
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -24,6 +24,7 @@ from six.moves.urllib.parse import (
     urlencode as parse_urlencode,
     urlparse,
     urlunparse,
+    quote
 )
 
 from infogami import config
@@ -937,6 +938,7 @@ class Request:
     path = property(lambda self: web.ctx.path)
     home = property(lambda self: web.ctx.home)
     domain = property(lambda self: web.ctx.host)
+    fullpath = property(lambda self: quote(web.ctx.fullpath))
 
     @property
     def canonical_url(self):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -13,6 +13,7 @@ import datetime
 import logging
 from html.parser import HTMLParser
 from typing import Optional
+from urllib.parse import quote
 
 import requests
 
@@ -934,7 +935,7 @@ def get_blog_feeds():
 
 
 class Request:
-    path = property(lambda self: web.ctx.path)
+    path = property(lambda self: web.ctx.path + quote(web.ctx.query))
     home = property(lambda self: web.ctx.home)
     domain = property(lambda self: web.ctx.host)
 

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -41,7 +41,7 @@ $def with (page)
         <h2>$:_('Help')</h2>
         <ul>
           <li><a href="/help">$_('Help Center')</a></li>
-          <li><a href="/contact?path=$request.fullpath" title="$_('Problems')">$_('Report A Problem')</a></li>
+          <li><a href="/contact?$:urlencode(dict(path=request.fullpath))" title="$_('Problems')">$_('Report A Problem')</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_('Suggesting Edits')</a></li>
         </ul>
         <aside id="footer-icons">

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -41,7 +41,7 @@ $def with (page)
         <h2>$:_('Help')</h2>
         <ul>
           <li><a href="/help">$_('Help Center')</a></li>
-          <li><a href="/contact?path=$request.path" title="$_('Problems')">$_('Report A Problem')</a></li>
+          <li><a href="/contact?path=$request.fullpath" title="$_('Problems')">$_('Report A Problem')</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_('Suggesting Edits')</a></li>
         </ul>
         <aside id="footer-icons">


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #6153 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The query parameters were not included earlier from the user's url while reporting a problem. This Pr fixes that by concatenating the query part of the url.

@cdrini Please review this and let me know if any change is to be done. :smile: 
### Technical
<!-- What should be noted about the implementation? -->
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
