### PR TITLE
Prevent loan/waiting list status calls with old-style username format

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -563,7 +563,6 @@ def get_loans_of_user(user_key):
     loandata = web.ctx.site.store.values(type='/type/loan', name='user', value=user_key)
     loans = [Loan(d) for d in loandata] + (
         _get_ia_loans_of_user(account.itemname)
-        + _get_ia_loans_of_user(userkey2userid(user_key))
     )
     return loans
 

--- a/openlibrary/core/waitinglist.py
+++ b/openlibrary/core/waitinglist.py
@@ -129,9 +129,7 @@ class WaitingLoan(dict):
         if not itemname:
             account = OpenLibraryAccount.get(key=user_key)
             itemname = account.itemname
-        result = cls.query(userid=itemname, identifier=identifier) or cls.query(
-            userid=lending.userkey2userid(user_key), identifier=identifier
-        )
+        result = cls.query(userid=itemname, identifier=identifier)
         if result:
             return result[0]
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6304

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents book page loan status and waiting list queries using obsolete usernames (having the format: `ol:${username}`)

### Technical
<!-- What should be noted about the implementation? -->
Calls made to `userkey2userid` will return obsolete `ol:foo` user identifiers.  Seeing this function in our code should indicate that said code may need to be updated.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. While `tail`ing the web logs, visit a book page.
2. Ensure that only one call each is made for loan status and waiting list status.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
