### PR TITLE
Expose edition_count as "editions" in search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -53,6 +53,7 @@ ALL_FIELDS = [
     "subtitle",
     "alternative_title",
     "alternative_subtitle",
+    "edition_count",
     "edition_key",
     "by_statement",
     "publish_date",
@@ -107,6 +108,7 @@ FACET_FIELDS = [
 FIELD_NAME_MAP = {
     'author': 'author_name',
     'authors': 'author_name',
+    'editions': 'edition_count',
     'by': 'author_name',
     'publishers': 'publisher',
     # "Private" fields


### PR DESCRIPTION
You can now search for number of editions; eg. `editions:10` or `editions:[* TO 100]`


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] confirm works on search page https://testing.openlibrary.org/search?q=editions%3A%5B100+TO+*%5D&mode=everything
- [x] confirm works on search.json page https://testing.openlibrary.org/search.json?q=editions%3A[100+TO+*]&mode=everything

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
![image](https://user-images.githubusercontent.com/6251786/157327783-cf1e267a-353f-4fb8-b9ef-e979e5fa5f94.png)


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
