### PR TITLE
Make subject page work count a link to search results

### DIFF
--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -12,7 +12,7 @@ $ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), 
     </h1>
     <span class="heading">
         <span class="count" id="coversCount">
-            <strong><span>$ungettext("1 work", "%(count)d works", page.work_count, count=page.work_count)</span></strong>
+            <strong><span><a href="/search?$page.subject_type=$page.name.replace('&','%26')" title="$_('See all works')">$ungettext("1 work", "%(count)d works", page.work_count, count=page.work_count)</a></span></strong>
         </span>
     </span>
     <a href="#search" class="shift">$_('Search for books with subject %(name)s.', name=page.name)</a>


### PR DESCRIPTION
This minor change addresses the underlying complaint in issue #2375 — that the subject page is a dead-end from which it isn't possible to get to a list of all the works that match the subject (/time/place/person/etc), which is kind of what you expect the subject page to do. I'll let someone else decide whether it actually closes the issue.

### Technical
This fix adds a link to the text "N works" next to the subject title; the link performs a work search for that subject. 

I would have liked to have formed the search URL based on the subject term slug in the page URL, but that value isn't trivially available in the environment, so I copied the behavior elsewhere on the template of using a minimally-encoded page name string.

### Testing
Visit a variety of subject pages and see if the search link works as expected.


### Stakeholders
@mheiman @mekarpeles 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
