### PR TITLE
DRY Book Byline rendering + make it more i18n-able

### DIFF
--- a/openlibrary/i18n/de/messages.po
+++ b/openlibrary/i18n/de/messages.po
@@ -4947,10 +4947,10 @@ msgstr "Buch zurückgeben"
 
 #: SearchResultsWork.html:67
 #, python-format
-msgid "and 1 other"
-msgid_plural "and %(n)s others"
-msgstr[0] "und 1 weitere"
-msgstr[1] "und %(n)s weitere"
+msgid "1 other"
+msgid_plural "%(n)s others"
+msgstr[0] "1 weitere"
+msgstr[1] "%(n)s weitere"
 
 #: SearchResultsWork.html:78
 msgid "languages"

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -4971,10 +4971,10 @@ msgstr "Rendre le livre"
 
 #: SearchResultsWork.html:67
 #, python-format
-msgid "and 1 other"
-msgid_plural "and %(n)s others"
-msgstr[0] "et 1 autre"
-msgstr[1] "et %(n)s autres"
+msgid "1 other"
+msgid_plural "%(n)s others"
+msgstr[0] "1 autre"
+msgstr[1] "%(n)s autres"
 
 #: SearchResultsWork.html:78
 msgid "languages"

--- a/openlibrary/i18n/hr/messages.po
+++ b/openlibrary/i18n/hr/messages.po
@@ -4941,11 +4941,11 @@ msgstr "Vrati knjigu"
 
 #: SearchResultsWork.html:67
 #, python-format
-msgid "and 1 other"
-msgid_plural "and %(n)s others"
-msgstr[0] "i još 1"
-msgstr[1] "i još %(n)s"
-msgstr[2] "i još %(n)s"
+msgid "1 other"
+msgid_plural "%(n)s others"
+msgstr[0] "još 1"
+msgstr[1] "još %(n)s"
+msgstr[2] "još %(n)s"
 
 #: SearchResultsWork.html:78
 msgid "languages"

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -4728,8 +4728,8 @@ msgstr ""
 
 #: SearchResultsWork.html:67
 #, python-format
-msgid "and 1 other"
-msgid_plural "and %(n)s others"
+msgid "1 other"
+msgid_plural "%(n)s others"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/openlibrary/macros/AuthorList.html
+++ b/openlibrary/macros/AuthorList.html
@@ -1,7 +1,0 @@
-$def with (authors)
-
-$if authors:
-    $ author_list = ', '.join('<a class="borrowResults" href="%s">%s</a>' % (a.url(), truncate(a.name, 40)) for a in authors)
-    $_("by") <span title="$_('Go to this author\'s page')">$:author_list</span>
-$else:
-    $:_("by an <em>unknown author</em>")

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -1,0 +1,11 @@
+$def with(author_names_and_urls, limit=None, overflow_url=None, itemprop='author')
+
+$def render_author_link(name, url):
+  $ itemprop_attr = 'itemprop="%s"' % itemprop if itemprop else ''
+  $ rendered_name = cond(name, truncate(name, 40), _("Unknown author"))
+  $if url:
+    <a href="$url" $:itemprop_attr>$rendered_name</a>
+  $else:
+    <span $:itemprop_attr>$rendered_name</span>
+
+$:_("by %(name)s", name=commify_list([render_author_link(name, url) for name, url in author_names_and_urls]))

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -20,4 +20,7 @@ $code:
   if remaining_authors > 0:
     render_items.append(render_overflow_link(remaining_authors, overflow_url))
 
-$:_("by %(name)s", name=commify_list(render_items))
+$if render_items:
+  $:_("by %(name)s", name=commify_list(render_items))
+$else:
+  $:_("by an <em>unknown author</em>")

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -1,11 +1,23 @@
-$def with(author_names_and_urls, limit=None, overflow_url=None, itemprop='author')
+$def with(author_names_and_urls, limit=None, overflow_url=None, attrs='')
 
 $def render_author_link(name, url):
-  $ itemprop_attr = 'itemprop="%s"' % itemprop if itemprop else ''
   $ rendered_name = cond(name, truncate(name, 40), _("Unknown author"))
   $if url:
