### PR TITLE
Librarian queue follow-up

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -8,6 +8,7 @@ from openlibrary.i18n import gettext as _
 
 from . import db
 
+
 @public
 def get_status_for_view(status_code: int) -> str:
     """Returns localized status string that corresponds with the given status code."""
@@ -20,6 +21,7 @@ def get_status_for_view(status_code: int) -> str:
     if status_code == CommunityEditsQueue.STATUS['CLAIMED']:
         return _('Claimed')
     return _('Unknown')
+
 
 class CommunityEditsQueue:
 
@@ -42,13 +44,25 @@ class CommunityEditsQueue:
     }
 
     MODES = {
-        'all': [STATUS['DECLINED'], STATUS['PENDING'], STATUS['MERGED'], STATUS['CLAIMED']],
+        'all': [
+            STATUS['DECLINED'],
+            STATUS['PENDING'],
+            STATUS['MERGED'],
+            STATUS['CLAIMED'],
+        ],
         'open': [STATUS['PENDING'], STATUS['CLAIMED']],
         'closed': [STATUS['DECLINED'], STATUS['MERGED']],
     }
 
     @classmethod
-    def get_requests(cls, limit: int = 50, page: int = 1, mode: str = 'all', order: str = None, **kwargs):
+    def get_requests(
+        cls,
+        limit: int = 50,
+        page: int = 1,
+        mode: str = 'all',
+        order: str = None,
+        **kwargs,
+    ):
         oldb = db.get_db()
         wheres = []
         if kwargs.get("status"):
@@ -70,16 +84,14 @@ class CommunityEditsQueue:
         statuses = cls.MODES[mode]
 
         data = {}
-        status_wheres = []
         if mode != 'all':  # No need to add every status to the WHERE clause
-            for i, status in enumerate(statuses):
-                data[f'status_{i}'] = status
-                status_wheres.append(f'status=$status_{i}')
+            data = {f'status_{i}': status for i, status in enumerate(statuses)}
 
+        status_wheres = [f'status=${status}' for status in data]
         query_kwargs = {
             "limit": limit,
             "offset": limit * (page - 1),
-            "vars": {**kwargs, **data}
+            "vars": {**kwargs, **data},
         }
 
         if wheres:
@@ -95,7 +107,9 @@ class CommunityEditsQueue:
         return oldb.select("community_edits_queue", **query_kwargs)
 
     @classmethod
-    def submit_work_merge_request(cls, work_ids: list[str], submitter: str, comment: str = None):
+    def submit_work_merge_request(
+        cls, work_ids: list[str], submitter: str, comment: str = None
+    ):
         """
         Creates new work merge requests with the given work olids.
 
@@ -124,7 +138,14 @@ class CommunityEditsQueue:
         cls.submit_request(cls, url, submitter=submitter, comment=comment)
 
     @classmethod
-    def submit_request(cls, url: str, submitter: str, reviewer: str = None, status: int = STATUS['PENDING'], comment: str = None):
+    def submit_request(
+        cls,
+        url: str,
+        submitter: str,
+        reviewer: str = None,
+        status: int = STATUS['PENDING'],
+        comment: str = None,
+    ):
         """
         Inserts a new record into the table.
 
@@ -141,11 +162,13 @@ class CommunityEditsQueue:
             reviewer=reviewer,
             url=url,
             status=status,
-            comments=json_comment
+            comments=json_comment,
         )
 
     @classmethod
