### PR TITLE
Add profiling to "My Books" sidebar

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -50,7 +50,7 @@ $var title: $header_title
 
 <div class="mybooks">
 
-  $:render_template("account/sidebar", user, key=key, public=public, owners_page=owners_page, counts=counts, lists=lists)
+  $:render_template("account/sidebar", user, key=key, public=public, owners_page=owners_page, counts=counts, lists=lists, component_times=component_times)
 
   <div class="mybooks-details">
     $ component_times['Details header'] = time()

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -1,7 +1,4 @@
-$def with (user, key=None, owners_page=False, public=False, counts=None, lists=None)
-
-$ component_times = {}
-$ component_times['TotalTime'] = time()
+$def with (user, key=None, owners_page=False, public=False, counts=None, lists=None, component_times={})
 
 $ username = user.key.split('/')[-1]
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
While looking at the "My Books" sidebar template, I noticed that render times were captured for the sidebar but not displayed in the debug message.

This PR adds the sidebar render times to `component_times`

### Technical
<!-- What should be noted about the implementation? -->
`component_times` are now passed to the sidebar template.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Add `?debug=true` to any "My Books" page URL, and load the page.
2. Scroll to the bottom of the page.  Ensure that the sidebar render times are present in the profile component.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![sidebar_profiling](https://user-images.githubusercontent.com/28732543/182736651-e645ebfa-b20b-431b-82c8-7b9b8dd706ae.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
