### PR TITLE
Create a Trending Books Carousel in the Home page 

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -76,22 +76,23 @@ class Bookshelves(db.CommonExtras):
         return results[0] if results else None
 
     @classmethod
-    def most_logged_books(cls, shelf_id=None, limit=10, since=False):
+    def most_logged_books(cls, shelf_id=None, limit=10, since=False, page=1):
         """Returns a ranked list of work OLIDs (in the form of an integer --
         i.e. OL123W would be 123) which have been most logged by
         users. This query is limited to a specific shelf_id (e.g. 1
         for "Want to Read").
         """
+        offset=(page-1)*limit
         oldb = db.get_db()
         where = 'WHERE bookshelf_id' + ('=$shelf_id' if shelf_id else ' IS NOT NULL ')
         if since:
             where += ' AND created >= $since'
         query = f'select work_id, count(*) as cnt from bookshelves_books {where}'
-        query += ' group by work_id order by cnt desc limit $limit'
+        query += ' group by work_id order by cnt desc limit $limit offset $offset'
         logger.info("Query: %s", query)
         logged_books = list(
             oldb.query(
-                query, vars={'shelf_id': shelf_id, 'limit': limit, 'since': since}
+                query, vars={'shelf_id': shelf_id, 'limit': limit, 'offset': offset, 'since': since}
             )
         )
         logger.info("Results: %s", logged_books)

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -187,7 +187,7 @@ class Bookshelves(db.CommonExtras):
     @classmethod
     def get_recently_logged_books(cls, bookshelf_id=None, limit=50, page=1):
         oldb = db.get_db()
