### PR TITLE
Added resolve_edition_author_redirects function

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -169,6 +169,7 @@ class AuthorMergeEngine(BasicMergeEngine):
             },
             'docs': docs,
         }
+        docs = resolve_edition_author_redirects(docs)
 
         result = web.ctx.site.save_many(
             docs,
@@ -201,6 +202,20 @@ class AuthorMergeEngine(BasicMergeEngine):
 
 
 re_whitespace = re.compile(r'\s+')
+
+
+def resolve_edition_author_redirects(docs):
+    """
+    Finds the editions in a set of docs, checks if any of their author values
+    resolve to redirects, and replaces those redirects with the resolved value.
+    """
+    for doc in docs:
+        if doc['type']['key'] == '/type/edition' and 'authors' in doc:
+            for author in doc['authors']:
+                thing = web.ctx.site.get(author['key'])
+                if thing.type.key == '/type/redirect':
+                    author['key'] = thing.location
+    return docs
 
 
 def space_squash_and_strip(s):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5594

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Resolves the periodic failure of author merges caused by author redirect entries in edition records.

### Technical
I've added a new function, resolve_edition_author_redirects() that is called before the set of docs involved in an author merge is sent to InfoBase for saving. It finds the editions in the set of docs, checks if any of their author values resolve to redirects, and replaces those redirects with the resolved location.

I was able to reproduce the Alexandre Dumas fils merge failure (https://openlibrary.org/authors/merge?key=OL3745151A&key=OL9158169A) in development by manually adding the offending author redirect value to the JSON in the appropriate data table row.  This fix successfully corrects that record during merging and allows the merge to complete.

### Testing
Try it on some of the failing merges listed in this issue.

### Stakeholders
@mheiman @cdrini 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
