### PR TITLE
Override spam checks when adding or editing books

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -192,7 +192,7 @@ class addbook(delegate.page):
             _test="false",
         )
 
-        if spamcheck.is_spam(i):
+        if spamcheck.is_spam(i, allow_privileged_edits=True):
             return render_template(
                 "message.html", "Oops", 'Something went wrong. Please try again later.'
             )
@@ -837,7 +837,7 @@ class book_edit(delegate.page):
     def POST(self, key):
         i = web.input(v=None, _method="GET")
 
-        if spamcheck.is_spam():
+        if spamcheck.is_spam(allow_privileged_edits=True):
             return render_template(
                 "message.html", "Oops", 'Something went wrong. Please try again later.'
             )
@@ -907,7 +907,7 @@ class work_edit(delegate.page):
     def POST(self, key):
         i = web.input(v=None, _method="GET")
 
-        if spamcheck.is_spam():
+        if spamcheck.is_spam(allow_privileged_edits=True):
             return render_template(
                 "message.html", "Oops", 'Something went wrong. Please try again later.'
             )

--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -28,12 +28,16 @@ def _update_spam_doc(**kwargs):
     web.ctx.site.store["spamwords"] = doc
 
 
-def is_spam(i=None):
+def is_spam(i=None, allow_privileged_edits=False):
     user = web.ctx.site.get_user()
 
-    # Prevent deleted users from making edits.
-    if user and user.type.key == '/type/delete':
-        return True
+    if user:
+        # Allow admins and librarians to make edits:
+        if allow_privileged_edits and (user.is_admin() or user.is_librarian()):
+            return False
+        # Prevent deleted users from making edits:
+        if user.type.key == '/type/delete':
+            return True
 
     email = user and user.get_email() or ""
     if is_spam_email(email):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6363

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Spam checks for adding new books and editing works and editions are now skipped if the request was submitted by an admin or librarian.

Spam checks for creating new lists and updating patron profiles have not been affected.

### Technical
<!-- What should be noted about the implementation? -->
New boolean parameter `allow_privileged_edits` has been added to `is_spam()`.  If ever we want to bypass list and profile spam checks, we need only add the parameter to those `is_spam()` calls.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Test BAU functionality:
1. Log in as a non-privileged patron.
2. Attempt to add a book that contains a spam word in it's title.  Expect this to fail.
3. Navigate to a book page and click the edit button. Attempt to add a spam word to any edition field and submit the form.  This should fail.
4. Repeat step three, but add a spam word to a work field instead.  Expect this to fail.

Test new functionality:
1. Log in as an admin or librarian.
2. Repeat steps 2 through 4 in the "Test BAU functionality" section, above.  Expect each step to succeed, and ensure that they do.
3. Don't forget to delete the new book (if it is not real), and revert all edits (if they were not real edits).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
