### PR TITLE
Move books page list section

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -448,7 +448,7 @@ $if is_privileged_user:
         $ component_times['Review component'] = time()
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']
-      <a id="lists-section" name="lists-section" class="section-anchor"></a>
+      <a id="lists-section" name="lists-section tab-section" class="section-anchor"></a>
       <div class="workFooter">
         $# pages like /books/ia:foo00bar are fake records created from metadata API.
         $# Adding them to lists doesn't work. Disabling it to avoid any issues.

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -448,11 +448,12 @@ $if is_privileged_user:
         $ component_times['Review component'] = time()
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']
+      <a id="lists-section" name="lists-section" class="section-anchor"></a>
       <div class="workFooter">
         $# pages like /books/ia:foo00bar are fake records created from metadata API.
         $# Adding them to lists doesn't work. Disabling it to avoid any issues.
         $if "lists" in ctx.features and not page.is_fake_record():
-          <h2 class="home-h2" id="lists-section"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
+          <h2 class="home-h2"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
           <div class="user-book-options">
             <div class="Tools tools-override">
               $if work:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -448,27 +448,26 @@ $if is_privileged_user:
         $ component_times['Review component'] = time()
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']
-    </div>
-  </div>
+      <div class="workFooter">
+        $# pages like /books/ia:foo00bar are fake records created from metadata API.
+        $# Adding them to lists doesn't work. Disabling it to avoid any issues.
+        $if "lists" in ctx.features and not page.is_fake_record():
+          <h2 class="home-h2" id="lists-section"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
+          <div class="user-book-options">
+            <div class="Tools tools-override">
+              $if work:
+                $ component_times['lists widget: WorkListTime'] = time()
+                $:render_template("lists/widget", work, include_header=False, include_widget=False)
+                $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
 
-  <div class="workFooter">
-    $# pages like /books/ia:foo00bar are fake records created from metadata API.
-    $# Adding them to lists doesn't work. Disabling it to avoid any issues.
-    $if "lists" in ctx.features and not page.is_fake_record():
-      <h2 class="home-h2" id="lists-section"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
-      <div class="user-book-options">
-        <div class="Tools tools-override">
-          $if work:
-            $ component_times['lists widget: WorkListTime'] = time()
-            $:render_template("lists/widget", work, include_header=False, include_widget=False)
-            $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
-
-          $if edition:
-            $ component_times['lists widget: EditionListTime'] = time()
-            $:render_template("lists/widget", edition, include_header=False, include_widget=False)
-            $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']
-        </div>
+              $if edition:
+                $ component_times['lists widget: EditionListTime'] = time()
+                $:render_template("lists/widget", edition, include_header=False, include_widget=False)
+                $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']
+            </div>
+          </div>
       </div>
+    </div>
   </div>
 
   $ component_times['RelatedWorksCarousel'] = time()

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -57,7 +57,6 @@ div.editionAbout {
 }
 
 .workFooter {
-  border-top: 1px solid @lighter-grey;
   ul.listLists {
     display: flex;
   }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Moves books page list section into the main content area.  Now the navbar will remain in view when the lists section is displayed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
