### PR TITLE
Convert Python type comments to type hints

### DIFF
--- a/openlibrary/coverstore/server.py
+++ b/openlibrary/coverstore/server.py
@@ -36,8 +36,7 @@ def load_config(configfile):
         web.config.fastcgi = d['fastcgi']
 
 
-def setup(configfile):
-    # type: (str) -> None
+def setup(configfile: str) -> None:
     load_config(configfile)
 
     sentry = Sentry(getattr(config, 'sentry', {}))

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -15,11 +15,11 @@ class TestDockerCompose:
         match with any profile, meaning the service would get deployed everywhere!
         """
         with open(p('..', 'docker-compose.yml')) as f:
-            root_dc = yaml.safe_load(f)  # type: dict
+            root_dc: dict = yaml.safe_load(f)
         with open(p('..', 'docker-compose.production.yml')) as f:
-            prod_dc = yaml.safe_load(f)  # type: dict
-        root_services = set(root_dc['services'].keys())
-        prod_services = set(prod_dc['services'].keys())
+            prod_dc: dict = yaml.safe_load(f)
+        root_services = set(root_dc['services'])
+        prod_services = set(prod_dc['services'])
         missing = root_services - prod_services
         assert missing == set(), "docker-compose.production.yml missing services"
 
@@ -30,6 +30,6 @@ class TestDockerCompose:
         this service to make things explicit.
         """
         with open(p('..', 'docker-compose.production.yml')) as f:
-            prod_dc = yaml.safe_load(f)  # type: dict
+            prod_dc: dict = yaml.safe_load(f)
         for serv, opts in prod_dc['services'].items():
             assert 'profiles' in opts, f"{serv} is missing 'profiles' field"


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Convert Python type comments to [type hints](https://docs.python.org/library/typing.html)
Avoid `solr` related files because of Cython.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
