### PR TITLE
fixing logic for sponsor btn

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -115,11 +115,8 @@ $elif availability.get('is_lendable'):
   $if secondary_action:
     $:macros.BookPreview(ocaid, linkback=not no_index)
 
-$elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availability.get('is_lendable')):
-  $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc, donate_only=True)
-  $if sponsorship.get('is_eligible'):
-    <a href="$(sponsorship['sponsor_url'])"
-       class="cta-btn cta-btn--sponsor dialog--open"
+$elif ('eligibility' in doc) or (check_sponsorship and not ocaid and qualifies_for_sponsorship(doc, donate_only=True).get('is_eligible')):
+    <a class="cta-btn cta-btn--sponsor dialog--open"
        aria-controls="seeDonate"
        data-ol-link-track="CTAClick|Sponsor">$_('Donate Book')</a>
     $if sponsorship_help:

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -116,7 +116,7 @@ $elif availability.get('is_lendable'):
     $:macros.BookPreview(ocaid, linkback=not no_index)
 
 $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and qualifies_for_sponsorship(doc, donate_only=True).get('is_eligible')):
-    <a class="cta-btn cta-btn--sponsor dialog--open"
+    <a class="cta-btn cta-btn--shell cta-btn--sponsor dialog--open"
        aria-controls="seeDonate"
        data-ol-link-track="CTAClick|Sponsor">$_('Donate Book')</a>
     $if sponsorship_help:

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -115,7 +115,7 @@ $elif availability.get('is_lendable'):
   $if secondary_action:
     $:macros.BookPreview(ocaid, linkback=not no_index)
 
-$elif ('eligibility' in doc) or (check_sponsorship and not ocaid and qualifies_for_sponsorship(doc, donate_only=True).get('is_eligible')):
+$elif not ocaid and ('eligibility' in doc or (check_sponsorship and qualifies_for_sponsorship(doc, donate_only=True).get('is_eligible'))):
     <a class="cta-btn cta-btn--shell cta-btn--sponsor dialog--open"
        aria-controls="seeDonate"
        data-ol-link-track="CTAClick|Sponsor">$_('Donate Book')</a>


### PR DESCRIPTION
Minimal fix -- sometimes the sponsorship criteria would pass the first `if` statement, enter the `if` body and then fail the second condition, and in this case no btn would render (when really we wanted to show e.g. `Not in Library`). This combines the `if` statements so we check one condition. The sponsorship_url is no longer needed since clicking "donate" not pops up a modal instead of redirecting to archive.org sponsorship.

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