-    <a href="$url" $:itemprop_attr>$rendered_name</a>
+    <a href="$url" $:attrs>$rendered_name</a>
   $else:
-    <span $:itemprop_attr>$rendered_name</span>
+    <span $:attrs>$rendered_name</span>
 
-$:_("by %(name)s", name=commify_list([render_author_link(name, url) for name, url in author_names_and_urls]))
+$def render_overflow_link(remaining_authors, overflow_url):
+  <small><em><a href="$overflow_url" $:attrs>$ungettext('1 other', '%(n)s others', remaining_authors, n=remaining_authors)</a></em></small>
+
+$code:
+  if limit is None:
+    limit = len(author_names_and_urls)
+
+  remaining_authors = max(0, len(author_names_and_urls) - limit)
+  render_items = [render_author_link(name, url) for name, url in author_names_and_urls][:limit]
+
+  if remaining_authors > 0:
+    render_items.append(render_overflow_link(remaining_authors, overflow_url))
+
+$:_("by %(name)s", name=commify_list(render_items))

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -38,7 +38,7 @@ $ max_rendered_authors = 9
              ($(doc['publish_date']))
          </h3>
         </div>
-      <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">$_('by')
+      <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
         $ authors = None
         $if doc_type == 'infogami_work':
           $ authors = doc.get_authors()
@@ -52,15 +52,15 @@ $ max_rendered_authors = 9
         $if not authors:
           <em>$_('Unknown author')</em>
         $else:
-          $ remaining_authors = len(authors) - max_rendered_authors
-          $for a in authors[:max_rendered_authors]:
-            $ separator = ',' if not loop.last or remaining_authors > 0 else ''
-            $ url = a.get('url') or a.get('key') or a.get('author', {}).get('url') or a.get('author', {}).get('key')
-            $ name = a.get('name') or a.get('author', {}).get('name') or _('Unknown author')
-            <a itemprop="url" href="$url" class="results">$name</a>$separator
-          $if remaining_authors > 0:
-            <small><em><a itemprop="url" href="$work_edition_url"
-                                         class="results">$ungettext('and 1 other', 'and %(n)s others', remaining_authors, n=remaining_authors)</a></em></small>
+          $code:
+            author_names_and_urls = [
+              (
+                a.get('name') or a.get('author', {}).get('name'),
+                a.get('url') or a.get('key') or a.get('author', {}).get('url') or a.get('author', {}).get('key')
+              )
+              for a in authors
+            ]
+          $:macros.BookByline(author_names_and_urls, limit=max_rendered_authors, overflow_url=work_edition_url, attrs='class="results"')
       </span>
       <span class="resultPublisher">
         $if doc.get('first_publish_year'):

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -89,7 +89,7 @@ $else:
                     </a>
                     </span>
                     <span class="author">
-                    $:macros.AuthorList(book.get_authors())
+                    $:macros.BookByline([(a.name, a.url()) for a in book.get_authors()])
                     </span>
                     <div class="date">
                     Borrowed $datestr(datetime_from_utc_timestamp(loan['loaned_at']))

--- a/openlibrary/templates/account/waitlist.html
+++ b/openlibrary/templates/account/waitlist.html
@@ -82,7 +82,7 @@ $else:
                           <a href="$book.key" class="borrowResults"><strong>$book.title</strong></a>
                       </span>
                       <span class="author">
-                          $:macros.AuthorList(book.get_authors())
+                          $:macros.BookByline([(a.name, a.url()) for a in book.get_authors()])
                       </span>
                       <div class="date">
                           $ ndays = record.get_waiting_in_days()

--- a/openlibrary/templates/admin/loans_table.html
+++ b/openlibrary/templates/admin/loans_table.html
@@ -63,7 +63,7 @@ $else:
                     </span>
 
                     <span class="author">
