### PR TITLE
Prevent serving unneeded JS on many pages

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -258,7 +258,7 @@ jQuery(function () {
     const $notesModalLinks = $('.notes-modal-link');
     const $notesPageButtons = $('.note-page-buttons');
     const $shareModalLinks = $('.share-modal-link');
-    if ($observationModalLinks.length || $notesModalLinks.length || $notesPageButtons.length || $shareModalLinks) {
+    if ($observationModalLinks.length || $notesModalLinks.length || $notesPageButtons.length || $shareModalLinks.length) {
         import(/* webpackChunkName: "modal-links" */ './modals')
             .then(module => {
                 if ($observationModalLinks.length) {
@@ -381,7 +381,7 @@ jQuery(function () {
 
     // Prevent default star rating behavior:
     const ratingForms = document.querySelectorAll('.star-rating-form')
-    if (ratingForms) {
+    if (ratingForms.length) {
         import(/* webpackChunkName: "star-ratings" */'./handlers')
             .then((module) => module.initRatingHandlers(ratingForms));
     }
@@ -404,22 +404,22 @@ jQuery(function () {
     const showCommentsLinks = document.querySelectorAll('.comment-expand')
     const unassignElements = document.querySelectorAll('.mr-unassign')
 
-    if (mergeRequestCloseLinks || mergeRequestCommentButtons || showCommentsLinks || mergeRequestResolveLinks || unassignElements) {
+    if (mergeRequestCloseLinks.length || mergeRequestCommentButtons.length || showCommentsLinks.length || mergeRequestResolveLinks.length || unassignElements.length) {
         import(/* webpackChunkName: "merge-request-table" */'./merge-request-table')
             .then(module => {
-                if (mergeRequestCloseLinks) {
+                if (mergeRequestCloseLinks.length) {
                     module.initCloseLinks(mergeRequestCloseLinks)
                 }
-                if (mergeRequestCommentButtons) {
+                if (mergeRequestCommentButtons.length) {
                     module.initCommenting(mergeRequestCommentButtons)
                 }
-                if (showCommentsLinks) {
+                if (showCommentsLinks.length) {
                     module.initShowAllCommentsLinks(showCommentsLinks)
                 }
-                if (mergeRequestResolveLinks) {
+                if (mergeRequestResolveLinks.length) {
                     module.initRequestClaiming(mergeRequestResolveLinks)
                 }
-                if (unassignElements) {
+                if (unassignElements.length) {
                     module.initUnassignment(unassignElements)
                 }
             })


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Javascript code for our async star ratings, modal icon links, and merge table are being served on every page, not just on pages where the JS is needed.  This code updates the conditionals that guard loading these modules. 

### Technical
<!-- What should be noted about the implementation? -->
`querySelectorAll` and `getElementsByClassName` return empty arrays if no matching elements are found.  Javascript considers empty arrays to be truthy, but the original code assumes that empty arrays are falsey.

This update corrects things by checking the length of the arrays returned by these methods.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to https://openlibrary.org and open your browser's dev tools.
2. View the JS code that was served.  In FF, this is found in the `debug` tab in Sources -> Main Thread -> static/build
3. Note the presence of `merge-request-table`, `modal-links`, and `star-ratings` files.  These are not needed for the home page.
4. Navigate to https://testing.openlibrary.org and repeat step 2.  The unrelated files should not be listed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-07-27 11-57-43](https://user-images.githubusercontent.com/28732543/181293910-bd9ba596-a3e5-42a0-8d61-0b1ab108fdfd.png)
_Screenshot of Firefox dev tools. The files below the selected `graphs` JS code should not be served on the homepage_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
