### PR TITLE
My Books page interim Mobile Navigation Fixes #6858

### DIFF
--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -119,10 +119,10 @@
     width: 100%;
     position: relative;
     height: 21vh;
-    background: #e8e8e8;
-    border-radius: 0px;
+    background: @grey-e7e7e7;
+    border-radius: 0;
     resize: vertical;
     overflow: auto;
-    border-bottom: 3px solid #ddd;
+    border-bottom: 3px solid @lighter-grey;
   }
 }

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -118,6 +118,11 @@
   .mybooks-menu {
     width: 100%;
     position: relative;
-    max-height: 42vh;
+    height: 21vh;
+    background: #e8e8e8;
+    border-radius: 0px;
+    resize: vertical;
+    overflow: auto;
+    border-bottom: 3px solid #ddd;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This is interim fix number 1 for mobile My Books menu (issue #6858), done initially because it took only a few minutes and helped me get familiar with the development environment. 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Made the menu shorter, resizable, and gave it a slightly darker background. 
This is only the quickest interim fix and I will quickly iterate on this version to do away with the confusing menu entirely

### Technical
<!-- What should be noted about the implementation? -->
Changed css for mybooks-menu on mobile screens to make it resizable, height: 21vh (previously 42) and slightly darker grey background
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to 'My Books' page, inspect element, and toggle to mobile device in staging and compare to live site to see the changes. Select mybooks-menu and check out its mobile css to see the changes
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
#### Three screenshots showing resizability of menu
<img width="351" alt="Screen Shot 2022-08-09 at 6 43 23 PM" src="https://user-images.githubusercontent.com/69476557/183774487-ce262b03-c08e-44aa-be44-31187d7a1a5e.png">

<img width="349" alt="Screen Shot 2022-08-09 at 6 43 35 PM" src="https://user-images.githubusercontent.com/69476557/183774531-a818a9b4-4d71-46dd-be90-d044de3e5bec.png">

<img width="349" alt="Screen Shot 2022-08-09 at 6 43 52 PM" src="https://user-images.githubusercontent.com/69476557/183774548-bda2e5d5-fb3b-4308-94c3-0f3225b9d2e0.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jimchamp @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
