### PR TITLE
Dead code: openlibrary.plugins.upstream.utils.radio_list()

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -307,17 +307,6 @@ def radio_input(checked=False, **params):
     )
 
 
-@public
-def radio_list(name, args, value):
-    html = []
-    for arg in args:
-        if isinstance(arg, tuple):
-            arg, label = arg
-        else:
-            label = arg
-        html.append(radio_input())
-
-
 def get_coverstore_url() -> str:
     return config.get('coverstore_url', 'https://covers.openlibrary.org').rstrip('/')
 


### PR DESCRIPTION
[`openlibrary.plugins.upstream.utils.radio_list()`](https://github.com/internetarchive/openlibrary/blob/b897c8c51a79308e38f9825fac82864a5cc7d3ae/openlibrary/plugins/upstream/utils.py#L311) builds a list but returns no value to its caller and [is never called](https://github.com/internetarchive/openlibrary/search?q=radio_list).

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
