### PR TITLE
Add book identifiers above the fold for librarians

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,6 +1,7 @@
 $def with (page, edition=None)
 
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
+$ is_librarian = ctx.user and ctx.user.is_librarian()
 
 $ component_times = {}
 $ component_times['TotalTime'] = time()
@@ -199,22 +200,32 @@ $if is_privileged_user:
 
       $:macros.EditionNavBar(work.edition_count, show_observations)
       <a id="edition-overview" name="edition-overview"></a>
-      <div class="edition-omniline">
-        $:render_template("type/edition/publisher_line", edition)
+      <div>
+        <div class="edition-omniline">
+          $:render_template("type/edition/publisher_line", edition)
 
-        $if edition:
-          $if edition.languages:
-            <h4 class="language">
-              $def lang_span(): <span itemprop="inLanguage">$:thingrepr(edition.languages)</span>
-              $:_('Written in %(language)s', language=lang_span())
-            </h4>
-          $if edition.number_of_pages:
-            <h4 class="year">&mdash;
-              <span class="edition-pages"
-                    itemprop="numberOfPages">$edition.number_of_pages</span> $_("pages")
-            </h4>
+          $if edition:
+            $if edition.languages:
+              <h4 class="language">
+                $def lang_span(): <span itemprop="inLanguage">$:thingrepr(edition.languages)</span>
+                $:_('Written in %(language)s', language=lang_span())
+              </h4>
+            $if edition.number_of_pages:
+              <h4 class="year">&mdash;
+                <span class="edition-pages"
+                      itemprop="numberOfPages">$edition.number_of_pages</span> $_("pages")
+              </h4>
+        </div>
+        $if is_librarian:
+          <div>
+            <ul>
+              $if edition:
+                <li><span>Open Library: </span><span>$edition.key.split("/")[-1]</span></li>
+              $if ocaid:
+                <li><span>Internet Archive: </span><span><a href="https://www.archive.org/details/$ocaid">$ocaid</a></span></li>
+            </ul>
+          </div>
       </div>
-
       $if work and work.description or edition and edition.description:
         <div class="book-description">
             <div class="book-description-content restricted-view">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -201,31 +201,68 @@ $if is_privileged_user:
       $:macros.EditionNavBar(work.edition_count, show_observations)
       <a id="edition-overview" name="edition-overview"></a>
       <div>
-        <div class="edition-omniline">
-          $:render_template("type/edition/publisher_line", edition)
-
-          $if edition:
+        $if edition:
+          <div class="edition-omniline">
+            $if edition.publish_date:
+              <div class="edition-omniline-item">
+                <div>$_("Publish Date")</div>
+                <span itemprop="datePublished">$edition.publish_date</span>
+              </div>
+            $if edition.publishers:
+              <div class="edition-omniline-item">
+                <div>$_("Publishers")</div>
+                <span>
+                $for p in edition.publishers:
+                  $if "publishers" in ctx.features:
+                    <a itemprop="publisher" href="/publishers/$p.replace(' ', '_')"
+                       title="$_('Show other books from %(publisher)s', publisher=p)"
+                       >$p</a>$cond(loop.last, "", ", ")
+                  $else:
+                    <a itemprop="publisher" href="/search?publisher_facet=$p.replace('&','%26')"
+                       title="$_('Search for other books from %(publisher)s', publisher=p)"
+                       >$p</a>$cond(loop.last, "", ", ")
+                </span>
+              </div>
             $if edition.languages:
-              <h4 class="language">
-                $def lang_span(): <span itemprop="inLanguage">$:thingrepr(edition.languages)</span>
-                $:_('Written in %(language)s', language=lang_span())
-              </h4>
+              <div class="edition-omniline-item">
+                <div class="language">$_("Language")</div>
+                <span itemprop="inLanguage">$:thingrepr(edition.languages)</span>
+              </div>
             $if edition.number_of_pages:
-              <h4 class="year">&mdash;
+              <div class="edition-omniline-item">
+                <div class="pages">$_("Pages")</div>
                 <span class="edition-pages"
-                      itemprop="numberOfPages">$edition.number_of_pages</span> $_("pages")
-              </h4>
-        </div>
-        $if is_librarian:
-          <div>
-            <ul class="id-list">
-              $if edition:
-                <li><span>Open Library: </span><span>$edition.key.split("/")[-1]</span></li>
+                      itemprop="numberOfPages"
+                      >$edition.number_of_pages</span>
+              </div>
+            $if is_librarian:
+              <div class="edition-omniline-item">
+                <div>Open Library</div>
+                <span>$edition.key.split("/")[-1]</span>
+              </div>
               $if ocaid:
-                <li><span>Internet Archive: </span><span><a href="https://www.archive.org/details/$ocaid">$ocaid</a></span></li>
-            </ul>
+                <div class="edition-omniline-item">
+                 <div>Internet Archive</div>
+                  <span><a href="https://www.archive.org/details/$ocaid">$ocaid</a></span>
+                </div>
+              $if edition.identifiers.get('isbn_10') or edition.identifiers.get('isbn_13'):
+                <div class="edition-omniline-item">
+                  <div>ISBN</div>
+                  <span>$(edition.identifiers.get('isbn_10') or edition.identifiers.get('isbn_13'))</span>
+                </div>
           </div>
       </div>
