### PR TITLE
Changed scrolling of long titles to only scroll title

### DIFF
--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -45,6 +45,7 @@
     margin: 0;
   }
   .resultTitle {
+    overflow: auto;
     margin: 0 !important;
     font-family: @lucida_sans_serif-1;
     color: @grey;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5810

As requested here: https://github.com/internetarchive/openlibrary/pull/6793, this is a minor change to ensure that only the title scrolls when the title is too long, as opposed to the entire work/blurb / author scrolling.

### Technical

### Testing

Visit https://openlibrary.org/search?q=language%3Ajpn&mode=everything&sort=new to see example of works with long titles

Copy some to a local instance with the fix and conduct the same search.

### Screenshot

![Uploading working.PNG…]()

### Stakeholders

@mekarpeles 
