### PR TITLE
Expand patron exports

### DIFF
--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -95,6 +95,15 @@ class CommonExtras:
                     rows_deleted -= 1
         return rows_changed, rows_deleted, failed_deletes
 
+    @classmethod
+    def select_all_by_username(cls, username, _test=False):
+        oldb = get_db()
+        return list(oldb.select(
+            cls.TABLENAME,
+            where="username=$username",
+            vars={"username": username}
+        ))
+
 
 def _proxy(method_name):
     """Create a new function that call method with given name on the

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -1090,3 +1090,17 @@ class Observations(db.CommonExtras):
             where_clause += ' AND observation_type=$observation_type AND observation_value=$observation_value'
 
         return oldb.delete('observations', where=(where_clause), vars=data)
+
+    @classmethod
+    def select_all_by_username(cls, username, _test=False):
+        rows = super().select_all_by_username(username, _test=_test)
+        types_and_values = _get_all_types_and_values()
+
+        for row in rows:
+            type_id = f"{row['observation_type']}"
+            value_id = f"{row['observation_value']}"
+            row['observation_type'] = types_and_values[type_id]['type']
+            row['observation_value'] = types_and_values[type_id]['values'][value_id]['name']
+
+        return rows
+

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1,3 +1,4 @@
+from pydoc import describe
 import web
 import logging
 import json
@@ -19,7 +20,10 @@ import infogami.core.code as core
 from openlibrary import accounts
 from openlibrary.i18n import gettext as _
 from openlibrary.core import helpers as h, lending
+from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.observations import Observations
+from openlibrary.core.ratings import Ratings
 from openlibrary.plugins.recaptcha import recaptcha
 from openlibrary.plugins.upstream.mybooks import MyBooksTemplate
 from openlibrary.plugins import openlibrary as olib
@@ -806,10 +810,39 @@ class fetch_goodreads(delegate.page):
 class export_books(delegate.page):
     path = "/account/export"
 
+    date_format = '%Y-%m-%d %H:%M:%S'
+
     @require_login
     def GET(self):
+        i = web.input(type='')
+        filename = ''
+
         user = accounts.get_current_user()
         username = user.key.split('/')[-1]
+
+        if i.type == 'reading_log':
+            data = self.generate_reading_log(username)
+            filename = 'OpenLibrary_ReadingLog.csv'
+        elif i.type == 'book_notes':
+            data = self.generate_book_notes(username)
+            filename = 'OpenLibrary_BookNotes.csv'
+        elif i.type == 'reviews':
+            data = self.generate_reviews(username)
+            filename = 'OpenLibrary_Reviews.csv'
+        elif i.type == 'lists':
+            data = self.generate_list_overview(user.get_lists(limit=1000))
+            filename = 'Openlibrary_ListOverview.csv'
+        elif i.type == 'ratings':
+            data = self.generate_star_ratings(username)
+            filename = 'OpenLibrary_Ratings.csv'
+
+        web.header('Content-Type', 'text/csv')
+        web.header(
+            'Content-disposition', f'attachment; filename={filename}'
+        )
+        return delegate.RawText('' or data, content_type="text/csv")
+
+    def generate_reading_log(self, username):
         books = Bookshelves.get_users_logged_books(username, limit=10000)
         csv = []
         csv.append('Work Id,Edition Id,Bookshelf\n')
@@ -821,12 +854,84 @@ class export_books(delegate.page):
                 '{}\n'.format(mapping[book['bookshelf_id']]),
             ]
             csv.append(','.join(row))
-        web.header('Content-Type', 'text/csv')
-        web.header(
-            'Content-disposition', 'attachment; filename=OpenLibrary_ReadingLog.csv'
-        )
-        csv = ''.join(csv)
-        return delegate.RawText(csv, content_type="text/csv")
+        return ''.join(csv)
+
+    def generate_book_notes(self, username):
+        csv = []
+        csv.append('Work ID,Edition ID,Note,Created On')
+        notes = Booknotes.select_all_by_username(username)
+
+        for note in notes:
+            escaped_note = note['notes'].replace('"', '""')
+            row = [
+                f"OL{note['work_id']}W",
+                f"OL{note['edition_id']}M",
+                f'"{escaped_note}"',
+                note['created'].strftime(self.date_format)
+            ]
+            csv.append(','.join(row))
+
+        return '\n'.join(csv)
+
+    def generate_reviews(self, username):
+        csv = []
+        csv.append('Work ID,Review Category,Review Value,Created On')
+        observations = Observations.select_all_by_username(username)
+
+        for o in observations:
+            row = [
+                f"OL{o['work_id']}W",
+                f'"{o["observation_type"]}"',
+                f'"{o["observation_value"]}"',
+                o['created'].strftime(self.date_format)
+            ]
+            csv.append(','.join(row))
+
+        return '\n'.join(csv)
+
+    def generate_list_overview(self, lists):
+        csv = []
+        csv.append('List ID,List Name,List Description,Entry,Created On,Last Updated')
+
+        for list in lists:
+            logger.info(list)
+            logger.info(vars(list))
+            logger.info(dir(list))
+            list_id = list.key.split('/')[-1]
+            created_on = list.created.strftime(self.date_format)
+            last_updated = list.last_modified.strftime(self.date_format) if list.last_modified else ''
+            for seed in list.seeds:
+                entry = seed
+                if not isinstance(seed, str):
+                    entry = seed.key
+                row = [
+                    list_id,
+                    f'"{list.name}"' if list.name else '', # Replace double quotes?
+                    f'"{list.description}"' if list.description else '',
+                    entry,
+                    created_on,
+                    last_updated
+                ]
+                csv.append(','.join(row))
+
+        return '\n'.join(csv)
+
+
+    def generate_star_ratings(self, username):
+        csv = []
+        csv.append('Work ID,Edition ID,Rating,Created On')
+        ratings = Ratings.select_all_by_username(username)
+
+        for rating in ratings:
+            row = [
+                f"OL{rating['work_id']}W",
+                f"OL{rating['edition_id']}M" if rating['edition_id'] else '',
+                f"{rating['rating']}",
+                rating['created'].strftime(self.date_format)
+            ]
+            csv.append(','.join(row))
+
+        return '\n'.join(csv)
 
 
 class account_loans(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1,4 +1,3 @@
-from pydoc import describe
 import web
 import logging
 import json

--- a/openlibrary/templates/account/import.html
+++ b/openlibrary/templates/account/import.html
@@ -4,7 +4,6 @@ $def with (books=None, books_wo_isbns=None)
 
   $if not books:
     <div class="import-export">
-      <h2>$_("Import Options")</h2>
       <div class="import-export__section">
         <h3>$_("Import from Goodreads")</h3>
         <p>For instructions on exporting data refer to: <a href="https://www.goodreads.com/review/import">Goodreads Import/Export</a></p>
@@ -20,7 +19,6 @@ $def with (books=None, books_wo_isbns=None)
           </div>
         </form>
       </div>
-      <h2>$_("Export Options")</h2>
       <div class="import-export__section">
         <h3>$_("Export your Reading Log")</h3>
         <p>$_("Download a copy of your reading log.") <a href="/help/faq/reading-log.en#reading-log">$_("What is this?")</a></p>

--- a/openlibrary/templates/account/import.html
+++ b/openlibrary/templates/account/import.html
@@ -4,6 +4,7 @@ $def with (books=None, books_wo_isbns=None)
 
   $if not books:
     <div class="import-export">
+      <h2>$_("Import Options")</h2>
       <div class="import-export__readinglog">
         <h3>$_("Import from Goodreads")</h3>
         <p>For instructions on exporting data refer to: <a href="https://www.goodreads.com/review/import">Goodreads Import/Export</a></p>
@@ -19,10 +20,57 @@ $def with (books=None, books_wo_isbns=None)
           </div>
         </form>
       </div>
+      <h2>$_("Export Options")</h2>
       <div class="import-export__readinglog">
         <h3>$_("Export your Reading Log")</h3>
+        <p>$_("Download a copy of your reading log.") <a href="/help/faq/reading-log.en#reading-log">$_("What is this?")</a></p>
         <form method="GET" action="/account/export"
             enctype="multipart/form-data" class="olform olform--decoration">
+          <input type="hidden" name="type" value="reading_log">
+          <div>
+            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+          </div>
+        </form>
+      </div>
+      <div class="import-export__readinglog">
+        <h3>$_("Export your book notes")</h3>
+        <p>$_("Download a copy of your book notes.") <a href="/help/faq/book-notes">$_("What are book notes?")</a></p>
+        <form method="GET" action="/account/export"
+            enctype="multipart/form-data" class="olform olform--decoration">
+          <input type="hidden" name="type" value="book_notes">
+          <div>
+            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+          </div>
+        </form>
+      </div>
+      <div class="import-export__readinglog">
+        <h3>$_("Export your reviews")</h3>
+        <p>$_("Download a copy of your review tags.") <a href="/help/faq/reviews#book-tags">$_("What are review tags?")</a></p>
+        <form method="GET" action="/account/export"
+            enctype="multipart/form-data" class="olform olform--decoration">
+          <input type="hidden" name="type" value="reviews">
+          <div>
+            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+          </div>
+        </form>
+      </div>
+      <div class="import-export__readinglog">
+        <h3>$_("Export your list overview")</h3>
+        <p>$_("Download a summary of your lists and their contents.") <a href="/help/faq/reading-log.en#lists">$_("What are lists?")</a></p>
+        <form method="GET" action="/account/export"
+            enctype="multipart/form-data" class="olform olform--decoration">
+          <input type="hidden" name="type" value="lists">
+          <div>
+            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+          </div>
+        </form>
+      </div>
+      <div class="import-export__readinglog">
+        <h3>$_("Export your star ratings")</h3>
+        <p>$_("Download a copy of your star ratings") <a href="/help/faq/reviews#star-ratings">$_("What are star ratings?")</a></p>
+        <form method="GET" action="/account/export"
+            enctype="multipart/form-data" class="olform olform--decoration">
+          <input type="hidden" name="type" value="ratings">
           <div>
             <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
           </div>

--- a/openlibrary/templates/account/import.html
+++ b/openlibrary/templates/account/import.html
@@ -5,7 +5,7 @@ $def with (books=None, books_wo_isbns=None)
   $if not books:
     <div class="import-export">
       <h2>$_("Import Options")</h2>
-      <div class="import-export__readinglog">
+      <div class="import-export__section">
         <h3>$_("Import from Goodreads")</h3>
         <p>For instructions on exporting data refer to: <a href="https://www.goodreads.com/review/import">Goodreads Import/Export</a></p>
         <form method="POST" action="/account/import/goodreads"
@@ -21,58 +21,58 @@ $def with (books=None, books_wo_isbns=None)
         </form>
       </div>
       <h2>$_("Export Options")</h2>
-      <div class="import-export__readinglog">
+      <div class="import-export__section">
         <h3>$_("Export your Reading Log")</h3>
         <p>$_("Download a copy of your reading log.") <a href="/help/faq/reading-log.en#reading-log">$_("What is this?")</a></p>
         <form method="GET" action="/account/export"
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="reading_log">
           <div>
-            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
           </div>
         </form>
       </div>
-      <div class="import-export__readinglog">
+      <div class="import-export__section">
         <h3>$_("Export your book notes")</h3>
         <p>$_("Download a copy of your book notes.") <a href="/help/faq/book-notes">$_("What are book notes?")</a></p>
         <form method="GET" action="/account/export"
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="book_notes">
           <div>
-            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
           </div>
         </form>
       </div>
-      <div class="import-export__readinglog">
+      <div class="import-export__section">
         <h3>$_("Export your reviews")</h3>
         <p>$_("Download a copy of your review tags.") <a href="/help/faq/reviews#book-tags">$_("What are review tags?")</a></p>
         <form method="GET" action="/account/export"
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="reviews">
           <div>
-            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
           </div>
         </form>
       </div>
-      <div class="import-export__readinglog">
+      <div class="import-export__section">
         <h3>$_("Export your list overview")</h3>
         <p>$_("Download a summary of your lists and their contents.") <a href="/help/faq/reading-log.en#lists">$_("What are lists?")</a></p>
         <form method="GET" action="/account/export"
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="lists">
           <div>
-            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
           </div>
         </form>
       </div>
-      <div class="import-export__readinglog">
+      <div class="import-export__section">
         <h3>$_("Export your star ratings")</h3>
         <p>$_("Download a copy of your star ratings") <a href="/help/faq/reviews#star-ratings">$_("What are star ratings?")</a></p>
         <form method="GET" action="/account/export"
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="ratings">
           <div>
-            <input type="submit" class="readingLog_download cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
           </div>
         </form>
       </div>

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -160,7 +160,7 @@ th.toggle-all {
 .import-export {
   display: flex;
   flex-direction: column;
-  &__readinglog {
+  &__section {
     padding: 0 10px;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6457

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Provides an easy way for patrons to download their book notes, book reviews, star ratings, and lists overview from the account import/export page.  New data is available in CSV format only (maybe it would be nice to export the data as JSON in the future).

Several new buttons have been added to the original UI.  We may want to revisit that page's design in the near future, as the page is more cluttered now.

Added links to Open Library help pages in order to show patrons _what_ they are exporting.  The copy on these pages could probably use a review, as well.

### Technical
<!-- What should be noted about the implementation? -->
Created new CommonExtras method for getting all data by username.  This method, `select_all_by_username`, was overridden in the Observations class to transform numeric book tag values into words.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