-                    $# :macros.AuthorList(book.get_authors())
+                    $# :macros.BookByline([(a.name, a.url()) for a in book.get_authors()])
                     </span>
                     <div class="date">
                     $if waiting_loan:

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -47,8 +47,9 @@ $putctx("robots", "noindex,nofollow")
         $ authors = work.authors and [a.author for a in work.authors]
         <h1 class="editFormBookTitle">$this_title</h1>
         $if authors:
-            $ all_authors = u"By {},".format(" ".join(author.name for author in authors if author.name))
-            <h3 class="editFormBookAuthors">$all_authors[:-1]</h3>
+            <h3 class="editFormBookAuthors">
+                $:macros.BookByline([(author.name, author.url()) for author in authors], itemprop=None)
+            </h3>
         <div id="tabsAddbook">
             <ul>
                 <li><a href="#about" id="link_about">$_("Work Details")</a></li>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -48,7 +48,7 @@ $putctx("robots", "noindex,nofollow")
         <h1 class="editFormBookTitle">$this_title</h1>
         $if authors:
             <h3 class="editFormBookAuthors">
-                $:macros.BookByline([(author.name, author.url()) for author in authors], itemprop=None)
+                $:macros.BookByline([(author.name, author.url()) for author in authors])
             </h3>
         <div id="tabsAddbook">
             <ul>

--- a/openlibrary/templates/borrow_admin.html
+++ b/openlibrary/templates/borrow_admin.html
@@ -53,7 +53,7 @@ $def format_users(users):
                             </span>
                             <span class="author">
                             $ authors = page.works[0].get_authors()
-                            $:macros.AuthorList(authors)
+                            $:macros.BookByline([(a.name, a.url()) for a in authors])
                             </span>
                             <br/>
                             <span class="publisher">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -197,11 +197,11 @@ $if is_privileged_user:
       $ author_names = (work or edition).author_names
       $if authors:
         <h2 class="edition-byline">
-          $:macros.BookByline([(author.name, author.url()) for author in authors])
+          $:macros.BookByline([(author.name, author.url()) for author in authors], attrs='itemprop="author"')
         </h2>
       $elif author_names:
         <h2 class="edition-byline">
-          $:macros.BookByline([(name, None) for name in author_names])
+          $:macros.BookByline([(name, None) for name in author_names], attrs='itemprop="author"')
         </h2>
 
       $ component_times['ReadlogStats'] = time()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -119,13 +119,6 @@ $code:
     description = get_description(page)
     putctx("description", description)
 
-$def render_author_link(name, url):
-  $ rendered_name = cond(name, truncate(name, 40), _("Unknown author"))
-  $if url:
-    <a href="$url" itemprop="author">$rendered_name</a>
-  $else:
-    <span itemprop="author">$rendered_name</span>
-
 $def display_value(label, value, itemprop=None):
     $if value:
         <dt>$label</dt>
@@ -204,11 +197,11 @@ $if is_privileged_user:
       $ author_names = (work or edition).author_names
       $if authors:
         <h2 class="edition-byline">
-          $:_("by %(name)s", name=commify_list([render_author_link(author.name, author.url()) for author in authors]))
+          $:macros.BookByline([(author.name, author.url()) for author in authors])
         </h2>
       $elif author_names:
         <h2 class="edition-byline">
-          $:_("by %(name)s", name=commify_list([render_author_link(name, None) for name in author_names]))
+          $:macros.BookByline([(name, None) for name in author_names])
         </h2>
 
       $ component_times['ReadlogStats'] = time()


### PR DESCRIPTION
Prep refactor of some code for editions in solr.

### Technical
- Uses babel to commify lists instead of manual `', '.join` combining. This i18n better
- Delete an old template, but there are load of other places we do this type of thing

### Testing
- Truncation works the same: https://testing.openlibrary.org/authors/OL60550A/Olaudah_Equiano?q=Prentice+Hall+Literature
- i18n's better: https://testing.openlibrary.org/authors/OL60550A/Olaudah_Equiano?q=Prentice+Hall+Literature&lang=zh
- Edit page now also same: https://testing.openlibrary.org/books/OL32560269M/Prentice_Hall_Literature/edit?lang=zh
- Loans page shows author byline

### Screenshot
- Edit pages now also link to authors

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
