### PR TITLE
Handle newlines in tag editing

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -723,7 +723,7 @@ class SaveBookHelper:
             """
             if not subjects:
                 return
-            f = six.StringIO(subjects)
+            f = six.StringIO(subjects.replace('\r\n',''))
             dedup = set()
             for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
                 if s.lower() not in dedup:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6346

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the problem of line breaks in tag fields (subjects/places/times/people) causing items after the line break to be lost.

### Technical
I had hoped that the csv.py library being used to parse tag data would have a configuration option to ignore line breaks, but the documentation indicates that the reader() method explicitly ignores attempts to redefine line breaks (which is what caused the bug in the first place).

Failing that, the best solution seemed to be to just strip out any line breaks immediately before parsing. I tested on both Mac and Windows to verify that the form is sending \r\n regardless of platform.

### Testing
Edit a work subject list, adding a line break between entries. They should now all save correctly.

### Stakeholders
@seabelis @cdrini @mekarpeles 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
