### PR TITLE
Add collapsible work descriptions

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -272,7 +272,10 @@ $if is_privileged_user:
         $if work.description:
           <h4>$_("Work Description")</h4>
           <div class="work-description">
-            $:sanitize(format(work.description))
+            <div class="work-description-content restricted-view">
+              $:sanitize(format(work.description))
+            </div>
+            $:macros.ReadMore('work-description')
           </div>
 
         $if work.original_languages:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6172

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes book page work descriptions collapsible.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to a book page that has a lengthy work description.
2. Scroll to the work details component, found below the editions table.
3. Ensure that the work description is truncated, and that a "Read more" link is present below the description.
4. Click the "Read more" link.  Ensure that the entire description is displayed, the "Read more" link is hidden, and a "Read less" link is present.
5. Click the "Read less" link.  Ensure that the description assumes its previous truncated form.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![collapsible_work_desc](https://user-images.githubusercontent.com/28732543/156678744-0fd212e0-0cd7-497e-acf2-ae5ff1c25e7e.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
