### PR TITLE
Create usergroup that cannot edit

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -758,6 +758,9 @@ class User(Thing):
     def has_librarian_tools(self):
         return self.is_usergroup_member('/usergroup/librarian-tools')
 
+    def is_read_only(self):
+        return self.is_usergroup_member('/usergroup/read-only')
+
     def get_lists(self, seed=None, limit=100, offset=0, sort=True):
         """Returns all the lists of this user.
 

--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -35,6 +35,8 @@ def is_spam(i=None, allow_privileged_edits=False):
         # Allow admins and librarians to make edits:
         if allow_privileged_edits and (user.is_admin() or user.is_librarian()):
             return False
+        if user.is_read_only():
+            return True
         # Prevent deleted users from making edits:
         if user.type.key == '/type/delete':
             return True

--- a/scripts/dev-instance/create-dev-db-pgdump.sh
+++ b/scripts/dev-instance/create-dev-db-pgdump.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Creates database backup SQL script file.
+#
+# This script generates `dev_db.pg_dump` when the following commands are executed:
+#
+# docker-compose exec db bash
+# ./openlibrary/scripts/dev-instance/create-dev-db-pgdump.sh > openlibrary/scripts/dev-instance/dev_db.pg_dump
+
 OL_USER=openlibrary
 
 pg_dump --host=db -U $OL_USER openlibrary

--- a/scripts/dev-instance/dev_db.pg_dump
+++ b/scripts/dev-instance/dev_db.pg_dump
@@ -2,19 +2,27 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.3.25
--- Dumped by pg_dump version 11.14 (Debian 11.14-0+deb10u1)
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
-SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
 
 --
 -- Name: get_olid(text); Type: FUNCTION; Schema: public; Owner: openlibrary
@@ -45,7 +53,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: account; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: account; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.account (
@@ -61,7 +69,7 @@ CREATE TABLE public.account (
 ALTER TABLE public.account OWNER TO openlibrary;
 
 --
--- Name: author_boolean; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: author_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_boolean (
@@ -75,7 +83,7 @@ CREATE TABLE public.author_boolean (
 ALTER TABLE public.author_boolean OWNER TO openlibrary;
 
 --
--- Name: author_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: author_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_int (
@@ -89,7 +97,7 @@ CREATE TABLE public.author_int (
 ALTER TABLE public.author_int OWNER TO openlibrary;
 
 --
--- Name: author_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: author_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_ref (
@@ -103,7 +111,7 @@ CREATE TABLE public.author_ref (
 ALTER TABLE public.author_ref OWNER TO openlibrary;
 
 --
--- Name: author_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: author_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_str (
@@ -117,7 +125,7 @@ CREATE TABLE public.author_str (
 ALTER TABLE public.author_str OWNER TO openlibrary;
 
 --
--- Name: booknotes; Type: TABLE; Schema: public; Owner: postgres
+-- Name: booknotes; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.booknotes (
@@ -133,7 +141,7 @@ CREATE TABLE public.booknotes (
 ALTER TABLE public.booknotes OWNER TO postgres;
 
 --
--- Name: bookshelves; Type: TABLE; Schema: public; Owner: postgres
+-- Name: bookshelves; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.bookshelves (
@@ -149,7 +157,7 @@ CREATE TABLE public.bookshelves (
 ALTER TABLE public.bookshelves OWNER TO postgres;
 
 --
--- Name: bookshelves_books; Type: TABLE; Schema: public; Owner: postgres
+-- Name: bookshelves_books; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.bookshelves_books (
@@ -187,7 +195,7 @@ ALTER SEQUENCE public.bookshelves_id_seq OWNED BY public.bookshelves.id;
 
 
 --
--- Name: bookshelves_votes; Type: TABLE; Schema: public; Owner: postgres
+-- Name: bookshelves_votes; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.bookshelves_votes (
@@ -222,7 +230,7 @@ ALTER SEQUENCE public.bookshelves_votes_bookshelf_id_seq OWNED BY public.bookshe
 
 
 --
--- Name: data; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: data; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.data (
@@ -235,7 +243,7 @@ CREATE TABLE public.data (
 ALTER TABLE public.data OWNER TO openlibrary;
 
 --
--- Name: datum_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: datum_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.datum_int (
@@ -249,7 +257,7 @@ CREATE TABLE public.datum_int (
 ALTER TABLE public.datum_int OWNER TO openlibrary;
 
 --
--- Name: datum_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: datum_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.datum_ref (
@@ -263,7 +271,7 @@ CREATE TABLE public.datum_ref (
 ALTER TABLE public.datum_ref OWNER TO openlibrary;
 
 --
--- Name: datum_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: datum_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.datum_str (
@@ -277,7 +285,7 @@ CREATE TABLE public.datum_str (
 ALTER TABLE public.datum_str OWNER TO openlibrary;
 
 --
--- Name: edition_boolean; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: edition_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_boolean (
@@ -291,7 +299,7 @@ CREATE TABLE public.edition_boolean (
 ALTER TABLE public.edition_boolean OWNER TO openlibrary;
 
 --
--- Name: edition_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: edition_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_int (
@@ -305,7 +313,7 @@ CREATE TABLE public.edition_int (
 ALTER TABLE public.edition_int OWNER TO openlibrary;
 
 --
--- Name: edition_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: edition_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_ref (
@@ -319,7 +327,7 @@ CREATE TABLE public.edition_ref (
 ALTER TABLE public.edition_ref OWNER TO openlibrary;
 
 --
--- Name: edition_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: edition_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_str (
@@ -333,7 +341,7 @@ CREATE TABLE public.edition_str (
 ALTER TABLE public.edition_str OWNER TO openlibrary;
 
 --
--- Name: meta; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: meta; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.meta (
@@ -344,7 +352,7 @@ CREATE TABLE public.meta (
 ALTER TABLE public.meta OWNER TO openlibrary;
 
 --
--- Name: observations; Type: TABLE; Schema: public; Owner: postgres
+-- Name: observations; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.observations (
@@ -360,7 +368,7 @@ CREATE TABLE public.observations (
 ALTER TABLE public.observations OWNER TO postgres;
 
 --
--- Name: property; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: property; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.property (
@@ -394,7 +402,7 @@ ALTER SEQUENCE public.property_id_seq OWNED BY public.property.id;
 
 
 --
--- Name: publisher_boolean; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: publisher_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_boolean (
@@ -408,7 +416,7 @@ CREATE TABLE public.publisher_boolean (
 ALTER TABLE public.publisher_boolean OWNER TO openlibrary;
 
 --
--- Name: publisher_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: publisher_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_int (
@@ -422,7 +430,7 @@ CREATE TABLE public.publisher_int (
 ALTER TABLE public.publisher_int OWNER TO openlibrary;
 
 --
--- Name: publisher_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: publisher_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_ref (
@@ -436,7 +444,7 @@ CREATE TABLE public.publisher_ref (
 ALTER TABLE public.publisher_ref OWNER TO openlibrary;
 
 --
--- Name: publisher_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: publisher_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_str (
@@ -450,7 +458,7 @@ CREATE TABLE public.publisher_str (
 ALTER TABLE public.publisher_str OWNER TO openlibrary;
 
 --
--- Name: ratings; Type: TABLE; Schema: public; Owner: postgres
+-- Name: ratings; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.ratings (
@@ -466,7 +474,7 @@ CREATE TABLE public.ratings (
 ALTER TABLE public.ratings OWNER TO postgres;
 
 --
--- Name: scan_boolean; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: scan_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_boolean (
@@ -480,7 +488,7 @@ CREATE TABLE public.scan_boolean (
 ALTER TABLE public.scan_boolean OWNER TO openlibrary;
 
 --
--- Name: scan_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: scan_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_int (
@@ -494,7 +502,7 @@ CREATE TABLE public.scan_int (
 ALTER TABLE public.scan_int OWNER TO openlibrary;
 
 --
--- Name: scan_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: scan_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_ref (
@@ -508,7 +516,7 @@ CREATE TABLE public.scan_ref (
 ALTER TABLE public.scan_ref OWNER TO openlibrary;
 
 --
--- Name: scan_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: scan_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_str (
@@ -522,7 +530,7 @@ CREATE TABLE public.scan_str (
 ALTER TABLE public.scan_str OWNER TO openlibrary;
 
 --
--- Name: seq; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: seq; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.seq (
@@ -556,7 +564,7 @@ ALTER SEQUENCE public.seq_id_seq OWNED BY public.seq.id;
 
 
 --
--- Name: store; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: store; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.store (
@@ -590,7 +598,7 @@ ALTER SEQUENCE public.store_id_seq OWNED BY public.store.id;
 
 
 --
--- Name: store_index; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: store_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.store_index (
@@ -626,7 +634,7 @@ ALTER SEQUENCE public.store_index_id_seq OWNED BY public.store_index.id;
 
 
 --
--- Name: subject_boolean; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: subject_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_boolean (
@@ -640,7 +648,7 @@ CREATE TABLE public.subject_boolean (
 ALTER TABLE public.subject_boolean OWNER TO openlibrary;
 
 --
--- Name: subject_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: subject_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_int (
@@ -654,7 +662,7 @@ CREATE TABLE public.subject_int (
 ALTER TABLE public.subject_int OWNER TO openlibrary;
 
 --
--- Name: subject_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: subject_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_ref (
@@ -668,7 +676,7 @@ CREATE TABLE public.subject_ref (
 ALTER TABLE public.subject_ref OWNER TO openlibrary;
 
 --
--- Name: subject_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: subject_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_str (
@@ -682,7 +690,7 @@ CREATE TABLE public.subject_str (
 ALTER TABLE public.subject_str OWNER TO openlibrary;
 
 --
--- Name: thing; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: thing; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.thing (
@@ -719,7 +727,7 @@ ALTER SEQUENCE public.thing_id_seq OWNED BY public.thing.id;
 
 
 --
--- Name: transaction; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: transaction; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.transaction (
@@ -759,7 +767,7 @@ ALTER SEQUENCE public.transaction_id_seq OWNED BY public.transaction.id;
 
 
 --
--- Name: transaction_index; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: transaction_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.transaction_index (
@@ -800,7 +808,7 @@ CREATE SEQUENCE public.type_edition_seq
 ALTER TABLE public.type_edition_seq OWNER TO openlibrary;
 
 --
--- Name: type_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: type_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.type_int (
@@ -828,7 +836,7 @@ CREATE SEQUENCE public.type_publisher_seq
 ALTER TABLE public.type_publisher_seq OWNER TO openlibrary;
 
 --
--- Name: type_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: type_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.type_ref (
@@ -842,7 +850,7 @@ CREATE TABLE public.type_ref (
 ALTER TABLE public.type_ref OWNER TO openlibrary;
 
 --
--- Name: type_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: type_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.type_str (
@@ -870,7 +878,7 @@ CREATE SEQUENCE public.type_work_seq
 ALTER TABLE public.type_work_seq OWNER TO openlibrary;
 
 --
--- Name: user_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: user_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.user_int (
@@ -884,7 +892,7 @@ CREATE TABLE public.user_int (
 ALTER TABLE public.user_int OWNER TO openlibrary;
 
 --
--- Name: user_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: user_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.user_ref (
@@ -898,7 +906,7 @@ CREATE TABLE public.user_ref (
 ALTER TABLE public.user_ref OWNER TO openlibrary;
 
 --
--- Name: user_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: user_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.user_str (
@@ -912,7 +920,7 @@ CREATE TABLE public.user_str (
 ALTER TABLE public.user_str OWNER TO openlibrary;
 
 --
--- Name: version; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: version; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.version (
@@ -947,7 +955,7 @@ ALTER SEQUENCE public.version_id_seq OWNED BY public.version.id;
 
 
 --
--- Name: work_boolean; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: work_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_boolean (
@@ -961,7 +969,7 @@ CREATE TABLE public.work_boolean (
 ALTER TABLE public.work_boolean OWNER TO openlibrary;
 
 --
--- Name: work_int; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: work_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_int (
@@ -975,7 +983,7 @@ CREATE TABLE public.work_int (
 ALTER TABLE public.work_int OWNER TO openlibrary;
 
 --
--- Name: work_ref; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: work_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_ref (
@@ -989,7 +997,7 @@ CREATE TABLE public.work_ref (
 ALTER TABLE public.work_ref OWNER TO openlibrary;
 
 --
--- Name: work_str; Type: TABLE; Schema: public; Owner: openlibrary
+-- Name: work_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_str (
@@ -1003,63 +1011,63 @@ CREATE TABLE public.work_str (
 ALTER TABLE public.work_str OWNER TO openlibrary;
 
 --
--- Name: bookshelves id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.bookshelves ALTER COLUMN id SET DEFAULT nextval('public.bookshelves_id_seq'::regclass);
 
 
 --
--- Name: bookshelves_votes bookshelf_id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: bookshelf_id; Type: DEFAULT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.bookshelves_votes ALTER COLUMN bookshelf_id SET DEFAULT nextval('public.bookshelves_votes_bookshelf_id_seq'::regclass);
 
 
 --
--- Name: property id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.property ALTER COLUMN id SET DEFAULT nextval('public.property_id_seq'::regclass);
 
 
 --
--- Name: seq id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.seq ALTER COLUMN id SET DEFAULT nextval('public.seq_id_seq'::regclass);
 
 
 --
--- Name: store id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.store ALTER COLUMN id SET DEFAULT nextval('public.store_id_seq'::regclass);
 
 
 --
--- Name: store_index id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.store_index ALTER COLUMN id SET DEFAULT nextval('public.store_index_id_seq'::regclass);
 
 
 --
--- Name: thing id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.thing ALTER COLUMN id SET DEFAULT nextval('public.thing_id_seq'::regclass);
 
 
 --
--- Name: transaction id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.transaction ALTER COLUMN id SET DEFAULT nextval('public.transaction_id_seq'::regclass);
 
 
 --
--- Name: version id; Type: DEFAULT; Schema: public; Owner: openlibrary
+-- Name: id; Type: DEFAULT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.version ALTER COLUMN id SET DEFAULT nextval('public.version_id_seq'::regclass);
@@ -1355,9 +1363,9 @@ COPY public.booknotes (username, work_id, edition_id, notes, updated, created) F
 --
 
 COPY public.bookshelves (id, name, description, archived, updated, created) FROM stdin;
-1	Want to Read	A list of books I want to read	f	2022-05-13 00:31:44.347658	2022-05-13 00:31:44.347658
-2	Currently Reading	A list of books I am currently reading	f	2022-05-13 00:31:44.350272	2022-05-13 00:31:44.350272
-3	Already Read	A list of books I have finished reading	f	2022-05-13 00:31:44.360133	2022-05-13 00:31:44.360133
+1	Want to Read	A list of books I want to read	f	2022-05-25 22:03:50.632041	2022-05-25 22:03:50.632041
+2	Currently Reading	A list of books I am currently reading	f	2022-05-25 22:03:50.633232	2022-05-25 22:03:50.633232
+3	Already Read	A list of books I have finished reading	f	2022-05-25 22:03:50.634206	2022-05-25 22:03:50.634206
 \.
 
 
@@ -1370,11 +1378,25 @@ COPY public.bookshelves_books (username, work_id, bookshelf_id, edition_id, priv
 
 
 --
+-- Name: bookshelves_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.bookshelves_id_seq', 3, true);
+
+
+--
 -- Data for Name: bookshelves_votes; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
 COPY public.bookshelves_votes (username, bookshelf_id, updated, created) FROM stdin;
 \.
+
+
+--
+-- Name: bookshelves_votes_bookshelf_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.bookshelves_votes_bookshelf_id_seq', 1, false);
 
 
 --
@@ -2064,6 +2086,7 @@ COPY public.data (thing_id, revision, data) FROM stdin;
 667	1	{"identifiers": [{"label": "ISNI", "name": "isni", "notes": "", "url": "http://www.isni.org/@@@", "website": "http://www.isni.org/"}, {"label": "LibriVox", "name": "librivox", "notes": "Should be a number", "url": "https://librivox.org/author/@@@", "website": "https://librivox.org"}, {"label": "Project Gutenberg", "name": "project_gutenberg", "notes": "Should be a number", "url": "https://www.gutenberg.org/ebooks/author/@@@", "website": "https://www.gutenberg.org"}, {"label": "VIAF", "name": "viaf", "notes": "", "url": "https://viaf.org/viaf/@@@", "website": "https://viaf.org"}, {"label": "Wikidata", "name": "wikidata", "notes": "", "url": "https://www.wikidata.org/wiki/@@@", "website": "https://wikidata.org"}], "key": "/config/author", "type": {"key": "/type/object"}, "latest_revision": 1, "revision": 1, "created": {"type": "/type/datetime", "value": "2021-10-07T20:31:34.001079"}, "last_modified": {"type": "/type/datetime", "value": "2021-10-07T20:31:34.001079"}}
 668	1	{"body": {"type": "/type/text", "value": "{{PageList(\\"/usergroup\\")}}"}, "type": {"key": "/type/page"}, "title": "User Groups", "m": "edit", "key": "/usergroup", "latest_revision": 1, "revision": 1, "created": {"type": "/type/datetime", "value": "2022-05-13T00:32:11.984130"}, "last_modified": {"type": "/type/datetime", "value": "2022-05-13T00:32:11.984130"}}
 669	1	{"description": {"type": "/type/text", "value": "Librarians who are permitted to use work merge UI."}, "key": "/usergroup/librarian-work-merge", "members": [{"key": "/people/openlibrary"}], "type": {"key": "/type/usergroup"}, "latest_revision": 1, "revision": 1, "created": {"type": "/type/datetime", "value": "2022-05-13T00:32:45.651043"}, "last_modified": {"type": "/type/datetime", "value": "2022-05-13T00:32:45.651043"}}
+670	1	{"description": {"type": "/type/text", "value": "Patrons who are not permitted to edit records that are spam-checked."}, "type": {"key": "/type/usergroup"}, "m": "edit", "key": "/usergroup/read-only", "latest_revision": 1, "revision": 1, "created": {"type": "/type/datetime", "value": "2022-05-25T21:42:26.830114"}, "last_modified": {"type": "/type/datetime", "value": "2022-05-25T21:42:26.830114"}}
 \.
 
 
@@ -4966,6 +4989,13 @@ COPY public.property (id, type, name) FROM stdin;
 
 
 --
+-- Name: property_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.property_id_seq', 135, true);
+
+
+--
 -- Data for Name: publisher_boolean; Type: TABLE DATA; Schema: public; Owner: openlibrary
 --
 
@@ -5046,6 +5076,13 @@ COPY public.seq (id, name, value) FROM stdin;
 
 
 --
+-- Name: seq_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.seq_id_seq', 1, false);
+
+
+--
 -- Data for Name: store; Type: TABLE DATA; Schema: public; Owner: openlibrary
 --
 
@@ -5055,14 +5092,21 @@ COPY public.store (id, key, json) FROM stdin;
 5	account-email/userbot@example.com	{"username": "AccountBot", "type": "account-email"}
 6	account/AccountBot	{"status": "active", "username": "AccountBot", "type": "account", "data": {"displayname": "AccountBot"}, "created_on": "2013-03-20T10:27:02.560602", "lusername": "accountbot", "enc_password": "b859a$7677638bb1c3f82bf7e1484b4b34b014", "email": "userbot@example.com"}
 8	account-email/openlibrary@example.com	{"username": "openlibrary", "type": "account-email"}
-10	account/openlibrary	{"status": "active", "username": "openlibrary", "enc_password": "dcd90$ab61967218c45d5095dac4f61ab82ccc", "created_on": "2013-03-20T10:27:09.689977", "last_login": "2013-03-26T11:15:26.425677", "lusername": "openlibrary", "type": "account", "data": {"displayname": "Open Library"}, "email": "openlibrary@example.com"}
 22	ebooks/books/OL24503867M	{"borrowed": "false", "type": "ebook", "book_key": "/books/OL24503867M"}
 23	ebooks/books/OL24620876M	{"borrowed": "false", "type": "ebook", "book_key": "/books/OL24620876M"}
 24	ebooks/books/OL24405389M	{"borrowed": "false", "type": "ebook", "book_key": "/books/OL24405389M"}
 25	ebooks/books/OL24972169M	{"borrowed": "false", "type": "ebook", "book_key": "/books/OL24972169M"}
 30	ebooks/books/OL24982896M	{"borrowed": "false", "type": "ebook", "book_key": "/books/OL24982896M"}
 31	ebooks/books/OL24605334M	{"borrowed": "false", "type": "ebook", "book_key": "/books/OL24605334M"}
+33	account/openlibrary	{"status": "active", "username": "openlibrary", "enc_password": "dcd90$ab61967218c45d5095dac4f61ab82ccc", "created_on": "2013-03-20T10:27:09.689977", "last_login": "2013-03-26T11:15:26.425677", "lusername": "openlibrary", "type": "account", "data": {"displayname": "Open Library"}, "email": "openlibrary@example.com", "internetarchive_itemname": "@openlibrary", "s3_keys": {"access": "foo", "secret": "foo"}}
 \.
+
+
+--
+-- Name: store_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.store_id_seq', 33, true);
 
 
 --
@@ -5092,15 +5136,6 @@ COPY public.store_index (id, store_id, type, name, value) FROM stdin;
 36	6	account	lusername	accountbot
 45	8	account-email	_key	account-email/openlibrary@example.com
 46	8	account-email	username	openlibrary
-55	10	account	_key	account/openlibrary
-56	10	account	data.displayname	Open Library
-57	10	account	last_login	2013-03-26T11:15:26.425677
-58	10	account	status	active
-59	10	account	enc_password	dcd90$ab61967218c45d5095dac4f61ab82ccc
-60	10	account	created_on	2013-03-20T10:27:09.689977
-61	10	account	lusername	openlibrary
-62	10	account	username	openlibrary
-63	10	account	email	openlibrary@example.com
 132	22	ebook	_key	ebooks/books/OL24503867M
 133	22	ebook	book_key	/books/OL24503867M
 134	22	ebook	borrowed	false
@@ -5119,7 +5154,26 @@ COPY public.store_index (id, store_id, type, name, value) FROM stdin;
 173	31	ebook	_key	ebooks/books/OL24605334M
 174	31	ebook	book_key	/books/OL24605334M
 175	31	ebook	borrowed	false
+186	33	account	_key	account/openlibrary
+187	33	account	enc_password	dcd90$ab61967218c45d5095dac4f61ab82ccc
+188	33	account	last_login	2013-03-26T11:15:26.425677
+189	33	account	s3_keys.secret	foo
+190	33	account	created_on	2013-03-20T10:27:09.689977
+191	33	account	s3_keys.access	foo
+192	33	account	email	openlibrary@example.com
+193	33	account	internetarchive_itemname	@openlibrary
+194	33	account	status	active
+195	33	account	username	openlibrary
+196	33	account	lusername	openlibrary
+197	33	account	data.displayname	Open Library
 \.
+
+
+--
+-- Name: store_index_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.store_index_id_seq', 197, true);
 
 
 --
@@ -5828,7 +5882,15 @@ COPY public.thing (id, key, type, latest_revision, created, last_modified) FROM 
 667	/config/author	14	1	2021-10-07 20:31:34.001079	2021-10-07 20:31:34.001079
 668	/usergroup	50	1	2022-05-13 00:32:11.98413	2022-05-13 00:32:11.98413
 669	/usergroup/librarian-work-merge	12	1	2022-05-13 00:32:45.651043	2022-05-13 00:32:45.651043
+670	/usergroup/read-only	12	1	2022-05-25 21:42:26.830114	2022-05-25 21:42:26.830114
 \.
+
+
+--
+-- Name: thing_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.thing_id_seq', 670, true);
 
 
 --
@@ -5884,7 +5946,15 @@ COPY public.transaction (id, action, author_id, ip, comment, bot, created, chang
 46	update	524	172.18.0.1		f	2021-10-07 20:31:34.001079	[{"key": "/config/author", "revision": 1}]	{}
 47	update	524	192.168.16.1		f	2022-05-13 00:32:11.98413	[{"key": "/usergroup", "revision": 1}]	{}
 48	update	524	192.168.16.1		f	2022-05-13 00:32:45.651043	[{"key": "/usergroup/librarian-work-merge", "revision": 1}]	{}
+49	update	524	172.22.0.1	Create read-only usergroup	f	2022-05-25 21:42:26.830114	[{"key": "/usergroup/read-only", "revision": 1}]	{}
 \.
+
+
+--
+-- Name: transaction_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.transaction_id_seq', 49, true);
 
 
 --
@@ -5896,11 +5966,32 @@ COPY public.transaction_index (tx_id, key, value) FROM stdin;
 
 
 --
+-- Name: type_author_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.type_author_seq', 1, false);
+
+
+--
+-- Name: type_edition_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.type_edition_seq', 1, false);
+
+
+--
 -- Data for Name: type_int; Type: TABLE DATA; Schema: public; Owner: openlibrary
 --
 
 COPY public.type_int (thing_id, key_id, value, ordering) FROM stdin;
 \.
+
+
+--
+-- Name: type_publisher_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.type_publisher_seq', 1, false);
 
 
 --
@@ -6333,6 +6424,13 @@ COPY public.type_str (thing_id, key_id, value, ordering) FROM stdin;
 
 
 --
+-- Name: type_work_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.type_work_seq', 1, false);
+
+
+--
 -- Data for Name: user_int; Type: TABLE DATA; Schema: public; Owner: openlibrary
 --
 
@@ -6388,6 +6486,7 @@ COPY public.user_str (thing_id, key_id, value, ordering) FROM stdin;
 27	14	AccountBot	\N
 524	14	Open Library	\N
 666	133	edit	\N
+670	133	edit	\N
 \.
 
 
@@ -7078,7 +7177,15 @@ COPY public.version (id, thing_id, revision, transaction_id) FROM stdin;
 680	667	1	46
 681	668	1	47
 682	669	1	48
+683	670	1	49
 \.
+
+
+--
+-- Name: version_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
+--
+
+SELECT pg_catalog.setval('public.version_id_seq', 683, true);
 
 
 --
@@ -7721,98 +7828,7 @@ COPY public.work_str (thing_id, key_id, value, ordering) FROM stdin;
 
 
 --
--- Name: bookshelves_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
---
-
-SELECT pg_catalog.setval('public.bookshelves_id_seq', 3, true);
-
-
---
--- Name: bookshelves_votes_bookshelf_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
---
-
-SELECT pg_catalog.setval('public.bookshelves_votes_bookshelf_id_seq', 1, false);
-
-
---
--- Name: property_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.property_id_seq', 135, true);
-
-
---
--- Name: seq_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.seq_id_seq', 1, false);
-
-
---
--- Name: store_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.store_id_seq', 31, true);
-
-
---
--- Name: store_index_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.store_index_id_seq', 175, true);
-
-
---
--- Name: thing_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.thing_id_seq', 669, true);
-
-
---
--- Name: transaction_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.transaction_id_seq', 48, true);
-
-
---
--- Name: type_author_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.type_author_seq', 1, false);
-
-
---
--- Name: type_edition_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.type_edition_seq', 1, false);
-
-
---
--- Name: type_publisher_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.type_publisher_seq', 1, false);
-
-
---
--- Name: type_work_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.type_work_seq', 1, false);
-
-
---
--- Name: version_id_seq; Type: SEQUENCE SET; Schema: public; Owner: openlibrary
---
-
-SELECT pg_catalog.setval('public.version_id_seq', 682, true);
-
-
---
--- Name: account account_email_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: account_email_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.account
@@ -7820,7 +7836,7 @@ ALTER TABLE ONLY public.account
 
 
 --
--- Name: booknotes booknotes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: booknotes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.booknotes
@@ -7828,7 +7844,7 @@ ALTER TABLE ONLY public.booknotes
 
 
 --
--- Name: bookshelves_books bookshelves_books_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: bookshelves_books_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.bookshelves_books
@@ -7836,7 +7852,7 @@ ALTER TABLE ONLY public.bookshelves_books
 
 
 --
--- Name: bookshelves bookshelves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: bookshelves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.bookshelves
@@ -7844,7 +7860,7 @@ ALTER TABLE ONLY public.bookshelves
 
 
 --
--- Name: bookshelves_votes bookshelves_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: bookshelves_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.bookshelves_votes
@@ -7852,7 +7868,7 @@ ALTER TABLE ONLY public.bookshelves_votes
 
 
 --
--- Name: observations observations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: observations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.observations
@@ -7860,7 +7876,7 @@ ALTER TABLE ONLY public.observations
 
 
 --
--- Name: property property_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: property_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.property
@@ -7868,7 +7884,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: property property_type_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: property_type_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.property
@@ -7876,7 +7892,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: ratings ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.ratings
@@ -7884,7 +7900,7 @@ ALTER TABLE ONLY public.ratings
 
 
 --
--- Name: seq seq_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: seq_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.seq
@@ -7892,7 +7908,7 @@ ALTER TABLE ONLY public.seq
 
 
 --
--- Name: seq seq_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: seq_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.seq
@@ -7900,7 +7916,7 @@ ALTER TABLE ONLY public.seq
 
 
 --
--- Name: store_index store_index_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: store_index_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.store_index
@@ -7908,7 +7924,7 @@ ALTER TABLE ONLY public.store_index
 
 
 --
--- Name: store store_key_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: store_key_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.store
@@ -7916,7 +7932,7 @@ ALTER TABLE ONLY public.store
 
 
 --
--- Name: store store_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: store_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.store
@@ -7924,7 +7940,7 @@ ALTER TABLE ONLY public.store
 
 
 --
--- Name: thing thing_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: thing_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.thing
@@ -7932,7 +7948,7 @@ ALTER TABLE ONLY public.thing
 
 
 --
--- Name: transaction transaction_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: transaction_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.transaction
@@ -7940,7 +7956,7 @@ ALTER TABLE ONLY public.transaction
 
 
 --
--- Name: version version_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: version_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.version
@@ -7948,7 +7964,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: version version_thing_id_revision_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: version_thing_id_revision_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.version
@@ -7956,595 +7972,595 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: account_thing_active_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: account_thing_active_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_active_idx ON public.account USING btree (active);
 
 
 --
--- Name: account_thing_bot_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: account_thing_bot_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_bot_idx ON public.account USING btree (bot);
 
 
 --
--- Name: account_thing_email_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: account_thing_email_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_email_idx ON public.account USING btree (active);
 
 
 --
--- Name: account_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: account_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_id_idx ON public.account USING btree (thing_id);
 
 
 --
--- Name: author_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_boolean_idx ON public.author_boolean USING btree (key_id, value);
 
 
 --
--- Name: author_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_boolean_thing_id_idx ON public.author_boolean USING btree (thing_id);
 
 
 --
--- Name: author_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_int_idx ON public.author_int USING btree (key_id, value);
 
 
 --
--- Name: author_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_int_thing_id_idx ON public.author_int USING btree (thing_id);
 
 
 --
--- Name: author_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_ref_idx ON public.author_ref USING btree (key_id, value);
 
 
 --
--- Name: author_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_ref_thing_id_idx ON public.author_ref USING btree (thing_id);
 
 
 --
--- Name: author_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_str_idx ON public.author_str USING btree (key_id, value);
 
 
 --
--- Name: author_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: author_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_str_thing_id_idx ON public.author_str USING btree (thing_id);
 
 
 --
--- Name: data_thing_id_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: data_thing_id_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE UNIQUE INDEX data_thing_id_revision_idx ON public.data USING btree (thing_id, revision);
 
 
 --
--- Name: datum_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: datum_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_int_idx ON public.datum_int USING btree (key_id, value);
 
 
 --
--- Name: datum_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: datum_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_int_thing_id_idx ON public.datum_int USING btree (thing_id);
 
 
 --
--- Name: datum_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: datum_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_ref_idx ON public.datum_ref USING btree (key_id, value);
 
 
 --
--- Name: datum_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: datum_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_ref_thing_id_idx ON public.datum_ref USING btree (thing_id);
 
 
 --
--- Name: datum_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: datum_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_str_idx ON public.datum_str USING btree (key_id, value);
 
 
 --
--- Name: datum_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: datum_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_str_thing_id_idx ON public.datum_str USING btree (thing_id);
 
 
 --
--- Name: edition_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_boolean_idx ON public.edition_boolean USING btree (key_id, value);
 
 
 --
--- Name: edition_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_boolean_thing_id_idx ON public.edition_boolean USING btree (thing_id);
 
 
 --
--- Name: edition_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_int_idx ON public.edition_int USING btree (key_id, value);
 
 
 --
--- Name: edition_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_int_thing_id_idx ON public.edition_int USING btree (thing_id);
 
 
 --
--- Name: edition_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_ref_idx ON public.edition_ref USING btree (key_id, value);
 
 
 --
--- Name: edition_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_ref_thing_id_idx ON public.edition_ref USING btree (thing_id);
 
 
 --
--- Name: edition_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_str_idx ON public.edition_str USING btree (key_id, value);
 
 
 --
--- Name: edition_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: edition_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_str_thing_id_idx ON public.edition_str USING btree (thing_id);
 
 
 --
--- Name: publisher_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_boolean_idx ON public.publisher_boolean USING btree (key_id, value);
 
 
 --
--- Name: publisher_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_boolean_thing_id_idx ON public.publisher_boolean USING btree (thing_id);
 
 
 --
--- Name: publisher_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_int_idx ON public.publisher_int USING btree (key_id, value);
 
 
 --
--- Name: publisher_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_int_thing_id_idx ON public.publisher_int USING btree (thing_id);
 
 
 --
--- Name: publisher_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_ref_idx ON public.publisher_ref USING btree (key_id, value);
 
 
 --
--- Name: publisher_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_ref_thing_id_idx ON public.publisher_ref USING btree (thing_id);
 
 
 --
--- Name: publisher_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_str_idx ON public.publisher_str USING btree (key_id, value);
 
 
 --
--- Name: publisher_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: publisher_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_str_thing_id_idx ON public.publisher_str USING btree (thing_id);
 
 
 --
--- Name: scan_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_boolean_idx ON public.scan_boolean USING btree (key_id, value);
 
 
 --
--- Name: scan_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_boolean_thing_id_idx ON public.scan_boolean USING btree (thing_id);
 
 
 --
--- Name: scan_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_int_idx ON public.scan_int USING btree (key_id, value);
 
 
 --
--- Name: scan_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_int_thing_id_idx ON public.scan_int USING btree (thing_id);
 
 
 --
--- Name: scan_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_ref_idx ON public.scan_ref USING btree (key_id, value);
 
 
 --
--- Name: scan_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_ref_thing_id_idx ON public.scan_ref USING btree (thing_id);
 
 
 --
--- Name: scan_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_str_idx ON public.scan_str USING btree (key_id, value);
 
 
 --
--- Name: scan_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: scan_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_str_thing_id_idx ON public.scan_str USING btree (thing_id);
 
 
 --
--- Name: store_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: store_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX store_idx ON public.store_index USING btree (type, name, value);
 
 
 --
--- Name: store_index_store_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: store_index_store_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX store_index_store_id_idx ON public.store_index USING btree (store_id);
 
 
 --
--- Name: subject_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_boolean_idx ON public.subject_boolean USING btree (key_id, value);
 
 
 --
--- Name: subject_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_boolean_thing_id_idx ON public.subject_boolean USING btree (thing_id);
 
 
 --
--- Name: subject_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_int_idx ON public.subject_int USING btree (key_id, value);
 
 
 --
--- Name: subject_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_int_thing_id_idx ON public.subject_int USING btree (thing_id);
 
 
 --
--- Name: subject_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_ref_idx ON public.subject_ref USING btree (key_id, value);
 
 
 --
--- Name: subject_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_ref_thing_id_idx ON public.subject_ref USING btree (thing_id);
 
 
 --
--- Name: subject_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_str_idx ON public.subject_str USING btree (key_id, value);
 
 
 --
--- Name: subject_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: subject_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_str_thing_id_idx ON public.subject_str USING btree (thing_id);
 
 
 --
--- Name: thing_created_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: thing_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_created_idx ON public.thing USING btree (created);
 
 
 --
--- Name: thing_key_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: thing_key_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE UNIQUE INDEX thing_key_idx ON public.thing USING btree (key);
 
 
 --
--- Name: thing_last_modified_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: thing_last_modified_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_last_modified_idx ON public.thing USING btree (last_modified);
 
 
 --
--- Name: thing_latest_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: thing_latest_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_latest_revision_idx ON public.thing USING btree (latest_revision);
 
 
 --
--- Name: thing_olid_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: thing_olid_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_olid_idx ON public.thing USING btree (public.get_olid(key));
 
 
 --
--- Name: thing_type_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: thing_type_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_type_idx ON public.thing USING btree (type);
 
 
 --
--- Name: transaction_author_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: transaction_author_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_author_id_idx ON public.transaction USING btree (author_id);
 
 
 --
--- Name: transaction_created_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: transaction_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_created_idx ON public.transaction USING btree (created);
 
 
 --
--- Name: transaction_index_key_value_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: transaction_index_key_value_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_index_key_value_idx ON public.transaction_index USING btree (key, value);
 
 
 --
--- Name: transaction_index_tx_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: transaction_index_tx_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_index_tx_id_idx ON public.transaction_index USING btree (tx_id);
 
 
 --
--- Name: transaction_ip_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: transaction_ip_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_ip_idx ON public.transaction USING btree (ip);
 
 
 --
--- Name: type_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: type_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_int_idx ON public.type_int USING btree (key_id, value);
 
 
 --
--- Name: type_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: type_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_int_thing_id_idx ON public.type_int USING btree (thing_id);
 
 
 --
--- Name: type_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: type_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_ref_idx ON public.type_ref USING btree (key_id, value);
 
 
 --
--- Name: type_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: type_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_ref_thing_id_idx ON public.type_ref USING btree (thing_id);
 
 
 --
--- Name: type_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: type_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_str_idx ON public.type_str USING btree (key_id, value);
 
 
 --
--- Name: type_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: type_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_str_thing_id_idx ON public.type_str USING btree (thing_id);
 
 
 --
--- Name: user_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: user_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_int_idx ON public.user_int USING btree (key_id, value);
 
 
 --
--- Name: user_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: user_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_int_thing_id_idx ON public.user_int USING btree (thing_id);
 
 
 --
--- Name: user_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: user_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_ref_idx ON public.user_ref USING btree (key_id, value);
 
 
 --
--- Name: user_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: user_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_ref_thing_id_idx ON public.user_ref USING btree (thing_id);
 
 
 --
--- Name: user_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: user_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_str_idx ON public.user_str USING btree (key_id, value);
 
 
 --
--- Name: user_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: user_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_str_thing_id_idx ON public.user_str USING btree (thing_id);
 
 
 --
--- Name: work_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_boolean_idx ON public.work_boolean USING btree (key_id, value);
 
 
 --
--- Name: work_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_boolean_thing_id_idx ON public.work_boolean USING btree (thing_id);
 
 
 --
--- Name: work_int_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_int_idx ON public.work_int USING btree (key_id, value);
 
 
 --
--- Name: work_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_int_thing_id_idx ON public.work_int USING btree (thing_id);
 
 
 --
--- Name: work_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_ref_idx ON public.work_ref USING btree (key_id, value);
 
 
 --
--- Name: work_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_ref_thing_id_idx ON public.work_ref USING btree (thing_id);
 
 
 --
--- Name: work_str_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_str_idx ON public.work_str USING btree (key_id, value);
 
 
 --
--- Name: work_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary
+-- Name: work_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_str_thing_id_idx ON public.work_str USING btree (thing_id);
 
 
 --
--- Name: account account_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: account_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.account
@@ -8552,7 +8568,7 @@ ALTER TABLE ONLY public.account
 
 
 --
--- Name: author_boolean author_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_boolean
@@ -8560,7 +8576,7 @@ ALTER TABLE ONLY public.author_boolean
 
 
 --
--- Name: author_boolean author_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_boolean
@@ -8568,7 +8584,7 @@ ALTER TABLE ONLY public.author_boolean
 
 
 --
--- Name: author_int author_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_int
@@ -8576,7 +8592,7 @@ ALTER TABLE ONLY public.author_int
 
 
 --
--- Name: author_int author_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_int
@@ -8584,7 +8600,7 @@ ALTER TABLE ONLY public.author_int
 
 
 --
--- Name: author_ref author_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_ref
@@ -8592,7 +8608,7 @@ ALTER TABLE ONLY public.author_ref
 
 
 --
--- Name: author_ref author_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_ref
@@ -8600,7 +8616,7 @@ ALTER TABLE ONLY public.author_ref
 
 
 --
--- Name: author_ref author_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_ref
@@ -8608,7 +8624,7 @@ ALTER TABLE ONLY public.author_ref
 
 
 --
--- Name: author_str author_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_str
@@ -8616,7 +8632,7 @@ ALTER TABLE ONLY public.author_str
 
 
 --
--- Name: author_str author_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: author_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.author_str
@@ -8624,7 +8640,7 @@ ALTER TABLE ONLY public.author_str
 
 
 --
--- Name: bookshelves_books bookshelves_books_bookshelf_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: bookshelves_books_bookshelf_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.bookshelves_books
@@ -8632,7 +8648,7 @@ ALTER TABLE ONLY public.bookshelves_books
 
 
 --
--- Name: bookshelves_votes bookshelves_votes_bookshelf_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: bookshelves_votes_bookshelf_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 
 ALTER TABLE ONLY public.bookshelves_votes
@@ -8640,7 +8656,7 @@ ALTER TABLE ONLY public.bookshelves_votes
 
 
 --
--- Name: data data_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: data_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.data
@@ -8648,7 +8664,7 @@ ALTER TABLE ONLY public.data
 
 
 --
--- Name: datum_int datum_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_int
@@ -8656,7 +8672,7 @@ ALTER TABLE ONLY public.datum_int
 
 
 --
--- Name: datum_int datum_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_int
@@ -8664,7 +8680,7 @@ ALTER TABLE ONLY public.datum_int
 
 
 --
--- Name: datum_ref datum_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_ref
@@ -8672,7 +8688,7 @@ ALTER TABLE ONLY public.datum_ref
 
 
 --
--- Name: datum_ref datum_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_ref
@@ -8680,7 +8696,7 @@ ALTER TABLE ONLY public.datum_ref
 
 
 --
--- Name: datum_ref datum_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_ref
@@ -8688,7 +8704,7 @@ ALTER TABLE ONLY public.datum_ref
 
 
 --
--- Name: datum_str datum_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_str
@@ -8696,7 +8712,7 @@ ALTER TABLE ONLY public.datum_str
 
 
 --
--- Name: datum_str datum_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: datum_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.datum_str
@@ -8704,7 +8720,7 @@ ALTER TABLE ONLY public.datum_str
 
 
 --
--- Name: edition_boolean edition_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_boolean
@@ -8712,7 +8728,7 @@ ALTER TABLE ONLY public.edition_boolean
 
 
 --
--- Name: edition_boolean edition_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_boolean
@@ -8720,7 +8736,7 @@ ALTER TABLE ONLY public.edition_boolean
 
 
 --
--- Name: edition_int edition_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_int
@@ -8728,7 +8744,7 @@ ALTER TABLE ONLY public.edition_int
 
 
 --
--- Name: edition_int edition_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_int
@@ -8736,7 +8752,7 @@ ALTER TABLE ONLY public.edition_int
 
 
 --
--- Name: edition_ref edition_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_ref
@@ -8744,7 +8760,7 @@ ALTER TABLE ONLY public.edition_ref
 
 
 --
--- Name: edition_ref edition_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_ref
@@ -8752,7 +8768,7 @@ ALTER TABLE ONLY public.edition_ref
 
 
 --
--- Name: edition_ref edition_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_ref
@@ -8760,7 +8776,7 @@ ALTER TABLE ONLY public.edition_ref
 
 
 --
--- Name: edition_str edition_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_str
@@ -8768,7 +8784,7 @@ ALTER TABLE ONLY public.edition_str
 
 
 --
--- Name: edition_str edition_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: edition_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.edition_str
@@ -8776,7 +8792,7 @@ ALTER TABLE ONLY public.edition_str
 
 
 --
--- Name: property property_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: property_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.property
@@ -8784,7 +8800,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: publisher_boolean publisher_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_boolean
@@ -8792,7 +8808,7 @@ ALTER TABLE ONLY public.publisher_boolean
 
 
 --
--- Name: publisher_boolean publisher_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_boolean
@@ -8800,7 +8816,7 @@ ALTER TABLE ONLY public.publisher_boolean
 
 
 --
--- Name: publisher_int publisher_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_int
@@ -8808,7 +8824,7 @@ ALTER TABLE ONLY public.publisher_int
 
 
 --
--- Name: publisher_int publisher_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_int
@@ -8816,7 +8832,7 @@ ALTER TABLE ONLY public.publisher_int
 
 
 --
--- Name: publisher_ref publisher_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_ref
@@ -8824,7 +8840,7 @@ ALTER TABLE ONLY public.publisher_ref
 
 
 --
--- Name: publisher_ref publisher_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_ref
@@ -8832,7 +8848,7 @@ ALTER TABLE ONLY public.publisher_ref
 
 
 --
--- Name: publisher_ref publisher_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_ref
@@ -8840,7 +8856,7 @@ ALTER TABLE ONLY public.publisher_ref
 
 
 --
--- Name: publisher_str publisher_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_str
@@ -8848,7 +8864,7 @@ ALTER TABLE ONLY public.publisher_str
 
 
 --
--- Name: publisher_str publisher_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: publisher_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.publisher_str
@@ -8856,7 +8872,7 @@ ALTER TABLE ONLY public.publisher_str
 
 
 --
--- Name: scan_boolean scan_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_boolean
@@ -8864,7 +8880,7 @@ ALTER TABLE ONLY public.scan_boolean
 
 
 --
--- Name: scan_boolean scan_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_boolean
@@ -8872,7 +8888,7 @@ ALTER TABLE ONLY public.scan_boolean
 
 
 --
--- Name: scan_int scan_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_int
@@ -8880,7 +8896,7 @@ ALTER TABLE ONLY public.scan_int
 
 
 --
--- Name: scan_int scan_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_int
@@ -8888,7 +8904,7 @@ ALTER TABLE ONLY public.scan_int
 
 
 --
--- Name: scan_ref scan_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_ref
@@ -8896,7 +8912,7 @@ ALTER TABLE ONLY public.scan_ref
 
 
 --
--- Name: scan_ref scan_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_ref
@@ -8904,7 +8920,7 @@ ALTER TABLE ONLY public.scan_ref
 
 
 --
--- Name: scan_ref scan_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_ref
@@ -8912,7 +8928,7 @@ ALTER TABLE ONLY public.scan_ref
 
 
 --
--- Name: scan_str scan_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_str
@@ -8920,7 +8936,7 @@ ALTER TABLE ONLY public.scan_str
 
 
 --
--- Name: scan_str scan_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: scan_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.scan_str
@@ -8928,7 +8944,7 @@ ALTER TABLE ONLY public.scan_str
 
 
 --
--- Name: store_index store_index_store_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: store_index_store_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.store_index
@@ -8936,7 +8952,7 @@ ALTER TABLE ONLY public.store_index
 
 
 --
--- Name: subject_boolean subject_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_boolean
@@ -8944,7 +8960,7 @@ ALTER TABLE ONLY public.subject_boolean
 
 
 --
--- Name: subject_boolean subject_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_boolean
@@ -8952,7 +8968,7 @@ ALTER TABLE ONLY public.subject_boolean
 
 
 --
--- Name: subject_int subject_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_int
@@ -8960,7 +8976,7 @@ ALTER TABLE ONLY public.subject_int
 
 
 --
--- Name: subject_int subject_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_int
@@ -8968,7 +8984,7 @@ ALTER TABLE ONLY public.subject_int
 
 
 --
--- Name: subject_ref subject_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_ref
@@ -8976,7 +8992,7 @@ ALTER TABLE ONLY public.subject_ref
 
 
 --
--- Name: subject_ref subject_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_ref
@@ -8984,7 +9000,7 @@ ALTER TABLE ONLY public.subject_ref
 
 
 --
--- Name: subject_ref subject_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_ref
@@ -8992,7 +9008,7 @@ ALTER TABLE ONLY public.subject_ref
 
 
 --
--- Name: subject_str subject_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_str
@@ -9000,7 +9016,7 @@ ALTER TABLE ONLY public.subject_str
 
 
 --
--- Name: subject_str subject_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: subject_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.subject_str
@@ -9008,7 +9024,7 @@ ALTER TABLE ONLY public.subject_str
 
 
 --
--- Name: thing thing_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: thing_type_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.thing
@@ -9016,7 +9032,7 @@ ALTER TABLE ONLY public.thing
 
 
 --
--- Name: transaction transaction_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: transaction_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.transaction
@@ -9024,7 +9040,7 @@ ALTER TABLE ONLY public.transaction
 
 
 --
--- Name: transaction_index transaction_index_tx_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: transaction_index_tx_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.transaction_index
@@ -9032,7 +9048,7 @@ ALTER TABLE ONLY public.transaction_index
 
 
 --
--- Name: type_int type_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_int
@@ -9040,7 +9056,7 @@ ALTER TABLE ONLY public.type_int
 
 
 --
--- Name: type_int type_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_int
@@ -9048,7 +9064,7 @@ ALTER TABLE ONLY public.type_int
 
 
 --
--- Name: type_ref type_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_ref
@@ -9056,7 +9072,7 @@ ALTER TABLE ONLY public.type_ref
 
 
 --
--- Name: type_ref type_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_ref
@@ -9064,7 +9080,7 @@ ALTER TABLE ONLY public.type_ref
 
 
 --
--- Name: type_ref type_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_ref
@@ -9072,7 +9088,7 @@ ALTER TABLE ONLY public.type_ref
 
 
 --
--- Name: type_str type_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_str
@@ -9080,7 +9096,7 @@ ALTER TABLE ONLY public.type_str
 
 
 --
--- Name: type_str type_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: type_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.type_str
@@ -9088,7 +9104,7 @@ ALTER TABLE ONLY public.type_str
 
 
 --
--- Name: user_int user_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_int
@@ -9096,7 +9112,7 @@ ALTER TABLE ONLY public.user_int
 
 
 --
--- Name: user_int user_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_int
@@ -9104,7 +9120,7 @@ ALTER TABLE ONLY public.user_int
 
 
 --
--- Name: user_ref user_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_ref
@@ -9112,7 +9128,7 @@ ALTER TABLE ONLY public.user_ref
 
 
 --
--- Name: user_ref user_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_ref
@@ -9120,7 +9136,7 @@ ALTER TABLE ONLY public.user_ref
 
 
 --
--- Name: user_ref user_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_ref
@@ -9128,7 +9144,7 @@ ALTER TABLE ONLY public.user_ref
 
 
 --
--- Name: user_str user_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_str
@@ -9136,7 +9152,7 @@ ALTER TABLE ONLY public.user_str
 
 
 --
--- Name: user_str user_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: user_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.user_str
@@ -9144,7 +9160,7 @@ ALTER TABLE ONLY public.user_str
 
 
 --
--- Name: version version_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: version_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.version
@@ -9152,7 +9168,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: version version_transaction_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: version_transaction_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.version
@@ -9160,7 +9176,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: work_boolean work_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_boolean_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_boolean
@@ -9168,7 +9184,7 @@ ALTER TABLE ONLY public.work_boolean
 
 
 --
--- Name: work_boolean work_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_boolean_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_boolean
@@ -9176,7 +9192,7 @@ ALTER TABLE ONLY public.work_boolean
 
 
 --
--- Name: work_int work_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_int_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_int
@@ -9184,7 +9200,7 @@ ALTER TABLE ONLY public.work_int
 
 
 --
--- Name: work_int work_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_int_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_int
@@ -9192,7 +9208,7 @@ ALTER TABLE ONLY public.work_int
 
 
 --
--- Name: work_ref work_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_ref_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_ref
@@ -9200,7 +9216,7 @@ ALTER TABLE ONLY public.work_ref
 
 
 --
--- Name: work_ref work_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_ref_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_ref
@@ -9208,7 +9224,7 @@ ALTER TABLE ONLY public.work_ref
 
 
 --
--- Name: work_ref work_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_ref_value_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_ref
@@ -9216,7 +9232,7 @@ ALTER TABLE ONLY public.work_ref
 
 
 --
--- Name: work_str work_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_str_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_str
@@ -9224,7 +9240,7 @@ ALTER TABLE ONLY public.work_str
 
 
 --
--- Name: work_str work_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
+-- Name: work_str_thing_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: openlibrary
 --
 
 ALTER TABLE ONLY public.work_str


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6500

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates `read-only` usergroup.  Edits by members of this group will fail our spam checks (unless the member is also an admin or librarian).

### Technical
<!-- What should be noted about the implementation? -->
Before deploying this code to testing or production, `/usergroup/read-only` must be created.  I suspect that all spam checks will fail if this isn't done.  ~Labeling this PR as `Needs: Special Deploy` in order to bring attention to this.~

__Edit:__ `/usergroup/read-only` has been created in production.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
These instructions assume that you are testing locally.  We will be adding local user `openlibrary` to the new usergroup.
1. Login as user `admin`. Remove user `openlibrary` from usergroup `admin`.
2. Add `/people/openlibrary` to the `/usergroup/read-only` group.
3. While still logged in as `admin`, navigate to a book page, and make a test edit (don't include spam words in the edit). The edit should be successful.
4. Log in as `openlibrary`.  Navigate to a book page and attempt to make an edit.  The edit should fail.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
