### PR TITLE
Enhanced Reading Log Exports

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import date
-from typing import Iterable, Literal, Optional, cast
+from typing import Literal, Optional, cast
+from collections.abc import Iterable
 
 from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
@@ -227,11 +228,7 @@ class Bookshelves(db.CommonExtras):
         LIMIT = 100  # Is there an ideal block size?!?
 
         def get_a_block_of_books() -> list:
-            data = {
-                "username": username,
-                "limit": LIMIT,
-                "offset": LIMIT * block
-            }
+            data = {"username": username, "limit": LIMIT, "offset": LIMIT * block}
             query = (
                 "SELECT * from bookshelves_books WHERE username=$username "
                 "ORDER BY created DESC LIMIT $limit OFFSET $offset"

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1,7 +1,8 @@
 import logging
 import json
 import re
-from typing import Any, Callable, Iterable, Mapping
+from typing import Any, Callable
+from collections.abc import Iterable, Mapping
 
 import web
 
@@ -988,6 +989,7 @@ class export_books(delegate.page):
             }
 
         return csv_string(Ratings.select_all_by_username(username), format_rating)
+
 
 class account_loans(delegate.page):
     path = "/account/loans"

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1,9 +1,9 @@
-from typing import Any
-from collections.abc import Callable, Iterable, Mapping
-import web
 import logging
 import json
 import re
+from typing import Any, Callable, Iterable, Mapping
+
+import web
 
 from infogami.utils import delegate
 from infogami import config
@@ -13,9 +13,7 @@ from infogami.utils.view import (
     render_template,
     add_flash_message,
 )
-
 from infogami.infobase.client import ClientException
-from infogami.utils.context import context
 import infogami.core.code as core
 
 from openlibrary import accounts
@@ -36,8 +34,6 @@ from openlibrary.accounts import (
     valid_email,
 )
 from openlibrary.plugins.upstream import borrow, forms, utils
-
-import urllib
 
 
 logger = logging.getLogger("openlibrary.account")
@@ -758,7 +754,7 @@ class account_my_books(delegate.page):
     def GET(self):
         user = accounts.get_current_user()
         username = user.key.split('/')[-1]
-        raise web.seeother('/people/%s/books' % (username))
+        raise web.seeother(f'/people/{username}/books')
 
 
 # This would be by the civi backend which would require the api keys
@@ -885,19 +881,49 @@ class export_books(delegate.page):
         web.header('Content-disposition', f'attachment; filename={filename}')
         return delegate.RawText('' or data, content_type="text/csv")
 
-    def generate_reading_log(self, username):
-        books = Bookshelves.get_users_logged_books(username, limit=10000)
-        csv = []
-        csv.append('Work Id,Edition Id,Bookshelf\n')
-        mapping = {1: 'Want to Read', 2: 'Currently Reading', 3: 'Already Read'}
-        for book in books:
-            row = [
-                'OL{}W'.format(book['work_id']),
-                'OL{}M'.format(book['edition_id']) if book['edition_id'] else '',
-                '{}\n'.format(mapping[book['bookshelf_id']]),
-            ]
-            csv.append(','.join(row))
-        return ''.join(csv)
+    def generate_reading_log(self, username: str) -> str:
+        from openlibrary.plugins.upstream.models import Work  # Avoid a circular import
+
+        bookshelf_map = {1: 'Want to Read', 2: 'Currently Reading', 3: 'Already Read'}
+
+        def get_subjects(work: Work, subject_type: str) -> str:
+            return " | ".join(
+                s.title.replace(",", ";") for s in work.get_subject_links(subject_type)
+            )
+
+        def format_reading_log(book: dict) -> dict:
+            """
+            Adding, deleting, renaming, or reordering the fields of the dict returned
+            below will automatically be reflected in the CSV that is generated.
+            """
+            work_key = f"/works/OL{book['work_id']}W"
+            work: Work = web.ctx.site.get(work_key)
+            if not work:
+                raise ValueError(f"No Work found for {work_key}.")
+            if edition_id := book.get("edition_id") or "":
+                edition_id = f"OL{edition_id}M"
+            ratings = work.get_rating_stats() or {"average": "", "count": ""}
+            ratings_average, ratings_count = ratings.values()
+            return {
+                "work_id": work_key.split("/")[-1],
+                "title": work.title,
+                "authors": " | ".join(work.get_author_names()),
+                "first_publish_year": work.first_publish_year,
+                "edition_id": edition_id,
+                "edition_count": work.edition_count,
+                "bookshelf": bookshelf_map[work.get_users_read_status(username)],
+                "my_ratings": work.get_users_rating(username) or "",
+                "ratings_average": ratings_average,
+                "ratings_count": ratings_count,
+                "has_ebook": work.has_ebook(),
+                "subjects": get_subjects(work=work, subject_type="subject"),
+                "subject_people": get_subjects(work=work, subject_type="person"),
+                "subject_places": get_subjects(work=work, subject_type="place"),
+                "subject_times": get_subjects(work=work, subject_type="time"),
+            }
+
+        books = Bookshelves.iterate_users_logged_books(username)
+        return csv_string(books, format_reading_log)
 
     def generate_book_notes(self, username: str) -> str:
         def format_booknote(booknote: Mapping) -> dict:
