### PR TITLE
Switch olbase to use python:3.9.4-slim image instead of ubuntu:xenial -- AGAIN

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -82,8 +82,6 @@ services:
 
   home:
     image: "oldev:${OLDEV_TAG:-latest}"
-    environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -81,7 +81,7 @@ services:
       - db
 
   home:
-    image: "oldev:${OLDEV_TAG:-latest}"
+    image: "${OLIMAGE:-oldev:latest}"
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -266,7 +266,6 @@ services:
     restart: unless-stopped
     hostname: "$HOSTNAME"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OL_URL=https://openlibrary.org/
       - STATE_FILE=solr-next-update.offset
@@ -288,7 +287,6 @@ services:
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OPENLIBRARY_RCFILE=/olsystem/etc/olrc-importbot
-      - PYENV_VERSION=${PYENV_VERSION:-}
     volumes:
       - ../olsystem:/olsystem
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   web:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 4 --timeout 180}
     command: docker/ol-web-start.sh
@@ -39,7 +38,6 @@ services:
     hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=conf/openlibrary.yml
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - OL_URL=http://web:8080/
       - STATE_FILE=solr-update.offset
     volumes:
@@ -56,7 +54,6 @@ services:
   covers:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --max-requests 250}
     command: docker/ol-covers-start.sh
@@ -73,7 +70,6 @@ services:
   infobase:
     image: "${OLIMAGE:-oldev:latest}"
     environment:
-      - PYENV_VERSION=${PYENV_VERSION:-}
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}
       - INFOBASE_OPTS=${INFOBASE_OPTS:-}
     command: docker/ol-infobase-start.sh

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,4 +1,4 @@
-FROM python:3.9.4
+FROM python:3.9.4-slim
 
 ENV LANG en_US.UTF-8
 

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -73,5 +73,3 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 RUN ln -s vendor/infogami/infogami infogami \
  && make \
  && python -m pip list --outdated
-
-ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -5,9 +5,13 @@ ENV LANG en_US.UTF-8
 # required for postgres
 ENV LC_ALL POSIX
 
-# add openlibrary users
-RUN groupadd --system openlibrary \
-  && useradd --no-log-init --system --gid openlibrary --create-home openlibrary
+# Create openlibrary users
+# We use 999:999 for the openlibrary user. Any volume mounts which require read/write
+# access by the container should be set to this user. Ideally we would use a number
+# larger than 10,000 to avoid host OS uid/gid conflicts, but this is what we have
+# at the moment.
+RUN groupadd --system --gid 999 openlibrary \
+  && useradd --no-log-init --system -u 999 --gid openlibrary --create-home openlibrary
 
 # Misc OL dependencies
 RUN apt-get -qq update && apt-get install -y \

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -68,6 +68,13 @@ COPY --chown=openlibrary:openlibrary requirements*.txt ./
 RUN python -m pip install --upgrade pip wheel \
  && python -m pip install --default-timeout=100 -r requirements.txt
 
+# Link the ia CLI binary into /usr/local/bin so that it shows up
+# on the PATH. Do this instead of trying to modify the PATH, because
+# that causes headaches with su, cron, etc.
+USER root
+RUN ln -s /home/openlibrary/.local/bin/ia /usr/local/bin/ia
+USER openlibrary
+
 COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm ci
 

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM python:3.9.4
 
 ENV LANG en_US.UTF-8
 
@@ -30,21 +30,9 @@ RUN apt-get -qq update && apt-get install -y \
     unzip \
     lftp
 
-# Print gnu parallel citation
-USER openlibrary
-RUN echo 'will cite' | parallel --citation
-USER root
-RUN echo 'will cite' | parallel --citation
-
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs
-
-# Install pyenv
-# Python build deps: https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
-RUN apt-get -qq update && apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
 
 # Install Archive.org nginx w/ IP anonymization
 USER root
@@ -63,23 +51,6 @@ RUN chmod +x /usr/sbin/nginx
 # Remove the stock nginx config file
 RUN rm /etc/nginx/sites-enabled/default
 