-        page = int(page) if page else 1
+        page = int(page) if page else 1 
         data = {
             'bookshelf_id': bookshelf_id,
             'limit': limit,

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -4,11 +4,12 @@ its experience. This does not include public facing APIs with LTS
 (long term support)
 """
 
+from openlibrary.views.loanstats import get_logged_books_carousel
 import web
 import re
 import json
 from collections import defaultdict
-
+from openlibrary.views.loanstats import get_logged_books_carousel
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import render_template  # noqa: F401 used for its side effects
@@ -67,21 +68,26 @@ class browse(delegate.page):
 
     def GET(self):
         i = web.input(
-            q='', page=1, limit=100, subject='', work_id='', _type='', sorts=''
+            q='', page=1, limit=100, subject='', work_id='', _type='', sorts='',
+            trending=False
         )
-        sorts = i.sorts.split(',')
-        page = int(i.page)
-        limit = int(i.limit)
-        url = lending.compose_ia_url(
-            query=i.q,
-            limit=limit,
-            page=page,
-            subject=i.subject,
-            work_id=i.work_id,
-            _type=i._type,
-            sorts=sorts,
-        )
-        works = lending.get_available(url=url) if url else []
+        if i.trending:
+           works= get_logged_books_carousel(limit = int(i.limit),page=int(i.page))
+           url=""
+        else:
+            sorts = i.sorts.split(',')
+            page = int(i.page)
+            limit = int(i.limit)
+            url = lending.compose_ia_url(
+                query=i.q,
+                limit=limit,
+                page=page,
+                subject=i.subject,
+                work_id=i.work_id,
+                _type=i._type,
+                sorts=sorts,
+            )
+            works = lending.get_available(url=url) if url else []
         result = {
             'query': url,
             'works': [work.dict() for work in works],

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -72,8 +72,12 @@ class browse(delegate.page):
             trending=False
         )
         if i.trending:
-           works= get_logged_books_carousel(limit = int(i.limit),page=int(i.page))
+           works = get_logged_books_carousel(limit = int(i.limit), page = int(i.page))
            url=""
+           result = {
+            'query': url,
+            'works': [dict(work) for work in works],
+            }
         else:
             sorts = i.sorts.split(',')
             page = int(i.page)
@@ -88,10 +92,10 @@ class browse(delegate.page):
                 sorts=sorts,
             )
             works = lending.get_available(url=url) if url else []
-        result = {
-            'query': url,
-            'works': [work.dict() for work in works],
-        }
+            result = {
+                'query': url,
+                'works': [work.dict() for work in works],
+            }
         return delegate.RawText(json.dumps(result), content_type="application/json")
 
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -775,6 +775,7 @@ def readonline_carousel():
         if len(data) > 30:
             data = lending.add_availability(random.sample(data, 30))
             data = [d for d in data if d['availability'].get('is_readable')]
+        print(storify(data))
         return storify(data)
 
     except Exception:

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -19,7 +19,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("home/welcome", test=test)
 
-  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test,load_more={"url": "/browse.json?trending=true", "mode": "page", "limit": 7})
+  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test,load_more={"url": "/browse.json?trending=true", "mode": "page", "limit": 18})
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -21,7 +21,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 
-  $:render_template("books/custom_carousel", books=get_most_logged_books(), title=_('PAO Books'), url="/trending", test=test)
+  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test)
 
 
   $if monthly_reads and not test:

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -19,7 +19,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("home/welcome", test=test)
 
-  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test,load_more={"url": "/browse.json?trending=true", "mode": "page", "limit": 20})
+  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test,load_more={"url": "/browse.json?trending=true", "mode": "page", "limit": 7})
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -19,10 +19,9 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("home/welcome", test=test)
 
+  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test,load_more={"url": "/browse.json?trending=true", "mode": "page", "limit": 20})
+
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
-
-  $:render_template("books/custom_carousel", books=get_logged_books_carousel(), title=_('Trending Books'), url="/trending", test=test)
-
 
   $if monthly_reads and not test:
     $:macros.QueryCarousel(query=monthly_reads['query'], title=monthly_reads['title'], key="monthly_reads", url=monthly_reads['url'], sort='random.hourly')

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -21,6 +21,9 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
 
+  $:render_template("books/custom_carousel", books=get_most_logged_books(), title=_('PAO Books'), url="/trending", test=test)
+
+
   $if monthly_reads and not test:
     $:macros.QueryCarousel(query=monthly_reads['query'], title=monthly_reads['title'], key="monthly_reads", url=monthly_reads['url'], sort='random.hourly')
 

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -39,7 +39,7 @@ def cached_get_most_logged_books(shelf_id=None, since_days=1, limit=20):
     )(shelf_id=shelf_id, since_days=since_days, limit=limit)
 
 @public
-def get_logged_books_carousel(since_days=1, limit=20 ,page=1):
+def get_logged_books_carousel(since_days=1, limit=7 ,page=1):
     books = get_most_logged_books(since_days = since_days, limit = limit, page = page)
     work_index = get_solr_works(f"/works/OL{book['work_id']}W" for book in books)
     availability_index = get_availabilities(work_index.values())

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -39,7 +39,7 @@ def cached_get_most_logged_books(shelf_id=None, since_days=1, limit=20):
     )(shelf_id=shelf_id, since_days=since_days, limit=limit)
 
 @public
-def get_logged_books_carousel(since_days=1, limit=7 ,page=1):
+def get_logged_books_carousel(since_days=1, limit=18 ,page=1):
     books = get_most_logged_books(since_days = since_days, limit = limit, page = page)
     work_index = get_solr_works(f"/works/OL{book['work_id']}W" for book in books)
     availability_index = get_availabilities(work_index.values())

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -4,6 +4,7 @@ import web
 from infogami.utils import delegate
 from ..core.lending import get_availabilities
 from ..plugins.worksearch.code import get_solr_works
+from infogami.utils.view import public
 
 from ..utils import dateutil
 from .. import app
@@ -37,6 +38,7 @@ def cached_get_most_logged_books(shelf_id=None, since_days=1, limit=20):
         get_most_logged_books, 'stats.trending', timeout=dateutil.HOUR_SECS
     )(shelf_id=shelf_id, since_days=since_days, limit=limit)
 
+@public
 def get_most_logged_books(shelf_id=None, since_days=1, limit=20):
     """
     shelf_id: Bookshelves.PRESET_BOOKSHELVES['Want to Read'|'Already Read'|'Currently Reading']

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -40,7 +40,7 @@ def cached_get_most_logged_books(shelf_id=None, since_days=1, limit=20):
 
 @public
 def get_logged_books_carousel(since_days=1, limit=20 ,page=1):
-    books = get_most_logged_books(since_days,limit,page)
+    books = get_most_logged_books(since_days = since_days, limit = limit, page = page)
     work_index = get_solr_works(f"/works/OL{book['work_id']}W" for book in books)
     availability_index = get_availabilities(work_index.values())
     for work_key in availability_index:

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -39,6 +39,26 @@ def cached_get_most_logged_books(shelf_id=None, since_days=1, limit=20):
     )(shelf_id=shelf_id, since_days=since_days, limit=limit)
 
 @public
