### PR TITLE
Add merge request submitters to patron anonymization process

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -23,6 +23,7 @@ from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
+from openlibrary.core.edits import CommunityEditsQueue
 
 try:
     from simplejson.errors import JSONDecodeError
@@ -353,6 +354,9 @@ class Account(web.storage):
             self.username, new_username, _test=test
         )
         results['bookshelves_count'] = Bookshelves.update_username(
+            self.username, new_username, _test=test
+        )
+        results['merge_request_count'] = CommunityEditsQueue.update_submitter_name(
             self.username, new_username, _test=test
         )
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -384,6 +384,7 @@ class people_view:
             f"Ratings updated: {results['ratings_count']}. "
             f"Observations updated: {results['observations_count']}. "
             f"Bookshelves updated: {results['bookshelves_count']}."
+            f"Merge requests updated: {results['merge_request_count']}"
         )
         add_flash_message("info", msg)
         raise web.seeother(web.ctx.path)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds the `community_edits_queue` table entries to the patron anonymization flow.  __Only submitters are anonymized__, not reviewers.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as an `admin` on your local instance:
1. Ensure that there are entries in the `community_edits_queue` table.  Choose a `submitter` to anonymize from one of the rows.  Note the number of entries that the `submitter` submitted.
2. Navigate to the `/merges` view that contains the `submitter`'s name.
3. Navigate to `/admin/people/${submitter}`. In the admin history table, tick the "Dry Run" checkbox and press the "Anonymize Account" button. Ensure that the updated row count is correct for `community_edits_queue`.
4. Uncheck the "Dry Run" checkbox, if ticked.  Press the "Anonymize Account" button again. Note the new username.
5. Navigate back to the `/merges` page.  Ensure that the submitter's username has been updated correctly in the view.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
