### PR TITLE
Remove print argument in print_dump

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
 
 
-def print_dump(json_records, filter=None, print=print):
+def print_dump(json_records, filter=None):
     """Print the given json_records in the dump format."""
     for i, raw_json_data in enumerate(json_records):
         if i % 1_000_000 == 0:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
refactor

### Technical
<!-- What should be noted about the implementation? -->
print argument was used for tests, not really needed anymore
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This change shouldn't require testing
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
