### PR TITLE
BUG: 6369 Add correct width to book covers with no image.

### DIFF
--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -22,6 +22,9 @@
     a {
       margin: auto;
     }
+    a {
+      width: 100%;
+    }
   }
 
   img.bookcover {

--- a/static/css/components/book.less
+++ b/static/css/components/book.less
@@ -21,8 +21,6 @@
     }
     a {
       margin: auto;
-    }
-    a {
       width: 100%;
     }
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6369

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[Fix]
This PR sets the width for books on the publisher page that _don't_ have a cover image.

### Technical
<!-- What should be noted about the implementation? -->
I updated the Less to set the width for anchor tags in the "book-cover" class to be a 100%.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-04-07 18-26-15](https://user-images.githubusercontent.com/348648/162330089-5143b846-50fc-4d67-bb7e-8ba17543a087.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
