### PR TITLE
com2ann: Convert Python type comments to type hints

### DIFF
--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -2,7 +2,7 @@ import infogami
 from infogami.utils import delegate
 from openlibrary.utils.sentry import Sentry
 
-sentry = None  # type: Sentry
+sentry: Sentry = None
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 import infogami
 from infogami.utils import delegate
 from openlibrary.utils.sentry import Sentry
 
-sentry: Sentry = None
+sentry: Optional[Sentry] = None
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -7,6 +7,7 @@ import re
 import sys
 import time
 import traceback
+from typing import Optional
 
 from infogami.utils.app import find_page, find_view, find_mode
 from openlibrary.core import stats as graphite_stats
@@ -177,8 +178,8 @@ def _get_top_level_path_for_metric(full_path):
 
 class GraphiteRequestStats:
     def __init__(self):
-        self.start: float = None
-        self.end: float = None
+        self.start: Optional[float] = None
+        self.end: Optional[float] = None
         self.state = None  # oneof 'started', 'completed'
         self.method = 'unknown'
         self.path_page_name = 'unknown'

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -177,8 +177,8 @@ def _get_top_level_path_for_metric(full_path):
 
 class GraphiteRequestStats:
     def __init__(self):
-        self.start = None  # type: float
-        self.end = None  # type: float
+        self.start: float = None
+        self.end: float = None
         self.state = None  # oneof 'started', 'completed'
         self.method = 'unknown'
         self.path_page_name = 'unknown'

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -265,7 +265,7 @@ class account_create(delegate.page):
         )
 
     def POST(self):
-        f = self.get_form()  # type: forms.RegisterForm
+        f: forms.RegisterForm = self.get_form()
 
         if f.validates(web.input()):
             try:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Use [`com2ann -v 9 .`](https://pypi.org/project/com2ann) to convert Python type comments into type hints.  Avoid changes to `solr` code which uses Cython.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
