### PR TITLE
Don't fetch facets in /search.json requests

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -205,7 +205,7 @@ export class SearchBar {
     static composeSearchUrl(facetEndpoint, q, json=false, limit=null, fields=null) {
         let url = facetEndpoint;
         if (json) {
-            url += `.json?q=${q}&_facet=false&_spellcheck_count=0`;
+            url += `.json?q=${q}&_spellcheck_count=0`;
         } else {
             url += `?q=${q}`;
         }

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -1263,7 +1263,6 @@ class search_json(delegate.page):
             page = safeint(query.pop("page", "1"), default=1)
 
         fields = query.pop('fields', '*').split(',')
-        facet = query.pop('_facet', 'true').lower() in ['true']
         spellcheck_count = safeint(
             query.pop("_spellcheck_count", default_spellcheck_count),
             default=default_spellcheck_count,
@@ -1279,7 +1278,9 @@ class search_json(delegate.page):
             offset=offset,
             limit=limit,
             fields=fields,
-            facet=facet,
+            # We do not support returning facets from /search.json,
+            # so disable it. This makes it much faster.
+            facet=False,
             spellcheck_count=spellcheck_count,
         )
         response['q'] = q

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -5,7 +5,7 @@
     <Image height="16" width="16" type="image/x-icon">https://openlibrary.org/favicon.ico</Image>
     <Image height="64" width="64" type="image/png">https://openlibrary.org/static/images/openlibrary-128x128.png</Image>
     <Url type="text/html" template="https://openlibrary.org/search?q={searchTerms}&amp;mode=everything"/>
-	<Url type="application/x-suggestions+json" method="get" template="https://openlibrary.org/search.json?q={searchTerms}&amp;_facet=false&amp;_spellcheck_count=0&amp;limit=10&amp;fields=title&amp;mode=everything" />
+	<Url type="application/x-suggestions+json" method="get" template="https://openlibrary.org/search.json?q={searchTerms}&amp;_spellcheck_count=0&amp;limit=10&amp;fields=title&amp;mode=everything" />
     <Url type="application/opensearchdescription+xml" rel="self" template="https://openlibrary.org/opensearch.xml" />
     <Query role="example" searchTerms="Cory Doctorow"/>
     <InputEncoding>UTF-8</InputEncoding>


### PR DESCRIPTION
Facets aren't returned in the response, and make the requests quite slow!

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
Facets are extra data added to a solr query including various group counts. E.g. for a solr query `harry potter`, with facets enabled we would get how many of those books are ebooks, how many are in each language, mention a certain author, etc. This is what powers the numbers in the side bar on the search page.

However we've never exposed this data in our `/search.json` response, but we are fetching it! This data is expensive to calculate. In the past, a GET arg was added, `_facet=true/false` that defaulted to `true`. The thinking back then was that facets were fetched by default, and we didn't want to make a breaking change. We didn't realize that the fetched facets were never even included in the response! So we remove that argument as well.

This will have a general speed boost to any user of the `/search.json` API. It also means we can now make queries for larger query sets which previously caused the endpoint to timeout. Impacts will also be felt on Library Explorer, since it makes a lot of `/search.json` requests.

### Testing
- Compare
    - http://testing.openlibrary.org/search.json?q=first_publish_year:[1980%20TO%20*]&mode=everything&limit=0
        - Returns a response
    - http://openlibrary.org/search.json?q=first_publish_year:[1980%20TO%20*]&mode=everything&limit=0
        - Times out!
- Library Explorer also faster

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
