### PR TITLE
rm collection checks for Bulk Availability changes

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -337,11 +337,10 @@ def get_availability(key, ids):
         return {}
 
     def update_availability_schema_to_v2(v1_resp, ocaid):
-        collections = v1_resp.get('collection', [])
         v1_resp['identifier'] = ocaid
         v1_resp['is_restricted'] = v1_resp['status'] != 'open'
-        v1_resp['is_printdisabled'] = 'printdisabled' in collections
-        v1_resp['is_lendable'] = 'inlibrary' in collections
+        v1_resp['is_printdisabled'] = v1_resp.get('is_printdisabled', False)
+        v1_resp['is_lendable'] = v1_resp['status'] == 'borrow_available'
         v1_resp['is_readable'] = v1_resp['status'] == 'open'
         # TODO: Make less brittle; maybe add simplelists/copy counts to IA availability
         # endpoint


### PR DESCRIPTION
Fixes a problem introduced via https://git.archive.org/ia/petabox/-/merge_requests/3118

We still had code which was using `collections` to determine availability. Now Bulk Availability API (see https://archive.org/services/availability?identifier=lostfound0000coec) should be much more robust (includes new reliable fields)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
