### PR TITLE
Trending Carousel missing default bookcovers

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -111,15 +111,16 @@ const Carousel = {
 
             const default_cover_url = 'https://openlibrary.org/images/icons/avatar_book-lg.png';
 
-            if (!cover.id) {
-                var book_cover = `
+            let book_cover = undefined
+            if (cover.id) {
+                book_cover = `
                     <div class="book-cover">
                         <a href="${work.key}">
                             <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}">
                         </a>
                     </div>`
             } else {
-                var book_cover = `
+                book_cover = `
                     <a href="${work.key}">
                         <div class="carousel__item__blankcover bookcover">
                             <div class="carousel__item__blankcover--title">${work.title}</div>

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -110,15 +110,27 @@ const Carousel = {
 
 
             const default_cover_url = 'https://openlibrary.org/images/icons/avatar_book-lg.png';
-            const cover_url = cover.id ? `//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}` : default_cover_url
+
+            if (!cover.id) {
+                var book_cover = `
+                    <div class="book-cover">
+                        <a href="${work.key}">
+                            <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}">
+                        </a>
+                    </div>`
+            } else {
+                var book_cover = `
+                    <a href="${work.key}">
+                        <div class="carousel__item__blankcover bookcover">
+                            <div class="carousel__item__blankcover--title">${work.title}</div>
+                            ${work.author_name ? `<div class="carousel__item__blankcover--authors">${work.author_name}</div>` : ''}
+                        </div>
+                    <a/>`
+            }
 
             const $el = $(`
                 <div class="book carousel__item">
-                    <div class="book-cover">
-                        <a href="${work.key}">
-                            <img class="bookcover" src=${cover_url}>
-                        </a>
-                    </div>
+                    ${book_cover}
                     <div class="book-cta">
                         <a class="btn cta-btn ${cls}"
                            data-ol-link-track="subjects"

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -109,8 +109,8 @@ const Carousel = {
             }
 
 
-            const default_cover_url = `https://openlibrary.org/images/icons/avatar_book-lg.png`;
-            var cover_url = cover.id ? `//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}` : default_cover_url
+            const default_cover_url = 'https://openlibrary.org/images/icons/avatar_book-lg.png';
+            const cover_url = cover.id ? `//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}` : default_cover_url
 
             const $el = $(`
                 <div class="book carousel__item">

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -108,12 +108,9 @@ const Carousel = {
                 cover.id = ocaid;
             }
 
-
-            const default_cover_url = 'https://openlibrary.org/images/icons/avatar_book-lg.png';
-
-            let book_cover = undefined
+            let bookCover;
             if (cover.id) {
-                book_cover = `
+                bookCover = `
                     <div class="book-cover">
                         <a href="${work.key}">
                             <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}">

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -108,11 +108,15 @@ const Carousel = {
                 cover.id = ocaid;
             }
 
+
+            const default_cover_url = `https://openlibrary.org/images/icons/avatar_book-lg.png`;
+            var cover_url = cover.id ? `//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}` : default_cover_url
+
             const $el = $(`
                 <div class="book carousel__item">
                     <div class="book-cover">
                         <a href="${work.key}">
-                            <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg">
+                            <img class="bookcover" src=${cover_url}>
                         </a>
                     </div>
                     <div class="book-cta">

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -117,7 +117,7 @@ const Carousel = {
                         </a>
                     </div>`
             } else {
-                book_cover = `
+                bookCover = `
                     <a href="${work.key}">
                         <div class="carousel__item__blankcover bookcover">
                             <div class="carousel__item__blankcover--title">${work.title}</div>
@@ -128,7 +128,7 @@ const Carousel = {
 
             const $el = $(`
                 <div class="book carousel__item">
-                    ${book_cover}
+                    ${bookCover}
                     <div class="book-cta">
                         <a class="btn cta-btn ${cls}"
                            data-ol-link-track="subjects"

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -110,25 +110,22 @@ const Carousel = {
 
             let bookCover;
             if (cover.id) {
-                bookCover = `
-                    <div class="book-cover">
-                        <a href="${work.key}">
-                            <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default='https://openlibrary.org/images/icons/avatar_book.png'">
-                        </a>
-                    </div>`
+                bookCover = `<img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default='https://openlibrary.org/images/icons/avatar_book.png'">`
             } else {
                 bookCover = `
-                    <a href="${work.key}">
-                        <div class="carousel__item__blankcover bookcover">
-                            <div class="carousel__item__blankcover--title">${work.title}</div>
-                            ${work.author_name ? `<div class="carousel__item__blankcover--authors">${work.author_name}</div>` : ''}
-                        </div>
-                    <a/>`
+                    <div class="carousel__item__blankcover bookcover">
+                        <div class="carousel__item__blankcover--title">${work.title}</div>
+                        ${work.author_name ? `<div class="carousel__item__blankcover--authors">${work.author_name}</div>` : ''}
+                    </div>`
             }
 
             const $el = $(`
                 <div class="book carousel__item">
-                    ${bookCover}
+                    <div class="book-cover">
+                        <a href="${work.key}">
+                            ${bookCover}
+                        </a>
+                    </div>
                     <div class="book-cta">
                         <a class="btn cta-btn ${cls}"
                            data-ol-link-track="subjects"

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -113,7 +113,7 @@ const Carousel = {
                 bookCover = `
                     <div class="book-cover">
                         <a href="${work.key}">
-                            <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default=${default_cover_url}">
+                            <img class="bookcover" src="//covers.openlibrary.org/b/${cover.type}/${cover.id}-M.jpg?default='https://openlibrary.org/images/icons/avatar_book.png'">
                         </a>
                     </div>`
             } else {

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -17,7 +17,7 @@ $def render_carousel_cover(book, lazy):
   $elif book.get('cover_id') or book.get('cover_i'):
     $if book.get('cover_id') == 'undefined' and book.get('cover_i') == 'undefined':
       $ cover_url = False
-    $else
+    $else:
       $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
   $elif book.get('ia'):
     $if book.get('ia') == 'undefined':

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -15,7 +15,7 @@ $def render_carousel_cover(book, lazy):
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
   $elif book.get('cover_id') or book.get('cover_i'):
-    $if (book.get('cover_id') == 'undefined' or book.get('cover_id') == None) and (book.get('cover_i') == 'undefined' or book.get('cover_i') == None):
+    $if book.get('cover_id') == 'undefined' and book.get('cover_i') == 'undefined':
       $cover_url = False
     $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
   $elif book.get('ia'):

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -16,12 +16,19 @@ $def render_carousel_cover(book, lazy):
     $ cover_url = book.get('cover_url')
   $elif book.get('cover_id') or book.get('cover_i'):
     $if book.get('cover_id') == 'undefined' and book.get('cover_i') == 'undefined':
-      $cover_url = False
-    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
+      $ cover_url = False
+    $else
+      $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
   $elif book.get('ia'):
-    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
+    $if book.get('ia') == 'undefined':
+      $ cover_url = False
+    $else:
+      $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
   $elif book.get('cover_edition_key'):
-    $ cover_url = '%s/b/olid/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
+    $if book.get('cover_edition_key') == 'undefined':
+      $ cover_url = False
+    $else:
+      $ cover_url = '%s/b/olid/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
   $else:
      $ cover_url = False
   $if book.get('authors'):

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -44,7 +44,7 @@ $def render_carousel_cover(book, lazy):
           $else:
             src="$(cover_url)"/>
         $else:
-          <div class="carousel__item__blankcover">
+          <div class="carousel__item__blankcover"  title="$(title)">
             <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
             $if author_names:
               <div class="carousel__item__blankcover--authors">$:macros.TruncateString(', '.join(author_names), 30)</div>

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -15,6 +15,8 @@ $def render_carousel_cover(book, lazy):
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
   $elif book.get('cover_id') or book.get('cover_i'):
+    $if (book.get('cover_id') == 'undefined' or book.get('cover_id') == None) and (book.get('cover_i') == 'undefined' or book.get('cover_i') == None):
+      $cover_url = False
     $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
   $elif book.get('ia'):
     $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -7,7 +7,7 @@ $if slick_font not in ctx.links:
   $ ctx.links.append(slick_font)
 
 $def render_carousel_cover(book, lazy):
-  $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
+  $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book-lg.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
   $ title = book.title

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -15,22 +15,13 @@ $def render_carousel_cover(book, lazy):
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
   $elif book.get('cover_id') or book.get('cover_i'):
-    $if book.get('cover_id') == 'undefined' and book.get('cover_i') == 'undefined':
-      $ cover_url = False
-    $else:
-      $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
+    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
   $elif book.get('ia'):
-    $if book.get('ia') == 'undefined':
-      $ cover_url = False
-    $else:
-      $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
+    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
   $elif book.get('cover_edition_key'):
-    $if book.get('cover_edition_key') == 'undefined':
-      $ cover_url = False
-    $else:
-      $ cover_url = '%s/b/olid/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
+    $ cover_url = '%s/b/olid/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
   $else:
-     $ cover_url = False
+    $ cover_url = False
   $if book.get('authors'):
     $ author_names = [author.name for author in book.authors]
     $ byline = _(' by %(name)s', name=', '.join(author_names))

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -7,7 +7,7 @@ $if slick_font not in ctx.links:
   $ ctx.links.append(slick_font)
 
 $def render_carousel_cover(book, lazy):
-  $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book-lg.png'
+  $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
   $ title = book.title


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6648

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] --> fix


### Technical
<!-- What should be noted about the implementation? -->

I believe the problem exists:

- On [line 15](https://github.com/internetarchive/openlibrary/pull/6722#discussion_r917009198) (bug: the conditional statement should not be satisfied when `book.get('cover_id')` returns the string value, 'undefined')
- ...which is resulting in another bug on [line 18](https://github.com/internetarchive/openlibrary/blob/71a074f49b64e391ed92022668488a6fdec11d5d/openlibrary/templates/books/custom_carousel.html#L18) in **openlibrary/templates/books/custom_carousel.html** (as we are passing an undefined value into our course_url string - which leads to a "dead" link i.e. no image)

### Explanation

From looking in browser developer console (shown below), it seems [`book.get('cover_id')`](https://github.com/internetarchive/openlibrary/blob/71a074f49b64e391ed92022668488a6fdec11d5d/openlibrary/templates/books/custom_carousel.html#L18) and/or [`book.get('cover_i')`](https://github.com/internetarchive/openlibrary/blob/71a074f49b64e391ed92022668488a6fdec11d5d/openlibrary/templates/books/custom_carousel.html#L18) are returning the string value, 'undefined', which is ending up in the image `src=" "` attribute [here](https://github.com/internetarchive/openlibrary/blob/71a074f49b64e391ed92022668488a6fdec11d5d/openlibrary/templates/books/custom_carousel.html#L45).

See below:

If you _right-click_ then choose _Inspect_ on the items with missing default bookcovers, they all seem to have `src="//covers.openlibrary.org/b/id/undefined-M.jpg"` (an invalid link).

![image](https://user-images.githubusercontent.com/95453696/178029337-6af6f58c-fcdb-42e4-81e7-fe72c8e5cb26.png)

![image](https://user-images.githubusercontent.com/95453696/178029539-7b698331-7428-4010-be69-10056c5d02fb.png)

![image](https://user-images.githubusercontent.com/95453696/178029131-f7cdeb45-ba76-45f4-a818-d56a4c05d358.png)


# Proposed solution:

There may be a better way to solve this, but a quick temporary fix is to add a conditional statement that sets `cover_url` to **`False`** if `book.get('cover_id')` returns a string value of 'undefined' or anything that isn't a _valid_ cover id.

By setting `cover_url` to **`False`**, it means that [this conditional statement on line 37](https://github.com/internetarchive/openlibrary/blob/71a074f49b64e391ed92022668488a6fdec11d5d/openlibrary/templates/books/custom_carousel.html#L37) performs correctly (i.e. only items with valid cover_urls should satisfy the condition, and all other items are dealt with by the else statement which creates a default cover.)

Before:
![image](https://user-images.githubusercontent.com/95453696/178035750-f9cab3e7-43e8-41c1-854f-0a19631d2f5d.png)

After:
![image](https://user-images.githubusercontent.com/95453696/178035614-258abadd-6407-4843-a07f-88bbe4d85a81.png)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Note, this hasn't been tested as I'm not sure how to get the trending carousel to show up in the development mode (plus I'm only seeing like 6 books there .)

Is there a way to run the site as it is online (i.e. not development version), but in my local environment? If so, I'll test this solution.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
