### PR TITLE
Hotfix nginx logrotate not working

### DIFF
--- a/docker/ol-nginx-start.sh
+++ b/docker/ol-nginx-start.sh
@@ -6,9 +6,10 @@ if [ -n "$CRONTAB_FILES" ] ; then
 fi
 
 # logrotate comes from olsystem which is volume mounted
-# logrotate requires files to be 644
+# logrotate requires files to be 644 and owned by root??? (WHAT)
 # expect conflicts writing to file
 chmod 644 /etc/logrotate.d/nginx
+chown root:root /etc/logrotate.d/nginx
 logrotate --verbose /etc/logrotate.d/nginx
 
 nginx -g "daemon off;"


### PR DESCRIPTION
The logrotate file has to be owned by root for some inexplicable reason. Fixes covers0 running out of storage on /1/

### Technical
<!-- What should be noted about the implementation? -->

### Testing
I ran the steps manually on the nginx container; after the chown, `logrotate --verbose -f /etc/logrotate.d/nginx` finally worked. It's still being weird, and storing all the logs in access.log (which are since Dec 2021) into `access.log-20220410.gz` but whatever; at least they're gzipping.

Haven't tested the full flow here of running it when the image is constructed, but I imagine it should work ok?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
