### PR TITLE
Change usergroup for author merge tool

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -65,7 +65,7 @@ features:
     lists: enabled
     merge-authors:
         filter: usergroup
-        usergroup: /usergroup/librarians
+        usergroup: /usergroup/librarian-work-merge
     merge-editions: admin
     publishers: enabled
     recentchanges_v2: enabled


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes usergroup that is permitted to use the author merge tool from `/usergroup/librarians` to `/usergroup/librarian-work-merge`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
