### PR TITLE
 Add access solr fields to non-IA book providers 

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -22,7 +22,6 @@ from openlibrary.core.models import Edition  # noqa: E402
 from openlibrary.plugins.inside.code import fulltext_search
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.upstream.utils import get_language_name, urlencode
-from openlibrary.solr.update_work import get_solr_next
 from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.utils import escape_bracket
 from openlibrary.utils.ddc import (


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #6379

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
- Moved EbookAccess and IALiteMetadata to book_providers
- Had some import nightmares, so had to import book provider kind of funny :/ There's a circular import somewhere I can't find!

### Testing
- [x] copydocs some openstax books and confirm they show up when has_fulltext: true

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
