### PR TITLE
Misc books page fixes

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -337,7 +337,6 @@ $if is_privileged_user:
             <p>"$(edition.first_sentence)"</p>
             </div>
 
-        $if edition:
           $ component_times['TableOfContents'] = time()
           $:macros.TableOfContents(edition, ocaid)
           $ component_times['TableOfContents'] = time() - component_times['TableOfContents']

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -243,15 +243,16 @@ $if is_privileged_user:
                 </div>
 
               $ edition_identifiers = edition.get_identifiers()
-              $ isbn = None
+              $ isbns = []
               $if 'isbn_13' in edition_identifiers.keys():
-                $ isbn = edition_identifiers['isbn_13']['value']
-              $elif 'isbn_10' in edition_identifiers.keys():
-                $ isbn = edition_identifiers['isbn_10']['value']
-              $if isbn:
+                $ isbns.append(edition_identifiers['isbn_13']['value'])
+              $if 'isbn_10' in edition_identifiers.keys():
+                $ isbns.append(edition_identifiers['isbn_10']['value'])
+              $if isbns:
                 <div class="edition-omniline-item">
-                  <div>ISBN</div>
-                  <span>$isbn</span>
+                  <div>ISBNs</div>
+                  $for isbn in isbns:
+                    <span>$isbn</span>
                 </div>
           </div>
       </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -81,7 +81,7 @@ $var title: $title
 
 $code:
     def has_any(*keys):
-        return any(page[k] for k in keys)
+        return any(edition[k] for k in keys)
 
 $code:
     def get_description(book):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects the following book page issues:
1. Physical object data not present in work pages, even if best-fit edition has this data.
2. Some ISBNs missing from the omniline
3. Book Details component has needless `edition` check.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![physical_object_on_work_page](https://user-images.githubusercontent.com/28732543/160718219-b1f91516-7e34-4e45-b210-91d6b6636a7d.png)

_Physical object data now present in book details._

![multiple_isbns_in_omniline](https://user-images.githubusercontent.com/28732543/160718212-221be43f-0c31-43f9-b760-d6d4a8b337f5.png)

_All ISBNs listed in omniline._

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
