### PR TITLE
Adding Main Banner to Mobile Book Page Surveys (Mazes)

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1094,6 +1094,7 @@ def setup_template_globals():
             'isbn_10_to_isbn_13': isbn_10_to_isbn_13,
             'NEWLINE': '\n',
             'random': random.Random(),
+            'choose_random_from': random.choice,
             'get_lang': lambda: web.ctx.lang,
             'ceil': math.ceil,
             'get_best_edition': get_best_edition,

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -36,7 +36,7 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
       $ maze_urls = ["https://t.maze.co/107767467", "https://t.maze.co/107767827", "https://t.maze.co/107767954", "https://t.maze.co/107769065", "https://t.maze.co/107769576", "https://t.maze.co/107769995"]
       $ random_maze_url = choose_random_from(maze_urls)
-      $ announcement = 'Please help us improve the design of Open Library by taking this short <a href="%s" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Survey</a>' % random_maze_url
+      $ announcement = 'Please help us improve the design of Open Library by taking this short <a href="%s" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary" target="_blank">Survey</a>' % random_maze_url
       $if announcement:
         <div class="page-banner page-banner-body">
          $:announcement

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -34,7 +34,7 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       </div>
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
-      $ maze_urls = ["https://t.maze.co/107617129", "https://t.maze.co/107617183", "https://t.maze.co/107531360", "https://t.maze.co/107617646", "https://t.maze.co/107617836", "https://t.maze.co/107618078"]
+      $ maze_urls = ["https://t.maze.co/107767467", "https://t.maze.co/107767827", "https://t.maze.co/107767954", "https://t.maze.co/107769065", "https://t.maze.co/107769576", "https://t.maze.co/107769995"]
       $ random_maze_url = choose_random_from(maze_urls)
       $ announcement = 'Please help us improve the design of Open Library by taking this short <a href="%s" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Survey</a>' % random_maze_url
       $if announcement:

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -34,9 +34,9 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       </div>
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
-      $ maze_urls = ["https://t.maze.co/107617129", "https://t.maze.co/107617183", "https://t.maze.co/107531360", "https://t.maze.co/107617646", "https://t.maze.co/107617836", "https://t.maze.co/107618078"]                                                                   
-      $ random_maze_url = choose_random_from(maze_urls)                                                                                                                                                                                                                          
-      $ announcement = 'Please help us improve the design of Open Library by taking this short <a href="%s" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Survey</a>' % random_maze_url  
+      $ maze_urls = ["https://t.maze.co/107617129", "https://t.maze.co/107617183", "https://t.maze.co/107531360", "https://t.maze.co/107617646", "https://t.maze.co/107617836", "https://t.maze.co/107618078"]
+      $ random_maze_url = choose_random_from(maze_urls)
+      $ announcement = 'Please help us improve the design of Open Library by taking this short <a href="%s" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Survey</a>' % random_maze_url
       $if announcement:
         <div class="page-banner page-banner-body">
          $:announcement

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -34,7 +34,9 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       </div>
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
-      $ announcement = None
+      $ maze_urls = ["https://t.maze.co/107617129", "https://t.maze.co/107617183", "https://t.maze.co/107531360", "https://t.maze.co/107617646", "https://t.maze.co/107617836", "https://t.maze.co/107618078"]                                                                   
+      $ random_maze_url = choose_random_from(maze_urls)                                                                                                                                                                                                                          
+      $ announcement = 'Please help us improve the design of Open Library by taking this short <a href="%s" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Survey</a>' % random_maze_url  
       $if announcement:
         <div class="page-banner page-banner-body">
          $:announcement

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -51,8 +51,8 @@
     display: block;
     max-width: 200px;
     margin: auto;
-    border: 1px solid @lightest-grey;                                                                                                                                                                                                                                            
-    font-weight: bold; 
+    border: 1px solid @lightest-grey;
+    font-weight: bold;
   }
   &-body {
     font-size: .9em;

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -9,7 +9,7 @@
   display: block;
   color: @white;
   font-family: @lucida_sans_serif-1;
-  background: @black;
+  background: @dark-grey;
   padding: 15px;
   border-bottom: 1px solid @beige;
   z-index: @z-index-level-2;
@@ -51,9 +51,11 @@
     display: block;
     max-width: 200px;
     margin: auto;
+    border: 1px solid @lightest-grey;                                                                                                                                                                                                                                            
+    font-weight: bold; 
   }
   &-body {
-    font-size: .85em;
+    font-size: .9em;
     padding: 10px;
     line-height: 25px;
     text-align: center;

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -51,7 +51,7 @@
     display: block;
     max-width: 200px;
     margin: auto;
-    border: 1px solid @lightest-grey;
+    border: 1px solid @button-hover-blue;
     font-weight: bold;
   }
   &-body {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Works towards #6714
Closes #6716

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This PR adds a banner to OpenLibrary.org and encourage folks to take a quick survey.

The code adds a random choice function to our templates so that we can evenly spread out the different survey links to patrons.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
