### PR TITLE
pytest: Set asyncio_mode to strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [tool.black]
 skip-string-normalization = true
-target-version = ['py39', 'py310']
+target-version = ["py39", "py310"]
 
 [tool.pytest.ini_options]
-asyncio_mode = strict
+asyncio_mode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@
 [tool.black]
 skip-string-normalization = true
 target-version = ['py39', 'py310']
+
+[tool.pytest.ini_options]
+asyncio_mode = strict


### PR DESCRIPTION
[`pyproject.toml: [tool.pytest.ini_options] asyncio_mode = strict`](https://github.com/pytest-dev/pytest-asyncio#modes)

Removes pytest warning:
```
=============================== warnings summary ===============================
../../../../../opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/pytest_asyncio/plugin.py:191
  /opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/pytest_asyncio/plugin.py:191:
  DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future,
   please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)
```

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
