### PR TITLE
Fix for adding identifiers, correct modified / matched status

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -827,11 +827,12 @@ def load(rec, account_key=None):
 
     # Add new identifiers
     if 'identifiers' in rec:
-        identifiers = defaultdict(set, e.get('identifiers', {}))
+        identifiers = defaultdict(list, e.dict().get('identifiers', {}))
         for k, vals in rec['identifiers'].items():
-            identifiers[k].update(vals)
-        if e.get('identifiers') != identifiers:
-            e['identifiers'] = {k: list(vals) for k, vals in identifiers.items()}
+            identifiers[k].extend(vals)
+            identifiers[k] = list(set(identifiers[k]))
+        if e.dict().get('identifiers') != identifiers:
+            e['identifiers'] = identifiers
             need_edition_save = True
 
     edits = []

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -828,7 +828,7 @@ def load(rec, account_key=None):
     # Add new identifiers
     if 'identifiers' in rec:
         identifiers = defaultdict(set, e.get('identifiers', {}))
-        for k, vals in rec['identifiers']:
+        for k, vals in rec['identifiers'].items():
             identifiers[k].update(vals)
         if e.get('identifiers') != identifiers:
             e['identifiers'] = {k: list(vals) for k, vals in identifiers.items()}


### PR DESCRIPTION
Apologies @mekarpeles , this needs one more fix.

The Edition model was hiding the raw `identifiers` dict, it looks like `Edition.dict().get('identifiers')` is the most reliable way to get the raw identifiers.


`Edition.get_identifiers()`  combines other values, and `Edition.identifiers` is always `None`.  

I have tested this locally now after getting the Docker images back up.

For matching, modifying, and creating new records from https://archive.org/details/marc_dnb_202006 MARC records.
