### PR TITLE
Avoid duplicate list widget items in showcase on `/subjects` pages

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -58,7 +58,7 @@ $if isbn_10 and not asin:
         $ edition = page.works and page
 
         $ render_times['databarWork: List widget'] = time()
-        $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False, user_lists_only=False)
+        $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False)
         $ render_times['databarWork: List widget'] = time() - render_times['databarWork: List widget']
 
         $# For the Works & Editions page, only use ground_truth_availability API for selected Edition

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -1,4 +1,4 @@
-$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, user_lists_only=False, read_status=None, _user_lists=None, exclude_own_lists=False)
+$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, read_status=None, _user_lists=None, exclude_own_lists=False)
 
 $ edition = page if page.key.startswith("/books/") else None
 $ work = (page.works and page.works[0]) if page.key.startswith("/books/") else page if page.key.startswith("/works/") else None
@@ -58,15 +58,11 @@ $code:
         return [get_list_data(list, seed_info['seed'], include_cover_url=True) for list in _user_lists]
 
     def get_page_lists(page, seed_info):
-        user_key = ctx.user and ctx.user.key
         return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
 
 $ seed_info = get_seed_info(page)
 $ user_lists = get_user_lists(seed_info)
-$if user_lists_only:
-    $ page_lists = [list for list in user_lists if list.active]
-$else:
-    $ page_lists = get_page_lists(page, seed_info)
+$ page_lists = get_page_lists(page, seed_info)
 $ user_key = ctx.user and ctx.user.key
 $ page_url = page.url()
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -1,4 +1,4 @@
-$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, user_lists_only=False, read_status=None, _user_lists=None)
+$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, user_lists_only=False, read_status=None, _user_lists=None, exclude_own_lists=False)
 
 $ edition = page if page.key.startswith("/books/") else None
 $ work = (page.works and page.works[0]) if page.key.startswith("/books/") else page if page.key.startswith("/works/") else None
@@ -105,10 +105,19 @@ $def render_already_lists(lists, user_key):
         $if list['active']:
             $:show_list(list, user_key)
 
-$def render_widget_display(lists, limit, user_key):
+$def render_widget_display(lists, limit, user_key, exclude_own_lists):
+    $ count = 0
     $for i, list in enumerate(lists):
-        $if i < limit:
-            $:show_list(list, user_key)
+        $if count < limit:
+            $if exclude_own_lists:
+                $if user_key != list.owner.key:
+                    $:show_list(list, user_key)
+                    $ count = count + 1
+            $else:
+                $:show_list(list, user_key)
+                $ count = count + 1
+        $else:
+            break
 
 $def render_head(seed_type, page_lists, page_url):
     $if seed_type == "subject":
@@ -160,7 +169,7 @@ $if include_showcase:
   $if render_once('lists/widget.i18n-strings'):
     $i18n_input()
   <ul id="list-lists" class="listLists">
-    $:render_widget_display(page_lists, 3, user_key)
+    $:render_widget_display(page_lists, 3, user_key, exclude_own_lists)
   </ul>
 
 $if render_once('lists/widget.remove-dialog'):

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -110,7 +110,7 @@ $jsdef renderPublishers(publishers):
 $if "lists" in ctx.features:
     <div class="spacer"></div>
     <div id="subjectLists" class="widget-box">
-        $:render_template("lists/widget", page, include_rating=False)
+        $:render_template("lists/widget", page, include_rating=False, exclude_own_lists=True)
     </div>
 
 <div class="section clearfix"></div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6740

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents lists from being displayed twice in `/subjects` pages list widget showcases.  Also, cleans up unused code in the list widget.

__Note:__ Assigned to myself as a reminder to deploy to testing on Monday.

### Technical
<!-- What should be noted about the implementation? -->
On subjects pages, two sets of list previews are displayed in the list widget: the owner's lists and a showcase of up to three lists that the subject appears in.  Both use different functions to populate the preview elements (this could probably be DRYed).  The function that populates the showcase now accepts a boolean that will exclude the patron's lists from the showcase.

The whole of the final commit cleans up code unrelated to this functionality.  If those changes are undesirable for any reason, we can easily revert it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Navigate to a `/subjects` page and add the subject to a list.  The UI should update with a single entry for that list.  This is BAU.
2. Refresh the page and ensure that there are no duplicates listed in the widget.
3. Confirm that list widgets are working properly in search and book pages.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
