### PR TITLE
Simplify new language onboarding

### DIFF
--- a/openlibrary/i18n/README.md
+++ b/openlibrary/i18n/README.md
@@ -37,6 +37,9 @@ Before creating the new directory, you will need to know your language's two-let
 
 2. **Make a copy of the latest messages to translate.** The messages template file, `/openlibrary/i18n/messages.pot` should be copied as `messages.po` (note the difference in extension, the `t` for template is dropped for the copy) to your newly created folder.
 
+### Updating UI to include new language
+In order for a new language option to be available in our language drop-down and footer, the [language_list.html](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/languages/language_list.html) template must be updated to include the new language.  An Open Library staff member can do this if you are unfamiliar with HTML.
+
 ## Submitting translations
 You can edit the `message.po` file using your favourite editor, or a .po specific tool such as [poedit](https://poedit.net/), and send in a Pull Request. Pull Request Guidelines can be found on our [CONTRIBUTING](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) guide and our [Git Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet).
 

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -150,7 +150,7 @@ export function initPreviewButton() {
 }
 
 export function initWebsiteTranslationOptions() {
-    $('#locale-options li a').on('click', function (event) {
+    $('.locale-options li a').on('click', function (event) {
         event.preventDefault();
         const locale = $(this).data('lang-id');
         setValueInCookie('HTTP_LANG', locale);

--- a/openlibrary/templates/languages/language_list.html
+++ b/openlibrary/templates/languages/language_list.html
@@ -1,0 +1,14 @@
+$def with (classes=None)
+
+$ class_attr = 'class=%s' % classes if classes else ''
+
+<ul id="locale-options" $class_attr>
+  <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a></li>
+  <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a></li>
+  <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li>
+  <li><a href="#" lang="es" data-lang-id="es" title="$_('Spanish')">Español (es)</a></li>
+  <li><a href="#" lang="fr" data-lang-id="fr" title="$_('French')">Français (fr)</a></li>
+  <li><a href="#" lang="hr" data-lang-id="hr" title="$_('Croatian')">Hrvatski (hr)</a></li>
+  <li><a href="#" lang="zh" data-lang-id="zh" title="$_('Chinese')">中文 (zh)</a></li>
+  <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li>
+</ul>

--- a/openlibrary/templates/languages/language_list.html
+++ b/openlibrary/templates/languages/language_list.html
@@ -1,8 +1,6 @@
-$def with (classes=None)
+$def with (classes='')
 
-$ class_attr = 'class=%s' % classes if classes else ''
-
-<ul id="locale-options" $class_attr>
+<ul class="locale-options $classes">
   <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a></li>
   <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a></li>
   <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li>

--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -51,15 +51,7 @@ $def with (page)
       </div>
       <div id="footer-locale-menu">
         <h2>$_('Change Website Language')</h2>
-        <ul id="locale-options">
-          <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a> </li>
-          <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a> </li>
-          <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li>
-          <li><a href="#" lang="es" data-lang-id="es" title="$_('Spanish')">Español (es)</a></li>
-          <li><a href="#" lang="fr" data-lang-id="fr" title="$_('French')">Français (fr)</a></li>
-          <li><a href="#" lang="hr" data-lang-id="hr" title="$_('Croatian')">Hrvatski (hr)</a></li>
-          <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li>
-        </ul>
+        $:render_template('languages/language_list')
       </div>
     </div>
     <hr>

--- a/openlibrary/templates/site/alert.html
+++ b/openlibrary/templates/site/alert.html
@@ -12,16 +12,7 @@ $if not is_bot():
             <img class="translate-icon" src="/static/images/language-icon.svg" title="Change Website Language" alt="Change Website Language"/>
           </summary>
           <div class="language-dropdown-component">
-            <ul class="dropdown-menu" id="locale-options">
-              <li><a href="#" lang="cs" data-lang-id="cs" title="$_('Czech')">Čeština (cs)</a> </li>
-              <li><a href="#" lang="de" data-lang-id="de" title="$_('German')">Deutsch (de)</a> </li>
-              <li><a href="#" lang="en" data-lang-id="en" title="$_('English')">English (en)</a></li>
-              <li><a href="#" lang="es" data-lang-id="es" title="$_('Spanish')">Español (es)</a></li>
-              <li><a href="#" lang="fr" data-lang-id="fr" title="$_('French')">Français (fr)</a></li>
-              <li><a href="#" lang="hr" data-lang-id="hr" title="$_('Croatian')">Hrvatski (hr)</a></li>
-              <li><a href="#" lang="zh" data-lang-id="zh" title="$_('Chinese')">中文 (zh)</a></li>
-              <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li>
-            </ul>
+            $:render_template('languages/language_list', classes="dropdown-menu")
           </div>
         </details>
       </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates template for language lists that are found in the footer and the language drop-down.  Adds information about updating the new template in the i18n `README`, which can be viewed [here](https://github.com/jimchamp/openlibrary/tree/i18n-onboarding/openlibrary/i18n#updating-ui-to-include-new-language).

### Technical
<!-- What should be noted about the implementation? -->
This PR __does not__ address the fact that we are rendering two language lists with the same ID on the same page.  JS functionality is added to these lists based on their ID (`#locale-options`).  In the future, `locale-options` should probably be changed to a class, and the JS initialization code should be updated accordingly.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
