### PR TITLE
fixes remaining archival and sitemaps bugs

### DIFF
--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -53,6 +53,7 @@ fi
 function cleanup() {
     rm -f $TMPDIR/dumps/data.txt.gz
     rm -rf $TMPDIR/dumps/ol_*
+    rm -rf $TMPDIR/sitemaps
 }
 
 function log() {
@@ -178,10 +179,14 @@ ls -lhR
 # Archival
 # ========
 # Only archive if that caller has requested it and we are not testing.
-if [ $@ == *'--archive'* ]; then
+if [[ $@ == *'--archive'* ]]; then
   if [[ -z $OLDUMP_TESTING ]]; then
     archive_dumps
+  else
+    log "Skipping archival: Test mode"
   fi
+else
+  log "Skipping archival: Option omitted"
 fi
 
 # =================


### PR DESCRIPTION
- Removes the `$TMPDIR/sitemaps` dir as part of `cleanup`
- Fixes the archive step which was failing because of a syntax issue only using `[]` instead of `[[ ]]`

good riddance :rofl: 
#5892 #6358  #6253 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
