### PR TITLE
Data Dumps: Fix remaining archival and sitemaps bugs

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -30,9 +30,8 @@ logger.setLevel(logging.DEBUG)
 
 
 def log(*args) -> None:
-    msg = f"{datetime.now():%Y-%m-%d %H:%M:%S} [openlibrary.dump] " + " ".join(
-        str(a) for a in args
-    )
+    args_str = " ".join(str(a) for a in args)
+    msg = f"{datetime.now():%Y-%m-%d %H:%M:%S} [openlibrary.dump] {args_str}"
     logger.info(msg)
     print(msg, file=sys.stderr)
 

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -67,7 +67,7 @@ def print_dump(json_records, filter=None):
 
         print("\t".join([type_key, key, str(d["revision"]), timestamp, json_data]))
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"print_dump() processed {i} records in {minutes} minutes.")
+    log(f"    print_dump() processed {i:,} records in {minutes:,} minutes.")
 
 
 def read_data_file(filename: str, max_lines: int = 0):
@@ -83,7 +83,7 @@ def read_data_file(filename: str, max_lines: int = 0):
         if max_lines and i >= max_lines:
             break
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"read_data_file() processed {i} records in {minutes} minutes.")
+    log(f"read_data_file() processed {i:,} records in {minutes:,} minutes.")
 
 
 def xopen(path: str, mode: str):
@@ -107,7 +107,7 @@ def read_tsv(file, strip=True):
             line = line.strip()
         yield line.split("\t")
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"read_tsv() processed {i} records in {minutes} minutes.")
+    log(f" read_tsv() processed {i:,} records in {minutes:,} minutes.")
 
 
 def generate_cdump(data_file, date=None):
@@ -165,7 +165,7 @@ def sort_dump(dump_file=None, tmpdir="/tmp/", buffer_size="1G"):
         if status != 0:
             raise Exception("sort failed with status %d" % status)
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"sort_dump() processed {i} records in {minutes} minutes.")
+    log(f"sort_dump() processed {i:,} records in {minutes:,} minutes.")
 
 
 def generate_dump(cdump_file=None):
