### PR TITLE
Add book note and star rating info to `/stats`

### DIFF
--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -26,7 +26,7 @@ class Booknotes(db.CommonExtras):
         }
 
     @classmethod
-    def total_booknotes(cls, since=None):
+    def total_booknotes(cls, since=None) -> int:
         oldb = db.get_db()
         query = f"SELECT count(*) from {cls.TABLENAME}"
         if since:

--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -1,5 +1,7 @@
 from . import db
 
+from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
+
 
 class Booknotes(db.CommonExtras):
 
@@ -9,10 +11,28 @@ class Booknotes(db.CommonExtras):
     ALLOW_DELETE_ON_CONFLICT = False
 
     @classmethod
-    def total_booknotes(cls):
+    def summary(cls) -> dict:
+        return {
+            'total_notes_created': {
+                'total': cls.total_booknotes(),
+                'month': cls.total_booknotes(since=DATE_ONE_MONTH_AGO),
+                'week': cls.total_booknotes(since=DATE_ONE_WEEK_AGO),
+            },
+            'total_note_takers': {
+                'total': cls.total_unique_users(),
+                'month': cls.total_unique_users(since=DATE_ONE_MONTH_AGO),
+                'week': cls.total_unique_users(since=DATE_ONE_WEEK_AGO),
+            },
+        }
+
+    @classmethod
+    def total_booknotes(cls, since=None):
         oldb = db.get_db()
         query = f"SELECT count(*) from {cls.TABLENAME}"
-        return oldb.query(query)['count']
+        if since:
+            query += " WHERE created >= $since"
+        results = oldb.query(query, vars={'since': since})
+        return results[0]['count'] if results else 0
 
     @classmethod
     def total_unique_users(cls, since=None):
@@ -30,7 +50,7 @@ class Booknotes(db.CommonExtras):
         if since:
             query += " WHERE created >= $since"
         results = oldb.query(query, vars={'since': since})
-        return results[0] if results else None
+        return results[0]['count'] if results else 0
 
     @classmethod
     def most_notable_books(cls, limit=10, since=False):

--- a/openlibrary/core/booknotes.py
+++ b/openlibrary/core/booknotes.py
@@ -35,7 +35,7 @@ class Booknotes(db.CommonExtras):
         return results[0]['count'] if results else 0
 
     @classmethod
-    def total_unique_users(cls, since=None):
+    def total_unique_users(cls, since=None) -> int:
         """Returns the total number of unique patrons who have made
         booknotes. `since` may be provided to only return the number of users after
         a certain datetime.date.

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -49,7 +49,7 @@ class Ratings(db.CommonExtras):
         return results[0]['count'] if results else 0
 
     @classmethod
-    def total_num_unique_raters(cls, since=None) -> Optional[int]:
+    def total_num_unique_raters(cls, since=None) -> int:
         oldb = db.get_db()
         query = "select count(DISTINCT username) from ratings"
         if since:

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -29,8 +29,12 @@ class Ratings(db.CommonExtras):
                 'total': Ratings.total_num_books_rated(),
                 'month': Ratings.total_num_books_rated(since=DATE_ONE_MONTH_AGO),
                 'week': Ratings.total_num_books_rated(since=DATE_ONE_WEEK_AGO),
-                'unique': Ratings.total_num_unique_raters(),
-            }
+            },
+            'total_star_raters': {
+                'total': Ratings.total_num_unique_raters(),
+                'month': Ratings.total_num_unique_raters(since=DATE_ONE_MONTH_AGO),
+                'week': Ratings.total_num_unique_raters(since=DATE_ONE_WEEK_AGO),
+            },
         }
 
     @classmethod
@@ -42,7 +46,7 @@ class Ratings(db.CommonExtras):
         if since:
             query += " WHERE created >= $since"
         results = oldb.query(query, vars={'since': since})
-        return results[0] if results else None
+        return results[0]['count'] if results else 0
 
     @classmethod
     def total_num_unique_raters(cls, since=None) -> Optional[int]:
@@ -51,7 +55,7 @@ class Ratings(db.CommonExtras):
         if since:
             query += " WHERE created >= $since"
         results = oldb.query(query, vars={'since': since})
-        return results[0] if results else None
+        return results[0]['count'] if results else 0
 
     @classmethod
     def most_rated_books(cls, limit=10, since=False) -> list:

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -191,6 +191,36 @@ $ stats = get_admin_stats()
       <td></td>
       <td class="amount">$commify(counts.reading_log['total_reviewers']['total'])</td>
     </tr>
+
+    <tr class="major">
+      <td>Notes Created</td>
+      <td class="amount">$commify(counts.reading_log['total_notes_created']['week'])</td>
+      <td class="amount">$commify(counts.reading_log['total_notes_created']['month'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_notes_created']['total'])</td>
+    </tr>
+    <tr class="major">
+      <td>Patrons Creating Notes</td>
+      <td class="amount">$commify(counts.reading_log['total_note_takers']['week'])</td>
+      <td class="amount">$commify(counts.reading_log['total_note_takers']['month'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_note_takers']['total'])</td>
+    </tr>
+
+    <tr class="major">
+      <td>Books Starred</td>
+      <td class="amount">$commify(counts.reading_log['total_books_starred']['week'])</td>
+      <td class="amount">$commify(counts.reading_log['total_books_starred']['month'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_books_starred']['total'])</td>
+    </tr>
+    <tr class="major">
+      <td>Star Rating Patrons</td>
+      <td class="amount">$commify(counts.reading_log['total_star_raters']['week'])</td>
+      <td class="amount">$commify(counts.reading_log['total_star_raters']['month'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_star_raters']['total'])</td>
+    </tr>
   </table>
 
   <div class="clearfix"></div>

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -10,6 +10,7 @@ from ..utils import dateutil
 from .. import app
 from ..core import cache
 from ..core.observations import Observations
+from ..core.booknotes import Booknotes
 from ..core.bookshelves import Bookshelves
 from ..core.ratings import Ratings
 from ..plugins.admin.code import get_counts
@@ -36,6 +37,7 @@ def reading_log_summary():
     stats = Bookshelves.summary()
     stats.update(Ratings.summary())
     stats.update(Observations.summary())
+    stats.update(Booknotes.summary())
     return stats
 
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds weekly, monthly, and total counts for the following:
- Book notes created
- Unique patrons creating notes
- Star ratings created
- Unique patrons star rating books

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-08-05 14-27-21](https://user-images.githubusercontent.com/28732543/183142492-e932db85-df93-43c5-b783-418157096f8b.png)

### Special Deploy Instructions
Reading log stats entry needs to be cleared once this is deployed. This can be done from the admin "Inspect Memcache" view.  Just paste that following key into the textarea and press the delete button:
`stats.readling_log_summary-`

__Note:__ The trailing `-` symbol is required for key deletion.

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