-    def assign_request(cls, rid: int, reviewer: Optional[str]) -> dict[str, Optional[str]]:
+    def assign_request(
+        cls, rid: int, reviewer: Optional[str]
+    ) -> dict[str, Optional[str]]:
         """Changes assignees to the request with the given ID.
 
         This method only modifies requests that are not closed.
@@ -159,7 +182,7 @@ class CommunityEditsQueue:
             if request['reviewer'] == reviewer:
                 return {
                     'status': 'error',
-                    'error': f'{reviewer} is already assigned to this request'
+                    'error': f'{reviewer} is already assigned to this request',
                 }
             oldb = db.get_db()
 
@@ -167,18 +190,15 @@ class CommunityEditsQueue:
                 "community_edits_queue",
                 where="id=$rid",
                 reviewer=reviewer,
-                status = cls.STATUS['CLAIMED'],
+                status=cls.STATUS['CLAIMED'],
                 updated=datetime.datetime.utcnow(),
-                vars={"rid": rid}
+                vars={"rid": rid},
             )
             return {
                 'reviewer': reviewer,
                 'newStatus': get_status_for_view(cls.STATUS['CLAIMED']),
             }
-        return {
-            'status': 'error',
-            'error': 'This request has already been closed'
-        }
+        return {'status': 'error', 'error': 'This request has already been closed'}
 
     @classmethod
     def unassign_request(cls, rid: int):
@@ -196,7 +216,9 @@ class CommunityEditsQueue:
         )
 
     @classmethod
-    def update_request_status(cls, rid: int, status: int, reviewer: str, comment: str = None) -> int:
+    def update_request_status(
+        cls, rid: int, status: int, reviewer: str, comment: str = None
+    ) -> int:
         """
         Changes the status of the request with the given rid.
 
@@ -235,7 +257,7 @@ class CommunityEditsQueue:
             where="id=$rid",
             comments=json.dumps(comments),
             updated=datetime.datetime.utcnow(),
-            vars={"rid": rid}
+            vars={"rid": rid},
         )
 
     @classmethod

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -101,7 +101,7 @@ class merge_work(delegate.page):
     path = "/works/merge"
 
     def GET(self):
-        i = web.input(records='', comment=None, mrid=None)
+        i = web.input(records='', mrid=None)
         user = web.ctx.site.get_user()
         has_access = user and (
             (user.is_admin() or user.is_librarian())

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -23,7 +23,6 @@ class community_edits_queue(delegate.page):
     path = '/merges'
 
     def POST(self):
-
         def response(status='ok', **kwargs):
             return {'status': status, **kwargs}
 
@@ -32,7 +31,7 @@ class community_edits_queue(delegate.page):
             rtype="merge-works",
             mrid=None,
             action=None,  # create, approve, decline, comment, unassign
-            comment=None
+            comment=None,
         )
         user = accounts.get_current_user()
         username = user['key'].split('/')[-1]
@@ -40,12 +39,22 @@ class community_edits_queue(delegate.page):
             if i.action == 'comment':
                 if i.comment:
                     CommunityEditsQueue.comment_request(i.mrid, username, i.comment)
-                    return delegate.RawText(json.dumps(response()), content_type="application/json")
+                    return delegate.RawText(
+                        json.dumps(response()), content_type="application/json"
+                    )
                 else:
-                    return delegate.RawText(json.dumps(response(status='error', error='No comment sent in request.')))
+                    return delegate.RawText(
+                        json.dumps(
+                            response(
+                                status='error', error='No comment sent in request.'
+                            )
+                        )
+                    )
             elif i.action == 'claim':
-                    result = CommunityEditsQueue.assign_request(i.mrid, username)
-                    return delegate.RawText(json.dumps(response(**result)), content_type="application/json")
+                result = CommunityEditsQueue.assign_request(i.mrid, username)
+                return delegate.RawText(
+                    json.dumps(response(**result)), content_type="application/json"
+                )
             elif i.action == 'unassign':
                 CommunityEditsQueue.unassign_request(i.mrid)
                 status = get_status_for_view(CommunityEditsQueue.STATUS['PENDING'])
@@ -55,13 +64,26 @@ class community_edits_queue(delegate.page):
                     status = CommunityEditsQueue.STATUS['DECLINED']
                 elif i.action == 'approve':
                     status = CommunityEditsQueue.STATUS['MERGED']
-                CommunityEditsQueue.update_request_status(i.mrid, status, username, comment=i.comment)
-                return delegate.RawText(json.dumps(response()), content_type="application/json")
+                CommunityEditsQueue.update_request_status(
+                    i.mrid, status, username, comment=i.comment
+                )
+                return delegate.RawText(
+                    json.dumps(response()), content_type="application/json"
+                )
         elif i.rtype == "merge-works":
             if i.action == 'create':
                 result = create_request(i.work_ids, username, i.comment)
