### PR TITLE
Fix copydocs: Move sys path insert up to fix import

### DIFF
--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -8,10 +8,9 @@ from typing import Union
 
 import web
 
-sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
+import _init_path
 
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
-import scripts._init_path  # noqa: E402,F401
 from openlibrary.api import OpenLibrary, marshal  # noqa: E402
 
 __version__ = "0.2"

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -8,9 +8,9 @@ from typing import Union
 
 import web
 
-from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
-
 sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
+
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 import scripts._init_path  # noqa: E402,F401
 from openlibrary.api import OpenLibrary, marshal  # noqa: E402
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6790 

Fix #6790 by moving sys.path.insert up to allow import call to work

### Technical

### Testing

Run copydocs.py on example work

### Screenshot


### Stakeholders

@jimchamp 