### PR TITLE
Fixes CTA + lending v2 fields

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -337,16 +337,14 @@ def get_availability(key, ids):
         return {}
 
     def update_availability_schema_to_v2(v1_resp, ocaid):
+        """This functionattempts to take the output of e.g. Bulk Availability
+        API and add/infer attributes which are missing (but are
+        present on Ground Truth API)
+        """
+        # TODO: Make less brittle; maybe add simplelists/copy counts to Bulk Availability
         v1_resp['identifier'] = ocaid
         v1_resp['is_restricted'] = v1_resp['status'] != 'open'
-        v1_resp['is_printdisabled'] = v1_resp.get('is_printdisabled', False)
-        v1_resp['is_lendable'] = v1_resp['status'] == 'borrow_available'
-        v1_resp['is_readable'] = v1_resp['status'] == 'open'
-        # TODO: Make less brittle; maybe add simplelists/copy counts to IA availability
-        # endpoint
-        v1_resp['is_browseable'] = (
-            v1_resp['is_lendable'] and v1_resp['status'] == 'error'
-        )
+        v1_resp['is_browseable'] = v1_resp.get('available_to_browse', False)
         # For debugging
         v1_resp['__src__'] = 'core.models.lending.get_availability'
         return v1_resp

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,10 +1,11 @@
 $def with (ocaid, linkback=True)
 $# :param str ocaid:
-
-<a class="cta-btn cta-btn--shell cta-btn--preview"
-   data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
-   data-iframe-link="https://archive.org/details/$ocaid"
-   data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview')</a>
+<div class="cta-button-group">
+  <a class="cta-btn cta-btn--shell cta-btn--preview"
+     data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
+     data-iframe-link="https://archive.org/details/$ocaid"
+     data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview')</a>
+</div>
 
 $if render_once('book-preview-floater'):
   <div class="hidden">

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,12 +1,14 @@
 $def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False, check_loan_status=False, user_lists=None, post='')
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
-$# * listen whether to display listen button
-$# * allow_expensive_availability_check whether to check the groundtruth availability if can't get availability from specified fields
-$# * secondary_action whether to display the preview/search inside button
-$# * check_sponsorship whether to check if the book is eligible for sponsorship
-$# * sponsorship_help whether to show the sponsorship help text
-$# * check_loan_status whether to check the user's loan status to determine read button
+$# * listen - whether to display listen button
+$# * allow_expensive_availability_check - whether to check the groundtruth availability
+$#     if can't get availability from specified fields
+$# * secondary_action - whether to display elements (e.g. preview, searhc inside)
+$#     on just e.g. editions page or within search results, editions table, etc
+$# * check_sponsorship - whether to check if the book is eligible for sponsorship
+$# * sponsorship_help - whether to show the sponsorship help text
+$# * check_loan_status - whether to check the user's loan status to determine read button
 
 $ loanstatus_start_time = time()
 
@@ -32,6 +34,7 @@ $if allow_expensive_availability_check and ocaid:
 
 $ borrow_link = '/borrow/ia/%s' % ocaid
 
+$# Checks to see if patron has actively loan / waitlist for this book
 $ get_loan_for_start_time = time()
 $ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
 $ get_loan_for_total_time = time() - get_loan_for_start_time
@@ -55,16 +58,25 @@ $if user_loan:
     </script>
 
 $elif book_provider and book_provider.short_name != 'ia':
+  $# Partner Trusted Book Provider Read Buttons
   $:book_provider.render_read_button(doc)
 
 $elif availability.get('is_readable'):
+  $# Open / Publicly Readable (Unrestricted)
   $:macros.ReadButton(ocaid, listen=listen)
   $if secondary_action:
     $:macros.BookSearchInside(ocaid)
 
 $elif ocaid and ctx.user and ctx.user.is_printdisabled():
+  $# Exemptions for patrons with Print Disabilities
+  $# We know there's an ocaid
+  $# We know we don't have this book loaned / waitlisted
+  $# We know this book is not `is_readable`
+  $# This book must either be: `is_lendable`, `is_printdisabled`, `is_restricted`
   $ std_borrow = availability and availability.get('is_lendable')
   $:macros.ReadButton(ocaid, borrow=std_borrow, printdisabled=not std_borrow, listen=listen)
+  $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
+    $:macros.BookPreview(ocaid, linkback=not no_index)
 
 $elif availability.get('is_lendable'):
   $if availability.get("available_to_borrow") or availability.get("available_to_browse"):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -115,6 +115,8 @@ $elif availability.get('is_lendable'):
       <a href="$work_key" class="cta-btn cta-btn--missing" title="$_('This book is currently checked out, please check back later.')"
        data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
     </div>
+    $if not secondary_action:
+      $:macros.BookPreview(ocaid, linkback=not no_index)
   $if secondary_action:
     $:macros.BookPreview(ocaid, linkback=not no_index)
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -110,13 +110,11 @@ $elif availability.get('is_lendable'):
         <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
       </form>
   $else:
-    $# Checked out
+    $# Checked out: Show checkout out + preview if secondary, else just preview
     <div class="cta-button-group">
       <a href="$work_key" class="cta-btn cta-btn--missing" title="$_('This book is currently checked out, please check back later.')"
        data-ol-link-track="CTAClick|CheckedOut">$_('Checked Out')</a>
     </div>
-    $if not secondary_action:
-      $:macros.BookPreview(ocaid, linkback=not no_index)
   $if secondary_action:
     $:macros.BookPreview(ocaid, linkback=not no_index)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6302

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

1. Before, Preview was not showing up on mek's account (because it uses print-disabled access for testing)
2. The `update_availability_schema_to_v2` adapter had an incorrect/incomplete definition for `is_lendable` which did not consider the `borrow_unavailable` cases, which resulted in us not showing the Checked Out
3. The changes to Bulk Availability API haven't been `pi`'d and so some books were returning `error` because Bulk Availability didn't have access to `printdisabled` scope and thus returned `error` status, causing Ground Truth API to be called. On testing, we used the deploy app from archive.org to confirm that values are now correct

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![ol-dev1 us archive org_1337_works_OL14933414W_The_Fellowship_of_the_Ring_edition=ia%3Amojiezhihuanwang0001tolk debug=true](https://user-images.githubusercontent.com/978325/158680349-3853929c-bd07-46ae-b5ff-fcbdc0c8212d.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
