### PR TITLE
Fix #6656: Docker: The "HOSTNAME" variable is not set on zsh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   solr-updater:
     image: "${OLIMAGE:-oldev:latest}"
     command: docker/ol-solr-updater-start.sh
-    hostname: "$HOSTNAME"
+    hostname: "${HOSTNAME:$HOST}"
     environment:
       - OL_CONFIG=conf/openlibrary.yml
       - OL_URL=http://web:8080/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
   solr-updater:
     image: "${OLIMAGE:-oldev:latest}"
     command: docker/ol-solr-updater-start.sh
-    hostname: "${HOSTNAME:$HOST}"
+    hostname: "${HOSTNAME:-$HOST}"
     environment:
       - OL_CONFIG=conf/openlibrary.yml
       - OL_URL=http://web:8080/


### PR DESCRIPTION
Fix #6656

Docker: The "HOSTNAME" variable is not set. Defaulting to a blank string on zsh.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
