### PR TITLE
Unified Search Navigation

### DIFF
--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -13,7 +13,7 @@ $ q = query_param("q")
   </li>
   <li class="$('selected' if ctx.path=='/search/inside' else '')">
     <a data-ol-link-track="Navigation|SearchFulltext"
-       href="/search/inside?q=$(q)">$_("Quotes")</a>
+       href="/search/inside?q=$(q)">$_("Search Inside")</a>
   </li>
   <li class="$('selected' if ctx.path=='/advancedsearch' else '')">
     <a data-ol-link-track="Navigation|SearchAdvanced"

--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -4,19 +4,27 @@ $ q = query_param("q")
 
 <ul class="work-menu">
   <li class="$('selected' if ctx.path=='/search' else '')">
-    <a data-ol-link-track="SearchNav|Search"
+    <a data-ol-link-track="SearchNav|SearchBooks"
        href="/search?q=$(q)">$_("Books")</a>
   </li>
   <li class="$('selected' if ctx.path=='/search/authors' else '')">
-    <a data-ol-link-track="Navigation|SearchAuthors"
+    <a data-ol-link-track="SearchNav|SearchAuthors"
        href="/search/authors?$urlencode(dict(q=q))">$_("Authors")</a>
   </li>
   <li class="$('selected' if ctx.path=='/search/inside' else '')">
-    <a data-ol-link-track="Navigation|SearchFulltext"
+    <a data-ol-link-track="SearchNav|SearchFulltext"
        href="/search/inside?q=$(q)">$_("Search Inside")</a>
   </li>
+  <li class="$('selected' if ctx.path=='/search/subjects' else '')">
+    <a data-ol-link-track="SearchNav|SearchSubjects"
+       href="/search/subjects?q=$(q)">$_("Subjects")</a>
+  </li>
+  <li class="$('selected' if ctx.path=='/search/lists' else '')">
+    <a data-ol-link-track="SearchNav|SearchLists"
+       href="/search/lists?q=$(q)">$_("Lists")</a>
+  </li>
   <li class="$('selected' if ctx.path=='/advancedsearch' else '')">
-    <a data-ol-link-track="Navigation|SearchAdvanced"
+    <a data-ol-link-track="SearchNav|SearchAdvanced"
        href="/advancedsearch">$_("Advanced Search")</a>
   </li>
 </ul>

--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -1,0 +1,22 @@
+$def with ()
+
+$ q = query_param("q")
+
+<ul class="work-menu">
+  <li class="$('selected' if ctx.path=='/search' else '')">
+    <a data-ol-link-track="Navigation|Search"
+       href="/search?q=$(q)">$_("Books")</a>
+  </li>
+  <li class="$('selected' if ctx.path=='/search/authors' else '')">
+    <a data-ol-link-track="Navigation|SearchAuthors"
+       href="/search/authors?q=$(q)">$_("Authors")</a>
+  </li>
+  <li class="$('selected' if ctx.path=='/search/inside' else '')">
+    <a data-ol-link-track="Navigation|SearchFulltext"
+       href="/search/inside?q=$(q)">$_("Quotes")</a>
+  </li>
+  <li class="$('selected' if ctx.path=='/advancedsearch' else '')">
+    <a data-ol-link-track="Navigation|SearchAdvanced"
+       href="/advancedsearch">$_("Advanced Search")</a>
+  </li>
+</ul>

--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -2,7 +2,7 @@ $def with ()
 
 $ q = query_param("q")
 
-<ul class="work-menu">
+<ul class="nav-bar">
   <li class="$('selected' if ctx.path=='/search' else '')">
     <a data-ol-link-track="SearchNav|SearchBooks"
        href="/search?q=$(q)">$_("Books")</a>

--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -4,12 +4,12 @@ $ q = query_param("q")
 
 <ul class="work-menu">
   <li class="$('selected' if ctx.path=='/search' else '')">
-    <a data-ol-link-track="Navigation|Search"
+    <a data-ol-link-track="SearchNav|Search"
        href="/search?q=$(q)">$_("Books")</a>
   </li>
   <li class="$('selected' if ctx.path=='/search/authors' else '')">
     <a data-ol-link-track="Navigation|SearchAuthors"
-       href="/search/authors?q=$(q)">$_("Authors")</a>
+       href="/search/authors?$urlencode(dict(q=q))">$_("Authors")</a>
   </li>
   <li class="$('selected' if ctx.path=='/search/inside' else '')">
     <a data-ol-link-track="Navigation|SearchFulltext"

