### PR TITLE
Add analytics to "My Books" sidebar links

### DIFF
--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -14,26 +14,26 @@ $ counts = counts or pa.get_sidebar_counts
   <div class="mybooks-menu">
     <ul class="sidebar-section">
       <li class="section-header">$username</li>
-      <li><a href="/people/$username" $('class=selected' if key == 'profile' else '')>$_('Profile Page')</a></li>
+      <li><a href="/people/$username" data-ol-link-track="MyBooksSidebar|Profile" $('class=selected' if key == 'profile' else '')>$_('Profile Page')</a></li>
       $if owners_page:
-        <li><a href="/account" $('class=selected' if key == 'settings' else '')>$_('Settings & Privacy')</a></li>
+        <li><a href="/account" data-ol-link-track="MyBooksSidebar|Settings" $('class=selected' if key == 'settings' else '')>$_('Settings & Privacy')</a></li>
         <hr/>
-        <li><a href="/account/loans" $('class=selected' if key == 'loans' else '')>$_('Loans')</a></li>
-        <li><a class="external-link" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a></li>
+        <li><a href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('Loans')</a></li>
+        <li><a class="external-link" data-ol-link-track="MyBooksSidebar|LoanHistory" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a></li>
     </ul>
     $if public or owners_page:
       <ul class="sidebar-section">
         <li class="section-header">$_('Reading Log')</li>
-        <li><a href="/people/$username/books/currently-reading" $('class=selected' if key == 'currently-reading' else '')><span class="li-count">$counts['currently-reading']</span>$_('Currently Reading')</a></li>
-        <li><a href="/people/$username/books/want-to-read" $('class=selected' if key == 'want-to-read' else '')><span class="li-count">$counts['want-to-read']</span>$_('Want to Read')</a></li>
-        <li><a href="/people/$username/books/already-read" $('class=selected' if key == 'already-read' else '')><span class="li-count">$counts['already-read']</span>$_('Already Read')</a></li>
+        <li><a href="/people/$username/books/currently-reading" data-ol-link-track="MyBooksSidebar|CurrentlyReading" $('class=selected' if key == 'currently-reading' else '')><span class="li-count">$counts['currently-reading']</span>$_('Currently Reading')</a></li>
+        <li><a href="/people/$username/books/want-to-read" data-ol-link-track="MyBooksSidebar|WantToRead" $('class=selected' if key == 'want-to-read' else '')><span class="li-count">$counts['want-to-read']</span>$_('Want to Read')</a></li>
+        <li><a href="/people/$username/books/already-read" data-ol-link-track="MyBooksSidebar|AlreadyRead" $('class=selected' if key == 'already-read' else '')><span class="li-count">$counts['already-read']</span>$_('Already Read')</a></li>
       $if owners_page:
         <hr>
-        <li><a $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
-        <li><a $('class=selected' if key=='observations' else '') href="/people/$username/books/observations"><span class="li-count">$counts['observations']</span>$_('My Reviews')</a></li>
+        <li><a data-ol-link-track="MyBooksSidebar|MyNotes" $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
+        <li><a data-ol-link-track="MyBooksSidebar|MyReviews" $('class=selected' if key=='observations' else '') href="/people/$username/books/observations"><span class="li-count">$counts['observations']</span>$_('My Reviews')</a></li>
         <hr>
-        <li><a href="/account/books/already-read/stats">$_('Reading Stats')</a></li>
-        <li><a href="/account/import" $('class=selected' if key=='imports' else '')>$_("Import & Export Options")</a></li>
+        <li><a data-ol-link-track="MyBooksSidebar|ReadingStats" href="/account/books/already-read/stats">$_('Reading Stats')</a></li>
+        <li><a data-ol-link-track="MyBooksSidebar|ImportExport" href="/account/import" $('class=selected' if key=='imports' else '')>$_("Import & Export Options")</a></li>
       </ul>
     $if owners_page and ctx.user and ctx.user.in_sponsorship_beta():
       <ul class="sidebar-section">
@@ -41,10 +41,10 @@ $ counts = counts or pa.get_sidebar_counts
         $ sponsorship_count = ''
         $if counts.get('sponsorships', None):
           $ sponsorship_count = "%d" % counts['sponsorships']
-        <li><a href="/people/$username/books/sponsorships" $('class=selected' if key == 'sponsorships' else '')><span class="li-count">$sponsorship_count</span>$_('Sponsoring')</a></li>
+        <li><a href="/people/$username/books/sponsorships" data-ol-link-track="MyBooksSidebar|Sponsorships" $('class=selected' if key == 'sponsorships' else '')><span class="li-count">$sponsorship_count</span>$_('Sponsoring')</a></li>
       </ul>
     <ul class="sidebar-section">
-      <li class="section-header section-header-split"><span>$_('Lists')</span> <a href="/people/$username/lists" class="li-count">$_('See All') ($len(lists))</a></li>
+      <li class="section-header section-header-split"><span>$_('Lists')</span> <a href="/people/$username/lists" data-ol-link-track="MyBooksSidebar|AllLists" class="li-count">$_('See All') ($len(lists))</a></li>
         <div class="list-overflow">
           $ placeholder_name = _('Untitled list')
           $for lst in lists:
@@ -56,7 +56,7 @@ $ counts = counts or pa.get_sidebar_counts
               $ path_id = ctx.path.split('/')[4]
               $if list_id == path_id:
                 $ class_list = class_list + 'selected'
-            <li><a class="$class_list" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$(lst['name'] if lst['name'] else '[%s]' % placeholder_name)</a></li>
+            <li><a class="$class_list" data-ol-link-track="MyBooksSidebar|PatronList" href="/people/$username/lists/$list_id"><span class="li-count">$(len(lst.seeds))</span>$(lst['name'] if lst['name'] else '[%s]' % placeholder_name)</a></li>
         </div>
     </ul>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6802

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds analytics to all "My Books" page sidebar links.

Event Category for all new analytics events is __MyBooksSidebar__

Events actions and their associated links are as follows:
| Action | Sidebar Link |
| --- | --- |
| Profile | "Profile Page" |
| Settings | "Settings & Privacy" |
| Loans | "Loans" |
| LoanHistory | "Loan History" |
| CurrentlyReading | "Currently Reading" |
| WantToRead | "Want to Read" |
| MyNotes | "Already Read" |
| MyReviews | "My Reviews" |
| ReadingStats | "Reading Stats" |
| ImportExport | "Import & Export Options" |
| Sponsorships | "Sponsoring" |
| AllLists | "See all" lists |
| PatronList | All list details |

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
