### PR TITLE
importbot importing books that are of bad quality

### DIFF
--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -173,6 +173,14 @@ def csv_to_ol_json_item(line):
     b = Biblio(data)
     return {'ia_id': b.source_id, 'data': b.json()}
 
+def is_low_quality_book(book_item):
+    """check if a book item is of low quality"""
+    book_title_breakup = book_item.title.split()
+    if "Notebook" in book_title_breakup and book_item.publisher == "Independently Published":
+        return True
+    else:
+        return False
+
 
 def batch_import(path, batch, batch_size=5000):
     logfile = os.path.join(path, 'import.log')
@@ -191,7 +199,9 @@ def batch_import(path, batch, batch_size=5000):
                     offset = 0
 
                 try:
-                    book_items.append(csv_to_ol_json_item(line))
+                    book_item = csv_to_ol_json_item(line)
+                    if not is_low_quality_book(book_item["data"]):
+                        book_items.append(book_item)
                 except AssertionError as e:
                     logger.info(f"Error: {e} from {line}")
 
@@ -205,7 +215,6 @@ def batch_import(path, batch, batch_size=5000):
             if book_items:
                 batch.add_items(book_items)
             update_state(logfile, fname, line_num)
-
 
 def main(ol_config: str, batch_path: str):
     load_config(ol_config)

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -175,11 +175,7 @@ def csv_to_ol_json_item(line):
 
 def is_low_quality_book(book_item):
     """check if a book item is of low quality"""
-    book_title_breakup = book_item.title.split()
-    if "Notebook" in book_title_breakup and book_item.publisher == "Independently Published":
-        return True
-    else:
-        return False
+    return ("notebook" in book_item.title.casefold() and "independently published" in book_item.publisher.casefold())
 
 
 def batch_import(path, batch, batch_size=5000):


### PR DESCRIPTION
in this commit a new function is added that checks a book's title and other attributes for known exclusions.
The effect of this commit is that, the importbot will discriminate low quality books

<!-- What issue does this PR close? -->
Closes #4151 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
hotfix

### Technical
<!-- What should be noted about the implementation? -->
This is not a complete solution yet, it is just an initial try

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The importbot must be its periodic imports, filtering books that have the keyword "Notebook" in their titles and the publisher is independent publisher.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
