### PR TITLE
psf/black: openlibrary/book_providers.py

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -41,10 +41,9 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
     identifier_key: str
 
     def get_olids(self, identifier):
-        return web.ctx.site.things({
-            "type": "/type/edition",
-            self.db_selector: identifier
-        })
+        return web.ctx.site.things(
+            {"type": "/type/edition", self.db_selector: identifier}
+        )
 
     @property
     def editions_query(self):
@@ -333,35 +332,34 @@ def get_book_providers(
 
 
 def get_book_provider(
-        ed_or_solr: Union[Edition, dict]
+    ed_or_solr: Union[Edition, dict]
 ) -> Optional[AbstractBookProvider]:
     return next(get_book_providers(ed_or_solr), None)
 
 
 def get_best_edition(
-        editions: list[Edition]
+    editions: list[Edition],
 ) -> tuple[Optional[Edition], Optional[AbstractBookProvider]]:
     provider_order = get_provider_order(True)
 
     # Map provider name to position/ranking
     provider_rank_lookup: dict[Optional[AbstractBookProvider], int] = {
-        provider: i
-        for i, provider in enumerate(provider_order)
+        provider: i for i, provider in enumerate(provider_order)
     }
 
     # Here, we prefer the ia editions
-    augmented_editions = [
-        (edition, get_book_provider(edition))
-        for edition in editions
-    ]
+    augmented_editions = [(edition, get_book_provider(edition)) for edition in editions]
 
-    best = multisort_best(augmented_editions, [
-        # Prefer the providers closest to the top of the list
-        ('min', lambda rec: provider_rank_lookup.get(rec[1], float('inf'))),
-        # Prefer the editions with the most fields
-        ('max', lambda rec: len(dict(rec[0]))),
-        # TODO: Language would go in this queue somewhere
-    ])
+    best = multisort_best(
+        augmented_editions,
+        [
+            # Prefer the providers closest to the top of the list
+            ('min', lambda rec: provider_rank_lookup.get(rec[1], float('inf'))),
+            # Prefer the editions with the most fields
+            ('max', lambda rec: len(dict(rec[0]))),
+            # TODO: Language would go in this queue somewhere
+        ],
+    )
 
     return best if best else (None, None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ skip-string-normalization = true
 target-version = ['py39', 'py310']
 force-exclude = '''
 (
-    ^/openlibrary/book_providers.py
-    | ^/openlibrary/core/db.py
+    ^/openlibrary/core/db.py
     | ^/openlibrary/core/lists/model.py
     | ^/openlibrary/core/observations.py
     | ^/openlibrary/coverstore/code.py


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Canonical formatting will make future diffs easier to read thus making pull requests easier to review.
[Commits:](https://github.com/internetarchive/openlibrary/pull/6747/commits)
1. Remove one `black --force-exclude` line from `pyproject.toml`.
2. (Done by pre-commit.ci) Use black to format the corresponding file.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
