### PR TITLE
Remove unneeded declaration

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -51,7 +51,6 @@ $ previews = [e for e in editions if e.get('ocaid')]
 $# Choose an edition to render
 $if not edition:
   $# We're presumably on a work url
-  $ edition = editions[0]
   $# edition selection strategy (e.g. language, by id, first w/ ocaid)
   $if query_param('edition'):
     $if ':' in query_param('edition'):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6271

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects error that occurs whenever an element is accessed from an empty `editions` list.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
