### PR TITLE
fix read more link issue

### DIFF
--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -1,3 +1,5 @@
+import { debounce } from './nonjquery_utils.js';
+
 export function initReadMoreButton() {
     $('.read-more-button').on('click',function(){
         const up = $(this).parent().parent();
@@ -11,13 +13,21 @@ export function initReadMoreButton() {
         $(`.${up.attr('class')}.read-more`).removeClass('hidden');
         $(`.${up.attr('class')}.read-less`).addClass('hidden');
     });
-    $('.restricted-view').each(function() {
-        if ($(this).outerHeight()<50) {
-            $(`.${$(this).parent().attr('class')}.read-more`).addClass('hidden');
+    const resetReadMoreButtons = () => $('.restricted-view').each(function() {
+        const className = $(this).parent().attr('class');
+        // 58 is based on the height attribute of .restricted-height
+        if ($(this)[0].scrollHeight <= 58) {
+            $(`.${className}.read-more`).addClass('hidden');
+            $(`.${className}.read-less`).addClass('hidden');
+            $(this).removeClass('restricted-height');
         } else {
+            $(`.${className}.read-more`).removeClass('hidden');
+            $(`.${className}.read-less`).addClass('hidden');
             $(this).addClass('restricted-height');
         }
     });
+    resetReadMoreButtons();
+    $(window).on('resize', debounce(resetReadMoreButtons, 50));
 }
 
 export function initClampers(clampers) {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -1,4 +1,21 @@
 import { debounce } from './nonjquery_utils.js';
+import $ from 'jquery';
+
+export function resetReadMoreButtons(){
+    $('.restricted-view').each(function() {
+        const className = $(this).parent().attr('class');
+        // 58 is based on the height attribute of .restricted-height
+        if ($(this)[0].scrollHeight <= 58) {
+            $(`.${className}.read-more`).addClass('hidden');
+            $(`.${className}.read-less`).addClass('hidden');
+            $(this).removeClass('restricted-height');
+        } else {
+            $(`.${className}.read-more`).removeClass('hidden');
+            $(`.${className}.read-less`).addClass('hidden');
+            $(this).addClass('restricted-height');
+        }
+    });
+}
 
 export function initReadMoreButton() {
     $('.read-more-button').on('click',function(){
@@ -13,20 +30,6 @@ export function initReadMoreButton() {
         $(`.${up.attr('class')}.read-more`).removeClass('hidden');
         $(`.${up.attr('class')}.read-less`).addClass('hidden');
     });
-    const resetReadMoreButtons = () => $('.restricted-view').each(function() {
-        const className = $(this).parent().attr('class');
-        // 58 is based on the height attribute of .restricted-height
-        if ($(this)[0].scrollHeight <= 58) {
-            $(`.${className}.read-more`).addClass('hidden');
-            $(`.${className}.read-less`).addClass('hidden');
-            $(this).removeClass('restricted-height');
-        } else {
-            $(`.${className}.read-more`).removeClass('hidden');
-            $(`.${className}.read-less`).addClass('hidden');
-            $(this).addClass('restricted-height');
-        }
-    });
-    resetReadMoreButtons();
     $(window).on('resize', debounce(resetReadMoreButtons, 50));
 }
 

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -30,6 +30,7 @@ export function initReadMoreButton() {
         $(`.${up.attr('class')}.read-more`).removeClass('hidden');
         $(`.${up.attr('class')}.read-less`).addClass('hidden');
     });
+    resetReadMoreButtons();
     $(window).on('resize', debounce(resetReadMoreButtons, 50));
 }
 

--- a/tests/unit/js/readMore.test.js
+++ b/tests/unit/js/readMore.test.js
@@ -1,0 +1,22 @@
+import { resetReadMoreButtons } from '../../../openlibrary/plugins/openlibrary/js/readmore';
+import $ from 'jquery';
+
+
+describe('resetReadMoreButtons', () => {
+    const $dummyEl = $('<div class="a-parent"><div class="restricted-view"></div></div>');
+    $dummyEl.appendTo(document.body);
+    test('restricted view if big scroll height', () => {
+        const restrictedViewEl = $dummyEl.find('.restricted-view')[0];
+        jest.spyOn(restrictedViewEl, 'scrollHeight', 'get').mockImplementation(() => 100);
+        resetReadMoreButtons();
+        expect(restrictedViewEl.classList.contains('restricted-height')).toBe(true);
+    });
+    test('no restricted view if small scroll height', () => {
+        const restrictedViewEl = $dummyEl.find('.restricted-view')[0];
+        jest.spyOn(restrictedViewEl, 'scrollHeight', 'get').mockImplementation(() => 50);
+        resetReadMoreButtons();
+        expect(restrictedViewEl.classList.contains('restricted-height')).toBe(false);
+        $dummyEl.remove();
+
+    });
+});


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6401 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Fix such that the "read more/less" button does not appear
- Button will also appear/disappear when the screen gets resized

### Technical
<!-- What should be noted about the implementation? -->
- Resizing based off of code from `SearchBar.js`
- Hardcoded `58` is based off of the height of `.restricted-height` (made a comment in the code itself)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
(Locally): [http://localhost:8080/works/OL13101191W/Alice%27s_Adventures_in_Wonderland](http://localhost:8080/works/OL13101191W/Alice%27s_Adventures_in_Wonderland
)
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
With resizing in action (sorry for low quality):
![read_more](https://user-images.githubusercontent.com/34128141/163333894-e633d5ce-f13d-4fa8-8a9e-fb0c926a48d6.gif)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
