### PR TITLE
Data Dumps: Add Sentry error logging

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -182,5 +182,11 @@ sentry:
     dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
     environment: 'local'
 
+sentry_cron_jobs:
+    enabled: false
+    # Dummy endpoint; where sentry logs are sent to
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    environment: 'local'
+
 # Observations cache settings:
 observation_cache_duration: 86400

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -18,13 +18,23 @@ import time
 
 import web
 
+from infogami import config
 from infogami.infobase.utils import flatten_dict
 from openlibrary.data import db
 from openlibrary.data.sitemap import generate_html_index, generate_sitemaps
 from openlibrary.plugins.openlibrary.processors import urlsafe
+from openlibrary.utils.sentry import Sentry
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
+
+
+sentry = Sentry(getattr(config, 'sentry', {}))
+if sentry.enabled:
+    sentry.init()
+
+
+division_by_zero = 1 / 0
 
 
 def print_dump(json_records, filter=None):

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -29,12 +29,6 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
 
 
-sentry = Sentry(getattr(config, 'sentry', {}))
-if sentry.enabled:
-    sentry.init()
-    division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!
-
-
 def print_dump(json_records, filter=None):
     """Print the given json_records in the dump format."""
     for i, json_data in enumerate(json_records):
@@ -380,4 +374,9 @@ def main(cmd, args):
 
 
 if __name__ == "__main__":
+    sentry = Sentry(getattr(config, 'sentry', {}))
+    if sentry.enabled:
+        sentry.init()
+        division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!
+
     main(sys.argv[1], sys.argv[2:])

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -34,7 +34,7 @@ if sentry.enabled:
     sentry.init()
 
 
-division_by_zero = 1 / 0
+division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!
 
 
 def print_dump(json_records, filter=None):

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -374,7 +374,7 @@ def main(cmd, args):
 
 
 if __name__ == "__main__":
-    sentry = Sentry(getattr(config, 'sentry', {}))
+    sentry = Sentry(getattr(config, 'sentry_cron_jobs', {}))
     if sentry.enabled:
         sentry.init()
         division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -20,6 +20,7 @@ import web
 
 from infogami import config
 from infogami.infobase.utils import flatten_dict
+from openlibrary.config import load_config
 from openlibrary.data import db
 from openlibrary.data.sitemap import generate_html_index, generate_sitemaps
 from openlibrary.plugins.openlibrary.processors import urlsafe
@@ -374,9 +375,12 @@ def main(cmd, args):
 
 
 if __name__ == "__main__":
-    sentry = Sentry(getattr(config, 'sentry_cron_jobs', {}))
-    if sentry.enabled:
-        sentry.init()
-        division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!
+    ol_config = os.getenv("OL_CONFIG")
+    if ol_config:
+        logger.info(f"loading config from {ol_config}")
+        load_config(ol_config)
+        sentry = Sentry(getattr(config, 'sentry_cron_jobs', {}))
+        if sentry.enabled:
+            sentry.init()
 
     main(sys.argv[1], sys.argv[2:])

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -32,9 +32,7 @@ logger.setLevel(logging.DEBUG)
 sentry = Sentry(getattr(config, 'sentry', {}))
 if sentry.enabled:
     sentry.init()
-
-
-division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!
+    division_by_zero = 1 / 0  # TODO (cclauss): Remove this line!!
 
 
 def print_dump(json_records, filter=None):

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -38,6 +38,7 @@ source /home/openlibrary/.bashrc
 SCRIPTS=/openlibrary/scripts
 PSQL_PARAMS=${PSQL_PARAMS:-"-h db openlibrary"}
 TMPDIR=${TMPDIR:-/openlibrary/dumps}
+OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
 
 yymm=`date +\%Y-\%m`
 yymmdd=$1


### PR DESCRIPTION
<!-- What issue does this PR close? -->
As discussed in several issues related to #5402 our [data dumps](https://github.com/internetarchive/openlibrary/wiki/Generating-Data-Dumps) can be quite tricky so this PR logs data dump error output into [Sentry](https://docs.sentry.io/platforms/python) to ease debugging.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See the cron workflow at #5892

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
