### PR TITLE
Fix books with ia ids not indexed in solr

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -612,6 +612,11 @@ class SolrProcessor:
 
         d |= self.get_ebook_info(editions, ia_metadata)
 
+        # See https://github.com/internetarchive/openlibrary/issues/6836
+        # This was half-implemented
+        if 'ia_collection' in d and not get_solr_next():
+            del d['ia_collection']
+
         return d
 
     @staticmethod


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6835 

This field, `ia_collection` only exists in `solr_next`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Patch deployed, previously failing indexes are now working.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
