### PR TITLE
[oldump] Fix oldumpsort location

### DIFF
--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -152,10 +152,10 @@ then
 
   if [[ ! -f $(compgen -G "ol_dump_*_$yymm*.txt.gz") ]]
   then
-      mkdir -p $TMPDIR/../oldumpsort
+      mkdir -p $TMPDIR/oldumpsort
       echo "splitting the dump: ol_dump_%s_$yymmdd.txt.gz -- takes approx. 85 minutes for 68,000,000+ records..."
       time gzip -cd $dump.txt.gz | python $SCRIPTS/oldump.py split --format ol_dump_%s_$yymmdd.txt.gz
-      rm -rf $TMPDIR/../oldumpsort
+      rm -rf $TMPDIR/oldumpsort
   else
       echo "Skipping $(compgen -G "ol_dump_*_$yymm*.txt.gz")"
   fi


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This folder exists in the tmpdir not in the parent of the tmpdir.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Ran the full data dump job as part of #6306 and it worked!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
