### PR TITLE
Delay merge request creation for super librarians (and small tweaks)

### DIFF
--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -17,7 +17,7 @@
 
 <script>
 import MergeTable from './MergeUI/MergeTable.vue'
-import { do_merge, update_merge_request } from './MergeUI/utils.js';
+import { do_merge, update_merge_request, createMergeRequest } from './MergeUI/utils.js';
 
 export default {
     name: 'app',
@@ -52,7 +52,13 @@ export default {
             try {
                 const r = await do_merge(master, dupes, editions_to_move, this.mrid);
                 this.mergeStatus = await r.json();
-                await update_merge_request(this.mrid, 'approve', this.comment)
+
+                if (this.mrid) {
+                    await update_merge_request(this.mrid, 'approve', this.comment)
+                } else {
+                    const workIds = [master.key].concat(Array.from(dupes, item => item.key))
+                    await createMergeRequest(workIds)
+                }
                 this.mergeStatus = `${this.mergeStatus} Merge request closed`
             } catch (e) {
                 this.mergeStatus = e.message;

--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -59,7 +59,6 @@ export default {
                     const workIds = [master.key].concat(Array.from(dupes, item => item.key))
                     await createMergeRequest(workIds)
                 }
-                this.mergeStatus = `${this.mergeStatus} Merge request closed`
             } catch (e) {
                 this.mergeStatus = e.message;
                 throw e;
@@ -92,10 +91,12 @@ export default {
 
     .merge-btn {
         background-color: green;
+        color: white;
     }
 
     .reject-btn {
         background-color: red;
+        color: white;
     }
 }
 

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -1,6 +1,8 @@
 /* eslint no-console: 0 */
 import _ from 'lodash';
 
+const collator = new Intl.Collator('en-US', {numeric: true})
+
 /**
  *
  * @param {string} field field from a work object
@@ -149,6 +151,39 @@ export function update_merge_request(mrid, action, comment) {
         method: 'POST',
         body: formData
     })
+}
+
+/**
+ * Composes and POSTs a merge request with status "Merged"
+ *
+ * @param {Array<string>} workIds Un-normalized work OLIDs
+ *
+ * @returns {Promise<Response>}
+ */
+export function createMergeRequest(workIds) {
+    const formData = new FormData()
+    const normalizedIds = prepareIds(workIds)
+    formData.set('action', 'create-merged')
+    formData.set('work_ids', normalizedIds.join(','))
+    return fetch('/merges', {
+        method: 'POST',
+        body: formData
+    })
+}
+
+/**
+ * Normalizes and sorts an array of OLIDs.
+ *
+ * OLIDs will be naturally ordered in the returned array.
+ *
+ * @param {Array<string>} workIds Un-normalized work OLIDs
+ * @returns {Array<string>} Noralized and sorted array of OLIDs
+ */
+function prepareIds(workIds) {
+    return Array.from(workIds, id => {
+        const splitArr = id.split('/')
+        return splitArr[splitArr.length - 1]
+    }).sort(collator.compare)
 }
 
 /**

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -135,6 +135,19 @@ class CommunityEditsQueue:
             return cls.submit_request(url, submitter=submitter, comment=comment)
 
     @classmethod
+    def submit_completed_merge_request(cls, work_ids: list[str], username: str):
+        """
+        Creates a new work merge request with "Merged" status.
+
+        Precondition: OLIDs in work_ids list expected to be normalized and sorted.
+        """
+        url = f"/works/merge?records={','.join(work_ids)}"
+        if not cls.exists(url):
+            return cls.submit_request(
+                url, submitter=username, reviewer=username, status=cls.STATUS['MERGED']
+            )
+
+    @classmethod
     def submit_author_merge_request(cls, author_ids, submitter, comment=None):
         if not comment:
             # some default note from submitter

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -122,7 +122,12 @@ class CommunityEditsQueue:
 
     @classmethod
     def submit_work_merge_request(
-        cls, work_ids: list[str], submitter: str, comment: str = None
+        cls,
+        work_ids: list[str],
+        submitter: str,
+        comment: str = None,
+        reviewer: str = None,
+        status: int = STATUS['PENDING'],
     ):
         """
         Creates new work merge requests with the given work olids.
@@ -132,19 +137,12 @@ class CommunityEditsQueue:
 
         url = f"/works/merge?records={','.join(work_ids)}"
         if not cls.exists(url):
-            return cls.submit_request(url, submitter=submitter, comment=comment)
-
-    @classmethod
-    def submit_completed_merge_request(cls, work_ids: list[str], username: str):
-        """
-        Creates a new work merge request with "Merged" status.
-
-        Precondition: OLIDs in work_ids list expected to be normalized and sorted.
-        """
-        url = f"/works/merge?records={','.join(work_ids)}"
-        if not cls.exists(url):
             return cls.submit_request(
-                url, submitter=username, reviewer=username, status=cls.STATUS['MERGED']
+                url,
+                submitter=submitter,
+                comment=comment,
+                reviewer=reviewer,
+                status=status,
             )
 
     @classmethod

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -109,9 +109,7 @@ class merge_work(delegate.page):
         )
         if not has_access:
             raise web.HTTPError('403 Forbidden')
-        if not i.mrid:
-            username = user['key'].split('/')[-1]
-            i.mrid = create_request(i.records, username)
+
         return render_template('merge/works', mrid=i.mrid)
 
 

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -30,7 +30,7 @@ class community_edits_queue(delegate.page):
             work_ids="",  # Comma-separated OLIDs (OL1W,OL2W,OL3W,...,OL111W)
             rtype="merge-works",
             mrid=None,
-            action=None,  # create, approve, decline, comment, unassign
+            action=None,  # create, approve, decline, comment, unassign, create-merged
             comment=None,
         )
         user = accounts.get_current_user()
@@ -83,6 +83,13 @@ class community_edits_queue(delegate.page):
                 )
                 return delegate.RawText(
                     json.dumps(resp), content_type="application/json"
+                )
+            elif i.action == 'create-merged':
+                result = CommunityEditsQueue.submit_completed_merge_request(
+                    i.work_ids.split(','), username
+                )
+                return delegate.RawText(
+                    json.dumps(response(id=result)), content_type='application/json'
                 )
 
     def GET(self):

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -85,8 +85,11 @@ class community_edits_queue(delegate.page):
                     json.dumps(resp), content_type="application/json"
                 )
             elif i.action == 'create-merged':
-                result = CommunityEditsQueue.submit_completed_merge_request(
-                    i.work_ids.split(','), username
+                result = CommunityEditsQueue.submit_work_merge_request(
+                    i.work_ids.split(','),
+                    submitter=username,
+                    reviewer=username,
+                    status=CommunityEditsQueue.STATUS['MERGED'],
                 )
                 return delegate.RawText(
                     json.dumps(response(id=result)), content_type='application/json'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6746 
Closes #6769 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents merge request creation for super librarians until the merge has completed successfully.  When the merge is successful, a request that creates a "Merged" MR is POSTed.

This PR also restores the useful status message on successful merge.

Text color of red and green merge UI buttons has been changed to white.

### Technical
<!-- What should be noted about the implementation? -->
The `/works/merge` controller (which displays the merge UI) no longer creates a "Pending" merge request if an `mrid` is not in the query parameters.  In these cases, `mrid` will be undefined in `mergeUI.vue`, and work IDs are POSTed to the MR update controller on merge success.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
As a super librarian:
1. Select at least two works on a search results page.
2. Click the "Merge Works..." button in the right side of the blue ILE bar.  A new tab with the merge UI should open.
3. Navigate to the `/merges` page.  Ensure that a new MR has not been created.
4. Merge the works with the merge UI.  Note the contrast of the merge button, and the useful message that appears when the merge has completed.
5. View the closed merge requests at `/merges`. Ensure that a "Merged" MR has been created.

As a librarian:
1. Ensure that MR creation works as usual.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-07-22 18-14-46](https://user-images.githubusercontent.com/28732543/180577246-fc7a0d37-5b37-4473-a3a4-87ad40e6d80f.png)
_Useful message and human-readable merge button_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