+
+      $ seen = set()
+      $if previews:
+        <p class="preview-languages">
+          Previews available in:
+          $for e in previews:
+            $if e.languages[0].name not in seen:
+              $ seen.add(e.languages[0].name)
+              <a href="$work.key?edition=$(e.ocaid)">$e.languages[0].name</a>
+        </p>
+
       $if work and work.description or edition and edition.description:
         <div class="book-description">
             <div class="book-description-content restricted-view">
@@ -257,16 +294,6 @@ $if is_privileged_user:
           $_("Showing %(count)d featured editions", count=len(editions)).
           <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>
         </p>
-
-      <p class="preview-languages">
-        $ seen = set()
-        $if previews:
-          Previews available in:
-          $for e in previews:
-            $if e.languages[0].name not in seen:
-              $ seen.add(e.languages[0].name)
-              <a href="$work.key?edition=$(e.ocaid)">$e.languages[0].name</a>
-      </p>
 
       <a id="editions-list" name="editions-list" class="section-anchor"></a>
       $ component_times['EditionsTable'] = time()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -245,10 +245,17 @@ $if is_privileged_user:
                  <div>Internet Archive</div>
                   <span><a href="https://www.archive.org/details/$ocaid">$ocaid</a></span>
                 </div>
-              $if edition.identifiers.get('isbn_10') or edition.identifiers.get('isbn_13'):
+
+              $ edition_identifiers = edition.get_identifiers()
+              $ isbn = None
+              $if 'isbn_13' in edition_identifiers.keys():
+                $ isbn = edition_identifiers['isbn_13']['value']
+              $elif 'isbn_10' in edition_identifiers.keys():
+                $ isbn = edition_identifiers['isbn_10']['value']
+              $if isbn:
                 <div class="edition-omniline-item">
                   <div>ISBN</div>
-                  <span>$(edition.identifiers.get('isbn_10') or edition.identifiers.get('isbn_13'))</span>
+                  <span>$isbn</span>
                 </div>
           </div>
       </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -218,7 +218,7 @@ $if is_privileged_user:
         </div>
         $if is_librarian:
           <div>
-            <ul>
+            <ul class="id-list">
               $if edition:
                 <li><span>Open Library: </span><span>$edition.key.split("/")[-1]</span></li>
               $if ocaid:

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -247,8 +247,19 @@ div.editionTools {
 
 .edition-omniline {
   display: flex;
+  padding: 10px;
+  overflow-x: auto;
   border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
+
+  &-item {
+    flex: 1;
+    font-size: .8em;
+
+    div {
+      font-weight: bold;
+    }
+  }
 
   h4 {
     padding-right: 5px;
@@ -256,17 +267,6 @@ div.editionTools {
 
   h4:last-child {
     padding-right: 0;
-  }
-}
-
-.id-list {
-  font-size: 12px;
-  border-bottom: 1px solid @lighter-grey;
-  padding-bottom: 10px;
-
-  li {
-    display: flex;
-    justify-content: space-between;
   }
 }
 
@@ -278,7 +278,6 @@ div.editionTools {
 }
 
 .preview-languages {
-  margin-bottom: -30px !important;
   font-size: .8em;
   color: @grey;
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -247,12 +247,14 @@ div.editionTools {
 
 .edition-omniline {
   display: flex;
+  flex-direction: column;
   padding: 10px;
-  overflow-x: auto;
   border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
 
   &-item {
+    display: flex;
+    justify-content: space-between;
     flex: 1;
     font-size: .8em;
 
@@ -267,6 +269,20 @@ div.editionTools {
 
   h4:last-child {
     padding-right: 0;
+  }
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+  .edition-omniline {
+    flex-direction: row;
+    justify-content: space-between;
+    overflow-x: scroll;
+
+    &-item {
+      flex-direction: column;
+      justify-content: flex-start;
+      align-items: center;
+    }
   }
 }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -288,7 +288,7 @@ div.editionTools {
   .edition-omniline {
     flex-direction: row;
     justify-content: space-between;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     &-item {
       flex-direction: column;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -259,6 +259,17 @@ div.editionTools {
   }
 }
 
+.id-list {
+  font-size: 12px;
+  border-bottom: 1px solid @lighter-grey;
+  padding-bottom: 10px;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
 .tab-section {
   padding: 10px;
   border: 1px solid @lighter-grey;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In order to aid librarians, the following changes have been made:
- Important identifiers are now available above the fold (for usergroup `librarians`).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-03-10 15-31-06](https://user-images.githubusercontent.com/28732543/157750426-cd32ddc3-fab1-4601-979e-4d97798b0b94.png)

![sticky_title](https://user-images.githubusercontent.com/28732543/157750473-d622055e-f4ae-4384-b903-5a68ff9eaa9b.gif)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
