### PR TITLE
Add workflow that removes "On testing" labels

### DIFF
--- a/.github/workflows/remove_labels.yml
+++ b/.github/workflows/remove_labels.yml
@@ -1,0 +1,12 @@
+name: remove_labels
+on:
+  pull_request:
+    types: [synchronize]
+jobs:
+  remove_on_testing_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr edit $PR_NUM --remove-label "On testing.openlibrary.org","On ol-mek (http://ol-dev1.us.archive.org:1337)","On ol-jchamp" --repo $GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the following labels from a PR when new code is pushed:
`On testing.openlibrary.org`
`On ol-mek (http://ol-dev1.us.archive.org:1337)`
`On ol-jchamp`

__Edit:__ It may not make sense to remove `On ol-mek (http://ol-dev1.us.archive.org:1337)` with this workflow. @mekarpeles to confirm.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
