### PR TITLE
Make solr search alternative_title field

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -494,7 +494,7 @@ def run_solr_query(
         if use_dismax:
             params.append(('q', ' '.join(q_list)))
             params.append(('defType', 'dismax'))
-            params.append(('qf', 'text title^20 author_name^20'))
+            params.append(('qf', 'text alternative_title^20 author_name^20'))
             params.append(('bf', 'min(100,edition_count)'))
         else:
             params.append(('q', ' '.join(q_list + ['_val_:"sqrt(edition_count)"^10'])))


### PR DESCRIPTION
Feature. This field is comprised of all the edition titles, but does not include the work title. This results in better matches when searching for books without their original language in mind. We should include the work title in here during the next re-index.


### Technical
<!-- What should be noted about the implementation? -->

### Testing

- Try it out on testing.openlibrary.org with "All" selected in the drop down. Do a Before/After on https://codepen.io/cdrini/full/wvJqzaK 


### Screenshot

https://docs.google.com/spreadsheets/d/1BN5I7-OkTPaoTr2Es6jQ4O9ICWFmH0q9CP6kEgolCgg/edit#gid=1006480604

Much better rankings for our search set. This means that the works we want to appear high for user queries are now appearing higher.

Search Class | AVERAGE of Prod Ranking | AVERAGE of Testing Ranking
-- | -- | --
Author | 31.40952381 | 25.82698413
Non-English Books | 68 | 34.33333333
Popular Books | 10.97142857 | 8.228571429
Series | 57.98518519 | 31.84126984
**Grand Total** | **25.19967716** | **16.73720743**


Search Class | AVERAGE of Prod Ranking | AVERAGE of Testing Ranking
-- | -- | --
Drini | 36.2952381 | 25.16190476
Top user searches | 40.1447619 | 32.02190476
Wikipedia most published | 15.97222222 | 7.543650794
**Grand Total** | **25.19967716** | **16.73720743**


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
