### PR TITLE
fix opds rendering

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -593,11 +593,9 @@ class opds(delegate.mode):
         if not page:
             raise web.notfound('')
         else:
-            from infogami.utils import template
             from openlibrary.plugins.openlibrary import opds
-
             try:
-                result = template.typetemplate('opds')(page, opds)
+                result = opds.OPDSEntry(page).to_string()
             except:
                 raise web.notfound('')
             else:

--- a/openlibrary/templates/type/edition/opds.html
+++ b/openlibrary/templates/type/edition/opds.html
@@ -1,7 +1,0 @@
-$def with (book, opds)
-$code:
-    def get_opds_tree(book):
-        entry = opds.OPDSEntry(book)
-        return entry.to_string()
-
-$:get_opds_tree(book)\


### PR DESCRIPTION
Previously e.g. https://openlibrary.org/books/OL32050722M.opds was rendering as a python `b''` string

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
