### PR TITLE
Fix `readonline_carousel()` if any book has no `is_readable` attribute

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -774,7 +774,7 @@ def readonline_carousel():
         data = random_ebooks()
         if len(data) > 30:
             data = lending.add_availability(random.sample(data, 30))
-            data = [d for d in data if d['availability']['is_readable']]
+            data = [d for d in data if d['availability'].get('is_readable')]
         return storify(data)
 
     except Exception:


### PR DESCRIPTION
According to Sentry, `home.readonline_carousel()` has returned `None` at least 33k times because one of the books does not have an `.is_readable` attribute.  https://sentry.archive.org/organizations/ia-ux/issues/24173 (2nd most common issue)

This PR would not store and return books that do not have `.is_readable` attribute but would allow other books which are readable to be stored and returned to the caller.

<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/organizations/ia-ux/issues/24173

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
