### PR TITLE
Book Page: Deduplicate work description / Remove work-level classifications

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -215,15 +215,14 @@ $if is_privileged_user:
             </h4>
       </div>
 
-      $ work_desc_displayed = False
       $if work and work.description or edition and edition.description:
+        $if edition and edition.description:
+          $ overview_desc = edition.description
+        $else:
+          $ overview_desc = work.description
         <div class="book-description">
             <div class="book-description-content restricted-view">
-                $if edition and edition.description:
-                    $:sanitize(format(edition.description))
-                $elif work and work.description:
-                    $:sanitize(format(work.description))
-                    $ work_desc_displayed = True
+                $:sanitize(format(overview_desc))
             </div>
             $:macros.ReadMore("book-description")
         </div>
@@ -286,7 +285,7 @@ $if is_privileged_user:
           <h4>$_("First Sentence")</h4>
           <p class="largest" title=$_("First Sentence")><em>"$work.first_sentence"</em></p>
 
-        $if work.description and not work_desc_displayed:
+        $if work.description and work.description != overview_desc:
           <h4>$_("Work Description")</h4>
           <div class="work-description">
             <div class="work-description-content restricted-view">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -215,6 +215,7 @@ $if is_privileged_user:
             </h4>
       </div>
 
+      $ work_desc_displayed = False
       $if work and work.description or edition and edition.description:
         <div class="book-description">
             <div class="book-description-content restricted-view">
@@ -222,6 +223,7 @@ $if is_privileged_user:
                     $:sanitize(format(edition.description))
                 $elif work and work.description:
                     $:sanitize(format(work.description))
+                    $ work_desc_displayed = True
             </div>
             $:macros.ReadMore("book-description")
         </div>
@@ -284,7 +286,7 @@ $if is_privileged_user:
           <h4>$_("First Sentence")</h4>
           <p class="largest" title=$_("First Sentence")><em>"$work.first_sentence"</em></p>
 
-        $if work.description:
+        $if work.description and not work_desc_displayed:
           <h4>$_("Work Description")</h4>
           <div class="work-description">
             <div class="work-description-content restricted-view">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -331,20 +331,6 @@ $if is_privileged_user:
                   <li><a href="$link.url">$link.title</a></li>
               </ul>
           </div>
-
-        $if work.edition_count > 1:
-          $if (work.lc_classifications or work.dewey_number):
-              <div class="section">
-                  <h4 class="collapse">$_("Classifications")</h4>
-                  <table class="meta"><tbody>
-                  $if work.lc_classifications:
-                      <tr><td class="title"><span class="title">$_('Library of Congress')</span></td>
-                      <td><span class="object">$thingrepr(work.lc_classifications)</span></td></tr>
-                  $if work.dewey_number:
-                      <tr><td class="title"><span class="title">$_('Dewey')</span></td>
-                      <td><span class="object">$thingrepr(work.dewey_number)</span></td></tr>
-                  </tbody></table>
-              </div>
       </div>
 
       <a id="edition-details" name="edition-details" class="section-anchor"></a>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR includes two book page changes:
1. Work descriptions are only displayed once per page.
2. Work-level classifications are removed altogether.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
