### PR TITLE
psf/black: core/bookshelves and upstream/account

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -96,7 +96,13 @@ class Bookshelves(db.CommonExtras):
         logger.info("Query: %s", query)
         logged_books = list(
             oldb.query(
-                query, vars={'shelf_id': shelf_id, 'limit': limit, 'offset': offset, 'since': since}
+                query,
+                vars={
+                    'shelf_id': shelf_id,
+                    'limit': limit,
+                    'offset': offset,
+                    'since': since,
+                },
             )
         )
         return cls.fetch(logged_books) if fetch else logged_books
@@ -113,8 +119,7 @@ class Bookshelves(db.CommonExtras):
         # This gives us a dict of all the works representing
         # the logged_books, keyed by work_id
         work_index = get_solr_works(
-            f"/works/OL{i['work_id']}W"
-            for i in readinglog_items
+            f"/works/OL{i['work_id']}W" for i in readinglog_items
         )
 
         # Loop over each work in the index and inject its availability
@@ -221,7 +226,9 @@ class Bookshelves(db.CommonExtras):
         return list(oldb.query(query, vars=data))
 
     @classmethod
-    def get_recently_logged_books(cls, bookshelf_id=None, limit=50, page=1, fetch=False) -> list:
+    def get_recently_logged_books(
+        cls, bookshelf_id=None, limit=50, page=1, fetch=False
+    ) -> list:
         oldb = db.get_db()
         page = int(page or 1)
         data = {

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -367,8 +367,7 @@ class account_login(delegate.page):
     def GET(self):
         referer = web.ctx.env.get('HTTP_REFERER', '')
         # Don't set referer if request is from offsite
-        if ('openlibrary.org' not in referer
-            or referer.endswith('openlibrary.org/')):
+        if 'openlibrary.org' not in referer or referer.endswith('openlibrary.org/'):
             referer = None
         i = web.input(redirect=referer)
         f = forms.Login()
@@ -906,7 +905,7 @@ class export_books(delegate.page):
             return {
                 "work_id": f"OL{booknote['work_id']}W",
                 "edition_id": f"OL{booknote['edition_id']}M",
-                "note":  f'"{escaped_note}"',
+                "note": f'"{escaped_note}"',
                 "created_on": booknote['created'].strftime(self.date_format),
             }
 
@@ -931,20 +930,26 @@ class export_books(delegate.page):
         for list in lists:
             list_id = list.key.split('/')[-1]
             created_on = list.created.strftime(self.date_format)
-            last_updated = list.last_modified.strftime(self.date_format) if list.last_modified else ''
+            last_updated = (
+                list.last_modified.strftime(self.date_format)
+                if list.last_modified
+                else ''
+            )
             for seed in list.seeds:
                 entry = seed
                 if not isinstance(seed, str):
                     entry = seed.key
                 list_name = list.name.replace('"', '""') if list.name else ''
-                list_desc = list.description.replace('"', '""') if list.description else ''
+                list_desc = (
+                    list.description.replace('"', '""') if list.description else ''
+                )
                 row = [
                     list_id,
                     f'"{list_name}"',
                     f'"{list_desc}"',
                     entry,
                     created_on,
-                    last_updated
+                    last_updated,
                 ]
                 csv.append(','.join(row))
 
@@ -995,6 +1000,7 @@ class account_waitlist(delegate.page):
 
     def GET(self):
         raise web.seeother("/account/loans")
+
 
 # Disabling be cause it prevents account_my_books_redirect from working
 # for some reason. The purpose of this class is to not show the "Create" link for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ force-exclude = '''
 (
     ^/openlibrary/accounts/model.py
     | ^/openlibrary/book_providers.py
-    | ^/openlibrary/core/bookshelves.py
     | ^/openlibrary/core/db.py
     | ^/openlibrary/core/lending.py
     | ^/openlibrary/core/lists/model.py
@@ -25,7 +24,6 @@ force-exclude = '''
     | ^/openlibrary/plugins/admin/code.py
     | ^/openlibrary/plugins/openlibrary/api.py
     | ^/openlibrary/plugins/openlibrary/lists.py
-    | ^/openlibrary/plugins/upstream/account.py
     | ^/openlibrary/plugins/upstream/covers.py
     | ^/openlibrary/plugins/upstream/models.py
     | ^/openlibrary/plugins/upstream/mybooks.py


### PR DESCRIPTION
Canonical formatting will make future diffs easier to read thus making pull requests easier to review.
`openlibrary/core/bookshelves.py` will be modified in both #6621
`openlibrary/plugins/upstream/account.py` will be modified in both #6621 and #6653

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