-                resp = response(id=result) if result else response(status='error', error='A request to merge these works has already been submitted.')
-                return delegate.RawText(json.dumps(resp), content_type="application/json")
+                resp = (
+                    response(id=result)
+                    if result
+                    else response(
+                        status='error',
+                        error='A request to merge these works has already been submitted.',
+                    )
+                )
+                return delegate.RawText(
+                    json.dumps(resp), content_type="application/json"
+                )
 
     def GET(self):
         i = web.input(page=1, open='true', closed='false', submitter=None)
@@ -69,14 +91,22 @@ class community_edits_queue(delegate.page):
         show_opened = i.open == 'true'
         show_closed = i.closed == 'true'
 
-        mode = 'open' if show_opened and not show_closed else (
-            'closed' if not show_opened and show_closed else 'all'
+        mode = (
+            'open'
+            if show_opened and not show_closed
+            else ('closed' if not show_opened and show_closed else 'all')
         )
 
-        merge_requests = CommunityEditsQueue.get_requests(page=i.page, mode=mode, submitter=i.submitter, order='created').list()
+        merge_requests = CommunityEditsQueue.get_requests(
+            page=i.page, mode=mode, submitter=i.submitter, order='created'
+        ).list()
         enriched_requests = self.enrich(merge_requests)
 
-        return render_template('merge_queue/merge_queue', merge_requests=enriched_requests, submitter=i.submitter)
+        return render_template(
+            'merge_queue/merge_queue',
+            merge_requests=enriched_requests,
+            submitter=i.submitter,
+        )
 
     def enrich(self, merge_requests):
         results = []

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -31,7 +31,7 @@ class community_edits_queue(delegate.page):
             work_ids="",  # Comma-separated OLIDs (OL1W,OL2W,OL3W,...,OL111W)
             rtype="merge-works",
             mrid=None,
-            action=None,  # create, approve, decline, comment
+            action=None,  # create, approve, decline, comment, unassign
             comment=None
         )
         user = accounts.get_current_user()
@@ -64,15 +64,13 @@ class community_edits_queue(delegate.page):
                 return delegate.RawText(json.dumps(resp), content_type="application/json")
 
     def GET(self):
-        i = web.input(page=1, open='true', closed='false', claimed='false', submitter=None)
+        i = web.input(page=1, open='true', closed='false', submitter=None)
 
         show_opened = i.open == 'true'
         show_closed = i.closed == 'true'
-        show_claimed = i.claimed == 'true'
 
