### PR TITLE
Ensure requested work edition fetched

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -18,9 +18,19 @@ class AbstractBookProvider:
     """
     identifier_key: str
 
+    def get_olids(self, identifier):
+        return web.ctx.site.things({
+            "type": "/type/edition",
+            self.db_selector: identifier
+        })
+
     @property
     def editions_query(self):
-        return {f"identifiers.{self.identifier_key}~": "*"}
+        return {f"{self.db_selector}~": "*"}
+
+    @property
+    def db_selector(self):
+        return f"identifiers.{self.identifier_key}"
 
     @property
     def solr_key(self):
@@ -72,8 +82,8 @@ class InternetArchiveProvider(AbstractBookProvider):
     identifier_key = 'ocaid'
 
     @property
-    def editions_query(self):
-        return {f"{self.identifier_key}~": "*"}
+    def db_selector(self):
+        return self.identifier_key
 
     @property
     def solr_key(self):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -719,10 +719,6 @@ class Work(models.Work):
             if 'openlibrary_edition' in availability[work_id]:
                 return '/books/%s' % availability[work_id]['openlibrary_edition']
 
-    @staticmethod
-    def get_olid_by_ocaid(ocaid):
-        return web.ctx.site.get(f"/books/ia:{ocaid}").location
-
     def get_sorted_editions(self, ebooks_only=False, covers_only=False, limit=None, keys=None):
         """
         Get this work's editions sorted by publication year

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -731,11 +731,10 @@ class Work(models.Work):
         :param list[str] keys: ensure keys included in fetched editions
         :rtype: list[Edition]
         """
-        edition_keys = keys or []
         db_query = {"type": "/type/edition", "works": self.key}
-        if limit:
-            db_query['limit'] = limit
+        db_query['limit'] = limit or 10000
 
+        edition_keys = []
         if ebooks_only:
             if self._solr_data:
                 from openlibrary.book_providers import get_book_providers
@@ -767,6 +766,7 @@ class Work(models.Work):
                 # given librarians are probably doing this, show all editions
                 edition_keys += web.ctx.site.things(db_query)
 
+        edition_keys.extend(keys or [])
         editions = web.ctx.site.get_many(list(set(edition_keys)))
         editions.sort(
             key=lambda ed: ed.get_publish_year() or -sys.maxsize, reverse=True

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -719,6 +719,10 @@ class Work(models.Work):
             if 'openlibrary_edition' in availability[work_id]:
                 return '/books/%s' % availability[work_id]['openlibrary_edition']
 
+    @staticmethod
+    def get_olid_by_ocaid(ocaid):
+        return web.ctx.site.get(f"/books/ia:{ocaid}").location
+
     def get_sorted_editions(self, ebooks_only=False, covers_only=False, limit=None, keys=None):
         """
         Get this work's editions sorted by publication year

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -719,7 +719,7 @@ class Work(models.Work):
             if 'openlibrary_edition' in availability[work_id]:
                 return '/books/%s' % availability[work_id]['openlibrary_edition']
 
