### PR TITLE
Add ISSN identifiers on MARC import

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -39,6 +39,7 @@ want = (
         '010',  # lccn
         '016',  # National Bibliographic Agency Control Number (for DNB)
         '020',  # isbn
+        '022',  # issn
         '035',  # oclc
         '050',  # lc classification
         '082',  # dewey
@@ -79,6 +80,19 @@ def read_dnb(rec):
         (control_number,) = f.get_subfield_values('a') or [None]
         if source == DNB_AGENCY_CODE and control_number:
             return {'dnb': [control_number]}
+
+
+def read_issn(rec):
+    fields = rec.get_fields('022')
+    if not fields:
+        return
+    found = []
+    for f in fields:
+        for k, v in f.get_subfields(['a']):
+            issn = v.strip()
+            if issn:
+                found.append(issn)
+    return {'issn': found}
 
 
 def read_lccn(rec):
@@ -659,6 +673,7 @@ def read_edition(rec):
 
     update_edition(rec, edition, read_lccn, 'lccn')
     update_edition(rec, edition, read_dnb, 'identifiers')
+    update_edition(rec, edition, read_issn, 'identifiers')
     update_edition(rec, edition, read_authors, 'authors')
     update_edition(rec, edition, read_oclc, 'oclc_numbers')
     update_edition(rec, edition, read_lc_classification, 'lc_classifications')

--- a/openlibrary/catalog/marc/tests/test_data/bin_expect/ithaca_two_856u.mrc
+++ b/openlibrary/catalog/marc/tests/test_data/bin_expect/ithaca_two_856u.mrc
@@ -41,5 +41,6 @@
     "Great Britain. Office for National Statistics"
   ],
   "subjects": ["Statistics", "Periodicals"],
-  "subject_places": ["Great Britain"]
+  "subject_places": ["Great Britain"],
+  "identifiers": {"issn": ["0068-1075"]}
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds another bib id to partner imports.
ISSN is available in edition edit dropdown,

now it is imported from MARC records, if it is present.
![image](https://user-images.githubusercontent.com/905545/172989289-6f8b99e4-6f8c-4c0f-9006-10c3db999703.png)



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Tested MARC import locally:

![image](https://user-images.githubusercontent.com/905545/172989164-e63883ba-6009-42b9-8808-0eeb4314ac7f.png)

One existing test modified to test the new functionality.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