--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -1,5 +1,9 @@
-<div id="contentBody">
+<div id="contentHead">
   <h1>$_('Advanced Search')</h1>
+</div>
+
+<div id="contentBody">
+  $:macros.SearchNavigation()
   <form method="get" action="/search" class="siteSearch">
     <fieldset class="home">
       <legend>$_('Advanced Search')</legend>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -12,40 +12,20 @@ $ offset = (page - 1) * results_per_page
 $var title: Search Open Library for "$q"
 
 <div id="contentHead">
-    $if q:
-        $ results = get_results(q, offset=offset, limit=results_per_page)
-        $if 'error' not in results:
-            $ response = results['response']
-            $ num_found = int(response['numFound'])
-            $if num_found >= 2 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
-                $ keys = '&'.join('key=%s' % doc['key'] for doc in response['docs'])
-                <div class="mergeThis">
-                    <p class="smaller brown sansserif collapse">$_('Is the same author listed twice?')</p>
-                    <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a>
-                </div>
     <h1>$_("Search Authors")</h1>
 </div>
 
 <div id="contentBody">
-    $:macros.SearchNavigation()
+  $:macros.SearchNavigation()
+
+  <form class="siteSearch olform" action="">
+    <input type="text" class="larger" name="q" size="100" value="$q"/>
+    <input type="submit"  class="large" value="$_('Search')"/>
+  </form>
 </div>
 
 <div id="contentMeta">
-
-  <div class="section">
-
-    <form class="siteSearch olform" action="">
-        <input type="text" class="larger" name="q" size="100" value="$q"/>
-        <input type="submit"  class="large" value="$_('Search')"/>
-    </form>
-
-  </div>
-
-    $if q and 'error' not in results:
-        $if num_found:
-            <p class="sansserif collapse"><strong>$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</strong></p>
-        $else:
-            <p class="sansserif red collapse"><strong>$_('No hits')</strong></p>
+    $ results = get_results(q, offset=offset, limit=results_per_page)
 
     $if q and 'error' in results:
         <strong>
@@ -56,6 +36,18 @@ $var title: Search Open Library for "$q"
         </strong>
 
     $if q and 'error' not in results:
+	$ response = results['response']
+        $ num_found = int(response['numFound'])
+
+        $if num_found:
+            <div class="search-results-stats">$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))
+              $if num_found >= 2 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
+                $ keys = '&'.join('key=%s' % doc['key'] for doc in response['docs'])
+                <div class="mergeThis">$_('Is the same author listed twice?') <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a></div>
+            </div>
+        $else:
+            <p class="sansserif red collapse">$_('No hits')</p>
+
         <ul class="authorList list-books">
         $for doc in response['docs']:
             $ n = doc['name']
@@ -67,7 +59,7 @@ $var title: Search Open Library for "$q"
             $elif 'date' in doc:
                 $ date = doc['date']
             <li class="searchResultItem">
-	      <img src="https://covers.openlibrary.org/a/olid/$(doc['key'])-M.jpg" itemprop="image" class="cover" alt="Photo of J. K. Rowling">
+	      <img src="$get_coverstore_public_url()/a/olid/$(doc['key'])-M.jpg" itemprop="image" class="cover author" alt="Photo of $n">
 	      <div>
 		<a href="/authors/$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
 		<span class="small grey"><b>$wc</b>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -11,7 +11,6 @@ $ offset = (page - 1) * results_per_page
 
 $var title: Search Open Library for "$q"
 
-<div id="contentBody">
 <div id="contentHead">
     $if q:
         $ results = get_results(q, offset=offset, limit=results_per_page)
@@ -24,27 +23,29 @@ $var title: Search Open Library for "$q"
                     <p class="smaller brown sansserif collapse">$_('Is the same author listed twice?')</p>
                     <a class="large sansserif" href="/authors/merge?$keys">$_('Merge authors')</a>
                 </div>
-    <h1>
-        $_("Author Search")
-    </h1>
+    <h1>$_("Search Authors")</h1>
+</div>
 
-    $if q and 'error' not in results:
-        $if num_found:
-            <p class="sansserif darkgreen collapse"><strong>$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</strong></p>
-        $else:
-            <p class="sansserif red collapse"><strong>$_('No hits')</strong></p>
+<div id="contentBody">
+    $:macros.SearchNavigation()
 </div>
 
 <div id="contentMeta">
 
