### PR TITLE
minimal fix for carousel waitlist btn

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -80,7 +80,7 @@ $elif availability.get('is_lendable'):
     $:macros.ReadButton(ocaid, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
     $if waiting_loan:
-      $if seconday_action:
+      $if secondary_action:
         <p class="waitinglist-message">
         $ spot = waiting_loan['position']
         $ wlsize = waiting_loan['wl_size']

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -80,14 +80,15 @@ $elif availability.get('is_lendable'):
     $:macros.ReadButton(ocaid, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
     $if waiting_loan:
-      <p class="waitinglist-message">
+      $if seconday_action:
+        <p class="waitinglist-message">
         $ spot = waiting_loan['position']
         $ wlsize = waiting_loan['wl_size']
         $if spot == 1:
           $:_('You are <strong>next</strong> on the waiting list')
         $else:
           $:_('You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list.', spot=spot, wlsize=wlsize)
-      </p>
+        </p>
       <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
         <input type="hidden" name="action" value="leave-waitinglist"/>
         <input type="submit" class="cta-btn" id="unwaitlist_ebook"
@@ -96,16 +97,17 @@ $elif availability.get('is_lendable'):
     $else:
       $# "JOIN-WAITLIST" button
       $ wlsize = availability.get('users_on_waitlist') or availability.get('num_waitlist')
-      <p class="waitinglist-message">
-        $if wlsize:
-          $_("Readers waiting for this title: %(count)s", count=wlsize)
-        $else:
-          $_("You'll be next in line.")
-      </p>
       <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
         <input type="hidden" name="action" value="join-waitinglist"/>
         <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
       </form>
+      $if secondary_action:
+        <p class="waitinglist-message">
+          $if wlsize:
+            $_("Readers in line: %(count)s", count=wlsize)
+          $else:
+            $_("You'll be next in line.")
+        </p>
   $else:
     $# Checked out: Show checkout out + preview if secondary, else just preview
     <div class="cta-button-group">

--- a/static/css/components/buttonCta--js.less
+++ b/static/css/components/buttonCta--js.less
@@ -18,7 +18,7 @@ a.cta-btn {
   &--unavailable {
     &--load {
       background: url(/static/images/indicator.gif) center center no-repeat;
-      background-color: @burnt-sienna !important;
+      background-color: @primary-blue !important;
       opacity: .6;
     }
   }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -59,9 +59,9 @@ a.cta-btn {
   }
 
   &--unavailable {
-    background-color: @burnt-sienna;
+    background-color: @primary-blue;
     color: @white;
-    &:hover { background-color: darken(@burnt-sienna, 20%); }
+    &:hover { background-color: darken(@primary-blue, 20%); }
   }
   &--shell, &--shell:link, &--shell:visited {
     background-color: @white;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6652 

Colors are now standard, the messaging appears under the btn (on books page) and don't appear on carousels (due to when not `secondary_action`)

NB: The cta-btns are **still** different sizes either because:
* the cta-btn--shell border or because of the cta-btn 
* form for waitling list

![testing openlibrary org_](https://user-images.githubusercontent.com/978325/175840917-ae219485-19b7-4067-9cc9-a97dbf1d5783.png)

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
