### PR TITLE
Refactor get_ebook_info to explicitly take IA metadata

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -542,7 +542,6 @@ class SolrProcessor:
         w: dict,
         editions: list[dict],
         subjects: dict[str, dict[str, int]],
-        has_fulltext: bool,
         ia_metadata: dict[str, Optional[IALiteMetadata]],
     ) -> dict:
         """
@@ -641,7 +640,7 @@ class SolrProcessor:
         # Anand - Oct 2013
         # If not public scan then add the work to Protected DAISY subject.
         # This is not the right place to add it, but seems to the quickest way.
-        if has_fulltext and not d.get('public_scan_b'):
+        if d.get('has_fulltext') and not d.get('public_scan_b'):
             subjects['subject']['Protected DAISY'] = 1
 
         return d
@@ -854,7 +853,7 @@ def build_data2(
     def add_field_list(doc, name, field_list):
         doc[name] = list(field_list)
 
-    doc = p.build_data(w, editions, subjects, has_fulltext, ia)
+    doc = p.build_data(w, editions, subjects, ia)
 
     work_cover_id = next(
         itertools.chain(


### PR DESCRIPTION
Work towards #6564 and #6379 . Having the ia metadata be implicit was making it difficult to generalize for different trusted book providers (See WIP pr #6559)
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
- I added a few too many type hints, and it awoke the sleeping mypy :P So last commit is just things to appease mypy

### Testing
- Trusting unit tests on this one
- Did a reindex of local data, and results were the same
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
