### PR TITLE
Make table of contents collapsible

### DIFF
--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -3,18 +3,23 @@ $def with (edition, ocaid=None)
 $ table_of_contents = edition.get_table_of_contents()
 $if table_of_contents and len(table_of_contents) > 1:
   <div class="section">
-    <h3 class="collapse">$_("Table of Contents")</h3>
-    <table class="meta sansserif" id="toc-table">
-      <tbody>
-        $for toc in table_of_contents:
-          <tr class="toc-level-$toc.level">
-            <td class="toc-label">$toc.label</td>
-              $if ocaid and toc.pagenum.isdigit():
-                <td class="toc-title"><a href="//archive.org/stream/$ocaid#page/$toc.pagenum">$toc.title</a></td>
-              $else:
-                <td class="toc-title">$toc.title</td>
-              <td class="toc-pagenum">$toc.pagenum</td>
-          </tr>
-      </tbody>
-    </table>
+    <div class="toc">
+      <div class="toc-content restricted-view">
+        <h3 class="collapse">$_("Table of Contents")</h3>
+        <table class="meta sansserif" id="toc-table">
+          <tbody>
+            $for toc in table_of_contents:
+              <tr class="toc-level-$toc.level">
+                <td class="toc-label">$toc.label</td>
+                  $if ocaid and toc.pagenum.isdigit():
+                    <td class="toc-title"><a href="//archive.org/stream/$ocaid#page/$toc.pagenum">$toc.title</a></td>
+                  $else:
+                    <td class="toc-title">$toc.title</td>
+                  <td class="toc-pagenum">$toc.pagenum</td>
+              </tr>
+          </tbody>
+        </table>
+      </div>
+      $:macros.ReadMore('toc')
+    </div>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6171

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add "Read more" link below tables of content found on books pages.

### Technical
<!-- What should be noted about the implementation? -->
Added some `div`s to the table of contents template in order to satisfy class naming conventions used by the read more JS.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![toc_collapse](https://user-images.githubusercontent.com/28732543/159361710-d98023fe-6a75-4bbc-b911-38573992282c.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
