### PR TITLE
Anonymize patron data

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -354,7 +354,10 @@ class Account(web.storage):
                 grp.remove_user(patron.key)
 
             # Set preferences to default:
-            patron.save_preferences(patron.DEFAULT_PREFERENCES, msg='Reset preferences to default')
+            patron.save_preferences({
+                'updates': 'no',
+                'public_readlog': 'no'
+            })
 
             # Clear patron's profile page:
             data = {'key': patron.key, 'type': '/type/delete'}

--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -104,6 +104,43 @@ class CommonExtras:
             vars={"username": username}
         ))
 
+    @classmethod
+    def update_username(cls, username, new_username, _test=False):
+        oldb = get_db()
+        t = oldb.transaction()
+
+        try:
+            rows_changed = oldb.update(
+                cls.TABLENAME,
+                where="username=$username",
+                username=new_username,
+                vars={"username": username}
+            )
+        except (UniqueViolation, IntegrityError):
+            # if any of the records would conflict with an exiting
+            # record associated with new_username
+            pass  # assuming impossible for now, not a great assumption
+
+        t.rollback() if _test else t.commit()
+        return rows_changed
+
+    @classmethod
+    def delete_all_by_username(cls, username, _test=False):
+        oldb = get_db()
+        t = oldb.transaction()
+
+        try:
+            rows_deleted = oldb.delete(
+                cls.TABLENAME,
+                where="username=$username",
+                vars={"username": username}
+            )
+        except (UniqueViolation, IntegrityError):
+            pass
+
+        t.rollback() if _test else t.commit()
+        return rows_deleted
+
 
 def _proxy(method_name):
     """Create a new function that call method with given name on the

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -877,6 +877,10 @@ class User(Thing):
         # Why nofollow?
         return f'<a rel="nofollow" href="{self.key}" {extra_attrs}>{web.net.htmlquote(self.displayname)}</a>'
 
+    def set_data(self, data):
+        self._data = data
+        self._save()
+
 
 class List(Thing, ListMixin):
     """Class to represent /type/list objects in OL.
@@ -992,6 +996,21 @@ class UserGroup(Thing):
             members.append({'key': userkey})
             self.members = members
             web.ctx.site.save(self.dict(), f"Adding {userkey} to {self.key}")
+
+    def remove_user(self, userkey):
+        if not web.ctx.site.get(userkey):
+            raise KeyError("Invalid userkey")
+
+        members = self.get('members', [])
+
+        # find index of userkey and remove user
+        for i, m in enumerate(members):
+            if m.get('key', None) == userkey:
+                members.pop(i)
+                break
+
+        self.members = members
+        web.ctx.site.save(self.dict(), f"Removing {userkey} from {self.key}")
 
 
 class Subject(web.storage):

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -290,7 +290,7 @@ class people_view:
         if not user:
             raise web.notfound()
 
-        i = web.input(action=None, tag=None, bot=None)
+        i = web.input(action=None, tag=None, bot=None, dry_run=None)
         if i.action == "update_email":
             return self.POST_update_email(user, i)
         elif i.action == "update_password":
@@ -316,7 +316,8 @@ class people_view:
         elif i.action == "su":
             return self.POST_su(user)
         elif i.action == "anonymize_account":
-            return self.POST_anonymize_account(user)
+            test = True if i.dry_run else False
+            return self.POST_anonymize_account(user, test)
         else:
             raise web.seeother(web.ctx.path)
 
@@ -403,8 +404,8 @@ class people_view:
         web.setcookie(config.login_cookie_name, code, expires="")
         return web.seeother("/")
 
