### PR TITLE
Reorder npm `build-assets` steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "watch": "env WEBPACK_PACKAGE=webpack5 npx webpack --watch --mode=development --progress",
     "watch-css": "npm-watch build-assets:css",
     "build-assets:webpack": "env NODE_ENV=production WEBPACK_PACKAGE=webpack5 npx webpack --mode=production",
-    "build-assets": "make js && make css && make components",
+    "build-assets": "make css && make js && make components",
     "build-assets:css": "make css",
     "build-assets:components": "make components",
     "build-assets:js": "make js",


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Some of our .js files reference .less files.  If a change is made to one of the referenced files, and `build-assets` is called, the changes will not be served until `make js` is executed again.

This PR ensures that our Less files are built before our JS when `build-assets` is executed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
A good way to test this is to make a change to `cbox.less` then run `npm run build-assets`.  If the style change is present in, say, the book notes modal, then this PR is working as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