-    <div class="section">
+  <div class="section">
 
     <form class="siteSearch olform" action="">
         <input type="text" class="larger" name="q" size="100" value="$q"/>
         <input type="submit"  class="large" value="$_('Search')"/>
     </form>
 
-    </div>
+  </div>
+
+    $if q and 'error' not in results:
+        $if num_found:
+            <p class="sansserif collapse"><strong>$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</strong></p>
+        $else:
+            <p class="sansserif red collapse"><strong>$_('No hits')</strong></p>
 
     $if q and 'error' in results:
         <strong>
@@ -55,7 +56,7 @@ $var title: Search Open Library for "$q"
         </strong>
 
     $if q and 'error' not in results:
-        <ul class="authorList">
+        <ul class="authorList list-books">
         $for doc in response['docs']:
             $ n = doc['name']
             $ num = doc['work_count']
@@ -65,16 +66,19 @@ $var title: Search Open Library for "$q"
                 $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')
             $elif 'date' in doc:
                 $ date = doc['date']
-            <li class="sansserif">
-            <a href="/authors/$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
-            <span class="small grey"><b>$wc</b>
-            $if 'top_subjects' in doc:
-                $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
-            $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
+            <li class="searchResultItem">
+	      <img src="https://covers.openlibrary.org/a/olid/$(doc['key'])-M.jpg" itemprop="image" class="cover" alt="Photo of J. K. Rowling">
+	      <div>
+		<a href="/authors/$doc['key']" class="larger">$n</a>&nbsp;<span class="brown small">$date</span><br />
+		<span class="small grey"><b>$wc</b>
+                $if 'top_subjects' in doc:
+                  $_('about %(subjects)s', subjects=', '.join(doc['top_subjects'])),
+                $:_('including <i>%(topwork)s</i>', topwork=doc.get('top_work', ''))</span>
+	      </div>
             </li>
         </ul>
 
         $:macros.Pager(page, num_found, results_per_page)
-</div>
-<div class="clearfix"></div>
+  </div>
+  <div class="clearfix"></div>
 </div>

--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -3,7 +3,7 @@ $def with (q, results, search_time, page=1, results_per_page=20)
 $var title: $_('Search Open Library for %s', q)
 
 <div id="contentHead">
-  <h1>$_("Search Quotes")</h1>
+  <h1>$_("Search Inside")</h1>
 </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -3,11 +3,11 @@ $def with (q, results, search_time, page=1, results_per_page=20)
 $var title: $_('Search Open Library for %s', q)
 
 <div id="contentHead">
-    <h1>$_("Search Inside")</h1>
+  <h1>$_("Search Quotes")</h1>
 </div>
 
 <div id="contentBody">
-
+  $:macros.SearchNavigation()
   <form class="siteSearch searchInsideForm" action="/search/inside">
     <input type="text" class="larger" name="q" value="$q"/>
     <input type="submit" class="generic-button" value="$_('Search')">

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -3,11 +3,11 @@ $def with (q, lists)
 $var title: $_('Search results for Lists')
 
 <div id="contentHead">
-  <h1>$_("Lists")</h1>
+  <h1>$_("Search Lists")</h1>
 </div>
 
 <div id="contentBody">
-
+  $:macros.SearchNavigation()
   <form class="siteSearch searchInsideForm" action="/search/lists">
     <input type="text" class="larger" name="q" value="$q"/>
     <input type="submit" class="generic-button" value="$_('Search')">

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -1,6 +1,8 @@
 $def with (selected_sort, exclude=None, default_sort='relevance')
 