@@ -175,7 +175,7 @@ def generate_dump(cdump_file=None):
     """
 
     def process(data):
-        revision = lambda cols: int(cols[2])
+        revision = lambda cols: int(cols[2])  # noqa: E731
         for key, rows in itertools.groupby(data, key=lambda cols: cols[1]):
             row = max(rows, key=revision)
             yield row
@@ -186,7 +186,7 @@ def generate_dump(cdump_file=None):
     # group by key and find the max by revision
     sys.stdout.writelines(tjoin(row) for row in process(data))
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"generate_dump({cdump_file}) ran in {minutes} minutes.")
+    log(f"generate_dump({cdump_file}) ran in {minutes:,} minutes.")
 
 
 def generate_idump(day, **db_parameters):
@@ -208,6 +208,7 @@ def generate_idump(day, **db_parameters):
 
 def split_dump(dump_file=None, format="oldump_%s.txt"):
     """Split dump into authors, editions and works."""
+    log(f"split_dump({dump_file}, format={format})")
     start_time = datetime.now()
     types = ("/type/edition", "/type/author", "/type/work", "/type/redirect")
     files = {}
@@ -226,11 +227,12 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
     for f in files.values():
         f.close()
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"split_dump() processed {i} records in {minutes} minutes.")
+    log(f"split_dump() processed {i:,} records in {minutes:,} minutes.")
 
 
 def make_index(dump_file):
     """Make index with "path", "title", "created" and "last_modified" columns."""
+    log(f"make_index({dump_file})")
     start_time = datetime.now()
     for i, type, key, revision, timestamp, json_data in enumerate(read_tsv(dump_file)):
         data = json.loads(json_data)
@@ -252,7 +254,7 @@ def make_index(dump_file):
             created = "-"
         print("\t".join([web.safestr(path), web.safestr(title), created, timestamp]))
     minutes = (datetime.now() - start_time).seconds // 60
-    log(f"split_dump() processed {i} records in {minutes} minutes.")
+    log(f"make_index() processed {i:,} records in {minutes:,} minutes.")
 
 
 def _process_key(key):

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -18,12 +18,9 @@ from datetime import datetime
 
 import web
 
-from infogami import config
-from openlibrary.config import load_config
 from openlibrary.data import db
 from openlibrary.data.sitemap import generate_html_index, generate_sitemaps
 from openlibrary.plugins.openlibrary.processors import urlsafe
-from openlibrary.utils.sentry import Sentry
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
@@ -348,13 +345,4 @@ def main(cmd, args):
 
 
 if __name__ == "__main__":
-    ol_config = os.getenv("OL_CONFIG")
-    if ol_config:
-        logger.info(f"loading config from {ol_config}")
-        load_config(ol_config)
-        sentry = Sentry(getattr(config, "sentry_cron_jobs", {}))
-        if sentry.enabled:
-            sentry.init()
-
-    log(f"sentry.enabled = {bool(ol_config and sentry.enabled)}")
     main(sys.argv[1], sys.argv[2:])

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -1,16 +1,38 @@
 #!/usr/bin/env python
 
+import logging
+import os
 import sys
 from datetime import datetime
 
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.DEBUG)
+
+
+def log(*args) -> None:
+    args_str = " ".join(str(a) for a in args)
+    msg = f"{datetime.now():%Y-%m-%d %H:%M:%S} [openlibrary.dump] {args_str}"
+    logger.info(msg)
+    print(msg, file=sys.stderr)
+
 
 if __name__ == "__main__":
-    now = f"{datetime.now():%Y-%m-%d %H:%M:%S}"  # 2022-06-01 07:18:34
-    py_ver = "Python {}.{}.{}".format(*sys.version_info)  # Python 3.10.4
-    print(f"{now} [openlibrary.dump] {sys.argv} on {py_ver}", file=sys.stderr)
-
+    from infogami import config
+    from openlibrary.config import load_config
     from openlibrary.data import dump
+    from openlibrary.utils.sentry import Sentry
+
+    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.10.4
+
+    ol_config = os.getenv("OL_CONFIG")
+    if ol_config:
+        logger.info(f"loading config from {ol_config}")
+        load_config(ol_config)
+        sentry = Sentry(getattr(config, "sentry_cron_jobs", {}))
+        if sentry.enabled:
+            sentry.init()
+    log(f"sentry.enabled = {bool(ol_config and sentry.enabled)}")
 
     dump.main(sys.argv[1], sys.argv[2:])

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -48,7 +48,7 @@ yyyymm=${yyyymmdd:0:7}  # 2022-05-31 --> 2022-05
 cdump=ol_cdump_$yyyymmdd
 dump=ol_dump_$yyyymmdd
 
-if [ $# -lt 1 ]
+if [[ $# -lt 1 ]]
 then
     echo "USAGE: $0 yyyy-mm-dd [--archive] [--overwrite]" 1>&2
     exit 1
@@ -57,6 +57,7 @@ fi
 function cleanup() {
     rm -f $TMPDIR/dumps/data.txt.gz
     rm -rf $TMPDIR/dumps/ol_*
+    rm -rf $TMPDIR/sitemaps
 }
 
 function log() {
@@ -185,10 +186,14 @@ ls -lhR
 # Archival
 # ========
 # Only archive if that caller has requested it and we are not testing.
-if [ $@ == *'--archive'* ]; then
+if [[ $@ == *'--archive'* ]]; then
   if [[ -z $OLDUMP_TESTING ]]; then
     archive_dumps
+  else
+    log "Skipping archival: Test mode"
   fi
+else
+  log "Skipping archival: Option omitted"
 fi
 
 # =================

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -14,6 +14,9 @@
 #             --> scripts/oldump.py
 #                 --> openlibrary/data/dump.py
 #
+# To watch the logs on ol-home0, use:
+# ol-home0% docker logs -f openlibrary_cron-jobs_1 2>&1 | grep openlibrary.dump
+#
 # Testing (stats as of November 2021):
 # The cron job takes 18+ hours to process 192,000,000+ records in 29GB of data!!
 #
@@ -45,7 +48,8 @@ yyyymm=${yyyymmdd:0:7}  # 2022-05-31 --> 2022-05
 cdump=ol_cdump_$yyyymmdd
 dump=ol_dump_$yyyymmdd
 
-if [ $# -lt 1 ]; then
+if [ $# -lt 1 ]
+then
     echo "USAGE: $0 yyyy-mm-dd [--archive] [--overwrite]" 1>&2
     exit 1
 fi
@@ -68,8 +72,11 @@ function archive_dumps() {
     is_uploaded=$(ia list ${dump} | wc -l)
     if [[ $is_uploaded == 0 ]]
     then
+        log "archive_dumps(): $dump"
 	ia --config-file=/olsystem/etc/ia.ini upload $dump  $dump/  --metadata "collection:ol_exports" --metadata "year:${yyyymm:0:4}" --metadata "format:Data" --retries 300
+        log "archive_dumps(): $cdump"
 	ia --config-file=/olsystem/etc/ia.ini upload $cdump $cdump/ --metadata "collection:ol_exports" --metadata "year:${yyyymm:0:4}" --metadata "format:Data" --retries 300
+        log "archive_dumps(): $dump and $cdump have been archived to https://archive.org/details/ol_exports?sort=-publicdate"
     else
 	log "Skipping: Archival Zip already exists"
     fi
@@ -199,7 +206,7 @@ else
     log "Skipping sitemaps"
 fi
 
-log $USER has completed $@ in $TMPDIR on ${HOSTNAME:-$HOST}"
+log "$USER has completed $@ in $TMPDIR on ${HOSTNAME:-$HOST}"
 
 # remove the dump of data table
 # In production, we remove the raw database dump to save disk space.

--- a/scripts/sitemaps/sitemap.py
+++ b/scripts/sitemaps/sitemap.py
@@ -6,13 +6,13 @@ USAGE:
     python sitemaps.py suffix dump.txt.gz
 """
 
