### PR TITLE
simpify resolve redirects, don't require max_limit

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -644,7 +644,6 @@ class Work(Thing):
         cls,
         batch_size=1000,
         start_offset=0,
-        limit=1000,
         grace_period_days=7,
         cutoff_date=datetime.datetime(year=2017, month=1, day=1),
         test=True,
@@ -652,37 +651,40 @@ class Work(Thing):
         """
         batch_size - how many records to fetch per batch
         start_offset - what offset to start from
-        limit - total number of records to process from start_offset
         grace_period_days - ignore redirects created within period of days
         cutoff_date - ignore redirects created before this date
         test - don't resolve stale redirects, just identify them
         """
+        batch = 0
         pos = start_offset
-        max_limit = start_offset + limit
         grace_date = datetime.datetime.today() - datetime.timedelta(
             days=grace_period_days
         )
-        batch_offsets = enumerate(range(start_offset, max_limit, batch_size))
-        for batch, offset in batch_offsets:
+
+        go = True
+        while go:
             logger.info(
-                f"[update-redirects] Batch {batch+1}: #{pos} of {max_limit}",
+                f"[update-redirects] Batch {batch+1}: #{pos}",
             )
             work_redirect_ids = web.ctx.site.things(
                 {
                     "type": "/type/redirect",
                     "key~": "/works/*",
                     "limit": batch_size,
-                    "offset": offset,
+                    "offset": start_offset + (batch * batch_size),
                     "sort": "-last_modified",
                 }
             )
+            if not work_redirect_ids:
+                logger.info(f"[update-redirects] Stop: #{pos} No more records.")
+                break
             work_redirect_batch = web.ctx.site.get_many(work_redirect_ids)
             for work in work_redirect_batch:
-                if pos >= max_limit:
-                    break
+                logger.info(f"Modified: {work.last_modified}")
                 pos += 1
                 if work.last_modified < cutoff_date:
-                    logger.info(f"[update-redirects] Stop: {cutoff_date}")
+                    logger.info(f"[update-redirects] Stop: #{pos} <{work.key}> {work.last_modified} < {cutoff_date}")
+                    go = False
                     break
                 if work.last_modified > grace_date:
                     logger.info(f"[update-redirects] Skip: #{pos} <{work.key}> grace")
@@ -697,8 +699,9 @@ class Work(Thing):
                             "[update-redirects] No Update Required: "
                             f"#{pos} <{work.key}> {chain}"
                         )
+            batch += 1
 
-        logger.info(f"[update-redirects] Done: #{pos} of {max_limit}")
+        logger.info(f"[update-redirects] Done")
 
 
 class Author(Thing):

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -680,7 +680,6 @@ class Work(Thing):
                 break
             work_redirect_batch = web.ctx.site.get_many(work_redirect_ids)
             for work in work_redirect_batch:
-                logger.info(f"Modified: {work.last_modified}")
                 pos += 1
                 if work.last_modified < cutoff_date:
                     logger.info(

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -683,7 +683,9 @@ class Work(Thing):
                 logger.info(f"Modified: {work.last_modified}")
                 pos += 1
                 if work.last_modified < cutoff_date:
-                    logger.info(f"[update-redirects] Stop: #{pos} <{work.key}> {work.last_modified} < {cutoff_date}")
+                    logger.info(
+                        f"[update-redirects] Stop: #{pos} <{work.key}> {work.last_modified} < {cutoff_date}"
+                    )
                     go = False
                     break
                 if work.last_modified > grace_date:


### PR DESCRIPTION
Previously, a limit was required when running resolve redirects.

But what we like usually want is to run on a date range, not a number of entries.

This PR reworks the bulk resolve redirects #6752 #6667 #6511 to prepare us for a monthly cron.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
