### PR TITLE
Fix navbar scroll listener

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/index.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/index.js
@@ -73,7 +73,7 @@ export function initNavbar(navbarElem) {
                     const br = linkedSections[i].getBoundingClientRect()
 
                     // If navbar overlaps with an unselected target section, select that section:
-                    if (br.top < navbarBoundingRect.bottom && br.bottom > navbarBoundingRect.bottom) {
+                    if (br.top <= navbarBoundingRect.bottom && br.bottom >= navbarBoundingRect.bottom) {
                         selectElement(listItems[i], i)
                         break;
                     }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The "Overview" navbar item was not being selected upon scrolling to the top of the page in Chrome and Safari, due to mishandling of bounds checking for zero-height elements.  This has been corrected.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![chrome_scroll_fixed](https://user-images.githubusercontent.com/28732543/157351386-d162cf96-16f7-441c-ab6a-f3d21bfbdf11.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
