### PR TITLE
Correct waitlist LoanStatus.html error

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -71,10 +71,10 @@ $elif availability.get('is_lendable'):
   $if availability.get("available_to_borrow") or availability.get("available_to_browse"):
     $:macros.ReadButton(ocaid, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
-    $ wlsize = availability.get('users_on_waitlist') or availability.get('num_waitlist')
     $if waiting_loan:
       <p class="waitinglist-message">
         $ spot = waiting_loan['position']
+        $ wlsize = waiting_loan['wl_size']
         $if spot == 1:
           $:_('You are <strong>next</strong> on the waiting list')
         $else:
@@ -87,6 +87,7 @@ $elif availability.get('is_lendable'):
       </form>
     $else:
       $# "JOIN-WAITLIST" button
+      $ wlsize = availability.get('users_on_waitlist') or availability.get('num_waitlist')
       <p class="waitinglist-message">
         $if wlsize:
           $_("Readers waiting for this title: %(count)s", count=wlsize)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6184

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The root cause of this bug is that it is possible for `wlsize` to incorrectly be `None`.  Pulling the number of folks waiting from `waiting_loan` corrects the page not rendering, but other issues remain:

1. After joining the waitlist, the primary borrow button and the edition table borrow buttons are mismatched.
2. "Join Waitlist" button incorrectly states that you;l be the next to borrow the book.

Both issues can be observed in this screenshot:
![Screenshot from 2022-02-25 12-21-02](https://user-images.githubusercontent.com/28732543/155760467-67981eef-a261-497c-b105-fb732e59aba5.png)

For the edition referenced in the issue, bulk availability is not returning the waitlist count, but the ground-truth availability API is:

https://archive.org/services/availability?identifier=shadowbone0000bard

https://archive.org/services/loans/loan/?action=availability&identifier=shadowbone0000bard

Not sure if this is due to a data issue with the record, or if this is more widespread...

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to https://testing.openlibrary.org/books/OL25086706M/Shadow_and_Bone and join the waitlist.
2. Ensure that the page renders properly on reload.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
