### PR TITLE
6399/accessibility/fix not focusing login button

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -31,7 +31,7 @@ h1 {
   margin: 20px 0;
 }
 button {
-//deleted outline
+
 }
 body,
 p,

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -31,7 +31,7 @@ h1 {
   margin: 20px 0;
 }
 button {
-  outline: none;
+//deleted outline
 }
 body,
 p,


### PR DESCRIPTION
Closes #6399 

Accessibility
This pull request achieves fixing accessibility issues firstly in the Login page and other pages too. We noticed that the accessibility issue stated in  #6399 applies to more pages and not only the Login page. So we removed the outline attribute from the common.less file to fix the issue in all the pages.


### Technical
Removed the 
```
button{
outline : none
}
```
from the common.less file.

### Testing
Start from the top of the Login Page and using the tab button, while scrolling down, the login button does not get focus as it is supposed to. This applies to other pages to, such as the edit profile page.

### Screenshot
![image](https://user-images.githubusercontent.com/72794144/162578119-3dfdf571-c8b2-446a-9e92-c36cfc702309.png)  ![image](https://user-images.githubusercontent.com/72794144/162578144-9ceec8a9-b5a8-497a-a468-7d438128cb8a.png)



### Stakeholders
@mekarpeles 
@cdrini 

Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
