### PR TITLE
Remove "break" statement from list widget

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -112,8 +112,6 @@ $def render_widget_display(lists, limit, user_key, exclude_own_lists):
             $else:
                 $:show_list(list, user_key)
                 $ count = count + 1
-        $else:
-            break
 
 $def render_head(seed_type, page_lists, page_url):
     $if seed_type == "subject":


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removed "break" statement from template, due to it rendering "break" in the UI.

![Screenshot from 2022-07-18 12-34-51](https://user-images.githubusercontent.com/28732543/179560173-78553a8a-de1c-4ad6-9155-851f3d0aed87.png)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
