### PR TITLE
6811/feature/bubble

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -325,3 +325,15 @@ class CommunityEditsQueue:
             "message": message,
             # XXX It may be easier to update these comments if they had IDs
         }
+
+@public
+def get_counts_mode(mode='all', **kwargs):
+    return CommunityEditsQueue.get_counts_by_mode(mode)
+    oldb = db.get_db()
+
+    query = 'SELECT count(*) from community_edits_queue'
+
+    where_clause = cls.where_clause(mode, **kwargs)
+    if where_clause:
+        query = f'{query} WHERE {where_clause}'
+    return oldb.query(query, vars=kwargs)[0]['count']

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -21,6 +21,7 @@ $ singleton = len(props.get('links', [])) == 1
       <summary $:cond(props['name'] == 'hamburger', 'data-ol-link-track="HeaderBar|Hamburger"')>
         $if props['name'] == 'hamburger' and ctx.user:
             <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')">
+            <div class="mr-notifications">17</div>
             <img class="$(props['image-class']) logged" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'image' in props:
             <img class="$(props['image-class'])" src="$(props['image'])" alt="$(props['label'])"/>
@@ -57,6 +58,8 @@ $ singleton = len(props.get('links', [])) == 1
                   <button $(tracker)>$(link["text"])</button>
                 </form>
               $else:
+                $if (link['text'] == 'Pending Requests'): 
+                  <div class="mr-notifications">17</div>
                 <a href="$(link['href'])" $(tracker)>
                   $if 'new' in link and props['name'] == 'hamburger':
                     <span>$(link['text'])</span><span class="app-drawer__badge">$_('New!')</span>

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -21,7 +21,8 @@ $ singleton = len(props.get('links', [])) == 1
       <summary $:cond(props['name'] == 'hamburger', 'data-ol-link-track="HeaderBar|Hamburger"')>
         $if props['name'] == 'hamburger' and ctx.user:
             <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')">
-            <div class="mr-notifications">17</div>
+            $if get_counts_mode(mode='open') > 0:
+              <div class="mr-notifications">$(get_counts_mode(mode='open'))</div>
             <img class="$(props['image-class']) logged" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'image' in props:
             <img class="$(props['image-class'])" src="$(props['image'])" alt="$(props['label'])"/>
@@ -58,8 +59,8 @@ $ singleton = len(props.get('links', [])) == 1
                   <button $(tracker)>$(link["text"])</button>
                 </form>
               $else:
-                $if (link['text'] == 'Pending Requests'): 
-                  <div class="mr-notifications">17</div>
+                $if (link['text'] == 'Pending Requests') and get_counts_mode(mode='open') > 0: 
+                  <div class="mr-notifications">$(get_counts_mode(mode='open'))</div>
                 <a href="$(link['href'])" $(tracker)>
                   $if 'new' in link and props['name'] == 'hamburger':
                     <span>$(link['text'])</span><span class="app-drawer__badge">$_('New!')</span>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,7 +1,19 @@
 $def with (page)
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 
 <header id="header-bar" class="header-bar">
-  $if ctx.user:
+  $if is_privileged_user:
+    $ loginLinks = [
+    $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MainNav|MyProfile" },
+    $     { "href": homepath() + "/merges", "text": _("Pending Requests"), "class": "mr-notifications" ,"track": "MainNav|MyRequests" },
+    $     { "href": homepath() + "/account/loans", "text": _("My Loans"), "track": "MainNav|MyLoans" },
+    $     { "href": "/account/books", "text": _("My Reading Log"), "track": "MainNav|MyReadingLog" },
+    $     { "href": "/account/lists", "text": _("My Lists"), "track": "MainNav|MyLists" },
+    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats"), "track": "MainNav|MyReadingStats" },
+    $     { "href": homepath() + "/account", "text": _("Settings"), "track": "MainNav|MySettings" },
+    $     { "post": "/account/logout", "text": _("Log out"), "track": "MainNav|Logout" },
+    $ ]
+  $elif ctx.user:
     $ loginLinks = [
     $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MainNav|MyProfile" },
     $     { "href": homepath() + "/account/loans", "text": _("My Loans"), "track": "MainNav|MyLoans" },

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -287,6 +287,18 @@
       height: 30px;
     }
 
+    .mr-notifications {
+      position: absolute;
+      background: #02598b;
+      color: white;
+      border-radius: 8px;
+      padding: 3px 7px;
+      font-size: 12px;
+      margin-left: 0px;
+      margin-top: 25px;
+      font-weight: bold;
+    }
+
     button,
     a {
       color: @white;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6811 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature - Added a bubble to the avatar and then a entry + bubble into the sub-navigation within the hamburger.

### Technical
<!-- What should be noted about the implementation? -->
- The bubble is only visible when `admin/super-librarians` have atleast one pending merge requests.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
[https://gist.github.com/jimchamp/dd83ae3fe1ea86ae9621707fa96b4edf](url)
Execute these commands and you can see the bubble.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/72622483/183292551-f1b594f2-a462-4e2d-a3d2-0197ce46d10b.png)
Avatar
![image](https://user-images.githubusercontent.com/72622483/183292566-a9d00ad5-6041-4bd3-ab63-e63e8013d8a4.png)
Hamburger List

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
