### PR TITLE
GitHub Action to verify successful completion of our cron jobs

### DIFF
--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -1,0 +1,21 @@
+# A GitHub Action to verify that certain Open Library cron jobs have completed successfully.
+# Data dumps happen on the 1st day of the month so check on them on the 2nd day of the month.
+# Partner dumps happen on the 17th day of the month so check on them on the 18th day of the month.
+# Always check again two days later in case they needed to be re-run.
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+
+name: cron_watcher
+on:
+  schedule:  # At 3:45am on the 2nd, 4th, 18th, and 20th day of the month.
+    - cron: '45 3 2,4,18,20 * *'  # https://cron.help
+  workflow_dispatch:  # This job can also be run on-demand.
+jobs:
+  cron_watcher:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-python@v3
+      - run: pip install internetarchive
+      - run: scripts/cron_watcher.py

--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: actions/setup-python@v3
       - run: pip install internetarchive
       - run: scripts/cron_watcher.py


### PR DESCRIPTION
<!-- What issue does this PR close? -->
### A GitHub Action to verify that certain Open Library cron jobs have completed successfully.
Data dumps happen on the 1st day of the month so check on them on the 2nd day of the month.
Partner dumps happen on the 17th day of the month so check on them on the 18th day of the month.
Always check again two days later in case they needed to be re-run.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

Runs [`scripts/cron_watcher.py`](https://github.com/internetarchive/openlibrary/blob/master/scripts/cron_watcher.py)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
