### PR TITLE
Remove debugging `div` from modal links template

### DIFF
--- a/openlibrary/templates/type/edition/modal_links.html
+++ b/openlibrary/templates/type/edition/modal_links.html
@@ -15,7 +15,6 @@ $def icon_link(link_class, img_src, link_text, login_redirect=True, ga_data=None
 
 <div class="modal-links">
   $if work and work.get('key', ''):
-    <div>work.key: $work.key</div>
     $ review_content = icon_link("observations-modal-link", "/static/images/icons/reviews.svg", _("Review"), ga_data="ModalLinkClick|ReviewIcon")
     $:macros.ObservationsModal(work, review_content, 'sidebar-review')
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removing debug `div` from modal links template.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
