### PR TITLE
Author merge requests

### DIFF
--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -1,5 +1,6 @@
 /* eslint no-console: 0 */
 import _ from 'lodash';
+import { approveRequest, declineRequest, createRequest, REQUEST_TYPES } from '../../plugins/openlibrary/js/merge-request-table/MergeRequestService'
 
 const collator = new Intl.Collator('en-US', {numeric: true})
 
@@ -153,22 +154,12 @@ export function get_ratings(key) {
  * @returns {Promise<Response>} A response to the request
  */
 export function update_merge_request(mrid, action, comment) {
-    const data = {
-        rtype: 'merge-works',
-        action: action,
-        mrid: mrid
+    if (action === 'approve') {
+        return approveRequest(mrid, comment)
     }
-    if (comment) {
-        data['comment'] = comment
+    else if (action === 'decline') {
+        return declineRequest(mrid, comment)
     }
-    return fetch('/merges', {
-        method: 'POST',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
-    })
 }
 
 /**
@@ -179,20 +170,8 @@ export function update_merge_request(mrid, action, comment) {
  * @returns {Promise<Response>}
  */
 export function createMergeRequest(workIds) {
-    const normalizedIds = prepareIds(workIds)
-    const data = {
-        rtype: 'merge-works',
-        action: 'create-merged',
-        olids: normalizedIds.join(',')
-    }
-    return fetch('/merges', {
-        method: 'POST',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
-    })
+    const normalizedIds = prepareIds(workIds).join(',')
+    return createRequest(normalizedIds, 'create-merged', REQUEST_TYPES['WORK_MERGE'])
 }
 
 /**

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -153,15 +153,21 @@ export function get_ratings(key) {
  * @returns {Promise<Response>} A response to the request
  */
 export function update_merge_request(mrid, action, comment) {
-    const formData = new FormData();
-    formData.set('mrid', mrid)
-    formData.set('action', action)
+    const data = {
+        rtype: 'merge-works',
+        action: action,
+        mrid: mrid
+    }
     if (comment) {
-        formData.set('comment', comment)
+        data['comment'] = comment
     }
     return fetch('/merges', {
         method: 'POST',
-        body: formData
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
     })
 }
 
@@ -173,13 +179,19 @@ export function update_merge_request(mrid, action, comment) {
  * @returns {Promise<Response>}
  */
 export function createMergeRequest(workIds) {
-    const formData = new FormData()
     const normalizedIds = prepareIds(workIds)
-    formData.set('action', 'create-merged')
-    formData.set('work_ids', normalizedIds.join(','))
+    const data = {
+        rtype: 'merge-works',
+        action: 'create-merged',
+        olids: normalizedIds.join(',')
+    }
     return fetch('/merges', {
         method: 'POST',
-        body: formData
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
     })
 }
 

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -39,6 +39,11 @@ class CommunityEditsQueue:
 
     TABLENAME = 'community_edits_queue'
 
+    TYPE = {
+        'WORK_MERGE': 1,
+        'AUTHOR_MERGE': 2,
+    }
+
     STATUS = {
         'DECLINED': 0,
         'PENDING': 1,
@@ -144,50 +149,6 @@ class CommunityEditsQueue:
         return rows_changed
 
     @classmethod
-    def submit_work_merge_request(
-        cls,
-        work_ids: list[str],
-        submitter: str,
-        comment: str = None,
-        reviewer: str = None,
-        status: int = STATUS['PENDING'],
-    ):
-        """
-        Creates new work merge requests with the given work olids.
-
-        Precondition: OLIDs in work_ids list must be sanitized and normalized.
-        """
-        url = f"/works/merge?records={','.join(work_ids)}"
-        if not cls.exists(url):
-            return cls.submit_request(
-                url,
-                submitter=submitter,
-                comment=comment,
-                reviewer=reviewer,
-                status=status,
-                title=cls.get_work_merge_title(work_ids),
-            )
-
-    @staticmethod
-    def get_work_merge_title(olids):
-        title = None
-        for olid in olids:
-            book = web.ctx.site.get(f'/works/{olid}')
-            if book and book.title:
-                title = book.title
-                break
-        return title
-
-    @classmethod
-    def submit_author_merge_request(cls, author_ids, submitter, comment=None):
-        if not comment:
-            # some default note from submitter
-            pass
-        # XXX IDs should be santiized & normalized
-        url = f"/authors/merge?key={'&key='.join(author_ids)}"
-        cls.submit_request(url, submitter=submitter, comment=comment)
-
-    @classmethod
     def submit_delete_request(cls, olid, submitter, comment=None):
         if not comment:
             # some default note from submitter
@@ -204,6 +165,7 @@ class CommunityEditsQueue:
         status: int = STATUS['PENDING'],
         comment: str = None,
         title: str = None,
+        type: int = None,
     ):
         """
         Inserts a new record into the table.
@@ -223,6 +185,7 @@ class CommunityEditsQueue:
             status=status,
             comments=json_comment,
             title=title,
+            type=type,
         )
 
     @classmethod

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -165,7 +165,7 @@ class CommunityEditsQueue:
         status: int = STATUS['PENDING'],
         comment: str = None,
         title: str = None,
-        type: int = None,
+        mr_type: int = None,
     ):
         """
         Inserts a new record into the table.
@@ -185,7 +185,7 @@ class CommunityEditsQueue:
             status=status,
             comments=json_comment,
             title=title,
-            type=type,
+            mr_type=mr_type,
         )
 
     @classmethod

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE community_edits_queue (
     submitter text not null,
     reviewer text default null,
     url text not null,
+    type int not null,
     status int not null default 1,
     comments json,
     created timestamp without time zone default (current_timestamp at time zone 'utc'),

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -69,7 +69,7 @@ CREATE TABLE community_edits_queue (
     submitter text not null,
     reviewer text default null,
     url text not null,
-    type int not null,
+    mr_type int not null default 1,
     status int not null default 1,
     comments json,
     created timestamp without time zone default (current_timestamp at time zone 'utc'),

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -38,6 +38,10 @@ function initConfirmationDialogs() {
         $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
             buttons: {
                 'Yes, Merge': function() {
+                    const commentInput = document.querySelector('#author-merge-comment')
+                    if (commentInput.value) {
+                        document.querySelector('#hidden-comment-input').value = commentInput.value
+                    }
                     $('#mergeForm').trigger('submit');
                     $(this).parents().find('button').attr('disabled','disabled');
                 },

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import { move_to_work, move_to_author } from '../ol.js';
 import { PersistentToast } from '../../../Toast.js';
 import './SelectionManager.less';
+import { createRequest, REQUEST_TYPES } from '../../../merge-request-table/MergeRequestService'
 
 /**
  * The SelectionManager is responsible for making things (e.g. books in search results,
@@ -211,7 +212,7 @@ SelectionManager.SELECTION_PROVIDERS = [
      * This selection provider makes books in search results selectable.
      */
     {
-        path: /(\/authors\/OL\d+A.*|\/search)/,
+        path: /^(\/search)$/,
         selector: '.searchResultItem',
         image: el => $(el).find('.bookcover img')[0].src,
         singular: 'work',
@@ -253,6 +254,17 @@ SelectionManager.SELECTION_PROVIDERS = [
          **/
         data: el => el.href.match(/OL\d+A/)[0],
     },
+    /**
+     * This selection provider makes authors selectable on search result pages
+     */
+    {
+        path: /^(\/search\/authors)$/,
+        selector: '.searchResultItem',
+        image: el => $(el).find('img.cover')[0].src,
+        singular: 'author',
+        plural: 'authors',
+        data: el => $(el).find('a')[0].href.match(/OL\d+A/)[0],
+    },
 ];
 
 /**
@@ -280,32 +292,7 @@ SelectionManager.ACTIONS = [
                 const url = new URL(href)
                 const params = new URLSearchParams(url.search)
                 const records = params.get('records')
-                const data = {
-                    olids: records,
-                    comment: comment,
-                    rtype: 'merge-works',
-                    action: 'create'
-                }
-                $.ajax({
-                    url: '/merges',
-                    method: 'POST',
-                    dataType: 'json',
-                    data: JSON.stringify(data)
-                })
-                    .done(function(resp) {
-                        let message = resp.error ? resp.error : 'Merge request submitted!'
-                        if (resp.error) {
-                            message = resp.error
-                        } else {
-                            const username = document.querySelector('body').dataset.username
-                            window.ILE.reset()
-                            message = `Merge request submitted! View request <a href="/merges?submitter=${username}#mrid-${resp.id}" target="_blank">here</a>.`
-                        }
-                        new PersistentToast(message, 'light-yellow').show()
-                    })
-                    .fail(function() {
-                        new PersistentToast('Merge request failed. Please try again in a few moments.', 'light-yellow').show()
-                    })
+                createMergeRequest(records, REQUEST_TYPES['WORK_MERGE'], comment)
             }
         }
     },
@@ -321,10 +308,45 @@ SelectionManager.ACTIONS = [
         applies_to_type: 'author',
         multiple_only: true,
         name: 'Merge Authors...',
-        href: olids => `https://openlibrary.org/authors/merge?${olids.map(olid => `key=${olid}`).join('&')}`,
+        href: olids => `/authors/merge?${olids.map(olid => `key=${olid}`).join('&')}`,
         elevated_permissions: true,
     },
+    {
+        applies_to_type: 'author',
+        multiple_only: true,
+        name: 'Merge Authors...',
+        href: olids => `/authors/merge?${olids.map(olid => `key=${olid}`).join('&')}`,
+        elevated_permissions: false,
+        click_listener: evt => {
+            evt.preventDefault()
+            const comment = prompt('(Optional) Are there specific details our librarians should note about this merge request?')
+            if (comment !== null) {
+                const href = document.querySelector('#ile-drag-actions').children[0].href
+                const olids = href.match(/OL(\d)+A/g)
+                createMergeRequest(olids.join(','), REQUEST_TYPES['AUTHOR_MERGE'], comment)
+            }
+        }
+    },
 ];
+
+async function createMergeRequest(olids, type, comment) {
+    return createRequest(olids, 'create-pending', type, comment)
+        .then(result => result.json())
+        .then(data => {
+            let message;
+            if (data.status === 'ok') {
+                const username = document.querySelector('body').dataset.username
+                window.ILE.reset()
+                message = `Merge request submitted! View request <a href="/merges?submitter=${username}#mrid-${data.id}" target="_blank">here</a>.`
+            } else {
+                message = data.error
+            }
+            new PersistentToast(message, 'light-yellow').show()
+        })
+        .catch(function() {
+            new PersistentToast('Merge request failed. Please try again in a few moments.', 'light-yellow').show()
+        })
+}
 
 function sigmoid(x) {
     return Math.exp(x) / (Math.exp(x) + 1);

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -280,15 +280,17 @@ SelectionManager.ACTIONS = [
                 const url = new URL(href)
                 const params = new URLSearchParams(url.search)
                 const records = params.get('records')
+                const data = {
+                    olids: records,
+                    comment: comment,
+                    rtype: 'merge-works',
+                    action: 'create'
+                }
                 $.ajax({
                     url: '/merges',
                     method: 'POST',
-                    data: {
-                        work_ids: records,
-                        comment: comment,
-                        rtype: 'merge-works',
-                        action: 'create'
-                    }
+                    dataType: 'json',
+                    data: JSON.stringify(data)
                 })
                     .done(function(resp) {
                         let message = resp.error ? resp.error : 'Merge request submitted!'

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/MergeRequestService.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/MergeRequestService.js
@@ -8,7 +8,7 @@ export async function createRequest(olids, action, type, comment = null) {
     const data = {
         rtype: 'create-request',
         action: action,
-        type: type,
+        mr_type: type,
         olids: olids
     }
     if (comment) {

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/MergeRequestService.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/MergeRequestService.js
@@ -1,0 +1,86 @@
+
+export const REQUEST_TYPES = {
+    WORK_MERGE: 1,
+    AUTHOR_MERGE: 2
+}
+
+export async function createRequest(olids, action, type, comment = null) {
+    const data = {
+        rtype: 'create-request',
+        action: action,
+        type: type,
+        olids: olids
+    }
+    if (comment) {
+        data['comment'] = comment
+    }
+
+    return fetch('/merges', {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    })
+}
+
+/**
+ * Updates an existing librarian request.
+ *
+ * @param {'comment'|'claim'|'approve'|'decline'} action Denotes the type of update being sent
+ * @param {Number} mrid Unique ID of the request that's being updated
+ * @param {string} comment Optional comment about the update
+ * @returns {Promise<Response>}
+ */
+async function updateRequest(action, mrid, comment = null) {
+    const data = {
+        rtype: 'update-request',
+        action: action,
+        mrid: mrid
+    }
+    if (comment) {
+        data['comment'] = comment
+    }
+
+    return fetch('/merges', {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
+    })
+}
+
+/**
+ * POSTs comment update to Open Library's servers.
+ *
+ * @param {Number} mrid Unique identifier for a librarian request
+ * @param {string} comment The new comment
+ * @returns {Promise<Response>} The results of the update POST request
+ */
+export async function commentOnRequest(mrid, comment) {
+    return updateRequest('comment', mrid, comment)
+}
+
+/**
+ * Sends a claim request to the server.
+ *
+ * @param {Number} mrid Unique identifier for the request being claimed
+ */
+export async function claimRequest(mrid) {
+    return updateRequest('claim', mrid)
+}
+
+export async function unassignRequest(mrid) {
+    return updateRequest('unassign', mrid)
+}
+
+export async function declineRequest(mrid, comment) {
+    return updateRequest('decline', mrid, comment)
+}
+
+export async function approveRequest(mrid, comment) {
+    return updateRequest('approve', mrid, comment)
+}

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -99,7 +99,7 @@ async function onCommentClick(textarea, mrid) {
  * @returns {Promise<Response>} The results of the update POST request
  */
 async function commentOnRequest(mrid, comment) {
-    return updateRequest('comment', mrid, comment)
+    return updateRequest('comment', mrid, comment, 'comment')
 }
 
 /**
@@ -149,9 +149,9 @@ async function updateCommentsView(mrid, comment) {
  * @param {string} comment Optional comment about the update
  * @returns
  */
-async function updateRequest(action, mrid, comment = null) {
+async function updateRequest(action, mrid, comment = null, rtype = 'merge-works') {
     const data = {
-        rtype: 'merge-works',
+        rtype: rtype,
         action: action,
         mrid: mrid
     }

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -150,16 +150,22 @@ async function updateCommentsView(mrid, comment) {
  * @returns
  */
 async function updateRequest(action, mrid, comment = null) {
-    const formData = new FormData();
-    formData.set('mrid', mrid)
-    formData.set('action', action)
-    if (comment) {
-        formData.set('comment', comment)
+    const data = {
+        rtype: 'merge-works',
+        action: action,
+        mrid: mrid
     }
+    if (comment) [
+        data['comment'] = comment
+    ]
 
     return fetch('/merges', {
         method: 'POST',
-        body: formData
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(data)
     })
 }
 

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -1,4 +1,5 @@
 import { FadingToast } from '../Toast';
+import { commentOnRequest, declineRequest, claimRequest, unassignRequest } from './MergeRequestService';
 
 /**
  * Adds functionality for closing librarian requests.
@@ -26,7 +27,7 @@ export function initCloseLinks(elems) {
 async function onCloseClick(mrid, parentRow) {
     const comment = prompt('(Optional) Why are you closing this request?')
     if (comment !== null) {
-        await closeRequest(mrid, comment)
+        await close(mrid, comment)
             .then(result => result.json())
             .then(data => {
                 if (data.status === 'ok') {
@@ -46,8 +47,8 @@ async function onCloseClick(mrid, parentRow) {
  * @param {string} comment Message stating why the request was closed
  * @returns {Promise<Response>} The results of the update POST
  */
-async function closeRequest(mrid, comment) {
-    return updateRequest('decline', mrid, comment)
+async function close(mrid, comment) {
+    return declineRequest(mrid, comment)
 }
 
 /**
@@ -71,15 +72,15 @@ export function initCommenting(elems) {
  * @param {Number} mrid Unique identifier for the request that is being commented on
  */
 async function onCommentClick(textarea, mrid) {
-    const comment = textarea.value;
+    const c = textarea.value;
 
-    if (comment) {
-        await commentOnRequest(mrid, comment)
+    if (c) {
+        await comment(mrid, c)
             .then(result => result.json())
             .then(data => {
                 if (data.status === 'ok') {
                     new FadingToast('Comment updated!').show()
-                    updateCommentsView(mrid, comment)
+                    updateCommentsView(mrid, c)
                     textarea.value = ''
                 } else {
                     new FadingToast('Failed to submit comment. Please try again in a few moments.').show()
@@ -98,8 +99,8 @@ async function onCommentClick(textarea, mrid) {
  * @param {string} comment The new comment
  * @returns {Promise<Response>} The results of the update POST request
  */
-async function commentOnRequest(mrid, comment) {
-    return updateRequest('comment', mrid, comment, 'comment')
+async function comment(mrid, comment) {
+    return commentOnRequest(mrid, comment)
 }
 
 /**
@@ -139,34 +140,6 @@ async function updateCommentsView(mrid, comment) {
             // Display new
             newCommentDiv.appendChild(template.content.firstChild)
         })
-}
-
-/**
- * Updates an existing librarian request.
- *
- * @param {'comment'|'claim'|'approve'|'decline'} action Denotes the type of update being sent
- * @param {Number} mrid Unique ID of the request that's being updated
- * @param {string} comment Optional comment about the update
- * @returns
- */
-async function updateRequest(action, mrid, comment = null, rtype = 'merge-works') {
-    const data = {
-        rtype: rtype,
-        action: action,
-        mrid: mrid
-    }
-    if (comment) [
-        data['comment'] = comment
-    ]
-
-    return fetch('/merges', {
-        method: 'POST',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data)
-    })
 }
 
 /**
@@ -221,7 +194,7 @@ export function initRequestClaiming(elems) {
     for (const elem of elems) {
         elem.addEventListener('click', function() {
             const mrid = elem.dataset.mrid
-            claimRequest(mrid, elem)
+            claim(mrid, elem)
         })
     }
 }
@@ -231,8 +204,8 @@ export function initRequestClaiming(elems) {
  *
  * @param {Number} mrid Unique identifier for the request being claimed
  */
-async function claimRequest(mrid) {
-    await updateRequest('claim', mrid)
+async function claim(mrid) {
+    await claimRequest(mrid)
         .then(result => result.json())
         .then(data => {
             if (data.status === 'ok') {
@@ -273,7 +246,7 @@ export function initUnassignment(elems) {
 }
 
 async function unassign(mrid) {
-    updateRequest('unassign', mrid)
+    await unassignRequest(mrid)
         .then(result => result.json())
         .then(data => {
             if (data.status === 'ok') {

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -1,3 +1,5 @@
+import { declineRequest } from './merge-request-table/MergeRequestService';
+
 export function initAuthorMergePage() {
     $('#save').on('click', function () {
         const n = $('#mergeForm input[type=radio]:checked').length;
@@ -33,6 +35,23 @@ export function initAuthorMergePage() {
             }
         }
     });
+    initRejectButton()
+}
+
+function initRejectButton() {
+    const rejectButton = document.querySelector('#reject-author-merge-btn')
+    rejectButton.addEventListener('click', function() {
+        rejectMerge()
+        rejectButton.disabled = true
+        const approveButton = document.querySelector('#save')
+        approveButton.disabled = true
+    })
+}
+
+function rejectMerge() {
+    const commentInput = document.querySelector('#author-merge-comment')
+    const mridInput = document.querySelector('#mrid-input')
+    declineRequest(Number(mridInput.value), commentInput.value)
 }
 
 /**
@@ -49,20 +68,27 @@ export function initAuthorView() {
 
     const data = {
         master: dataKeysJSON['master'],
-        duplicates: dataKeysJSON['duplicates']
+        duplicates: dataKeysJSON['duplicates'],
+        olids: dataKeysJSON['olids']
     };
+
+    const mrid = dataKeysJSON['mrid']
+    const comment = dataKeysJSON['comment']
+
+    if (mrid) {
+        data['mrid'] = mrid
+    }
+    if (comment) {
+        data['comment'] = comment
+    }
 
     $.ajax({
         url: '/authors/merge.json',
         type: 'POST',
         data: JSON.stringify(data),
-        success: function() {
+        complete: function() {
             $('#preMerge').fadeOut();
             $('#postMerge').fadeIn();
-        },
-        error: function() {
-            $('#preMerge').fadeOut();
-            $('#errorMerge').fadeIn();
         }
     });
 }

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -24,7 +24,6 @@ from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.upstream import merge_authors
 from openlibrary.plugins.upstream import edits
 from openlibrary.plugins.upstream import borrow, recentchanges  # TODO: unused imports?
-from openlibrary.plugins.upstream.edits import create_request
 from openlibrary.plugins.upstream.utils import render_component
 
 if not config.get('coverstore_url'):

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -37,6 +37,8 @@ class community_edits_queue(delegate.page):
 
         if type == 'merge-works':
             resp = self.work_merge_request(username, **data)
+        elif type == 'comment':
+            resp = self.comment_on_request(username, data['mrid'], data['comment'])
         else:
             resp = response(status='error', error='Unknown request type')
 
@@ -91,13 +93,6 @@ class community_edits_queue(delegate.page):
                 status=CommunityEditsQueue.STATUS['MERGED'],
             )
             resp = response(id=result)
-        # Add a comment to an existing MR
-        elif action == 'comment':
-            if comment:
-                CommunityEditsQueue.comment_request(mrid, username, comment)
-                resp = response()
-            else:
-                resp = response(status='error', error='No comment sent in request')
         # Assign an existing MR to a patron
         elif action == 'claim':
             result = CommunityEditsQueue.assign_request(mrid, username)
@@ -127,14 +122,17 @@ class community_edits_queue(delegate.page):
 
         return resp
 
-    def extract_olids(self, url):
-        query_string = url.split('?')[1]
-        split_params = query_string.split('&')
-        params = {}
-        for p in split_params:
-            kv = p.split('=')
-            params[kv[0]] = kv[1]
-        return params['records'].split(',')
+    def comment_on_request(self, username, mrid, comment):
+        if comment:
+            CommunityEditsQueue.comment_request(mrid, username, comment)
+            resp = response()
+        else:
+            resp = response(status='error', error='No comment sent in request')
+
+        return resp
+
+    def author_merge_request(self, username, olids='', mrid=None, action=None):
+        pass
 
 
 class ui_partials(delegate.page):

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -349,7 +349,7 @@ class merge_authors_json(delegate.page):
             else:
                 # Create new request
                 rtype = 'create-request'
-                data = {'type': 2, 'olids': olids, 'action': 'create-merged'}
+                data = {'mr_type': 2, 'olids': olids, 'action': 'create-merged'}
             if comment:
                 data['comment'] = comment
             process_merge_request(rtype, data)

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -1,4 +1,4 @@
-$def with (keys, top_books_from_author, formdata=None)
+$def with (keys, top_books_from_author, formdata=None, mrid=None)
 
 $var title: $_("Merge Authors")
 
@@ -41,6 +41,9 @@ $if formdata:
 
 <form method="POST" id="mergeForm" name="mergeForm">
     <input type="hidden" name="merge" value="true"/>
+    $if mrid:
+        <input type="hidden" id="mrid-input" name="mrid" value="$mrid"/>
+        <input type="hidden" id="hidden-comment-input" name="comment" value=""/>
     <div class="merge" id="include">
 
         <div class="entry header">
@@ -87,11 +90,16 @@ $if formdata:
             </div>
     </div>
 
-<p>
-<button id="save" class="larger" value="Merge Authors">$_('Merge Authors')</button>
-&nbsp;&nbsp;
-<a href="javascript:history.go(-1);" class="small red sansserif">$_('Cancel')</a>
-</p>
+    <div class="merge-feedback">
+        <label for="merge-comment">$_('Comment:') <input type="text" id="author-merge-comment" name="merge-comment" placeholder="$_('Comment...')"></label>
+        <div class="merge-feedback__buttons">
+            <button id="save" class="larger merge-feedback__submit" value="Merge Authors">$_('Merge Authors')</button>
+            $if mrid:
+                <button id="reject-author-merge-btn" type="button" class="larger merge-feedback__reject">$_('Reject Merge')</button>
+            $else:
+                <a href="javascript:history.go(-1);" class="small red sansserif">$_('Cancel')</a>
+    </div>
+</div>
 
 </form>
 

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -63,7 +63,7 @@ $ page = int(input(page=1).page)
           $ is_open = r['status'] == 1
           $ url = "%s&mrid=%s" % (r['url'], r['id'])
           $ is_submitter = username == r['submitter']
-          $ type_str = _('Work') if r['type'] == 1 else _('Author')
+          $ type_str = _('Author') if r['mr_type'] == 2 else _('Work')
           <tr id="mrid-$(r['id'])">
             <td>$r['submitter']<br>$datestr(r['created'])</td>
             <td id="status-cell-$(r['id'])">$status</td>
@@ -93,21 +93,21 @@ $ page = int(input(page=1).page)
                 <hr>
                 <div class="comment-cell__input">
                   <textarea rows="1" placeholder="$_('Add a comment...')"></textarea>
-                  <input class="mr-comment-btn" type="button" value="Reply" data-mrid="$r['id']" data-merge-type="$r['type']">
+                  <input class="mr-comment-btn" type="button" value="Reply" data-mrid="$r['id']" data-merge-type="$r['mr_type']">
                 </div>
             </td>
             <td id="reviewer-cell-$(r['id'])">
               $if can_merge and is_open and r.get('reviewer') == username:
-                $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']" data-merge-type="$r['type']">&times;</span>
+                $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']" data-merge-type="$r['mr_type']">&times;</span>
               $elif r.get('reviewer'):
                 $r['reviewer']
             </td>
             <td>
               $if is_open:
                 $if is_submitter:
-                  <a class="mr-close-link" data-mrid="$r['id']" data-merge-type="$r['type']" href="javascript:;">$_('Close')</a>
+                  <a class="mr-close-link" data-mrid="$r['id']" data-merge-type="$r['mr_type']" href="javascript:;">$_('Close')</a>
                 $elif can_merge and (not r.get('reviewer') or r.get('reviewer') == username):
-                  <a class="mr-resolve-link" data-mrid="$r['id']" data-merge-type="$r['type']" href="$url" target="_blank">$_('Merge')</a>
+                  <a class="mr-resolve-link" data-mrid="$r['id']" data-merge-type="$r['mr_type']" href="$url" target="_blank">$_('Merge')</a>
             </td>
           </tr>
         </tbody>

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -52,6 +52,10 @@ $ page = int(input(page=1).page)
           </tr>
         </thead>
         <tbody>
+        $if not merge_requests:
+          <tr>
+            <td colspan="5">$_('No entries here!')</td>
+          </tr>
         $for r in merge_requests:
           $ work_title = r.get('title', 'an untitled work')
           $ comments = r.get('comments', {}).get('comments', [])
@@ -59,13 +63,14 @@ $ page = int(input(page=1).page)
           $ is_open = r['status'] == 1
           $ url = "%s&mrid=%s" % (r['url'], r['id'])
           $ is_submitter = username == r['submitter']
+          $ type_str = _('Work') if r['type'] == 1 else _('Author')
           <tr id="mrid-$(r['id'])">
             <td>$r['submitter']<br>$datestr(r['created'])</td>
             <td id="status-cell-$(r['id'])">$status</td>
 
             <td id="comment-cell-$(r['id'])" class="comment-cell">
               <div class="comment-cell__summary">
-                <span>$:_('Merge request for <span class="book-title">%(title)s</span>', title=work_title)</span>
+                <span>$:_('<strong>%(type)s</strong> merge request for <span class="book-title">%(title)s</span>', title=work_title, type=type_str)</span>
                 <span>$_('Comments'): $len(comments)</span>
               </div>
 
@@ -88,25 +93,23 @@ $ page = int(input(page=1).page)
                 <hr>
                 <div class="comment-cell__input">
                   <textarea rows="1" placeholder="$_('Add a comment...')"></textarea>
-                  <input class="mr-comment-btn" type="button" value="Reply" data-mrid="$r['id']">
+                  <input class="mr-comment-btn" type="button" value="Reply" data-mrid="$r['id']" data-merge-type="$r['type']">
                 </div>
             </td>
             <td id="reviewer-cell-$(r['id'])">
               $if can_merge and is_open and r.get('reviewer') == username:
-                $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']">&times;</span>
+                $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']" data-merge-type="$r['type']">&times;</span>
               $elif r.get('reviewer'):
                 $r['reviewer']
             </td>
             <td>
-              $if can_merge and is_open:
-                $if (not r.get('reviewer') or r.get('reviewer') == username):
-                  <a class="mr-resolve-link" data-mrid="$r['id']" href="$url" target="_blank">$_('Merge')</a>
-                $elif is_submitter:
-                  <a class="mr-close-link" data-mrid="$r['id']" href="javascript:;">$_('Close')</a>
+              $if is_open:
+                $if is_submitter:
+                  <a class="mr-close-link" data-mrid="$r['id']" data-merge-type="$r['type']" href="javascript:;">$_('Close')</a>
+                $elif can_merge and (not r.get('reviewer') or r.get('reviewer') == username):
+                  <a class="mr-resolve-link" data-mrid="$r['id']" data-merge-type="$r['type']" href="$url" target="_blank">$_('Merge')</a>
             </td>
           </tr>
-          $if not merge_requests:
-            <p>$_('No entries here!')</p>
         </tbody>
       </table>
   </div>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -53,11 +53,22 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 </div>
 
 <div id="contentBody">
-
     $if ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()) and query_param('merge', 'false') == 'true':
-        $ duplicates = ["/authors/" + k for k in query_param("duplicates", "").split(",")]
+        $ mrid = query_param('mrid', None)
+        $ comment = query_param('comment', None)
+        $ duplicate_olids = query_param('duplicates', '').split(',')
+        $ duplicates = ["/authors/" + k for k in duplicate_olids]
+        $ data = {'master': page.key, 'duplicates': duplicates}
+        $if mrid:
+            $ data['mrid'] = mrid
+        $if comment:
+            $ data['comment'] = comment
+
+        $ olids = '%s,%s' % (page.key.split('/')[-1], query_param('duplicates', ''))
+        $ data['olids'] = olids
+
         <div class="message" style="display: none;">
-            <div id="preMerge" style="display: none;" data-keys="$dumps({'master': page.key, 'duplicates': duplicates})">
+            <div id="preMerge" style="display: none;" data-keys="$dumps(data)">
                 <p class="larger collapse"><strong>$_('Merging Authors...')</strong></p>
                 <p class="collapse adjust"><img src="/images/ajax-loader-bar.gif" width="220" height="19" alt="$_('In progress...')"/></p>
                 <p class="smaller lightgreen collapse">$_('Duplicates')</p>

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -89,6 +89,24 @@ div.merge {
   }
 }
 
+.merge-feedback {
+  input {
+    width: 100%;
+    margin-top: 5px;
+  }
+
+  &__buttons {
+    margin-top: 5px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__reject {
+    color: @white;
+    background-color: @red-two;
+  }
+}
+
 @media all and ( min-width: @width-breakpoint-desktop ) {
   div.merge {
     .record {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6812

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows author merge requests to be added to the librarian request queue.  Author merge requests are added similarly to work merge requests: `librarians` can submit a request via an author search results page via the ILE blue bar, and `super-librarians` can accept or decline the request from the author merge UI.  Author merges by `super-librarians` trigger the creation of an approved merge request.

### Technical
<!-- What should be noted about the implementation? -->
This PR alters the `community_edits_queue` table, adding a new column 'type` which is used to differentiate work and author merge requests.  __Before this is deployed to any environment, the following queries should be executed:__
```
ALTER TABLE community_edits_queue ADD type int;
UPDATE community_edits_queue set type = 1; /* designates all existing requests as work merges */
```

The `/merges` POST controller has significantly changed.  MR `url` and `title` generation is now handled by the controller.  Total request types (`rtype`) accepted by the controller have been reduced to two: `create-request` and `update-request`.

The author merge flow seems a bit unusual to me.  Here is a refresher on how this works today:
1. The "Merge Authors" button in the author merge UI is clicked.
2. Data is POSTed to `/authors/merge`, and is validated
3. On successful validation, we are redirected to the parent author page.  The redirect URL contains `merge=true` and a list of duplicate OLIDs.  A loading indicator is displayed on the page (due to the `merge` query parameter's presence).
4. The loading indicator's presence on the page triggers a client-side request to the `/authors/merge` JSON endpoint. This triggers the author merge.
5. The loading indicator is updated when the JSON endpoint response is received.

We now pass an optional `mrid` and `comment` to the author page when a request is submitted.  If an `mrid` is passed to the JSON author merge endpoint, a MR is updated.  Otherwise, a new "Approved" author MR is created.

On author search result pages, `super-librarians` can access the author merge UI by using the usual "Merge authors" link (next to the magic wand near the top of the page), or by using the link on the ILE blue bar.  The old-school "Merge authors" link will display all of the authors in the merge UI, while specific authors can be displayed when the ILE merge link is used.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ensure that all work merge request flows still work as expected.
As a `librarian`:
1. Search for duplicate author candidates.  Select the duplicates and press the "Merge authors..." link in the ILE blue bar.
2. A dialog prompting for an optional comment will appear. Type a comment and press "OK".
3. Click on the link in the toast message to see the MR table.  Ensure that your MR is present, and that it is an author merge.
4. Add a comment on the author MR. Ensure that the view updates with the new comment.  Refresh the page, and ensure that the new comment is visible on page load.
5. Try closing the MR from the table view.  Click the "Closed" tab, and ensure that the newly closed MR is present.
6. Make two more author MRs.  These will be used to test author MR approval and rejection.
7. Switch to a `super-librarian` account and navigate to the MR table.
8. Enter the author merge UI by clicking the "merge" link for one of the author MRs.
9. Leave a comment and press the "Reject" button.  Ensure that the MR is in the "Closed" merge table view.
10. Switch back to the "Open" merge request table view, and click the "merge" link for the other author MR.
11. Select the records you'd like to merge, type a comment, and click the "Merge Authors" button.
12. You will be redirected to the author page of the parent record.  Once you see a success message, ensure that the MR is listed in the "Closed" view as "Merged".
13. Finally, test the whole author merge flow as a `super-librarian`.  Select authors from a search result page and click the merge link in the ILE blue bar.  Note that the "Reject" button has been replaced by the "Cancel" link.  Select the authors and press the merge button.  On success, ensure that a new entry was created in the "Closed" MR table view.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-08-11 15-59-26](https://user-images.githubusercontent.com/28732543/184229686-c5d92083-c2c8-4f5c-a67c-a7724d0a5951.png)
_New comment input and rejection button_

![Screenshot from 2022-08-11 16-03-13](https://user-images.githubusercontent.com/28732543/184230494-b45418b6-5129-4d13-b165-1039ca79f901.png)
_Merge types now present in MR titles_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