-import datetime
 import gzip
 import itertools
 import json
+import logging
 import os
 import re
-import time
+from datetime import datetime
 
 import web
 
@@ -38,8 +38,18 @@ t_siteindex = """$def with (names, timestamp)
 </sitemapindex>
 """
 
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.DEBUG)
+
 sitemap = web.template.Template(t_sitemap)
 siteindex = web.template.Template(t_siteindex)
+
+
+def log(*args) -> None:
+    args_str = " ".join(str(a) for a in args)
+    msg = f"{datetime.now():%Y-%m-%d %H:%M:%S} [openlibrary.dump] {args_str}"
+    logger.info(msg)
+    print(msg, file=sys.stderr)
 
 
 def xopen(filename):
@@ -60,7 +70,7 @@ def urlsafe(name):
     space = ' \n\r'
 
     unsafe = reserved + delims + unwise + space
-    pattern = '[%s]+' % "".join(re.escape(c) for c in unsafe)
+    pattern = f"[{''.join(re.escape(c) for c in unsafe)}]+"
     safepath_re = re.compile(pattern)
     return safepath_re.sub('_', name).replace(' ', '-').strip('_')[:100]
 
@@ -116,14 +126,14 @@ def generate_sitemaps(filename):
             things.append(web.storage(path=path, last_modified=last_modified))
 
         if things:
-            write("sitemaps/sitemap_%s.xml.gz" % sortkey, sitemap(things))
+            write(f"sitemaps/sitemap_{sortkey}.xml.gz", sitemap(things))
 
 
 def generate_siteindex():
     filenames = sorted(os.listdir("sitemaps"))
     if "siteindex.xml.gz" in filenames:
         filenames.remove("siteindex.xml.gz")
-    timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S') + 'Z'
+    timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S') + 'Z'
     index = siteindex(filenames, timestamp)
     write("sitemaps/siteindex.xml.gz", index)
 
@@ -135,7 +145,7 @@ def write(path, text):
         with gzip.open(path, 'w') as f:
             f.write(text.encode())
     except Exception as e:
-        print(f'write fail {e}')
+        log(f'write fail {e}')
     # os.system("gzip " + path)
 
 
@@ -161,11 +171,6 @@ def system(cmd):
     status = os.system(cmd)
     if status != 0:
         raise Exception("%r failed with exit status: %d" % (cmd, status))
-
-
-def log(*args):
-    msg = " ".join(map(str, args))
-    print(f"{time.asctime()} {msg}")
 
 
 def main(dumpfile):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #5402

good riddance :rofl: 
closes #5892
closes #6253 
closes #6358
closes #6643

- Remove the `$TMPDIR/sitemaps` dir as part of `cleanup`
- Unify logging in `scripts/sitemaps/sitemap.py` with the other Open Library data dumps jobs
- Fix the `scripts/oldump.sh`  archive step which was failing because of a syntax issue only using `[]` instead of `[[ ]]`
- Fix the unbalanced quote in `scripts/oldump.sh`
- Enable Sentry in `scripts.oldump.__main__` instead of `openlibrary.data.dump.__main__` because the latter is never called in the dumps process.

For readability in the logs of the OpenLibrary data dump, add commas to large numbers:
```
log(f"read_data_file() processed {i} records in {minutes} minutes.")
# -->
log(f"read_data_file() processed {i:,} records in {minutes:,} minutes.")

Results:
2022-06-08 04:21:36 [openlibrary.dump] read_data_file() processed 202670667 records in 435 minutes.
2022-06-08 04:21:36 [openlibrary.dump] print_dump() processed 202670667 records in 435 minutes.
# -->
2022-06-08 04:21:36 [openlibrary.dump] read_data_file() processed 202,670,667 records in 435 minutes.
2022-06-08 04:21:36 [openlibrary.dump]     print_dump() processed 202,670,667 records in 435 minutes.
```
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
https://archive.org/details/ol_exports?sort=-publicdate
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
