### PR TITLE
Add analytics to book page navbar items

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -4,25 +4,25 @@ $ total_reviews = reader_observations.get('total_respondents', '')
 
 <ul class="work-menu sticky">
   <li class="selected">
-    <a href="#edition-overview">$_("Overview")</a>
+    <a href="#edition-overview" data-ol-link-track="BookPageNav|Overview">$_("Overview")</a>
   </li>
   <li>
-    <a href="#editions-list">
+    <a href="#editions-list" data-ol-link-track="BookPageNav|EditionTable">
       $ungettext('View %(count)s Edition', 'View %(count)s Editions', edition_count, count=edition_count)
     </a>
   </li>
   <li>
-    <a href="#details">$_("Details")</a>
+    <a href="#details" data-ol-link-track="BookPageNav|Details">$_("Details")</a>
   </li>
   <li>
-    <a href="#reader-observations">
+    <a href="#reader-observations" data-ol-link-track="BookPageNav|Reviews">
       $ungettext('%(reviews)s Review', '%(reviews)s Reviews', total_reviews, reviews=total_reviews)
     </a>
   </li>
   <li>
-    <a href="#lists-section">$_("Lists")</a>
+    <a href="#lists-section" data-ol-link-track="BookPageNav|Lists">$_("Lists")</a>
   </li>
   <li>
-    <a href="#related-work-carousel">$_("Related Books")</a>
+    <a href="#related-work-carousel" data-ol-link-track="BookPageNav|RelatedBooks">$_("Related Books")</a>
   </li>
 </ul>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6437

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds Google Analytics to our book page navbar.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
