### PR TITLE
Patron export bug fix

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -893,9 +893,6 @@ class export_books(delegate.page):
         csv.append('List ID,List Name,List Description,Entry,Created On,Last Updated')
 
         for list in lists:
-            logger.info(list)
-            logger.info(vars(list))
-            logger.info(dir(list))
             list_id = list.key.split('/')[-1]
             created_on = list.created.strftime(self.date_format)
             last_updated = list.last_modified.strftime(self.date_format) if list.last_modified else ''
@@ -903,10 +900,12 @@ class export_books(delegate.page):
                 entry = seed
                 if not isinstance(seed, str):
                     entry = seed.key
+                list_name = list.name.replace('"', '""') if list.name else ''
+                list_desc = list.description.replace('"', '""') if list.description else ''
                 row = [
                     list_id,
-                    f'"{list.name}"' if list.name else '', # Replace double quotes?
-                    f'"{list.description}"' if list.description else '',
+                    f'"{list_name}"',
+                    f'"{list_desc}"',
                     entry,
                     created_on,
                     last_updated


### PR DESCRIPTION
Double-quotes were not escaped in the new patron list overview CSV export.  This PR addresses that, and also removes unnecessary log statements.

See also: #6473

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Find or create a list that contains double-quotes in the description or title (for more confidence, add some commas as well).
2. Export the list overview and open it with your favorite CSV viewer.
3. Ensure that there are exactly six columns per row in the exported data, and that each cell contains reasonable information (only list OLIDs in the `List ID` column, etc).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
