### PR TITLE
Create generic navbar component

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,25 +1,44 @@
 $def with (edition_count=1, show_observations=False)
 
-<ul class="work-menu sticky">
-  <li class="selected">
-    <a href="#edition-overview">$_("Overview")</a>
-  </li>
-  <li>
-    <a href="#editions-list">
-      $ungettext('View %(count)s Edition', 'View %(count)s Editions', edition_count, count=edition_count)
-    </a>
-  </li>
-  <li>
-    <a href="#details">$_("Details")</a>
-  </li>
-  $if show_observations:
-    <li>
-      <a href="#reader-observations">$_("Reviews")</a>
-    </li>
-  <li>
-    <a href="#lists-section">$_("Lists")</a>
-  </li>
-  <li>
-    <a href="#related-work-carousel">$_("Related Books")</a>
-  </li>
-</ul>
+$ navbar_class = "work-menu sticky"
+$ selected_index = 0
+
+$code:
+  nav_items = [
+    {
+      "link_text": _("Overview"),
+      "href": "#edition-overview",
+      "ol_link_track": "BookPageNavBar|Overview"
+    },
+    {
+      "link_text": ungettext('View %(count)s Edition', 'View %(count)s Editions', edition_count, count=edition_count),
+      "href": "#editions-list",
+      "ol_link_track": "BookPageNavBar|EditionTable"
+    },
+    {
+      "link_text": _("Details"),
+      "href": "#details",
+      "ol_link_track": "BookPageNavBar|Details"
+    },
+    {
+      "link_text": _("Lists"),
+      "href": "#lists-section",
+      "ol_link_track": "BookPageNavBar|Lists"
+    },
+    {
+      "link_text": _("Related Books"),
+      "href": "#related-work-carousel",
+      "ol_link_track": "BookPageNavBar|RelatedBooks"
+    }
+  ]
+
+  if show_observations:
+    nav_items.insert(3,
+      {
+        "link_text": _("Reviews"),
+        "href": "#reader-observations",
+        "ol_link_track": "BookPageNavBar|Reviews"
+      }
+    )
+
+$:render_template("lib/navbar", nav_items, navbar_class=navbar_class, selected_index=3)

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -12,9 +12,10 @@ $def with (edition_count=1, show_observations=False)
   <li>
     <a href="#details">$_("Details")</a>
   </li>
-  <li>
-    <a href="#reader-observations">$_("Reviews")</a>
-  </li>
+  $if show_observations:
+    <li>
+      <a href="#reader-observations">$_("Reviews")</a>
+    </li>
   <li>
     <a href="#lists-section">$_("Lists")</a>
   </li>

--- a/openlibrary/templates/lib/navbar.html
+++ b/openlibrary/templates/lib/navbar.html
@@ -1,0 +1,26 @@
+$def with (nav_items, navbar_class='', selected_index=None)
+
+$# nav_items : list of objects containing data for rendering navbar item
+$# An element of the nav_items list has the following properties:
+$#   link_text : Required string used as the navbar item's text
+$#   "href": Required string URL of the navbar item
+$#   "ol_link_track": Optional string used to populate data-ol-link-track attributes
+$#
+$# navbar_class : String class list assigned to the navbar's parent element
+$# selected_index : Integer denoting the index of the selected navbar item
+
+$if nav_items:
+  <ul class="$navbar_class">
+    $for item in nav_items:
+      $ selected = ''
+      $if selected_index and selected_index == loop.index0:
+        $ selected = "selected"
+
+      $ data = ''
+      $if item.get("ol_link_track", None):
+        $ data = 'data-ol-link-track=%s' % item["ol_link_track"]
+
+      <li class="$selected">
+        <a href="$item['href']" $data>$item['link_text']</a>
+      </li>
+  </ul>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6437

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates component that renders book page style navbars dynamically.  Modified `EditionNavBar.html` to use the new, generic, template.  Added analytics to book page navbar.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
