### PR TITLE
Fix "Previews available in:" sometimes displayed without any preview languages #6408 

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -265,14 +265,10 @@ $if is_privileged_user:
           </div>
       </div>
 
-      $ seen = set()
-      $if previews:
-        <p class="preview-languages">
-          $for e in previews:
-            $if len(e.languages)!=0:
-               Previews available in:
-               $break
-            $break
+      $ seen = set()      
+      $if previews and any([len(e.languages) for e in previews]):
+        <p class="preview-languages">         
+          Previews available in:            
           $for e in previews:
             $if e.languages[0].name not in seen:
               $ seen.add(e.languages[0].name)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -265,10 +265,10 @@ $if is_privileged_user:
           </div>
       </div>
 
-      $ seen = set()      
+      $ seen = set()
       $if previews and any([len(e.languages) for e in previews]):
-        <p class="preview-languages">         
-          Previews available in:            
+        <p class="preview-languages">
+          Previews available in:
           $for e in previews:
             $if e.languages[0].name not in seen:
               $ seen.add(e.languages[0].name)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -267,7 +267,11 @@ $if is_privileged_user:
       $ seen = set()
       $if previews:
         <p class="preview-languages">
-          Previews available in:
+          $for e in previews:             
+            $if len(e.languages)!=0:
+               Previews available in:
+               $break
+            $break
           $for e in previews:
             $if e.languages[0].name not in seen:
               $ seen.add(e.languages[0].name)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -267,7 +267,7 @@ $if is_privileged_user:
       $ seen = set()
       $if previews:
         <p class="preview-languages">
-          $for e in previews:             
+          $for e in previews:
             $if len(e.languages)!=0:
                Previews available in:
                $break


### PR DESCRIPTION
Made the caption "Previews available in:" appear only when they are available preview languages.

Closes #6408 

### Screenshot
![image](https://user-images.githubusercontent.com/72806587/162796162-4b086872-c6e8-45cb-b465-1af0b091a3e7.png)


### Stakeholders
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
