### PR TITLE
Configure renovate to read all requirements*.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true
   },
   "pip_requirements": {
-    "fileMatch": ["requirements.*\\.txt$"]
+    "fileMatch": ["(^|/)requirements[^/]*\\.txt$"]
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true
   },
   "pip_requirements": {
-    "fileMatch": ["requirements.*\.txt$"]
+    "fileMatch": ["requirements.*\\.txt$"]
   },
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   "git-submodules": {
     "enabled": true
   },
+  "pip_requirements": {
+    "fileMatch": ["requirements.*\.txt$"]
+  },
   "packageRules": [
     {
       "matchPackageNames": ["eslint", "babel-eslint", "eslint-plugin-no-jquery", "eslint-plugin-vue"],


### PR DESCRIPTION
Fix eg `pytest` missing from #6234 .


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
