### PR TITLE
Changing '0 Reviews' to just 'Reviews'

### DIFF
--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,7 +1,6 @@
 $def with (reader_observations, edition_count=1, show_observations=False)
 
-$ total_reviews = reader_observations.get('total_respondents', '')
-$ if total_reviews == 0: total_reviews = ''
+$ total_reviews = reader_observations.get('total_respondents', '') if total_reviews > 0 else '' 
 
 <ul class="work-menu sticky">
   <li class="selected">

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,6 +1,6 @@
 $def with (reader_observations, edition_count=1, show_observations=False)
 
-$ total_reviews = reader_observations.get('total_respondents', '') if total_reviews > 0 else '' 
+$ total_reviews = reader_observations.get('total_respondents', '') if total_reviews > 0 else ''
 
 <ul class="work-menu sticky">
   <li class="selected">

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,6 +1,6 @@
 $def with (reader_observations, edition_count=1, show_observations=False)
 
-$ total_reviews = reader_observations.get('total_respondents', '') if total_reviews > 0 else ''
+$ total_reviews = reader_observations.get('total_respondents', 0) or ''
 
 <ul class="work-menu sticky">
   <li class="selected">

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,6 +1,8 @@
 $def with (reader_observations, edition_count=1, show_observations=False)
 
 $ total_reviews = reader_observations.get('total_respondents', '')
+$ if total_reviews == 0:
+  $ total_reviews = ''
 
 <ul class="work-menu sticky">
   <li class="selected">

--- a/openlibrary/macros/EditionNavBar.html
+++ b/openlibrary/macros/EditionNavBar.html
@@ -1,8 +1,7 @@
 $def with (reader_observations, edition_count=1, show_observations=False)
 
 $ total_reviews = reader_observations.get('total_respondents', '')
-$ if total_reviews == 0:
-  $ total_reviews = ''
+$ if total_reviews == 0: total_reviews = ''
 
 <ul class="work-menu sticky">
   <li class="selected">


### PR DESCRIPTION
This is following up on a previous pull request, where @mekarpeles requested this:
> If there are 0 Reviews, I think me may just want to stick with "Reviews" instead of "0 Reviews".

Just noticed on the live site, the solution I implemented originally doesn't do this.

So have made some changes in this PR.