### PR TITLE
Fix books page sticky navbar for mobile views

### DIFF
--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -137,11 +137,17 @@ h2.edition-byline {
 
   &.sticky {
     position: sticky;
-    top: 0;
+    top: 50px;
     display: block;
     background: @white;
     z-index: @z-index-level-3;
     padding-top: 10px;
+  }
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+  .work-menu.sticky {
+    top: 0;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6288

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Offsets the sticky position for mobile books page navbars by the height of the header.  This prevents the navbar from being stickied "behind" the header.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![sticky_offset](https://user-images.githubusercontent.com/28732543/158276835-64da2248-7cb0-4f2e-a24e-61d4a53b443f.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
