### PR TITLE
cron_watcher: actions/setup-python@v4 needs python-version

### DIFF
--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - run: pip install internetarchive slack-sdk
       - shell: python
         env:


### PR DESCRIPTION
```
actions/setup-python@v4
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied.
Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.
```
https://github.com/actions/setup-python/releases

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
