### PR TITLE
Datadumps: logger is blocking the cron job

### DIFF
--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -55,7 +55,7 @@ function log() {
 
 MSG="$USER has started $0 $1 $2 in $TMPDIR on ${HOSTNAME:-$HOST} at $(date)"
 log $MSG
-logger $MSG
+# logger $MSG  # logger is blocking the cron job
 
 # create a clean directory
 log "clean directory: $TMPDIR/dumps"
@@ -143,6 +143,6 @@ ls -lh
 
 MSG="$USER has completed $0 $1 $2 in $TMPDIR on ${HOSTNAME:-$HOST} at $(date)"
 echo $MSG
-logger $MSG
+# logger $MSG  # logger is blocking the cron job
 
 echo "done"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
The linux utility `logger` is blocking our monthly data dumps

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Testing was done by @mekarpeles and @cclauss on ol-home0.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
