### PR TITLE
Show editions table w/o limit if < 10 editions

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -33,7 +33,7 @@ $ ebooks_only = query_param('mode') != 'all'
 
 $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
-$ editions_limit = 10 if not query_param('mode') and edition_count <= 10 else None
+$ editions_limit = 10 if not query_param('mode') and edition_count > 10 else None
 $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=edition and [edition.key])
 
 $if not editions:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -34,7 +34,8 @@ $ ebooks_only = query_param('mode') != 'all'
 $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
 $ editions_limit = 10 if not query_param('mode') and edition_count > 10 else None
-$ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=edition and [edition.key])
+$if editions_limit:
+  $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=edition and [edition.key])
 
 $if not editions:
   $# use ebooks_only to determine whether to lazyload editions table

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -34,7 +34,7 @@ $ ebooks_only = query_param('mode') != 'all'
 $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
 $ editions_limit = 10 if not query_param('mode') and edition_count > 10 else None
-$if editions_limit:
+$if editions_limit or query_param('mode') == 'ebooks':
   $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=edition and [edition.key])
 
 $if not editions:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -28,11 +28,12 @@ $ component_times['get_sorted_editions'] = time()
 $# Fetch a work's editions
 $# Used for loading the editions table
 $# Book availability of editions injected by bulk get_availability API
+$ edition_count = work.edition_count if work and work.edition_count else 1
 $ ebooks_only = query_param('mode') != 'all'
 
-$# For performance reasons, only load 10
-$# Tradeoff: decreases/limits our ability to select best edition
-$ editions_limit = 10 if not query_param('mode') else None
+$# For performance reasons, limit to 10 ebooks
+$# Tradeoff: limits our ability to select best edition
+$ editions_limit = 10 if not query_param('mode') and edition_count <= 10 else None
 $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=edition and [edition.key])
 
 $if not editions:
@@ -73,7 +74,6 @@ $ book_subtitle = edition.get('subtitle', '')
 $ title_suffix = cond(edition.get('publish_date'), u"({0} edition)".format(edition.get('publish_date')), "(edition)")
 $ title = book_title + " " + title_suffix
 $ title_with_site = _("%(page_title)s | Open Library", page_title=title)
-$ edition_count = work.edition_count if work and work.edition_count else 1
 $ meta_cover_url = item_image((edition or work).get_cover_url("L"), default="https://openlibrary.org/images/icons/avatar_book-sm.png")
 $ _x = ctx.setdefault('cssfile', 'book')
 


### PR DESCRIPTION
Use edition_count to ignore limit and show all books if total editions_count < 10.

### Technical
<!-- What should be noted about the implementation? -->

Moved editions_count up (which hits solr). Can this ever fail? When it does, edition_count is set to 1. Can this cause problems?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