-    def POST_anonymize_account(self, account):
-        results = account.anonymize()
+    def POST_anonymize_account(self, account, test):
+        results = account.anonymize(test=test)
         msg = (
             f"Account anonymized. New username: {results['new_username']}. "
             f"Notes deleted: {results['booknotes_count']}. "

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -315,6 +315,8 @@ class people_view:
             return self.POST_set_bot_flag(user, i.bot)
         elif i.action == "su":
             return self.POST_su(user)
+        elif i.action == "anonymize_account":
+            return self.POST_anonymize_account(user)
         else:
             raise web.seeother(web.ctx.path)
 
@@ -400,6 +402,18 @@ class people_view:
         code = account.generate_login_code()
         web.setcookie(config.login_cookie_name, code, expires="")
         return web.seeother("/")
+
+    def POST_anonymize_account(self, account):
+        results = account.anonymize(test=True)
+        msg = (
+            f"Account anonymized. New username: {results['new_username']}. "
+            f"Notes deleted: {results['booknotes_count']}. "
+            f"Ratings updated: {results['ratings_count']}. "
+            f"Observations updated: {results['observations_count']}. "
+            f"Bookshelves updated: {results['bookshelves_count']}."
+        )
+        add_flash_message("info", msg)
+        raise web.seeother(web.ctx.path)
 
 
 class people_edits:

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -404,7 +404,7 @@ class people_view:
         return web.seeother("/")
 
     def POST_anonymize_account(self, account):
-        results = account.anonymize(test=True)
+        results = account.anonymize()
         msg = (
             f"Account anonymized. New username: {results['new_username']}. "
             f"Notes deleted: {results['booknotes_count']}. "

--- a/openlibrary/plugins/openlibrary/js/admin.js
+++ b/openlibrary/plugins/openlibrary/js/admin.js
@@ -27,7 +27,7 @@ export function initAnonymizationButton(button) {
     const displayName = button.dataset.displayName;
     const confirmMessage = `Really anonymize ${displayName}'s account? This will delete ${displayName}'s profile page and booknotes, and anonymize ${displayName}'s reading log, reviews, and star ratings.`;
     button.addEventListener('click', function(event) {
-        if(!confirm(confirmMessage)) {
+        if (!confirm(confirmMessage)) {
             event.preventDefault();
         }
     })

--- a/openlibrary/plugins/openlibrary/js/admin.js
+++ b/openlibrary/plugins/openlibrary/js/admin.js
@@ -22,3 +22,13 @@ export function initAdmin() {
         $('form.olform').find(':checkbox').prop('checked', this.checked);
     });
 }
+
+export function initAnonymizationButton(button) {
+    const displayName = button.dataset.displayName;
+    const confirmMessage = `Really anonymize ${displayName}'s account? This will delete ${displayName}'s profile page and booknotes, and anonymize ${displayName}'s reading log, reviews, and star ratings.`;
+    button.addEventListener('click', function(event) {
+        if(!confirm(confirmMessage)) {
+            event.preventDefault();
+        }
+    })
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -301,9 +301,18 @@ jQuery(function () {
         document.getElementById('password').value = 'admin123'
         document.getElementById('remember').checked = true
     }
-    if (document.getElementById('adminLinks')) {
+    const anonymizationButton = document.querySelector('.account-anonymization-button')
+    const adminLinks = document.getElementById('adminLinks')
+    if (adminLinks || anonymizationButton) {
         import(/* webpackChunkName: "admin" */ './admin')
-            .then((module) => module.initAdmin());
+            .then(module => {
+                if (adminLinks) {
+                    module.initAdmin();
+                }
+                if (anonymizationButton) {
+                    module.initAnonymizationButton(anonymizationButton);
+                }
+            });
     }
 
     if (window.matchMedia('(display-mode: standalone)').matches) {

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -312,7 +312,7 @@ class ReadingLog:
     def reading_log_counts(self):
         counts = Bookshelves.count_total_books_logged_by_user_per_shelf(
             self.user.get_username()
-        )
+        ) if self.user.get_username() else {}
         return {
             'want-to-read': counts.get(
                 Bookshelves.PRESET_BOOKSHELVES['Want to Read'], 0

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -113,7 +113,6 @@ $ has_profile = person.get_user() is not None
             <button type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">block and revert all edits</button>
             <button type="submit" name="action" value="block_account">block this account</button>
             &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">send password reset email</button>
-            <button type="submit" name="action" value="anonymize_account" style="float: right; background: #ffbbbb;">Anonymize Account</button>
             <br/>
             <br/>
             <div class="small">Registered on <span class="time">$datestr(person.registered_on, relative=False)</span>.</div>
@@ -214,9 +213,24 @@ $ has_profile = person.get_user() is not None
                 <a class="tag $cond(person.has_tag(t), 'active')">$t</a>
         </td>
     </tr>
+    <tr>
+        <td>$_("Anonymize Account:")</td>
+        <td>
+            <form method="POST" id="anonymize-form">
+                <button type="submit" name="action" value="anonymize_account" style="float: right;" onclick="confirmAnonymize(event)">$_("Anonymize Account")</button>
+            </form>
+        </td>
+    </tr>
     </tbody>
   </table>
 
+<script>
+    function confirmAnonymize(event) {
+        if(!confirm('Really anonymize this patron? This will delete the patron\'s profile page and booknotes, and anonymize the patron\'s reading log, reviews, and star ratings.')) {
+            event.preventDefault()
+        }
+    }
+</script>
 
 <h2>$_("Loans")</h2>
 <div>

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -120,7 +120,7 @@ $ has_profile = person.get_user() is not None
             <button type="submit" name="action" value="su" style="float: right; background: #ffbbbb;">login as this user</button>
             <div class="small">Activated on <span class="time">$datestr(person.activated_on, relative=False)</span> from <a href="/admin/ip/$v.ip">$v.ip</a>.</div>
         $if person.status == "blocked":
-	        <button type="submit" name="action" value="unblock_account">unblock this account</button>
+            <button type="submit" name="action" value="unblock_account">unblock this account</button>
         $elif person.status == "pending":
             <button type="submit" name="action" value="activate_account">activate account</button>
             <br/>
@@ -133,13 +133,12 @@ $ has_profile = person.get_user() is not None
                     <strong>Activation link expired.</strong>
 
                 <button type="submit" name="action" value="resend_link">Resend activation link</button>.
-                </div>
-            </form>
+            </div>
+        </form>
     </div>
 
   <table id="adminHistory" style="clear: both;">
     <tbody>
-    </tr>
     <tr>
         <td>$_("Name:")</td>
         <td>$person.displayname - <a href="$homepath()$person.username" style="color: #900; text-decoration: none;">view profile</a></td>

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -216,21 +216,15 @@ $ has_profile = person.get_user() is not None
     <tr>
         <td>$_("Anonymize Account:")</td>
         <td>
-            <form method="POST" id="anonymize-form">
-                <button type="submit" name="action" value="anonymize_account" style="float: right;" onclick="confirmAnonymize(event)">$_("Anonymize Account")</button>
+            <form method="POST" id="anonymize-form" action="?debug=true">
+                <input type="checkbox" id="dry-run-checkbox" name="dry_run">
+                <label for="dry-run-checkbox">Dry Run</label>
+                <button type="submit" name="action" value="anonymize_account" style="float: right;" class="account-anonymization-button" data-display-name="$person.username">$_("Anonymize Account")</button>
             </form>
         </td>
     </tr>
     </tbody>
   </table>
-
-<script>
-    function confirmAnonymize(event) {
-        if(!confirm('Really anonymize this patron? This will delete the patron\'s profile page and booknotes, and anonymize the patron\'s reading log, reviews, and star ratings.')) {
-            event.preventDefault()
-        }
-    }
-</script>
 
 <h2>$_("Loans")</h2>
 <div>

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -113,6 +113,7 @@ $ has_profile = person.get_user() is not None
             <button type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">block and revert all edits</button>
             <button type="submit" name="action" value="block_account">block this account</button>
             &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">send password reset email</button>
+            <button type="submit" name="action" value="anonymize_account" style="float: right; background: #ffbbbb;">Anonymize Account</button>
             <br/>
             <br/>
             <div class="small">Registered on <span class="time">$datestr(person.registered_on, relative=False)</span>.</div>

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -2,6 +2,49 @@ import web
 from openlibrary.core.db import get_db
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.booknotes import Booknotes
+from openlibrary.core.observations import Observations
+from openlibrary.core.ratings import Ratings
+
+READING_LOG_DDL = """
+CREATE TABLE bookshelves_books (
+    username text NOT NULL,
+    work_id integer NOT NULL,
+    bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    edition_id integer default null,
+    primary key (username, work_id, bookshelf_id)
+);
+"""
+
+BOOKNOTES_DDL = """
+CREATE TABLE booknotes (
+    username text NOT NULL,
+    work_id integer NOT NULL,
+    edition_id integer NOT NULL default -1,
+    notes text NOT NULL,
+    primary key (username, work_id, edition_id)
+);
+"""
+
+RATINGS_DDL = """
+CREATE TABLE ratings (
+    username text NOT NULL,
+    work_id integer NOT NULL,
+    rating integer,
+    edition_id integer default null,
+    primary key (username, work_id)
+);
+"""
+
+OBSERVATIONS_DDL = """
+CREATE TABLE observations (
+    work_id INTEGER not null,
+    edition_id INTEGER default -1,
+    username text not null,
+    observation_type INTEGER not null,
+    observation_value INTEGER not null,
+    primary key (work_id, edition_id, username, observation_value, observation_type)
+);
+"""
 
 class TestUpdateWorkID:
 
@@ -9,26 +52,14 @@ class TestUpdateWorkID:
     def setup_class(cls):
         web.config.db_parameters = dict(dbn="sqlite", db=":memory:")
         db = get_db()
-        db.query("""
-        CREATE TABLE bookshelves_books (
-        username text NOT NULL,
-        work_id integer NOT NULL,
-        bookshelf_id INTEGER references bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
-        edition_id integer default null,
-        primary key (username, work_id, bookshelf_id)
-        );""")
+        db.query(READING_LOG_DDL)
+        db.query(BOOKNOTES_DDL)
 
-        db.query(
-            """
-            CREATE TABLE booknotes (
-                username text NOT NULL,
-                work_id integer NOT NULL,
-                edition_id integer NOT NULL default -1,
-                notes text NOT NULL,
-                primary key (username, work_id, edition_id)
-            );
-            """
-        )
+    @classmethod
+    def teardown_class(cls):
+        db = get_db()
+        db.query("delete from bookshelves_books;")
+        db.query("delete from booknotes;")
 
     def setup_method(self, method):
         self.db = get_db()
@@ -79,3 +110,85 @@ class TestUpdateWorkID:
         resp = Booknotes.update_work_id("1", "2")
         assert resp == {'rows_changed': 0, 'rows_deleted': 0, 'failed_deletes': 1}
         assert [dict(row) for row in self.db.select("booknotes")] == rows
+
+class TestUsernameUpdate:
+
+    READING_LOG_SETUP_ROWS = [
+        {"username": "@kilgore_trout", "work_id": 1, "edition_id": 1, "bookshelf_id": 1},
+        {"username": "@kilgore_trout", "work_id": 2, "edition_id": 2, "bookshelf_id": 1},
+        {"username": "@billy_pilgrim", "work_id": 1, "edition_id": 1, "bookshelf_id": 2},
+    ]
+    BOOKNOTES_SETUP_ROWS = [
+        {"username": "@kilgore_trout", "work_id": 1, "edition_id": 1, "notes": "Hello"},
+        {"username": "@billy_pilgrim", "work_id": 1, "edition_id": 1, "notes": "World"},
+    ]
+    RATINGS_SETUP_ROWS = [
+        {"username": "@kilgore_trout", "work_id": 1, "edition_id": 1, "rating": 4},
+        {"username": "@billy_pilgrim", "work_id": 5, "edition_id": 1, "rating": 2},
+    ]
+    OBSERVATIONS_SETUP_ROWS = [
+        {"username": "@kilgore_trout", "work_id": 1, "edition_id": 3, "observation_type": 1, "observation_value": 2},
+        {"username": "@billy_pilgrim", "work_id": 2, "edition_id": 4, "observation_type": 4, "observation_value": 1},
+    ]
+
+    @classmethod
+    def setup_class(cls):
+        web.config.db_parameters = dict(dbn="sqlite", db=":memory:")
+        db = get_db()
+        db.query(RATINGS_DDL)
+        db.query(OBSERVATIONS_DDL)
+
+    def setup_method(self):
+        self.db = get_db()
+        self.db.multiple_insert("bookshelves_books", self.READING_LOG_SETUP_ROWS)
+        self.db.multiple_insert("booknotes", self.BOOKNOTES_SETUP_ROWS)
+        self.db.multiple_insert("ratings", self.RATINGS_SETUP_ROWS)
+        self.db.multiple_insert("observations", self.OBSERVATIONS_SETUP_ROWS)
+        # self.db.multiple_insert("observations", self.OBSERVATIONS_SETUP_ROWS)
+
+    def teardown_method(self):
+        self.db.query("delete from bookshelves_books;")
+        self.db.query("delete from booknotes;")
+        self.db.query("delete from ratings;")
+        self.db.query("delete from observations;")
+
+    def test_delete_all_by_username(self):
+        assert len(list(self.db.select("bookshelves_books"))) == 3
+        Bookshelves.delete_all_by_username("@kilgore_trout")
+        assert len(list(self.db.select("bookshelves_books"))) == 1
+
+        assert len(list(self.db.select("booknotes"))) == 2
+        Booknotes.delete_all_by_username('@kilgore_trout')
+        assert len(list(self.db.select("booknotes"))) == 1
+
+        assert len(list(self.db.select("ratings"))) == 2
+        Ratings.delete_all_by_username("@kilgore_trout")
+        assert len(list(self.db.select("ratings"))) == 1
+
+        assert len(list(self.db.select("observations"))) == 2
+        Observations.delete_all_by_username("@kilgore_trout")
+        assert len(list(self.db.select("observations"))) == 1
+
+    def test_update_username(self):
+        before_where = {"username": "@kilgore_trout"}
+        after_where = {"username": "@anonymous"}
+
+        assert len(list(self.db.select("bookshelves_books", where=before_where))) == 2
+        Bookshelves.update_username("@kilgore_trout", "@anonymous")
+        assert len(list(self.db.select("bookshelves_books", where=before_where))) == 0
+        assert len(list(self.db.select("bookshelves_books", where=after_where))) == 2
+
+        assert len(list(self.db.select("booknotes", where=before_where))) == 1
+        Booknotes.update_username("@kilgore_trout", "@anonymous")
+        assert len(list(self.db.select("booknotes", where=before_where))) == 0
+        assert len(list(self.db.select("booknotes", where=after_where))) == 1
+
+        assert len(list(self.db.select("ratings", where=before_where))) == 1
+        Ratings.update_username("@kilgore_trout", "@anonymous")
+        assert len(list(self.db.select("ratings", where=before_where))) == 0
+        assert len(list(self.db.select("ratings", where=after_where))) == 1
+
+        assert len(list(self.db.select("observations", where=before_where))) == 1
+        Observations.update_username("@kilgore_trout", "@anonymous")
+        assert len(list(self.db.select("observations", where=before_where))) == 0
+        assert len(list(self.db.select("observations", where=after_where))) == 1


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates the means for an admin to anonymize a patron's account.  This PR can be moved from draft when the following tasks are complete:
- [X] Add "Anonymize Account" button to `/admin/people` view
- [X] Create testable methods for updating and deleting by username
- [x] Delete or otherwise reset the patron's profile page
- [x] Remove patron from all usergroups
- [x] Reset patron's preferences to default 
- [x] Create unit tests for new DB model methods
- [x] Disable `test` flag for anonymize function (no updates/deletions are committed while `test` is true)

### Technical
<!-- What should be noted about the implementation? -->
The `/admin/people/view.html` template was producing invalid HTML.  The initial commit of this PR solely addresses those issues.

__Important Note:__ If the anonymization process throws an error before it completes we can re-run, but some operations may not be possible during the re-run.  This may result in some lingering records.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![admin_people_new_view](https://user-images.githubusercontent.com/28732543/166081728-f96cc5fd-a797-449f-a3e6-ec08e1f81472.png)
_New button in `/admin/people`._

![anon_success_flash_message](https://user-images.githubusercontent.com/28732543/167227789-df928e10-57ac-40b5-81e9-a4a93656f8bc.png)
_Flash message that is displayed on success_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
