### PR TITLE
Fix waitlist CTA button styling

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -99,7 +99,9 @@ $elif availability.get('is_lendable'):
       $ wlsize = availability.get('users_on_waitlist') or availability.get('num_waitlist')
       <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
         <input type="hidden" name="action" value="join-waitinglist"/>
-        <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
+        <div class="cta-button-group">
+          <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
+        </div>
       </form>
       $if secondary_action:
         <p class="waitinglist-message">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the size of waitlist CTA buttons in carousels and edition tables.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
![waitlist-edition-table-after](https://user-images.githubusercontent.com/28732543/179035477-00278c92-1165-48f1-b10c-2bccd1e5f0cc.png)
![Screenshot from 2022-07-14 12-45-38](https://user-images.githubusercontent.com/28732543/179035519-01d10444-de0d-455f-b583-aab3969491a6.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
