### PR TITLE
Removes link around book page publish location

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -322,10 +322,7 @@ $if is_privileged_user:
               <h3 class="edition-header">$_('Published in')</h3>
               <p>
               $for p in edition.publish_places:
-                <a href="/search/subjects?q=$p.replace('&','%26').replace(' ','%20')"
-                  title="$_('Search for subjects about %(place)s', place=p)">
-                    $p
-                </a>$cond(loop.last, "", ", ")
+                $(p)$cond(loop.last, "", ", ")
               </p>
             </div>
           $if edition.first_sentence:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6518 

This removes the link around the book page publish location because it was bringing patrons to a subject results page often with no results (and the experience wasn't very intuitive)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->


Once on testing.openlibrary.org, go to a books page and look at the "published in" section an ensure the item gets rendered as text and not a link

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
