### PR TITLE
Refactor: Split openlibrary/core/vendors to make it easier to manage

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 from collections import OrderedDict
 from infogami.utils.view import public
 from openlibrary.core import lending
-from openlibrary.core.vendors import get_betterworldbooks_metadata, get_amazon_metadata
+from openlibrary.core.vendors import get_amazon_metadata, get_betterworldbooks_metadata
 from openlibrary import accounts
 from openlibrary.accounts.model import get_internet_archive_id, sendmail
 from openlibrary.core.civicrm import (

--- a/openlibrary/core/vendors/__init__.py
+++ b/openlibrary/core/vendors/__init__.py
@@ -1,0 +1,6 @@
+from .amazon import (  # noqa: F401
+    create_edition_from_amazon_metadata,
+    get_amazon_metadata,
+    setup,
+)
+from .betterworldbooks import get_betterworldbooks_metadata  # noqa: F401

--- a/openlibrary/core/vendors/amazon.py
+++ b/openlibrary/core/vendors/amazon.py
@@ -24,18 +24,12 @@ from openlibrary.utils.isbn import (
     normalize_isbn,
 )
 
-logger = logging.getLogger("openlibrary.vendors")
+logger = logging.getLogger("openlibrary.vendors.amazon")
 
-BETTERWORLDBOOKS_BASE_URL = 'https://betterworldbooks.com'
-BETTERWORLDBOOKS_API_URL = (
-    'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
-)
-affiliate_server_url = None
-BWB_AFFILIATE_LINK = 'http://www.anrdoezrs.net/links/{}/type/dlg/http://www.betterworldbooks.com/-id-%s'.format(
-    h.affiliate_id('betterworldbooks')
-)
 AMAZON_FULL_DATE_RE = re.compile(r'\d{4}-\d\d-\d\d')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
+
+affiliate_server_url = None
 
 
 def setup(config):
@@ -226,7 +220,7 @@ class AmazonAPI:
             'url': "https://www.amazon.com/dp/{}/?tag={}".format(
                 product.asin, h.affiliate_id('amazon')
             ),
-            'source_records': ['amazon:%s' % product.asin],
+            'source_records': [f'amazon:{product.asin}'],
             'isbn_10': [product.asin],
             'isbn_13': [isbn_10_to_isbn_13(product.asin)],
             'price': price and price.display_amount,
@@ -400,7 +394,7 @@ def clean_amazon_metadata_for_load(metadata: dict) -> dict:
         conforming_metadata['subtitle'] = subtitle
     # Record original title if some content has been removed (i.e. parentheses)
     if metadata['title'] != conforming_metadata.get('full_title', title):
-        conforming_metadata['notes'] = "Source title: %s" % metadata['title']
+        conforming_metadata['notes'] = f"Source title: {metadata['title']}"
 
     return conforming_metadata
 
@@ -451,89 +445,3 @@ def cached_get_amazon_metadata(*args, **kwargs):
     result = memoized_get_amazon_metadata(*args, **kwargs)
     # if no result, then recache / update this controller's cached value
     return result or memoized_get_amazon_metadata.update(*args, **kwargs)[0]
-
-
-@public
-def get_betterworldbooks_metadata(isbn: str) -> Optional[dict]:
-    """
-    :param str isbn: Unnormalisied ISBN10 or ISBN13
-    :return: Metadata for a single BWB book, currently listed on their catalog, or
-             an error dict.
-    :rtype: dict or None
-    """
-
-    isbn = normalize_isbn(isbn)
-    try:
-        return _get_betterworldbooks_metadata(isbn)
-    except Exception:
-        logger.exception(f"_get_betterworldbooks_metadata({isbn})")
-        return betterworldbooks_fmt(isbn)
-
-
-def _get_betterworldbooks_metadata(isbn: str) -> Optional[dict]:
-    """Returns price and other metadata (currently minimal)
-    for a book currently available on betterworldbooks.com
-
-    :param str isbn: Normalised ISBN10 or ISBN13
-    :return: Metadata for a single BWB book currently listed on their catalog,
-            or an error dict.
-    :rtype: dict or None
-    """
-
-    url = BETTERWORLDBOOKS_API_URL + isbn
-    response = requests.get(url)
-    if response.status_code != requests.codes.ok:
-        return {'error': response.text, 'code': response.status_code}
-    text = response.text
-    new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", text)
-    new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", text)
-    used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", text)
-    used_qty = re.findall("<TotalUsed>([0-9]+)</TotalUsed>", text)
-    market_price = re.findall(
-        r"<LowestMarketPrice>\$([0-9.]+)</LowestMarketPrice>", text
-    )
-    price = qlt = None
-
-    if used_qty and used_qty[0] and used_qty[0] != '0':
-        price = used_price[0] if used_price else ''
-        qlt = 'used'
-
-    if new_qty and new_qty[0] and new_qty[0] != '0':
-        _price = new_price[0] if new_price else None
-        if _price and (not price or float(_price) < float(price)):
-            price = _price
-            qlt = 'new'
-
-    market_price = ('$' + market_price[0]) if market_price else None
-    return betterworldbooks_fmt(isbn, qlt, price, market_price)
-
-
-def betterworldbooks_fmt(
-    isbn: str,
-    qlt: Optional[str] = None,
-    price: Optional[str] = None,
-    market_price: Optional[list[str]] = None,
-) -> Optional[dict]:
-    """Defines a standard interface for returning bwb price info
-
-    :param str isbn:
-    :param str qlt: Quality of the book, e.g. "new", "used"
-    :param str price: Price of the book as a decimal str, e.g. "4.28"
-    :rtype: dict or None
-    """
-    price_fmt = f"${price} ({qlt})" if price and qlt else None
-    return {
-        'url': BWB_AFFILIATE_LINK % isbn,
-        'isbn': isbn,
-        'market_price': market_price,
-        'price': price_fmt,
-        'price_amt': price,
-        'qlt': qlt,
-    }
-
-
-cached_get_betterworldbooks_metadata = cache.memcache_memoize(
-    _get_betterworldbooks_metadata,
-    "upstream.code._get_betterworldbooks_metadata",
-    timeout=dateutil.HALF_DAY_SECS,
-)

--- a/openlibrary/core/vendors/betterworldbooks.py
+++ b/openlibrary/core/vendors/betterworldbooks.py
@@ -1,0 +1,107 @@
+import logging
+import re
+
+import requests
+from infogami.utils.view import public
+
+from openlibrary.core import cache
+from openlibrary.core import helpers as h
+from openlibrary.utils import dateutil
+from openlibrary.utils.isbn import normalize_isbn
+
+logger = logging.getLogger("openlibrary.vendors.betterworldbooks")
+
+BETTERWORLDBOOKS_API_URL = (
+    'https://products.betterworldbooks.com/service.aspx?IncludeAmazon=True&ItemId='
+)
+BETTERWORLDBOOKS_BASE_URL = 'https://betterworldbooks.com'
+BWB_AFFILIATE_LINK = (
+    f'http://www.anrdoezrs.net/links/{h.affiliate_id("betterworldbooks")}/type/dlg/'
+    'http://www.betterworldbooks.com/-id-%s'
+)
+
+
+@public
+def get_betterworldbooks_metadata(isbn: str) -> dict:
+    """
+    :param str isbn: Unnormalisied ISBN10 or ISBN13
+    :return: Metadata for a single BWB book, currently listed on their catalog, or
+             an error dict.
+    :rtype: dict
+    """
+
+    isbn = normalize_isbn(isbn)
+    try:
+        return _get_betterworldbooks_metadata(isbn)
+    except Exception:
+        logger.exception(f"_get_betterworldbooks_metadata({isbn})")
+        return betterworldbooks_fmt(isbn)
+
+
+def _get_betterworldbooks_metadata(isbn: str) -> dict:
+    """Returns price and other metadata (currently minimal)
+    for a book currently available on betterworldbooks.com
+
+    :param str isbn: Normalised ISBN10 or ISBN13
+    :return: Metadata for a single BWB book currently listed on their catalog,
+            or an error dict.
+    :rtype: dict
+    """
+
+    url = BETTERWORLDBOOKS_API_URL + isbn
+    response = requests.get(url)
+    if response.status_code != requests.codes.ok:
+        return {'error': response.text, 'code': response.status_code}
+    text = response.text
+    new_qty = re.findall("<TotalNew>([0-9]+)</TotalNew>", text)
+    new_price = re.findall(r"<LowestNewPrice>\$([0-9.]+)</LowestNewPrice>", text)
+    used_price = re.findall(r"<LowestUsedPrice>\$([0-9.]+)</LowestUsedPrice>", text)
+    used_qty = re.findall("<TotalUsed>([0-9]+)</TotalUsed>", text)
+    market_price = re.findall(
+        r"<LowestMarketPrice>\$([0-9.]+)</LowestMarketPrice>", text
+    )
+    price = qlt = None
+
+    if used_qty and used_qty[0] and used_qty[0] != '0':
+        price = used_price[0] if used_price else ''
+        qlt = 'used'
+
+    if new_qty and new_qty[0] and new_qty[0] != '0':
+        _price = new_price[0] if new_price else None
+        if _price and (not price or float(_price) < float(price)):
+            price = _price
+            qlt = 'new'
+
+    market_price = ('$' + market_price[0]) if market_price else None
+    return betterworldbooks_fmt(isbn, qlt, price, market_price)
+
+
+def betterworldbooks_fmt(
+    isbn: str,
+    qlt: str = None,
+    price: str = None,
+    market_price: list[str] = None,
+) -> dict:
+    """Defines a standard interface for returning bwb price info
+
+    :param str isbn:
+    :param str qlt: Quality of the book, e.g. "new", "used"
+    :param str price: Price of the book as a decimal str, e.g. "4.28"
+    :rtype: dict
+    """
+    price_fmt = f"${price} ({qlt})" if price and qlt else None
+    return {
+        'url': BWB_AFFILIATE_LINK % isbn,
+        'isbn': isbn,
+        'market_price': market_price,
+        'price': price_fmt,
+        'price_amt': price,
+        'qlt': qlt,
+    }
+
+
+cached_get_betterworldbooks_metadata = cache.memcache_memoize(
+    _get_betterworldbooks_metadata,
+    "upstream.code._get_betterworldbooks_metadata",
+    timeout=dateutil.HALF_DAY_SECS,
+)

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -1,9 +1,9 @@
 import pytest
-from openlibrary.core.vendors import (
-    split_amazon_title,
+from openlibrary.core.vendors.amazon import (
     clean_amazon_metadata_for_load,
-    betterworldbooks_fmt,
+    split_amazon_title,
 )
+from openlibrary.core.vendors.betterworldbooks import betterworldbooks_fmt
 
 
 def test_clean_amazon_metadata_for_load_non_ISBN():

--- a/scripts/affiliate-server
+++ b/scripts/affiliate-server
@@ -14,7 +14,6 @@ start affiliate-server as fastcgi:
 start affiliate-server using gunicorn webserver:
 
     ./scripts/affiliate-server openlibrary.yml --gunicorn -b 0.0.0.0:31337
-
 """
 
 import json
@@ -26,24 +25,28 @@ import threading
 import time
 
 import web
-import yaml
 
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 
 import infogami
 from infogami import config
 from openlibrary.core import stats
-from openlibrary.core.vendors import AmazonAPI
+from openlibrary.core.vendors.amazon import AmazonAPI
 from openlibrary.utils.dateutil import WEEK_SECS
 from openlibrary.utils.isbn import (
-    normalize_isbn, isbn_13_to_isbn_10, isbn_10_to_isbn_13)
+    normalize_isbn,
+    isbn_13_to_isbn_10,
+    isbn_10_to_isbn_13,
+)
 
 logger = logging.getLogger("affiliate-server")
 
+# fmt: off
 urls = (
     '/isbn/([0-9X-]+)', 'Submit',
     '/status', 'Status',
 )
+# fmt: on
 
 API_MAX_ITEMS_PER_CALL = 10
 API_MAX_WAIT_SECONDS = 0.9
@@ -51,41 +54,35 @@ API_MAX_WAIT_SECONDS = 0.9
 web.amazon_queue = queue.Queue()  # a thread-safe multi-producer, multi-consumer queue
 
 
-def process_amazon_batch(isbn_10s):
+def process_amazon_batch(isbn_10s: list[str]) -> None:
     """
-    def process_amazon_batch(isbn_10s: list[str]) -> None:
-
     Call the Amazon API to get the products for a list of isbn_10s and store
     each product in memcache using amazon_product_{isbn_13} as the cache key.
     """
-    logger.info("process_amazon_batch(): {} items".format(len(isbn_10s)))
+    logger.info(f"process_amazon_batch(): {len(isbn_10s)} items")
     try:
         products = web.amazon_api.get_products(isbn_10s, serialize=True)
     except Exception:
-        logger.exception("amazon_api.get_product({}, serialize=True)".format(isbn_10s))
+        logger.exception(f"amazon_api.get_product({isbn_10s}, serialize=True)")
         products = []
     for product in products:
         # Make sure we have an isbn_13 for cache key
         cache_key = (
-            product.get('isbn_13') and product.get('isbn_13')[0] or
-            isbn_10_to_isbn_13(product.get('isbn_10')[0])
+            product.get('isbn_13')
+            and product.get('isbn_13')[0]
+            or isbn_10_to_isbn_13(product.get('isbn_10')[0])
         )
         cache.memcache_cache.set(
-            'amazon_product_%s' % cache_key, product, expires=WEEK_SECS
+            f'amazon_product_{cache_key}', product, expires=WEEK_SECS
         )
 
 
-def seconds_remaining(start_time):
-    """
-    def seconds_remaining(start_time: int) -> int:
-    """
+def seconds_remaining(start_time: int) -> int:
     return max(API_MAX_WAIT_SECONDS - (time.time() - start_time), 0)
 
 
-def amazon_lookup():
+def amazon_lookup() -> None:
     """
-    def amazon_lookup() -> None:
-
     A separate thread of execution that uses the time up to API_MAX_WAIT_SECONDS to
     create a list of isbn_10s that is not larger than API_MAX_ITEMS_PER_CALL and then
     passes them to process_amazon_batch()
@@ -107,20 +104,26 @@ def amazon_lookup():
 
 threading.Thread(target=amazon_lookup).start()
 
+
 class Status:
     def GET(self):
-        return json.dumps({
-            "queue_size": web.amazon_queue.qsize(),
-            "queue": list(web.amazon_queue.queue),
-        })
+        return json.dumps(
+            {
+                "queue_size": web.amazon_queue.qsize(),
+                "queue": list(web.amazon_queue.queue),
+            }
+        )
 
 
 class Submit:
-
     @classmethod
     def unpack_isbn(cls, isbn):
         isbn = normalize_isbn(isbn.replace('-', ''))
-        isbn10 = isbn if len(isbn) == 10 else isbn.startswith('978') and isbn_13_to_isbn_10(isbn)
+        isbn10 = (
+            isbn
+            if len(isbn) == 10
+            else isbn.startswith('978') and isbn_13_to_isbn_10(isbn)
+        )
         isbn13 = isbn if len(isbn) == 13 else isbn_10_to_isbn_13(isbn)
         return isbn10, isbn13
 
@@ -134,14 +137,12 @@ class Submit:
 
         isbn10, isbn13 = self.unpack_isbn(isbn)
         if not isbn10:
-            return json.dumps({
-                "error": "rejected_isbn",
-                "isbn10": isbn10,
-                "isbn13": isbn13
-            })
+            return json.dumps(
+                {"error": "rejected_isbn", "isbn10": isbn10, "isbn13": isbn13}
+            )
 
         # Cache lookup by isbn13. If there's a hit return the product to the caller
-        product = cache.memcache_cache.get('amazon_product_%s' % isbn13)
+        product = cache.memcache_cache.get(f'amazon_product_{isbn13}')
         if product:
             return json.dumps({"status": "success", "hit": product})
 
@@ -156,28 +157,30 @@ class Submit:
 def load_config(configfile):
     infogami.load_config(configfile)
 
-    #if 'fastcgi' in d:
+    # if 'fastcgi' in d:
     #    web.config.fastcgi = d['fastcgi']
 
     web.amazon_api = None
     args = [
         config.amazon_api.get('key'),
         config.amazon_api.get('secret'),
-        config.amazon_api.get('id')
+        config.amazon_api.get('id'),
     ]
     if all(args):
         web.amazon_api = AmazonAPI(*args, throttling=0.9)
         logger.info("AmazonAPI Initialized")
     else:
-        raise RuntimeError("{} is missing required keys.".format(configfile))
+        raise RuntimeError(f"{configfile} is missing required keys.")
 
 
 def init_sentry(app):
     from openlibrary.utils.sentry import Sentry
+
     sentry = Sentry(getattr(config, 'sentry', {}))
     if sentry.enabled:
         sentry.init()
         sentry.bind_to_webpy_app(app)
+
 
 def setup_env():
     # make sure PYTHON_EGG_CACHE is writable
@@ -186,7 +189,9 @@ def setup_env():
     # required when run as fastcgi
     os.environ['REAL_SCRIPT_NAME'] = ""
 
+
 cache = None
+
 
 def start_server():
     sysargs = sys.argv[1:]
@@ -196,15 +201,16 @@ def start_server():
     load_config(configfile)
     global cache
     from openlibrary.core import cache
+
     # sentry could be loaded here
     # init_sentry(app)
 
     sys.argv = [sys.argv[0]] + list(args)
     app.run()
 
+
 def start_gunicorn_server():
-    """Starts the affiliate server using gunicorn server.
-    """
+    """Starts the affiliate server using gunicorn server."""
     from gunicorn.app.base import Application
 
     configfile = sys.argv.pop(1)
@@ -231,10 +237,12 @@ def https_middleware(app):
     Using that value to overwrite wsgi.url_scheme in the WSGI environ,
     which is used by all redirects and other utilities.
     """
+
     def wrapper(environ, start_response):
         if environ.get('HTTP_X_SCHEME') == 'https':
             environ['wsgi.url_scheme'] = 'https'
         return app(environ, start_response)
+
     return wrapper
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
It isn't easy to understand and modify our affiliates/vendors code because it mixes both Amazon and Better World Books logic in a single file which is used to drive the affiliate server and several different web activities.

Separating the logic into vendor-specific files should make it easier to understand and maintain.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make certain relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with essential attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
