### PR TITLE
Check for work before rendering modals

### DIFF
--- a/openlibrary/templates/type/edition/modal_links.html
+++ b/openlibrary/templates/type/edition/modal_links.html
@@ -14,7 +14,8 @@ $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None
   </a>
 
 <div class="modal-links">
-  $if work:
+  $if work and work.get('key', ''):
+    <div>work.key: $work.key</div>
     $ review_content = icon_link("observations-modal-link", "/static/images/icons/reviews.svg", _("Review"), ga_data="ModalLinkClick|ReviewIcon")
     $:macros.ObservationsModal(work, review_content, 'sidebar-review')
 

--- a/openlibrary/templates/type/edition/modal_links.html
+++ b/openlibrary/templates/type/edition/modal_links.html
@@ -14,11 +14,12 @@ $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None
   </a>
 
 <div class="modal-links">
-  $ review_content = icon_link("observations-modal-link", "/static/images/icons/reviews.svg", _("Review"), ga_data="ModalLinkClick|ReviewIcon")
-  $:macros.ObservationsModal(work, review_content, 'sidebar-review')
+  $if work:
+    $ review_content = icon_link("observations-modal-link", "/static/images/icons/reviews.svg", _("Review"), ga_data="ModalLinkClick|ReviewIcon")
+    $:macros.ObservationsModal(work, review_content, 'sidebar-review')
 
-  $ notes_content = icon_link("notes-modal-link", "/static/images/icons/notes.svg", _("Notes"), ga_data="ModalLinkClick|NoteIcon")
-  $:macros.NotesModal(work, edition, notes_content, 'sidebar-notes')
+    $ notes_content = icon_link("notes-modal-link", "/static/images/icons/notes.svg", _("Notes"), ga_data="ModalLinkClick|NoteIcon")
+    $:macros.NotesModal(work, edition, notes_content, 'sidebar-notes')
 
   $if ctx.get('share_links'):
     $ share_content = icon_link("share-modal-link", "/static/images/icons/share.svg", _("Share"), login_redirect=False, ga_data="ModalLinkClick|ShareIcon")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6761

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Affects orphaned edition book pages.  Checks for `work` before rendering note and review modals.  Share modal link will be rendered regardless.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Compare the following orphaned edition page in testing and production:
https://openlibrary.org/books/OL12580742M/Florence_Nighingale
https://testing.openlibrary.org/books/OL12580742M/Florence_Nighingale

Note the render error on production.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-07-27 18-29-52](https://user-images.githubusercontent.com/28732543/181383823-fbc88554-587b-42f5-996d-fa134f415ab5.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
