### PR TITLE
Place "Delete" button on book edit page in it's own form

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -632,7 +632,7 @@ class SaveBookHelper:
 
     def process_new_fields(self, formdata):
         def f(name):
-            val = formdata.get(name, None)
+            val = formdata.get(name)
             return val and json.loads(val)
 
         new_roles = f('select-role-json')

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -542,7 +542,8 @@ class SaveBookHelper:
         formdata = utils.unflatten(formdata)
         work_data, edition_data = self.process_input(formdata)
 
-        self.process_new_fields(formdata)
+        if not delete:
+            self.process_new_fields(formdata)
 
         saveutil = DocSaveHelper()
 
@@ -631,7 +632,7 @@ class SaveBookHelper:
 
     def process_new_fields(self, formdata):
         def f(name):
-            val = formdata.get(name)
+            val = formdata.get(name, None)
             return val and json.loads(val)
 
         new_roles = f('select-role-json')

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -41,7 +41,9 @@ $# the default "enter" action.
     <h2 class="editFormTitle">$:title</h2>
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
         <span class="adminOnly right">
-            <button type="submit" name="_delete" value="true" id="delete" form="addWork">$_("Delete Record")</button>
+            <form method="post" id="delete-record" name="delete">
+                <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>
+            </form>
         </span>
     $if not ctx.user:
         $:render_template("lib/not_logged")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents record deletion on book page "Enter" key press.  This was largely handled by #6472, but not for some iOS devices running Firefox.  Marking this PR as a draft until this is tested on the platforms in question.

### Technical
<!-- What should be noted about the implementation? -->
If the POST is a delete, the `process_new_fields` method is not called.  This method processes `select-*` inputs found in [addfield.html](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/books/edit/addfield.html).  This inputs are irrelevant for delete requests.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