+def get_logged_books_carousel():
+    books = cached_get_most_logged_books()
+    work_index = get_solr_works(f"/works/OL{book['work_id']}W" for book in books)
+    availability_index = get_availabilities(work_index.values())
+    for work_key in availability_index:
+        work_index[work_key]['availability'] = availability_index[work_key]
+
+    tab = []
+    for i, logged_book in enumerate(books):
+        key = f"/works/OL{logged_book['work_id']}W"
+        if key in work_index:
+            tab.append(work_index[key])
+    print(tab)
+    return tab 
+
+
+
+
+
+@public
 def get_most_logged_books(shelf_id=None, since_days=1, limit=20):
     """
     shelf_id: Bookshelves.PRESET_BOOKSHELVES['Want to Read'|'Already Read'|'Currently Reading']

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -39,8 +39,8 @@ def cached_get_most_logged_books(shelf_id=None, since_days=1, limit=20):
     )(shelf_id=shelf_id, since_days=since_days, limit=limit)
 
 @public
-def get_logged_books_carousel():
-    books = cached_get_most_logged_books()
+def get_logged_books_carousel(since_days=1, limit=20 ,page=1):
+    books = get_most_logged_books(since_days,limit,page)
     work_index = get_solr_works(f"/works/OL{book['work_id']}W" for book in books)
     availability_index = get_availabilities(work_index.values())
     for work_key in availability_index:
@@ -59,7 +59,7 @@ def get_logged_books_carousel():
 
 
 @public
-def get_most_logged_books(shelf_id=None, since_days=1, limit=20):
+def get_most_logged_books(shelf_id=None, since_days=1, limit=20 ,page=1):
     """
     shelf_id: Bookshelves.PRESET_BOOKSHELVES['Want to Read'|'Already Read'|'Currently Reading']
     since: DATE_ONE_YEAR_AGO, DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO, DATE_ONE_DAY_AGO
@@ -73,7 +73,8 @@ def get_most_logged_books(shelf_id=None, since_days=1, limit=20):
             Bookshelves.most_logged_books(
                 shelf_id=shelf_id,
                 since=dateutil.date_n_days_ago(since_days),
-                limit=limit)]
+                limit=limit,
+                page=page)]
 
 
 def reading_log_leaderboard(limit=None):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6186

With this PR, a carousel containing the **_Today's_ Trending Books** in the Home page.


### Technical
<!-- What should be noted about the implementation? -->
The `get_most_logged_books` method used to fetch the Trending Books for the `/trending/today` page did not return the books in the correct format in order for the carousel to process and view them. So, we created the `get_logged_books_carousel` which calls `get_most_logged_books` and then formats the output. This created the carousel for the first step of the implementation.

Considering the second step and the carousels ability to load more books, we adjusted `browse.json` with adding the trending parameter. If `trending = true`, then the `get_logged_books_carousel` is called. To achieve pagination, the `most_logged_books` method gets the page number as a parameter. Lastly, we added an offset variable `offset=(page-1)*limit` and integrated it in the sql query. 

### Testing
If testing in a localhost environment make sure to mark books as 'Want to Read' in order for the carousel to appear (works only for today's trending books).  A `docker-compose restart memcached` is needed. 


### Stakeholders
@mekarpeles 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
