### PR TITLE
Fix fulltext card issues + Re-order onboarding cards

### DIFF
--- a/openlibrary/templates/home/welcome.html
+++ b/openlibrary/templates/home/welcome.html
@@ -41,20 +41,6 @@ $def with (test=False)
 
       <div class="carousel__item tutorial__item">
         <a
-        href="/search/inside"
-        tabindex="0"
-        data-ol-link-track="OnboardingCarouselClick|FulltextSearch"
-        >
-          <img src="/static/images/onboarding/fulltext.png" />
-          <div class="card__text">
-            <p>$_('Try Fulltext Search')</p>
-            <p class="small">$_('Find matching results within the text of millions of books')</p>
-          </div>
-        </a>
-      </div>
-
-      <div class="carousel__item tutorial__item">
-        <a
           href="/explore"
           tabindex="0"
           data-ol-link-track="OnboardingCarouselClick|Explore"
@@ -63,6 +49,20 @@ $def with (test=False)
           <div class="card__text">
             <p>$_("Try the virtual Library Explorer")</p>
             <p class="small">$_("Digital shelves organized like a physical library")</p>
+          </div>
+        </a>
+      </div>
+
+      <div class="carousel__item tutorial__item">
+        <a
+        href="/search/inside"
+        tabindex="0"
+        data-ol-link-track="OnboardingCarouselClick|FulltextSearch"
+        >
+          <img src="/static/images/onboarding/fulltext.png" />
+          <div class="card__text">
+            <p>$_('Try Fulltext Search')</p>
+            <p class="small">$_('Find matching results within the text of millions of books')</p>
           </div>
         </a>
       </div>

--- a/openlibrary/templates/home/welcome.html
+++ b/openlibrary/templates/home/welcome.html
@@ -47,8 +47,8 @@ $def with (test=False)
         >
           <img src="/static/images/onboarding/fulltext.png" />
           <div class="card__text">
-            <p>Try Fulltext Search</p>
-            <p class="small">Find matching results within the text of millions of books.</p>
+            <p>$_('Try Fulltext Search')</p>
+            <p class="small">$_('Find matching results within the text of millions of books')</p>
           </div>
         </a>
       </div>

--- a/openlibrary/templates/home/welcome.html
+++ b/openlibrary/templates/home/welcome.html
@@ -43,7 +43,7 @@ $def with (test=False)
         <a
         href="/search/inside"
         tabindex="0"
-        data-ol-link-track="OnboardingCarouselClick|Explore"
+        data-ol-link-track="OnboardingCarouselClick|FulltextSearch"
         >
           <img src="/static/images/onboarding/fulltext.png" />
           <div class="card__text">


### PR DESCRIPTION
- [Fix Fulltext search card using wrong GA event](https://github.com/internetarchive/openlibrary/commit/51b4a799fca03a0bd53785131d90d69f1c89d8a7)
- [i18n fulltext onboarding card](https://github.com/internetarchive/openlibrary/commit/5b2e7797acee4b22c3be8c027cba89ec86807d73)
- [Place LibraryExplorer card before fulltext card](https://github.com/internetarchive/openlibrary/commit/4944a322605c8a02852d3b321453f187937c70b2)
    - The ordering was causing a reduction in traffic to LibraryExplorer, without a corresponding rise in traffic to search inside.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Carousel looks right in testing: testing.openlibrary.org (after memcache delete: https://testing.openlibrary.org/admin/inspect/memcache?keys=home.homepage.en-&action=delete )

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
