### PR TITLE
Replace SpyPrint with capsys fixure

### DIFF
--- a/openlibrary/tests/data/test_dump.py
+++ b/openlibrary/tests/data/test_dump.py
@@ -15,26 +15,18 @@ class TestPrintDump:
         ]
 
         print_dump(map(json.dumps, records))
-        assert (
-            capsys.readouterr().out
-            == "\t".join(
-                [
-                    "/type/edition",
-                    "/books/OL1M",
-                    "1",
-                    "2019-01-01T00:00:00.000",
-                    json.dumps(
-                        {
-                            "key": "/books/OL1M",
-                            "type": {"key": "/type/edition"},
-                            "revision": 1,
-                            "last_modified": {"value": "2019-01-01T00:00:00.000"},
-                        }
-                    ),
-                ]
-            )
-            + "\n"
-        )
+        assert capsys.readouterr().out.strip() == "\t".join([
+            "/type/edition",
+            "/books/OL1M",
+            "1",
+            "2019-01-01T00:00:00.000",
+            json.dumps({
+                "key": "/books/OL1M",
+                "type": {"key": "/type/edition"},
+                "revision": 1,
+                "last_modified": {"value": "2019-01-01T00:00:00.000"},
+            }),
+        ])
 
     def test_excludes_sensitive_pages(self, capsys):
         records = [

--- a/openlibrary/tests/data/test_dump.py
+++ b/openlibrary/tests/data/test_dump.py
@@ -3,16 +3,8 @@ import json
 from openlibrary.data.dump import print_dump
 
 
-class SpyPrint:
-    def __init__(self):
-        self.output = []
-
-    def __call__(self, msg: str):
-        self.output.append(msg)
-
-
 class TestPrintDump:
-    def test_fixes_prefixes(self):
+    def test_fixes_prefixes(self, capsys):
         records = [
             {
                 "key": "/b/OL1M",
@@ -21,41 +13,43 @@ class TestPrintDump:
                 "last_modified": {"value": "2019-01-01T00:00:00.000"},
             },
         ]
-        spy_print = SpyPrint()
 
-        print_dump(map(json.dumps, records), print=spy_print)
-        assert spy_print.output == [
-            "\t".join([
-                "/type/edition",
-                "/books/OL1M",
-                "1",
-                "2019-01-01T00:00:00.000",
-                json.dumps({
-                    "key": "/books/OL1M",
-                    "type": {"key": "/type/edition"},
-                    "revision": 1,
-                    "last_modified": {"value": "2019-01-01T00:00:00.000"},
-                }),
-            ]),
-        ]
+        print_dump(map(json.dumps, records))
+        assert (
+            capsys.readouterr().out
+            == "\t".join(
+                [
+                    "/type/edition",
+                    "/books/OL1M",
+                    "1",
+                    "2019-01-01T00:00:00.000",
+                    json.dumps(
+                        {
+                            "key": "/books/OL1M",
+                            "type": {"key": "/type/edition"},
+                            "revision": 1,
+                            "last_modified": {"value": "2019-01-01T00:00:00.000"},
+                        }
+                    ),
+                ]
+            )
+            + "\n"
+        )
 
-    def test_excludes_sensitive_pages(self):
+    def test_excludes_sensitive_pages(self, capsys):
         records = [
             {"key": "/people/foo"},
             {"key": "/user/foo"},
             {"key": "/admin/foo"},
         ]
-        spy_print = SpyPrint()
+        print_dump(map(json.dumps, records))
+        assert capsys.readouterr().out == ""
 
-        print_dump(map(json.dumps, records), print=spy_print)
-        assert spy_print.output == []
-
-    def test_excludes_obsolete_pages(self):
+    def test_excludes_obsolete_pages(self, capsys):
         records = [
             {"key": "/scan_record/foo"},
             {"key": "/old/what"},
         ]
-        spy_print = SpyPrint()
 
-        print_dump(map(json.dumps, records), print=spy_print)
-        assert spy_print.output == []
+        print_dump(map(json.dumps, records))
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
This uses a pytest fixture [capsys](https://docs.pytest.org/en/6.2.x/capture.html#accessing-captured-output-from-a-test-function)
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
These test should output the same results as the previous version
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
