### PR TITLE
Show count of Reviews on Books Page nav bar

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,9 +1,6 @@
 $def with (reader_observations, edition_count=1, show_observations=False)
 
-$if reader_observations['total_respondents']:
-  $ total_reviews = reader_observations['total_respondents']
-$else:
-  $ total_reviews = ''
+$ total_reviews = reader_observations.get('total_respondents', '')
 
 <ul class="work-menu sticky">
   <li class="selected">

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,4 +1,9 @@
-$def with (edition_count=1, show_observations=False)
+$def with (reader_observations, edition_count=1, show_observations=False)
+
+$if reader_observations['total_respondents']:
+  $ total_reviews = reader_observations['total_respondents']
+$else:
+  $ total_reviews = 0
 
 <ul class="work-menu sticky">
   <li class="selected">
@@ -13,7 +18,9 @@ $def with (edition_count=1, show_observations=False)
     <a href="#details">$_("Details")</a>
   </li>
   <li>
-    <a href="#reader-observations">$_("Reviews")</a>
+    <a href="#reader-observations">
+      $ungettext('%(reviews)s Review', '%(reviews)s Reviews', total_reviews, reviews=total_reviews)
+    </a>
   </li>
   <li>
     <a href="#lists-section">$_("Lists")</a>

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -3,7 +3,7 @@ $def with (reader_observations, edition_count=1, show_observations=False)
 $if reader_observations['total_respondents']:
   $ total_reviews = reader_observations['total_respondents']
 $else:
-  $ total_reviews = 0
+  $ total_reviews = ''
 
 <ul class="work-menu sticky">
   <li class="selected">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -198,7 +198,10 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
         $ edit_url = page.key + "?m=edit"
     </div>
       $:render_template("type/edition/compact_title", book_title, edit_url)
-      $:macros.EditionNavBar(get_observation_metrics(work['key']), work.edition_count, show_observations)
+      $ component_times['get_observation_metrics'] = time()
+      $ reader_observations = get_observation_metrics(work['key']) if show_observations else {}
+      $ component_times['get_observation_metrics'] = time() - component_times['get_observation_metrics']
+      $:macros.EditionNavBar(reader_observations, work.edition_count, show_observations)
       <a id="edition-overview" name="edition-overview"></a>
       <div>
         $if edition:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -198,7 +198,7 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
         $ edit_url = page.key + "?m=edit"
     </div>
       $:render_template("type/edition/compact_title", book_title, edit_url)
-      $:macros.EditionNavBar(work.edition_count, show_observations)
+      $:macros.EditionNavBar(get_observation_metrics(work['key']), work.edition_count, show_observations)
       <a id="edition-overview" name="edition-overview"></a>
       <div>
         $if edition:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -463,10 +463,6 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
       </div>
 
       $if show_observations:
-        $ component_times['get_observation_metrics'] = time()
-        $ reader_observations = get_observation_metrics(work['key'])
-        $ component_times['get_observation_metrics'] = time() - component_times['get_observation_metrics']
-
         $ component_times['Review component'] = time()
         $:render_template("observations/review_component", work, reader_observations, page.key)
         $ component_times['Review component'] = time() - component_times['Review component']


### PR DESCRIPTION
Fixes #6647

<!-- What issue does this PR close? -->
Closes #6647

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> feature


### Technical
<!-- What should be noted about the implementation? -->


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to any work or book page and you'll initially see `0 Reviews` in the nav bar.
2. Scroll down to Community Reviews and add a review
3. Refresh the page and you'll see the review count has updated, and "reviews" has been changed to "review" to be grammatically correct.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/95453696/177790627-e85fe9fe-6894-4e28-b193-dcf1206f14ae.png)
![image](https://user-images.githubusercontent.com/95453696/177790826-5a3e23d6-f275-4746-9b64-985c79608f36.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
