### PR TITLE
Remove black option --diff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,6 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black  # See pyproject.toml for args
-        args:
-        - --diff
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -352,7 +352,7 @@ def setup():
     addbook.setup()
     covers.setup()
     merge_authors.setup()
-    #merge_works.setup() # ILE code
+    # merge_works.setup() # ILE code
     edits.setup()
 
     from openlibrary.plugins.upstream import data, jsdef

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ force-exclude = '''
     | ^/openlibrary/core/bookshelves.py
     | ^/openlibrary/core/cache.py
     | ^/openlibrary/core/db.py
+    | ^/openlibrary/core/edits.py
     | ^/openlibrary/core/lending.py
     | ^/openlibrary/core/lists/model.py
     | ^/openlibrary/core/observations.py
@@ -36,6 +37,7 @@ force-exclude = '''
     | ^/openlibrary/plugins/upstream/account.py
     | ^/openlibrary/plugins/upstream/addbook.py
     | ^/openlibrary/plugins/upstream/covers.py
+    | ^/openlibrary/plugins/upstream/edits.py
     | ^/openlibrary/plugins/upstream/models.py
     | ^/openlibrary/plugins/upstream/mybooks.py
     | ^/openlibrary/plugins/worksearch/code.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,50 @@
 [tool.black]
 skip-string-normalization = true
 target-version = ['py39', 'py310']
+force-exclude = '''
+(
+    ^/openlibrary/accounts/model.py
+    | ^/openlibrary/api.py
+    | ^/openlibrary/book_providers.py
+    | ^/openlibrary/catalog/amazon/import.py
+    | ^/openlibrary/catalog/marc/parse.py
+    | ^/openlibrary/core/bookshelves.py
+    | ^/openlibrary/core/cache.py
+    | ^/openlibrary/core/db.py
+    | ^/openlibrary/core/lending.py
+    | ^/openlibrary/core/lists/model.py
+    | ^/openlibrary/core/observations.py
+    | ^/openlibrary/core/sponsorships.py
+    | ^/openlibrary/core/vendors.py
+    | ^/openlibrary/coverstore/code.py
+    | ^/openlibrary/plugins/admin/code.py
+    | ^/openlibrary/plugins/openlibrary/api.py
+    | ^/openlibrary/plugins/openlibrary/borrow_home.py
+    | ^/openlibrary/plugins/openlibrary/code.py
+    | ^/openlibrary/plugins/openlibrary/lists.py
+    | ^/openlibrary/plugins/openlibrary/processors.py
+    | ^/openlibrary/plugins/upstream/account.py
+    | ^/openlibrary/plugins/upstream/addbook.py
+    | ^/openlibrary/plugins/upstream/covers.py
+    | ^/openlibrary/plugins/upstream/models.py
+    | ^/openlibrary/plugins/upstream/mybooks.py
+    | ^/openlibrary/plugins/worksearch/code.py
+    | ^/openlibrary/plugins/worksearch/subjects.py
+    | ^/openlibrary/tests/core/test_db.py
+    | ^/openlibrary/tests/core/test_models.py
+    | ^/openlibrary/tests/core/test_sponsors.py
+    | ^/openlibrary/tests/data/test_dump.py
+    | ^/openlibrary/utils/__init__.py
+    | ^/openlibrary/views/loanstats.py
+    | ^/scripts/copydocs.py
+    | ^/scripts/coverstore-server
+    | ^/scripts/i18n-messages
+    | ^/scripts/import_standard_ebooks.py
+    | ^/scripts/infobase-server
+    | ^/scripts/openlibrary-server
+    | ^/scripts/solr_builder/solr_builder/fn_to_cli.py
+    | ^/scripts/sync
+    | ^/scripts/tests/test_copydocs.py
+    | ^/vendor/js/wmd/jsmin.py
+)
+'''


### PR DESCRIPTION
<!-- What issue does this PR close? -->
One of the last remains tasks of #4776
Closes #5079

Remove [--diff](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#diffs) option which currently prevents black from re-formatting modified Python files.

I only made changes to `.pre-commit-config.yaml`.  Pre-commit CI automatically made the changes to all other files.

### After Slacking with @mekarpeles, we will move the following question to a separate PR.

Question: If we are going to modify 40 Python files, given https://github.com/internetarchive/openlibrary/issues/2981#issuecomment-693664342 should we modify even more by:
1. Dropping [`--skip-string-normalization`](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#strings) and allowing black to favor double-quoted strings in Python code. **-- OR --**
2. ~Adding [double-quote-string-fixer](https://github.com/pre-commit/pre-commit-hooks#double-quote-string-fixer) to prefer single-quotes in Python files instead of black-standard double-quotes.  See: #6602~

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Once this is landed we should establish a flake8 baseline against:
`flake8 **/*.py --exclude="./.*,./vendor/*" --ignore=E203,W503 --max-complexity=41 --max-line-length=1195`


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
