### PR TITLE
Fix mobile book page has a horizontal scroll

### DIFF
--- a/static/css/legacy-datatables.less
+++ b/static/css/legacy-datatables.less
@@ -43,7 +43,6 @@
 }
 
 .dataTables_length {
-  width: 50%;
   font-size: 12px;
   color: @grey;
   display: inline-block;
@@ -232,10 +231,10 @@ td.details {
 }
 
 div.dataTables_filter {
-  width: 50%;
   float: right;
   text-align: right;
   font-size: 12px;
+  margin: 0 0 0 0;
   color: @grey;
 }
 
@@ -414,6 +413,11 @@ tr.even.gradeU td.sorting_3 {
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
+  }
+  div.dataTables_filter {
+    float: none;
+    text-align: left;
+    margin: 5px 0 0 0;
   }
   span.number {
     order: 4;

--- a/static/css/legacy-datatables.less
+++ b/static/css/legacy-datatables.less
@@ -234,7 +234,7 @@ div.dataTables_filter {
   float: right;
   text-align: right;
   font-size: 12px;
-  margin: 0 0 0 0;
+  margin: 0;
   color: @grey;
 }
 
@@ -417,7 +417,7 @@ tr.even.gradeU td.sorting_3 {
   div.dataTables_filter {
     float: none;
     text-align: left;
-    margin: 5px 0 0 0;
+    margin: 5px 0 0;
   }
   span.number {
     order: 4;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes https://github.com/internetarchive/openlibrary/issues/6535

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

Belatedly, I see the .less file I modified says not to add to it, through perhaps a 'modification' is okay in this instance? With a bit more direction I can try to comply with the admonition in static/css/legacy-datatables.less.

### Technical
<!-- What should be noted about the implementation? -->
This addresses https://github.com/internetarchive/openlibrary/issues/6535 by changing the CSS such that, on mobile, the search input is left-aligned and appears below the edition count selector. On desktop/laptop/tablet (or anything at or above @width-breakpoint-tablet as specified in the existing file) the search bar is still to the right of the edition count selector.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verify that the search box is below the edition count selector and left aligned and mobile, and on the same level as the edition count selector and right aligned everywhere else.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Desktop:
![image](https://user-images.githubusercontent.com/26524678/171759547-edb10d36-7e4c-488c-9d1d-82986c0914ea.png)

iPhone 11 Pro:
![image](https://user-images.githubusercontent.com/26524678/171759640-6ec8f377-c7b6-452d-8cde-517ecea29416.png)

iPad:
![image](https://user-images.githubusercontent.com/26524678/171759683-62b45862-3629-4cde-bc1e-5327e9badb9f.png)


### Stakeholders
@tuminzee, @jimchamp, @mekarpeles   


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
