### PR TITLE
Prevent long titles from overflowing results box

### DIFF
--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -38,6 +38,7 @@
     font-family: @lucida_sans_serif-6;
   }
   .details {
+    overflow: auto;
     display: inline;
     width: 100%;
     padding: 5px;

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1087,6 +1087,7 @@ div.editThis {
 
 div#searchResults,
 div#searchResults ul {
+  min-width: 0;
   flex: 1;
   margin-left: 0;
   margin-bottom: 0;


### PR DESCRIPTION
Closes #5810

Fix #5810 so that long titles do not spill over outside the results box.

### Technical

Added min-width: 0 property and overflow: auto to results box.

### Testing

Visit https://openlibrary.org/search?q=language%3Ajpn&mode=everything&sort=new to see example of works with long titles

Copy some to a local instance with the fix and conduct the same search.

### Screenshot

![fixed](https://user-images.githubusercontent.com/43460834/181437527-87b3200b-a0bf-43d8-8ac8-105487b1ed44.PNG)

### Stakeholders

@lephemere 
