### PR TITLE
tag-on to cta btn changes, fixes pd

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -69,12 +69,9 @@ $elif availability.get('is_readable'):
 
 $elif ocaid and ctx.user and ctx.user.is_printdisabled():
   $# Exemptions for patrons with Print Disabilities
-  $# We know there's an ocaid
-  $# We know we don't have this book loaned / waitlisted
-  $# We know this book is not `is_readable`
-  $# This book must either be: `is_lendable`, `is_printdisabled`, `is_restricted`
-  $ std_borrow = availability and availability.get('is_lendable')
-  $:macros.ReadButton(ocaid, borrow=std_borrow, printdisabled=not std_borrow, listen=listen)
+  $ pd_eligible = availability and availability.get('is_printdisabled')
+  $ std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
+  $:macros.ReadButton(ocaid, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen)
   $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
     $:macros.BookPreview(ocaid, linkback=not no_index)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Tags on to #6303 (forgot to add this patch to PR) 

This should show "special access" for patrons with certified print disabilities when book is_lendable but borrow_unavailable

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
