### PR TITLE
Increase padding on a book's nav region

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -82,7 +82,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "11KB"
+      "maxSize": "12KB"
     },
     {
       "path": "static/build/page-edit.css",

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -211,11 +211,11 @@ h2.edition-byline {
 
 .work-menu li.selected a {
   color: @link-blue;
-  border-bottom: 2px solid #02598b;
+  border-bottom: 2px solid @link-blue;
 }
 
 .work-menu li:hover a {
-  border-bottom: 2px solid #02598b;
+  border-bottom: 2px solid @link-blue;
 }
 
 a.section-anchor {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -153,7 +153,6 @@ h2.edition-byline {
 
 .work-menu {
   border-bottom: 1px solid @lighter-grey;
-  padding-bottom: 5px;
   font-weight: bold;
 
   &.sticky {
@@ -162,7 +161,6 @@ h2.edition-byline {
     display: block;
     background: @white;
     z-index: @z-index-level-3;
-    padding-top: 10px;
     white-space: nowrap;
     overflow-x: auto;
     // Make tab bar full width on mobile
@@ -191,7 +189,6 @@ h2.edition-byline {
 @media only screen and (min-width: @width-breakpoint-tablet) {
   .work-menu.sticky {
     top: @compact-title-height;
-    padding-top: 2px;
     margin-left: 0;
     margin-right: 0;
   }
@@ -205,8 +202,11 @@ h2.edition-byline {
 .work-menu li a {
   text-decoration: none;
   color: @grey;
-  padding: 0 15px;
-  padding-bottom: 5px;
+  padding: 12px 15px 8px 15px;
+  display: inline-block;
+  @media only screen and (min-width: @width-breakpoint-tablet) {
+    padding-top: 4px;
+  }
 }
 
 .work-menu li.selected a {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -202,7 +202,7 @@ h2.edition-byline {
 .work-menu li a {
   text-decoration: none;
   color: @grey;
-  padding: 12px 15px 8px 15px;
+  padding: 12px 15px 8px;
   display: inline-block;
   @media only screen and (min-width: @width-breakpoint-tablet) {
     padding-top: 4px;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -214,6 +214,10 @@ h2.edition-byline {
   border-bottom: 2px solid #02598b;
 }
 
+.work-menu li:hover a {
+  border-bottom: 2px solid #02598b;
+}
+
 a.section-anchor {
   height: 20px;
   display: block;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -199,26 +199,19 @@ h2.edition-byline {
 
 .work-menu li {
   display: inline;
-  padding: 0 15px;
-  padding-bottom: 5px;
   font-size: 13px;
 }
 
 .work-menu li a {
   text-decoration: none;
   color: @grey;
-}
-
-.work-menu li.selected {
-  border-bottom: 2px solid @link-blue;
-}
-
-.work-menu li:hover {
-  border-bottom: 2px solid @link-blue;
+  padding: 0 15px;
+  padding-bottom: 5px;
 }
 
 .work-menu li.selected a {
   color: @link-blue;
+  border-bottom: 2px solid #02598b;
 }
 
 a.section-anchor {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6538.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Increase padding on a book's nav region so it's easier to click on phone/tablets.

### Technical
<!-- What should be noted about the implementation? -->
Moved padding from .work-menu li to .work-menu li a.
Moved bottom border from .work-menu li.selected and .work-menu li:hover to .work-menu li.selected a and .work-menu li:hover a to match the padding changes.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/69836033/168232847-0c2ce07c-0f4a-4cc2-8389-0162ebb6c5dd.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@mekarpeles

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
