### PR TITLE
Allow dashes in list URL pattern

### DIFF
--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -33,7 +33,7 @@ class ReadableUrlProcessor:
         (r'/\w+/ia:[a-zA-Z0-9_\.-]+', '/type/edition', 'title', 'untitled'),
         (r'/\w+/OL\d+A', '/type/author', 'name', 'noname'),
         (r'/\w+/OL\d+W', '/type/work', 'title', 'untitled'),
-        (r'/[/\w]+/OL\d+L', '/type/list', 'name', 'unnamed'),
+        (r'/[/\w\-]+/OL\d+L', '/type/list', 'name', 'unnamed'),
     ]
 
     def __call__(self, handler):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I noticed that the readable URL processor wasn't handling lists of people with dashes in their usernames.  This causes list URLs that contain the human-readable list name slug to fail with a `404` if the list creator has a dash in their username.  Updating the list URL pattern has corrected this issue.

### Technical
<!-- What should be noted about the implementation? -->
The list pattern has been updated to allow dashes before the list OLID in the URL.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the following URLs:
  - Production: https://openlibrary.org/people/agent-lisa/lists/OL206833L/ala_challenged_2018_w
  - Testing: https://testing.openlibrary.org/people/agent-lisa/lists/OL206833L/ala_challenged_2018_w
2. Observe that the production link results in a `404`, while the testing link renders as expected.
3. Visit some of your own list pages. Ensure that they render properly, and that the human-readable slug is present in the URL.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
