### PR TITLE
Small import improvements

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -809,6 +809,7 @@ def load(rec, account_key=None):
         'local_id',
         'lccn',
         'lc_classifications',
+        'oclc_numbers',
         'source_records',
     ]
     for f in edition_fields:

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -805,6 +805,7 @@ def load(rec, account_key=None):
 
     # Add list fields to edition as needed
     edition_fields = [
+        'identifiers',
         'local_id',
         'lccn',
         'lc_classifications',

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -811,7 +811,7 @@ def load(rec, account_key=None):
         'source_records',
     ]
     for f in edition_fields:
-        if f not in rec:
+        if f not in rec or not rec[f]:
             continue
         # ensure values is a list
         values = rec[f] if isinstance(rec[f], list) else [rec[f]]

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -805,7 +805,6 @@ def load(rec, account_key=None):
 
     # Add list fields to edition as needed
     edition_fields = [
-        'identifiers',
         'local_id',
         'lccn',
         'lc_classifications',
@@ -824,6 +823,15 @@ def load(rec, account_key=None):
         else:
             e[f] = to_add = values
         if to_add:
+            need_edition_save = True
+
+    # Add new identifiers
+    if 'identifiers' in rec:
+        identifiers = defaultdict(set, e.get('identifiers', {}))
+        for k, vals in rec.identifiers:
+            identifiers[k].update(vals)
+        if e.get('identifiers') != identifiers:
+            e['identifiers'] = {k: list(vals) for k, vals in identifiers.items()}
             need_edition_save = True
 
     edits = []


### PR DESCRIPTION

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
On reimporting existing editions:

* Prevents empty lists being written to the record
  * Closes #4978
  * Closes #5671
* Writes any new identifiers (e.g. DNB id) to a matched edition
* Writes OCLC numbers to a matched edition

Previously OCLC number and other identifiers were not added to existing editions if a match was found.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