-    def get_sorted_editions(self, ebooks_only=False, covers_only=False, limit=None, keys=None):
+    def get_sorted_editions(self, ebooks_only=False, limit=None, keys=None):
         """
         Get this work's editions sorted by publication year
         :param bool ebooks_only:
@@ -743,10 +743,6 @@ class Work(models.Work):
                     edition_keys += web.ctx.site.things(query)
             else:
                 db_query["ocaid~"] = "*"
-        elif limit and covers_only:
-            # if we're going to be picky and there's no ebooks
-            # try to favor editions with covers
-            db_query["covers_i~"] = "*"
 
         if not edition_keys:
             solr_is_up_to_date = (

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -24,6 +24,14 @@ $if page.key.startswith('/books'):
   $# We are on an editions page: an edition has been explicitly selected
   $ edition = page
 
+$ selected_provider = None
+$ selected_id = None
+$if query_param('edition'):
+  $if ':' in query_param('edition'):
+    $ [selected_provider, selected_id] = query_param('edition').split(':')
+  $else:
+    $ [selected_provider, selected_id] = ['ia', query_param('edition')]
+
 $ component_times['get_sorted_editions'] = time()
 
 $# Fetch a work's editions
@@ -36,8 +44,9 @@ $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
 $ editions_limit = None if not query_param('mode') else 10
 $if ebooks_only:
-  $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=edition and [edition.key])
-
+  $# key ensures the current edition we're on or requested edition are fetched by get_sorted_editions
+  $ keys = (edition and [edition.key]) or (selected_provider=="ia" and selected_id and [work.get_olid_by_ocaid(selected_id)])
+  $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=keys)
 $if not editions:
   $# use ebooks_only to determine whether to lazyload editions table
   $ ebooks_only = False
@@ -52,11 +61,7 @@ $# Choose an edition to render
 $if not edition:
   $# We're presumably on a work url
   $# edition selection strategy (e.g. language, by id, first w/ ocaid)
-  $if query_param('edition'):
-    $if ':' in query_param('edition'):
-      $ [selected_provider, selected_id] = query_param('edition').split(':')
-    $else:
-      $ [selected_provider, selected_id] = ['ia', query_param('edition')]
+  $if selected_provider and selected_id:
     $ provider = get_book_provider_by_name(selected_provider)
     $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), edition)
   $else:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -52,10 +52,6 @@ $if ebooks_only:
 $if not editions:
   $# use ebooks_only to determine whether to lazyload editions table
   $ ebooks_only = False
-  $# if there's a limit, attempt to choose books w/ covers
-  $ editions = work.get_sorted_editions(limit=editions_limit, covers_only=True, keys=keys)
-$if not editions:
-  $# if there weren't any editions with covers, just fetch what we have (edge case)
   $ editions = work.get_sorted_editions(limit=editions_limit, keys=keys)
 $ availabilities = {e.availability.get('identifier'): e.availability for e in editions}
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -38,19 +38,23 @@ $# Fetch a work's editions
 $# Used for loading the editions table
 $# Book availability of editions injected by bulk get_availability API
 $ edition_count = work.edition_count if work and work.edition_count else 1
-$ ebooks_only = query_param('mode') == 'ebooks' or (query_param('mode') != 'all' and edition_count > 10)
+$ ebooks_only = (query_param('mode') == 'ebooks') or (query_param('mode') != 'all' and edition_count > 10)
 
 $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
-$ editions_limit = None if not query_param('mode') else 10
+$ editions_limit = 10 if not query_param('mode') else None
+$# key ensures the current edition we're on or requested edition are fetched by get_sorted_editions
+$ keys = (edition and [edition.key]) or (selected_provider=="ia" and selected_id and [work.get_olid_by_ocaid(selected_id)])
 $if ebooks_only:
-  $# key ensures the current edition we're on or requested edition are fetched by get_sorted_editions
-  $ keys = (edition and [edition.key]) or (selected_provider=="ia" and selected_id and [work.get_olid_by_ocaid(selected_id)])
   $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=keys)
 $if not editions:
   $# use ebooks_only to determine whether to lazyload editions table
   $ ebooks_only = False
-  $ editions = work.get_sorted_editions(limit=editions_limit, covers_only=True)
+  $# if there's a limit, attempt to choose books w/ covers
+  $ editions = work.get_sorted_editions(limit=editions_limit, covers_only=True, keys=keys)
+$if not editions:
+  $# if there weren't any editions with covers, just fetch what we have (edge case)
+  $ editions = work.get_sorted_editions(limit=editions_limit, keys=keys)
 $ availabilities = {e.availability.get('identifier'): e.availability for e in editions}
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']
 
@@ -58,9 +62,10 @@ $# This collects which books are previewable in any manner
 $ previews = [e for e in editions if e.get('ocaid')]
 
 $# Choose an edition to render
-$if not edition:
+$if editions and not edition:
   $# We're presumably on a work url
   $# edition selection strategy (e.g. language, by id, first w/ ocaid)
+  $ edition = editions[0]
   $if selected_provider and selected_id:
     $ provider = get_book_provider_by_name(selected_provider)
     $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), edition)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -44,7 +44,7 @@ $ ebooks_only = (query_param('mode') == 'ebooks') or (query_param('mode') != 'al
 
 $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
-$ editions_limit = 10 if not query_param('mode') else None
+$ editions_limit = None if query_param('mode') in ['all', 'ebooks'] else 10
 $# key ensures the current edition we're on or requested edition are fetched by get_sorted_editions
 $ keys = (edition and [edition.key]) or (provider and provider.get_olids(selected_id))
 $if ebooks_only:
@@ -63,9 +63,8 @@ $# Choose an edition to render
 $if editions and not edition:
   $# We're presumably on a work url
   $# edition selection strategy (e.g. language, by id, first w/ ocaid)
-  $ edition = editions[0]
   $if provider:
-    $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), edition)
+    $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), editions[0])
   $else:
     $ edition, provider = get_best_edition(editions)
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -26,11 +26,13 @@ $if page.key.startswith('/books'):
 
 $ selected_provider = None
 $ selected_id = None
+$ provider = None
 $if query_param('edition'):
   $if ':' in query_param('edition'):
     $ [selected_provider, selected_id] = query_param('edition').split(':')
   $else:
     $ [selected_provider, selected_id] = ['ia', query_param('edition')]
+  $ provider = get_book_provider_by_name(selected_provider)
 
 $ component_times['get_sorted_editions'] = time()
 
@@ -44,7 +46,7 @@ $# For performance reasons, limit to 10 ebooks
 $# Tradeoff: limits our ability to select best edition
 $ editions_limit = 10 if not query_param('mode') else None
 $# key ensures the current edition we're on or requested edition are fetched by get_sorted_editions
-$ keys = (edition and [edition.key]) or (selected_provider=="ia" and selected_id and [work.get_olid_by_ocaid(selected_id)])
+$ keys = (edition and [edition.key]) or (provider and provider.get_olids(selected_id))
 $if ebooks_only:
   $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=keys)
 $if not editions:
@@ -66,8 +68,7 @@ $if editions and not edition:
   $# We're presumably on a work url
   $# edition selection strategy (e.g. language, by id, first w/ ocaid)
   $ edition = editions[0]
-  $if selected_provider and selected_id:
-    $ provider = get_book_provider_by_name(selected_provider)
+  $if provider:
     $ edition = next((e for e in editions if selected_id in provider.get_identifiers(e)), edition)
   $else:
     $ edition, provider = get_best_edition(editions)


### PR DESCRIPTION
Closes #6339 

The Books Page only requests a certain number of ebook editions by default when the work has more than e.g. 10 editions.

A problem occurs when a work edition is requested by url e.g. http://ol-dev1.us.archive.org:1337/works/OL17732W/Bible?edition=catholicyouthbib00wino but the corresponding edition with this edition identifier is not available / hasn't been fetched by get_sorted_editions (because of this limit).

As a result, a refactor was required which allows us to tell work.get_sorted_editions that we explicitly wish to include the aforementioned edition (having ocaid catholicyouthbib00wino) into the set of returned editions.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
