### PR TITLE
Don't run Python tests when only JS changes

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -4,12 +4,16 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.github/workflows/javascript_tests.yml'
+      - 'vendor/js/**'
+      - 'package*.json'
+      - '**.js'
+      - '**.vue'
+      - '**.less'
+      - '**.css'
 jobs:
   python_tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.9]
     runs-on: ubuntu-18.04  # Should match Dockerfile.olbase, but had to be bumped as older version no longer supported
     steps:
       - uses: actions/checkout@v3
@@ -17,7 +21,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}


### PR DESCRIPTION
- Basically the same as the paths in https://github.com/internetarchive/openlibrary/blob/master/.github/workflows/javascript_tests.yml .
- Note `paths-ignore` will skip the job only if ALL modified paths match the patterns. Even if one path does not, it will run the job.  See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
- Also remove Python version matrix since we'll only be on one python for the foreseeable future.


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
