### PR TITLE
Show list widget on subject pages

### DIFF
--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -7,6 +7,7 @@ $ edition_key = edition and edition.key
 
 $if ctx.user or not work_key:
   <div class="widget-add $:(not work_key and 'old-style-lists')">
+    <input type="hidden" name="user-key" value="$(user_key)" />
     <div class="dropit Tools">
       $if edition_key and not work_key:
         <div class="dropper on edition-page-lists-dropdown">
@@ -29,7 +30,6 @@ $if ctx.user or not work_key:
 
             <input type="hidden" name="action" value="$(action_value)"/>
             <input type="hidden" name="bookshelf_id" value="$(bookshelf_id_value)"/>
-            <input type="hidden" name="user-key" value="$(user_key)" />
             <input type="hidden" name="default-key" value="$(key)" />
 
             <button class="book-progress-btn want-to-read $(activated_status)" type="submit">

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -53,7 +53,7 @@ export function createList(userKey, data, success) {
 export function addToList(listKey, seed, success) {
     post({
         url: `${listKey}/seeds.json`,
-        data: { add: [ { key: seed } ] },
+        data: { add: [seed] },
         success: success
     });
 }
@@ -69,7 +69,7 @@ export function addToList(listKey, seed, success) {
 export function removeFromList(listKey, seed, success) {
     post({
         url: `${listKey}/seeds.json`,
-        data: { remove: [ { key: seed } ] },
+        data: { remove: [seed] },
         success: success
     });
 }

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -47,7 +47,7 @@ export function createList(userKey, data, success) {
  *
  * Executes given callback on success.
  * @param {string} listKey The list's key.
- * @param {string|object} seed The item being added to the list.
+ * @param {string|{ key: string }} seed The item being added to the list.
  * @param {function} success Callback to be executed on successful POST.
  */
 export function addToList(listKey, seed, success) {
@@ -63,7 +63,7 @@ export function addToList(listKey, seed, success) {
  *
  * Executes given callback on success.
  * @param {string} listKey The list's key.
- * @param {string|object} seed The item being removed from the list.
+ * @param {string|{ key: string }} seed The item being removed from the list.
  * @param {function} success Callback to be executed on successful POST.
  */
 export function removeFromList(listKey, seed, success) {

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -85,8 +85,10 @@ function addListClickListener(elem, parentDropper) {
         const seedIsSubject = hiddenKeyInput.value[0] !== '/'
         if (isWork) {
             seed = { key: hiddenWorkInput.value }
+        } else if (seedIsSubject) {
+            seed = hiddenKeyInput.value
         } else {
-            seed = seedIsSubject ? hiddenKeyInput.value : { key: hiddenKeyInput.value }
+            seed = { key: hiddenKeyInput.value }
         }
 
         const listKey = elem.dataset.listKey;

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -81,10 +81,12 @@ function addListClickListener(elem, parentDropper) {
         let seed;
         const isWork = workCheckBox && workCheckBox.checked
 
+        // Seed will be a string if it's type is 'subject'
         if (isWork) {
-            seed = hiddenWorkInput.value
+            seed = { key: hiddenWorkInput.value }
         } else {
-            seed = hiddenKeyInput.value
+            const seedIsSubject = hiddenKeyInput.value[0] !== '/'
+            seed = seedIsSubject ? hiddenKeyInput.value : { key: hiddenKeyInput.value }
         }
 
         const listKey = elem.dataset.listKey;
@@ -183,7 +185,7 @@ function addCreateListClickListener(button, parentDropper) {
             const data = {
                 name: websafe(nameField.value),
                 description: websafe(descriptionField.value),
-                seeds: [ { key: seed } ],
+                seeds: [seed],
             }
 
             const successCallback = function(listKey, listTitle) {
@@ -332,7 +334,11 @@ function addRemoveClickListener(elem) {
     const anchors = label.querySelectorAll('a');
     const listTitle = anchors[0].dataset.listTitle;
     const listKey = anchors[1].dataset.listKey;
-    const seed = label.querySelector('input[name=seed-key').value;
+    const type = label.querySelector('input[name=seed-type]').value;
+    const key = label.querySelector('input[name=seed-key]').value;
+
+    const seed = type === 'subject' ? key : { key: key }
+
     anchors[1].addEventListener('click', function(event) {
         event.preventDefault()
 

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -82,10 +82,10 @@ function addListClickListener(elem, parentDropper) {
         const isWork = workCheckBox && workCheckBox.checked
 
         // Seed will be a string if it's type is 'subject'
+        const seedIsSubject = hiddenKeyInput.value[0] !== '/'
         if (isWork) {
             seed = { key: hiddenWorkInput.value }
         } else {
-            const seedIsSubject = hiddenKeyInput.value[0] !== '/'
             seed = seedIsSubject ? hiddenKeyInput.value : { key: hiddenKeyInput.value }
         }
 
@@ -93,9 +93,10 @@ function addListClickListener(elem, parentDropper) {
 
         const successCallback = function() {
             if (!isWork) {
+                const seedKey = seedIsSubject ? seed : seed['key']
                 const listTitle = elem.innerText;
                 const listUrl = elem.dataset.listCoverUrl
-                const li = updateAlreadyList(listKey, listTitle, listUrl)
+                const li = updateAlreadyList(listKey, listTitle, listUrl, seedKey)
 
                 if (dropperLists.hasOwnProperty(listKey)) {
                     dropperLists[listKey].element.remove()
@@ -189,8 +190,9 @@ function addCreateListClickListener(button, parentDropper) {
             }
 
             const successCallback = function(listKey, listTitle) {
+                const seedKey = typeof seed === 'string' ? seed : seed['key']
                 // Add actionable item to view, map
-                const li = updateAlreadyList(listKey, listTitle, '/images/icons/avatar_book-sm.png')
+                const li = updateAlreadyList(listKey, listTitle, '/images/icons/avatar_book-sm.png', seedKey)
                 actionableItems[listKey] = [li]
             }
 
@@ -402,12 +404,13 @@ function updateDropperList(listKey, listTitle, coverUrl) {
  *
  * @returns {HTMLLIElement} The newly created list item element.
  */
-function updateAlreadyList(listKey, listTitle, coverUrl) {
+function updateAlreadyList(listKey, listTitle, coverUrl, seedKey) {
     const alreadyLists = document.querySelector('.already-lists');
     const splitKey = listKey.split('/')
     const userKey = `/${splitKey[1]}/${splitKey[2]}`
     const i18nInput = document.querySelector('input[name=list-i18n-strings]')
     const i18nStrings = JSON.parse(i18nInput.value)
+    const seedType = seedKey[0] !== '/' ? 'subject' : ''
 
     const itemMarkUp = `<span class="image">
           <a href="${listKey}"><img src="${coverUrl}" alt="${i18nStrings['cover_of']}${listTitle}" title="${i18nStrings['cover_of']}${listTitle}"/></a>
@@ -416,8 +419,8 @@ function updateAlreadyList(listKey, listTitle, coverUrl) {
             <span class="label">
                 <a href="${listKey}" data-list-title="${listTitle}" title="${i18nStrings['see_this_list']}">${listTitle}</a>
                 <input type="hidden" name="seed-title" value="${listTitle}"/>
-                <input type="hidden" name="seed-key" value="${listKey}"/>
-                <input type="hidden" name="seed-type" value="edition"/>
+                <input type="hidden" name="seed-key" value="${seedKey}"/>
+                <input type="hidden" name="seed-type" value="${seedType}"/>
                 <a href="${listKey}" class="remove-from-list red smaller arial plain" data-list-key="${listKey}" title="${i18nStrings['remove_from_list']}">[X]</a>
             </span>
             <span class="owner">${i18nStrings['from']} <a href="${userKey}">${i18nStrings['you']}</a></span>

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -401,6 +401,7 @@ function updateDropperList(listKey, listTitle, coverUrl) {
  * @param {string} listKey    The list's key, in the form of "/people/{username}/lists/{list OLID}"
  * @param {string} listTitle  The name of the list.
  * @param {string} coverUrl   Location of the list's cover image.
+ * @param {string} seedKey    The target seed's key.
  *
  * @returns {HTMLLIElement} The newly created list item element.
  */

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -83,9 +83,14 @@ $def show_list(list, user_key):
             <span class="label">
                 <a href="$list.key" data-list-title="$(list.name)" title="$_('See this list')">$list.name</a>
                 $if remove:
+                    $if seed_info['type'] == 'subject':
+                        $ seed_key = seed_info['seed']
+                    $else:
+                        $ seed_key = seed_info['seed']['key']
                     <input type="hidden" name="seed-title" value="$(seed_info['title'])"/>
-                    <input type="hidden" name="seed-key" value="$(seed_info['seed']['key'])"/>
+                    <input type="hidden" name="seed-key" value="$seed_key"/>
                     <input type="hidden" name="seed-type" value="$(seed_info['type'])"/>
+
                     <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-key="$list.key" title="$_('Remove from your list?')">[X]</a>
             </span>
             $if remove:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6374
Closes #6540

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Subject page list widgets were broken with PR #6338, which POSTs _all_ list changes in `{key: ${seedKey}}` format.  This works perfectly for every type but subjects, which are expected to be strings.

This PR remedies the issues with seed key formatting, ensures that the patron's user key is always available on pages with list widgets (if the patron is logged in), and corrects a separate bug that prevents newly added list items from being removed when using the `[X]` link in dynamically generated "Already list" list items.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit any subject page while logged in.
2. Create a new list.
3. Ensure that the subject is in the new list.
4. Refresh the subject page.  Ensure that the list widget is present and functional.
5. Remove the subject by clicking the `[X]` link.  Ensure that the subject is actually removed from your list on the list page.
6. Test adding and removing books and authors to and from a list.  Ensure that there are no regressions.
7. Follow the testing steps in #6338, ensuring that list history is working as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
