### PR TITLE
Update Wikipedia Cite book format

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -488,7 +488,7 @@ class Edition(models.Edition):
                 self['isbn_13'][0] if self.get('isbn_13') else self['isbn_10'][0]
             )
         if self.lccn:
-            citation['lccn'] = self.lccn[0]
+            citation['lccn'] = self.lccn[0].replace(' ', '')
         if self.get('oclc_numbers'):
             citation['oclc'] = self.oclc_numbers[0]
         citation['ol'] = str(self.get_olid())[2:]

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -473,6 +473,7 @@ class Edition(models.Edition):
             for i, a in enumerate(authors):
                 citation['author%s' % (i + 1)] = a.name
 
+        isbns = self.get('isbn_13', []) + self.get('isbn_10', [None])
         citation.update({
             'date': self.get('publish_date'),
             'orig-date': self.works[0]['first_publish_year'],
@@ -480,13 +481,10 @@ class Edition(models.Edition):
             'url': f'https://archive.org/details/{self.ocaid}' if self.ocaid else None,
             'publication-place': self.get('publish_places', [None])[0],
             'publisher': self.get('publishers', [None])[0],
+            'isbn': isbns[0],
+            'issn': self.get('identifiers', []).get('issn', [None])[0],
         })
-        if self.issn:
-            citation['issn'] = self.issn[0]
-        if self.get('isbn_10'):
-            citation['isbn'] = (
-                self['isbn_13'][0] if self.get('isbn_13') else self['isbn_10'][0]
-            )
+
         if self.lccn:
             citation['lccn'] = self.lccn[0].replace(' ', '')
         if self.get('oclc_numbers'):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -476,13 +476,13 @@ class Edition(models.Edition):
         isbns = self.get('isbn_13', []) + self.get('isbn_10', [None])
         citation.update({
             'date': self.get('publish_date'),
-            'orig-date': self.works[0]['first_publish_year'],
+            'orig-date': self.works[0].get('first_publish_date'),
             'title': self.title.replace("[", "&#91").replace("]", "&#93"),
             'url': f'https://archive.org/details/{self.ocaid}' if self.ocaid else None,
             'publication-place': self.get('publish_places', [None])[0],
             'publisher': self.get('publishers', [None])[0],
             'isbn': isbns[0],
-            'issn': self.get('identifiers', []).get('issn', [None])[0],
+            'issn': self.get('identifiers', {}).get('issn', [None])[0],
         })
 
         if self.lccn:
@@ -491,6 +491,8 @@ class Edition(models.Edition):
             citation['oclc'] = self.oclc_numbers[0]
         citation['ol'] = str(self.get_olid())[2:]
         # TODO: add 'ol-access': 'free' if the item is free to read.
+        if citation['date'] == citation['orig-date']:
+            citation.pop('orig-date')
         return citation
 
     def is_fake_record(self):

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -57,10 +57,8 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                         </div>
                         <p>$_('Copy and paste this code into your Wikipedia page.') <a href="https://en.wikipedia.org/wiki/Template:Cite_book" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
                         <form method="get">
-                            <textarea cols="30" rows="20" readonly="readonly" id="wikiselect">{{cite book
-                $for k, v in page.wp_citation_fields.items():
-                   |$k = $v
-                }}</textarea>
+                          $ cite = " |".join([k + '=' + v for k, v in page.wp_citation_fields.items()])
+                          <textarea cols="70" rows="10" readonly="readonly" id="wikiselect">{{cite book|$cite}}</textarea>
                         </form>
                     </div>
                 </div>

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -57,7 +57,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
                         </div>
                         <p>$_('Copy and paste this code into your Wikipedia page.') <a href="https://en.wikipedia.org/wiki/Template:Cite_book" target="_blank" title="Get instructions at Wikipedia in a new window">Need help</a>?</p>
                         <form method="get">
-                          $ cite = " |".join([k + '=' + v for k, v in page.wp_citation_fields.items()])
+                          $ cite = " |".join([k + '=' + v for k, v in page.wp_citation_fields.items() if v])
                           <textarea cols="70" rows="10" readonly="readonly" id="wikiselect">{{cite book|$cite}}</textarea>
                         </form>
                     </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

* Matches order of  [Cite book](https://en.wikipedia.org/wiki/Template:Cite_book) template (completes the move from the original [Citation](https://en.wikipedia.org/wiki/Template:Citation#Citing_books) template)
* Strips whitespace from LCCNs (whitespace breaks the loc link)
* Correctly adds ISSNs, if present
* Correctly adds `first_publish_date` if different from `date`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://user-images.githubusercontent.com/905545/166893180-6e2f61f9-f635-43d1-8af6-20af9de02efc.png)
After:
![image](https://user-images.githubusercontent.com/905545/166855943-85d68500-7ccd-470e-b4f2-f00ec7b4d7ae.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
