### PR TITLE
Initialize clampers independently

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -196,9 +196,18 @@ jQuery(function () {
             .then(module => module.initRealTimeValidation());
     }
     // conditionally load readmore button based on class in the page
-    if (document.getElementsByClassName('read-more-button').length) {
+    const readMoreButtons = document.getElementsByClassName('read-more-button');
+    const clampers = document.getElementsByClassName('clamp');
+    if (readMoreButtons.length || clampers.length) {
         import(/* webpackChunkName: "readmore" */ './readmore.js')
-            .then(module => module.initReadMoreButton());
+            .then(module => {
+                if (readMoreButtons.length) {
+                    module.initReadMoreButton();
+                }
+                if (clampers.length) {
+                    module.initClampers();
+                }
+            });
     }
     // conditionally loads Goodreads import based on class in the page
     if (document.getElementsByClassName('import-table').length) {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -1,20 +1,4 @@
 export function initReadMoreButton() {
-    /*
-      Clamper shows used to show more/less by toggling `hidden`
-      style on parent .clamp tag
-     */
-    $('.clamp').on('click', function(){
-        const up = $(this);
-        if (up.hasClass('clamp')) {
-            up.css({display: up.css('display') === '-webkit-box' ? 'unset' : '-webkit-box'});
-
-            if (up.attr('data-before') === '+ ') {
-                up.attr('data-before', '- ')
-            } else {
-                up.attr('data-before', '+ ')
-            }
-        }
-    });
     $('.read-more-button').on('click',function(){
         const up = $(this).parent().parent();
         $(`.${up.attr('class')}-content`).removeClass('restricted-height', 300);
@@ -32,6 +16,25 @@ export function initReadMoreButton() {
             $(`.${$(this).parent().attr('class')}.read-more`).addClass('hidden');
         } else {
             $(this).addClass('restricted-height');
+        }
+    });
+}
+
+export function initClampers() {
+    /*
+      Clamper shows used to show more/less by toggling `hidden`
+      style on parent .clamp tag
+     */
+    $('.clamp').on('click', function(){
+        const up = $(this);
+        if (up.hasClass('clamp')) {
+            up.css({display: up.css('display') === '-webkit-box' ? 'unset' : '-webkit-box'});
+
+            if (up.attr('data-before') === '+ ') {
+                up.attr('data-before', '- ')
+            } else {
+                up.attr('data-before', '+ ')
+            }
         }
     });
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Solves issue where subject clamper functionality is only imported when there is a "Read more" link on the page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
