### PR TITLE
Add subject clamping conditionally

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "static/build/readmore.*.js",
-      "maxSize": "1KB"
+      "maxSize": "2KB"
     },
     {
       "path": "static/build/modal-links.*.js",

--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -3,7 +3,7 @@ $def with(work, tags=[])
 $def render_subjects(label, subjects, track_value, prefix=""):
   $if subjects:
     <div class="section link-box">
-      <span class="clamp" data-before="	&#9656; ">
+      <span class="clamp" data-before="&#9656; ">
       <h6>$label</h6>
         $for subject in subjects:
           <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track_value">$subject</a>$cond(not loop.last, ",", "")

--- a/openlibrary/macros/SubjectTags.html
+++ b/openlibrary/macros/SubjectTags.html
@@ -3,7 +3,7 @@ $def with(work, tags=[])
 $def render_subjects(label, subjects, track_value, prefix=""):
   $if subjects:
     <div class="section link-box">
-      <span class="clamp" data-before="+ ">
+      <span class="clamp" data-before="	&#9656; ">
       <h6>$label</h6>
         $for subject in subjects:
           <a href="/subjects/$prefix$utf8(subject.lower().replace(' ', '_').replace(',', '').replace('/', ''))" data-ol-link-track="$track_value">$subject</a>$cond(not loop.last, ",", "")

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -197,7 +197,7 @@ jQuery(function () {
     }
     // conditionally load readmore button based on class in the page
     const readMoreButtons = document.getElementsByClassName('read-more-button');
-    const clampers = document.getElementsByClassName('clamp');
+    const clampers = document.querySelectorAll('.clamp');
     if (readMoreButtons.length || clampers.length) {
         import(/* webpackChunkName: "readmore" */ './readmore.js')
             .then(module => {
@@ -205,7 +205,7 @@ jQuery(function () {
                     module.initReadMoreButton();
                 }
                 if (clampers.length) {
-                    module.initClampers();
+                    module.initClampers(clampers);
                 }
             });
     }

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -20,21 +20,27 @@ export function initReadMoreButton() {
     });
 }
 
-export function initClampers() {
-    /*
-      Clamper shows used to show more/less by toggling `hidden`
-      style on parent .clamp tag
-     */
-    $('.clamp').on('click', function(){
-        const up = $(this);
-        if (up.hasClass('clamp')) {
-            up.css({display: up.css('display') === '-webkit-box' ? 'unset' : '-webkit-box'});
+export function initClampers(clampers) {
+    for (const clamper of clampers) {
+        if (clamper.clientHeight === clamper.scrollHeight) {
+            clamper.classList.remove('clamp')
+        } else {
+            /*
+                Clamper shows used to show more/less by toggling `hidden`
+                style on parent .clamp tag
+            */
+            $(clamper).on('click', function() {
+                const up = $(this);
+                if (up.hasClass('clamp')) {
+                    up.css({display: up.css('display') === '-webkit-box' ? 'unset' : '-webkit-box'});
 
-            if (up.attr('data-before') === '+ ') {
-                up.attr('data-before', '- ')
-            } else {
-                up.attr('data-before', '+ ')
-            }
+                    if (up.attr('data-before') === '\u25BE ') {
+                        up.attr('data-before', '\u25B8 ')
+                    } else {
+                        up.attr('data-before', '\u25BE ')
+                    }
+                }
+            })
         }
-    });
+    }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes clamper symbols from "+" and "-" to a small right-pointing triangle and a small down-pointing arrow, respectively.

Only adds clamp symbol and click listener if the content is able to be clamped.

Blocked until #6323 is merged. Alternatively, this can be merged into the `books-page-integration` branch.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![clampers](https://user-images.githubusercontent.com/28732543/159765634-8d85dbed-3bfa-499d-8cb8-73eba24feab3.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
