### PR TITLE
Removes all spaces from ISNI numbers

### DIFF
--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -77,7 +77,7 @@ export default {
             if (!this.setButtonEnabled) return
 
             if (this.selectedIdentifier === 'isni') {
-                this.inputValue = this.inputValue.replaceAll(' ', '')
+                this.inputValue = this.inputValue.replace(/\s/g, '')
             }
 
             // We use $set otherwise we wouldn't get the reactivity desired

--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -76,6 +76,10 @@ export default {
             // if no identifier selected don't execute
             if (!this.setButtonEnabled) return
 
+            if (this.selectedIdentifier === 'isni') {
+                this.inputValue = this.inputValue.replaceAll(' ', '')
+            }
+
             // We use $set otherwise we wouldn't get the reactivity desired
             // See https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats
             this.$set(this.assignedIdentifiers, this.selectedIdentifier, this.inputValue);


### PR DESCRIPTION
Closes: #5696
Closes: #6423
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes all spaces from ISNI numbers before POSTed.  ISNI links do not render properly if there are spaces in the identifier.

### Technical
<!-- What should be noted about the implementation? -->
This only cleans up ISNI identifiers that are submitted via the author edit page.  ISNI identifiers consumed from other sources (if any) will be persisted as-is.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to an author edit page.
2. Select "ISNI" from the identifiers drop-down, and input an ISNI identifier (with spaces) in the text field.
3. Click the "Set" button, then click the "Save" button at the bottom of the page.
4. Ensure that the ISNI is present in the sidebar, and that the link contains no encoded spaces.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
