### PR TITLE
pyproject.toml: Configure Black to skip-string-normalization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,6 @@ repos:
         language_version: python3  # Should be a command that runs python3.6+
         args:
         - --diff
-        - --skip-string-normalization
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+# Minimal configuration to ensure that Black does not convert quotes.
+# Black does not support reading its configuration from `setup.cfg`.
+# This file can be deleted when we convert to favoring double quotes.
+# https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html
+
+# NOTE: You have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+[tool.black]
+skip-string-normalization = true
+target-version = ['py39', 'py310', 'py311']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@
 
 [tool.black]
 skip-string-normalization = true
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py39', 'py310']


### PR DESCRIPTION
Minimal configuration to ensure that Black does not convert quotes.
Black does not support reading its configuration from `setup.cfg`.
This file can be deleted when we convert to favoring double quotes.
https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
