### PR TITLE
Disable gitpod auto-build on self-PRs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,3 +17,9 @@ tasks:
   init: ./scripts/setup_gitpod.sh
   # command runs each time a user starts their workspace
   command: docker-compose up
+
+github:
+  prebuilds:
+    # Don't prebuild for PRs coming from this repo
+    # Don't need this running on all renovatebot's PRs; it's slow
+    pullRequests: true


### PR DESCRIPTION
Don't need this running on all renovatebot's PRs; it's slow!


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
