### PR TITLE
Use correct archive.org URL

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -239,7 +239,7 @@ $if is_privileged_user:
               $if ocaid:
                 <div class="edition-omniline-item">
                  <div>Internet Archive</div>
-                  <span><a href="https://www.archive.org/details/$ocaid">$ocaid</a></span>
+                  <span><a href="https://archive.org/details/$ocaid">$ocaid</a></span>
                 </div>
 
               $ edition_identifiers = edition.get_identifiers()


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents redirect by using the correct archive.org URL for above-fold OCAIDs.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
