### PR TITLE
HOTFIX: correct 'identifiers'

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -828,7 +828,7 @@ def load(rec, account_key=None):
     # Add new identifiers
     if 'identifiers' in rec:
         identifiers = defaultdict(set, e.get('identifiers', {}))
-        for k, vals in rec.identifiers:
+        for k, vals in rec['identifiers']:
             identifiers[k].update(vals)
         if e.get('identifiers') != identifiers:
             e['identifiers'] = {k: list(vals) for k, vals in identifiers.items()}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes the following error on re-importing from a bulk MARC record:

```
<class 'AttributeError'> at /api/import/ia
'dict' object has no attribute 'identifiers'
Python	/openlibrary/openlibrary/catalog/add_book/__init__.py in load, line 830
Web	POST https://openlibrary.org/api/import/ia
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
