### PR TITLE
disable infobase ports for local development

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -67,8 +67,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
-    ports:
-      - 7000:7000
+    # Commented out because not needed for most dev work
+    # See https://github.com/internetarchive/openlibrary/issues/6315
+    # ports:
+    #  - 7000:7000
     volumes:
       - ol-vendor:/openlibrary/vendor
       - .:/openlibrary


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/6315

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Just turns off the ports since we don't need them and the conflict on the latest version of mac.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
TBD

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
n/a

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
