### PR TITLE
refactors + adds sidebar to account settings

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -155,6 +155,10 @@ class readinglog_stats(delegate.page):
             lang=web.ctx.lang,
         )
 
+@public
+def get_public_patron_account(username):
+    user = web.ctx.site.get('/people/%s' % username)
+    return ReadingLog(user=user)
 
 class MyBooksTemplate:
     # Reading log shelves
@@ -286,6 +290,23 @@ class ReadingLog:
     @property
     def lists(self):
         return self.user.get_lists()
+
+    @property
+    def sponsorship_counts(self):
+        return {
+            'sponsorships': len(get_sponsored_editions(self.user))
+        }
+
+    @property
+    def booknotes_counts(self):
+        return PatronBooknotes.get_counts(self.user.get_username())
+
+    @property
+    def get_sidebar_counts(self):
+        counts = self.reading_log_counts
+        counts.update(self.sponsorship_counts)
+        counts.update(self.booknotes_counts)
+        return counts
 
     @property
     def reading_log_counts(self):

--- a/openlibrary/templates/account.html
+++ b/openlibrary/templates/account.html
@@ -2,24 +2,29 @@ $def with (user)
 
 $var title: $_("Settings")
 
-<div id="contentHead">
-    <div class="small sansserif grey account-settings-menu">
-      <a href="$ctx.user.key">$ctx.user.displayname</a>
-      &raquo; $_("Settings")
+<div class="mybooks">
+  $:render_template("account/sidebar", user, key="settings", owners_page=True)
+  <div>
+    <div id="contentHead">
+      <div class="small sansserif grey account-settings-menu">
+	<a href="$ctx.user.key">$ctx.user.displayname</a>
+	&raquo; $_("Settings")
+      </div>
     </div>
 
-<div id="contentBody">
-    <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Change Password")</a></p>
-    <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Update Email Address")</a></p>
-    <p class="sansserif larger"><a href="/account/notifications">$_("Your Notifications")</a></p>
-    <p class="sansserif larger"><a href="//archive.org/account/index.php?settings=1">$_("Internet Archive Announcements")</a></p>
-    <p class="sansserif larger"><a href="/account/privacy">$_("Your Privacy Settings")</a></p>
-    <p class="sansserif larger"><a href="$user.key">$_("View")</a> $_("or") <a href="$user.key?m=edit">$_("Edit")</a> $_("Your Profile Page")</p>
-    <p class="sansserif larger"><a href="/account/books">$_("View or Edit your Reading Log")</a></p>
-    <p class="sansserif larger"><a href="/account/lists">$_("View or Edit your Lists")</a></p>
-    <p class="sansserif larger"><a href="/account/import">$_("Import and Export Options")</a></p>
-    <br/>
-    <p class="sansserif larger"><a href="/contact">$_("Please contact us if you need help with anything else.")</a></p>
-
+    <div id="contentBody">
+      <h1>$_('Settings & Privacy')</h1>
+      <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Change Password")</a></p>
+      <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Update Email Address")</a></p>
+      <p class="sansserif larger"><a href="/account/notifications">$_("Your Notifications")</a></p>
+      <p class="sansserif larger"><a href="//archive.org/account/index.php?settings=1">$_("Internet Archive Announcements")</a></p>
+      <p class="sansserif larger"><a href="/account/privacy">$_("Your Privacy Settings")</a></p>
+      <p class="sansserif larger"><a href="$user.key">$_("View")</a> $_("or") <a href="$user.key?m=edit">$_("Edit")</a> $_("Your Profile Page")</p>
+      <p class="sansserif larger"><a href="/account/books">$_("View or Edit your Reading Log")</a></p>
+      <p class="sansserif larger"><a href="/account/lists">$_("View or Edit your Lists")</a></p>
+      <p class="sansserif larger"><a href="/account/import">$_("Import and Export Options")</a></p>
+      <br/>
+      <p class="sansserif larger"><a href="/contact">$_("Please contact us if you need help with anything else.")</a></p>
     </div>
+  </div>
 </div>

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -19,9 +19,15 @@ $ total_items = counts.get(key, None)
 $ userDisplayName = user.displayname or ctx.user.displayname
 $ userKey = user.key or ctx.user.key
 
-$ header_title = unicode(render_template('account/readinglog_shelf_name', key)).strip()
 $ breadcrumb = _("Reading Log")
+$ header_title = ""
 
+$if key == 'currently-reading':
+  $ header_title = _("Currently Reading")
+$elif key == 'want-to-read':
+  $ header_title = _("Want To Read")
+$elif key == 'already-read':
+  $ header_title = _("Already Read")
 $if not header_title:
   $if key == 'sponsorships':
     $ header_title = _("Sponsorships")
