### PR TITLE
Remove reference to `page` in Daisy template

### DIFF
--- a/openlibrary/macros/daisy.html
+++ b/openlibrary/macros/daisy.html
@@ -3,7 +3,7 @@ $# * url (daisy link)
 $# * protected (is daisy encrypted or not)
 
 <div class="cta-section print-disabled-download">
-  <a href="$page.url('/daisy')" title="$_('Encrypted daisy download for authorized print-disabled patrons')">
+  <a href="$url" title="$_('Encrypted daisy download for authorized print-disabled patrons')">
     $if protected:
       <img src="/static/images/icons/icon-encrypto-sm.png" class="daisy-lock" width="8" height="12" alt="$_('Encrypted daisy lock')"/>
     <meta itemprop="bookFormat" content="EBook/DAISY3"/>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6183

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes reference to `page` in Daisy macro.  The macro appears to only be called from `LoanStatus.html` with a properly constructed URL.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
