### PR TITLE
Fix Accesibility issues on the Login page concerning a button not getting focus

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -31,7 +31,7 @@ h1 {
   margin: 20px 0;
 }
 button {
-//deleted outline
+
 }
 body,
 p,

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -31,7 +31,7 @@ h1 {
   margin: 20px 0;
 }
 button {
-  outline: none;
+//deleted outline
 }
 body,
 p,

--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -30,9 +30,6 @@ td {
 h1 {
   margin: 20px 0;
 }
-button {
-
-}
 body,
 p,
 li {


### PR DESCRIPTION
Closes https://github.com/internetarchive/openlibrary/issues/6399

Accessibility
This pull request achieves fixing accessibility issues firstly in the Login page and other pages too. We noticed that the accessibility issue stated in #6399  applies to more pages and not only the Login page. So we removed the outline attribute from the common.less file to fix the issue in all the pages.

### Technical
Removed the
```
button {
outline : none
}
```

from the common.less file.

### Testing
Start from the top of the Login Page and using the tab button, while scrolling down, the login button does not get focus as it is supposed to. This applies to other pages to, such as the edit profile page.

### Screenshot

![image](https://user-images.githubusercontent.com/72794144/162578865-803d1959-d132-44d1-991b-b2a362076203.png)  ![image](https://user-images.githubusercontent.com/72794144/162578879-0cc5dca8-6986-4cc9-b84f-90d66a9b3375.png)



### Stakeholders
@mekarpeles
@cdrini

Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.