### PR TITLE
resolves navbar overflow mobile

### DIFF
--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -159,6 +159,8 @@ h2.edition-byline {
     background: @white;
     z-index: @z-index-level-3;
     padding-top: 10px;
+    white-space: nowrap;
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6431 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- Fixes Book Page navigation bar overflow on mobile

### Technical
<!-- What should be noted about the implementation? -->

N/A

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. `docker-compose exec web make css js` 
2. Inspect element 
3. Toggle device toolbar 
4. Scroll down to nav bar 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![chrome_2022-04-16_21-29-07](https://user-images.githubusercontent.com/54966957/163750286-a873e9dc-d8b5-4e4d-bf44-b0156eefef5e.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
