### PR TITLE
Remove Python dependency six -- again

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -23,7 +23,6 @@ import json
 import web
 import logging
 import requests
-import six
 from configparser import ConfigParser
 
 logger = logging.getLogger("openlibrary.api")

--- a/openlibrary/catalog/amazon/arc_view.py
+++ b/openlibrary/catalog/amazon/arc_view.py
@@ -1,6 +1,6 @@
 import web
 import os
-from six import StringIO
+from io import StringIO
 
 arc_dir = '/2/edward/amazon/arc'
 urls = (

--- a/openlibrary/catalog/amazon/import.py
+++ b/openlibrary/catalog/amazon/import.py
@@ -10,8 +10,7 @@ from openlibrary.catalog.get_ia import get_from_local, get_ia
 from openlibrary.catalog.merge.merge_marc import build_marc
 import openlibrary.catalog.marc.fast_parse as fast_parse
 
-import six
-from six.moves import urllib
+import urllib
 
 
 re_amazon = re.compile(r'^([A-Z0-9]{10}),(\d+):(.*)$', re.S)

--- a/openlibrary/catalog/amazon/load_merge.py
+++ b/openlibrary/catalog/amazon/load_merge.py
@@ -1,7 +1,7 @@
 from catalog.marc.MARC21 import MARC21Record
 from catalog.marc.parse import pick_first_date
 
-from six.moves import urllib
+import urllib
 
 
 entity_fields = ('name', 'birth_date', 'death_date', 'date')

--- a/openlibrary/catalog/amazon/parse.py
+++ b/openlibrary/catalog/amazon/parse.py
@@ -6,8 +6,7 @@ from warnings import warn
 from math import floor
 from pprint import pprint
 
-import six
-from six.moves import html_entities
+from html.entities import name2codepoint
 
 
 class BrokenTitle(Exception):
@@ -69,7 +68,7 @@ def unescape(text):
         else:
             # named entity
             try:
-                text = chr(html_entities.name2codepoint[text[1:-1]])
+                text = chr(name2codepoint[text[1:-1]])
             except KeyError:
                 pass
         return text  # leave as is

--- a/openlibrary/catalog/importer/db_read.py
+++ b/openlibrary/catalog/importer/db_read.py
@@ -4,7 +4,7 @@ from time import sleep
 
 import requests
 from deprecated import deprecated
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 
 staging = False

--- a/openlibrary/catalog/lang.py
+++ b/openlibrary/catalog/lang.py
@@ -1,5 +1,5 @@
 import sys
-from six import StringIO
+from io import StringIO
 import time
 import re
 

--- a/openlibrary/catalog/marc/marc_xml.py
+++ b/openlibrary/catalog/marc/marc_xml.py
@@ -3,8 +3,6 @@ from unicodedata import normalize
 
 from openlibrary.catalog.marc.marc_base import MarcBase, MarcException
 
-import six
-
 data_tag = '{http://www.loc.gov/MARC21/slim}datafield'
 control_tag = '{http://www.loc.gov/MARC21/slim}controlfield'
 subfield_tag = '{http://www.loc.gov/MARC21/slim}subfield'

--- a/openlibrary/catalog/marc/parse_xml.py
+++ b/openlibrary/catalog/marc/parse_xml.py
@@ -2,8 +2,6 @@ from lxml import etree
 from openlibrary.catalog.marc.parse import read_edition
 from unicodedata import normalize
 
-import six
-
 slim = '{http://www.loc.gov/MARC21/slim}'
 leader_tag = slim + 'leader'
 data_tag = slim + 'datafield'

--- a/openlibrary/catalog/marc/tests/test_parse.py
+++ b/openlibrary/catalog/marc/tests/test_parse.py
@@ -11,7 +11,7 @@ from openlibrary.catalog.marc.marc_xml import DataField, MarcXml
 from lxml import etree
 import os
 import json
-from six.moves.collections_abc import Iterable
+from collections.abc import Iterable
 
 collection_tag = '{http://www.loc.gov/MARC21/slim}collection'
 record_tag = '{http://www.loc.gov/MARC21/slim}record'

--- a/openlibrary/catalog/merge/normalize.py
+++ b/openlibrary/catalog/merge/normalize.py
@@ -1,8 +1,6 @@
 import re
 import unicodedata
 
-import six
-
 # re_brace = re.compile('{[^{}]+?}')
 re_normalize = re.compile('[^[:alpha:] ]', re.I)
 re_whitespace_and_punct = re.compile(r'[-\s,;:.]+')

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -3,14 +3,9 @@ import web
 from unicodedata import normalize
 import openlibrary.catalog.merge.normalize as merge
 
-import six
 
-try:
-    cmp = cmp  # Python 2
-except NameError:
-
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
+def cmp(x, y):
+    return (x > y) - (x < y)
 
 
 re_date = map(
@@ -179,7 +174,7 @@ def match_with_bad_chars(a, b):
         return True
 
     def drop(s):
-        return re_drop.sub('', six.ensure_text(s))
+        return re_drop.sub('', s.decode() if isinstance(s, bytes) else s)
 
     return drop(a) == drop(b)
 

--- a/openlibrary/catalog/utils/edit.py
+++ b/openlibrary/catalog/utils/edit.py
@@ -5,8 +5,6 @@ from openlibrary.catalog.importer.db_read import get_mc
 from openlibrary.api import unmarshal
 from time import sleep
 
-import six
-
 re_meta_mrc = re.compile('([^/]+)_(meta|marc).(mrc|xml)')
 re_skip = re.compile(r'\b([A-Z]|Co|Dr|Jr|Capt|Mr|Mrs|Ms|Prof|Rev|Revd|Hon)\.$')
 

--- a/openlibrary/catalog/utils/query.py
+++ b/openlibrary/catalog/utils/query.py
@@ -2,7 +2,7 @@ import requests
 import web
 import json
 from time import sleep
-from six.moves import urllib
+import urllib
 import sys
 
 

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -3,8 +3,6 @@
 import pytest
 import web
 
-import six
-
 from infogami.infobase.tests.pytest_wildcard import Wildcard
 from infogami.utils import template
 from infogami.utils.view import render_template as infobase_render_template

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -18,8 +18,6 @@ from openlibrary.utils import olmemcache
 from openlibrary.utils.dateutil import MINUTE_SECS
 from openlibrary.core.helpers import NothingEncoder
 
-import six
-
 
 __all__ = [
     "cached_property",

--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -6,7 +6,7 @@ import web
 from infogami import config
 from openlibrary.core.lending import get_availability_of_ocaids
 from openlibrary.plugins.openlibrary.home import format_book_data
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 logger = logging.getLogger("openlibrary.inside")
 

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -12,8 +12,6 @@ from infogami.utils import stats
 from openlibrary.core import cache
 from openlibrary.utils.dateutil import date_n_days_ago
 
-import six
-
 logger = logging.getLogger('openlibrary.ia')
 
 # FIXME: We can't reference `config` in module scope like this; it will always be undefined!

--- a/openlibrary/core/lists/engine.py
+++ b/openlibrary/core/lists/engine.py
@@ -4,8 +4,6 @@
 import collections
 import re
 
-import six
-
 
 def reduce_seeds(values):
     """Function to reduce the seed values got from works db."""

--- a/openlibrary/core/middleware.py
+++ b/openlibrary/core/middleware.py
@@ -1,7 +1,7 @@
 """WSGI middleware used in Open Library.
 """
 import web
-from six import BytesIO
+from io import BytesIO
 import gzip
 
 

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -23,7 +23,7 @@ from openlibrary.core.vendors import create_edition_from_amazon_metadata
 from openlibrary.core.lists.model import ListMixin, Seed
 from . import cache, waitinglist
 
-from six.moves import urllib
+import urllib
 
 from .ia import get_metadata_direct
 from .waitinglist import WaitingLoan

--- a/openlibrary/core/processors/readableurls.py
+++ b/openlibrary/core/processors/readableurls.py
@@ -7,7 +7,7 @@ import web
 from infogami.utils.view import render
 from openlibrary.core import helpers as h
 
-from six.moves import urllib
+import urllib
 
 logger = logging.getLogger("openlibrary.readableurls")
 

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -3,7 +3,7 @@ import logging
 import requests
 import web
 
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from collections import OrderedDict
 from infogami.utils.view import public

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -8,8 +8,6 @@ import time
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import find_image_path
 
-import six
-
 
 # logfile = open('log.txt', 'a')
 

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -4,7 +4,7 @@ from logging import getLogger
 import os
 from typing import Optional
 
-from six import BytesIO
+from io import BytesIO
 
 from PIL import Image
 import web

--- a/openlibrary/coverstore/tests/test_code.py
+++ b/openlibrary/coverstore/tests/test_code.py
@@ -1,5 +1,5 @@
 from .. import code
-from six.moves import cStringIO as StringIO
+from io import StringIO
 import web
 import datetime
 

--- a/openlibrary/coverstore/tests/test_webapp.py
+++ b/openlibrary/coverstore/tests/test_webapp.py
@@ -4,7 +4,7 @@ from os.path import abspath, dirname, join, pardir
 
 import pytest
 import web
-from six.moves import urllib
+import urllib
 
 from openlibrary.coverstore import archive, code, config, coverlib, schema, utils
 

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -9,15 +9,12 @@ import string
 
 import requests
 import web
-from six.moves.urllib.parse import splitquery, unquote, unquote_plus
-from six.moves.urllib.parse import urlencode as real_urlencode
+from urllib.parse import splitquery, unquote, unquote_plus
+from urllib.parse import urlencode as real_urlencode
 
 from openlibrary.coverstore import config, oldb
 
-try:
-    file  # Python 2
-except NameError:  # Python 3
-    from io import IOBase as file
+from io import IOBase as file
 
 socket.setdefaulttimeout(10.0)
 

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -9,8 +9,6 @@ import web
 from infogami.infobase import client, common, account, config as infobase_config
 from infogami import config
 
-import six
-
 
 key_patterns = {
     'work': '/works/OL%dW',

--- a/openlibrary/plugins/admin/graphs.py
+++ b/openlibrary/plugins/admin/graphs.py
@@ -3,7 +3,7 @@
 import web
 from infogami import config
 
-from six.moves import urllib
+import urllib
 
 
 def get_graphite_base_url():

--- a/openlibrary/plugins/admin/mem.py
+++ b/openlibrary/plugins/admin/mem.py
@@ -4,8 +4,6 @@ from openlibrary.plugins.admin import memory
 import web
 import gc
 
-import six
-
 
 def render_template(name, *a, **kw):
     return render[name](*a, **kw)

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -3,7 +3,7 @@
 
 import json
 import re
-from six.moves import urllib
+import urllib
 import web
 
 from infogami.utils import delegate

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -5,7 +5,6 @@ import sys
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.core import helpers as h
 from openlibrary.core import ia
-import six
 
 from infogami.utils.delegate import register_exception
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -29,7 +29,7 @@ from openlibrary.plugins.importapi import (
 from lxml import etree
 import logging
 
-from six.moves import urllib
+import urllib
 
 MARC_LENGTH_POS = 5
 logger = logging.getLogger('openlibrary.importapi')

--- a/openlibrary/plugins/importapi/import_opds.py
+++ b/openlibrary/plugins/importapi/import_opds.py
@@ -4,8 +4,6 @@ OL Import API OPDS parser
 
 from openlibrary.plugins.importapi import import_edition_builder
 
-import six
-
 
 def parse_string(e, key):
     return (key, e.text)

--- a/openlibrary/plugins/importapi/import_rdf.py
+++ b/openlibrary/plugins/importapi/import_rdf.py
@@ -4,8 +4,6 @@ OL Import API RDF parser
 
 from openlibrary.plugins.importapi import import_edition_builder
 
-import six
-
 
 def parse_string(e, key):
     return (key, e.text)

--- a/openlibrary/plugins/ol_infobase.py
+++ b/openlibrary/plugins/ol_infobase.py
@@ -12,7 +12,6 @@ import sys
 import traceback
 
 import requests
-import six
 import web
 
 from infogami.infobase import cache, common, config, dbstore, server

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -863,7 +863,7 @@ def changequery(query=None, **kw):
 
 from infogami.core.db import get_recent_changes as _get_recentchanges
 
-from six.moves import urllib
+import urllib
 
 
 @public

--- a/openlibrary/plugins/openlibrary/connection.py
+++ b/openlibrary/plugins/openlibrary/connection.py
@@ -12,8 +12,6 @@ from openlibrary.core import ia
 
 import logging
 
-import six
-
 
 logger = logging.getLogger("openlibrary")
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -16,9 +16,6 @@ from openlibrary.utils import dateutil
 from openlibrary.plugins.upstream.utils import get_blog_feeds, get_coverstore_public_url
 from openlibrary.plugins.worksearch import search, subjects
 
-import six
-
-
 logger = logging.getLogger("openlibrary.home")
 
 CAROUSELS_PRESETS = {

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -8,8 +8,6 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template, public
 from infogami.infobase import client, common
 
-import six
-
 from openlibrary.accounts import get_current_user
 from openlibrary.core import formats, cache
 import openlibrary.core.helpers as h

--- a/openlibrary/plugins/openlibrary/opds.py
+++ b/openlibrary/plugins/openlibrary/opds.py
@@ -6,8 +6,6 @@ A lightweight version of github.com/internetarchive/bookserver
 import lxml.etree as ET
 from infogami.infobase.utils import parse_datetime
 
-import six
-
 
 class OPDS:
     xmlns_atom = 'http://www.w3.org/2005/Atom'

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -3,7 +3,6 @@
 import web
 
 from openlibrary.core.processors import ReadableUrlProcessor
-import six
 
 from openlibrary.core import helpers as h
 

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -9,8 +9,6 @@ from openlibrary.core.admin import Stats
 from openlibrary.mocks.mock_infobase import MockSite
 from bs4 import BeautifulSoup
 
-import six
-
 from openlibrary import core
 from openlibrary.plugins.openlibrary import home
 

--- a/openlibrary/plugins/openlibrary/tests/test_listapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_listapi.py
@@ -4,7 +4,7 @@ import json
 
 import cookielib
 
-from six.moves import urllib
+import urllib
 
 
 def pytest_funcarg__config(request):

--- a/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
@@ -3,7 +3,7 @@ import web
 import json
 
 import cookielib
-from six.moves import urllib
+import urllib
 
 from openlibrary.plugins.openlibrary.api import ratings
 from openlibrary import accounts

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -35,7 +35,7 @@ from openlibrary.accounts import (
 )
 from openlibrary.plugins.upstream import borrow, forms, utils
 
-from six.moves import urllib
+import urllib
 
 
 logger = logging.getLogger("openlibrary.account")

--- a/openlibrary/plugins/upstream/adapter.py
+++ b/openlibrary/plugins/upstream/adapter.py
@@ -11,8 +11,7 @@ This adapter module is a filter that sits above an Infobase server and fakes the
 import json
 import web
 
-import six
-from six.moves import urllib
+import urllib
 
 
 urls = (

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1,5 +1,6 @@
 """Handlers for adding and editing books."""
 
+import io
 import itertools
 import web
 import json
@@ -26,8 +27,7 @@ from openlibrary.plugins.upstream.utils import render_template, fuzzy_find
 from openlibrary.plugins.upstream.account import as_admin
 from openlibrary.plugins.recaptcha import recaptcha
 
-import six
-from six.moves import urllib
+import urllib
 from web.webapi import SeeOther
 
 
@@ -724,7 +724,7 @@ class SaveBookHelper:
             """
             if not subjects:
                 return
-            f = six.StringIO(subjects.replace('\r\n',''))
+            f = io.StringIO(subjects.replace('\r\n',''))
             dedup = set()
             for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
                 if s.lower() not in dedup:

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -27,7 +27,7 @@ from openlibrary.utils import dateutil
 
 from lxml import etree
 
-from six.moves import urllib
+import urllib
 
 
 logger = logging.getLogger("openlibrary.borrow")

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -3,9 +3,8 @@
 from logging import getLogger
 
 import requests
-import six
 import web
-from six import BytesIO
+from io import BytesIO
 
 from infogami.utils import delegate
 from infogami.utils.view import safeint

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -3,7 +3,6 @@
 import re
 
 import json
-import six
 import web
 
 from infogami.infobase.client import ClientException

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -27,8 +27,6 @@ from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils import dateutil
 from openlibrary.utils.isbn import isbn_10_to_isbn_13, isbn_13_to_isbn_10
 
-import six
-
 
 def follow_redirect(doc):
     if isinstance(doc, str) and doc.startswith("/a/"):

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -19,10 +19,10 @@ from typing import Optional
 
 import requests
 
-import six
-from six.moves import urllib
-from six.moves.collections_abc import MutableMapping
-from six.moves.urllib.parse import (
+from html import unescape
+import urllib
+from collections.abc import MutableMapping
+from urllib.parse import (
     parse_qs,
     urlencode as parse_urlencode,
     urlparse,
@@ -530,7 +530,7 @@ def urlencode(dict_or_list_of_tuples: Union[dict, list[tuple[str, Any]]]) -> str
     You probably want to use this, if you're looking to urlencode parameters. This will
     encode things to utf8 that would otherwise cause urlencode to error.
     """
-    from six.moves.urllib.parse import urlencode as og_urlencode
+    from urllib.parse import urlencode as og_urlencode
 
     tuples = dict_or_list_of_tuples
     if isinstance(dict_or_list_of_tuples, dict):
@@ -541,10 +541,7 @@ def urlencode(dict_or_list_of_tuples: Union[dict, list[tuple[str, Any]]]) -> str
 
 @public
 def entity_decode(text):
-    try:
-        return six.moves.html_parser.unescape(text)
-    except AttributeError:
-        return six.moves.html_parser.HTMLParser().unescape(text)
+    return unescape(text)
 
 
 @public

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -11,7 +11,7 @@ from json import JSONDecodeError
 import requests
 import web
 from requests import Response
-from six.moves import urllib
+import urllib
 
 from infogami import config
 from infogami.utils import delegate, stats

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -13,7 +13,7 @@ from openlibrary.plugins.upstream.utils import get_language_name
 from . import subjects
 from . import search
 
-from six.moves import urllib
+import urllib
 
 
 logger = logging.getLogger("openlibrary.worksearch")

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -8,7 +8,7 @@ import logging
 from . import subjects
 from . import search
 
-from six.moves import urllib
+import urllib
 
 
 logger = logging.getLogger("openlibrary.worksearch")

--- a/openlibrary/solr/facet_hash.py
+++ b/openlibrary/solr/facet_hash.py
@@ -1,8 +1,6 @@
 import string
 from hashlib import sha1 as mkhash
 
-import six
-
 
 # choose token length to make collisions unlikely (if there is a
 # rare collision once in a while, we tolerate it, it just means

--- a/openlibrary/solr/solrwriter.py
+++ b/openlibrary/solr/solrwriter.py
@@ -2,12 +2,10 @@
 """
 import logging
 import re
+from http.client import HTTPConnection
 
 from lxml.etree import tostring, Element
 from unicodedata import normalize
-
-import six
-
 
 logger = logging.getLogger("openlibrary.solrwriter")
 
@@ -28,7 +26,7 @@ class SolrWriter:
 
     def get_conn(self):
         if self.conn is None:
-            self.conn = six.moves.http_client.HTTPConnection(self.host)
+            self.conn = HTTPConnection(self.host)
         return self.conn
 
     def request(self, xml):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -15,13 +15,12 @@ import sys
 import time
 
 from httpx import HTTPError, HTTPStatusError, TimeoutException
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 from collections import defaultdict
 from unicodedata import normalize
 
 import json
-import six
-from six.moves.http_client import HTTPConnection
+from http.client import HTTPConnection
 import web
 
 from openlibrary import config

--- a/openlibrary/utils/bulkimport.py
+++ b/openlibrary/utils/bulkimport.py
@@ -8,8 +8,6 @@ import web
 import datetime
 from collections import defaultdict
 
-import six
-
 
 class DocumentLoader:
     def __init__(self, **params):

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Callable, TypeVar, Iterable
 import requests
 import web
 
-from six.moves import urllib
+import urllib
 
 
 logger = logging.getLogger("openlibrary.logger")

--- a/scripts/oclc_to_marc.py
+++ b/scripts/oclc_to_marc.py
@@ -4,7 +4,7 @@ Usage: python oclc_to_marc.py oclc_1 oclc_2
 """
 import requests
 
-from six.moves import urllib
+import urllib
 
 
 root = "https://openlibrary.org"

--- a/scripts/solr_updater.py
+++ b/scripts/solr_updater.py
@@ -9,7 +9,6 @@ Changes:
 from typing import Iterator, Union
 import _init_path
 
-from six.moves import urllib
 import logging
 import json
 import datetime
@@ -18,6 +17,7 @@ import web
 import sys
 import re
 import socket
+import urllib
 
 from openlibrary.solr import update_work
 from openlibrary.config import load_config


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6560 with the help of `make git`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Remove Python 2 / 3 compatibility dependency [`six`](https://pypi.org/project/six)

Leave the dependency in `requirements.txt` for vendored code such as Infogami.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
