### PR TITLE
Implement books page feedback

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -475,11 +475,11 @@ $if is_privileged_user:
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']
       <a id="lists-section" name="lists-section tab-section" class="section-anchor"></a>
-      <div class="workFooter">
+      <div class="workFooter tab-section">
         $# pages like /books/ia:foo00bar are fake records created from metadata API.
         $# Adding them to lists doesn't work. Disabling it to avoid any issues.
         $if "lists" in ctx.features and not page.is_fake_record():
-          <h2 class="home-h2"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
+          <h2 class="list-heading"><a href="$page.url()/lists">$_('Lists containing this Book')</a></h2>
           <div class="user-book-options">
             <div class="Tools tools-override">
               $if work:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -238,10 +238,6 @@ $if is_privileged_user:
                       >$edition.number_of_pages</span>
               </div>
             $if is_librarian:
-              <div class="edition-omniline-item">
-                <div>Open Library</div>
-                <span>$edition.key.split("/")[-1]</span>
-              </div>
               $if ocaid:
                 <div class="edition-omniline-item">
                  <div>Internet Archive</div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -300,12 +300,12 @@ $if is_privileged_user:
       </div>
     </div>
 
-    <hr/>
-
       <a id="editions-list" name="editions-list" class="section-anchor"></a>
-      $ component_times['EditionsTable'] = time()
-      $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
-      $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
+      <div class="tab-section">
+        $ component_times['EditionsTable'] = time()
+        $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
+        $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
+      </div>
 
       <a id="details" name="details" class="section-anchor"></a>
       <div class="tab-section edition-info">

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -3,6 +3,12 @@ $def with (work, editions=None, edition=None, editions_limit=None)
 $ book_keys = []
 $ edition_list_start = time()
 
+$if editions_limit and len(editions) and len(editions) < work.edition_count:
+  <p class="small sansserif">
+
+    $ungettext('Showing one featured edition.', 'Showing %(count)d featured editions.', len(editions), count=len(editions))
+    <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>
+  </p>
 $if editions and len(editions):
   <table id="editions" class="editions-table editions-table--progressively-enhanced">
       <thead>
@@ -34,9 +40,6 @@ $else:
 $ edition_list_secs = time() - edition_list_start
 
 <p class="small sansserif edition-adder">
-  $if editions_limit and len(editions) and len(editions) < work.edition_count:
-    $_("Showing %(count)d featured editions", count=len(editions)).
-    <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>
   <a href="/books/add?work=$work.key" title="$_('Add another edition of %(work)s', work=work.title)">$_("Add another edition?")</a>
 </p>
 

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -4,7 +4,7 @@ $ book_keys = []
 $ edition_list_start = time()
 
 $if editions_limit and len(editions) and len(editions) < work.edition_count:
-  <p class="small sansserif">
+  <p class="small sansserif featured-count">
 
     $ungettext('Showing one featured edition.', 'Showing %(count)d featured editions.', len(editions), count=len(editions))
     <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -329,3 +329,9 @@ div.editionTools {
   justify-content: center;
   background: @lightest-grey;
 }
+
+.list-heading {
+  font-size: 1.2em;
+  font-weight: normal;
+  color: @link-blue;
+}

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -39,6 +39,9 @@ div.editionAbout {
     margin: 0;
   }
 
+  p.featured-count {
+    margin-bottom: 10px;
+  }
 }
 
 .work-title{


### PR DESCRIPTION
This PR attempts to resolve any feedback given for the recent books page PRs.  The following changes have been made:

- Prompt to see all editions moved above editions table
- Horizontal rule above editions table has been removed
- Singular case handled correctly when one featured edition is displayed in the table
- Removed OLID from omnibar
- Add border around table


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
