### PR TITLE
Avoid XSS when writing a hrefs

### DIFF
--- a/openlibrary/macros/Paginate.html
+++ b/openlibrary/macros/Paginate.html
@@ -5,8 +5,8 @@ $ pages = list_pages(path, limit=limit, offset=page * limit)
 
 <div class="sansserif">
 $if page != 0:
-    <a href="$:changequery(page=page - 1)" rel="nofollow">&lt; $_.prev</a> <strong>&middot;</strong>
+    <a href="$changequery(page=page - 1)" rel="nofollow">&lt; $_.prev</a> <strong>&middot;</strong>
 
 $if len(pages) == limit:
-    <a href="$:changequery(page=page + 1)" rel="nofollow">$_.next &gt;</a>
+    <a href="$changequery(page=page + 1)" rel="nofollow">$_.next &gt;</a>
 </div>

--- a/openlibrary/macros/RecentChanges.html
+++ b/openlibrary/macros/RecentChanges.html
@@ -51,10 +51,10 @@ $def render_changes(bot, hash=""):
     </table>
     <div class="historyPager small sansserif gray">
     $if len(changes) == limit:
-        <a href="$:changequery(page=page + 1)$hash" rel="nofollow">&larr; $_("Older")</a>
+        <a href="$changequery(page=page + 1)$hash" rel="nofollow">&larr; $_("Older")</a>
     $if page > 1:
          &nbsp;|&nbsp;
-        <a href="$:changequery(page=page - 1)$hash" rel="nofollow">$_("Newer") &rarr;</a>
+        <a href="$changequery(page=page - 1)$hash" rel="nofollow">$_("Newer") &rarr;</a>
     </div>
 
 $if ip or author:

--- a/openlibrary/macros/RecentChangesAdmin.html
+++ b/openlibrary/macros/RecentChangesAdmin.html
@@ -49,9 +49,9 @@ $ show_users = (query_param('show_users', 'false').lower() == 'true')
 
     <div class="historyPager small sansserif gray" style="width:100%;">
     $if len(changes) == limit:
-        <a href="$:changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a> &nbsp;|&nbsp;
+        <a href="$changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a> &nbsp;|&nbsp;
     $if page != 0:
-        <a href="$:changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
+        <a href="$changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
     $else:
         $_("Newer") &rarr;
     </div>

--- a/openlibrary/macros/RecentChangesUsers.html
+++ b/openlibrary/macros/RecentChangesUsers.html
@@ -51,10 +51,10 @@ $if len(changes) > 1:
 
     <div class="historyPager small sansserif gray" style="width:100%;">
     $if len(changes) == limit:
-        <a href="$:changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a>
+        <a href="$changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a>
     $if page != 0:
          &nbsp;|&nbsp;
-         <a href="$:changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
+         <a href="$changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
     </div>
 $else:
     <p>$_("No edits. Yet.")</p>

--- a/openlibrary/macros/WorkInfo.html
+++ b/openlibrary/macros/WorkInfo.html
@@ -20,7 +20,7 @@ $for name in s:
                 <td><span class="object">
                 $for name in subjects:
                     $for subject in page[name]:
-                        <a href="/search?ftokens=$:utf8(facet_token('subjects', subject.strip()))">$:utf8(thingrepr(subject)).replace(' -- ', '/')</a>,
+                        <a href="/search?ftokens=$utf8(facet_token('subjects', subject.strip()))">$:utf8(thingrepr(subject)).replace(' -- ', '/')</a>,
                 </span></td></tr>
             $else:
                 <td><span class="object">$:thingrepr(page[name])</span></td></tr>

--- a/openlibrary/templates/admin/people/edits.html
+++ b/openlibrary/templates/admin/people/edits.html
@@ -90,9 +90,9 @@ $def call_template(name, change):
 $if paginate:
     <div class="historyPager small sansserif gray">
         $if len(changes) == limit:
-            <a href="$:changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a>
+            <a href="$changequery(page=page + 1)" rel="nofollow">&larr; $_("Older")</a>
         $if page > 1:
              &nbsp;|&nbsp;
-            <a href="$:changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
+            <a href="$changequery(page=page - 1)" rel="nofollow">$_("Newer") &rarr;</a>
     </div>
 </div>

--- a/openlibrary/templates/history.html
+++ b/openlibrary/templates/history.html
@@ -78,9 +78,9 @@ $ rev = page.latest_revision or page.revision
         <div class="sansserif">
         $ page = safeint(query_param("page", "0"))
         $if page != 0:
