### PR TITLE
Disable "auto focus/scroll" on edit page

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -279,21 +279,18 @@ export function initEditLinks() {
 export function initEdit() {
     var hash = document.location.hash || '#edition';
     var tab = hash.split('/')[0];
-    var link = `#link_${tab.substr(1)}`;
+    var link = `#link_${tab.substring(1)}`;
     var fieldname = `:input${hash.replace('/', '-')}`;
 
     $(link).trigger('click');
 
     // input field is enabled only after the tab is selected and that takes some time after clicking the link.
     // wait for 1 sec after clicking the link and focus the input field
-    setTimeout(function() {
+    if ($(fieldname).length !== 0) {
+        setTimeout(function() {
         // scroll such that top of the content is visible
-        if ($(fieldname).length !== 0) {
             $(fieldname).trigger('focus');
-        }
-        else {
-            $('#tabsAddbook > div:visible :input').first().trigger('focus');
-        }
-        $(window).scrollTop($('#contentHead').offset().top);
-    }, 1000);
+            $(window).scrollTop($('#contentHead').offset().top);
+        }, 1000);
+    }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6293

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Modified initEdit function to only trigger focus and scroll if explicitly requested in URL; 
also replaced deprecated substr() call with substring().

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
 https://openlibrary.org/books/OL35615701M/The_Game/edit

should load the edit page with no jumping.

 https://openlibrary.org/books/OL35615701M/The_Game/edit#edition/subtitle

should focus and jump to the edition subtitle field.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @mheiman

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
