### PR TITLE
Show multiple of each type of ISBN in omniline

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -251,10 +251,10 @@ $if is_privileged_user:
 
               $ edition_identifiers = edition.get_identifiers()
               $ isbns = []
-              $if 'isbn_13' in edition_identifiers.keys():
-                $ isbns.append(edition_identifiers['isbn_13']['value'])
-              $if 'isbn_10' in edition_identifiers.keys():
-                $ isbns.append(edition_identifiers['isbn_10']['value'])
+              $for name, values in edition_identifiers.multi_items():
+                $if name in ["isbn_10", "isbn_13"]:
+                  $for value in values:
+                    $isbns.append(value['value'])
               $if isbns:
                 <div class="edition-omniline-item">
                   <div>ISBNs</div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The previous means of getting ISBNs for the books page omniline only gets the first ISBN 10 and ISBN 13 if multiples exist for either.  This PR ensures that all ISBNs are displayed in the omniline.

### Technical
<!-- What should be noted about the implementation? -->
The new code is modeled after the `display_identifiers` function, which is used to display IDs in the book details section of the page.  I'm assuming that the `openlib-` checks are not needed for ISBNs, and did not include them. __Please correct me if I'm wrong__.
https://github.com/internetarchive/openlibrary/blob/a112a9ee6b289ef12784d568446457e548118a30/openlibrary/templates/type/edition/view.html#L141-L159

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
