### PR TITLE
Fix EACCES errors with package*.json

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -89,10 +89,10 @@ RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:open
 WORKDIR /openlibrary
 
 USER openlibrary
-COPY requirements*.txt ./
+COPY --chown=openlibrary:openlibrary requirements*.txt ./
 RUN python3.9 -m pip install --default-timeout=100 -r requirements.txt
 
-COPY package*.json ./
+COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm ci
 
 COPY --chown=openlibrary:openlibrary . /openlibrary

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -1,8 +1,8 @@
 FROM openlibrary/olbase:latest
 WORKDIR /openlibrary
 
-COPY requirements*.txt ./
+COPY --chown=openlibrary:openlibrary requirements*.txt ./
 RUN python3.9 -m pip install -r requirements_test.txt
 
-COPY package*.json ./
+COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm install


### PR DESCRIPTION
Closes #6224

Fix. Apparently:

> All new files and directories are created with a UID and GID of 0, unless the optional --chown flag specifies a given username, groupname, or UID/GID combination to request specific ownership of the copied content.

https://docs.docker.com/engine/reference/builder/#copy

Why this never broke stuff before? No clue. Could be because we updated to node 16. Could be because of a docker update.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ Test on gitpod
- Didn't test on linux ; but fixing gitpod is already win :P

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
