### PR TITLE
re-enabling authors

### DIFF
--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -99,10 +99,8 @@ class Biblio:
 
         # Assert importable
         for field in self.REQUIRED_FIELDS + ['isbn_13']:
-            # XXX There is currently a bug where the authors check
-            # seems to fail for every record. Req's a regression test.
-            if field != "authors":
-                assert getattr(self, field), field
+            assert getattr(self, field), field
+        # This seems to be eliminating books too aggressively
         #assert self.primary_format not in self.NONBOOK, f"{self.primary_format} is NONBOOK"
 
     @staticmethod


### PR DESCRIPTION
After some experimenting, some records may succeed. Now that the script is running again, will wait until next month to see how many records are successfully imported when author assertion is enabled. If none or few, will follow-up with partners and add a unit test for author v. missing author (same for publish_date which is currently listed as required)

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
