### PR TITLE
allow local_ids to be imported from MARC 001

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -283,17 +283,17 @@ class ia_importapi(importapi):
                 id_field, id_subfield = local_id_type.id_location.split('$')
 
                 def get_subfield(field, id_subfield):
-                    if isinstance(field, str):
-                        return field
+                    if isinstance(field[1], str):
+                        return field[1]
                     subfields = field[1].get_subfield_values(id_subfield)
                     return subfields[0] if subfields else None
 
-                _ids = [
+                ids = [
                     get_subfield(f, id_subfield)
                     for f in rec.read_fields([id_field])
                     if f and get_subfield(f, id_subfield)
                 ]
-                edition['local_id'] = [f'urn:{prefix}:{_id}' for _id in _ids]
+                edition['local_id'] = [f'urn:{prefix}:{id_}' for id_ in ids]
 
             # Don't add the book if the MARC record is a non-monograph item,
             # unless it is a scanning partner record and/or force_import is set.


### PR DESCRIPTION
001 fields don't have subfields, just txt content. This fixes a bug where the wrong part of the return value was being tested for `str`.

Fixes this error on importing a partner MARC record with an `001$` barcode id (like Trent https://openlibrary.org/local_ids/trent )
```
<class 'AttributeError'> at /api/import/ia
'str' object has no attribute 'get_subfield_values'
Python	/openlibrary/openlibrary/plugins/importapi/code.py in get_subfield, line 287
Web	POST https://openlibrary.org/api/import/ia
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
