### PR TITLE
Fix random_edition only returns two works

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1,11 +1,12 @@
 """Module for providing core functionality of lending on Open Library.
 """
-from typing import Literal, Optional, List
+from typing import Literal, Optional
 
 import web
 import datetime
-import time
 import logging
+import random
+import time
 import uuid
 
 import eventer
@@ -207,21 +208,22 @@ def compose_ia_url(
     return base_url + '?' + urlencode(params)
 
 
-def get_random_available_ia_edition():
+def get_random_available_ia_edition() -> str:
     """uses archive advancedsearch to raise a random book"""
     try:
         url = (
             "http://%s/advancedsearch.php?q=_exists_:openlibrary_work"
-            "+AND+(lending___available_to_borrow:true OR lending___available_to_browse:true)"
+            "+AND+(lending___available_to_borrow:true"
+            " OR lending___available_to_browse:true)"
             "&fl=identifier,openlibrary_edition"
-            "&output=json&rows=1&sort[]=random" % (config_bookreader_host)
-        )
+            "&output=json&rows=25&sort[]=random" % (config_bookreader_host)
+        )  # internetarchive/openlibrary#6592: Request 25 editions and randomly choose
         response = requests.get(url, timeout=config_http_request_timeout)
         items = response.json().get('response', {}).get('docs', [])
-        return items[0]["openlibrary_edition"]
+        return random.choice(items)["openlibrary_edition"]
     except Exception:  # TODO: Narrow exception scope
-        logger.exception("get_random_available_ia_edition(%s)" % url)
-        return None
+        logger.exception(f"get_random_available_ia_edition({url})")
+        return ''
 
 
 @public


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6592
Instead of asking IA for just one random edition, ask for 25 and then use [`random.choice()`](https://docs.python.org/3/library/random.html#functions-for-sequences) to make the final selection.

The problem may be caused by query results being cached so only requesting a single edition is too small a population.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->
`docker compose up`
In a separate macOS terminal tab:
```bash
for i in {1..5}; do
    open http://localhost:8080/random
done
```
Before, repeated editions as described in #6592
After, different editions in each browser tab
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
