### PR TITLE
fixing revert + block flow

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -441,9 +441,7 @@ class ipaddress_view:
             for cid in changeset_ids
             for c in site.get_change(cid).changes
         ]
-        docs = [
-            doc for doc in docs if doc.get('type', {}).get('key') != '/type/delete'
-        ]
+        docs = [doc for doc in docs if doc.get('type', {}).get('key') != '/type/delete']
         logger.debug("Reverting %d docs", len(docs))
         data = {"reverted_changesets": [str(cid) for cid in changeset_ids]}
         manifest = web.ctx.site.save_many(

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -301,14 +301,16 @@ class people_view:
         edits = 0
         stop = False
         while not stop:
-            changes = account.get_recentchanges(limit=100, offset=100*i)
+            changes = account.get_recentchanges(limit=100, offset=100 * i)
             changeset_ids = [c.id for c in changes]
             _, len_docs = ipaddress_view().revert(changeset_ids, "Reverted Spam")
             edits += len_docs
             i += 1
             if len(changes) < 100:
                 stop = True
-        add_flash_message("info", f"Blocked the account and reverted all {edits} edits.")
+        add_flash_message(
+            "info", f"Blocked the account and reverted all {edits} edits."
+        )
         raise web.seeother(web.ctx.path)
 
     def POST_unblock_account(self, account):
@@ -439,10 +441,14 @@ class ipaddress_view:
             for cid in changeset_ids
             for c in site.get_change(cid).changes
         ]
-        docs = [doc for doc in docs if doc.get('type', {}).get('key') is not '/type/delete']
+        docs = [
+            doc for doc in docs if doc.get('type', {}).get('key') != '/type/delete'
+        ]
         logger.debug("Reverting %d docs", len(docs))
         data = {"reverted_changesets": [str(cid) for cid in changeset_ids]}
-        manifest = web.ctx.site.save_many(docs, action="revert", data=data, comment=comment)
+        manifest = web.ctx.site.save_many(
+            docs, action="revert", data=data, comment=comment
+        )
         return manifest, len(docs)
 
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -297,10 +297,18 @@ class people_view:
 
     def POST_block_account_and_revert(self, account):
         account.block()
-        changes = account.get_recentchanges(limit=1000)
-        changeset_ids = [c.id for c in changes]
-        ipaddress_view().revert(changeset_ids, "Reverted Spam")
-        add_flash_message("info", "Blocked the account and reverted all edits.")
+        i = 0
+        edits = 0
+        stop = False
+        while not stop:
+            changes = account.get_recentchanges(limit=100, offset=100*i)
+            changeset_ids = [c.id for c in changes]
+            _, len_docs = ipaddress_view().revert(changeset_ids, "Reverted Spam")
+            edits += len_docs
+            i += 1
+            if len(changes) < 100:
+                stop = True
+        add_flash_message("info", f"Blocked the account and reverted all {edits} edits.")
         raise web.seeother(web.ctx.path)
 
     def POST_unblock_account(self, account):
@@ -431,10 +439,11 @@ class ipaddress_view:
             for cid in changeset_ids
             for c in site.get_change(cid).changes
         ]
-
+        docs = [doc for doc in docs if doc.get('type', {}).get('key') is not '/type/delete']
         logger.debug("Reverting %d docs", len(docs))
         data = {"reverted_changesets": [str(cid) for cid in changeset_ids]}
-        return web.ctx.site.save_many(docs, action="revert", data=data, comment=comment)
+        manifest = web.ctx.site.save_many(docs, action="revert", data=data, comment=comment)
+        return manifest, len(docs)
 
 
 class stats:

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -106,7 +106,7 @@ $ has_profile = person.get_user() is not None
 <div id="contentBody">
 
     <div class="status status-$person.status">
-        <form method="POST">
+        <form method="POST" action="?debug=true">
             Status: <span class="status">$person.status</span>
 
         $if person.status in ['active', 'verified']:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6762

See this comment:
https://github.com/internetarchive/openlibrary/issues/6762#issuecomment-1189808416

There were 2 problem:
edits of /type/delete were breaking things
infobase was breaking when save_many request with changeset of 1000 items submitted.
This code ignores /type/delete records and then performs save_many of batches of 100 at a time.

This also fixes a 3rd problem which is, before, we were just fetching 1000 items irrespective of whether the patron had made more than 1000 edits! We basically weren't reverting everything, doh!

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

on testing.openlibrary.org as admin try blocking / reverting `whpnob2345`?

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
