### PR TITLE
Small fixes to mobile header PR

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -190,9 +190,8 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
           $ edit_url = page.url(suffix="/edit")
       $else:
         $ edit_url = page.key + "?m=edit"
-
-      $:render_template("type/edition/compact_title", book_title, edit_url)
     </div>
+      $:render_template("type/edition/compact_title", book_title, edit_url)
       $:macros.EditionNavBar(work.edition_count, show_observations)
       <a id="edition-overview" name="edition-overview"></a>
       <div>

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -194,6 +194,7 @@ h2.edition-byline {
     padding-top: 2px;
     margin-left: 0;
     margin-right: 0;
+    width: 100%;
   }
 }
 
@@ -373,6 +374,12 @@ div.editionTools {
 @media only screen and (max-width: @width-breakpoint-desktop){
   .desktop-book-header{
     display: none;
+  }
+}
+
+.mobile-book-header {
+  h1 {
+    line-height: normal;
   }
 }
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes the following issues that were blocking #6506 from being merged into `master`:
1. `compact_title.html` (the "sticky" title and edit button) not being displayed on screen widths that fall between our tablet and desktop headers.
2. Sticky navbar and compact title not spanning the width of the parent container.
3. Line spacing is too low for the mobile title.

### Technical
<!-- What should be noted about the implementation? -->

__Note:__ Once this PR is approved and merged, the `book-page-integration` branch can be merged into 'master`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![navbar_before](https://user-images.githubusercontent.com/28732543/167676967-924c2beb-e86d-42e5-b977-ba16359dda4f.png)
_Before navbar + title width changes_

![navbar_after](https://user-images.githubusercontent.com/28732543/167676981-2613001a-2ee9-43b7-ac33-5aca9963b555.png)
_After navbar + title width changes_

![line_height_before](https://user-images.githubusercontent.com/28732543/167677009-9f9faf67-8e12-436b-bf78-8641400e5230.png)
_Before title line height change_

![line_height_after](https://user-images.githubusercontent.com/28732543/167677020-486a740f-70c7-4f19-a9f9-276679dbbf89.png)
_After title line height change_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@constantinazouni 
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
