### PR TITLE
Fix incorrect selected element in navbar on fast scroll

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/index.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/index.js
@@ -16,6 +16,8 @@ export function initNavbar(navbarElem) {
     /**
      * The targets of the navbar links.
      *
+     * Elements are ordered from highest position on the page to lowest.
+     *
      * @type {Array<HTMLElement>}
      */
     const linkedSections = []
@@ -61,24 +63,11 @@ export function initNavbar(navbarElem) {
 
     // Add scroll listener that changes 'selected' navbar item based on page position:
     document.addEventListener('scroll', function() {
-        const navbarBoundingRect = navbarElem.getBoundingClientRect()
-        const selectedBoundingRect = selectedSection.getBoundingClientRect();
-
-        // Check if navbar is not within selected element's bounds:
-        if (selectedBoundingRect.bottom < navbarBoundingRect.top ||
-            selectedBoundingRect.top > navbarBoundingRect.bottom) {
-            for (let i = 0; i < linkedSections.length; ++i) {
-                // Do not do bounds check on selected item:
-                if (linkedSections[i].id !== selectedSection.id) {
-                    const br = linkedSections[i].getBoundingClientRect()
-
-                    // If navbar overlaps with an unselected target section, select that section:
-                    if (br.top <= navbarBoundingRect.bottom && br.bottom >= navbarBoundingRect.bottom) {
-                        selectElement(listItems[i], i)
-                        break;
-                    }
-                }
-            }
+        let i = linkedSections.length
+        // Find index of lowest element on the page that is positioned below the navbar:
+        while (--i > 0 && navbarElem.offsetTop < linkedSections[i].offsetTop) {}
+        if (linkedSections[i] !== selectedSection) {
+            selectElement(listItems[i], i)
         }
     })
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects issue where position-aware navbar is not updating properly when the page is quickly scrolled.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![superb_scrolling](https://user-images.githubusercontent.com/28732543/159817396-5c940a24-3e62-44f2-8955-6c24d933bc02.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
