### PR TITLE
Editions in Solr -- Search Results UI/API Integration piece

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -27,6 +27,10 @@ $code:
     edition_work = doc['works'][0]
 
   full_title = selected_ed.title + (': ' + selected_ed.subtitle if selected_ed.get('subtitle') else '')
+  if doc_type == 'infogami_edition' and edition_work:
+    full_work_title = edition_work.title + (': ' + edition_work.subtitle if edition_work.get('subtitle') else '')
+  else:
+    full_work_title = doc.title + (': ' + doc.subtitle if doc.get('subtitle') else '')
 
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
   <span class="bookcover">
@@ -90,6 +94,15 @@ $code:
                   </a>
               </span>
       </span>
+      $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+      $if is_privileged_user:
+        <div class="searchResultItem__librarian-extras" title="$_('This is only visible to librarians.')">
+          $if doc_type == 'solr_edition' or (doc_type == 'infogami_edition' and edition_work):
+            <div>$_('Work Title'): <i>$full_work_title</i></div>
+          $ is_orphan = doc_type.startswith('solr_') and doc['key'].endswith('M') or doc_type == 'infogami_edition' and not edition_work
+          $if is_orphan:
+            <div>$_('Orphaned Edition')</div>
+        </div>
       $if extra:
         $:extra
       </div>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False)
 
 $code:
   max_rendered_authors = 9
@@ -94,8 +94,7 @@ $code:
                   </a>
               </span>
       </span>
-      $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
-      $if is_privileged_user:
+      $if show_librarian_extras:
         <div class="searchResultItem__librarian-extras" title="$_('This is only visible to librarians.')">
           $if doc_type == 'solr_edition' or (doc_type == 'infogami_edition' and edition_work):
             <div>$_('Work Title'): <i>$full_work_title</i></div>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -16,7 +16,7 @@ $code:
   book_url = doc.url() if doc_type.startswith('infogami_') else doc.key
   book_provider = get_book_provider(doc)
   if doc_type == 'solr_edition':
-    work_edition_url = selected_ed.url
+    work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)
   elif book_provider and doc_type.endswith('_work'):
     work_edition_url = book_url + '?edition=' + urlquote(book_provider.get_best_identifier_slug(doc))
   else:
@@ -31,7 +31,7 @@ $code:
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
   <span class="bookcover">
     $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
-    <a href="https://openlibrary.org$work_edition_url"><img
+    <a href="$work_edition_url"><img
             itemprop="image"
             src="$cover"
             alt="$_('Cover of: %(title)s', title=full_title)"

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -5,12 +5,19 @@ $code:
   doc_type = (
     'infogami_work' if doc.get('type', {}).get('key') == '/type/work' else
     'infogami_edition' if doc.get('type', {}).get('key') == '/type/edition' else
-    'solr_work'
+    'solr_work' if not doc.get('editions') else
+    'solr_edition'
   )
+
+  selected_ed = doc
+  if doc_type == 'solr_edition':
+    selected_ed = doc.get('editions')[0]
 
   book_url = doc.url() if doc_type.startswith('infogami_') else doc.key
   book_provider = get_book_provider(doc)
-  if book_provider and doc_type.endswith('_work'):
+  if doc_type == 'solr_edition':
+    work_edition_url = selected_ed.url
+  elif book_provider and doc_type.endswith('_work'):
     work_edition_url = book_url + '?edition=' + urlquote(book_provider.get_best_identifier_slug(doc))
   else:
     work_edition_url = book_url
@@ -19,12 +26,12 @@ $code:
   if doc_type == 'infogami_edition' and 'works' in doc:
     edition_work = doc['works'][0]
 
-  full_title = doc.title + (': ' + doc.subtitle if doc.get('subtitle') else '')
+  full_title = selected_ed.title + (': ' + selected_ed.subtitle if selected_ed.get('subtitle') else '')
 
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
   <span class="bookcover">
-    $ cover = get_cover_url(doc) or "/images/icons/avatar_book-sm.png"
-    <a href="$work_edition_url"><img
+    $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
+    <a href="https://openlibrary.org$work_edition_url"><img
             itemprop="image"
             src="$cover"
             alt="$_('Cover of: %(title)s', title=full_title)"
@@ -36,8 +43,6 @@ $code:
       <div class="resultTitle">
          <h3 itemprop="name" class="booktitle">
            <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
-           $if doc.get('publish_date'):
-             ($(doc['publish_date']))
          </h3>
         </div>
       <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
@@ -46,7 +51,7 @@ $code:
           $ authors = doc.get_authors()
         $elif doc_type == 'infogami_edition':
           $ authors = edition_work.get_authors() if edition_work else doc.get_authors()
-        $elif doc_type == 'solr_work':
+        $elif doc_type.startswith('solr_'):
           $if 'authors' in doc:
             $ authors = doc['authors']
           $elif 'author_key' in doc:
@@ -98,8 +103,8 @@ $code:
 
       <div class="searchResultItemCTA-lending">
         $if cta:
-          $ doc['availability'] = doc.get('availability', {}) or availability or {}
-          $:macros.LoanStatus(doc, work_key=doc.key)
+          $ selected_ed['availability'] = selected_ed.get('availability', {}) or doc.get('availability', {}) or availability or {}
+          $:macros.LoanStatus(selected_ed, work_key=doc.key)
       </div>
 
       $if reading_log:

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -600,6 +600,7 @@ class Work(models.Work):
         from openlibrary.book_providers import get_solr_keys
 
         fields = [
+            "key",
             "cover_edition_key",
             "cover_id",
             "edition_key",

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -698,6 +698,14 @@ def get_language_name(lang_or_key: Union[Thing, str]):
     return safeget(lambda: lang['name_translated'][user_lang][0]) or lang.name
 
 
+@functools.cache
+def convert_iso_to_marc(iso_639_1: str) -> str:
+    for lang in get_languages().values():
+        code = safeget(lambda: lang['identifiers']['iso_639_1'][0])
+        if code == iso_639_1:
+            return lang.code
+
+
 @public
 def get_author_config():
     return _get_author_config()

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -684,26 +684,36 @@ def autocomplete_languages(prefix: str):
             continue
 
 
-def get_language(lang_or_key: Union[Thing, str]) -> Thing:
+def get_language(lang_or_key: Union[Thing, str]) -> Optional[Thing]:
     if isinstance(lang_or_key, str):
-        return get_languages()[lang_or_key]
+        return get_languages().get(lang_or_key)
     else:
         return lang_or_key
 
 
 @public
 def get_language_name(lang_or_key: Union[Thing, str]):
+    if isinstance(lang_or_key, str):
+        lang = get_language(lang_or_key)
+        if not lang:
+            return lang_or_key
+    else:
+        lang = lang_or_key
+
     user_lang = web.ctx.lang or 'en'
-    lang = get_language(lang_or_key)
     return safeget(lambda: lang['name_translated'][user_lang][0]) or lang.name
 
 
 @functools.cache
-def convert_iso_to_marc(iso_639_1: str) -> str:
+def convert_iso_to_marc(iso_639_1: str) -> Optional[str]:
+    """
+    e.g. 'en' -> 'eng'
+    """
     for lang in get_languages().values():
         code = safeget(lambda: lang['identifiers']['iso_639_1'][0])
         if code == iso_639_1:
             return lang.code
+    return None
 
 
 @public

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -21,7 +21,7 @@ from infogami import config
 from infogami.utils import delegate, stats
 from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core import cache
-from openlibrary.core.lending import add_availability, get_availability_of_ocaids
+from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.plugins.inside.code import fulltext_search
 from openlibrary.plugins.openlibrary.processors import urlsafe
@@ -178,11 +178,7 @@ OLID_URLS = {'A': 'authors', 'M': 'books', 'W': 'works'}
 
 re_isbn_field = re.compile(r'^\s*(?:isbn[:\s]*)?([-0-9X]{9,})\s*$', re.I)
 re_author_key = re.compile(r'(OL\d+A)')
-re_fields = re.compile(r'(-?%s):' % '|'.join(ALL_FIELDS + list(FIELD_NAME_MAP)), re.I)
-re_op = re.compile(' +(OR|AND)$')
-re_range = re.compile(r'\[(?P<start>.*) TO (?P<end>.*)\]')
 re_pre = re.compile(r'<pre>(.*)</pre>', re.S)
-re_subject_types = re.compile('^(places|times|people)/(.*)')
 re_olid = re.compile(r'^OL\d+([AMW])$')
 
 plurals = {f + 's': f for f in ('publisher', 'author')}
@@ -1006,7 +1002,6 @@ class search(delegate.page):
             ' '.join(q_list),
             do_search,
             get_doc,
-            get_availability_of_ocaids,
             fulltext_search,
             FACET_FIELDS,
         )

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -721,7 +721,8 @@ def run_solr_query(
                     # This is using the special parent query syntax to, on top of
                     # the user's `full_work_query`, also only find works which have
                     # editions matching the edition query.
-                    '+_query_:"{!parent which=type:work v=$edQuery filters=$editions.fq}"',
+                    # Also include edition-less works (i.e. edition_count:0)
+                    '+(_query_:"{!parent which=type:work v=$edQuery filters=$editions.fq}" OR edition_count:0)',
                 )
             )
             params.append(('q', q))

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -13,6 +13,8 @@ import requests
 import web
 from requests import Response
 import urllib
+import luqum
+from luqum.exceptions import ParseSyntaxError
 
 from infogami import config
 from infogami.utils import delegate, stats
@@ -28,6 +30,14 @@ from openlibrary.plugins.upstream.utils import (
     urlencode,
 )
 from openlibrary.solr.solr_types import SolrDocument
