### PR TITLE
Changing the diff color to darker-grey for better read - Closes #6855

### DIFF
--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -383,7 +383,7 @@ div.superNav {
 span {
   &.link {
     font-size: 12px;
-    color: @light-grey;
+    color: @darker-grey;
     font-weight: normal !important;
     font-family: @lucida_sans_serif-2;
     white-space: nowrap;


### PR DESCRIPTION
The contrast ratio for the modified text is not upto the mark. Changing the color of the link to darker-grey improved the readability. Check the image - 
<img width="1728" alt="Screenshot 2022-08-13 at 1 25 49 AM" src="https://user-images.githubusercontent.com/15162221/184435764-5974e940-a2c4-4d4c-b9e3-9d461eaefadd.png">
