### PR TITLE
Skip npm install if cache hit in GHA

### DIFF
--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: '16' # # Should match what's in our Dockerfile
       - uses: actions/cache@v2
+        id: npm-cache
         with:
           # Caching node_modules isn't recommended because it can break across
           # Node versions and won't work with npm ci (See https://github.com/actions/cache/blob/main/examples.md#node---npm )
@@ -32,7 +33,8 @@ jobs:
           path: 'node_modules'
           # Note the version number in this string -- update it when updating Node!
           key: ${{ runner.os }}-node16-${{ hashFiles('**/package-lock.json') }}
-      - run: npm install
+      - if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm install
       - run: npm run lint
       - run: make git
       - run: make js


### PR DESCRIPTION
Because we cache the entire node_modules directory, we don't need to run npm install at all if there are no changes to package-lock files. So let's not! Saves ~30s (18%) on JS CI.


### Technical
Following docs from https://github.com/actions/cache#Skipping-steps-based-on-cache-hit

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
