### PR TITLE
Tweaks to mobile navbar UX

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/index.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/index.js
@@ -59,6 +59,13 @@ export function initNavbar(navbarElem) {
         }
         selectedElem.classList.add('selected')
         selectedSection = linkedSections[targetIndex];
+        // Scroll to / center the item
+        // Note: We don't use the browser native scrollIntoView method because
+        // that method scrolls _recursively_, so it also tries to scroll the
+        // body to center the element on the screen, causing weird jitters.
+        navbarElem.scrollTo({
+            left: selectedElem.offsetLeft - (navbarElem.clientWidth - selectedElem.offsetWidth) / 2,
+        });
     }
 
     // Add scroll listener that changes 'selected' navbar item based on page position:

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -13,8 +13,7 @@
     position: fixed;
     top: 0;
     height: @compact-title-height;
-    // TODO: Magic 20px fixed in future PR
-    width: calc(100% - 20px);
+    width: calc(100% - @contentBody-padding);
     padding: 0 14px;
 
     &__edit-btn {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -165,6 +165,26 @@ h2.edition-byline {
     padding-top: 10px;
     white-space: nowrap;
     overflow-x: auto;
+    // Make tab bar full width on mobile
+    margin-left: -@contentBody-padding;
+    margin-right: -@contentBody-padding;
+
+    // indent it a bit to make it look more scrollable
+    &:before, &:after {
+      display: inline-block;
+      content: "";
+      width: 20%;
+    }
+
+    scroll-behavior: smooth;
+  }
+}
+
+@media (min-width: @width-breakpoint-mobile) {
+  .work-menu.sticky {
+    &:before, &:after {
+      display: none;
+    }
   }
 }
 
@@ -172,6 +192,8 @@ h2.edition-byline {
   .work-menu.sticky {
     top: @compact-title-height;
     padding-top: 2px;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -1,5 +1,7 @@
 @import (less) "v2.less";
 
+@contentBody-padding: 20px;
+
 #contentHead {
   padding: 10px;
   // Reset h1 margin set in common.less
@@ -9,7 +11,7 @@
 }
 div.contentBody,
 div#contentBody {
-  padding: 0 20px 20px;
+  padding: 0 @contentBody-padding @contentBody-padding;
   img {
     max-width: 100%;
   }


### PR DESCRIPTION
Addendum to #6451 . Adds auto scrolling to navbar, and some offset, to make it more clearly scrollable on mobile devices.
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
- Ignore the faint scrollbar; that's just desktop FF

https://user-images.githubusercontent.com/6251786/164290645-80031393-bd23-46a7-93db-cb5edebf112a.mp4




### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