-<span class="tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" width="9" height="11" style="margin-right:10px;"/>
+<span class="tools">
+    <img src="/images/icons/icon_sort.png" class="" alt="$_('Sorting by')" width="9" height="11" class="sorter" />
+    $_('Sorted by'):
     $code:
       sort_options = [
         { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
@@ -14,7 +16,7 @@ $def with (selected_sort, exclude=None, default_sort='relevance')
         $continue
       $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort or (selected_sort is None and sort_option['sort'] == default_sort)
       $if is_selected:
-          <strong class="lightgreen">$sort_option['name']</strong>
+          <a><strong>$sort_option['name']</strong></a>
       $else:
           <a href="$changequery(sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
              data-ol-link-track="SearchSort|$sort_option['ga_key']"

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -30,7 +30,7 @@ $if q:
     $if 'error' not in results:
         $ response = results['response']
         $ num_found = int(response['numFound'])
-        <p class="sansserif collapse"><strong>$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</strong></p>
+        <p class="search-results-stats">$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</p>
 
 $if q and 'error' in results:
     <strong>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -12,24 +12,25 @@ $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
 
 <div id="contentHead">
     <h1>
-        $_("Subject Search")
+        $_("Search Subjects")
     </h1>
-
-$if q:
-    $ results = get_results(q, offset=offset, limit=results_per_page)
-    $if 'error' not in results:
-        $ response = results['response']
-        $ num_found = int(response['numFound'])
-        <p class="sansserif darkgreen collapse"><strong>$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</strong></p>
 </div>
 
 <div id="contentBody">
+  $:macros.SearchNavigation()
     <div class="section">
         <form class="siteSearch olform" action="">
             <input type="text" class="larger" name="q" size="100" value="$q"/>
             <input type="submit" class="large" value="$_('Search')"/>
         </form>
     </div>
+
+$if q:
+    $ results = get_results(q, offset=offset, limit=results_per_page)
+    $if 'error' not in results:
+        $ response = results['response']
+        $ num_found = int(response['numFound'])
+        <p class="sansserif collapse"><strong>$ungettext('1 hit', '%(count)s hits', response['numFound'], count=commify(response['numFound']))</strong></p>
 
 $if q and 'error' in results:
     <strong>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -63,6 +63,7 @@ $ )
 <div id="contentBody">
   $:macros.SearchNavigation()
   <div class="section">
+
     <form method="get" action="/search" class="siteSearch olform">
       <label for="q" class="hidden">$_('Keywords')</label>
       <input type="text" name="q" id="q" value="$q_param" size="100"/>
@@ -75,14 +76,14 @@ $ )
         <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
         <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
-        $ sticky = set(['sort', 'author_facet', 'language', 'first_publish_year', 'publisher_facet',  'subject_facet', 'person_facet', 'place_facet', 'time_facet', 'public_scan_b'])
+      $ sticky = set(['sort', 'author_facet', 'language', 'first_publish_year', 'publisher_facet',  'subject_facet', 'person_facet', 'place_facet', 'time_facet', 'public_scan_b'])
 
-        $for k, values in param.items():
-            $if k not in sticky:
-                $continue
-            $for v in values if isinstance(values, list) else [values]:
-                <input type="hidden" name="$k" value="$v.replace('"', '&quot;')" />
-        </form>
+      $for k, values in param.items():
+        $if k not in sticky:
+          $continue
+        $for v in values if isinstance(values, list) else [values]:
+          <input type="hidden" name="$k" value="$v.replace('"', '&quot;')" />
+    </form>
 
         $if param and not error:
             $ title = []
@@ -151,7 +152,12 @@ $ )
         </center>
 
     $elif param and not error and len(docs):
-	<div class="search-results-stats">$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</div>
+        <div class="search-results-stats">
+          $ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))
+
+          $if num_found > 1:
+            $:render_template("search/sort_options.html", sort)
+        </div>
         <div class="resultsContainer search-results-container">
         <div id="searchResults">
           <ul class="list-books">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -44,7 +44,7 @@ $ facet_inc = 10
 
 <div>
     <div id="contentHead">
-      <h1>Search</h1>
+      <h1>$_("Search")</h1>
     </div>
 
 $ facet_map = (

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -43,14 +43,8 @@ $ start_facet_count = 5
 $ facet_inc = 10
 
 <div>
-$if param and not error and num_found:
     <div id="contentHead">
-      $if num_found > 0:
-        <span class="darkgreen"><strong>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</strong></span>
-&nbsp;
-      $if num_found > 1:
-        $:render_template("search/sort_options.html", sort)
-        <span class="advanced-search"><a href="/advancedsearch">$_('Advanced Search')</a></span>
+      <h1>Search</h1>
     </div>
 
 $ facet_map = (
@@ -67,8 +61,8 @@ $    ('public_scan_b', _('Classic eBooks')),
 $ )
 
 <div id="contentBody">
+  $:macros.SearchNavigation()
   <div class="section">
-
     <form method="get" action="/search" class="siteSearch olform">
       <label for="q" class="hidden">$_('Keywords')</label>
       <input type="text" name="q" id="q" value="$q_param" size="100"/>
@@ -157,7 +151,7 @@ $ )
         </center>
 
     $elif param and not error and len(docs):
