### PR TITLE
Fix Profile hamburger doesn't override "More" navigation button on Desktop

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -48,6 +48,7 @@
 
     .account-dropdown-component {
       position: absolute;
+      z-index: @z-index-level-2;  // #6705
       text-align: right;
       // Note, it must be padding so that the gap between the icon and
       // the dropdown menu is included in the hover-trigger area (#1575)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6705

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
This changes the z-index for the hamburger menu on desktops to 2 so that it's positioned above the 'more' menu.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The break point where this error occurs is right around where the display switches from desktop to mobile, or a display of around 767px/768 in width. At 767px the mobile menu appears and the error does not. At 768 the desktop menu appears and the hamburger menu displays under the 'more' menu, as noted in #6705.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Incorrect behavior:
![image](https://user-images.githubusercontent.com/26524678/177255330-5bdf3c26-f366-41ad-9e8f-f887f6f5f70d.png)

Correct behavior:
![image](https://user-images.githubusercontent.com/26524678/177255371-fc0e3159-c299-413b-a53d-ae3eafd7450a.png)

For further reference, mobile menu behavior, which is fine:
![image](https://user-images.githubusercontent.com/26524678/177255434-c371b107-b4cc-480c-a550-4ed740a12231.png)

And a wider display where the error doesn't occur:
![image](https://user-images.githubusercontent.com/26524678/177255536-9ca5cc73-d120-4a08-bbd8-f23e8d8938f6.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bicolino34 

Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
