### PR TITLE
Exclude node_modules from babel-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
     module: {
         rules: [{
             test: /\.js$/,
+            exclude: /node_modules/,
             use: {
                 loader: 'babel-loader',
                 options: {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
hotfix

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
babel-loader now ignores all node_modules not used in the bundling process in webpack

### Technical
<!-- What should be noted about the implementation? -->
babel-loader readme also  recommends this: https://github.com/babel/babel-loader
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Frontend works correctly
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
