### PR TITLE
pre-commit: Enable end-of-file-fixer for Python files only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,8 @@ repos:
     rev: v4.2.0
     hooks:
       - id: check-yaml
-      # - id: end-of-file-fixer
+      - id: end-of-file-fixer
+        types_or: [python]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         args:

--- a/openlibrary/core/observations.py
+++ b/openlibrary/core/observations.py
@@ -1103,4 +1103,3 @@ class Observations(db.CommonExtras):
             row['observation_value'] = types_and_values[type_id]['values'][value_id]['name']
 
         return rows
-

--- a/scripts/sync
+++ b/scripts/sync
@@ -323,4 +323,3 @@ def main(args):
 
 if __name__ == "__main__":
     main(sys.argv)
-


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Ensure that Python files end with one and only one blank line.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
