### PR TITLE
psf/black: openlibrary/core/vendors.py

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -405,7 +405,9 @@ def clean_amazon_metadata_for_load(metadata: dict) -> dict:
     return conforming_metadata
 
 
-def create_edition_from_amazon_metadata(id_: str, id_type: str = 'isbn') -> Optional[str]:
+def create_edition_from_amazon_metadata(
+    id_: str, id_type: str = 'isbn'
+) -> Optional[str]:
     """Fetches Amazon metadata by id from Amazon Product Advertising API, attempts to
     create OL edition from metadata, and returns the resulting edition key `/key/OL..M`
     if successful or None otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ force-exclude = '''
     | ^/openlibrary/book_providers.py
     | ^/openlibrary/core/bookshelves.py
     | ^/openlibrary/core/db.py
-    | ^/openlibrary/core/lending.py
     | ^/openlibrary/core/lists/model.py
     | ^/openlibrary/core/observations.py
     | ^/openlibrary/core/vendors.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ force-exclude = '''
     | ^/openlibrary/core/db.py
     | ^/openlibrary/core/lists/model.py
     | ^/openlibrary/core/observations.py
-    | ^/openlibrary/core/vendors.py
     | ^/openlibrary/coverstore/code.py
     | ^/openlibrary/plugins/admin/code.py
     | ^/openlibrary/plugins/openlibrary/api.py


### PR DESCRIPTION
Manual change: Remove two `black --force_exclude` lines from `pyproject.toml`
* `lending.py` was black formatted in #6726 as discussed at https://github.com/internetarchive/openlibrary/pull/6723#pullrequestreview-1034902145
* `vendors.py` that will be modified in #6684