### PR TITLE
chore: Set permissions for GitHub Actions

### DIFF
--- a/.github/workflows/codegen_api_docs.yml
+++ b/.github/workflows/codegen_api_docs.yml
@@ -1,5 +1,8 @@
 name: codegen_api_docs
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   codegen_api_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -9,6 +9,9 @@ on:
   schedule:  # At 3:45am on the 2nd, 4th, 18th, and 20th day of the month.
     - cron: '45 3 2,4,18,20 * *'  # https://cron.help
   workflow_dispatch:  # This job can also be run on-demand.
+permissions:
+  contents: read
+
 jobs:
   cron_watcher:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -4,6 +4,9 @@ on:
     branches: [ master ]
     paths: [ 'stories/**' ]
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   deploy_storybook:
     runs-on: ubuntu-latest

--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -14,6 +14,9 @@ on:
       - '**.less'
       - '**.css'
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   javascript_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -12,6 +12,9 @@ on:
       - '**.vue'
       - '**.less'
       - '**.css'
+permissions:
+  contents: read
+
 jobs:
   python_tests:
     runs-on: ubuntu-18.04  # Should match Dockerfile.olbase, but had to be bumped as older version no longer supported


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
