### PR TITLE
fixed q=None case for search nav

### DIFF
--- a/openlibrary/macros/SearchNavigation.html
+++ b/openlibrary/macros/SearchNavigation.html
@@ -9,7 +9,7 @@ $ q = query_param("q")
   </li>
   <li class="$('selected' if ctx.path=='/search/authors' else '')">
     <a data-ol-link-track="SearchNav|SearchAuthors"
-       href="/search/authors?$urlencode(dict(q=q))">$_("Authors")</a>
+       href="/search/authors?q=$(q)">$_("Authors")</a>
   </li>
   <li class="$('selected' if ctx.path=='/search/inside' else '')">
     <a data-ol-link-track="SearchNav|SearchFulltext"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to #6728 and followup of #6688 

Eventually we want to switch to `$urlencode(dict(q=q))` but doing so in the case of author was resulting in `q=None`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