-        <div class="shift">$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</div>
+	<div>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</div>
         <div class="resultsContainer search-results-container">
         <div id="searchResults">
           <ul class="list-books">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -151,7 +151,7 @@ $ )
         </center>
 
     $elif param and not error and len(docs):
-	<div>$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</div>
+	<div class="search-results-stats">$ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))</div>
         <div class="resultsContainer search-results-container">
         <div id="searchResults">
           <ul class="list-books">

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -156,14 +156,16 @@ h2.edition-byline {
   border-bottom: 1px solid @lighter-grey;
   font-weight: bold;
 
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  scroll-behavior: smooth;
+
   &.sticky {
     position: sticky;
     top: 50px;
-    display: block;
     background: @white;
     z-index: @z-index-level-3;
-    white-space: nowrap;
-    overflow-x: auto;
     // Make tab bar full width on mobile
     margin-left: -@contentBody-padding;
     margin-right: -@contentBody-padding;
@@ -172,10 +174,8 @@ h2.edition-byline {
     &:before, &:after {
       display: inline-block;
       content: "";
-      width: 20%;
+      width: 10%;
     }
-
-    scroll-behavior: smooth;
   }
 }
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1191,6 +1191,10 @@ div#searchResults {
     font-size: 1em;
     color: @grey;
   }
+  .cover {
+    width: 120px;
+    border-radius: 4px;
+  }
 }
 
 // openlibrary/templates/languages/index.html
@@ -1801,9 +1805,9 @@ div.addfield {
 // Merge button
 //openlibrary/templates/search/authors.html
 div.mergeThis {
-  float: right;
-  margin: 20px 20px 0 30px;
-  padding-left: 47px;
+  display: inline;
+  padding: 15px 0 0 45px;
+  margin-left: 80px;
   background: url(/images/icons/icon_merge.png) no-repeat 0 0;
 }
 @import (less) "components/merge-form.less";

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -394,6 +394,11 @@ span {
     font-weight: normal !important;
     font-family: @lucida_sans_serif-2;
 
+    &.sorter {
+      margin-right: 5px;
+      margin-left: 10px;
+    }
+
     span.label {
       background-color: @orange;
       color: @white;
@@ -1807,7 +1812,7 @@ div.addfield {
 div.mergeThis {
   display: inline;
   padding: 15px 0 0 45px;
-  margin-left: 80px;
+  margin-left: 15px;
   background: url(/images/icons/icon_merge.png) no-repeat 0 0;
 }
 @import (less) "components/merge-form.less";


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This meant to be an absolute minimal PR of adding Book Page style navigation tabs to Search Results

<!-- What issue does this PR close? -->
Closes #6542 

## Details

* Lists & Subjects are intentionally omitted from this 1st step because their experience doesn't feel ready -- patrons can still get to this in the same way (through the Browse menu and the main search).
* Google analytics has been added to see if anyone clicks "Quotes" (i.e. fulltext search, named according to Goodreads); see:
* `hits` has been moved consistently below the search box (and the green has been removed); still requires some normalization of font-weight
* Author results have been standardized using the Books format and author covers/imgs have been added. Bullet styles and anchor tags have been standardized across Author and Books results.

![www goodreads com_search_q=to+be+or+not+to+be qid=](https://user-images.githubusercontent.com/978325/175796328-df1f2cbc-635a-4600-b960-c03a74ff4f9a.png)

## Screenshots

**Books**

![ol-dev1 us archive org_1337_search_q=jk%20rowling (1)](https://user-images.githubusercontent.com/978325/175797155-a2149ef1-adce-4d6d-911a-7ecfb4504536.png)

**Authors**

![ol-dev1 us archive org_1337_search_authors_q=jk%20rowling](https://user-images.githubusercontent.com/978325/175797073-669877e0-406b-4ee0-adc1-5d25c0f8d66a.png)

**Quotes**

![ol-dev1 us archive org_1337_search_inside_q=jk%20rowling](https://user-images.githubusercontent.com/978325/175797180-bf338f0c-a18b-4f40-8809-f3dbb4aba082.png)

**Advanced Search**

![ol-dev1 us archive org_1337_advancedsearch](https://user-images.githubusercontent.com/978325/175797204-ae405582-c417-4a91-99cf-5bf6f3f21b88.png)

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
