### PR TITLE
Fix wrong keys data dump + internal ID field in dumps

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -266,17 +266,13 @@ def make_bsddb(dbfile, dump_file):
 
 
 def _process_key(key):
-    mapping = (
-        "/l/",
-        "/languages/",
-        "/a/",
-        "/authors/",
-        "/b/",
-        "/books/",
-        "/user/",
-        "/people/",
-    )
-    for old, new in web.group(mapping, 2):
+    mapping = {
+        "/l/": "/languages/",
+        "/a/": "/authors/",
+        "/b/": "/books/",
+        "/user/": "/people/",
+    }
+    for old, new in mapping.items():
         if key.startswith(old):
             return new + key[len(old) :]
     return key

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -30,17 +30,14 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
 
 
-def print_dump(json_records, filter=None):
+def print_dump(json_records, filter=None, print=print):
     """Print the given json_records in the dump format."""
-    for i, json_data in enumerate(json_records):
+    for i, raw_json_data in enumerate(json_records):
         if i % 1_000_000 == 0:
             log(f"{i:,}")
-        d = json.loads(json_data)
+        d = json.loads(raw_json_data)
         d.pop("id", None)
         d = _process_data(d)
-
-        if filter and filter(d) is False:
-            continue
 
         key = web.safestr(d["key"])
 
@@ -53,8 +50,12 @@ def print_dump(json_records, filter=None):
         if key.startswith(("/b/", "/scan", "/old/")) or not key.startswith("/"):
             continue
 
+        if filter and filter(d) is False:
+            continue
+
         type_key = d["type"]["key"]
         timestamp = d["last_modified"]["value"]
+        json_data = json.dumps(d)
 
         print("\t".join([type_key, key, str(d["revision"]), timestamp, json_data]))
 

--- a/openlibrary/tests/data/dump.py
+++ b/openlibrary/tests/data/dump.py
@@ -1,0 +1,61 @@
+import json
+
+from openlibrary.data.dump import print_dump
+
+
+class SpyPrint:
+    def __init__(self):
+        self.output = []
+
+    def __call__(self, msg: str):
+        self.output.append(msg)
+
+
+class TestPrintDump:
+    def test_fixes_prefixes(self):
+        records = [
+            {
+                "key": "/b/OL1M",
+                "type": {"key": "/type/edition"},
+                "revision": 1,
+                "last_modified": {"value": "2019-01-01T00:00:00.000"},
+            },
+        ]
+        spy_print = SpyPrint()
+
+        print_dump(map(json.dumps, records), print=spy_print)
+        assert spy_print.output == [
+            "\t".join([
+                "/type/edition",
+                "/books/OL1M",
+                "1",
+                "2019-01-01T00:00:00.000",
+                json.dumps({
+                    "key": "/books/OL1M",
+                    "type": {"key": "/type/edition"},
+                    "revision": 1,
+                    "last_modified": {"value": "2019-01-01T00:00:00.000"},
+                }),
+            ]),
+        ]
+
+    def test_excludes_sensitive_pages(self):
+        records = [
+            {"key": "/people/foo"},
+            {"key": "/user/foo"},
+            {"key": "/admin/foo"},
+        ]
+        spy_print = SpyPrint()
+
+        print_dump(map(json.dumps, records), print=spy_print)
+        assert spy_print.output == []
+
+    def test_excludes_obsolete_pages(self):
+        records = [
+            {"key": "/scan_record/foo"},
+            {"key": "/old/what"},
+        ]
+        spy_print = SpyPrint()
+
+        print_dump(map(json.dumps, records), print=spy_print)
+        assert spy_print.output == []


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6348 

* Partially revert https://github.com/internetarchive/openlibrary/commit/9403742e7a7509b2b0cb9aad24727e39a7850fae to make sure the process records is json.dumps and printed.
* Place filter in the righter ordering from https://github.com/internetarchive/openlibrary/commit/9403742e7a7509b2b0cb9aad24727e39a7850fae
* Add unit tests!


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- [x] Kick off full data dump

```sh
curl -L 'https://archive.org/download/ol_dump_2022-03-29/ol_dump_authors_2022-03-29.txt.gz' | zcat | grep -F '/a/' | head -n1
/type/author      /authors/OL6725672A     2       2009-09-08T12:14:54.827520     {"bio": {"type": "/type/text", "value": "Translator to English of [Astrid Lindgren](/a/OL24950A)'s <i>Pippi Longstocking</i> (from Swedish) and works by [Knut Hamsun](/a/OL41785A) (from Norwegian)."}, "name": "Gerry Bothmer", "created": {"type": "/type/datetime", "value": "2009-09-08T12:12:46.444934"}, "last_modified": {"type": "/type/datetime", "value": "2009-09-08T12:14:54.827520"}, "latest_revision": 2, "key": "/authors/OL6725672A", "type": {"key": "/type/author"}, "revision": 2}
```

One match in the description -- all good!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