@@ -930,19 +956,14 @@ class export_books(delegate.page):
         for list in lists:
             list_id = list.key.split('/')[-1]
             created_on = list.created.strftime(self.date_format)
-            last_updated = (
-                list.last_modified.strftime(self.date_format)
-                if list.last_modified
-                else ''
-            )
+            if last_updated := list.last_modified or "":
+                last_updated = last_updated.strftime(self.date_format)
             for seed in list.seeds:
                 entry = seed
                 if not isinstance(seed, str):
                     entry = seed.key
-                list_name = list.name.replace('"', '""') if list.name else ''
-                list_desc = (
-                    list.description.replace('"', '""') if list.description else ''
-                )
+                list_name = (list.name or '').replace('"', '""')
+                list_desc = (list.description or '').replace('"', '""')
                 row = [
                     list_id,
                     f'"{list_name}"',
@@ -967,7 +988,6 @@ class export_books(delegate.page):
             }
 
         return csv_string(Ratings.select_all_by_username(username), format_rating)
-
 
 class account_loans(delegate.page):
     path = "/account/loans"
@@ -1013,7 +1033,7 @@ class account_waitlist(delegate.page):
 
 
 def send_forgot_password_email(username, email):
-    key = "account/%s/password" % username
+    key = f"account/{username}/password"
 
     doc = create_link_doc(key, username, email)
     web.ctx.site.store[key] = doc


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6519 
Blocked by #6734 -- Rebase this PR after 6734 lands.
Related to #6645 and #6653 which also use `csv_string()`.

`Export your Reading Log` with attention to adding more fields and without building large lists in memory which makes this process unwieldy for users with large reading lists.
* [x] Create `iterate_users_logged_books()` to get around the bug discussed at the bottom of `get_users_logged_books()`
    * Repeatedly get blocks of books and yield one book at a time.  (lower memory footprint)
* [x] Create new `generate_reading_log()` to build the CSV by yielding one line at a time.  (lower memory footprint)
    * [x] Need to use database (NOT requests!) to access ~works~, editions, authors, redirects
    * [x] Need to know how to deal with long entries caused by long lists (ex. Tom Sawyer's Subjects, People, Places)
    * [x] Need to know how to access other data fields such as ~my_rating~, date_read, read_count
    
Current output: [OpenLibrary_ReadingLog(65).csv](https://github.com/internetarchive/openlibrary/files/8844522/OpenLibrary_ReadingLog.65.csv) or see Screenshots below.

What code returns the results for:
* http://localhost:8080/works/OL54120W.json
* http://localhost:8080/books/OL2058361M.json

The `/api/books` endpoint does not return enough information...
* http://localhost:8080/api/books?bibkeys=OLID:OL54120W&format=json
* http://localhost:8080/api/books?bibkeys=OLID:OL2058361M&format=json

```python
from openlibrary.plugins.books.dynlinks import ol_get_many_as_dict
ol_get_many_as_dict(['/books/OL2058361M', '/works/OL54120W'])
```
`ol_get_many_as_dict()` results are missing keys `covers` and `description` but we don't need them for CSV.

Being able to instantiate a [`openlibrary.code.models.Work`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/core/models.py#L420) would substantially reduce code complexity but this class has no `.__init__()` method.  If I know the key (e.g. `/works/OL8193488W`), how can I get an `openlibrary.code.models.Work` instance for that key?

### **Answer:** `web.ctx.site.get(key)`
As in `work: Work = web.ctx.site.get("/works/OL8193488W")` returns an `openlibrary.plugins.upstream.models.Work`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
___In one terminal tab:___ `docker compose up`
___In another terminal tab:___ open http://localhost:8080
Search on `Twain` and set one book each to: `Want to Read`, `Currently Reading`, `Already Read` and add star ratings.
On http://localhost:8080/account/import click Export your Reading Log --> `Download (.csv format)` 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2022-06-06 at 14 20 19](https://user-images.githubusercontent.com/3709715/172159937-67034a55-4020-482d-bd2d-84cb7dde9d79.png)
![Screenshot 2022-06-06 at 14 20 43](https://user-images.githubusercontent.com/3709715/172159939-34531435-cc66-4233-98e7-21afb3cdd881.png)
![Screenshot 2022-06-06 at 14 20 54](https://user-images.githubusercontent.com/3709715/172159940-39cb86f3-8a1b-43d3-bbb1-6fff7467cf92.png)
### Stakeholders @mheiman, @fl0rent
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