-# Install latest pyenv (https://github.com/pyenv/pyenv-installer)
-USER openlibrary
-RUN curl https://pyenv.run | bash && \
-    echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /home/openlibrary/.bashrc
-ENV PYENV_ROOT /home/openlibrary/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
-
-# Install wheel before other requirements to reduce Docker build time.
-RUN pyenv update && pyenv install 3.9.4 \
- && pyenv global 3.9.4 \
- && pyenv rehash \
- && python3.9 -m pip install --upgrade pip wheel
-
-USER root
-# Add pyenv to root's bashrc as well
-RUN echo '\nexport PATH="/home/openlibrary/.pyenv/bin:$PATH"\neval "$(pyenv init -)"\neval "$(pyenv virtualenv-init -)"' >> /root/.bashrc
-
 RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:openlibrary /var/log/openlibrary /var/lib/openlibrary \
  && mkdir /openlibrary && chown openlibrary:openlibrary /openlibrary \
  && mkdir -p /var/lib/coverstore && chown openlibrary:openlibrary /var/lib/coverstore \
@@ -90,7 +61,8 @@ WORKDIR /openlibrary
 
 USER openlibrary
 COPY --chown=openlibrary:openlibrary requirements*.txt ./
-RUN python3.9 -m pip install --default-timeout=100 -r requirements.txt
+RUN python -m pip install --upgrade pip wheel \
+ && python -m pip install --default-timeout=100 -r requirements.txt
 
 COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm ci
@@ -100,6 +72,6 @@ COPY --chown=openlibrary:openlibrary . /openlibrary
 # run make to initialize git submodules, build css and js files
 RUN ln -s vendor/infogami/infogami infogami \
  && make \
- && python3.9 -m pip list --outdated
+ && python -m pip list --outdated
 
 ENTRYPOINT ["/openlibrary/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends nginx curl \
     # log rotation service for ol-nginx
     logrotate
 RUN wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
-RUN echo "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main" \
+RUN echo "deb http://openresty.org/package/debian $(lsb_release -sc) openresty" \
     | tee /etc/apt/sources.list.d/openresty.list
 RUN apt-get update && apt-get -y install --no-install-recommends openresty
 RUN rm /usr/sbin/nginx

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -2,7 +2,8 @@ FROM openlibrary/olbase:latest
 WORKDIR /openlibrary
 
 COPY --chown=openlibrary:openlibrary requirements*.txt ./
-RUN python3.9 -m pip install -r requirements_test.txt
+RUN python -m pip install -r requirements_test.txt \
+ && python -m pip list --outdated
 
 COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm install

--- a/docker/README.md
+++ b/docker/README.md
@@ -158,11 +158,6 @@ docker-compose down && \
 
 # In your browser, navigate to http://localhost:8080
 
-# Test Open Library on another version of Python that is in `.python-version` and ol-dev
-# PYENV_VERSION can currently be set to: 3.9.4
-docker-compose down && \
-    PYENV_VERSION=3.9.4 docker-compose up -d && \
-    docker-compose logs -f --tail=10 web
-
-# In your browser, navigate to http://localhost:8080
+# To test Open Library on another version of Python, modify Dockerfile.olbase and then
+# rebuild olbase (see above) and oldev (`docker-compose build`)
 ```

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# Init PYENV vars
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-
-exec "$@"

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -34,7 +34,6 @@ set -e
 # To run a testing subset of the full ol-dump, uncomment the following line.
 # export OLDUMP_TESTING=true
 
-source /home/openlibrary/.bashrc
 SCRIPTS=/openlibrary/scripts
 PSQL_PARAMS=${PSQL_PARAMS:-"-h db openlibrary"}
 TMPDIR=${TMPDIR:-/openlibrary/dumps}

--- a/scripts/solr_builder/Dockerfile.olpython
+++ b/scripts/solr_builder/Dockerfile.olpython
@@ -1,7 +1,6 @@
 FROM openlibrary/olbase:latest
 
 ENV PYTHONPATH=/openlibrary:/openlibrary/vendor/infogami
-ENV PYENV_VERSION=3.9.4
 
 USER root
 COPY requirements*.txt ./


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5514

A second attempt at #5514 with sync to master plus mods to `conf/bashrc` and `scripts/setup_gitpod.sh`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Switch olbase to use [`python:3.9.4-slim` Docker image](https://hub.docker.com/_/python) instead of `ubuntu:xenial`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
* [x] Ensure that contributors on arm64 (like macOS M1) can build olbase (graceful sidestep of `openresty`)
    - Turns out this is a pre-existing issue unrelated to the changes here; tackle separately in #6316
* [x] Ensure the new olbase image works on oldev1, testing,openlibrary.org, and macOS M1
* [x] Test cron jobs
    * [x] oldump succeeds
    * [x] Other things run with not too many errors? There are some infobase errors popping up, but I don't think they're new?
* [x] Confirm 999 is the openlibrary userid
* [x] ~Test gitpod~ NA no changes to gitpod anymore

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
