### PR TITLE
GitHub Actions: lxml only need on dev releases of Python

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -29,11 +29,13 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-venv-${{ env.pythonLocation }}-${{ hashFiles('requirements*.txt') }}
-      - name: Install dependencies
+      - if: "contains(matrix.python-version, '-dev')"
         run: |
           sudo apt-get update
           # https://lxml.de/installation.html#requirements
-          sudo apt-get install libxml2-dev libxslt-dev
+          sudo apt-get install -y libxml2 libxslt-dev
+      - name: Install dependencies
+        run: |
           pip install --upgrade pip setuptools wheel
           pip install -r requirements_test.txt
           pip list --outdated


### PR DESCRIPTION
This should save on build time

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

@mekarpeles writes: This doesn't remove any packages from being installed in prod or on dev environments, it just changes what libraries are necessary for running our tests in github actions


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