@@ -47,6 +53,12 @@ $var title: $header_title
 <div class="mybooks">
   $ component_times['Sidebar'] = time()
   <div class="mybooks-menu">
+    <ul class="sidebar-section">
+      <li class="section-header">$username</li>
+      <li><a href="/people/$username" $('class=selected' if key == 'profile' else '')>$_('Profile Page')</a></li>
+      $if owners_page:
+        <li><a href="/account" $('class=selected' if key == 'settings' else '')>$_('Settings & Privacy')</a></li>
+    </ul>
     $if owners_page:
       <ul class="sidebar-section">
         <li class="section-header">$_('Loans')</li>

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -51,67 +51,9 @@ $if not header_title:
 $var title: $header_title
 
 <div class="mybooks">
-  $ component_times['Sidebar'] = time()
-  <div class="mybooks-menu">
-    <ul class="sidebar-section">
-      <li class="section-header">$username</li>
-      <li><a href="/people/$username" $('class=selected' if key == 'profile' else '')>$_('Profile Page')</a></li>
-      $if owners_page:
-        <li><a href="/account" $('class=selected' if key == 'settings' else '')>$_('Settings & Privacy')</a></li>
-    </ul>
-    $if owners_page:
-      <ul class="sidebar-section">
-        <li class="section-header">$_('Loans')</li>
-        <li>
-          <a href="/account/loans" $('class=selected' if key == 'loans' else '')>
-            $_('Checked out')
-          </a>
-        </li>
-        <li>
-          <a href="/account/waitlist" $('class=selected' if key == 'waitlist' else '')>
-            $_('Waitlist')
-          </a>
-        </li>
-        <li>
-          <a class="external-link" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a>
-        </li>
-      </ul>
-    $if public or owners_page:
-      <ul class="sidebar-section">
-        <li class="section-header">$_('Reading Log')</li>
-        <li><a href="/people/$username/books/currently-reading" $('class=selected' if key == 'currently-reading' else '')><span class="li-count">$counts['currently-reading']</span>$_('Currently Reading')</a></li>
-        <li><a href="/people/$username/books/want-to-read" $('class=selected' if key == 'want-to-read' else '')><span class="li-count">$counts['want-to-read']</span>$_('Want to Read')</a></li>
-        <li><a href="/people/$username/books/already-read" $('class=selected' if key == 'already-read' else '')><span class="li-count">$counts['already-read']</span>$_('Already Read')</a></li>
-      $if owners_page:
-        <hr>
-        <li><a $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
-        <li><a $('class=selected' if key=='observations' else '') href="/people/$username/books/observations"><span class="li-count">$counts['observations']</span>$_('My Reviews')</a></li>
-        <hr>
-        <li><a href="/account/books/already-read/stats">$_('Reading Stats')</a></li>
-        <li><a href="/account/import" $('class=selected' if key=='imports' else '')>$_("Import & Export Options")</a></li>
-      </ul>
-    $if owners_page and ctx.user and ctx.user.in_sponsorship_beta():
-      <ul class="sidebar-section">
-        <li class="section-header">$_('Sponsorships')</li>
-        $ sponsorship_count = ''
-        $if counts.get('sponsorships', None):
-          $ sponsorship_count = "%d" % counts['sponsorships']
-        <li><a href="/people/$username/books/sponsorships" $('class=selected' if key == 'sponsorships' else '')><span class="li-count">$sponsorship_count</span>$_('Sponsoring')</a></li>
-      </ul>
-    $if owners_page:
-      <ul class="sidebar-section">
-        <li class="section-header section-header-split"><span>$_('Lists')</span> <a href="/people/$username/lists" class="li-count">$_('See All') ($len(lists))</a></li>
-        <div class="list-overflow">
-          $for lst in lists:
-            $ list_id = lst.key.split('/')[-1]
-            $ class_list = ''
-            $if lst == items:
-              $ class_list = class_list + 'selected'
-            <li><a class="$class_list" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$lst['name']</a></li>
-        </div>
-      </ul>
-  </div>
-  $ component_times['Sidebar'] = time() - component_times['Sidebar']
+
+  $:render_template("account/sidebar", user, key=key, public=public, owners_page=owners_page, counts=counts, lists=lists)
+
   <div class="mybooks-details">
     $ component_times['Details header'] = time()
     <header>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -1,0 +1,72 @@
