### PR TITLE
Make Classics carousel show only classic books

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -762,50 +762,6 @@ def generic_carousel(
     return storify(books) if books else books
 
 
-@public
-def readonline_carousel():
-    """Return template code for books pulled from search engine.
-    TODO: If problems, use stock list.
-    """
-    try:
-        data = random_ebooks()
-        if len(data) > 30:
-            data = lending.add_availability(random.sample(data, 30))
-            data = [d for d in data if d['availability'].get('is_readable')]
-        return storify(data)
-
-    except Exception:
-        logger.error("Failed to compute data for readonline_carousel", exc_info=True)
-        return None
-
-
-def random_ebooks(limit=2000):
-    solr = search.get_solr()
-    sort = "edition_count desc"
-    result = solr.select(
-        query='has_fulltext:true -public_scan_b:false',
-        rows=limit,
-        sort=sort,
-        fields=[
-            'has_fulltext',
-            'key',
-            'ia',
-            "title",
-            "cover_edition_key",
-            "author_key",
-            "author_name",
-        ],
-    )
-
-    return [format_work_data(doc) for doc in result.get('docs', []) if doc.get('ia')]
-
-
-# cache the results of random_ebooks in memcache for 15 minutes
-random_ebooks = cache.memcache_memoize(
-    random_ebooks, "home.random_ebooks", timeout=15 * 60
-)
-
-
 def format_list_editions(key):
     """Formats the editions of a list suitable for display in carousel."""
     if 'env' not in web.ctx:

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -150,7 +150,6 @@ class TestHomeTemplates:
             "Kids",
             "Thrillers",
             "Romance",
-            "Classic Books",
             "Textbooks",
         ]
         for h in headers:

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -74,22 +74,6 @@ class TestHomeTemplates:
         html = str(render_template("home/stats"))
         assert html == ""
 
-    def test_read_template(self, render_template, monkeypatch):
-        # getting read-online books fails because solr is not defined.
-        # Empty list should be returned when there is error.
-        monkeypatch.setattr(home, 'random_ebooks', lambda: None)
-        books = home.readonline_carousel()
-        html = str(
-            render_template(
-                "books/custom_carousel",
-                books=books,
-                title="Classic Books",
-                url="/read",
-                key="public_domain",
-            )
-        )
-        assert html.strip() == ""
-
     def test_home_template(self, render_template, mock_site, monkeypatch):
         self.setup_monkeypatch(monkeypatch)
         docs = [

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -19,7 +19,8 @@ $add_metatag(name="twitter:card", content="homepage_summary")
 
   $:render_template("home/welcome", test=test)
 
-  $:render_template("books/custom_carousel", books=readonline_carousel(), title=_('Classic Books'), url="/read", key="public_domain", test=test)
+  $if not test:
+    $:macros.QueryCarousel(query="subject:classic -public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly')
 
   $if monthly_reads and not test:
     $:macros.QueryCarousel(query=monthly_reads['query'], title=monthly_reads['title'], key="monthly_reads", url=monthly_reads['url'], sort='random.hourly')

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -20,7 +20,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
   $:render_template("home/welcome", test=test)
 
   $if not test:
-    $:macros.QueryCarousel(query="subject:classic -public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly')
+    $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] -public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly')
 
   $if monthly_reads and not test:
     $:macros.QueryCarousel(query=monthly_reads['query'], title=monthly_reads['title'], key="monthly_reads", url=monthly_reads['url'], sort='random.hourly')


### PR DESCRIPTION
Getting complaints about some odd books showing up in here. Let's limit to something else, and monitor the Google Analytics to see if it does better or worse. Limiting to dewey decimal section 800s, books published before 1950, but which were also published sometime in the last 20 years.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@seabelis 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
