### PR TITLE
Profiling updates

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -8,6 +8,9 @@ $# :param list? lists:
 $# :param user:
 $# :param bool public:
 
+$ component_times = {}
+$ component_times['TotalTime'] = time()
+
 $ username = user.key.split('/')[-1]
 
 $ current_page = int(input(page=1).page)
@@ -42,6 +45,7 @@ $if not header_title:
 $var title: $header_title
 
 <div class="mybooks">
+  $ component_times['Sidebar'] = time()
   <div class="mybooks-menu">
     $if owners_page:
       <ul class="sidebar-section">
@@ -95,7 +99,9 @@ $var title: $header_title
         </div>
       </ul>
   </div>
+  $ component_times['Sidebar'] = time() - component_times['Sidebar']
   <div class="mybooks-details">
+    $ component_times['Details header'] = time()
     <header>
       <div>
         <div class="small sansserif grey account-settings-menu">
@@ -134,6 +140,8 @@ $var title: $header_title
           $:macros.databarView(items)
         </div>
     </header>
+    $ component_times['Details header'] = time() - component_times['Details header']
+    $ component_times['Details content'] = time()
     <div class="details-content">
     $if key == 'loans':
       $:render_template('account/loans', logged_in_user, items)
@@ -154,5 +162,10 @@ $var title: $header_title
     $else:
       $:render_template('type/list/view', items, check_owner=False, owns_page=True)
     </div>
+    $ component_times['Details content'] = time() - component_times['Details content']
   </div>
 </div>
+
+$ component_times['TotalTime'] = time() - component_times['TotalTime']
+$if query_param('debug'):
+  $:macros.Profile(component_times)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -471,14 +471,14 @@ $if is_privileged_user:
       <div class="user-book-options">
         <div class="Tools tools-override">
           $if work:
-            $ component_times['WorkListTime'] = time()
+            $ component_times['lists widget: WorkListTime'] = time()
             $:render_template("lists/widget", work, include_header=False, include_widget=False)
-            $ component_times['WorkListTime'] = time() - component_times['WorkListTime']
+            $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
 
           $if edition:
-            $ component_times['EditionListTime'] = time()
+            $ component_times['lists widget: EditionListTime'] = time()
             $:render_template("lists/widget", edition, include_header=False, include_widget=False)
-            $ component_times['EditionListTime'] = time() - component_times['EditionListTime']
+            $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']
         </div>
       </div>
   </div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Renames some component time keys on the books page.  No new profiling was added to this page.

Adds shallow profiling to 'My Books" page template (`.../templates/account/books.html`).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-02-23 19-08-54](https://user-images.githubusercontent.com/28732543/155432081-3d360c15-debf-4050-8559-b12021c2c32d.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