-            <a href="$:changequery(page=page - 1)" rel="nofollow">&larr; $_("Back")</a>
+            <a href="$changequery(page=page - 1)" rel="nofollow">&larr; $_("Back")</a>
         $if len(h) == 20:
-            <a href="$:changequery(page=page + 1)" rel="nofollow">$_("Next") &rarr;</a>
+            <a href="$changequery(page=page + 1)" rel="nofollow">$_("Next") &rarr;</a>
         </div>
 
 </div>

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -41,7 +41,7 @@ $def with (page)
         <h2>$:_('Help')</h2>
         <ul>
           <li><a href="/help">$_('Help Center')</a></li>
-          <li><a href="/contact?$:urlencode(dict(path=request.fullpath))" title="$_('Problems')">$_('Report A Problem')</a></li>
+          <li><a href="/contact?$urlencode(dict(path=request.fullpath))" title="$_('Problems')">$_('Report A Problem')</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_('Suggesting Edits')</a></li>
         </ul>
         <aside id="footer-icons">

--- a/openlibrary/templates/notfound.html
+++ b/openlibrary/templates/notfound.html
@@ -15,7 +15,7 @@ $if create is None:
 
     $# Show create link only to admins
     $if ctx.user and ctx.user.is_admin() and create:
-        <p><a class="adminOnly" href="$:url(path, m='edit')">$_("Create it?")</a></p>
+        <p><a class="adminOnly" href="$changequery(m='edit')">$_("Create it?")</a></p>
 
     <div>
     $if "/templates" in path or "/macros" in path:

--- a/openlibrary/templates/recentchanges/render.html
+++ b/openlibrary/templates/recentchanges/render.html
@@ -56,8 +56,8 @@ $if "ip" in query and ctx.user and ctx.user.is_admin():
 $if paginate:
     <div class="historyPager small sansserif gray">
         $if len(changes) == limit:
-            <a href="$:changequery(page=page + 1)$hash" rel="nofollow">&larr; $_("Older")</a>
+            <a href="$changequery(page=page + 1)$hash" rel="nofollow">&larr; $_("Older")</a>
         $if page > 1:
              &nbsp;|&nbsp;
-            <a href="$:changequery(page=page - 1)$hash" rel="nofollow">$_("Newer") &rarr;</a>
+            <a href="$changequery(page=page - 1)$hash" rel="nofollow">$_("Newer") &rarr;</a>
     </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -2,17 +2,18 @@ $def with (input, q_param, do_search, get_doc, get_availability_of_ocaids, fullt
 
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
 
-$def add_facet_url(k, v):
-    $if k != 'has_fulltext':
-        $changequery(page=None,**{k:param.get(k, []) + [v]})
-    $else:
-        $changequery(page=None,**{k:v})
+$code:
+    def add_facet_url(k, v):
+        if k != 'has_fulltext':
+            return changequery(page=None,**{k:param.get(k, []) + [v]})
+        else:
+            return changequery(page=None,**{k:v})
 
-$def del_facet_url(k, v):
-    $if k != 'has_fulltext':
-        $changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
-    $else:
-        $changequery(page=None,**{k:None})
+    def del_facet_url(k, v):
+        if k != 'has_fulltext':
+            return changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
+        else:
+            return changequery(page=None,**{k:None})
 
 $ param = {}
 $for p in ['q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor', 'publish_place', 'lccn', 'ia', 'first_sentence', 'publisher', 'author_key', 'debug', 'subject', 'place', 'person', 'time'] + facet_fields:
@@ -135,7 +136,7 @@ $ )
                             <span title="$_('Published by')">$display</span>
                         $elif header == 'author_key':
                             <span title="$_('Author')">$display</span>
-                        <span style="padding-right:15px;"><a href="$:del_facet_url(header, k)" title="$_('Click to remove this facet')" class="facetRemove plain red">[x]</a></span>
+                        <span style="padding-right:15px;"><a href="$del_facet_url(header, k)" title="$_('Click to remove this facet')" class="facetRemove plain red">[x]</a></span>
                 </strong></span></p>
             $var title: $_('%(title)s - search', title=', '.join(title))
 
@@ -214,9 +215,9 @@ $elif param and len(docs):
                        $ display = _('yes')
                     $else:
                        $ display = _('no')
-                    <span class="small"><a href="$:add_facet_url(header, k)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 $else:
-                    <span class="small"><a href="$:add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
                 <div class="facetMoreLess">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
- [x] https://github.com/internetarchive/infogami/pull/195

You are allowed to html encode `&` in urls to `&amp;` when writing out the `href`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- https://testing.openlibrary.org/%22%3E%3Cscript%3Ealert(document.cookie)%3C/script%3E doesn't xss
- pagination works in search
- facets work in search

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
