### PR TITLE
Make Docker Compose setup work with older versions

### DIFF
--- a/docker-compose.infogami-local.yml
+++ b/docker-compose.infogami-local.yml
@@ -3,7 +3,7 @@
 ## docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.infogami-local.yml up -d
 ##
 
-version: "3.8"
+version: "3.3"
 services:
   web:
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@
 # is used without the -f parameter. It contains local development specific
 # configuration options which we don't want to apply to production/staging
 
-version: "3.8"
+version: "3.3"
 services:
   web:
     build:
@@ -78,7 +78,7 @@ services:
   home:
     image: "oldev:${OLDEV_TAG:-latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,7 +5,7 @@
 ## docker-compose up -d
 ##
 
-version: "3.8"
+version: "3.3"
 services:
   web:
     profiles: ["ol-web1", "ol-web2"]
@@ -268,7 +268,7 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OL_URL=https://openlibrary.org/
       - STATE_FILE=solr-next-update.offset
@@ -292,7 +292,7 @@ services:
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OPENLIBRARY_RCFILE=/olsystem/etc/olrc-importbot
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
     volumes:
       - ../olsystem:/olsystem
     networks:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -5,7 +5,7 @@
 ## docker-compose up -d
 ##
 
-version: "3.8"
+version: "3.3"
 services:
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: "3.8"
+version: "3.3"
 services:
   web:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 4 --timeout 180}
     command: docker/ol-web-start.sh
@@ -39,7 +39,7 @@ services:
     hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=conf/openlibrary.yml
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
       - OL_URL=http://web:8080/
       - STATE_FILE=solr-update.offset
     volumes:
@@ -56,7 +56,7 @@ services:
   covers:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --max-requests 250}
     command: docker/ol-covers-start.sh
@@ -73,9 +73,9 @@ services:
   infobase:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
+      - PYENV_VERSION=${PYENV_VERSION}
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}
-      - INFOBASE_OPTS=${INFOBASE_OPTS:-}
+      - INFOBASE_OPTS=${INFOBASE_OPTS}
     command: docker/ol-infobase-start.sh
     expose:
       - 7000


### PR DESCRIPTION
The use of Bash-style environment variable defaults and explicitly specifying "version: 3.8"
make the Docker Compose setup unusable with a little less up-to-date versions of Docker Compose.

## Example

```console
$ docker-compose --version
docker-compose version 1.17.1, build unknown
```
```console
$ docker-compose up
ERROR: Invalid interpolation format for "environment" option in service "solr-updater": "PYENV_VERSION=${PYENV_VERSION:-}"
```

All sections that use the empty defaults notation are affected. After replacing all of them a version error is reported:

```console
$ docker-compose up
WARNING: The PYENV_VERSION variable is not set. Defaulting to a blank string.
WARNING: The HOSTNAME variable is not set. Defaulting to a blank string.
WARNING: The INFOBASE_OPTS variable is not set. Defaulting to a blank string.
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
```

After reducing the version to, e.g. "3.3", execution works, only the warning remain.

```console
$ docker-compose up
WARNING: The PYENV_VERSION variable is not set. Defaulting to a blank string.
WARNING: The HOSTNAME variable is not set. Defaulting to a blank string.
WARNING: The INFOBASE_OPTS variable is not set. Defaulting to a blank string.
Creating network "openlibrary_dbnet" with the default driver
Creating network "openlibrary_webnet" with the default driver
Creating openlibrary_home_1 ... 
Creating openlibrary_solr-updater_1 ... 
Creating openlibrary_solr_1 ... 
...
```

It looks like the empty defaults were added to silence the warnings. Apparently, that is an issue minor compared to excluding users with older versions of Docker Compose.