### PR TITLE
Remove extra double quote from MainNav analytic events

### DIFF
--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -14,7 +14,7 @@ $ singleton = len(props.get('links', [])) == 1
 <div class="$(props['name'])-component header-dropdown">
   $if singleton:
     $ link = props['links'][0]
-    $ tracker = link.get('track') and 'data-ol-link-track="%s"' % link.get('track') or ''
+    $ tracker = link.get('track') and 'data-ol-link-track=%s' % link.get('track') or ''
     <a href="$link['href']" $tracker>$(props['label'])</a>
   $else:
     <details>
@@ -40,7 +40,7 @@ $ singleton = len(props.get('links', [])) == 1
       >
         <ul class="dropdown-menu $(props['name'])-dropdown-menu">
           $for link in props['links']:
-            $ tracker = link.get('track') and 'data-ol-link-track="%s"' % link.get('track') or ''
+            $ tracker = link.get('track') and 'data-ol-link-track=%s' % link.get('track') or ''
             $if 'subsection' in link:
               <li class="subsection">
                 $(link['subsection'])


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Today, our `data-ol-link-track` value for our main navbar items is nested within two sets of double quotes:

![Screenshot from 2022-08-04 12-56-27](https://user-images.githubusercontent.com/28732543/182909686-0348567c-cb98-4ced-9f9f-b34e35adbd9f.png)

This is causing a `"` character to be prepended to the `MainNav` category and appended to each action in Google Analytics:
![Screenshot from 2022-08-04 12-55-41](https://user-images.githubusercontent.com/28732543/182909936-c9fc07cd-bde7-455a-85d0-c764a0370f3e.png)

![Screenshot from 2022-08-04 12-55-09](https://user-images.githubusercontent.com/28732543/182909919-076567f0-5202-4594-a4a0-3750c908ab95.png)

This PR removes the extra double quote characters.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Once deployed, navigate to any page and inspect a main nav link.  Ensure that the value of `data-ol-link-track` is surrounded by a single set of quotes.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
