### PR TITLE
docker/Dockerfile.olbase: Upgrade npm as we do with pip

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -37,7 +37,7 @@ RUN apt-get -qq update && apt-get install -y \
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g npm@latest
+    && npm install --location=global npm@latest
 
 # Install Archive.org nginx w/ IP anonymization
 USER root

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -36,7 +36,8 @@ RUN apt-get -qq update && apt-get install -y \
 
 # Install LTS version of node.js
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y nodejs
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest
 
 # Install Archive.org nginx w/ IP anonymization
 USER root


### PR DESCRIPTION
Olbase always upgrades to the latest version of Python's pip so why not do the same with Node.js' npm?  https://www.npmjs.com/package/npm

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

`docker build --no-cache -t openlibrary/olbase:npm_latest -f docker/Dockerfile.olbase .`
```
npm --version  # --> 8.11.0
npm install --location=global npm@latest
npm --version  # --> 8.16.0
```
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
