### PR TITLE
Render edition lists only on edition pages

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -64,6 +64,7 @@ $if not edition:
 
 $# Just in case edition is not set, treat as work
 $ edition = edition or page
+$ is_editionless_work = edition.type != '/type/edition'
 
 $if not edition.get('availability'):
   $ edition['availability'] = edition.get('ocaid') and availabilities.get(edition['ocaid']) or {}
@@ -496,7 +497,7 @@ $if is_privileged_user:
                 $:render_template("lists/widget", work, include_header=False, include_widget=False)
                 $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
 
-              $if edition and edition.type != '/type/edition':
+              $if edition and is_editionless_work:
                 $ component_times['lists widget: EditionListTime'] = time()
                 $:render_template("lists/widget", edition, include_header=False, include_widget=False)
                 $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -10,7 +10,6 @@ $ tab = input(tab=None).tab
 $ editions = []
 $ page_type = page.key.split('/')[1]
 $ show_observations = True
-$ is_work_page = page.key.startswith('/works')
 
 $if page.key.startswith('/works'):
   $ work = page
@@ -497,7 +496,7 @@ $if is_privileged_user:
                 $:render_template("lists/widget", work, include_header=False, include_widget=False)
                 $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
 
-              $if edition and not is_work_page:
+              $if edition and edition.type != '/type/edition':
                 $ component_times['lists widget: EditionListTime'] = time()
                 $:render_template("lists/widget", edition, include_header=False, include_widget=False)
                 $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -10,6 +10,7 @@ $ tab = input(tab=None).tab
 $ editions = []
 $ page_type = page.key.split('/')[1]
 $ show_observations = True
+$ is_work_page = page.key.startswith('/works')
 
 $if page.key.startswith('/works'):
   $ work = page
@@ -496,7 +497,7 @@ $if is_privileged_user:
                 $:render_template("lists/widget", work, include_header=False, include_widget=False)
                 $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']
 
-              $if edition:
+              $if edition and not is_work_page:
                 $ component_times['lists widget: EditionListTime'] = time()
                 $:render_template("lists/widget", edition, include_header=False, include_widget=False)
                 $ component_times['lists widget: EditionListTime'] = time() - component_times['lists widget: EditionListTime']


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The books page "Lists containing this Book" section typically has two rows: The first displays lists that contain the work; the second, lists containing the editions.  On work pages, both of the rows are the same.

This PR removes the edition lists from work pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
