### PR TITLE
Normalize all Python shebang lines to #!/usr/bin/env python

### DIFF
--- a/openlibrary/catalog/marc/cmdline.py
+++ b/openlibrary/catalog/marc/cmdline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/env python
 from openlibrary.catalog.marc.fast_parse import *
 from openlibrary.catalog.get_ia import get_from_archive
 import sys

--- a/openlibrary/catalog/marc/show_records.py
+++ b/openlibrary/catalog/marc/show_records.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/env python
 from openlibrary.catalog.marc.fast_parse import *
 import sys
 from collections import defaultdict

--- a/openlibrary/catalog/merge/build_db.py
+++ b/openlibrary/catalog/merge/build_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/env python
 # converts from text files containing MARC tags to text versions of merge pools
 
 import re

--- a/openlibrary/catalog/merge/merge_bot/bot.py
+++ b/openlibrary/catalog/merge/merge_bot/bot.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python
 
 import codecs
 import sys

--- a/openlibrary/catalog/merge/merge_bot/merge.py
+++ b/openlibrary/catalog/merge/merge_bot/merge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/env python
 
 import openlibrary.catalog.merge.merge_marc as marc
 import openlibrary.catalog.merge.amazon as amazon

--- a/openlibrary/coverstore/server.py
+++ b/openlibrary/coverstore/server.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """coverstore server.
 """
 

--- a/openlibrary/data/db.py
+++ b/openlibrary/data/db.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Library to provide fast access to Open Library database.
 
 How to use:

--- a/scripts/affiliate-server
+++ b/scripts/affiliate-server
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Run affiliate server.
 
 Usage:

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 from collections import namedtuple
 
 import json

--- a/scripts/coverstore-server
+++ b/scripts/coverstore-server
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Run coverstore server.
 
 Usage:

--- a/scripts/cron_watcher.py
+++ b/scripts/cron_watcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 Daily Cron-audit task (Python) sentry (who watches the watchers)

--- a/scripts/fake_loan_server.py
+++ b/scripts/fake_loan_server.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """
 Fake loan status server to make dev instance work with borrowing books.
 """

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Utility script to extract all translatable messages from templates and
 macros and write to openlibrary/i18n/messages.pot file.
 """

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 import json
 import requests
 import time

--- a/scripts/infobase-server
+++ b/scripts/infobase-server
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Script to run infobase.
 
 USAGE:

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 CAUTION: This file should continue to support both Python 2 and Python 3 until
     issues internetarchive/openlibrary#4060 and internetarchive/openlibrary#4252

--- a/scripts/mail_bad_author_query.py
+++ b/scripts/mail_bad_author_query.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import web
 import os
 import smtplib

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 import web

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Script to migrate the OL database to latest schema.
 """
 

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 from datetime import datetime

--- a/scripts/openlibrary-server
+++ b/scripts/openlibrary-server
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Script to run openlibrary server.
 
 USAGE:

--- a/scripts/pull-templates.py
+++ b/scripts/pull-templates.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Script to pull templates and macros from an openlibrary instance to repository.
 """
 import _init_path

--- a/scripts/sitemaps/sitemap.py
+++ b/scripts/sitemaps/sitemap.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python
 """Script to generate XML sitemap of openlibrary.org website.
 
 USAGE:

--- a/scripts/store_counts.py
+++ b/scripts/store_counts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 

--- a/scripts/sync
+++ b/scripts/sync
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """
 Utility script to sync templates, macros, css and js files between
 openlibrary website and repository.

--- a/scripts/update-loans.py
+++ b/scripts/update-loans.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Script to update loans and waiting loans on regular intervals.
 
 Tasks done:

--- a/scripts/upstream-adapter
+++ b/scripts/upstream-adapter
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 import _init_path
 from openlibrary.plugins.upstream import adapter

--- a/scripts/view_marc.py
+++ b/scripts/view_marc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.5
+#!/usr/bin/env python
 from openlibrary.catalog.marc.fast_parse import *
 from openlibrary.catalog.get_ia import get_from_archive
 import sys


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Normalize all Python shebang lines to `#! /usr/bin/env python3` because we had some Python 2.5 cruft lying around and because on my Mac at least there is no `/usr/bin/python` and `/usr/bin/python3` points to the older system Python 3.8:
```
% /usr/bin/python --version
zsh: no such file or directory: /usr/bin/python

% python --version
zsh: command not found: python

% /usr/bin/python3 --version
Python 3.8.9

 % python3 --version
Python 3.10.4
```
Finding Python shebangs on macOS: `git grep "\#\!" | grep python`
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
