### PR TITLE
Add ability to copydocs from solr search query

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -201,6 +201,14 @@ class OpenLibrary:
             response = self._request("/query.json", params=dict(query=json.dumps(q)))
             return unmarshal(response.json())
 
+    def search(self, query, limit=10, offset=0, fields: list[str] = None):
+        return self._request('/search.json', params={
+            'q': query,
+            'limit': limit,
+            'offset': offset,
+            **({'fields': ','.join(fields)} if fields else {})
+        }).json()
+
     def import_ocaid(self, ocaid, require_marc=True):
         data = {
             'identifier': ocaid,


### PR DESCRIPTION
Useful for testing edition-level solr things

### Technical
- Reviewing commit-by-commit is easiest:
- Switched this script to use FnToCLI
- Added a search cli argument

### Testing

```sh
mkdir foo
PYTHONPATH=. ./scripts/copydocs.py --dest foo --search "publisher:librivox AND NOT title:blah AND edition_count:[1 TO 5]" --search-limit 5
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