+from openlibrary.solr.query_utils import (
+    EmptyTreeError,
+    escape_unknown_fields,
+    fully_escape_query,
+    luqum_parser,
+    luqum_remove_child,
+    luqum_traverse,
+)
 from openlibrary.utils import escape_bracket
 from openlibrary.utils.ddc import (
     normalize_ddc,
@@ -260,170 +270,150 @@ def process_facet_counts(
         yield field, list(process_facet(field, web.group(facets, 2)))
 
 
-def lcc_transform(raw):
-    """
-    Transform the lcc search field value
-    :param str raw:
-    :rtype: str
-    """
+def lcc_transform(sf: luqum.tree.SearchField):
     # e.g. lcc:[NC1 TO NC1000] to lcc:[NC-0001.00000000 TO NC-1000.00000000]
     # for proper range search
-    m = re_range.match(raw)
-    if m:
-        lcc_range = [m.group('start').strip(), m.group('end').strip()]
-        normed = normalize_lcc_range(*lcc_range)
-        return f'[{normed[0] or lcc_range[0]} TO {normed[1] or lcc_range[1]}]'
-    elif '*' in raw and not raw.startswith('*'):
-        # Marshals human repr into solr repr
-        # lcc:A720* should become A--0720*
-        parts = raw.split('*', 1)
-        lcc_prefix = normalize_lcc_prefix(parts[0])
-        return (lcc_prefix or parts[0]) + '*' + parts[1]
-    else:
-        normed = short_lcc_to_sortable_lcc(raw.strip('"'))
+    val = sf.children[0]
+    if isinstance(val, luqum.tree.Range):
+        normed = normalize_lcc_range(val.low, val.high)
         if normed:
-            use_quotes = ' ' in normed or raw.startswith('"')
-            return ('"%s"' if use_quotes else '%s*') % normed
+            val.low, val.high = normed
+    elif isinstance(val, luqum.tree.Word):
+        if '*' in val.value and not val.value.startswith('*'):
+            # Marshals human repr into solr repr
+            # lcc:A720* should become A--0720*
+            parts = val.value.split('*', 1)
+            lcc_prefix = normalize_lcc_prefix(parts[0])
+            val.value = (lcc_prefix or parts[0]) + '*' + parts[1]
+        else:
+            normed = short_lcc_to_sortable_lcc(val.value.strip('"'))
+            if normed:
+                val.value = normed
+    elif isinstance(val, luqum.tree.Phrase):
+        normed = short_lcc_to_sortable_lcc(val.value.strip('"'))
+        if normed:
+            val.value = f'"{normed}"'
+    else:
+        logger.warning(f"Unexpected lcc SearchField value type: {type(val)}")
 
-    # If none of the transforms took
-    return raw
 
-
-def ddc_transform(raw):
-    """
-    Transform the ddc search field value
-    :param str raw:
-    :rtype: str
-    """
-    m = re_range.match(raw)
-    if m:
-        raw = [m.group('start').strip(), m.group('end').strip()]
+def ddc_transform(sf: luqum.tree.SearchField):
+    val = sf.children[0]
+    if isinstance(val, luqum.tree.Range):
         normed = normalize_ddc_range(*raw)
-        return f'[{normed[0] or raw[0]} TO {normed[1] or raw[1]}]'
-    elif raw.endswith('*'):
-        return normalize_ddc_prefix(raw[:-1]) + '*'
-    else:
-        normed = normalize_ddc(raw.strip('"'))
+        val.low, val.high = normed[0] or val.low, normed[1] or val.high
+    elif isinstance(val, luqum.tree.Word) and val.value.endswith('*'):
+        return normalize_ddc_prefix(val.value[:-1]) + '*'
+    elif isinstance(val, luqum.tree.Word) or isinstance(val, luqum.tree.Phrase):
+        normed = normalize_ddc(val.value.strip('"'))
         if normed:
-            return normed[0]
+            val.value = normed
+    else:
+        logger.warning(f"Unexpected ddc SearchField value type: {type(val)}")
 
-    # if none of the transforms took
-    return raw
+
+def isbn_transform(sf: luqum.tree.SearchField):
+    field_val = sf.children[0]
+    if isinstance(field_val, luqum.tree.Word) and '*' not in field_val.value:
+        isbn = normalize_isbn(field_val.value)
+        if isbn:
+            field_val.value = isbn
+    else:
+        logger.warning(f"Unexpected isbn SearchField value type: {type(field_val)}")
 
 
-def ia_collection_s_transform(raw):
+def ia_collection_s_transform(sf: luqum.tree.SearchField):
     """
     Because this field is not a multi-valued field in solr, but a simple ;-separate
     string, we have to do searches like this for now.
     """
-    result = raw
-    if not result.startswith('*'):
-        result = '*' + result
-    if not result.endswith('*'):
-        result += '*'
-    return result
+    val = sf.children[0]
+    if isinstance(val, luqum.tree.Word):
+        if val.value.startswith('*'):
+            val.value = '*' + val.value
+        if val.value.endswith('*'):
+            val.value += '*'
+    else:
+        logger.warning(
+            f"Unexpected ia_collection_s SearchField value type: {type(val)}"
+        )
 
 
-def parse_query_fields(q):
-    found = [(m.start(), m.end()) for m in re_fields.finditer(q)]
-    first = q[: found[0][0]].strip() if found else q.strip()
-    if first:
-        yield {'field': 'text', 'value': first.replace(':', r'\:')}
-    for field_num in range(len(found)):
-        op_found = None
-        f = found[field_num]
-        field_name = q[f[0] : f[1] - 1].lower()
-        if field_name in FIELD_NAME_MAP:
-            field_name = FIELD_NAME_MAP[field_name]
-        if field_num == len(found) - 1:
-            v = q[f[1] :].strip()
-        else:
-            v = q[f[1] : found[field_num + 1][0]].strip()
-            m = re_op.search(v)
-            if m:
-                v = v[: -len(m.group(0))]
-                op_found = m.group(1)
-        if field_name == 'isbn':
-            isbn = normalize_isbn(v)
-            if isbn:
-                v = isbn
-        if field_name in ('lcc', 'lcc_sort'):
-            v = lcc_transform(v)
-        if field_name == ('ddc', 'ddc_sort'):
-            v = ddc_transform(v)
-        if field_name == 'ia_collection_s':
-            v = ia_collection_s_transform(v)
+def process_user_query(q_param: str) -> str:
+    # Solr 4+ has support for regexes (eg `key:/foo.*/`)! But for now, let's not
+    # expose that and escape all '/'. Otherwise `key:/works/OL1W` is interpreted as
+    # a regex.
+    q_param = q_param.strip().replace('/', '\\/')
+    try:
+        q_param = escape_unknown_fields(
+            q_param,
+            lambda f: f in ALL_FIELDS or f in FIELD_NAME_MAP or f.startswith('id_'),
+        )
+        q_tree = luqum_parser(q_param)
+    except ParseSyntaxError:
+        # This isn't a syntactically valid lucene query
+        logger.warning("Invalid lucene query", exc_info=True)
+        # Escape everything we can
+        q_tree = luqum_parser(fully_escape_query(q_param))
+    has_search_fields = False
+    for node, parents in luqum_traverse(q_tree):
+        if isinstance(node, luqum.tree.SearchField):
+            has_search_fields = True
+            if node.name.lower() in FIELD_NAME_MAP:
+                node.name = FIELD_NAME_MAP[node.name]
+            if node.name == 'isbn':
+                isbn_transform(node)
+            if node.name in ('lcc', 'lcc_sort'):
+                lcc_transform(node)
+            if node.name in ('dcc', 'dcc_sort'):
+                ddc_transform(node)
+            if node.name == 'ia_collection_s':
+                ia_collection_s_transform(node)
 
-        yield {'field': field_name, 'value': v.replace(':', r'\:')}
-        if op_found:
-            yield {'op': op_found}
+    if not has_search_fields:
+        # If there are no search fields, maybe we want just an isbn?
+        isbn = normalize_isbn(q_param)
+        if isbn and len(isbn) in (10, 13):
+            q_tree = luqum_parser(f'isbn:({isbn})')
+
+    return str(q_tree)
 
 
-def build_q_list(param):
+def build_q_from_params(param: dict[str, str]) -> str:
     q_list = []
-    if 'q' in param:
-        # Solr 4+ has support for regexes (eg `key:/foo.*/`)! But for now, let's not
-        # expose that and escape all '/'. Otherwise `key:/works/OL1W` is interpreted as
-        # a regex.
-        q_param = param['q'].strip().replace('/', '\\/')
-    else:
-        q_param = None
-    use_dismax = False
-    if q_param:
-        if q_param == '*:*':
-            q_list.append(q_param)
-        elif 'NOT ' in q_param:  # this is a hack
-            q_list.append(q_param.strip())
-        elif re_fields.search(q_param):
-            q_list.extend(
-                i['op'] if 'op' in i else '{}:({})'.format(i['field'], i['value'])
-                for i in parse_query_fields(q_param)
-            )
+    if 'author' in param:
+        v = param['author'].strip()
+        m = re_author_key.search(v)
+        if m:
+            q_list.append(f"author_key:({m.group(1)})")
         else:
-            isbn = normalize_isbn(q_param)
-            if isbn and len(isbn) in (10, 13):
-                q_list.append('isbn:(%s)' % isbn)
-            else:
-                q_list.append(q_param.strip().replace(':', r'\:'))
-                use_dismax = True
-    else:
-        if 'author' in param:
-            v = param['author'].strip()
-            m = re_author_key.search(v)
-            if m:
-                q_list.append("author_key:(%s)" % m.group(1))
-            else:
-                v = re_to_esc.sub(r'\\\g<0>', v)
-                # Somehow v can be empty at this point,
-                #   passing the following with empty strings causes a severe error in SOLR
-                if v:
-                    q_list.append(
-                        "(author_name:({name}) OR author_alternative_name:({name}))".format(
-                            name=v
-                        )
-                    )
+            v = re_to_esc.sub(r'\\\g<0>', v)
+            # Somehow v can be empty at this point,
+            #   passing the following with empty strings causes a severe error in SOLR
+            if v:
+                q_list.append(f"(author_name:({v}) OR author_alternative_name:({v}))")
 
-        check_params = [
-            'title',
-            'publisher',
-            'oclc',
-            'lccn',
-            'contributor',
-            'subject',
-            'place',
-            'person',
-            'time',
-        ]
-        q_list += [
-            '{}:({})'.format(k, re_to_esc.sub(r'\\\g<0>', param[k]))
-            for k in check_params
-            if k in param
-        ]
-        if param.get('isbn'):
-            q_list.append(
-                'isbn:(%s)' % (normalize_isbn(param['isbn']) or param['isbn'])
-            )
-    return (q_list, use_dismax)
+    check_params = [
+        'title',
+        'publisher',
+        'oclc',
+        'lccn',
+        'contributor',
+        'subject',
+        'place',
+        'person',
+        'time',
+    ]
+    q_list += [
+        '{}:({})'.format(k, re_to_esc.sub(r'\\\g<0>', param[k]))
+        for k in check_params
+        if k in param
+    ]
+
+    if param.get('isbn'):
+        q_list.append('isbn:(%s)' % (normalize_isbn(param['isbn']) or param['isbn']))
+
+    return ' AND '.join(q_list)
 
 
 def execute_solr_query(
@@ -482,15 +472,18 @@ def has_solr_editions_enabled():
 
 
 def run_solr_query(
-    param=None,
+    param: Optional[dict] = None,
     rows=100,
     page=1,
-    sort=None,
+    sort: str = None,
     spellcheck_count=None,
     offset=None,
     fields: Union[str, list[str]] = None,
     facet=True,
 ):
+    """
+    :param param: dict of query parameters
+    """
     param = param or {}
 
     if not fields:
@@ -502,7 +495,6 @@ def run_solr_query(
     if offset is None:
         offset = rows * (page - 1)
 
-    (q_list, use_dismax) = build_q_list(param)
     params = [
         ('fq', 'type:work'),
         ('start', offset),
@@ -555,7 +547,12 @@ def run_solr_query(
         values = param[field]
         params += [('fq', f'{field}:"{val}"') for val in values if val]
 
-    if q_list:
+    if param.get('q'):
+        q = process_user_query(param['q'])
+    else:
+        q = build_q_from_params(param)
+
+    if q:
         if has_solr_editions_enabled():
             EDITION_FIELDS = {
                 # Internals
@@ -585,126 +582,109 @@ def run_solr_query(
                 'public_scan_b': 'public_scan_b',
             }
 
-            def convert_work_field_to_edition_field(
-                work_field_val: str,
-            ) -> Optional[str]:
-                field, val = work_field_val.split(':', 1)
+            def convert_work_field_to_edition_field(field: str) -> Optional[str]:
                 if field in EDITION_FIELDS:
-                    return f'{EDITION_FIELDS[field]}:{val}'
+                    return EDITION_FIELDS[field]
+                elif field.startswith('id_'):
+                    return field
                 elif field in ALL_FIELDS:
                     return None
                 else:
-                    # handle invalid fields; eg a search for "flatland: a romance"
-                    return work_field_val
+                    raise ValueError(f'Unknown field: {field}')
 
-            if True or use_dismax:
-                work_q_list = q_list
-                if work_q_list[0].startswith('text:'):
-                    work_q_list[0] = work_q_list[0][len('text:') :]
-                work_query = (
-                    '''({{!edismax q.op="AND" qf="{qf}" bf="{bf}" v="{v}"}})'''.format(
-                        qf='text alternative_title^20 author_name^20',
-                        bf='min(100,edition_count)',
-                        v=' '.join(work_q_list).replace('"', '\\"'),
-                    )
+            work_q_tree = luqum_parser(q)
+            work_query = (
+                '''({{!edismax q.op="AND" qf="{qf}" bf="{bf}" v="{v}"}})'''.format(
+                    qf='text alternative_title^20 author_name^20',
+                    bf='min(100,edition_count)',
+                    v=str(work_q_tree).replace('"', '\\"'),
                 )
+            )
 
-                ed_q_list = []
-                for q in q_list:
-                    if ':' not in q:
-                        ed_q_list.append(q)
-                        continue
+            def convert_work_query_to_edition_query(work_query: str) -> str:
+                q_tree = luqum_parser(work_query)
 
-                    ed_field_val = convert_work_field_to_edition_field(q)
-                    if ed_field_val:
-                        ed_q_list.append(ed_field_val)
+                for node, parents in luqum_traverse(q_tree):
+                    if isinstance(node, luqum.tree.SearchField):
+                        new_name = convert_work_field_to_edition_field(node.name)
+                        if new_name:
+                            node.name = new_name
+                        else:
+                            try:
+                                luqum_remove_child(node, parents)
+                            except EmptyTreeError:
+                                # Deleted the whole tree! Nothing left
+                                return ''
 
-                if ed_q_list and ed_q_list[0].startswith('text:'):
-                    ed_q_list[0] = ed_q_list[0][len('text:') :]
-                ed_q_list = [f'+{term}' if ':' in term else term for term in ed_q_list]
+                return str(q_tree)
 
-                # params.append(('edQuery', ed_query))
-                # params.append(
-                #     (
-                #         'fl',
-                #         ','.join(
-                #             (fields or list(DEFAULT_SEARCH_FIELDS))
-                #             + [
-                #                 'editions',
-                #                 '[child limit=1 childFilter=$edQuery]',
-                #             ]
-                #         ),
-                #     )
-                # )
+            ed_q = convert_work_query_to_edition_query(str(work_q_tree))
+            params.append(('editions.fq', 'type:edition'))
+            for param_name, param_value in params:
+                if param_name != 'fq' or param_value.startswith('type:'):
+                    continue
+                field_name, field_val = param_value.split(':', 1)
+                ed_field = convert_work_field_to_edition_field(field_name)
+                if ed_field:
+                    params.append(('editions.fq', f'{ed_field}:{field_val}'))
 
-                params.append(('editions.fq', 'type:edition'))
-                for param_name, param_value in params:
-                    if param_name != 'fq' or param_value.startswith('type:'):
-                        continue
-                    ed_q = convert_work_field_to_edition_field(param_value)
-                    if ed_q:
-                        params.append(('editions.fq', ed_q))
+            user_lang = convert_iso_to_marc(web.ctx.lang or 'en') or 'eng'
 
-                user_lang = convert_iso_to_marc(web.ctx.lang or 'en') or 'eng'
-
-                editions_query = '({!edismax bq="%(bq)s" v="%(v)s" qf="%(qf)s"})' % {
-                    'qf': 'text title^4',
-                    'v': ' '.join(ed_q_list).replace('"', '\\"') or '*:*',
-                    'bq': ' '.join(
-                        (
-                            f'language:{user_lang}^40',
-                            'ebook_access:public^10',
-                            'ebook_access:borrowable^8',
-                            'ebook_access:printdisabled^2',
-                            'cover_i:*^2',
-                        )
-                    ),
-                }
-
-                if ed_q_list:
-                    params.append(('edQuery', editions_query))
-                    q = ' '.join(
-                        (
-                            f'+{work_query}',
-                            '+_query_:"{!parent which=type:work v=$edQuery filters=$editions.fq}"',
-                        )
-                    )
-                    params.append(('q', q))
-                else:
-                    params.append(('q', work_query))
-
-                params.append(
+            editions_query = '({!edismax bq="%(bq)s" v="%(v)s" qf="%(qf)s"})' % {
+                'qf': 'text title^4',
+                'v': ed_q.replace('"', '\\"') or '*:*',
+                'bq': ' '.join(
                     (
-                        'editions.q',
-                        f'({{!terms f=_root_ v=$row.key}}) AND {editions_query}',
+                        f'language:{user_lang}^40',
+                        'ebook_access:public^10',
+                        'ebook_access:borrowable^8',
+                        'ebook_access:printdisabled^2',
+                        'cover_i:*^2',
                     )
-                )
-                params.append(('editions.rows', 1))
-                params.append(
+                ),
+            }
+
+            if ed_q:
+                # The elements in _this_ edition query should cause works not to
+                # match _at all_ if matching editions are not found
+                params.append(('edQuery', editions_query))
+                q = ' '.join(
                     (
-                        'fl',
-                        ','.join(
-                            (fields or list(DEFAULT_SEARCH_FIELDS))
-                            + [
-                                'editions:[subquery]',
-                            ]
-                        ),
+                        f'+{work_query}',
+                        '+_query_:"{!parent which=type:work v=$edQuery filters=$editions.fq}"',
                     )
                 )
+                params.append(('q', q))
             else:
-                raise NotImplementedError()
+                params.append(('q', work_query))
+
+            # The elements in _this_ edition query will match but not affect
+            # whether the work appears in search results
+            params.append(
+                (
+                    'editions.q',
+                    f'({{!terms f=_root_ v=$row.key}}) AND {editions_query}',
+                )
+            )
+            params.append(('editions.rows', 1))
+            params.append(
+                (
+                    'fl',
+                    ','.join(
+                        (fields or list(DEFAULT_SEARCH_FIELDS))
+                        + [
+                            'editions:[subquery]',
+                        ]
+                    ),
+                )
+            )
         else:
             params.append(('fl', ','.join(fields or DEFAULT_SEARCH_FIELDS)))
             params.append(('q.op', 'AND'))
-            if use_dismax:
-                params.append(('q', ' '.join(q_list)))
-                params.append(('defType', 'dismax'))
-                params.append(('qf', 'text alternative_title^20 author_name^20'))
-                params.append(('bf', 'min(100,edition_count)'))
-            else:
-                params.append(
-                    ('q', ' '.join(q_list + ['_val_:"sqrt(edition_count)"^10']))
-                )
+            params.append(('q', q))
+            params.append(('defType', 'dismax'))
+            params.append(('qf', 'text alternative_title^20 author_name^20'))
+            params.append(('bf', 'min(100,edition_count)'))
 
     if sort:
         params.append(('sort', sort))
@@ -713,10 +693,21 @@ def run_solr_query(
 
     response = execute_solr_query(solr_select_url, params)
     solr_result = response.json() if response else None
-    return (solr_result, url, q_list)
+    return (solr_result, url, [])
 
 
-def do_search(param, sort, page=1, rows=100, spellcheck_count=None):
+def do_search(
+    param: dict,
+    sort: Optional[str],
+    page=1,
+    rows=100,
+    spellcheck_count=None,
+):
+    """
+    :param param: dict of search url parameters
+    :param sort: csv sort ordering
+    :param spellcheck_count: Not really used; should probably drop
+    """
     if sort:
         sort = process_sort(sort)
     (solr_result, solr_select, q_list) = run_solr_query(

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -14,6 +14,7 @@ import web
 from requests import Response
 import urllib
 import luqum
+import luqum.tree
 from luqum.exceptions import ParseSyntaxError
 
 from infogami import config
@@ -621,7 +622,14 @@ def run_solr_query(
                     if isinstance(node, luqum.tree.SearchField):
                         new_name = convert_work_field_to_edition_field(node.name)
                         if new_name:
-                            node.name = new_name
+                            parent = parents[-1] if parents else None
+                            # Prefixing with + makes the field mandatory
+                            if isinstance(
+                                parent, (luqum.tree.Not, luqum.tree.Prohibit)
+                            ):
+                                node.name = new_name
+                            else:
+                                node.name = f'+{new_name}'
                         else:
                             try:
                                 luqum_remove_child(node, parents)

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -457,6 +457,26 @@ def parse_json_from_solr_query(
         return None
 
 
+@public
+def has_solr_editions_enabled():
+    def read_query_string():
+        return web.input(editions=None).get('editions')
+
+    def read_cookie():
+        if "SOLR_EDITIONS" in web.ctx.env.get("HTTP_COOKIE", ""):
+            return web.cookies().get('SOLR_EDITIONS')
+
+    qs_value = read_query_string()
+    if qs_value is not None:
+        return qs_value == 'true'
+
+    cookie_value = read_cookie()
+    if cookie_value is not None:
+        return cookie_value == 'true'
+
+    return True
+
+
 def run_solr_query(
     param=None,
     rows=100,
@@ -494,7 +514,7 @@ def run_solr_query(
             params.append(('facet.field', facet))
 
     if q_list:
-        if web.input(editions='').get('editions') == 'true':
+        if has_solr_editions_enabled():
             EDITION_FIELDS = {
                 # Internals
                 'edition_key': 'key',

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -637,7 +637,7 @@ def run_solr_query(
                     if ed_q:
                         params.append(('editions.fq', ed_q))
 
-                user_lang = convert_iso_to_marc(web.ctx.lang or 'en')
+                user_lang = convert_iso_to_marc(web.ctx.lang or 'en') or 'eng'
 
                 editions_query = '({!edismax bq="%(bq)s" v="%(v)s" qf="%(qf)s"})' % {
                     'qf': 'text title^4',

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -569,10 +569,13 @@ def run_solr_query(
                 # Identifiers
                 'isbn': 'isbn',
                 'id_*': 'id_*',
+                'ebook_access': 'ebook_access',
                 # IA
+                'has_fulltext': 'has_fulltext',
                 'ia': 'ia',
                 'ia_collection': 'ia_collection',
                 'ia_box_id': 'ia_box_id',
+                'public_scan_b': 'public_scan_b',
             }
 
             def convert_work_field_to_edition_field(
@@ -646,7 +649,15 @@ def run_solr_query(
                             % {
                                 'qf': 'text title^4',
                                 'v': " ".join(ed_q_list).replace('"', '\\"'),
-                                'bq': f'language:{user_lang}^40 ia:*^10',
+                                'bq': ' '.join(
+                                    (
+                                        f'language:{user_lang}^40',
+                                        'ebook_access:public^10',
+                                        'ebook_access:borrowable^8',
+                                        'ebook_access:printdisabled^2',
+                                        'cover_i:*^2',
+                                    )
+                                ),
                             }
                         ),
                     )

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -61,6 +61,7 @@ ALL_FIELDS = [
     "subtitle",
     "alternative_title",
     "alternative_subtitle",
+    "cover_i",
     "ebook_access",
     "edition_count",
     "edition_key",
@@ -86,7 +87,7 @@ ALL_FIELDS = [
     "edition_count",
     "publish_year",
     "language",
-    "number_of_pages",
+    "number_of_pages_median",
     "ia_count",
     "publisher_facet",
     "author_facet",
@@ -119,6 +120,7 @@ FIELD_NAME_MAP = {
     'authors': 'author_name',
     'editions': 'edition_count',
     'by': 'author_name',
+    'number_of_pages': 'number_of_pages_median',
     'publishers': 'publisher',
     'subtitle': 'alternative_subtitle',
     'title': 'alternative_title',
@@ -353,10 +355,16 @@ def ia_collection_s_transform(sf: luqum.tree.SearchField):
 
 
 def process_user_query(q_param: str) -> str:
-    # Solr 4+ has support for regexes (eg `key:/foo.*/`)! But for now, let's not
-    # expose that and escape all '/'. Otherwise `key:/works/OL1W` is interpreted as
-    # a regex.
-    q_param = q_param.strip().replace('/', '\\/')
+    q_param = (
+        # Solr 4+ has support for regexes (eg `key:/foo.*/`)! But for now, let's
+        # not expose that and escape all '/'. Otherwise `key:/works/OL1W` is
+        # interpreted as a regex.
+        q_param.strip()
+        .replace('/', '\\/')
+        # Also escape question marks/tildes, which have special meaning in lucene
+        .replace('?', '\\?')
+        .replace('~', '\\~')
+    )
     try:
         q_param = escape_unknown_fields(
             q_param,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -15,7 +15,7 @@ from requests import Response
 import urllib
 import luqum
 import luqum.tree
-from luqum.exceptions import ParseSyntaxError
+from luqum.exceptions import ParseError
 
 from infogami import config
 from infogami.utils import delegate, stats
@@ -372,7 +372,7 @@ def process_user_query(q_param: str) -> str:
             lower=True,
         )
         q_tree = luqum_parser(q_param)
-    except ParseSyntaxError:
+    except ParseError:
         # This isn't a syntactically valid lucene query
         logger.warning("Invalid lucene query", exc_info=True)
         # Escape everything we can

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -570,10 +570,10 @@ def run_solr_query(
                         'editions.q',
                         (
                             '({!terms f=_root_ v=$row.key}) AND '
-                            '({!edismax q.op="AND" bq="%(bq)s" v="%(v)s" qf="%(qf)s"})'
+                            '({!edismax bq="%(bq)s" v="%(v)s" qf="%(qf)s"})'
                             % {
                                 'qf': 'text title^4',
-                                'v': " ".join(ed_q_list),
+                                'v': " ".join(ed_q_list).replace('"', '\\"'),
                                 'bq': f'language:{user_lang}^40 ia:*^10',
                             }
                         ),

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -349,19 +349,18 @@ def ia_collection_s_transform(sf: luqum.tree.SearchField):
 
 
 def process_user_query(q_param: str) -> str:
-    q_param = (
-        # Solr 4+ has support for regexes (eg `key:/foo.*/`)! But for now, let's
-        # not expose that and escape all '/'. Otherwise `key:/works/OL1W` is
-        # interpreted as a regex.
-        q_param.strip()
-        .replace('/', '\\/')
-        # Also escape question marks/tildes, which have special meaning in lucene
-        .replace('?', '\\?')
-        .replace('~', '\\~')
-    )
     try:
         q_param = escape_unknown_fields(
-            q_param,
+            (
+                # Solr 4+ has support for regexes (eg `key:/foo.*/`)! But for now, let's
+                # not expose that and escape all '/'. Otherwise `key:/works/OL1W` is
+                # interpreted as a regex.
+                q_param.strip()
+                .replace('/', '\\/')
+                # Also escape unexposed lucene features
+                .replace('?', '\\?')
+                .replace('~', '\\~')
+            ),
             lambda f: f in ALL_FIELDS or f in FIELD_NAME_MAP or f.startswith('id_'),
             lower=True,
         )

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -769,7 +769,7 @@ def run_solr_query(
 
     response = execute_solr_query(solr_select_url, params)
     solr_result = response.json() if response else None
-    return (solr_result, url, [])
+    return (solr_result, url)
 
 
 def do_search(
@@ -786,7 +786,7 @@ def do_search(
     """
     if sort:
         sort = process_sort(sort)
-    (solr_result, solr_select, q_list) = run_solr_query(
+    (solr_result, solr_select) = run_solr_query(
         param, rows, page, sort, spellcheck_count
     )
 
@@ -797,7 +797,6 @@ def do_search(
             is_advanced=bool(param.get('q')),
             num_found=None,
             solr_select=solr_select,
-            q_list=q_list,
             error=(solr_result.get('error') if solr_result else None),
         )
 
@@ -821,7 +820,6 @@ def do_search(
         is_advanced=bool(param.get('q')),
         num_found=solr_result['response']['numFound'],
         solr_select=solr_select,
-        q_list=q_list,
         error=None,
         # spellcheck=spell_map,
     )
@@ -865,7 +863,6 @@ def get_doc(doc: SolrDocument):
         id_librivox=doc.get('id_librivox', []),
         id_standard_ebooks=doc.get('id_standard_ebooks', []),
         id_openstax=doc.get('id_openstax', []),
-        # matching_editions=doc.get('editions', {}).get('numFound'),
         editions=[
             web.storage(
                 {
@@ -876,10 +873,6 @@ def get_doc(doc: SolrDocument):
             )
             for ed in doc.get('editions', {}).get('docs', [])
         ],
-        # editions=[
-        #     web.storage({**ed, 'url': f"{ed['key']}/{urlsafe(ed['title'])}"})
-        #     for ed in doc.get('editions', [])
-        # ],
     )
 
 
@@ -1463,7 +1456,7 @@ def work_search(
         query['q'], page, offset, limit
     )
     try:
-        (reply, solr_select, q_list) = run_solr_query(
+        (reply, solr_select) = run_solr_query(
             query,
             rows=limit,
             page=page,

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -478,7 +478,7 @@ def has_solr_editions_enabled():
     if cookie_value is not None:
         return cookie_value == 'true'
 
-    return True
+    return False
 
 
 def run_solr_query(

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -606,6 +606,7 @@ def run_solr_query(
 
                 if ed_q_list and ed_q_list[0].startswith('text:'):
                     ed_q_list[0] = ed_q_list[0][len('text:') :]
+                ed_q_list = [f'+{term}' if ':' in term else term for term in ed_q_list]
 
                 # params.append(('edQuery', ed_query))
                 # params.append(

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -607,11 +607,12 @@ def run_solr_query(
                     raise ValueError(f'Unknown field: {field}')
 
             work_q_tree = luqum_parser(q)
+            params.append(('workQuery', str(work_q_tree)))
             work_query = (
-                '''({{!edismax q.op="AND" qf="{qf}" bf="{bf}" v="{v}"}})'''.format(
+                '''({{!edismax q.op="AND" qf="{qf}" bf="{bf}" v={v}}})'''.format(
                     qf='text alternative_title^20 author_name^20',
                     bf='min(100,edition_count)',
-                    v=str(work_q_tree).replace('"', '\\"'),
+                    v='$workQuery',
                 )
             )
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -22,7 +22,11 @@ from openlibrary.core.lending import add_availability, get_availability_of_ocaid
 from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.plugins.inside.code import fulltext_search
 from openlibrary.plugins.openlibrary.processors import urlsafe
-from openlibrary.plugins.upstream.utils import get_language_name, urlencode
+from openlibrary.plugins.upstream.utils import (
+    convert_iso_to_marc,
+    get_language_name,
+    urlencode,
+)
 from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.utils import escape_bracket
 from openlibrary.utils.ddc import (
@@ -559,6 +563,8 @@ def run_solr_query(
                 # )
 
                 params.append(('editions.fq', 'type:edition'))
+                user_lang = convert_iso_to_marc(web.ctx.lang or 'en')
+
                 params.append(
                     (
                         'editions.q',
@@ -568,7 +574,7 @@ def run_solr_query(
                             % {
                                 'qf': 'text title^4',
                                 'v': " ".join(ed_q_list),
-                                'bq': 'language:eng^40 ia:*^10',
+                                'bq': f'language:{user_lang}^40 ia:*^10',
                             }
                         ),
                     )

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -792,7 +792,13 @@ def get_doc(doc: SolrDocument):
         id_openstax=doc.get('id_openstax', []),
         # matching_editions=doc.get('editions', {}).get('numFound'),
         editions=[
-            web.storage({**ed, 'url': f"{ed['key']}/{urlsafe(ed['title'])}"})
+            web.storage(
+                {
+                    **ed,
+                    'title': ed.get('title', 'Untitled'),
+                    'url': f"{ed['key']}/{urlsafe(ed.get('title', 'Untitled'))}",
+                }
+            )
             for ed in doc.get('editions', {}).get('docs', [])
         ],
         # editions=[

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -484,10 +484,15 @@ def run_solr_query(
     sort=None,
     spellcheck_count=None,
     offset=None,
-    fields=None,
+    fields: Union[str, list[str]] = None,
     facet=True,
 ):
     param = param or {}
+
+    if not fields:
+        fields = []
+    elif isinstance(fields, str):
+        fields = fields.split(',')
 
     # use page when offset is not specified
     if offset is None:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -50,6 +50,7 @@ ALL_FIELDS = [
     "subtitle",
     "alternative_title",
     "alternative_subtitle",
+    "ebook_access",
     "edition_count",
     "edition_key",
     "by_statement",

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -5,8 +5,8 @@ import logging
 import random
 import re
 import string
-from typing import List, Tuple, Any, Union, Optional, Dict
-from collections.abc import Iterable
+import sys
+from typing import List, Tuple, Any, Union, Optional, Iterable, Dict
 from unicodedata import normalize
 from json import JSONDecodeError
 import requests
@@ -459,6 +459,9 @@ def parse_json_from_solr_query(
 
 @public
 def has_solr_editions_enabled():
+    if 'pytest' in sys.modules:
+        return True
+
     def read_query_string():
         return web.input(editions=None).get('editions')
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -524,23 +524,26 @@ def run_solr_query(
 
     if 'public_scan' in param:
         v = param.pop('public_scan').lower()
-        if v in ('true', 'false'):
-            if v == 'false':
-                # also constrain on print disabled since the index may not be in sync
-                param.setdefault('print_disabled', 'false')
-            params.append(('fq', 'public_scan_b:%s' % v))
+        if v == 'true':
+            params.append(('fq', 'ebook_access:public'))
+        elif v == 'false':
+            params.append(('fq', '-ebook_access:public'))
 
     if 'print_disabled' in param:
         v = param.pop('print_disabled').lower()
-        if v in ('true', 'false'):
-            minus = '-' if v == 'false' else ''
-            params.append(('fq', '%ssubject_key:protected_daisy' % minus))
+        if v == 'true':
+            params.append(('fq', 'ebook_access:printdisabled'))
+        elif v == 'false':
+            params.append(('fq', '-ebook_access:printdisabled'))
 
     if 'has_fulltext' in param:
         v = param['has_fulltext'].lower()
-        if v not in ('true', 'false'):
+        if v == 'true':
+            params.append(('fq', 'ebook_access:[printdisabled TO *]'))
+        elif v == 'false':
+            params.append(('fq', 'ebook_access:[* TO printdisabled}'))
+        else:
             del param['has_fulltext']
-        params.append(('fq', 'has_fulltext:%s' % v))
 
     for field in FACET_FIELDS:
         if field == 'has_fulltext':

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -588,9 +588,10 @@ def run_solr_query(
                 if field in EDITION_FIELDS:
                     return f'{EDITION_FIELDS[field]}:{val}'
                 elif field in ALL_FIELDS:
-                    return
+                    return None
                 else:
-                    raise ValueError(f'Unknown field: {field}')
+                    # handle invalid fields; eg a search for "flatland: a romance"
+                    return work_field_val
 
             if True or use_dismax:
                 work_q_list = q_list

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -65,6 +65,10 @@ QUERY_PARSER_TESTS = {
         'food rules By:pollan',
         'food rules author_name:pollan',
     ),
+    'Spaces after fields': (
+        'title: "Harry Potter"',
+        'alternative_title:"Harry Potter"',
+    ),
     'Quotes': (
         'title:"food rules" author:pollan',
         'alternative_title:"food rules" author_name:pollan',

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -2,11 +2,10 @@ import pytest
 import web
 from openlibrary.plugins.worksearch.code import (
     process_facet,
+    process_user_query,
     sorted_work_editions,
-    parse_query_fields,
     escape_bracket,
     get_doc,
-    build_q_list,
     escape_colon,
     parse_search_response,
 )
@@ -53,120 +52,75 @@ def test_sorted_work_editions():
 
 # {'Test name': ('query', fields[])}
 QUERY_PARSER_TESTS = {
-    'No fields': ('query here', [{'field': 'text', 'value': 'query here'}]),
+    'No fields': ('query here', 'query here'),
     'Author field': (
         'food rules author:pollan',
-        [
-            {'field': 'text', 'value': 'food rules'},
-            {'field': 'author_name', 'value': 'pollan'},
-        ],
+        'food rules author_name:pollan',
     ),
     'Field aliases': (
         'title:food rules by:pollan',
-        [
-            {'field': 'alternative_title', 'value': 'food rules'},
-            {'field': 'author_name', 'value': 'pollan'},
-        ],
+        'alternative_title:(food rules) author_name:pollan',
     ),
     'Fields are case-insensitive aliases': (
         'food rules By:pollan',
-        [
-            {'field': 'text', 'value': 'food rules'},
-            {'field': 'author_name', 'value': 'pollan'},
-        ],
+        'food rules author_name:pollan',
     ),
     'Quotes': (
         'title:"food rules" author:pollan',
-        [
-            {'field': 'alternative_title', 'value': '"food rules"'},
-            {'field': 'author_name', 'value': 'pollan'},
-        ],
+        'alternative_title:"food rules" author_name:pollan',
     ),
     'Leading text': (
         'query here title:food rules author:pollan',
-        [
-            {'field': 'text', 'value': 'query here'},
-            {'field': 'alternative_title', 'value': 'food rules'},
-            {'field': 'author_name', 'value': 'pollan'},
-        ],
+        'query here alternative_title:(food rules) author_name:pollan',
     ),
     'Colons in query': (
         'flatland:a romance of many dimensions',
-        [
-            {'field': 'text', 'value': r'flatland\:a romance of many dimensions'},
-        ],
+        'flatland\\:a romance of many dimensions',
     ),
     'Colons in field': (
         'title:flatland:a romance of many dimensions',
-        [
-            {
-                'field': 'alternative_title',
-                'value': r'flatland\:a romance of many dimensions',
-            },
-        ],
+        'alternative_title:(flatland\\:a romance of many dimensions)',
     ),
     'Operators': (
         'authors:Kim Harrison OR authors:Lynsay Sands',
-        [
-            {'field': 'author_name', 'value': 'Kim Harrison'},
-            {'op': 'OR'},
-            {'field': 'author_name', 'value': 'Lynsay Sands'},
-        ],
+        'author_name:(Kim Harrison) OR author_name:(Lynsay Sands)',
     ),
     # LCCs
     'LCC: quotes added if space present': (
         'lcc:NC760 .B2813 2004',
-        [
-            {'field': 'lcc', 'value': '"NC-0760.00000000.B2813 2004"'},
-        ],
+        'lcc:"NC-0760.00000000.B2813 2004"',
     ),
     'LCC: star added if no space': (
         'lcc:NC760 .B2813',
-        [
-            {'field': 'lcc', 'value': 'NC-0760.00000000.B2813*'},
-        ],
+        'lcc:NC-0760.00000000.B2813*',
     ),
     'LCC: Noise left as is': (
         'lcc:good evening',
-        [
-            {'field': 'lcc', 'value': 'good evening'},
-        ],
+        'lcc:(good evening)',
     ),
     'LCC: range': (
         'lcc:[NC1 TO NC1000]',
-        [
-            {'field': 'lcc', 'value': '[NC-0001.00000000 TO NC-1000.00000000]'},
-        ],
+        'lcc:[NC-0001.00000000 TO NC-1000.00000000]',
     ),
     'LCC: prefix': (
         'lcc:NC76.B2813*',
-        [
-            {'field': 'lcc', 'value': 'NC-0076.00000000.B2813*'},
-        ],
+        'lcc:NC-0076.00000000.B2813*',
     ),
     'LCC: suffix': (
         'lcc:*B2813',
-        [
-            {'field': 'lcc', 'value': '*B2813'},
-        ],
+        'lcc:*B2813',
     ),
     'LCC: multi-star without prefix': (
         'lcc:*B2813*',
-        [
-            {'field': 'lcc', 'value': '*B2813*'},
-        ],
+        'lcc:*B2813*',
     ),
     'LCC: multi-star with prefix': (
         'lcc:NC76*B2813*',
-        [
-            {'field': 'lcc', 'value': 'NC-0076*B2813*'},
-        ],
+        'lcc:NC-0076*B2813*',
     ),
     'LCC: quotes preserved': (
         'lcc:"NC760 .B2813"',
-        [
-            {'field': 'lcc', 'value': '"NC-0760.00000000.B2813"'},
-        ],
+        'lcc:"NC-0760.00000000.B2813"',
     ),
     # TODO Add tests for DDC
 }
@@ -176,7 +130,7 @@ QUERY_PARSER_TESTS = {
     "query,parsed_query", QUERY_PARSER_TESTS.values(), ids=QUERY_PARSER_TESTS.keys()
 )
 def test_query_parser_fields(query, parsed_query):
-    assert list(parse_query_fields(query)) == parsed_query
+    assert process_user_query(query) == parsed_query
 
 
 #     def test_public_scan(lf):
@@ -242,31 +196,19 @@ def test_get_doc():
     )
 
 
-def test_build_q_list():
-    param = {'q': 'test'}
-    expect = (['test'], True)
-    assert build_q_list(param) == expect
+def test_process_user_query():
+    assert process_user_query('test') == 'test'
 
-    param = {
-        'q': 'title:(Holidays are Hell) authors:(Kim Harrison) OR authors:(Lynsay Sands)'
-    }
-    expect = (
+    q = 'title:(Holidays are Hell) authors:(Kim Harrison) OR authors:(Lynsay Sands)'
+    expect = ' '.join(
         [
-            'alternative_title:((Holidays are Hell))',
-            'author_name:((Kim Harrison))',
+            'alternative_title:(Holidays are Hell)',
+            'author_name:(Kim Harrison)',
             'OR',
-            'author_name:((Lynsay Sands))',
-        ],
-        False,
+            'author_name:(Lynsay Sands)',
+        ]
     )
-    query_fields = [
-        {'field': 'alternative_title', 'value': '(Holidays are Hell)'},
-        {'field': 'author_name', 'value': '(Kim Harrison)'},
-        {'op': 'OR'},
-        {'field': 'author_name', 'value': '(Lynsay Sands)'},
-    ]
-    assert list(parse_query_fields(param['q'])) == query_fields
-    assert build_q_list(param) == expect
+    assert process_user_query(q) == expect
 
 
 def test_parse_search_response():

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -81,6 +81,10 @@ QUERY_PARSER_TESTS = {
         'flatland:a romance of many dimensions',
         'flatland\\:a romance of many dimensions',
     ),
+    'Spaced colons in query': (
+        'flatland : a romance of many dimensions',
+        'flatland\\: a romance of many dimensions',
+    ),
     'Colons in field': (
         'title:flatland:a romance of many dimensions',
         'alternative_title:(flatland\\:a romance of many dimensions)',

--- a/openlibrary/plugins/worksearch/tests/test_worksearch.py
+++ b/openlibrary/plugins/worksearch/tests/test_worksearch.py
@@ -237,6 +237,7 @@ def test_get_doc():
             'id_librivox': [],
             'id_standard_ebooks': [],
             'id_openstax': [],
+            'editions': [],
         }
     )
 

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional
 from luqum.parser import parser
-from luqum.tree import Item, SearchField, BaseOperation, Group, Word
+from luqum.tree import Item, SearchField, BaseOperation, Group, Word, Unary
 import re
 
 
@@ -16,7 +16,7 @@ def luqum_remove_child(child: Item, parents: list[Item]):
     parent = parents[-1] if parents else None
     if parent is None:
         raise EmptyTreeError()
-    elif isinstance(parent, BaseOperation) or isinstance(parent, Group):
+    elif isinstance(parent, (BaseOperation, Group, Unary)):
         new_children = tuple(c for c in parent.children if c != child)
         if not new_children:
             luqum_remove_child(parent, parents[:-1])

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -115,15 +115,13 @@ def luqum_parser(query: str) -> Item:
     """
     tree = parser.parse(query)
 
-    def find_next_word(item: Item) -> tuple[Optional[Word], Optional[BaseOperation]]:
+    def find_next_word(item: Item) -> Optional[tuple[Word, Optional[BaseOperation]]]:
         if isinstance(item, Word):
             return item, None
-        elif isinstance(item, BaseOperation):
-            op = item
-            if isinstance(op.children[0], Word):
-                return op.children[0], op
+        elif isinstance(item, BaseOperation) and isinstance(item.children[0], Word):
+            return item.children[0], item
         else:
-            return None, None
+            return None
 
     for node, parents in luqum_traverse(tree):
         if isinstance(node, BaseOperation):
@@ -134,7 +132,7 @@ def luqum_parser(query: str) -> Item:
             for child in node.children:
                 if isinstance(child, SearchField) and isinstance(child.expr, Word):
                     last_sf = child
-                elif last_sf and (next_word := find_next_word(child)) and next_word[0]:
+                elif last_sf and (next_word := find_next_word(child)):
                     word, parent_op = next_word
                     # Add it over
                     if not isinstance(last_sf.expr, Group):

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -78,7 +78,9 @@ def escape_unknown_fields(
     '(title:foo) OR (blah\\\\:bah)'
     """
     tree = parser.parse(query)
-    escaped_query = query
+    # Note we use the string of the tree, because it strips spaces
+    # like: "title : foo" -> "title:foo"
+    escaped_query = str(tree)
     offset = 0
     for sf, _ in luqum_traverse(tree):
         if isinstance(sf, SearchField) and not is_valid_field(

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -145,6 +145,8 @@ def luqum_parser(query: str) -> Item:
 
     This requires an annoying amount of manipulation of the default
     Luqum parser, unfortunately.
+
+    Also, OL queries allow spaces after fields.
     """
     tree = parser.parse(query)
 
@@ -202,5 +204,10 @@ def luqum_parser(query: str) -> Item:
                 node.children = tuple(
                     child for child in node.children if child not in to_rem
                 )
+
+    # Remove spaces before field names
+    for node, parents in luqum_traverse(tree):
+        if isinstance(node, SearchField):
+            node.expr.head = ''
 
     return tree

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -1,0 +1,132 @@
+from typing import Callable
+from luqum.parser import parser
+from luqum.tree import Item, SearchField, BaseOperation, Group, Word
+import re
+
+
+class EmptyTreeError(Exception):
+    pass
+
+
+def luqum_remove_child(child: Item, parents: list[Item]):
+    parent = parents[-1] if parents else None
+    if parent is None:
+        raise EmptyTreeError()
+    elif isinstance(parent, BaseOperation) or isinstance(parent, Group):
+        new_children = tuple(c for c in parent.children if c != child)
+        if not new_children:
+            luqum_remove_child(parent, parents[:-1])
+        else:
+            parent.children = new_children
+    else:
+        raise ValueError("Not supported for generic class Item")
+
+
+def luqum_traverse(item: Item, parents: list[Item] = None):
+    parents = parents or []
+    yield item, parents
+    new_parents = [*parents, item]
+    for child in item.children:
+        yield from luqum_traverse(child, new_parents)
+
+
+def luqum_find_and_replace(query: str, field_pattern: str, replacement: str) -> str:
+    """
+    >>> luqum_find_and_replace('hello AND has_fulltext:true', 'has_fulltext:true', 'ebook_access:[borrowable TO *]')
+    hello AND ebook_access:[borrowable TO *]
+    >>> luqum_find_and_replace('hello AND has_fulltext: true', 'has_fulltext:true', 'ebook_access:[borrowable TO *]')
+    hello AND ebook_access:[borrowable TO *]
+    >>> luqum_find_and_replace('hello AND (has_fulltext:true)', 'has_fulltext:true', 'ebook_access:[borrowable TO *]')
+    return hello AND (ebook_access:[borrowable TO *])
+    """
+    tree = parser.parse(query)
+    field_tree = parser.parse(field_pattern)
+    assert isinstance(field_tree, SearchField)
+    for item, parents in luqum_traverse(tree):
+        if item == field_tree:
+            replacement_tree = parser.parse(replacement)
+            replacement_tree.head = item.head
+            replacement_tree.tail = item.tail
+            print(item, parents)
+            parents[-1].children = tuple(
+                child if child is item else replacement_tree
+                for child in parents[-1].children
+            )
+    return str(tree)
+
+
+def escape_unknown_fields(query: str, is_valid_field: Callable[[str], bool]) -> str:
+    """
+    >>> escape_unknown_fields('title:foo', lambda field: False)
+    'title\\:foo'
+    >>> escape_unknown_fields('title:foo bar   blah:bar baz:boo', lambda field: False)
+    'title\\:foo bar   blah\\:bar baz\\:boo'
+    >>> escape_unknown_fields('title:foo bar', {'title'}.__contains__)
+    'title:foo bar'
+    >>> escape_unknown_fields('title:foo bar baz:boo', {'title'}.__contains__)
+    'title:foo bar baz\\:boo'
+    >>> escape_unknown_fields('hi', {'title'}.__contains__)
+    'hi'
+    """
+    # Treat as just normal text with the colon escaped
+    tree = parser.parse(query)
+    escaped_query = query
+    offset = 0
+    for sf, _ in luqum_traverse(tree):
+        if isinstance(sf, SearchField) and not is_valid_field(sf.name):
+            field = sf.name + r'\:'
+            if hasattr(sf, 'head'):
+                field = sf.head + field
+            escaped_query = (
+                escaped_query[: sf.pos + offset]
+                + field
+                + escaped_query[sf.pos + len(field) - 1 + offset :]
+            )
+            offset += 1
+    return escaped_query
+
+
+def fully_escape_query(query: str) -> str:
+    """
+    >>> fully_escape_query('title:foo')
+    'title\\:foo'
+    >>> fully_escape_query('title:foo bar')
+    'title\\:foo bar'
+    >>> fully_escape_query('title:foo (bar baz:boo)')
+    'title\\:foo \\(bar baz\\:boo\\)'
+    >>> fully_escape_query('x:[A TO Z}')
+    'x\\:\\[A TO Z\\}'
+    """
+    escaped = query
+    # Escape special characters
+    escaped = re.sub(r'[\[\]\(\)\{\}:]', lambda _1: f'\\{_1.group(0)}', escaped)
+    # Remove boolean operators by making them lowercase
+    escaped = re.sub(r'AND|OR|NOT', lambda _1: _1.lower(), escaped)
+    return escaped
+
+
+def luqum_parser(query: str) -> Item:
+    tree = parser.parse(query)
+
+    for node, parents in luqum_traverse(tree):
+        # if the first child is a search field and words, we bundle
+        # the words into the search field value
+        # eg. (title:foo) (bar) (baz) -> title:(foo bar baz)
+        if isinstance(node, BaseOperation) and isinstance(
+            node.children[0], SearchField
+        ):
+            sf = node.children[0]
+            others = node.children[1:]
+            if isinstance(sf.expr, Word) and all(isinstance(n, Word) for n in others):
+                # Replace BaseOperation with SearchField
+                node.children = others
+                sf.expr = Group(type(node)(sf.expr, *others))
+                parent = parents[-1] if parents else None
+                if not parent:
+                    tree = sf
+                else:
+                    parent.children = tuple(
+                        sf if child is node else child for child in parent.children
+                    )
+
+    return tree

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -119,7 +119,7 @@ def fully_escape_query(query: str) -> str:
     """
     escaped = query
     # Escape special characters
-    escaped = re.sub(r'[\[\]\(\)\{\}:"-+?~]', r'\\\g<0>', escaped)
+    escaped = re.sub(r'[\[\]\(\)\{\}:"-+?~^]', r'\\\g<0>', escaped)
     # Remove boolean operators by making them lowercase
     escaped = re.sub(r'AND|OR|NOT', lambda _1: _1.group(0).lower(), escaped)
     return escaped

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -119,7 +119,7 @@ def fully_escape_query(query: str) -> str:
     """
     escaped = query
     # Escape special characters
-    escaped = re.sub(r'[\[\]\(\)\{\}:"-+?~^]', r'\\\g<0>', escaped)
+    escaped = re.sub(r'[\[\]\(\)\{\}:"-+?~^/\\]', r'\\\g<0>', escaped)
     # Remove boolean operators by making them lowercase
     escaped = re.sub(r'AND|OR|NOT', lambda _1: _1.group(0).lower(), escaped)
     return escaped

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -20,14 +20,16 @@ $else:
   $ show_observations = False
 
 $ edition = storage({})
-$if page.key.startswith('/books'):
+$if query_param('edition', '').startswith('key:'):
+  $ edition = get_type(query_param('edition', '').split(':')[1])
+$elif page.key.startswith('/books'):
   $# We are on an editions page: an edition has been explicitly selected
   $ edition = page
 
 $ selected_provider = None
 $ selected_id = None
 $ provider = None
-$if query_param('edition'):
+$if query_param('edition') and not edition:
   $if ':' in query_param('edition'):
     $ [selected_provider, selected_id] = query_param('edition').split(':')
   $else:

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -77,7 +77,7 @@ $ )
         <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
       $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
-        <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to librarians.')">
+        <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to super librarians.')">
             <label
             style="padding: 4px; display: inline-block;"
             onchange="document.cookie = `SOLR_EDITIONS=\${this.firstElementChild.checked ? 'true' : 'false'}`; location.reload()"
@@ -183,11 +183,12 @@ $ )
             $ username = ctx.user and ctx.user.key.split('/')[-1]
             $if username:
                 $ works = add_read_statuses(username, works)
+            $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
 
             $for work in works:
                 $ read_status = work.get('readinglog', None)
                 $ dropper = macros.ReadingLogDropper([], work=work, reading_log_only=True, page_url="/search", users_work_read_status=read_status)
-                $:macros.SearchResultsWork(work, reading_log=dropper)
+                $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,4 +1,4 @@
-$def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fulltext_search, facet_fields)
+$def with (input, q_param, do_search, get_doc, fulltext_search, facet_fields)
 
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -184,14 +184,9 @@ $ )
                 $ works = add_read_statuses(username, works)
 
             $for work in works:
-                $ ocaid = work.ia[0] if work.ia else None
-                $ availability = (work.get('availability') or {}).get('status')
-                $# if we're explicitly showing *everything*...
-                $# or if we're showing only things with ocaids which are available...
-                $if 'has_fulltext' not in param or (ocaid and availability and availability not in ['error', 'private']):
-                    $ read_status = work.get('readinglog', None)
-                    $ dropper = macros.ReadingLogDropper([], work=work, reading_log_only=True, page_url="/search", users_work_read_status=read_status)
-                    $:macros.SearchResultsWork(work, reading_log=dropper)
+                $ read_status = work.get('readinglog', None)
+                $ dropper = macros.ReadingLogDropper([], work=work, reading_log_only=True, page_url="/search", users_work_read_status=read_status)
+                $:macros.SearchResultsWork(work, reading_log=dropper)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -76,15 +76,16 @@ $ )
         <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
         <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
-      <div style="display: flex; justify-content: flex-end">
-        <label
-          style="padding: 4px; display: inline-block;"
-          onchange="document.cookie = `SOLR_EDITIONS=\${this.firstElementChild.checked ? 'true' : 'false'}`; location.reload()"
-        >
-            <input type="checkbox" $:cond(has_solr_editions_enabled(), 'checked="checked"')/>
-            $:_('Solr Editions <i>Beta</i>')
-        </label>
-      </div>
+      $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+        <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to librarians.')">
+            <label
+            style="padding: 4px; display: inline-block;"
+            onchange="document.cookie = `SOLR_EDITIONS=\${this.firstElementChild.checked ? 'true' : 'false'}`; location.reload()"
+            >
+                <input type="checkbox" $:cond(has_solr_editions_enabled(), 'checked="checked"')/>
+                $:_('Solr Editions <i>Beta</i>')
+            </label>
+        </div>
       $ sticky = set(['sort', 'author_facet', 'language', 'first_publish_year', 'publisher_facet',  'subject_facet', 'person_facet', 'place_facet', 'time_facet', 'public_scan_b'])
 
       $for k, values in param.items():

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -76,6 +76,15 @@ $ )
         <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
         <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
+      <div style="display: flex; justify-content: flex-end">
+        <label
+          style="padding: 4px; display: inline-block;"
+          onchange="document.cookie = `SOLR_EDITIONS=\${this.firstElementChild.checked ? 'true' : 'false'}`; location.reload()"
+        >
+            <input type="checkbox" $:cond(has_solr_editions_enabled(), 'checked="checked"')/>
+            $:_('Solr Editions <i>Beta</i>')
+        </label>
+      </div>
       $ sticky = set(['sort', 'author_facet', 'language', 'first_publish_year', 'publisher_facet',  'subject_facet', 'person_facet', 'place_facet', 'time_facet', 'public_scan_b'])
 
       $for k, values in param.items():

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -168,7 +168,8 @@ $ )
         <div class="resultsContainer search-results-container">
         <div id="searchResults">
           <ul class="list-books">
-            $ works = add_availability([get_doc(d) for d in docs])
+            $ works = [get_doc(d) for d in docs]
+            $ add_availability([(w.get('editions') or [None])[0] or w for w in works])
             $ username = ctx.user and ctx.user.key.split('/')[-1]
             $if username:
                 $ works = add_read_statuses(username, works)

--- a/openlibrary/tests/solr/test_query_utils.py
+++ b/openlibrary/tests/solr/test_query_utils.py
@@ -1,0 +1,24 @@
+from openlibrary.solr.query_utils import luqum_parser
+
+
+def test_luqum_parser():
+    def fn(query: str) -> str:
+        return str(luqum_parser(query))
+
+    assert fn('title:foo') == 'title:foo'
+    assert fn('title:foo bar') == 'title:(foo bar)'
+    assert fn('title:foo AND bar') == 'title:(foo AND bar)'
+    assert fn('title:foo AND bar AND by:boo') == 'title:(foo AND bar) AND by:boo'
+    assert (
+        fn('title:foo AND bar AND by:boo blah blah')
+        == 'title:(foo AND bar) AND by:(boo blah blah)'
+    )
+    assert (
+        fn('title:foo AND bar AND NOT by:boo') == 'title:(foo AND bar) AND NOT by:boo'
+    )
+    assert (
+        fn('title:(foo bar) AND NOT title:blue') == 'title:(foo bar) AND NOT title:blue'
+    )
+    assert fn('no fields here!') == 'no fields here!'
+    # This is non-ideal
+    assert fn('NOT title:foo bar') == 'NOT title:foo bar'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ gunicorn==20.1.0
 httpx==0.23.0
 internetarchive==3.0.2
 isbnlib==3.10.10
+luqum==0.11.0
 lxml==4.9.1
 Pillow==9.2.0
 psycopg2==2.9.3

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -94,6 +94,22 @@
   }
 }
 
+.searchResultItem__librarian-extras {
+  font-size: .7em;
+  border-top: 1px dashed currentColor;
+  margin-top: 8px;
+  margin-bottom: -5px;
+  color: @grey;
+  padding: 7px 0;
+  line-height: 1em;
+  transition: color .2s;
+  text-decoration: dotted underline;
+
+  &:hover {
+    color: @primary-blue;
+  }
+}
+
 .preview-covers img:hover {
   opacity: 1;
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Most of #6377 . Closes #5991

### Technical
- **NEW**: Switched to _off_ by default while I work out perf issues. But should be good to merge!
- Updates search results to display a matching edition cover/title/ebook_access as opposed to work's
- No longer performs `has_fulltext` filter after-the-fact; this is all done by solr
- Installs a new library, `luqum` (for lucene query manipulator). We have to do a lot of manipulation to convert a user query to a query that can be run against editions. Doing regex replaces and string manipulation was making this impossible.
    - Note we kind of had a home grown "parser" written earlier using some clever regexes, but it wasn't flexible enough to do the sort of manipulations I needed.
- Added a Super librarian/admin-only cookie-backed toggle to switch between new edition-aware solr on work-only solr
- Converts all user provided work queries to edition queries by removing fields which do not exist on editions, and applying other various pieces of logic
- Books in search results now link to URLs like: https://testing.openlibrary.org/works/OL466799W/Hello_Lemuria_Hello?edition=key%3A/books/OL8131994M (note the `edition=key:/books/OL...M`). This is to be consistent with the way `ia` works (`edition=ia:some_ocaid`). If you notice, the value of the `edition=` param is starting to look more and more like a solr query. The idea being that in the future we'll be able to use this parameter to choose specific editions arbitrarily.

### Testing

- Compare queries side by side against production with the [OL side-by-side viewer](https://codepen.io/cdrini/full/wvJqzaK) on codepen
- [Search Rankings](https://docs.google.com/spreadsheets/d/1BN5I7-OkTPaoTr2Es6jQ4O9ICWFmH0q9CP6kEgolCgg/edit#gid=1006480604) improved over prod in most areas (second column is testing.openlibrary.org)
![image](https://user-images.githubusercontent.com/6251786/190277331-190ac278-a13a-4347-8e90-793c4a805e0c.png)
    - Note: If these results seem lackluster, it's because they were already greatly improved by #6422, #889, #6425 in the last full reindex

#### [Colab tests](https://colab.research.google.com/drive/1_LHu-e7SldMr7hzsTW7Mgc91bIBIcEhn#scrollTo=qsG50ozPv1EN) on testing.openlibrary.org are better than master:
- ✅ Searching for 'harry potter' should
    - ✅ Show 7 harry potter
    - ✅ Show 7 harry potter books first
    - ✅ Show English editions of each
    - ✅ Show IA editions of each
    - ✅ Show most readable editions
    - ⭕ Should be in order of publication
- ✅ Searching for "chambre des secrets" should
    - ✅ Show HP2 somewhere
    - ⭕ Show HP2 first (6)
    - ✅ Show French HP2 edition/title
    - ✅ Show most readable HP2 edition
- ❌ Searching for "Three body problem" should
    - ❌ Show "Three body problem" as first result (46)
    - ✅ Show English edition
    - ✅ Show readable edition
- ❌ Searching for "kleine hobbit" should
    - ❌ Show "The hobbit" as first result (1)
    - ✅ Show German edition for en users
    - ✅ Show German edition for fr users
    - ✅ Show German edition for de users
    - ✅ Show German edition for zh users
- ✅ French users searching for 'harry potter' should
    - ✅ Show French editions of each
- ✅ Albanian users searching for 'harry potter' should
    - ✅ Show results even if no Albanian edition
    - ⭕ Fallback to english ed
- ✅ Setting German facet should 
    - ✅ Only show German editions
- ✅ Setting German+Ebook facet should
    - ✅ Only show work with German editions available

<a name="screenshot"></a>

### Screenshot
- User's browser language is now used to choose a specific edition
    - ![image](https://user-images.githubusercontent.com/6251786/190331686-57e75f6f-70ae-420a-a393-f961f80515bc.png)
    - left: https://testing.openlibrary.org/search?q=harry+potter&mode=everything
    - right: https://testing.openlibrary.org/search?lang=fr&q=harry+potter&mode=everything
- Edition-specific fields now show the correct edition
    - eg [publisher:librivox](https://testing.openlibrary.org/search?q=publisher%3Alibrivox&mode=everything)
    - ![image](https://user-images.githubusercontent.com/6251786/190332219-e0347c20-b2c4-441e-838d-d5db2731c66c.png)
    - eg [language:chi](https://testing.openlibrary.org/search?q=language%3Achi&mode=everything)
    - ![image](https://user-images.githubusercontent.com/6251786/190337635-70a8a50e-2b06-4ccd-8beb-b36f9d4ae785.png)
- Even when no fields used, the edition _best_ matching the user's query is now surfaced
    - ![image](https://user-images.githubusercontent.com/6251786/190333758-674af5bf-cfc1-47eb-802f-949b330a45f2.png)
    - https://testing.openlibrary.org/search?q=resplandor+stephen+king&mode=everything
    - ![image](https://user-images.githubusercontent.com/6251786/190337927-62c4adf6-ca1b-463c-bf34-2cb932415b30.png)
    - ![image](https://user-images.githubusercontent.com/6251786/190338537-c5a1ff7f-0a2c-47fc-a753-9499b7937efc.png)
    - ![image](https://user-images.githubusercontent.com/6251786/190339751-69ba0319-b188-4322-95ff-43c2ca0e8233.png)
- Intersections of edition backed field now work as expected
    - eg "Find me librivox recording in German"
    - ![image](https://user-images.githubusercontent.com/6251786/190338935-9811da03-d960-4ee1-b8da-4d6049d16f72.png)
    - Previously, this would find all works which had _any_ edition in German, and any edition published by Librivox. It wouldn't find works with _an_ edition both in German and published by Librivox
    - Also powerfully, you can now find books available in certain languages. For example children's books available to read or borrow in French!
    - ![image](https://user-images.githubusercontent.com/6251786/190340609-bb699ced-e5fa-4340-8abc-7741b35c7dcf.png)
        - \* Note: We're using the new field `ebook_access` here instead of `has_fulltext` because `has_fulltext` includes preview-only materials
        - Note the lower number of results
    - Or maybe Stephen king books available in Chinese?
    - ![image](https://user-images.githubusercontent.com/6251786/190341047-876852a0-aca7-4fcc-87a7-455e21541b1c.png)
    - https://testing.openlibrary.org/search?q=author%3Astephen+king+language%3Achi+ebook_access%3A%5Bborrowable+TO+*%5D&mode=everything



### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
