### PR TITLE
Fix high volume sentry errors

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -287,10 +287,6 @@ def get_available(
         sorts=sorts,
     )
     if not url:
-        fmt = (
-            "get_available(limit={}, page={}, subject={}, query={}, "
-            "work_id={}, _type={}, sorts={}"
-        )
         logger.error(
             'get_available failed',
             extra={
@@ -299,7 +295,7 @@ def get_available(
                 'subject': subject,
                 'query': query,
                 'work_id': work_id,
-                '_type': _type,
+                'type': _type,
                 'sorts': sorts,
             },
         )

--- a/openlibrary/i18n/pl/messages.po
+++ b/openlibrary/i18n/pl/messages.po
@@ -2394,7 +2394,7 @@ msgstr "Przeglądaj według tematów"
 #: categories.html:26
 #, python-format
 msgid "browse %(subject)s books"
-msgstr "przeglądaj według %(subjects)s książek"
+msgstr "przeglądaj według %(subject)s książek"
 
 #: categories.html:31
 #, python-format

--- a/openlibrary/templates/books/RelatedWorksCarousel.html
+++ b/openlibrary/templates/books/RelatedWorksCarousel.html
@@ -2,8 +2,10 @@ $def with(work)
 
 $if work and not is_bot():
     $ work_subjects_authors = cached_work_authors_and_subjects(work.key)
-    $ authors = ', '.join([author if isinstance(author, basestring) else author.name for author in work_subjects_authors.get('authors', [])])
     <div class="related-books">
-      $:render_template("home/custom_ia_carousel", title="You might also like", key="related-subjects-carousel", work_id=work.key, _type="subjects", limit=42, min_books=1)
-      $:render_template("home/custom_ia_carousel", title="More by %s" % (authors or "this author"), key="related-authors-carousel", work_id=work.key, _type="authors", limit=42, min_books=1)
+        $if work_subjects_authors.get('subjects'):
+            $:render_template("home/custom_ia_carousel", title="You might also like", key="related-subjects-carousel", work_id=work.key, _type="subjects", limit=42, min_books=1)
+        $if work_subjects_authors.get('authors'):
+            $ authors = ', '.join([author if isinstance(author, basestring) else author.name for author in work_subjects_authors['authors']])
+            $:render_template("home/custom_ia_carousel", title="More by %s" % (authors or "this author"), key="related-authors-carousel", work_id=work.key, _type="authors", limit=42, min_books=1)
     </div>


### PR DESCRIPTION
See on Sentry: 
- `get_availability failed` ; 50% of all errors -\_- https://sentry.ux.archive.org/organizations/ia-ux/issues/1152/?project=7&query=is%3Aunresolved
- Polish homepage erroring due to bad translation string https://sentry.ux.archive.org/organizations/ia-ux/issues/1199/?project=7&query=is%3Aunresolved


### Technical

To create issues for:

- The `get_available` flow and related works carousel was suuuuper circuitious. We should
    - update that to hit solr instead of IA; solr is faster + more reliable in this case
    - Why is it making a second DB request for the work in the `partials` endpoint when we can just pass forward the subjects/authors in the lazy element? Or is it relying on memcache? Either way, we should remove remove that weird joint `get_author_and_subjects` function, passing it as url params, and make it near stateless.
- The i18n bug
    - We should have non-breaking "warnings" (for things like 'is fuzzy'), and hard errors for things like the things that caused this to break. Note only non-fuzzy strings can cause errors, so it should be easy to make sure none of the langauges throw errors.
    - Update `validate` to optionally take an exclude list of langauges
    - Update i18n to use FnToCLI -- needs changes to FnToCLI to support multiple functions.
- i18n everything related to related works carousel :( It seems like they were never done
- Add an automatic check for failing i18n in HTML; something like `alt="[^$]` -- since all alt text should be translated. With some file excludes. Or `^[^$]+>[^<\s$&_'"%]`

### Testing
- [x] Confirm related carousels load when subjects/author https://testing.openlibrary.org/books/OL21095725M/Contradictions_of_school_reform
    - Note authors sometimes randomly doesn't work, but also seeing that on prod
    - Note this is making the RelatedWorks request even if it's not needed?
- [x] Confirm no errors in logs when going to https://testing.openlibrary.org/works/OL20185225W/The_Man_Who_Took_the_Rap
- [x] Confirm no visible errors, subjects carousel loads on https://testing.openlibrary.org/?lang=pl

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
