### PR TITLE
Make `title` include all edition titles/subtitle so we can use it as default title search

### DIFF
--- a/openlibrary/config.py
+++ b/openlibrary/config.py
@@ -1,6 +1,7 @@
 """Utility for loading config file.
 """
 import os
+import sys
 import yaml
 import infogami
 from infogami import config
@@ -17,6 +18,9 @@ def load(config_file):
 
     WARNING: This function is deprecated, please use load_config instead.
     """
+    if 'pytest' in sys.modules:
+        # During pytest ensure we're not using like olsystem or something
+        assert config_file == 'conf/openlibrary.yml'
     # for historic reasons
     global runtime_config
     with open(config_file) as in_file:
@@ -28,6 +32,9 @@ def load_config(config_file):
 
     The loaded config will be available via infogami.config.
     """
+    if 'pytest' in sys.modules:
+        # During pytest ensure we're not using like olsystem or something
+        assert config_file == 'conf/openlibrary.yml'
     infogami.load_config(config_file)
     setup_infobase_config(config_file)
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -39,14 +39,6 @@ from openlibrary.utils.lcc import (
 
 logger = logging.getLogger("openlibrary.worksearch")
 
-if hasattr(config, 'plugin_worksearch'):
-    solr_select_url = (
-        config.plugin_worksearch.get('solr_base_url', 'localhost') + '/select'
-    )
-
-    default_spellcheck_count = config.plugin_worksearch.get('spellcheck_count', 10)
-
-
 ALL_FIELDS = [
     "key",
     "redirects",
@@ -177,6 +169,13 @@ re_subject_types = re.compile('^(places|times|people)/(.*)')
 re_olid = re.compile(r'^OL\d+([AMW])$')
 
 plurals = {f + 's': f for f in ('publisher', 'author')}
+
+if hasattr(config, 'plugin_worksearch'):
+    solr_select_url = (
+        config.plugin_worksearch.get('solr_base_url', 'localhost') + '/select'
+    )
+
+    default_spellcheck_count = config.plugin_worksearch.get('spellcheck_count', 10)
 
 
 @public

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -111,6 +111,8 @@ FIELD_NAME_MAP = {
     'editions': 'edition_count',
     'by': 'author_name',
     'publishers': 'publisher',
+    'subtitle': 'alternative_subtitle',
+    'work_subtitle': 'subtitle',
     # "Private" fields
     # This is private because we'll change it to a multi-valued field instead of a
     # plain string at the next opportunity, which will make it much more usable.

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -65,30 +65,30 @@ def test_sorted_work_editions():
 QUERY_PARSER_TESTS = {
     'No fields': ('query here', [{'field': 'text', 'value': 'query here'}]),
     'Author field': (
-        'title:food rules author:pollan',
+        'food rules author:pollan',
         [
-            {'field': 'title', 'value': 'food rules'},
+            {'field': 'text', 'value': 'food rules'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
     'Field aliases': (
         'title:food rules by:pollan',
         [
-            {'field': 'title', 'value': 'food rules'},
+            {'field': 'alternative_title', 'value': 'food rules'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
     'Fields are case-insensitive aliases': (
-        'title:food rules By:pollan',
+        'food rules By:pollan',
         [
-            {'field': 'title', 'value': 'food rules'},
+            {'field': 'text', 'value': 'food rules'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
     'Quotes': (
         'title:"food rules" author:pollan',
         [
-            {'field': 'title', 'value': '"food rules"'},
+            {'field': 'alternative_title', 'value': '"food rules"'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
@@ -96,7 +96,7 @@ QUERY_PARSER_TESTS = {
         'query here title:food rules author:pollan',
         [
             {'field': 'text', 'value': 'query here'},
-            {'field': 'title', 'value': 'food rules'},
+            {'field': 'alternative_title', 'value': 'food rules'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
@@ -109,7 +109,10 @@ QUERY_PARSER_TESTS = {
     'Colons in field': (
         'title:flatland:a romance of many dimensions',
         [
-            {'field': 'title', 'value': r'flatland\:a romance of many dimensions'},
+            {
+                'field': 'alternative_title',
+                'value': r'flatland\:a romance of many dimensions',
+            },
         ],
     ),
     'Operators': (
@@ -229,7 +232,7 @@ def test_build_q_list():
     }
     expect = (
         [
-            'title:((Holidays are Hell))',
+            'alternative_title:((Holidays are Hell))',
             'author_name:((Kim Harrison))',
             'OR',
             'author_name:((Lynsay Sands))',
@@ -237,7 +240,7 @@ def test_build_q_list():
         False,
     )
     query_fields = [
-        {'field': 'title', 'value': '(Holidays are Hell)'},
+        {'field': 'alternative_title', 'value': '(Holidays are Hell)'},
         {'field': 'author_name', 'value': '(Kim Harrison)'},
         {'op': 'OR'},
         {'field': 'author_name', 'value': '(Lynsay Sands)'},

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -7,7 +7,7 @@ from enum import IntEnum
 from json import JSONDecodeError
 from math import ceil
 from statistics import median
-from typing import Literal, List, Optional, cast, TypedDict, Any, Union
+from typing import Iterable, Literal, List, Optional, cast, TypedDict, Any, Union
 
 import httpx
 import requests
@@ -578,7 +578,7 @@ class SolrProcessor:
         add('title', w.get('title'))
         add('subtitle', w.get('subtitle'))
 
-        add_list("alternative_title", self.get_alternate_titles(w, editions))
+        add_list("alternative_title", self.get_alternate_titles((w, *editions)))
         add_list('alternative_subtitle', self.get_alternate_subtitles(w, editions))
 
         add('edition_count', len(editions))
@@ -657,24 +657,21 @@ class SolrProcessor:
 
         return d
 
-    def get_alternate_titles(self, w, editions):
-        """
-        Get titles from the editions as alternative titles.
-
-        :param dict w:
-        :param list[dict] editions:
-        :rtype: set[str]
-        """
+    @staticmethod
+    def get_alternate_titles(books: Iterable[dict]) -> set[str]:
+        """Get titles from the editions as alternative titles."""
         result = set()
-        for e in editions:
-            result.add(e.get('title'))
-            result.update(e.get('work_titles', []))
-            result.update(e.get('other_titles', []))
+        for bookish in books:
+            full_title = bookish.get('title')
+            if not full_title:
+                # None would've got in if any of the editions has no title.
+                continue
+            if bookish.get('subtitle'):
+                full_title += ': ' + bookish['subtitle']
+            result.add(full_title)
+            result.update(bookish.get('work_titles', []))
+            result.update(bookish.get('other_titles', []))
 
-        # Remove original title and None.
-        # None would've got in if any of the editions has no title.
-        result.discard(None)
-        result.discard(w.get('title'))
         return result
 
     def get_alternate_subtitles(self, w, editions):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -579,7 +579,7 @@ class SolrProcessor:
         add('subtitle', w.get('subtitle'))
 
         add_list("alternative_title", self.get_alternate_titles((w, *editions)))
-        add_list('alternative_subtitle', self.get_alternate_subtitles(w, editions))
+        add_list('alternative_subtitle', self.get_alternate_subtitles((w, *editions)))
 
         add('edition_count', len(editions))
 
@@ -674,20 +674,10 @@ class SolrProcessor:
 
         return result
 
-    def get_alternate_subtitles(self, w, editions):
-        """
-        Get subtitles from the editions as alternative titles.
-
-        :param dict w:
-        :param list[dict] editions:
-        :rtype: set[str]
-        """
-        subtitle = w.get('subtitle')
-        return {
-            e['subtitle']
-            for e in editions
-            if e.get('subtitle') and e['subtitle'] != subtitle
-        }
+    @staticmethod
+    def get_alternate_subtitles(books: Iterable[dict]) -> set[str]:
+        """Get subtitles from the editions as alternative titles."""
+        return {bookish['subtitle'] for bookish in books if bookish.get('subtitle')}
 
     def get_isbns(self, editions):
         """

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -6,8 +6,8 @@ from openlibrary.core import fulltext
 
 
 class Test_fulltext_search_api:
-    def test_config(self):
-        assert not hasattr(config, "plugin_inside")
+    def test_no_config(self, monkeypatch):
+        monkeypatch.delattr(config, "plugin_inside")
         response = fulltext.fulltext_search_api({})
         assert response == {"error": "Unable to prepare search engine"}
 

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -347,6 +347,18 @@ class Test_build_data:
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
+    def test_get_alternate_titles(self):
+        f = SolrProcessor.get_alternate_titles
+
+        no_title = {}
+        only_title = {'title': 'foo'}
+        with_subtitle = {'title': 'foo 2', 'subtitle': 'bar'}
+
+        assert f([]) == set()
+        assert f([no_title]) == set()
+        assert f([only_title, no_title]) == {'foo'}
+        assert f([with_subtitle, only_title]) == {'foo 2: bar', 'foo'}
+
     @pytest.mark.asyncio
     async def test_with_multiple_editions(self):
         w = make_work()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6422 . Closes #2355 (after a full reindex). Closes #6256 . 

Observable changes right now:
- `subtitle:` field in search queries will now search all edition subtitles
- `work_subtitle:` field in search queries will search only the work subtitle

Observable changes after full reindex:
- `title` field will search across all edition titles and subtitles
- `work_title:` field will search only work title

### Technical
- I was debating whether keeping subtitles out of `alternative_title` might be best to avoid noise in search results... We could potentially make title map to something like `alternative_title:$q^10 OR alternative_subtitle:$q`... I think we'll just have to compare results after the next reindex to see if they're better.
- I was also concerned with duplicating the subtitle data in `alternative_title` made sense... but hopefully shouldn't be too much duplication.
- Debating whether to delete `subtitle:` entirely... I don't think it's a very common usecase. And you can do such searches using the query.json endpoint....

### Testing
Testing searching locally; things work.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
