### PR TITLE
change url, avoid broken wrapper=false

### DIFF
--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -2,7 +2,7 @@ $def with (ocaid, linkback=True)
 $# :param str ocaid:
 <div class="cta-button-group">
   <a class="cta-btn cta-btn--shell cta-btn--preview"
-     data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
+     data-iframe-src="https://archive.org/embed/$ocaid"
      data-iframe-link="https://archive.org/details/$ocaid"
      data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview')</a>
 </div>


### PR DESCRIPTION
Presumably because of recent lending bar changes on petabox, previews using the ?wrapper=false syntax for inlibrary books appears to be broken (symptom is forever spinning).

This problem doesn't appear to exist when using the /embed syntax (see BWB). This PR converts from details to embed


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
