### PR TITLE
Add bulk reading log query

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -224,7 +224,7 @@ class Bookshelves:
             'work_ids': work_ids,
         }
         query = (
-            "SELECT bookshelf_id from bookshelves_books WHERE "
+            "SELECT work_id, bookshelf_id from bookshelves_books WHERE "
             "username=$username AND "
             "work_id IN $work_ids"
         )

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -217,6 +217,20 @@ class Bookshelves:
         return result[0].bookshelf_id if result else None
 
     @classmethod
+    def get_users_read_status_of_works(cls, username, work_ids):
+        oldb = db.get_db()
+        data = {
+            'username': username,
+            'work_ids': work_ids,
+        }
+        query = (
+            "SELECT bookshelf_id from bookshelves_books WHERE "
+            "username=$username AND "
+            "work_id IN $work_ids"
+        )
+        return list(oldb.query(query, vars=data))
+
+    @classmethod
     def add(cls, username, bookshelf_id, work_id, edition_id=None):
         """Adds a book with `work_id` to user's bookshelf designated by
         `bookshelf_id`"""

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -408,7 +408,8 @@ def add_read_statuses(username, works):
     for result in results:
         results_map[f"OL{result['work_id']}W"] = result['bookshelf_id']
     for work in works:
-        work['readinglog'] = results_map[work.key.split('/')[-1]] or None
+        work_olid = work.key.split('/')[-1]
+        work['readinglog'] = results_map.get(work_olid, None)
     return works
 
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -400,6 +400,18 @@ def get_read_status(work_key, username):
     return Bookshelves.get_users_read_status_of_work(username, work_id)
 
 
+@public
+def add_read_statuses(username, works):
+    work_ids = [extract_numeric_id_from_olid(work.key.split('/')[-1]) for work in works]
+    results = Bookshelves.get_users_read_status_of_works(username, work_ids)
+    results_map = {}
+    for result in results:
+        results_map[f"OL{result['work_id']}W"] = result['bookshelf_id']
+    for work in works:
+        work['readinglog'] = results_map[work.key.split('/')[-1]] or None
+    return works
+
+
 class PatronBooknotes:
     """Manages the patron's book notes and observations"""
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -163,7 +163,7 @@ $ )
             $ works = add_availability([get_doc(d) for d in docs])
             $ username = ctx.user and ctx.user.key.split('/')[-1]
             $if username:
-                works = add_read_statuses(username, works)
+                $ works = add_read_statuses(username, works)
 
             $for work in works:
                 $ ocaid = work.ia[0] if work.ia else None
@@ -171,7 +171,7 @@ $ )
                 $# if we're explicitly showing *everything*...
                 $# or if we're showing only things with ocaids which are available...
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):
-                    $ read_status = get_read_status(work.key, username) if username else None
+                    $ read_status = work.get('readinglog', None)
                     $ dropper = macros.ReadingLogDropper([], work=work, reading_log_only=True, page_url="/search", users_work_read_status=read_status)
                     $:macros.SearchResultsWork(work, reading_log=dropper)
           </ul>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -161,6 +161,9 @@ $ )
         <div id="searchResults">
           <ul class="list-books">
             $ works = add_availability([get_doc(d) for d in docs])
+            $ username = ctx.user and ctx.user.key.split('/')[-1]
+            $if username:
+                works = add_read_statuses(username, works)
 
             $for work in works:
                 $ ocaid = work.ia[0] if work.ia else None
@@ -168,7 +171,6 @@ $ )
                 $# if we're explicitly showing *everything*...
                 $# or if we're showing only things with ocaids which are available...
                 $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):
-                    $ username = ctx.user and ctx.user.key.split('/')[-1]
                     $ read_status = get_read_status(work.key, username) if username else None
                     $ dropper = macros.ReadingLogDropper([], work=work, reading_log_only=True, page_url="/search", users_work_read_status=read_status)
                     $:macros.SearchResultsWork(work, reading_log=dropper)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fetches all reading log entries at once on search results pages if the patron is logged in.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
