### PR TITLE
Add placeholder list names in sidebar

### DIFF
--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -46,6 +46,7 @@ $ counts = counts or pa.get_sidebar_counts
     <ul class="sidebar-section">
       <li class="section-header section-header-split"><span>$_('Lists')</span> <a href="/people/$username/lists" class="li-count">$_('See All') ($len(lists))</a></li>
         <div class="list-overflow">
+          $ placeholder_name = _('Untitled list')
           $for lst in lists:
           $# e.g. OL1L from /people/mekBot/lists/OL1L
             $ list_id = lst.key.split('/')[-1]
@@ -55,7 +56,7 @@ $ counts = counts or pa.get_sidebar_counts
               $ path_id = ctx.path.split('/')[4]
               $if list_id == path_id:
                 $ class_list = class_list + 'selected'
-            <li><a class="$class_list" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$lst['name']</a></li>
+            <li><a class="$class_list" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$(lst['name'] if lst['name'] else '[%s]' % placeholder_name)</a></li>
         </div>
     </ul>
   </div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds placeholder list name to account sidebar for any unnamed list.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
__Before:__
![untitled_list_BEFORE](https://user-images.githubusercontent.com/28732543/166993483-77c344c7-d244-45f1-8d1b-b866dc4734d3.png)
_This is how untitled lists are displayed in the sidebar in production today._

__After:__
![untitled_list_AFTER](https://user-images.githubusercontent.com/28732543/166993547-12636637-742a-47d2-b253-0276a9d389c3.png)
_Sidebar with placeholder list name._

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
