### PR TITLE
Sticky title to top of books page

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -98,7 +98,7 @@
     },
     {
       "path": "static/build/page-plain.css",
-      "maxSize": "22KB"
+      "maxSize": "23KB"
     },
     {
       "path": "static/build/page-subject.css",

--- a/openlibrary/plugins/openlibrary/js/compact-title/index.js
+++ b/openlibrary/plugins/openlibrary/js/compact-title/index.js
@@ -74,6 +74,7 @@ function onScroll(navbar, title) {
             title.style.top = offscreenY
             title.classList.remove('compact-title--slidein')
             title.classList.add('compact-title--slideout')
+            $(title).one('animationend', () => title.classList.add('hidden'))
         }
     }
 }

--- a/openlibrary/plugins/openlibrary/js/compact-title/index.js
+++ b/openlibrary/plugins/openlibrary/js/compact-title/index.js
@@ -1,8 +1,49 @@
+/**
+ * Defines functions related to the compact title component.
+ * @module compact-title/index
+ */
+
+/**
+ * True if compact title component is visible on screen.
+ * @type {boolean}
+ */
 let isTitleVisible = false
 
+/**
+ * Navbar is "stuck" when it reaches this position on the Y-axis.
+ */
+const navbarStickyHeight = getTitleComponentHeight()
+
+/**
+ * Returns a number representing the compact title component's height.
+ *
+ * The compact title's height is fetched from a CSS variable.
+ *
+ * @returns {Number} The height of the compact title component.
+ */
+function getTitleComponentHeight() {
+    const titleHeightWithUnits =  getComputedStyle(document.body).getPropertyValue('--compact-title-height');
+
+    return Number(titleHeightWithUnits.replace(/\D/g,''))
+}
+
+/**
+ * Enables compact title component.
+ *
+ * The compact title component is initially hidden and off-screen.
+ * The component's visibility is dependant on the navbar's position
+ * on the page.
+ *
+ * This function sets up the scroll event listener and ensures that
+ * the compact title is visible if the navbar is initially stickied
+ * to the top of the page (this can happen on page refresh).
+ *
+ * @param {HTMLElement} navbar The book page navbar component
+ * @param {HTMLElement} title The compact title component
+ */
 export function initCompactTitle(navbar, title) {
     // Show compact title on page reload:
-    if (navbar.getBoundingClientRect().top === 35) {
+    if (navbar.getBoundingClientRect().top === navbarStickyHeight) {
         title.classList.remove('hidden')
         title.style.top = '0px'
         isTitleVisible = true
@@ -13,10 +54,19 @@ export function initCompactTitle(navbar, title) {
     })
 }
 
+/**
+ * Displays or hides compact title component based on navbar's position.
+ *
+ * Determines navbar's Y-axis position on the page.  Repositions compact
+ * title component if navbar becomes either "stuck" or "unstuck".
+ *
+ * @param {HTMLElement} navbar The book page navbar component
+ * @param {HTMLELement} title The compact title component
+ */
 function onScroll(navbar, title) {
     const navbarY = navbar.getBoundingClientRect().top;
 
-    if (navbarY === 35) {
+    if (navbarY === navbarStickyHeight) {
         if (title.classList.contains('hidden')) {
             title.classList.remove('hidden')
         }
@@ -29,7 +79,7 @@ function onScroll(navbar, title) {
     } else {
         if (isTitleVisible) {
             isTitleVisible = false
-            title.style.top = '-35px'
+            title.style.top = `-${navbarStickyHeight}px`
             title.classList.remove('compact-title--slidein')
             title.classList.add('compact-title--slideout')
         }

--- a/openlibrary/plugins/openlibrary/js/compact-title/index.js
+++ b/openlibrary/plugins/openlibrary/js/compact-title/index.js
@@ -1,0 +1,37 @@
+let isTitleVisible = false
+
+export function initCompactTitle(navbar, title) {
+    // Show compact title on page reload:
+    if (navbar.getBoundingClientRect().top === 35) {
+        title.classList.remove('hidden')
+        title.style.top = '0px'
+        isTitleVisible = true
+    }
+
+    window.addEventListener('scroll', function() {
+        onScroll(navbar, title)
+    })
+}
+
+function onScroll(navbar, title) {
+    const navbarY = navbar.getBoundingClientRect().top;
+
+    if (navbarY === 35) {
+        if (title.classList.contains('hidden')) {
+            title.classList.remove('hidden')
+        }
+        if (!isTitleVisible) {
+            isTitleVisible = true
+            title.style.top = '0px'
+            title.classList.remove('compact-title--slideout')
+            title.classList.add('compact-title--slidein')
+        }
+    } else {
+        if (isTitleVisible) {
+            isTitleVisible = false
+            title.style.top = '-35px'
+            title.classList.remove('compact-title--slidein')
+            title.classList.add('compact-title--slideout')
+        }
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/compact-title/index.js
+++ b/openlibrary/plugins/openlibrary/js/compact-title/index.js
@@ -12,20 +12,12 @@ let isTitleVisible = false
 /**
  * Navbar is "stuck" when it reaches this position on the Y-axis.
  */
-const navbarStickyHeight = getTitleComponentHeight()
+const navbarStickyHeight = 35;
 
 /**
- * Returns a number representing the compact title component's height.
- *
- * The compact title's height is fetched from a CSS variable.
- *
- * @returns {Number} The height of the compact title component.
+ * Offscreen "top" value of compact title.
  */
-function getTitleComponentHeight() {
-    const titleHeightWithUnits =  getComputedStyle(document.body).getPropertyValue('--compact-title-height');
-
-    return Number(titleHeightWithUnits.replace(/\D/g,''))
-}
+const offscreenY = '-45px';
 
 /**
  * Enables compact title component.
@@ -79,7 +71,7 @@ function onScroll(navbar, title) {
     } else {
         if (isTitleVisible) {
             isTitleVisible = false
-            title.style.top = `-${navbarStickyHeight}px`
+            title.style.top = offscreenY
             title.classList.remove('compact-title--slidein')
             title.classList.add('compact-title--slideout')
         }

--- a/openlibrary/plugins/openlibrary/js/compact-title/index.js
+++ b/openlibrary/plugins/openlibrary/js/compact-title/index.js
@@ -15,11 +15,6 @@ let isTitleVisible = false
 const navbarStickyHeight = 35;
 
 /**
- * Offscreen "top" value of compact title.
- */
-const offscreenY = '-45px';
-
-/**
  * Enables compact title component.
  *
  * The compact title component is initially hidden and off-screen.
@@ -35,15 +30,11 @@ const offscreenY = '-45px';
  */
 export function initCompactTitle(navbar, title) {
     // Show compact title on page reload:
-    if (navbar.getBoundingClientRect().top === navbarStickyHeight) {
-        title.classList.remove('hidden')
-        title.style.top = '0px'
-        isTitleVisible = true
-    }
-
+    onScroll(navbar, title);
+    // And update on scroll
     window.addEventListener('scroll', function() {
         onScroll(navbar, title)
-    })
+    });
 }
 
 /**
@@ -53,10 +44,11 @@ export function initCompactTitle(navbar, title) {
  * title component if navbar becomes either "stuck" or "unstuck".
  *
  * @param {HTMLElement} navbar The book page navbar component
- * @param {HTMLELement} title The compact title component
+ * @param {HTMLElement} title The compact title component
  */
 function onScroll(navbar, title) {
     const navbarY = navbar.getBoundingClientRect().top;
+    const $titleChildren = $(title).children();
 
     if (navbarY === navbarStickyHeight) {
         if (title.classList.contains('hidden')) {
@@ -64,17 +56,16 @@ function onScroll(navbar, title) {
         }
         if (!isTitleVisible) {
             isTitleVisible = true
-            title.style.top = '0px'
-            title.classList.remove('compact-title--slideout')
-            title.classList.add('compact-title--slidein')
+            $titleChildren
+                .addClass('compact-title--slidein')
+                .one('animationend', () => $titleChildren.removeClass('compact-title--slidein'));
         }
     } else {
         if (isTitleVisible) {
             isTitleVisible = false
-            title.style.top = offscreenY
-            title.classList.remove('compact-title--slidein')
-            title.classList.add('compact-title--slideout')
-            $(title).one('animationend', () => title.classList.add('hidden'))
+            $(title)
+                .addClass('compact-title--slideout')
+                .one('animationend', () => $(title).addClass('hidden').removeClass('compact-title--slideout'));
         }
     }
 }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -368,7 +368,12 @@ jQuery(function () {
 
     const navbar = document.querySelector('.work-menu');
     if (navbar) {
+        const compactTitle = document.querySelector('.compact-title')
+        // Add position-aware navbar JS:
         import(/* webpackChunkName: "nav-bar" */ './edition-nav-bar')
             .then((module) => module.initNavbar(navbar));
+        // Add sticky title component animations:
+        import(/* webpackChunkName: "compact-title" */ './compact-title')
+            .then((module) => module.initCompactTitle(navbar, compactTitle))
     }
 });

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -31,9 +31,21 @@ $def with (page)
     $ style = 'build/page-%s.css'%ctx.get('cssfile', 'user')
     <link href="$static_url(style)" rel="stylesheet" type="text/css" />
 
-    <!-- Don't hide content with clamp if no js to show more/less -->
     <noscript>
-      <style>.clamp { -webkit-line-clamp: unset !important; }</style>
+      <style>
+        /* Don't hide content with clamp if no js to show more/less */
+        .clamp {
+          -webkit-line-clamp: unset !important;
+        }
+
+        /* @width-breakpoint-tablet media query: */
+        @media only screen and (min-width: 768px) {
+          /* Sticky navbar to top of screen if compact title cannot be stickied */
+          .work-menu {
+            top: 0 !important;
+          }
+        }
+      </style>
     </noscript>
  <script>
 

--- a/openlibrary/templates/type/edition/book_title.html
+++ b/openlibrary/templates/type/edition/book_title.html
@@ -1,6 +1,4 @@
-$def with (work, edition)
-
-$ book_title = edition.get('title', '') or (work.title if work else '')
+$def with (book_title, edition)
 
 <h1 class="work-title" itemprop="name">$book_title</h1>
 

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -2,8 +2,8 @@ $def with (book_title, edit_url)
 
 <div class="compact-title hidden">
   <span class="compact-title__heading">$book_title</span>
-  <div class="editButton">
-    <a class="linkButton linkButton--compact" href="$edit_url" title="$_('Edit this template')"
+  <div class="compact-title__edit-btn">
+    <a class="linkButton linkButton--large" href="$edit_url" title="$_('Edit this template')"
       data-ol-link-track="CTAClick|StickyEdit">$_("Edit")</a>
   </div>
 </div>

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -1,0 +1,30 @@
+$def with (work, edition, page)
+
+$ book_title = edition.get('title', '') or (work.title if work else '')
+
+$if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
+  $if edition and page.type.key in ["/type/work"]:
+    $ edit_url = edition.url(suffix="/edit")
+  $else:
+    $ edit_url = page.url(suffix="/edit")
+$else:
+  $ edit_url = page.key + "?m=edit"
+
+
+<div class="compact-title hidden">
+  <h1 class="work-title" itemprop="name">$book_title</h1>
+  <div class="editButton" id="sticky-edit">
+    <a class="linkButton" href="$edit_url" title="$_('Edit this template')"
+      data-ol-link-track="CTAClick|StickyEdit">$_("Edit")</a>
+  </div>
+
+  $if edition:
+    $if edition.subtitle:
+      <h2 class="work-subtitle">
+        $edition.subtitle
+      </h2>
+    $if edition.edition_name:
+      <div class="work-line">
+        $edition.edition_name
+      </div>
+</div>

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -1,6 +1,4 @@
-$def with (work, edition, page)
-
-$ book_title = edition.get('title', '') or (work.title if work else '')
+$def with (book_title, edition, page)
 
 $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
   $if edition and page.type.key in ["/type/work"]:

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -1,12 +1,4 @@
-$def with (book_title, edition, page)
-
-$if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
-  $if edition and page.type.key in ["/type/work"]:
-    $ edit_url = edition.url(suffix="/edit")
-  $else:
-    $ edit_url = page.url(suffix="/edit")
-$else:
-  $ edit_url = page.key + "?m=edit"
+$def with (book_title, edit_url)
 
 <div class="compact-title hidden">
   <span class="compact-title__heading">$book_title</span>

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -10,21 +10,10 @@ $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
 $else:
   $ edit_url = page.key + "?m=edit"
 
-
 <div class="compact-title hidden">
-  <h1 class="work-title" itemprop="name">$book_title</h1>
-  <div class="editButton" id="sticky-edit">
-    <a class="linkButton" href="$edit_url" title="$_('Edit this template')"
+  <span class="compact-title__heading">$book_title</span>
+  <div class="editButton">
+    <a class="linkButton linkButton--compact" href="$edit_url" title="$_('Edit this template')"
       data-ol-link-track="CTAClick|StickyEdit">$_("Edit")</a>
   </div>
-
-  $if edition:
-    $if edition.subtitle:
-      <h2 class="work-subtitle">
-        $edition.subtitle
-      </h2>
-    $if edition.edition_name:
-      <div class="work-line">
-        $edition.edition_name
-      </div>
 </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -190,7 +190,14 @@ $if is_privileged_user:
       </div>
 
       $ book_title = edition.get('title', '') or (work.title if work else '')
-      $:render_template("type/edition/compact_title", book_title, edition, page)
+      $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
+        $if edition and page.type.key in ["/type/work"]:
+          $ edit_url = edition.url(suffix="/edit")
+        $else:
+          $ edit_url = page.url(suffix="/edit")
+      $else:
+        $ edit_url = page.key + "?m=edit"
+      $:render_template("type/edition/compact_title", book_title, edit_url)
       $:render_template("type/edition/book_title", book_title, edition)
 
       $ authors = (work or edition).get_authors()
@@ -314,19 +321,6 @@ $if is_privileged_user:
 
       <a id="details" name="details" class="section-anchor"></a>
       <div class="tab-section edition-info">
-        $if not page.is_fake_record():
-          $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
-            $if edition and page.type.key in ["/type/work"]:
-                $ edit_url = edition.url(suffix="/edit")
-            $else:
-                $ edit_url = page.url(suffix="/edit")
-          $else:
-            $ edit_url = page.key + "?m=edit"
-          <div class="editButton">
-            <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
-            <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
-              data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
-          </div>
         $if edition:
           <h2 class="details-title" itemprop="name">$_("Book Details")</h2>
           <hr>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -189,6 +189,7 @@ $if is_privileged_user:
             </span>
       </div>
 
+      $:render_template("type/edition/compact_title", work, edition, page)
       $:render_template("type/edition/book_title", work, edition)
 
       $ authors = (work or edition).get_authors()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -189,8 +189,9 @@ $if is_privileged_user:
             </span>
       </div>
 
-      $:render_template("type/edition/compact_title", work, edition, page)
-      $:render_template("type/edition/book_title", work, edition)
+      $ book_title = edition.get('title', '') or (work.title if work else '')
+      $:render_template("type/edition/compact_title", book_title, edition, page)
+      $:render_template("type/edition/book_title", book_title, edition)
 
       $ authors = (work or edition).get_authors()
       $ author_names = (work or edition).author_names

--- a/static/css/components/buttonLink.less
+++ b/static/css/components/buttonLink.less
@@ -16,5 +16,10 @@ a {
     text-decoration: none;
     color: @grey;
     border: 1px solid @mid-grey;
+
+    &--compact {
+      padding: 3px 6px;
+      font-size: 12px;
+    }
   }
 }

--- a/static/css/components/buttonLink.less
+++ b/static/css/components/buttonLink.less
@@ -16,10 +16,5 @@ a {
     text-decoration: none;
     color: @grey;
     border: 1px solid @mid-grey;
-
-    &--compact {
-      padding: 3px 6px;
-      font-size: 12px;
-    }
   }
 }

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -11,7 +11,7 @@
     align-items: baseline;
     z-index: @z-index-level-4;
     position: fixed;
-    top: @offscreen-position;
+    top: 0;
     height: @compact-title-height;
     // TODO: Magic 20px fixed in future PR
     width: calc(100% - 20px);
@@ -37,10 +37,7 @@
 
     @keyframes slidein {
       from {
-        top: @offscreen-position;
-      }
-      to {
-        top: 0;
+        transform: translateY(@offscreen-position);
       }
     }
 
@@ -50,12 +47,8 @@
     }
 
     @keyframes slideout {
-      from {
-        top: 0;
-      }
-
       to {
-        top: @offscreen-position;
+        transform: translateY(@offscreen-position);
       }
     }
   }

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -8,16 +8,17 @@
     background: @white;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: baseline;
     z-index: @z-index-level-4;
     position: fixed;
     top: @offscreen-position;
     height: @compact-title-height;
-    width: 100%;
+    // TODO: Magic 20px fixed in future PR
+    width: calc(100% - 20px);
     padding: 0 14px;
 
     &__edit-btn {
-      transform: translate(-27px, 5px);
+      transform: translateY(6px);
     }
 
     &__heading {
@@ -60,12 +61,9 @@
   }
 }
 
-@media only screen and (min-width: @test-body-mobile-width) {
+@media only screen and (min-width: @width-breakpoint-desktop) {
   .compact-title {
+    width: calc(100% - @sidebar-width-with-margin);
     max-width: @desktop-title-max-width;
-
-    &__edit-btn {
-      transform: translate(0, 5px);
-    }
   }
 }

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -3,7 +3,7 @@
 @offscreen-position: -45px;
 @desktop-title-max-width: @test-body-mobile-width - @sidebar-width-with-margin;
 
-@media screen and (min-width: @width-breakpoint-tablet) {
+@media screen and (min-width: (@width-breakpoint-tablet + 1px)) {
   .compact-title {
     background: @white;
     display: flex;

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -1,0 +1,52 @@
+@import "../less/font-families.less";
+
+.compact-title {
+  background: @white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: @z-index-level-3;
+  position: fixed;
+  top: -35px;
+  height: var(--compact-title-height);
+  width: 100%;
+  max-width: calc(var(--test-body-mobile-width) - var(--sidebar-width-with-margin));
+
+  &__heading {
+    font-size: 1.25em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: @georgia_serif-1;
+    font-weight: 600;
+  }
+
+  &--slidein {
+    animation-duration: .75s;
+    animation-name: slidein;
+  }
+
+  @keyframes slidein {
+    from {
+      top: calc(-1 * var(--compact-title-height));
+    }
+    to {
+      top: 0;
+    }
+  }
+
+  &--slideout {
+    animation-duration: .25s;
+    animation-name: slideout;
+  }
+
+  @keyframes slideout {
+    from {
+      top: 0;
+    }
+
+    to {
+      top: calc(-1 * var(--compact-title-height));
+    }
+  }
+}

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -1,52 +1,71 @@
 @import "../less/font-families.less";
 
-.compact-title {
-  background: @white;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  z-index: @z-index-level-3;
-  position: fixed;
-  top: calc(-1 * var(--compact-title-height));
-  height: var(--compact-title-height);
-  width: 100%;
-  max-width: calc(var(--test-body-mobile-width) - var(--sidebar-width-with-margin));
+@offscreen-position: -45px;
+@desktop-title-max-width: @test-body-mobile-width - @sidebar-width-with-margin;
 
-  &__heading {
-    font-size: 1.25em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-family: @georgia_serif-1;
-    font-weight: 600;
-  }
+@media screen and (min-width: @width-breakpoint-tablet) {
+  .compact-title {
+    background: @white;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: @z-index-level-4;
+    position: fixed;
+    top: @offscreen-position;
+    height: @compact-title-height;
+    width: 100%;
+    padding: 0 14px;
 
-  &--slidein {
-    animation-duration: .75s;
-    animation-name: slidein;
-  }
-
-  @keyframes slidein {
-    from {
-      top: calc(-1 * var(--compact-title-height));
-    }
-    to {
-      top: 0;
-    }
-  }
-
-  &--slideout {
-    animation-duration: .25s;
-    animation-name: slideout;
-  }
-
-  @keyframes slideout {
-    from {
-      top: 0;
+    &__edit-btn {
+      transform: translate(-27px, 5px);
     }
 
-    to {
-      top: calc(-1 * var(--compact-title-height));
+    &__heading {
+      font-size: 1.25em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-family: @georgia_serif-1;
+      font-weight: 600;
+    }
+
+    &--slidein {
+      animation-duration: .5s;
+      animation-name: slidein;
+    }
+
+    @keyframes slidein {
+      from {
+        top: @offscreen-position;
+      }
+      to {
+        top: 0;
+      }
+    }
+
+    &--slideout {
+      animation-duration: .15s;
+      animation-name: slideout;
+    }
+
+    @keyframes slideout {
+      from {
+        top: 0;
+      }
+
+      to {
+        top: @offscreen-position;
+      }
+    }
+  }
+}
+
+@media only screen and (min-width: @test-body-mobile-width) {
+  .compact-title {
+    max-width: @desktop-title-max-width;
+
+    &__edit-btn {
+      transform: translate(0, 5px);
     }
   }
 }

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -7,7 +7,7 @@
   align-items: center;
   z-index: @z-index-level-3;
   position: fixed;
-  top: -35px;
+  top: calc(-1 * var(--compact-title-height));
   height: var(--compact-title-height);
   width: 100%;
   max-width: calc(var(--test-body-mobile-width) - var(--sidebar-width-with-margin));

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -6,6 +6,7 @@
 .readers-stats {
   color: @grey;
   font-size: .9em;
+  margin-bottom: 20px;
   li {
     list-style-type: none;
     display: inline-block;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -56,67 +56,6 @@ div.editionAbout {
   margin-bottom: 0;
 }
 
-.compact-title {
-  background: @white;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  z-index: @z-index-level-3;
-  position: fixed;
-  top: -35px;
-  height: var(--compact-title-height);
-  width: 100%;
-  max-width: calc(var(--test-body-mobile-width) - var(--sidebar-width-with-margin));
-
-  h1 {
-    font-size: 1.25em;
-    background: @white;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  div {
-    display: unset;
-    background: @white;
-    max-height: var(--compact-title-height);
-  }
-
-  .linkButton {
-    padding: 3px 6px;
-    font-size: 12px;
-  }
-
-  &--slidein {
-    animation-duration: .75s;
-    animation-name: slidein;
-  }
-
-  @keyframes slidein {
-    from {
-      top: calc(-1 * var(--compact-title-height));
-    }
-    to {
-      top: 0;
-    }
-  }
-
-  &--slideout {
-    animation-duration: .25s;
-    animation-name: slideout;
-  }
-
-  @keyframes slideout {
-    from {
-      top: 0;
-    }
-
-    to {
-      top: calc(-1 * var(--compact-title-height));
-    }
-  }
-}
-
 .work-subtitle{
   margin-top: 0;
 }
@@ -410,4 +349,8 @@ div.editionTools {
   font-size: 1.2em;
   font-weight: normal;
   color: @link-blue;
+}
+
+@media only screen and (min-width: @width-breakpoint-tablet) {
+  @import (less) "components/compact-title.less";
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -171,6 +171,7 @@ h2.edition-byline {
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .work-menu.sticky {
     top: @compact-title-height;
+    padding-top: 2px;
   }
 }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -1,11 +1,9 @@
 @import (less) "base/dl.less";
 
-:root {
-  --sidebar-width: 225px;
-  --sidebar-width-with-margin: calc(60px + var(--sidebar-width));
-  --compact-title-height: 35px;
-  --test-body-mobile-width: 1060px;
-}
+@sidebar-width: 225px;
+@sidebar-width-with-margin: 60px + @sidebar-width;
+@compact-title-height: 35px;
+@test-body-mobile-width: 1060px;
 
 /* stylelint-disable no-descending-specificity */
 .workDetails {
@@ -157,7 +155,6 @@ h2.edition-byline {
   border-bottom: 1px solid @lighter-grey;
   padding-bottom: 5px;
   font-weight: bold;
-  margin-top: 20px;
 
   &.sticky {
     position: sticky;
@@ -173,7 +170,7 @@ h2.edition-byline {
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .work-menu.sticky {
-    top: var(--compact-title-height);
+    top: @compact-title-height;
   }
 }
 
@@ -244,7 +241,7 @@ div.editionTools {
   }
   div.edition {
     &Cover {
-      width: var(--sidebar-width);
+      width: @sidebar-width;
       margin-right: 1.5em;
       margin-bottom: 0;
     }
@@ -351,6 +348,4 @@ div.editionTools {
   color: @link-blue;
 }
 
-@media only screen and (min-width: @width-breakpoint-tablet) {
-  @import (less) "components/compact-title.less";
-}
+@import (less) "components/compact-title.less";

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -1,5 +1,12 @@
 @import (less) "base/dl.less";
 
+:root {
+  --sidebar-width: 225px;
+  --sidebar-width-with-margin: calc(60px + var(--sidebar-width));
+  --compact-title-height: 35px;
+  --test-body-mobile-width: 1060px;
+}
+
 /* stylelint-disable no-descending-specificity */
 .workDetails {
   padding: 20px 0;
@@ -47,6 +54,67 @@ div.editionAbout {
 .work-title{
   margin-top: 5px;
   margin-bottom: 0;
+}
+
+.compact-title {
+  background: @white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: @z-index-level-3;
+  position: fixed;
+  top: -35px;
+  height: var(--compact-title-height);
+  width: 100%;
+  max-width: calc(var(--test-body-mobile-width) - var(--sidebar-width-with-margin));
+
+  h1 {
+    font-size: 1.25em;
+    background: @white;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  div {
+    display: unset;
+    background: @white;
+    max-height: var(--compact-title-height);
+  }
+
+  .linkButton {
+    padding: 3px 6px;
+    font-size: 12px;
+  }
+
+  &--slidein {
+    animation-duration: .75s;
+    animation-name: slidein;
+  }
+
+  @keyframes slidein {
+    from {
+      top: calc(-1 * var(--compact-title-height));
+    }
+    to {
+      top: 0;
+    }
+  }
+
+  &--slideout {
+    animation-duration: .25s;
+    animation-name: slideout;
+  }
+
+  @keyframes slideout {
+    from {
+      top: 0;
+    }
+
+    to {
+      top: calc(-1 * var(--compact-title-height));
+    }
+  }
 }
 
 .work-subtitle{
@@ -166,7 +234,7 @@ h2.edition-byline {
 
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .work-menu.sticky {
-    top: 0;
+    top: var(--compact-title-height);
   }
 }
 
@@ -237,7 +305,7 @@ div.editionTools {
   }
   div.edition {
     &Cover {
-      width: 225px;
+      width: var(--sidebar-width);
       margin-right: 1.5em;
       margin-bottom: 0;
     }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates a compact version of the books page title component.  New component includes an edit button and smaller text.  Title text overflow is replaced by an ellipsis.

Compact title component slides in and out of place, dependent on the navbar's position on the Y-axis.  The navbar appears below the compact title.

__This change does not affect mobile views__

### Technical
<!-- What should be noted about the implementation? -->
This requires JS to determine when to display or hide the compact title component.  This JS is loaded if a navbar is detected on the current page.

Internal CSS has been added for `noscript` patrons to ensure that the navbar is positioned at the top of the page.

CSS variables are used to help with component layout.  The `calc` function was particularly handy for this, and Less surprisingly (to me) did not have an equivalent function.

A new Google Analytics event label, `StickyEdit` has been created for the edit button in the compact title component.  Please advise as to whether a new label is necessary for this (I'm curious, but it may not be useful).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While using a large screen device:
1. Navigate to a book page.
2. Scroll down until the compact title component becomes affixed to the top of the page.
3. Ensure that everything looks good, and that the edit button functions as expected.
4. Scroll up to the top of the page.  Ensure that the compact title component disappears, and that it does so in a reasonable way.
5. Disable JS, and ensure that there is no gap between the stickied navbar and the top of the page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-04-05 19-11-39](https://user-images.githubusercontent.com/28732543/161867213-1cce773f-6b95-410e-ac2a-a78af7928686.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
