### PR TITLE
Exception.message was removed in Python 3

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -20,7 +20,6 @@ from openlibrary.plugins.worksearch import subjects
 from openlibrary.coverstore.code import render_list_preview_image
 
 
-
 class lists_home(delegate.page):
     path = "/lists"
 
@@ -175,7 +174,7 @@ class lists_json(delegate.page):
             )
         except client.ClientException as e:
             headers = {"Content-Type": self.get_content_type()}
-            data = {"message": e.message}
+            data = {"message": str(e)}
             raise web.HTTPError(e.status, data=self.dumps(data), headers=headers)
 
         web.header("Content-Type", self.get_content_type())
@@ -427,7 +426,7 @@ class list_subjects_json(delegate.page):
 
 
 # This class is defined twice in this file. Should this be list_subjects_yaml() ?
-class list_editions_yaml(list_subjects_json):    # type: ignore[no-redef]
+class list_editions_yaml(list_subjects_json):  # type: ignore[no-redef]
     encoding = "yml"
     content_type = 'text/yaml; charset="utf-8"'
 
@@ -454,12 +453,22 @@ class export(delegate.page):
 
         if format == "html":
             data = self.get_exports(lst)
-            html = render_template("lists/export_as_html", lst, data["editions"], data["works"], data["authors"])
+            html = render_template(
+                "lists/export_as_html",
+                lst,
+                data["editions"],
+                data["works"],
+                data["authors"],
+            )
             return delegate.RawText(html)
         elif format == "bibtex":
             data = self.get_exports(lst)
             html = render_template(
-                "lists/export_as_bibtex", lst, data["editions"], data["works"], data["authors"]
+                "lists/export_as_bibtex",
+                lst,
+                data["editions"],
+                data["works"],
+                data["authors"],
             )
             return delegate.RawText(html)
         elif format == "json":
@@ -496,7 +505,9 @@ class export(delegate.page):
 
         if not raw:
             if "editions" in export_data:
-                export_data["editions"] = [self.make_doc(e) for e in export_data["editions"]]
+                export_data["editions"] = [
+                    self.make_doc(e) for e in export_data["editions"]
+                ]
                 lst.preload_authors(export_data["editions"])
             else:
                 export_data["editions"] = []
@@ -506,7 +517,9 @@ class export(delegate.page):
             else:
                 export_data["works"] = []
             if "authors" in export_data:
-                export_data["authors"] = [self.make_doc(e) for e in export_data["authors"]]
+                export_data["authors"] = [
+                    self.make_doc(e) for e in export_data["authors"]
+                ]
                 lst.preload_authors(export_data["authors"])
             else:
                 export_data["authors"] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,13 @@ skip-string-normalization = true
 target-version = ['py39', 'py310']
 force-exclude = '''
 (
-    ^/openlibrary/accounts/model.py
-    | ^/openlibrary/book_providers.py
+    ^/openlibrary/book_providers.py
     | ^/openlibrary/core/db.py
     | ^/openlibrary/core/lists/model.py
     | ^/openlibrary/core/observations.py
     | ^/openlibrary/coverstore/code.py
     | ^/openlibrary/plugins/admin/code.py
     | ^/openlibrary/plugins/openlibrary/api.py
-    | ^/openlibrary/plugins/openlibrary/lists.py
     | ^/openlibrary/plugins/upstream/covers.py
     | ^/openlibrary/plugins/upstream/models.py
     | ^/openlibrary/plugins/upstream/mybooks.py

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -97,7 +97,7 @@ def main(config, start, end):
             count = count_unique_ips_for_day(current)
             store_data(dict(visitors=count), current)
         except IndexError as e:
-            print(e.message)
+            print(repr(e))
         current += timedelta(days=1)
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Python 2 `e.message` becomes `str(e)` in Python 3 as discussed at
* https://docs.python.org/3/whatsnew/3.0.html#changes-to-exceptions and
* https://portingguide.readthedocs.io/en/latest/exceptions.html#iterating-exceptions
```python
>>> e = ValueError("gigo")
>>> e
ValueError('gigo')
>>> e.message  # This used to work in Python 2 but does not Python 3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'ValueError' object has no attribute 'message'
>>> repr(e)
"ValueError('gigo')"
>>> str(e)
'gigo'
>>> e.args[-1]
'gigo'
```
Changes unrelated to `e.message` are automatically made by [`pre-commit`](https://results.pre-commit.ci/repo/github/69609)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