+$def with (user, key=None, selected_tab=None, owners_page=False, public=False, counts=None, lists=None)
+
+$ component_times = {}
+$ component_times['TotalTime'] = time()
+
+$ username = user.key.split('/')[-1]
+
+$if not (lists and counts):
+  $ pa = get_public_patron_account(username)
+$ lists = lists or pa.lists
+$ counts = counts or pa.get_sidebar_counts
+
+  $ component_times['Sidebar'] = time()
+  <div class="mybooks-menu">
+    <ul class="sidebar-section">
+      <li class="section-header">$username</li>
+      <li><a href="/people/$username" $('class=selected' if key == 'profile' else '')>$_('Profile Page')</a></li>
+      $if owners_page:
+        <li><a href="/account" $('class=selected' if key == 'settings' else '')>$_('Settings & Privacy')</a></li>
+    </ul>
+    $if owners_page:
+      <ul class="sidebar-section">
+        <li class="section-header">$_('Loans')</li>
+        <li>
+          <a href="/account/loans" $('class=selected' if key == 'loans' else '')>
+            $_('Checked out')
+          </a>
+        </li>
+        <li>
+          <a href="/account/waitlist" $('class=selected' if key == 'waitlist' else '')>
+            $_('Waitlist')
+          </a>
+        </li>
+        <li>
+          <a class="external-link" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a>
+        </li>
+      </ul>
+    $if public or owners_page:
+      <ul class="sidebar-section">
+        <li class="section-header">$_('Reading Log')</li>
+        <li><a href="/people/$username/books/currently-reading" $('class=selected' if key == 'currently-reading' else '')><span class="li-count">$counts['currently-reading']</span>$_('Currently Reading')</a></li>
+        <li><a href="/people/$username/books/want-to-read" $('class=selected' if key == 'want-to-read' else '')><span class="li-count">$counts['want-to-read']</span>$_('Want to Read')</a></li>
+        <li><a href="/people/$username/books/already-read" $('class=selected' if key == 'already-read' else '')><span class="li-count">$counts['already-read']</span>$_('Already Read')</a></li>
+      $if owners_page:
+        <hr>
+        <li><a $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
+        <li><a $('class=selected' if key=='observations' else '') href="/people/$username/books/observations"><span class="li-count">$counts['observations']</span>$_('My Reviews')</a></li>
+        <hr>
+        <li><a href="/account/books/already-read/stats">$_('Reading Stats')</a></li>
+        <li><a href="/account/import" $('class=selected' if key=='imports' else '')>$_("Import & Export Options")</a></li>
+      </ul>
+    $if owners_page and ctx.user and ctx.user.in_sponsorship_beta():
+      <ul class="sidebar-section">
+        <li class="section-header">$_('Sponsorships')</li>
+        $ sponsorship_count = ''
+        $if counts.get('sponsorships', None):
+          $ sponsorship_count = "%d" % counts['sponsorships']
+        <li><a href="/people/$username/books/sponsorships" $('class=selected' if key == 'sponsorships' else '')><span class="li-count">$sponsorship_count</span>$_('Sponsoring')</a></li>
+      </ul>
+    <ul class="sidebar-section">
+      <li class="section-header section-header-split"><span>$_('Lists')</span> <a href="/people/$username/lists" class="li-count">$_('See All') ($len(lists))</a></li>
+        <div class="list-overflow">
+          $for lst in lists:
+            $ list_id = lst.key.split('/')[-1]
+            $ class_list = ''
+            $if lst == items:
+              $ class_list = class_list + 'selected'
+            <li><a class="$class_list" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$lst['name']</a></li>
+        </div>
+    </ul>
+  </div>
+  $ component_times['Sidebar'] = time() - component_times['Sidebar']

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -61,10 +61,14 @@ $ counts = counts or pa.get_sidebar_counts
       <li class="section-header section-header-split"><span>$_('Lists')</span> <a href="/people/$username/lists" class="li-count">$_('See All') ($len(lists))</a></li>
         <div class="list-overflow">
           $for lst in lists:
+          $# e.g. OL1L from /people/mekBot/lists/OL1L
             $ list_id = lst.key.split('/')[-1]
             $ class_list = ''
-            $if lst == items:
-              $ class_list = class_list + 'selected'
+            $if key == 'list':
+              $# e.g. /people/openlibrary/lists/OL1L/MyList
+              $ path_id = ctx.path.split('/')[4]
+              $if list_id == path_id:
+                $ class_list = class_list + 'selected'
             <li><a class="$class_list" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$lst['name']</a></li>
         </div>
     </ul>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -1,4 +1,4 @@
-$def with (user, key=None, selected_tab=None, owners_page=False, public=False, counts=None, lists=None)
+$def with (user, key=None, owners_page=False, public=False, counts=None, lists=None)
 
 $ component_times = {}
 $ component_times['TotalTime'] = time()


### PR DESCRIPTION
Refactors the sidebar out of the account/books.html template and plugins/mybooks.py so that it can be added/used w/ the /account settings page.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

~NB: The old sidebar.html code is remains / is **duplicated** by this PR and needs to be consolidated + cleaned up in account/books.html template~

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![localhost_8080_account](https://user-images.githubusercontent.com/978325/163314641-2a30ed56-f7d0-4895-acad-97203dfca6e2.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
