### PR TITLE
Refactors Librarian Merge Queue

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -18,8 +18,6 @@ def get_status_for_view(status_code: int) -> str:
         return _('Pending')
     if status_code == CommunityEditsQueue.STATUS['MERGED']:
         return _('Merged')
-    if status_code == CommunityEditsQueue.STATUS['CLAIMED']:
-        return _('Claimed')
     return _('Unknown')
 
 
@@ -40,17 +38,11 @@ class CommunityEditsQueue:
         'DECLINED': 0,
         'PENDING': 1,
         'MERGED': 2,
-        'CLAIMED': 4,
     }
 
     MODES = {
-        'all': [
-            STATUS['DECLINED'],
-            STATUS['PENDING'],
-            STATUS['MERGED'],
-            STATUS['CLAIMED'],
-        ],
-        'open': [STATUS['PENDING'], STATUS['CLAIMED']],
+        'all': [STATUS['DECLINED'], STATUS['PENDING'], STATUS['MERGED']],
+        'open': [STATUS['PENDING']],
         'closed': [STATUS['DECLINED'], STATUS['MERGED']],
     }
 
@@ -67,13 +59,18 @@ class CommunityEditsQueue:
         wheres = []
         if kwargs.get("status"):
             wheres.append("status=$status")
-        if "reviewer" in kwargs:
-            wheres.append("reviewer='$reviewer'")
+        if kwargs.get('reviewer') is not None:
+            wheres.append(
+                # if reviewer="" then get all unassigned MRs
+                "reviewer IS NULL" if not kwargs.get('reviewer')
+                else "reviewer=$reviewer"
+            )
         if "submitter" in kwargs:
-            if kwargs.get("submitter") is None:
-                wheres.append("submitter IS NOT NULL")
-            else:
-                wheres.append("submitter=$submitter")
+            wheres.append(
+                # If submitter not specified, default to any
+                "submitter IS NOT NULL" if kwargs.get("submitter") is None
+                else "submitter=$submitter"
+            )
         if "url" in kwargs:
             wheres.append("url=$url")
         if "id" in kwargs:
@@ -190,13 +187,13 @@ class CommunityEditsQueue:
                 "community_edits_queue",
                 where="id=$rid",
                 reviewer=reviewer,
-                status=cls.STATUS['CLAIMED'],
+                status=cls.STATUS['PENDING'],
                 updated=datetime.datetime.utcnow(),
                 vars={"rid": rid},
             )
             return {
                 'reviewer': reviewer,
-                'newStatus': get_status_for_view(cls.STATUS['CLAIMED']),
+                'newStatus': get_status_for_view(cls.STATUS['PENDING']),
             }
         return {'status': 'error', 'error': 'This request has already been closed'}
 

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -62,13 +62,15 @@ class CommunityEditsQueue:
         if kwargs.get('reviewer') is not None:
             wheres.append(
                 # if reviewer="" then get all unassigned MRs
-                "reviewer IS NULL" if not kwargs.get('reviewer')
+                "reviewer IS NULL"
+                if not kwargs.get('reviewer')
                 else "reviewer=$reviewer"
             )
         if "submitter" in kwargs:
             wheres.append(
                 # If submitter not specified, default to any
-                "submitter IS NOT NULL" if kwargs.get("submitter") is None
+                "submitter IS NOT NULL"
+                if kwargs.get("submitter") is None
                 else "submitter=$submitter"
             )
         if "url" in kwargs:

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -86,27 +86,15 @@ class community_edits_queue(delegate.page):
                 )
 
     def GET(self):
-        i = web.input(page=1, open='true', closed='false', submitter=None)
-
-        show_opened = i.open == 'true'
-        show_closed = i.closed == 'true'
-
-        mode = (
-            'open'
-            if show_opened and not show_closed
-            else ('closed' if not show_opened and show_closed else 'all')
-        )
-
+        i = web.input(page=1, mode="open", submitter=None, reviewer=None)
         merge_requests = CommunityEditsQueue.get_requests(
-            page=i.page, mode=mode, submitter=i.submitter, order='created'
-        ).list()
-        enriched_requests = self.enrich(merge_requests)
-
-        return render_template(
-            'merge_queue/merge_queue',
-            merge_requests=enriched_requests,
+            page=i.page,
+            mode=i.mode,
             submitter=i.submitter,
-        )
+            reviewer=i.reviewer,
+            order='created').list()
+        enriched_requests = self.enrich(merge_requests)
+        return render_template('merge_queue/merge_queue', merge_requests=enriched_requests)
 
     def enrich(self, merge_requests):
         results = []

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -92,9 +92,12 @@ class community_edits_queue(delegate.page):
             mode=i.mode,
             submitter=i.submitter,
             reviewer=i.reviewer,
