### PR TITLE
Disable subjects list metadata for performance

### DIFF
--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -238,26 +238,30 @@ $def seed_attrs(seed):
 
         $:render_template("type/list/exports", list)
 
-        <h2 class="collapse">$_('List Metadata')</h2>
-        <div class="smaller lightgreen sansserif">$_('Derived from seed metadata')</div>
-        <br/>
+        $# This is making lists slow, and often the solr request times out,
+        $# so nothing is even rendered. Remove for now, investigate whether
+        $# we want to keep or improve later.
+        $if False:
+            <h2 class="collapse">$_('List Metadata')</h2>
+            <div class="smaller lightgreen sansserif">$_('Derived from seed metadata')</div>
+            <br/>
 
-        $def render_subjects(label, subjects):
-            $if subjects:
-                <div class="section">
-                    <h3 class="collapse black uppercase">$label</h3>
-                    <div class="sansserif">
-                    $for subject in subjects:
-                        <a href="$subject.url">$subject.title</a>$cond(not loop.last, ",", "")
+            $def render_subjects(label, subjects):
+                $if subjects:
+                    <div class="section">
+                        <h3 class="collapse black uppercase">$label</h3>
+                        <div class="sansserif">
+                        $for subject in subjects:
+                            <a href="$subject.url">$subject.title</a>$cond(not loop.last, ",", "")
+                        </div>
                     </div>
-                </div>
 
-        $ subjects = list.get_subjects()
+            $ subjects = list.get_subjects()
 
-        $:render_subjects(_("Subjects"), subjects.subjects)
-        $:render_subjects(_("People"), subjects.people)
-        $:render_subjects(_("Places"), subjects.places)
-        $:render_subjects(_("Times"), subjects.times)
+            $:render_subjects(_("Subjects"), subjects.subjects)
+            $:render_subjects(_("People"), subjects.people)
+            $:render_subjects(_("Places"), subjects.places)
+            $:render_subjects(_("Times"), subjects.times)
     </div>
 
     <div class="clearfix"></div>


### PR DESCRIPTION
This was hitting solr and often timing out, and blocking the whole page for ~10s. Investigate better fix later (in #6637 ).

Needed for #6608 , so there are less timeouts when twitter tries to fetch the data.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Lists are faster and no longer show the metadata section.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
