### PR TITLE
Do not call load_config before setup()

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -105,7 +105,7 @@ FIELD_NAME_MAP = {
     'by': 'author_name',
     'publishers': 'publisher',
     'subtitle': 'alternative_subtitle',
-    **({'title': 'alternative_title'} if get_solr_next() else {}),
+    #**({'title': 'alternative_title'} if get_solr_next() else {}),
     'work_subtitle': 'subtitle',
     'work_title': 'title',
     # "Private" fields

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -74,7 +74,7 @@ QUERY_PARSER_TESTS = {
     'Field aliases': (
         'title:food rules by:pollan',
         [
-            {'field': 'alternative_title', 'value': 'food rules'},
+            {'field': 'title', 'value': 'food rules'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
@@ -88,7 +88,7 @@ QUERY_PARSER_TESTS = {
     'Quotes': (
         'title:"food rules" author:pollan',
         [
-            {'field': 'alternative_title', 'value': '"food rules"'},
+            {'field': 'title', 'value': '"food rules"'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
@@ -96,7 +96,7 @@ QUERY_PARSER_TESTS = {
         'query here title:food rules author:pollan',
         [
             {'field': 'text', 'value': 'query here'},
-            {'field': 'alternative_title', 'value': 'food rules'},
+            {'field': 'title', 'value': 'food rules'},
             {'field': 'author_name', 'value': 'pollan'},
         ],
     ),
@@ -110,7 +110,7 @@ QUERY_PARSER_TESTS = {
         'title:flatland:a romance of many dimensions',
         [
             {
-                'field': 'alternative_title',
+                'field': 'title',
                 'value': r'flatland\:a romance of many dimensions',
             },
         ],
@@ -232,7 +232,7 @@ def test_build_q_list():
     }
     expect = (
         [
-            'alternative_title:((Holidays are Hell))',
+            'title:((Holidays are Hell))',
             'author_name:((Kim Harrison))',
             'OR',
             'author_name:((Lynsay Sands))',
@@ -240,7 +240,7 @@ def test_build_q_list():
         False,
     )
     query_fields = [
-        {'field': 'alternative_title', 'value': '(Holidays are Hell)'},
+        {'field': 'title', 'value': '(Holidays are Hell)'},
         {'field': 'author_name', 'value': '(Kim Harrison)'},
         {'op': 'OR'},
         {'field': 'author_name', 'value': '(Lynsay Sands)'},

--- a/openlibrary/tests/core/test_fulltext.py
+++ b/openlibrary/tests/core/test_fulltext.py
@@ -6,8 +6,7 @@ from openlibrary.core import fulltext
 
 
 class Test_fulltext_search_api:
-    def test_no_config(self, monkeypatch):
-        monkeypatch.delattr(config, "plugin_inside")
+    def test_no_config(self):
         response = fulltext.fulltext_search_api({})
         assert response == {"error": "Unable to prepare search engine"}
 


### PR DESCRIPTION
update_work.load_config always load conf/openlibrary.yml -_- Completely borking testing.openlibrary.org and staging.openlibrary.org

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
