### PR TITLE
Add share icon

### DIFF
--- a/static/images/icons/share.svg
+++ b/static/images/icons/share.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="33.867mm" height="33.867mm" version="1.1" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg">
+ <g transform="matrix(.22222 0 0 .22222 11.271 11.254)">
+  <g fill-rule="evenodd" stroke-width=".79375">
+   <circle cx="-25.319" cy="25.559" r="25.4"/>
+   <circle cx="76.281" cy="-25.241" r="25.4"/>
+   <circle cx="76.281" cy="76.359" r="25.4"/>
+  </g>
+  <rect transform="rotate(-26.87)" x="-40.87" y="4.1481" width="119.75" height="15.875" stroke-width=".9104"/>
+  <rect transform="matrix(.89203 .45197 .45197 -.89203 0 0)" x="-17.719" y="-41.545" width="119.75" height="15.875" stroke-width=".9104"/>
+ </g>
+</svg>

--- a/static/images/icons/share.svg
+++ b/static/images/icons/share.svg
@@ -1,13 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="33.867mm" height="33.867mm" version="1.1" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg">
- <g transform="matrix(.22222 0 0 .22222 11.271 11.254)">
-  <g fill-rule="evenodd" stroke-width=".79375">
-   <circle cx="-25.319" cy="25.559" r="25.4"/>
-   <circle cx="76.281" cy="-25.241" r="25.4"/>
-   <circle cx="76.281" cy="76.359" r="25.4"/>
-  </g>
-  <rect transform="rotate(-26.87)" x="-40.87" y="4.1481" width="119.75" height="15.875" stroke-width=".9104"/>
-  <rect transform="matrix(.89203 .45197 .45197 -.89203 0 0)" x="-17.719" y="-41.545" width="119.75" height="15.875" stroke-width=".9104"/>
- </g>
-</svg>
+<?xml version="1.0" encoding="UTF-8"?><svg width="128.001" height="128.001" viewBox="0 0 33.867 33.867" xmlns="http://www.w3.org/2000/svg"><g><g fill-rule="evenodd" stroke-width=".794" transform="translate(11.271 11.254) scale(.22222)"><circle cx="-25.319" cy="25.559" r="25.4"/><circle cx="76.281" cy="-25.241" r="25.4"/><circle cx="76.281" cy="76.359" r="25.4"/></g><path transform="rotate(-26.87 29.191 -17.964) scale(.22222)" d="M-40.87 4.148H78.88V20.023H-40.87z"/><path transform="matrix(.19823 .10044 .10044 -.19823 11.271 11.254)" d="M-17.719-41.545H102.031V-25.67H-17.719z"/></g></svg>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In support of #4578

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a share icon to our static images.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![share](https://user-images.githubusercontent.com/28732543/162858488-9d592697-fefd-4dc8-bb88-73a17b673b43.svg)

### Stakeholders
<!-- @ tag stakeholders of this bug -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
