### PR TITLE
Close dropper on "Want to Read" button click

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -255,6 +255,11 @@ function addReadingLogButtonClickListener(button) {
                 }
 
                 button.children[1].innerText = initialText
+
+                // Close dropper if expanded:
+                if ($(dropper).find('.arrow').first().hasClass('up')) {
+                    toggleDropper(dropper)
+                }
             } else {
                 toggleDropper(dropper)
                 // Secondary button pressed


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
If a reading log dropper is expanded and any reading log button is pressed, the dropper will collapse.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![collapse_on_main_button_click](https://user-images.githubusercontent.com/28732543/168665091-be00ebd3-7ca8-41af-9c22-6253a7e8ea71.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
