### PR TITLE
DRAFT: Batch add Better World Books covers

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -234,6 +234,7 @@ services:
     volumes:
       - ../olsystem:/olsystem
       - /opt/olsystem/etc/openlibrary.yml:/openlibrary.yml
+      - /1/var/tmp/imports:/imports:ro
     networks:
       - webnet
     logging:

--- a/scripts/add_bwb_covers.py
+++ b/scripts/add_bwb_covers.py
@@ -29,22 +29,23 @@ Issues:
 """
 from __future__ import annotations
 
+import os
 import sys
 from contextlib import contextmanager
+from os import environ
 from pathlib import Path
 from time import perf_counter
-from typing import Iterator
+from collections.abc import Iterator
 from zipfile import ZipFile
 
-"""
-from olclient import OpenLibrary  # , config
+from olclient import OpenLibrary, config
 
 ol = OpenLibrary(
-    # credentials=config.Credentials(
-    #     access=os.environ["OL_ACCESS_KEY"], secret=os.environ["OL_SECRET_KEY"]
-    # )
+    credentials=config.Credentials(
+        access=os.environ["OL_ACCESS_KEY"], secret=os.environ["OL_SECRET_KEY"]
+    )
 )
-"""
+
 COVERS_DIR = Path("/1/var/tmp/imports/2022/covers")
 
 

--- a/scripts/add_bwb_covers.py
+++ b/scripts/add_bwb_covers.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Add Better World Books cover images to corresponding Open Library Editions if needed.
+
+Phase 1: generate_covers_dict()
+Read thru all zipfiles in ol-home0:/1/var/tmp/imports/2022/covers to create a dict of
+the zip files and their ISBN-13s that have a cover image jpg file associated with them.
+
+Phase 2: edition_needs_a_cover()
+Determine which ISBN-13s need a cover image added to their Open Library record.
+Possible outcomes could be:
+1. ISBN is not in Open Library
+2. ISBN is in Open Library and already has a cover image
+3. ISBN is in Open Library and needs a cover image added
+Each ISBN's dict could be updated with NOT_IN_OPEN_LIBRARY, HAS_COVER, or NEEDS_COVER
+and the Edition.olid.
+There is a slow way to determine if a cover is needed by using the `olclient` module
+and a fast way of doing to determine this by using direct access to web.ctx.site.things
+
+Phase 3: update_cover_for_edition()
+For each Edition.olid that NEEDS_COVER in the dict, add the cover image jpg from the
+zipfile to its Open Library Edition.
+
+Issues:
+1. Phase 1 needs read access to BWB zipfiles in ol-home0:/1/var/tmp/imports/2022/covers
+2. slow_edition_needs_a_cover() takes a long time to find each Open Library Edition.
+3. fast_edition_needs_a_cover() required direct access to web.ctx.site.things().
+4. Could read-many methods of access accelerate the edition_needs_a_cover() process?
+"""
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from time import perf_counter
+from typing import Iterator
+from zipfile import ZipFile
+
+"""
+from olclient import OpenLibrary  # , config
+
+ol = OpenLibrary(
+    # credentials=config.Credentials(
+    #     access=os.environ["OL_ACCESS_KEY"], secret=os.environ["OL_SECRET_KEY"]
+    # )
+)
+"""
+COVERS_DIR = Path("/1/var/tmp/imports/2022/covers")
+
+
+@contextmanager
+def elapsed_time(name="elapsed_time"):
+    """
+    Two ways to use elapsed_time():
+    1. As a decorator to time the execution of an entire function:
+        @elapsed_time("my_slow_function")
+        def my_slow_function(n=10_000_000):
+            pass
+    2. As a context manager to time the execution of a block of code inside a function:
+        with elapsed_time("my_slow_block_of_code"):
+            pass
+    """
+    start = perf_counter()
+    yield
+    print(
+        f"Elapsed time ({name}): {perf_counter() - start:0.8} seconds", file=sys.stderr
+    )
+
+
+@elapsed_time("generate_covers_dict()")
+def generate_covers_dict(covers_dir: Path = COVERS_DIR) -> dict:
+    """
+    Generate a dictionary of all ISBN-13s that have an associated cover .jpg file in
+    the zip files in covers_dir.  This process currently takes about 17 sec to generate
+    a dict containing 1.3M ISBN-13s.
+
+    {'Apr2022_1_lc_13.zip': [{'9780000528742': []},
+                             {'9780006499268': []},
+                             {'9780006499305': []},
+    """
+    from operator import attrgetter
+
+    def get_isbn_13s_from_zipfile(zipfile_path: Path) -> Iterator[dict[str, list]]:
+        with ZipFile(zipfile_path) as in_file:
+            for cover_file in sorted(in_file.infolist(), key=attrgetter("filename")):
+                parts = cover_file.filename.split(".")  # 9780425030134.jpg
+                assert parts[-1] == "jpg", cover_file.filename
+                yield {parts[0]: []}
+
+    return {
+        zipfile_path.name: list(get_isbn_13s_from_zipfile(zipfile_path))
+        for zipfile_path in covers_dir.glob("*.zip")
+    }
+
+
+def slow_edition_needs_a_cover(isbn_13: str) -> str:
+    """
+    If the Open Library Edition with this ISBN-13 has no cover then return its olid.
+    """
+    if ol_edition := ol.Edition.get(isbn=isbn_13):
+        if not getattr(ol_edition, "covers", None):
+            return ol_edition.olid
+    return ""
+
+
+def fast_edition_needs_a_cover(isbn_13: str) -> str:
+    """
+    If the Open Library Edition with this ISBN-13 has no cover then return its olid.
+    """
+    import web
+
+    query = {"type": "/type/edition", "isbn_": isbn_13}
+    if keys := web.ctx.site.things(query):
+        ol_edition = keys[0]
+        if not getattr(ol_edition, "covers", None):
+            return ol_edition.olid
+    return ""
+
+
+def update_cover_for_edition(
+    edition_olid: str, file_name: str, cover_data: bytes, mime_type: str = "image/jpeg"
+) -> bool:
+    url = f"https://openlibrary.org/books/{edition_olid}/-/add-cover"
+    form_data_body = {
+        "file": (file_name, cover_data, mime_type),
+        "url": (None, "https://"),
+        "upload": (None, "Submit"),
+    }
+    resp = ol.session.post(url, files=form_data_body)
+    return resp.ok and "Saved!" in resp.text
+
+
+@elapsed_time("main()")
+def main(covers_dir: Path = COVERS_DIR):
+    edition_needs_a_cover = slow_edition_needs_a_cover
+    covers_dict = generate_covers_dict(covers_dir)
+    # from pprint import pprint
+    # pprint(covers_dict)
+    print(f"{len(covers_dict)} zip files with {sys.getsizeof(covers_dict)} bytes.")
+    for zipfile_name, isbn_13s in covers_dict.items():
+        with ZipFile(covers_dir / zipfile_name) as in_file:
+            covers_updated = 0
+            for i, isbn_13 in enumerate(isbn_13s):
+                """
+                if ol_edition := edition_needs_a_cover(isbn_13):
+                    cover_file_name = f"{isbn_13}.jpg"
+                    if cover_data := in_file.read(cover_file_name):
+                        if update_cover_for_edition(
+                            ol_edition.olid, cover_file_name, cover_data
+                        ):
+                """
+                covers_updated += 1
+            print(f"{zipfile_name}: {covers_updated} of {i+1} covers updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add Better World Books cover images to corresponding Open Library Editions if needed.

Phase 1: `generate_covers_dict()`
Read thru all zipfiles in ol-home0:/1/var/tmp/imports/2022/covers to create a dict of
the zip files and their ISBN-13s that have a cover image jpg file associated with them.

Phase 2: `edition_needs_a_cover()`
Determine which of those ISBN-13s need a cover image added to their Open Library record.
Possible outcomes could be:
1. ISBN is not in Open Library
2. ISBN is in Open Library and already has a cover image
3. ISBN is in Open Library and needs a cover image added

Each ISBN's dict could be updated with NOT_IN_OPEN_LIBRARY, HAS_COVER, or NEEDS_COVER
and the Edition.olid.
There is a slow way to determine if a cover is needed by using the `olclient` module
and a fast way of doing to determine this by using direct access to web.ctx.site.things

Phase 3: `update_cover_for_edition()`
For each Edition.olid that NEEDS_COVER in the dict, add the cover image jpg from the
zipfile to its Open Library Edition.

Issues:
1. Phases 1 and 3 needs read access to BWB zipfiles in ol-home0:/1/var/tmp/imports/2022/covers
2. `slow_edition_needs_a_cover()` takes a long time to find each Open Library Edition.
3. `fast_edition_needs_a_cover()` required direct access to `web.ctx.site.things()`.
5. Could read-many methods of access be used to accelerate the `edition_needs_a_cover()` process?
6. Need a file format or database to keep track of progress and avoid duplicate work.
```
    {'Apr2022_1_lc_13.zip': [{'9780000528742': [None, 'NOT_IN_OPEN_LIBRARY']},
                             {'9780006499268': ['OL123M', 'HAS_COVER']},
                             {'9780006499305': ['OL7500661M', 'NOT_IN_OPEN_LIBRARY']},
```

### Technical
<!-- What should be noted about the implementation? -->
Our `cron-jobs` container is not useful for this job because it does not have access to Python modules:
* `infogami`, `internetarchive`, and `web`

On `ol-home0`:
```
docker exec -it XXX bash
 python -c "import openlibrary, infogami, internetarchive, web"

* openlibrary_affiliate-server_1 - YES
* openlibrary_infobase_nginx_1 - ONLY `import openlibrary`
* openlibrary_infobase_1 - YES
* openlibrary_importbot_1 - YES
* openlibrary_cron-jobs_1 - ONLY `import openlibrary`
* openlibrary_solr-updater_1 - YES
* openlibrary_solr-next-updater_1 - YES
```
So, let's use the `affiliate-server` image...
```
docker exec -it openlibrary_affiliate-server_1 bash
cat > scripts/add_bwb_covers.py  # Paste contents from this PR.
python scripts/add_bwb_covers.py
```
The next problem is volume access (like `cron-jobs` has) to:
```
volumes:
      - /1/var/tmp:/1/var/tmp
```
Let's use the ideas at https://github.com/internetarchive/openlibrary/wiki/Deployment-Guide#recovering-from-restart-loops
### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
On `ol-home0`...
1. Ensure that `/opt/openlibrary/docker-compose.production.yml` is modified as in this PR to add `/imports` to the `openlibrary_affiliate-server_1` docker image.
2. Use [our wiki instructions](https://github.com/internetarchive/openlibrary/wiki/Deployment-Guide#recovering-from-restart-loops) to reboot `openlibrary_affiliate-server_1`
3. Bash into the docker image with `docker exec -it openlibrary_affiliate-server_1 bash`
4. `ls /imports` to ensure that steps 1. and 2. were done correctly.
5. `cat > scripts/add_bwb_covers.py`  # Paste contents from this PR.
6. `python scripts/add_bwb_covers.py`
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