-            order='created').list()
+            order='created',
+        ).list()
         enriched_requests = self.enrich(merge_requests)
-        return render_template('merge_queue/merge_queue', merge_requests=enriched_requests)
+        return render_template(
+            'merge_queue/merge_queue', merge_requests=enriched_requests
+        )
 
     def enrich(self, merge_requests):
         results = []

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -1,10 +1,11 @@
-$def with(merge_requests=None, submitter=None)
+$def with(merge_requests=None)
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ can_merge = ctx.user and (ctx.user.is_usergroup_member('/usergroup/librarian-work-merge'))
 
-$ show_open = query_param('open', True) in [True, 'true']
-$ show_closed = query_param('closed', False) in [True, 'true']
+$ reviewer = query_param('reviewer', None)
+$ submitter = query_param('submitter', None)
+$ mode = query_param('mode', 'open')
 
 $if submitter:
   $ desc = _("Showing %(username)s's requests only.", username=submitter)
@@ -23,13 +24,18 @@ $else:
   </div>
 
   <ul class="nav-bar">
-    <li class="$('selected' if show_open and not show_closed else '')"><a href="/merges$('?submitter=%s' % submitter if submitter else '')">$_('Open')</a></li>
-    <li class="$('selected' if show_closed and not show_open else '')"><a href="/merges?closed=true&open=false$('&submitter=%s' % submitter if submitter else '')">$_('Closed')</a></li>
-    <li class="$('selected' if show_open and show_closed else '')"><a href="/merges?closed=true$('&submitter=%s' % submitter if submitter else '')">$_('All')</a></li>
+    <li class="$(mode=='open' and 'selected' or '')">
+      <a href="$changequery(mode='open')">$_('Open')</a>
+    </li>
+    <li class="$(mode=='closed' and 'selected' or '')">
+      <a href="$changequery(mode='closed')">$_('Closed')</a>
+    </li>
+    <li class="$(mode=='all' and 'selected' or '')">
+      <a href="$changequery(mode='all')">$_('All')</a>
+    </li>
   </ul>
 
   <div class="table-wrapper">
-    $if merge_requests:
       <table class="mr-table">
         <thead>
           <tr>
@@ -43,8 +49,9 @@ $else:
         <tbody>
         $for r in merge_requests:
           $ work_title = r.get('title', 'an untitled work')
-          $ comments = r['comments']
+          $ comments = r.get('comments', [])
           $ status = get_status_for_view(r['status'])
+          $ is_open = r['status'] == 1
           $ url = "%s&mrid=%s" % (r['url'], r['id'])
           $ is_submitter = username == r['submitter']
           <tr id="mrid-$(r['id'])">
@@ -80,24 +87,22 @@ $else:
                 </div>
             </td>
             <td id="reviewer-cell-$(r['id'])">
-              $# Allow unassigning self if status is "Pending" or "Claimed" (status codes 1 and 4, respectively)
-              $if r['reviewer'] and r['reviewer'] == username and (r['status'] in [1, 4]):
+              $if can_merge and is_open and r.get('reviewer') == username:
                 $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']">&times;</span>
-              $else:
+              $elif r.get('reviewer'):
                 $r['reviewer']
             </td>
             <td>
-              $# Status code 1 is "Pending"; 4 is "Claimed"
-              $if r['status'] in [1, 4]:
-                $if can_merge and (r['reviewer'] == None or r['reviewer'] == username):
+              $if can_merge and is_open:
+                $if (not r.get('reviewer') or r.get('reviewer') == username):
                   <a class="mr-resolve-link" data-mrid="$r['id']" href="$url" target="_blank">$_('Merge')</a>
                 $elif is_submitter:
                   <a class="mr-close-link" data-mrid="$r['id']" href="javascript:;">$_('Close')</a>
             </td>
           </tr>
+          $if not merge_requests:
+            <p>$_('No entries here!')</p>
         </tbody>
       </table>
-    $else:
-      <p>$_('No entries here!')</p>
   </div>
 </div>


### PR DESCRIPTION
- Removes CLAIMED mode
- Standardizes `mode` selection in UI
- Adds filtering for reviewer / assignee

Shouldn't affect the UI but does allow `reviewer=` to be added to the URL

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
