### PR TITLE
api.py: vendors.search_amazon() is a stub function

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -25,9 +25,8 @@ from openlibrary.core.observations import Observations, get_observation_metrics
 from openlibrary.core.models import Booknotes, Work
 from openlibrary.core.sponsorships import qualifies_for_sponsorship
 from openlibrary.core.vendors import (
-    get_amazon_metadata,
     create_edition_from_amazon_metadata,
-    search_amazon,
+    get_amazon_metadata,
     get_betterworldbooks_metadata,
 )
 
@@ -395,34 +394,6 @@ class author_works(delegate.page):
             links['next'] = web.changequery(offset=offset + limit)
 
         return {"links": links, "size": size, "entries": works}
-
-
-class amazon_search_api(delegate.page):
-    """Librarian + admin only endpoint to check for books
-    available on Amazon via the Product Advertising API
-    ItemSearch operation.
-
-    https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
-
-    Currently experimental to explore what data is available to affiliates.
-
-    :return: JSON {"results": []} containing Amazon product metadata
-             for items matching the title and author search parameters.
-    :rtype: str
-    """
-
-    path = '/_tools/amazon_search'
-
-    @jsonapi
-    def GET(self):
-        user = accounts.get_current_user()
-        if not (user and (user.is_admin() or user.is_librarian())):
-            return web.HTTPError('403 Forbidden')
-        i = web.input(title='', author='')
-        if not (i.author or i.title):
-            return json.dumps({'error': 'author or title required'})
-        results = search_amazon(title=i.title, author=i.author)
-        return json.dumps(results)
 
 
 class sponsorship_eligibility_check(delegate.page):


### PR DESCRIPTION
```
def search_amazon(title='', author=''):
    pass
```
https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/openlibrary/api.py#L400-L425 -->
* https://github.com/internetarchive/openlibrary/blob/master/openlibrary/core/vendors.py#L283

<!-- What issue does this PR close? -->
See #2342
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
