### PR TITLE
Fix for #6851: refactor urldecode() from coverstore/utls.py to use urlsplit() and not the depreciated splitquery()

### DIFF
--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -2,7 +2,7 @@ import pytest
 import web
 from os.path import abspath, exists, join, dirname, pardir
 
-from openlibrary.coverstore import config, coverlib
+from openlibrary.coverstore import config, coverlib, utils
 
 static_dir = abspath(join(dirname(__file__), pardir, pardir, pardir, 'static'))
 
@@ -135,3 +135,21 @@ def test_image_path(image_dir):
         coverlib.find_image_path('covers_0000_00.tar:1234:10')
         == config.data_root + '/items/covers_0000/covers_0000_00.tar:1234:10'
     )
+
+
+def test_urldecode():
+    assert utils.urldecode('http://google.com/search?q=bar&x=y') == (
+        'http://google.com/search',
+        {'q': 'bar', 'x': 'y'},
+    )
+    assert utils.urldecode('google.com/search?q=bar&x=y') == (
+        'google.com/search',
+        {'q': 'bar', 'x': 'y'},
+    )
+    assert utils.urldecode('http://google.com/search') == (
+        'http://google.com/search',
+        {},
+    )
+    assert utils.urldecode('http://google.com/') == ('http://google.com/', {})
+    assert utils.urldecode('http://google.com/?') == ('http://google.com/', {})
+    assert utils.urldecode('?q=bar') == ('', {'q': 'bar'})

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -9,7 +9,7 @@ import string
 
 import requests
 import web
-from urllib.parse import splitquery, unquote, unquote_plus  # type: ignore[attr-defined]
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, unquote, unquote_plus  # type: ignore[attr-defined]
 from urllib.parse import urlencode as real_urlencode
 
 from openlibrary.coverstore import config, oldb
@@ -78,17 +78,17 @@ def download(url):
     return requests.get(url, headers={'User-Agent': USER_AGENT}).content
 
 
-def urldecode(url):
+def urldecode(url: str) -> tuple[str, dict[str, str]]:
     """
     >>> urldecode('http://google.com/search?q=bar&x=y')
     ('http://google.com/search', {'q': 'bar', 'x': 'y'})
     >>> urldecode('http://google.com/')
     ('http://google.com/', {})
     """
-    base, query = splitquery(url)
-    query = query or ""
-    items = [item.split('=', 1) for item in query.split('&') if '=' in item]
+    split_url = urlsplit(url)
+    items = parse_qsl(split_url.query)
     d = {unquote(k): unquote_plus(v) for (k, v) in items}
+    base = urlunsplit(split_url._replace(query=''))
     return base, d
 
 


### PR DESCRIPTION
Refactoring to use urlsplit() rather than splitquery() and to add type hints.

<!-- What issue does this PR close? -->
Closes #6851

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->
Ideally nothing has changed in terms of the inputs and outputs.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I added some tests and used the output from the previous implementation to get the test conditions.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
