### PR TITLE
Add title to merge request DB table

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -135,17 +135,6 @@ class CommunityEditsQueue:
 
         Precondition: OLIDs in work_ids list must be sanitized and normalized.
         """
-
-        def get_title(olids):
-            title = None
-            for olid in olids:
-                book = web.ctx.site.get(f'/works/{olid}')
-                if book:
-                    if not title and book.title:
-                        title = book.title
-                        break
-            return title
-
         url = f"/works/merge?records={','.join(work_ids)}"
         if not cls.exists(url):
             return cls.submit_request(
@@ -154,8 +143,18 @@ class CommunityEditsQueue:
                 comment=comment,
                 reviewer=reviewer,
                 status=status,
-                title=get_title(work_ids),
+                title=cls.get_work_merge_title(work_ids),
             )
+
+    @classmethod
+    def get_work_merge_title(cls, olids):
+        title = None
+        for olid in olids:
+            book = web.ctx.site.get(f'/works/{olid}')
+            if book and book.title:
+                title = book.title
+                break
+        return title
 
     @classmethod
     def submit_author_merge_request(cls, author_ids, submitter, comment=None):

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -146,8 +146,8 @@ class CommunityEditsQueue:
                 title=cls.get_work_merge_title(work_ids),
             )
 
-    @classmethod
-    def get_work_merge_title(cls, olids):
+    @staticmethod
+    def get_work_merge_title(olids):
         title = None
         for olid in olids:
             book = web.ctx.site.get(f'/works/{olid}')

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from typing import Optional
+import web
 
 from infogami.utils.view import public
 
@@ -135,6 +136,16 @@ class CommunityEditsQueue:
         Precondition: OLIDs in work_ids list must be sanitized and normalized.
         """
 
+        def get_title(olids):
+            title = None
+            for olid in olids:
+                book = web.ctx.site.get(f'/works/{olid}')
+                if book:
+                    if not title and book.title:
+                        title = book.title
+                        break
+            return title
+
         url = f"/works/merge?records={','.join(work_ids)}"
         if not cls.exists(url):
             return cls.submit_request(
@@ -143,6 +154,7 @@ class CommunityEditsQueue:
                 comment=comment,
                 reviewer=reviewer,
                 status=status,
+                title=get_title(work_ids),
             )
 
     @classmethod
@@ -170,6 +182,7 @@ class CommunityEditsQueue:
         reviewer: str = None,
         status: int = STATUS['PENDING'],
         comment: str = None,
+        title: str = None,
     ):
         """
         Inserts a new record into the table.
@@ -188,6 +201,7 @@ class CommunityEditsQueue:
             url=url,
             status=status,
             comments=json_comment,
+            title=title,
         )
 
     @classmethod

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -65,6 +65,7 @@ CREATE TABLE observations (
 
 CREATE TABLE community_edits_queue (
     id serial not null primary key,
+    title text,
     submitter text not null,
     reviewer text default null,
     url text not null,

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -105,41 +105,15 @@ class community_edits_queue(delegate.page):
             reviewer=i.reviewer,
             order='created',
         ).list()
-        enriched_requests = self.enrich(merge_requests)
+
         total_found = CommunityEditsQueue.get_counts_by_mode(
             mode=i.mode, submitter=i.submitter, reviewer=i.reviewer
         )
         return render_template(
             'merge_queue/merge_queue',
             total_found,
-            merge_requests=enriched_requests,
+            merge_requests=merge_requests,
         )
-
-    def enrich(self, merge_requests):
-        results = []
-        for r in merge_requests:
-            comments = r['comments']
-            obj = {
-                'id': r['id'],
-                'submitter': r['submitter'],
-                'reviewer': r['reviewer'],
-                'url': r['url'],
-                'status': r['status'],
-                'comments': (comments and comments.get('comments')) or [],
-                'created': r['created'],
-                'updated': r['updated'],
-            }
-            olids = self.extract_olids(r['url'])
-            obj['title'] = ''
-            for olid in olids:
-                book = web.ctx.site.get(f'/works/{olid}')
-                if book:
-                    if not obj['title']:
-                        obj['title'] = book.title
-                        break
-
-            results.append(obj)
-        return results
 
     def extract_olids(self, url):
         query_string = url.split('?')[1]

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -57,7 +57,7 @@ $ page = int(input(page=1).page)
         <tbody>
         $for r in merge_requests:
           $ work_title = r.get('title', 'an untitled work')
-          $ comments = r.get('comments', [])
+          $ comments = r.get('comments', {}).get('comments', [])
           $ status = get_status_for_view(r['status'])
           $ is_open = r['status'] == 1
           $ url = "%s&mrid=%s" % (r['url'], r['id'])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6788

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `title` field to `community_edits_queue` table.  Title is set whenever a merge request is created.

Removes `enrich` function from the controller.  This function's main purpose was to derive a title using the OLIDs saved in an MR's `url`.  Additionally, `enrich` flattened the `comments` object before passing the data to the template.  Because of this, `comments` is now accessed differently in the template (`r['comments']` v. r['comments']['comments'].

__Note:__ If an MR has a `NULL` title, the title will appear as "None" in the UI.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
