### PR TITLE
Add hidden submit button

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -34,6 +34,7 @@ $putctx("robots", "noindex,nofollow")
             note = ""
     <h2 class="editFormTitle">$:title</h2>
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
+        <button type="submit" class="hidden" name="_save" form="addWork" tabindex="-1"></button>
         <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete" form="addWork">$_("Delete Record")</button></span>
     $if not ctx.user:
         $:render_template("lib/not_logged")

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -5,6 +5,12 @@ $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) e
 $var title: $this_title
 $putctx("robots", "noindex,nofollow")
 
+$# Forms will bind the "enter" key to the first submit button ; in the case
+$# we show the delete button for librarians, that becomes the first submit
+$# button! So we duplicate the save button here to make sure that it's always
+$# the default "enter" action.
+<button type="submit" class="hidden" name="_save" form="addWork" tabindex="-1"></button>
+
 <div id="contentHead" class="editFormHead">
     $code:
         def find_mode():
@@ -34,8 +40,9 @@ $putctx("robots", "noindex,nofollow")
             note = ""
     <h2 class="editFormTitle">$:title</h2>
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
-        <button type="submit" class="hidden" name="_save" form="addWork" tabindex="-1"></button>
-        <span class="adminOnly right"><button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete" form="addWork">$_("Delete Record")</button></span>
+        <span class="adminOnly right">
+            <button type="submit" name="_delete" value="true" id="delete" form="addWork">$_("Delete Record")</button>
+        </span>
     $if not ctx.user:
         $:render_template("lib/not_logged")
     $:note


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6471

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a hidden submit button prior to the "Delete" submit button.

### Technical
<!-- What should be noted about the implementation? -->
A form's first submit button is triggered when `enter` is pressed. PR #6273 linked the previously broken top-of-page delete button to the form, making it the form's first submit button.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
