### PR TITLE
Add visual feedback for subject clamp

### DIFF
--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -3,7 +3,7 @@ $def with(work, tags=[])
 $def render_subjects(label, subjects, track_value, prefix=""):
   $if subjects:
     <div class="section link-box">
-      <span class="clamp">
+      <span class="clamp" data-before="+ ">
       <h6>$label</h6>
         $for subject in subjects:
           <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track_value">$subject</a>$cond(not loop.last, ",", "")

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -7,6 +7,12 @@ export function initReadMoreButton() {
         const up = $(this);
         if (up.hasClass('clamp')) {
             up.css({display: up.css('display') === '-webkit-box' ? 'unset' : '-webkit-box'});
+
+            if (up.attr('data-before') === '+ ') {
+                up.attr('data-before', '- ')
+            } else {
+                up.attr('data-before', '+ ')
+            }
         }
     });
     $('.read-more-button').on('click',function(){

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -88,10 +88,14 @@ div.editionAbout {
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
   overflow: hidden;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .clamp::before {
-  content: "+ ";
+  content: attr(data-before);
 }
 
 .restricted-view{


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes the cursor when hovering over a `.clamp`ed subject.  Toggles leading character to either `+` or `-` on click.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![subject_toggle](https://user-images.githubusercontent.com/28732543/158480971-09a51916-def2-4b4f-aa8d-b93be16510b1.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
