### PR TITLE
Check for key before rendering `link` with work key

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -166,7 +166,7 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
 
 <div id="contentBody" role="main" itemscope itemtype="https://schema.org/Book">
   <div class="workDetails">
-    $if work:
+    $if work and work.key:
         <link itemprop="exampleOfWork" href="$work.key">
 
     <div class="editionCover">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Book pages contain a schema.org [exampleOfWork](https://schema.org/exampleOfWork) `link` that references an Open Library work key.  On orphaned edition pages, the `href` for this link is an empty string.  This doesn't seem particularly helpful, so let's prevent these `link`s from rendering on orphaned edition pages.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