-        mode = 'all' if show_opened and show_closed and show_claimed else (
-            'claimed' if show_claimed else
-            'open' if show_opened and not show_closed else 'closed'
+        mode = 'open' if show_opened and not show_closed else (
+            'closed' if not show_opened and show_closed else 'all'
         )
 
         merge_requests = CommunityEditsQueue.get_requests(page=i.page, mode=mode, submitter=i.submitter, order='created').list()

--- a/openlibrary/templates/merge_queue/comment.html
+++ b/openlibrary/templates/merge_queue/comment.html
@@ -1,5 +1,18 @@
 $def with(comment=None, comment_str=None)
 
+$# Creates a single comment element for the librarian merge requests table.
+$#
+$# This template excepts comments in either object (`comment`) or string (`comment_str`) form.
+$# If a string is passed, it is assumed that the comment was submitted just now, and that the
+$# commenter is the currently logged-in patron.
+$#
+$# Parameters:
+$# comment : dict : Object that represents a single comment on a merge request.
+$#   comment['message'] : str : The comment
+$#   comment['username'] : str : Username of patron who left the comment
+$#   comment['timestamp'] : datetime : Timestamp of this comment
+$# comment_str : str : The comment
+
 $if comment_str:
   $ comment_time = _('Just now')
   $ commenter = ctx.user and ctx.user.key.split('/')[-1]

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -5,7 +5,6 @@ $ can_merge = ctx.user and (ctx.user.is_usergroup_member('/usergroup/librarian-w
 
 $ show_open = query_param('open', True) in [True, 'true']
 $ show_closed = query_param('closed', False) in [True, 'true']
-$ show_claimed = query_param('claimed', False) in [True, 'true']
 
 $if submitter:
   $ desc = _("Showing %(username)s's requests only.", username=submitter)
@@ -24,10 +23,9 @@ $else:
   </div>
 
   <ul class="nav-bar">
-    <li class="$('selected' if show_open and not (show_closed or show_claimed) else '')"><a href="/merges$('?submitter=%s' % submitter if submitter else '')">$_('Open')</a></li>
-    <li class="$('selected' if show_claimed and not show_closed else '')"><a href="/merges?claimed=true$('&submitter=%s' % submitter if submitter else '')">$_('Claimed')</a></li>
+    <li class="$('selected' if show_open and not show_closed else '')"><a href="/merges$('?submitter=%s' % submitter if submitter else '')">$_('Open')</a></li>
     <li class="$('selected' if show_closed and not show_open else '')"><a href="/merges?closed=true&open=false$('&submitter=%s' % submitter if submitter else '')">$_('Closed')</a></li>
-    <li class="$('selected' if show_open and show_closed and show_claimed else '')"><a href="/merges?closed=true&claimed=true$('&submitter=%s' % submitter if submitter else '')">$_('All')</a></li>
+    <li class="$('selected' if show_open and show_closed else '')"><a href="/merges?closed=true$('&submitter=%s' % submitter if submitter else '')">$_('All')</a></li>
   </ul>
 
   <div class="table-wrapper">

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -89,7 +89,7 @@ $else:
             <td>
               $# Status code 1 is "Pending"; 4 is "Claimed"
               $if r['status'] in [1, 4]:
-                $if can_merge:
+                $if can_merge and (r['reviewer'] == None or r['reviewer'] == username):
                   <a class="mr-resolve-link" data-mrid="$r['id']" href="$url" target="_blank">$_('Merge')</a>
                 $elif is_submitter:
                   <a class="mr-close-link" data-mrid="$r['id']" href="javascript:;">$_('Close')</a>

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -80,14 +80,15 @@ $else:
                 </div>
             </td>
             <td id="reviewer-cell-$(r['id'])">
-              $if r['reviewer'] == username:
+              $# Allow unassigning self if status is "Pending" or "Claimed" (status codes 1 and 4, respectively)
+              $if r['reviewer'] and r['reviewer'] == username and (r['status'] in [1, 4]):
                 $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']">&times;</span>
               $else:
                 $r['reviewer']
             </td>
             <td>
               $# Status code 1 is "Pending"; 4 is "Claimed"
-              $if r['status'] == 1 or r['status'] == 4:
+              $if r['status'] in [1, 4]:
                 $if can_merge:
                   <a class="mr-resolve-link" data-mrid="$r['id']" href="$url" target="_blank">$_('Merge')</a>
                 $elif is_submitter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ force-exclude = '''
     | ^/openlibrary/book_providers.py
     | ^/openlibrary/core/bookshelves.py
     | ^/openlibrary/core/db.py
-    | ^/openlibrary/core/edits.py
+    | ^/openlibrary/core/lending.py
     | ^/openlibrary/core/lists/model.py
     | ^/openlibrary/core/observations.py
     | ^/openlibrary/core/vendors.py
@@ -27,7 +27,6 @@ force-exclude = '''
     | ^/openlibrary/plugins/openlibrary/lists.py
     | ^/openlibrary/plugins/upstream/account.py
     | ^/openlibrary/plugins/upstream/covers.py
-    | ^/openlibrary/plugins/upstream/edits.py
     | ^/openlibrary/plugins/upstream/models.py
     | ^/openlibrary/plugins/upstream/mybooks.py
     | ^/openlibrary/plugins/worksearch/code.py


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR addresses review notes from #6665, and also prevents reviewers from unassigning themselves from closed requests via the UI.

The "Claimed" tab has been removed from the merge request table views.  Requests that are claimed are now displayed in the "Open" table.

`openlibrary/core/edits.py` and `openlibrary/plugins/upstream/edits.py` are no longer exempt from code formatting.  Reviewing this PR commit by commit will likely be helpful.

### Technical
<!-- What should be noted about the implementation? -->
The ability to filter results by assignee __is not__ included in this PR.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
