### PR TITLE
Change class names in merge request comment templates

### DIFF
--- a/openlibrary/templates/merge_queue/comment.html
+++ b/openlibrary/templates/merge_queue/comment.html
@@ -32,10 +32,10 @@ $else:
 
   $ message = comment['message']
 
-<div class="comment">
-  <div class="comment__header">
-    <span class="comment__username $owner">$commenter</span>
-    <span class="comment__timestamp">$comment_time</span>
+<div class="mr-comment">
+  <div class="mr-comment__header">
+    <span class="mr-comment__username $owner">$commenter</span>
+    <span class="mr-comment__timestamp">$comment_time</span>
   </div>
-  <div class="comment__body">$message</div>
+  <div class="mr-comment__body">$message</div>
 </div>

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -42,7 +42,7 @@
   color: @grey;
 }
 
-.comment {
+.mr-comment {
   border: 1px solid @lightest-grey;
   background-color: @white;
   margin: 5px 0;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes merge request (MR) comment component class names to avoid ruining our history table comments' styling. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Ensure that the MR table looks the same as it did before this change.
2. Go to  your profile page and look at the history table.  All cells should be the same color.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
