### PR TITLE
Add internal-only ferm rule setup to provisioning script

### DIFF
--- a/scripts/setup_olserver.sh
+++ b/scripts/setup_olserver.sh
@@ -50,4 +50,19 @@ sudo chmod g+w -R /opt/openlibrary /opt/olsystem
 sudo find /opt/openlibrary -type d -exec chmod g+s {} \;
 sudo find /opt/olsystem -type d -exec chmod g+s {} \;
 
+# Setup docker ferm rules for internal-only servers
+# Note: This is a bit of an anti-pattern ; we should be using docker, not ferm to manage
+# container network access. That would let us use expose/ports from our docker-compose
+# to determine what's public. But we'd need a cross-cluster network managed by swarm to
+# do that.
+PUBLIC_FACING=${PUBLIC_FACING:-'false'}
+if [[ $PUBLIC_FACING != 'true' ]]; then
+    echo "*** Setting up ferm rules for internal-only servers. ***"
+    echo "*** This server will not be accessible from the internet. ***"
+    sudo mkdir -p /etc/ferm/docker-user/
+    sudo cp /opt/olsystem/etc/ferm/docker-user/ferm.rules /etc/ferm/docker-user/ferm.rules
+    sudo service ferm restart
+    sudo service docker restart
+fi
+
 ls -Fla  # containerd, olsystem, openlibrary owned by openlibrary


### PR DESCRIPTION

### Technical
- Olsystem component: https://github.com/internetarchive/olsystem/pull/147

### Testing
I didn't test running the script, but ran each command individually while updating our prod servers

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
