### PR TITLE
librarian merge queue fixes

### DIFF
--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -96,7 +96,9 @@ class community_edits_queue(delegate.page):
                 )
 
     def GET(self):
-        i = web.input(page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc')
+        i = web.input(
+            page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc'
+        )
         merge_requests = CommunityEditsQueue.get_requests(
             page=int(i.page),
             limit=int(i.limit),
@@ -112,7 +114,7 @@ class community_edits_queue(delegate.page):
             ),
             "closed": CommunityEditsQueue.get_counts_by_mode(
                 mode='closed', submitter=i.submitter, reviewer=i.reviewer
-            )
+            ),
         }
         return render_template(
             'merge_queue/merge_queue',

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -96,19 +96,24 @@ class community_edits_queue(delegate.page):
                 )
 
     def GET(self):
-        i = web.input(page=1, limit=25, mode="open", submitter=None, reviewer=None)
+        i = web.input(page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc')
         merge_requests = CommunityEditsQueue.get_requests(
             page=int(i.page),
             limit=int(i.limit),
             mode=i.mode,
             submitter=i.submitter,
             reviewer=i.reviewer,
-            order='created desc',
+            order=f'created {i.order}',
         ).list()
 
-        total_found = CommunityEditsQueue.get_counts_by_mode(
-            mode=i.mode, submitter=i.submitter, reviewer=i.reviewer
-        )
+        total_found = {
+            "open": CommunityEditsQueue.get_counts_by_mode(
+                mode='open', submitter=i.submitter, reviewer=i.reviewer
+            ),
+            "closed": CommunityEditsQueue.get_counts_by_mode(
+                mode='closed', submitter=i.submitter, reviewer=i.reviewer
+            )
+        }
         return render_template(
             'merge_queue/merge_queue',
             total_found,

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -17,7 +17,7 @@ $if submitter:
 $else:
   $ desc = _('Showing all requests.')
   $ link_text = _('Show my requests') if username else ''
-  $ href = changequery(submitter=username) if username else changequery(submitter=None)
+  $ href = changequery(submitter=username, page=None) if username else changequery(submitter=None, page=None)
 
 <div class="librarian-queue-page">
   <h1>$_('Community Edit Requests')</h1>

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -1,6 +1,6 @@
 $def with(total, merge_requests=None)
 
-$# total : int : The total number of merge requests found for the current mode
+$# total : dict : {"open": int, "closed": int}; The total number of merge requests found for the current mode
 $# merge_requests : list : Merge requests to be displayed in the table
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
@@ -28,18 +28,15 @@ $else:
 
 $ page = int(input(page=1).page)
 <div class="pager">
-  $:macros.Pager(page, total, results_per_page=25)
+  $:macros.Pager(page, total[mode], results_per_page=25)
 </div>
 
   <ul class="nav-bar">
     <li class="$(mode=='open' and 'selected' or '')">
-      <a href="$changequery(mode='open')">$_('Open')</a>
+      <a href="$changequery(mode='open', page=None)">$_('Open') ($total['open'])</a>
     </li>
     <li class="$(mode=='closed' and 'selected' or '')">
-      <a href="$changequery(mode='closed')">$_('Closed')</a>
-    </li>
-    <li class="$(mode=='all' and 'selected' or '')">
-      <a href="$changequery(mode='all')">$_('All')</a>
+      <a href="$changequery(mode='closed', page=None)">$_('Closed') ($total['closed'])</a>
     </li>
   </ul>
 
@@ -114,6 +111,6 @@ $ page = int(input(page=1).page)
       </table>
   </div>
    <div class="pager">
-    $:macros.Pager(page, total, results_per_page=25)
+    $:macros.Pager(page, total[mode], results_per_page=25)
   </div>
 </div>


### PR DESCRIPTION
Closes #6807

- allows flexible sorting with ?order=asc or desc -- piggy backs on #6785 
- adds total counts to Open and Closed
- removes "All"
- fixes bug where page? persists when switching modes -- fixes **half** of #6782 (i.e. mode part, not submitter!)


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
