### PR TITLE
Update delete buttons for book edit form

### DIFF
--- a/openlibrary/macros/EditButtons.html
+++ b/openlibrary/macros/EditButtons.html
@@ -17,8 +17,4 @@ $def with (comment=None)
     <button type="submit" class="larger" name="_save" title="$_('Save')">$_("Save")</button>
     &nbsp;
     <a href="javascript:history.go(-1);" class="small red">$_('Cancel')</a>
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
-        <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete">$_("Delete Record")</button></span>
-    $else:
-        <div class="adminDelete">$:_('<em>Please Note:</em> Only Admins can delete things. <a href="/contact" class="blue">Let us know</a> if there\'s a problem.')</div>
 </div>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -34,7 +34,7 @@ $putctx("robots", "noindex,nofollow")
             note = ""
     <h2 class="editFormTitle">$:title</h2>
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
-        <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete">$_("Delete Record")</button></span>
+        <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete" form="addWork">$_("Delete Record")</button></span>
     $if not ctx.user:
         $:render_template("lib/not_logged")
     $:note


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6272

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the top delete button by associating it with the `#addWork` form, and removes delete button from the bottom of the page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
