### PR TITLE
Fix for 6830. Generate a WorldCat link even if the only ISBN is an invalid ISBN 10

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -95,7 +95,7 @@ $if isbn_10 and not asin:
         $ asin = isbn_10
     <div class="panel">
       <div class="btn-notice">
-        $:macros.WorldcatLink(isbn=isbn_13, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+        $:macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
 
         <div class="cta-section">
           <p class="cta-section-title">$_('Buy this book')</p>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -21,7 +21,7 @@ $ seeall = "//archive.org/download/XXX"
 
 $ oclc_numbers = (book.oclc_numbers and book.oclc_numbers[0]) or ""
 $ isbn_13 = book.get_isbn13()
-$ isbn_10 = isbn_13 and isbn_13_to_isbn_10(isbn_13)
+$ isbn_10 = (isbn_13 and isbn_13_to_isbn_10(isbn_13)) or book.get_isbn10()
 $ isbn = isbn_10 or isbn_13
 $ asin = isbn_10 or None
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6830

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
I am not sure it is the best approach, but a simple fix for the left-hand menu would be changing
`$:macros.WorldcatLink(isbn=isbn_13, oclc_numbers=oclc_numbers, referer=page.url(relative=False))` to `$:macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))`.

If I understand correctly, the WorldCat link in the left-hand menu is rendered by `openlibrary/macros/databarWork.html`, and only displays if `page.get_isbn13()` returns something. This is so in part because of the following, from line 98, `$:macros.WorldcatLink(isbn=isbn_13, oclc_numbers=oclc_numbers, referer=page.url(relative=False))`.

I think `databarWork.html` is using only ISBN 13 because the page presupposes if there is an ISBN 10, then it will be converted to ISBN 13 when the page is created. This happens from the line 14 assignment of `$ isbn_13 = page.get_isbn13()`. If I understand correctly, `get_isbn13()` is from `openlibrary/plugins/upstream/models.py`. That function transforms ISBN 10 to ISBN 13, if there is an ISBN 10 and isn’t an ISBN 13. However, when the ISBN 10 is invalid, as the one in question is, the call to `isbn_10_to_isbn13(isbn_10)` returns None:
```
def get_isbn13(self):
    """Fetches either isbn_13 or isbn_10 from record and returns canonical
    isbn_13
    """
    isbn_13 = self.isbn_13 and canonical(self.isbn_13[0])
    if not isbn_13:
        isbn_10 = self.isbn_10 and self.isbn_10[0]
        return isbn_10 and isbn_10_to_isbn_13(isbn_10)
   return isbn_13
```
Without an ISBN 13, and without a valid ISBN 10 that can convert to ISBN 13, I think the WorldCat link won’t show. Hence the suggestion to make the above one line change, which falls back to the ISBN 10 directly. 

Some things I tested, prior to making the change. Starting with no ISBN present (on the edit page):
1. add an invalid ISBN 10 and save: no WorldCat link;
2. add an invalid ISBN 10, save, and then add a a valid ISBN 10, save: no WorldCat link;
3. add a valid ISBN 10 and and a invalid ISBN 10 and then save: *yes*, there is a WorldCat link; and
4. add a invalid ISBN 10 and and a valid ISBN 10 and then save: *no*, there is not a WorldCat link.

This may be because `get_isbn13()` is only checking index 0 of `self.isbn_10`. So another fix might be to run `isbn_10_to_isbn_13()` on every ISBN listed, though I haven’t looked into this, in part because that wouldn’t fix this specific issue, as there is just one ISBN 10 here, and it’s invalid and won't convert to ISBN 13.

With the above change, each of the things I tried links to WorldCat, and the WorldCat link to the invalid ISBN 10 also works, at least for this book. However, if an invalid ISBN 10 is added first, and then a valid ISBN 10 is added later, with this change the WorldCat link will be to the invalid ISBN 10 rather than the valid one being used (and thereby converted to ISBN 13). If an ISBN 13 is added, that is used instead.


Edit 3: the edit to `openlibrary/templates/books/edition-sort.html` is a bit easier to explain, based on the above. It too was querying only ISBN 13, via `get_isbn13()`, which converts ISBN 10 to ISBN 13 if there is an ISBN 10 and there is no ISBN 13, but again, that won't work with this invalid ISBN 10.

There may be a reason for always using ISBN 13 and I want to make sure that using ISBN 10 in places instead of ISBN 13 won't break things.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try adding a book with just the invalid ISBN 10 in question: 7204051613. The link to WorldCat at https://worldcat.org/isbn/7204051613 should work. If a valid ISBN 13 is added, that should take precedence.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
With the proposed PR:
![image](https://user-images.githubusercontent.com/26524678/183864892-133ae180-e436-4743-b643-8474fa1fbc46.png)

Without the proposed PR (https://openlibrary.org/books/OL39212557M/Shou_xiang_bang_jia_an_Meng_mian_nu_ren):
![image](https://user-images.githubusercontent.com/26524678/183819577-ac9146a1-4026-4437-bcd2-752ee344f61b.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
