### PR TITLE
Adds async list loading to reading log droppers

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -74,7 +74,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "120KB"
+      "maxSize": "120.1KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -85,9 +85,9 @@ $if ctx.user or not work_key:
               <p class="reading-list-title">$_('My Reading Lists:')</p>
               <div class="my-lists">
                 $if async_load:
-                  $ attrs = 'data-edition-key=%s' % edition_key if edition_key else ''
-                  $ attrs = '%s data-work-key=%s' % (attrs, work_key) if work_key else attrs
-                  <div class="list-loading-indicator" $attrs>Loading<span class="loading-ellipsis">...</span></div>
+                  $ ed_attr = 'data-edition-key=%s' % edition_key if edition_key else ''
+                  $ work_attr = 'data-work-key=%s' % work_key if work_key else ''
+                  <div class="list-loading-indicator" $ed_attr $work_attr>Loading<span class="loading-ellipsis">...</span></div>
                 $else:
                   $:render_template('lists/dropper_lists', lists)
               </div>

--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -87,7 +87,7 @@ $if ctx.user or not work_key:
                 $if async_load:
                   $ attrs = 'data-edition-key=%s' % edition_key if edition_key else ''
                   $ attrs = '%s data-work-key=%s' % (attrs, work_key) if work_key else attrs
-                  <div class="list-loading-indicator" $attrs>Loading...</div>
+                  <div class="list-loading-indicator" $attrs>Loading<span class="loading-ellipsis">...</span></div>
                 $else:
                   $:render_template('lists/dropper_lists', lists)
               </div>
@@ -117,7 +117,7 @@ $if ctx.user or not work_key:
               <div class="dropdown">
                 <div class="my-lists">
                   $if async_load:
-                    <div class="list-loading-indicator">Loading...</div>
+                    <div class="list-loading-indicator">Loading<span class="loading-ellipsis">...</span></div>
                   $else:
                     $:render_template('lists/dropper_lists', lists)
                 </div>

--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -1,4 +1,4 @@
-$def with (lists, work=None, edition=None, key=None, users_work_read_status=None, reading_log_only=False, use_work=False, page_url=None)
+$def with (lists, work=None, edition=None, key=None, users_work_read_status=None, reading_log_only=False, use_work=False, page_url=None, async_load=False)
 
 $ user_key = ctx.user and ctx.user.key
 $ username = ctx.user and ctx.user.key.split('/')[-1]
@@ -84,11 +84,12 @@ $if ctx.user or not work_key:
             <div class="reading-lists">
               <p class="reading-list-title">$_('My Reading Lists:')</p>
               <div class="my-lists">
-                $for list in lists:
-                    $if not list['active']:
-                      <p class="list">
-                          <a href="$list.key" class="add-to-list" data-list-cover-url="$list.cover_url" data-list-key="$list.key">$list.name</a>
-                      </p>
+                $if async_load:
+                  $ attrs = 'data-edition-key=%s' % edition_key if edition_key else ''
+                  $ attrs = '%s data-work-key=%s' % (attrs, work_key) if work_key else attrs
+                  <div class="list-loading-indicator" $attrs>Loading...</div>
+                $else:
+                  $:render_template('lists/dropper_lists', lists)
               </div>
               $if edition_key:
                   <p class="create checkboxes">
@@ -115,11 +116,10 @@ $if ctx.user or not work_key:
               </a>
               <div class="dropdown">
                 <div class="my-lists">
-                  $for list in lists:
-                    $if not list['active']:
-                      <p class="list">
-                          <a href="$list.key" class="add-to-list" data-list-key="$list.key">$list.name</a>
-                      </p>
+                  $if async_load:
+                    <div class="list-loading-indicator">Loading...</div>
+                  $else:
+                    $:render_template('lists/dropper_lists', lists)
                 </div>
                 <p class="create"><a href="javascript:;" class="create-new-list">$_('Create a new list')</a>
                 </p>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -58,7 +58,7 @@ $if isbn_10 and not asin:
         $ edition = page.works and page
 
         $ render_times['databarWork: List widget'] = time()
