### PR TITLE
Add slack notification to cron_watcher

### DIFF
--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -15,5 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-      - run: pip install internetarchive
+      - run: pip install internetarchive slack-sdk
+      - shell: python
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_CHANNEL_ABC_TEAM: ${{ secrets.SLACK_CHANNEL_ABC_TEAM }}
+        run: |
+          import os, slack_sdk
+          token = os.getenv("SLACK_TOKEN")
+          channel = os.getenv("SLACK_CHANNEL_ABC_TEAM")
+          if token and channel:
+            slack_sdk.WebClient(token=token).chat_postMessage(channel=channel,
+              text="cron_watcher starting at https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml",
+            )
+          )
       - run: scripts/cron_watcher.py


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6632 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Send a Slack notification to Administrators when our [Cron Watcher](https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml) GitHub Action is started.  Once this is in better shape, we can send the Slack message only when Cron Watcher fails.

We need to create two [GitHub Action secrets](https://github.com/internetarchive/openlibrary/settings/secrets/actions) for this to work.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
