### PR TITLE
consolidate subjects

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -235,7 +235,9 @@ $if is_privileged_user:
 
     <div class="subjects">
         <div class="subjects-content restricted-view">
-        $:macros.SubjectTags(work,"overview", ["Subjects"])
+        $ component_times['SubjectsTags'] = time()
+        $:macros.SubjectTags(work,"work", ["Subjects", "People", "Places", "Times"])
+        $ component_times['SubjectsTags'] = time() - component_times['SubjectsTags']
         </div>
         $:macros.ReadMore("subjects")
     </div>
@@ -271,12 +273,6 @@ $if is_privileged_user:
             <p class="first-published-date">
               $_("First published in %s", work.first_publish_year)
             </p>
-        <hr>
-
-        $ component_times['SubjectsTags'] = time()
-        $:macros.SubjectTags(work,"work", ["Subjects", "People", "Places", "Times"])
-        $ component_times['SubjectsTags'] = time() - component_times['SubjectsTags']
-
         <hr>
 
         $if not work.excerpts and work.first_sentence:


### PR DESCRIPTION
merges duplicate subject sections -- take the full/complete list of subject tags and moves them up to section above the fold (replacing the abridged version in the overview). The complete subjects are show within a "show more" area.

i.e.

https://testing.openlibrary.org/works/OL17991110W/Puerto_Rican_women%27s_history

![openlibrary org_works_OL17991110W_Puerto_Rican_women%27s_history](https://user-images.githubusercontent.com/978325/156908272-05091a17-ed0c-42b1-b8ee-070666d5e3d8.png)

Gets substituted with this full content (which then is removed from the below section):

![openlibrary org_works_OL17991110W_Puerto_Rican_women%27s_history (1)](https://user-images.githubusercontent.com/978325/156908283-287b0524-35f6-432f-a8ed-79ab469392b8.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