-        $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False)
+        $ lists_widget = render_template('lists/widget', edition or work, include_rating=True, include_header=False, include_widget=True, include_showcase=False, async_load=True)
         $ render_times['databarWork: List widget'] = time() - render_times['databarWork: List widget']
 
         $# For the Works & Editions page, only use ground_truth_availability API for selected Edition

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -349,6 +349,7 @@ jQuery(function () {
     // "Want to Read" buttons:
     const droppers = document.getElementsByClassName('widget-add');
 
+    // Async lists components:
     const wtrLoadingIndicator = document.querySelector('.list-loading-indicator')
     const overviewLoadingIndicator = document.querySelector('.list-overview-loading-indicator')
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -349,13 +349,22 @@ jQuery(function () {
     // "Want to Read" buttons:
     const droppers = document.getElementsByClassName('widget-add');
 
-    if (droppers.length) {
+    const wtrLoadingIndicator = document.querySelector('.list-loading-indicator')
+    const overviewLoadingIndicator = document.querySelector('.list-overview-loading-indicator')
+
+    if (droppers.length || wtrLoadingIndicator || overviewLoadingIndicator) {
         import(/* webpackChunkName: "lists" */ './lists')
             .then((module) => {
-                module.initDroppers(droppers);
-                // Removable list items:
-                const actionableListItems = document.querySelectorAll('.actionable-item')
-                module.registerListItems(actionableListItems);
+                if (droppers.length) {
+                    module.initDroppers(droppers);
+                    // Removable list items:
+                    // TODO: Is this the correct place to initalize these?
+                    const actionableListItems = document.querySelectorAll('.actionable-item')
+                    module.registerListItems(actionableListItems);
+                }
+                if (wtrLoadingIndicator || overviewLoadingIndicator) {
+                    module.initListLoading(wtrLoadingIndicator, overviewLoadingIndicator)
+                }
             }
             );
     }

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -96,7 +96,7 @@ export function updateReadingLog(formElem, success) {
 /**
  * Fetches HTML for list components
  *
- * @param {string} key Dey of record that can be added/removed to the list
+ * @param {string} key Key of record that can be added/removed to the list
  * @param {function} success Callback to be executed on fetch success
  */
 export function fetchPartials(key, success) {

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -92,3 +92,11 @@ export function updateReadingLog(formElem, success) {
         success: success
     })
 }
+
+export function fetchPartials(key, success) {
+    $.ajax({
+        type: 'GET',
+        url: `/lists/partials?key=${key}`,
+        success: success
+    })
+}

--- a/openlibrary/plugins/openlibrary/js/lists/ListService.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListService.js
@@ -93,6 +93,12 @@ export function updateReadingLog(formElem, success) {
     })
 }
 
+/**
+ * Fetches HTML for list components
+ *
+ * @param {string} key Dey of record that can be added/removed to the list
+ * @param {function} success Callback to be executed on fetch success
+ */
 export function fetchPartials(key, success) {
     $.ajax({
         type: 'GET',

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -3,7 +3,7 @@
  * @module lists/index
  */
 
-import { createList, addToList, removeFromList, updateReadingLog } from './ListService'
+import { createList, addToList, removeFromList, updateReadingLog, fetchPartials } from './ListService'
 import { websafe } from '../jsdef'
 
 /**
@@ -437,4 +437,45 @@ function updateAlreadyList(listKey, listTitle, coverUrl, seedKey) {
     addRemoveClickListener(li)
 
     return li;
+}
+
+export function initListLoading(dropperLists, activeLists) {
+    let key
+    if (dropperLists.dataset.editionKey) {
+        key = dropperLists.dataset.editionKey
+    } else if (dropperLists.dataset.workKey) {
+        key = dropperLists.dataset.workKey
+    }
+
+    if (key) {
+        fetchPartials(key, function(data) {
+            replaceLoadingIndicators(dropperLists, activeLists, data)
+        })
+    }
+}
+
+function replaceLoadingIndicators(dropperLists, activeLists, partials) {
+    partials = JSON.parse(partials)
+
+    const dropperParent = dropperLists.parentElement
+    const activeListsParent = activeLists ? activeLists.parentElement : null
+
+    removeChildren(dropperParent)
+    dropperParent.insertAdjacentHTML('afterbegin', partials['dropper'])
+
+    const dropper = dropperParent.closest('.widget-add')
+    initDroppers([dropper])
+
+    if (activeListsParent) {
+        removeChildren(activeListsParent)
+        activeListsParent.insertAdjacentHTML('afterbegin', partials['active'])
+        const actionableListItems = activeListsParent.querySelectorAll('.actionable-item')
+        registerListItems(actionableListItems)
+    }
+}
+
+function removeChildren(elem) {
+    while (elem.firstChild) {
+        elem.removeChild(elem.firstChild)
+    }
 }

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -439,7 +439,10 @@ function updateAlreadyList(listKey, listTitle, coverUrl, seedKey) {
     return li;
 }
 
-export function initListLoading(dropperLists, activeLists) {
+export function initListLoading(dropperLists, activeLists) {  // TODO: make these singular
+    const loadingIndicators = [dropperLists.querySelector('.loading-ellipsis'), activeLists.querySelector('.loading-ellipsis')]
+    const intervalId = initLoadingAnimation(loadingIndicators)
+
     let key
     if (dropperLists.dataset.editionKey) {
         key = dropperLists.dataset.editionKey
@@ -449,9 +452,26 @@ export function initListLoading(dropperLists, activeLists) {
 
     if (key) {
         fetchPartials(key, function(data) {
+            clearInterval(intervalId)
             replaceLoadingIndicators(dropperLists, activeLists, data)
         })
     }
+}
+
+function initLoadingAnimation(loadingIndicators) {
+    let count = 0;
+    const intervalId = setInterval(function() {
+        let ellipsis = ''
+        for (let i = 0; i < count % 4; ++i) {
+            ellipsis += '.'
+        }
+        for (const elem of loadingIndicators) {
+            elem.innerText = ellipsis
+        }
+        ++count;
+    }, 1500)
+
+    return intervalId
 }
 
 function replaceLoadingIndicators(dropperLists, activeLists, partials) {

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -490,7 +490,7 @@ export function initListLoading(dropperList, activeList) {
  * Animates ellipsis that follows the word "Loading"
  *
  * A new dot is appended every 1.5 seconds, until there
- * is a full ellipsis.  This cycle repeats indefinately.
+ * is a full ellipsis.  This cycle repeats indefinitely.
  *
  * Returns an interval ID, which should be used to terminate
  * the `setInterval` call.

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -34,15 +34,7 @@ const dropperLists = {}
 export function initDroppers(droppers) {
     for (const dropper of droppers) {
         const anchors = dropper.querySelectorAll('.add-to-list');
-
-        for (const anchor of anchors) {
-            // Store reference to anchor and list title:
-            dropperLists[anchor.dataset.listKey] = {
-                title: anchor.innerText,
-                element: anchor
-            }
-            addListClickListener(anchor, dropper);
-        }
+        initAddToListAnchors(anchors, dropper)
 
         const openModalButton = dropper.querySelector('.create-new-list')
         if (openModalButton) {
@@ -59,6 +51,23 @@ export function initDroppers(droppers) {
         for (const button of submitButtons) {
             addReadingLogButtonClickListener(button)
         }
+    }
+}
+
+/**
+ * Adds click listeners to the given "add-to-list" anchors in dropper
+ *
+ * @param {NodeListOf<Element>} anchors The "add-to-list" links
+ * @param {HTMLElement} dropper The reading log dropper
+ */
+function initAddToListAnchors(anchors, dropper) {
+    for (const anchor of anchors) {
+        // Store reference to anchor and list title:
+        dropperLists[anchor.dataset.listKey] = {
+            title: anchor.innerText,
+            element: anchor
+        }
+        addListClickListener(anchor, dropper);
     }
 }
 
@@ -522,7 +531,8 @@ function replaceLoadingIndicators(dropperLists, activeLists, partials) {
         dropperParent.insertAdjacentHTML('afterbegin', partials['dropper'])
 
         const dropper = dropperParent.closest('.widget-add')
-        initDroppers([dropper])
+        const anchors = dropper.querySelectorAll('.add-to-list');
+        initAddToListAnchors(anchors, dropper)
     }
 
     if (activeListsParent) {

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -440,14 +440,19 @@ function updateAlreadyList(listKey, listTitle, coverUrl, seedKey) {
 }
 
 export function initListLoading(dropperLists, activeLists) {  // TODO: make these singular
-    const loadingIndicators = [dropperLists.querySelector('.loading-ellipsis'), activeLists.querySelector('.loading-ellipsis')]
+    const loadingIndicators = dropperLists ? [dropperLists.querySelector('.loading-ellipsis')] : []
+    if (activeLists) {
+        loadingIndicators.push(activeLists.querySelector('.loading-ellipsis'))
+    }
     const intervalId = initLoadingAnimation(loadingIndicators)
 
     let key
-    if (dropperLists.dataset.editionKey) {
-        key = dropperLists.dataset.editionKey
-    } else if (dropperLists.dataset.workKey) {
-        key = dropperLists.dataset.workKey
+    if (dropperLists) {  // Not defined for logged out patrons
+        if (dropperLists.dataset.editionKey) {
+            key = dropperLists.dataset.editionKey
+        } else if (dropperLists.dataset.workKey) {
+            key = dropperLists.dataset.workKey
+        }
     }
 
     if (key) {
@@ -455,6 +460,8 @@ export function initListLoading(dropperLists, activeLists) {  // TODO: make thes
             clearInterval(intervalId)
             replaceLoadingIndicators(dropperLists, activeLists, data)
         })
+    } else {
+        removeLoadingIndicators(dropperLists, activeLists)
     }
 }
 
@@ -475,16 +482,16 @@ function initLoadingAnimation(loadingIndicators) {
 }
 
 function replaceLoadingIndicators(dropperLists, activeLists, partials) {
-    partials = JSON.parse(partials)
-
-    const dropperParent = dropperLists.parentElement
+    const dropperParent = dropperLists ? dropperLists.parentElement : null
     const activeListsParent = activeLists ? activeLists.parentElement : null
 
-    removeChildren(dropperParent)
-    dropperParent.insertAdjacentHTML('afterbegin', partials['dropper'])
+    if (dropperParent) {
+        removeChildren(dropperParent)
+        dropperParent.insertAdjacentHTML('afterbegin', partials['dropper'])
 
-    const dropper = dropperParent.closest('.widget-add')
-    initDroppers([dropper])
+        const dropper = dropperParent.closest('.widget-add')
+        initDroppers([dropper])
+    }
 
     if (activeListsParent) {
         removeChildren(activeListsParent)
@@ -495,7 +502,18 @@ function replaceLoadingIndicators(dropperLists, activeLists, partials) {
 }
 
 function removeChildren(elem) {
-    while (elem.firstChild) {
-        elem.removeChild(elem.firstChild)
+    if (elem) {
+        while (elem.firstChild) {
+            elem.removeChild(elem.firstChild)
+        }
+    }
+}
+
+function removeLoadingIndicators(dropperList, activeList) {
+    if (dropperList) {
+        removeChildren(dropperList.parentElement)
+    }
+    if (activeList) {
+        removeChildren(activeList.parentElement)
     }
 }

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -31,7 +31,7 @@ class lists_home(delegate.page):
 
 @public
 def get_seed_info(doc):
-    """Takes a thiing, determines what type it is, and returns a seed summary"""
+    """Takes a thing, determines what type it is, and returns a seed summary"""
     if doc.key.startswith("/subjects/"):
         seed = doc.key.split("/")[-1]
         if seed.split(":")[0] not in ("place", "person", "time"):

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -3,7 +3,6 @@
 import json
 import random
 import tempfile
-from xml.etree.ElementInclude import include
 import web
 
 from infogami.utils import delegate
@@ -51,8 +50,7 @@ class lists_partials(delegate.page):
             'active': str(active),
         }
 
-        web.header("Content-Type", "application/json")
-        return delegate.RawText(formats.dump(partials, 'json'))
+        return delegate.RawText(json.dumps(partials), content_type="application/json")
 
     def get_doc(self, key):
         if key.startswith("/subjects/"):

--- a/openlibrary/templates/lists/active_lists.html
+++ b/openlibrary/templates/lists/active_lists.html
@@ -1,0 +1,5 @@
+$def with (lists, user_key, seed_info)
+
+$for list in lists:
+  $if list['active']:
+    $:render_template('lists/list_overview', list, user_key, seed_info)

--- a/openlibrary/templates/lists/dropper_lists.html
+++ b/openlibrary/templates/lists/dropper_lists.html
@@ -1,0 +1,7 @@
+$def with (lists)
+
+$for list in lists:
+  $if not list['active']:
+    <p class="list">
+      <a href="$list.key" class="add-to-list" data-list-cover-url="$list.cover_url" data-list-key="$list.key">$list.name</a>
+    </p>

--- a/openlibrary/templates/lists/list_overview.html
+++ b/openlibrary/templates/lists/list_overview.html
@@ -1,0 +1,28 @@
+$def with (list, user_key, seed_info)
+
+$ remove = (list.owner.key == user_key)
+$ actionable = 'class=actionable-item' if remove else ''
+<li $actionable>
+    <span class="image">
+      <a href="$list.key"><img src="$list.cover_url" alt="$_('Cover of: %(title)s', title=list.name)" title="$_('Cover of: %(title)s', title=list.name)"/></a>
+    </span>
+    <span class="data">
+        <span class="label">
+            <a href="$list.key" data-list-title="$(list.name)" title="$_('See this list')">$list.name</a>
+            $if remove:
+                $if seed_info['type'] == 'subject':
+                    $ seed_key = seed_info['seed']
+                $else:
+                    $ seed_key = seed_info['seed']['key']
+                <input type="hidden" name="seed-title" value="$(seed_info['title'])"/>
+                <input type="hidden" name="seed-key" value="$seed_key"/>
+                <input type="hidden" name="seed-type" value="$(seed_info['type'])"/>
+
+                <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-key="$list.key" title="$_('Remove from your list?')">[X]</a>
+        </span>
+        $if remove:
+            <span class="owner">from <a href="$list.owner.key">$_('You')</a></span>
+        $else:
+            <span class="owner">from <a href="$list.owner.key">$list.owner.displayname</a></span>
+    </span>
+</li>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -10,52 +10,6 @@ $if "lists" not in ctx.features:
     $return
 
 $code:
-    def get_seed_info(page):
-        """Takes a thing, determines what type it is, and returns a seed summary"""
-        if page.key.startswith("/subjects/"):
-            seed = page.key.split("/")[-1]
-            if seed.split(":")[0] not in ["place", "person", "time"]:
-                seed = "subject:" + seed
-            seed = seed.replace(",", "_").replace("__", "_")
-            seed_type = "subject"
-            title = page.name
-        else:
-            seed = {"key": page.key}
-            if page.key.startswith("/authors/"):
-                seed_type = "author"
-                title = page.get('name', 'name missing')
-            elif page.key.startswith("/works"):
-                seed_type = "work"
-                title = page.get("title", "untitled")
-            else:
-                seed_type = "edition"
-                title = page.get("title", "untitled")
-        return {
-            "seed": seed,
-            "type": seed_type,
-            "title": websafe(title),
-            "remove_dialog_html": _('Are you sure you want to remove <strong>%(title)s</strong> from your list?', title=websafe(title))
-        }
-
-    def get_list_data(list, seed, include_cover_url=True):
-        d = storage({
-            "name": list.name or "",
-            "key": list.key,
-            "active": list.has_seed(seed),
-        })
-        if include_cover_url:
-            cover = list.get_cover() or list.get_default_cover()
-            d['cover_url'] = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
-            if 'None' in d['cover_url']:
-                d['cover_url'] = "/images/icons/avatar_book-sm.png"
-        owner = list.get_owner()
-        d['owner'] = storage(displayname=owner.displayname or "", key=owner.key)
-        return d
-
-    def get_user_lists(seed_info):
-        _user_lists = (ctx.user and ctx.user.get_lists(sort=True) or [])
-        return [get_list_data(list, seed_info['seed'], include_cover_url=True) for list in _user_lists]
-
     def get_page_lists(page, seed_info):
         return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
 

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -125,7 +125,7 @@ $if include_widget:
   $:macros.ReadingLogDropper(user_lists, work=work, edition=edition, key=default_seed_key, users_work_read_status=users_work_read_status, page_url=page_url, async_load=async_load)
   <ul id="already-lists" class="listLists already-lists">
     $if async_load:
-        <div class="list-overview-loading-indicator">Loading...</div>
+        <div class="list-overview-loading-indicator">Loading<span class="loading-ellipsis">...</span></div>
     $else:
         $:render_already_lists(user_lists, user_key)
   </ul>

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -1,4 +1,4 @@
-$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, read_status=None, _user_lists=None, exclude_own_lists=False)
+$def with (page, include_rating=True, include_header=True, include_widget=True, include_showcase=True, read_status=None, exclude_own_lists=False, async_load=False)
 
 $ edition = page if page.key.startswith("/books/") else None
 $ work = (page.works and page.works[0]) if page.key.startswith("/books/") else page if page.key.startswith("/works/") else None
@@ -10,8 +10,6 @@ $if "lists" not in ctx.features:
     $return
 
 $code:
-    _user_lists = _user_lists or (ctx.user and ctx.user.get_lists(sort=True) or [])
-
     def get_seed_info(page):
         """Takes a thing, determines what type it is, and returns a seed summary"""
         if page.key.startswith("/subjects/"):
@@ -55,51 +53,24 @@ $code:
         return d
 
     def get_user_lists(seed_info):
+        _user_lists = (ctx.user and ctx.user.get_lists(sort=True) or [])
         return [get_list_data(list, seed_info['seed'], include_cover_url=True) for list in _user_lists]
 
     def get_page_lists(page, seed_info):
         return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
 
 $ seed_info = get_seed_info(page)
-$ user_lists = get_user_lists(seed_info)
+$ user_lists = [] if async_load else get_user_lists(seed_info)
 $ page_lists = get_page_lists(page, seed_info)
 $ user_key = ctx.user and ctx.user.key
 $ page_url = page.url()
 
 $var page_lists = page_lists
 
-$def show_list(list, user_key):
-    $ remove = (list.owner.key == user_key)
-    $ actionable = 'class=actionable-item' if remove else ''
-    <li $actionable>
-        <span class="image">
-          <a href="$list.key"><img src="$list.cover_url" alt="$_('Cover of: %(title)s', title=list.name)" title="$_('Cover of: %(title)s', title=list.name)"/></a>
-        </span>
-        <span class="data">
-            <span class="label">
-                <a href="$list.key" data-list-title="$(list.name)" title="$_('See this list')">$list.name</a>
-                $if remove:
-                    $if seed_info['type'] == 'subject':
-                        $ seed_key = seed_info['seed']
-                    $else:
-                        $ seed_key = seed_info['seed']['key']
-                    <input type="hidden" name="seed-title" value="$(seed_info['title'])"/>
-                    <input type="hidden" name="seed-key" value="$seed_key"/>
-                    <input type="hidden" name="seed-type" value="$(seed_info['type'])"/>
-
-                    <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-key="$list.key" title="$_('Remove from your list?')">[X]</a>
-            </span>
-            $if remove:
-                <span class="owner">from <a href="$list.owner.key">$_('You')</a></span>
-            $else:
-                <span class="owner">from <a href="$list.owner.key">$list.owner.displayname</a></span>
-        </span>
-    </li>
-
 $def render_already_lists(lists, user_key):
     $for list in lists:
         $if list['active']:
-            $:show_list(list, user_key)
+            $:render_template('lists/list_overview', list, user_key, seed_info)
 
 $def render_widget_display(lists, limit, user_key, exclude_own_lists):
     $ count = 0
@@ -107,10 +78,10 @@ $def render_widget_display(lists, limit, user_key, exclude_own_lists):
         $if count < limit:
             $if exclude_own_lists:
                 $if user_key != list.owner.key:
-                    $:show_list(list, user_key)
+                    $:render_template('lists/list_overview', list, user_key, seed_info)
                     $ count = count + 1
             $else:
-                $:show_list(list, user_key)
+                $:render_template('lists/list_overview', list, user_key, seed_info)
                 $ count = count + 1
 
 $def render_head(seed_type, page_lists, page_url):
@@ -151,13 +122,15 @@ $def i18n_input():
 $if include_widget:
   $if render_once('lists/widget.i18n-strings'):
     $:i18n_input()
-  $:macros.ReadingLogDropper(user_lists, work=work, edition=edition, key=default_seed_key, users_work_read_status=users_work_read_status, page_url=page_url)
+  $:macros.ReadingLogDropper(user_lists, work=work, edition=edition, key=default_seed_key, users_work_read_status=users_work_read_status, page_url=page_url, async_load=async_load)
   <ul id="already-lists" class="listLists already-lists">
-    $:render_already_lists(user_lists, user_key)
+    $if async_load:
+        <div class="list-overview-loading-indicator">Loading...</div>
+    $else:
+        $:render_already_lists(user_lists, user_key)
   </ul>
-  $if work:
-    $if include_rating:
-      $:macros.StarRatings(work, edition)
+  $if work and include_rating:
+    $:macros.StarRatings(work, edition)
 
 $if include_showcase:
   $if render_once('lists/widget.i18n-strings'):

--- a/static/css/components/listLists.less
+++ b/static/css/components/listLists.less
@@ -47,4 +47,8 @@ ul.listLists {
       margin: 5px 0;
     }
   }
+  .list-overview-loading-indicator {
+    display: flex;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6775

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Asynchronously loads reading log dropper lists.

### Technical
<!-- What should be noted about the implementation? -->
A number of functions have been moved from `lists/widget.html` to `lists.py`, and made `public`.  Similarly, some HTML rendering functions have been moved to dedicated template files.

For now, the list partials endpoint only returns HTML for a single list widget.  The endpoint can be easily modified to return a collection of partials in a single call, but the object returned will be unwieldy while list management is handled by two components (one for adding to a list, and one for removing from a list).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
