### PR TITLE
Convert not a == b --> a != b

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -551,7 +551,7 @@ class OpenLibraryAccount(Account):
 
     @property
     def verified(self):
-        return not (getattr(self, 'status', '') == 'pending')
+        return getattr(self, 'status', '') != 'pending'
 
     @property
     def blocked(self):

--- a/openlibrary/catalog/marc/marc_binary.py
+++ b/openlibrary/catalog/marc/marc_binary.py
@@ -224,7 +224,7 @@ class MarcBinary(MarcBase):
         except IndexError:
             pass
         tag_line = data[offset + 1 : offset + length + 1]
-        if not line[0:2] == '00':
+        if line[0:2] != '00':
             # marc_western_washington_univ/wwu_bibs.mrc_revrev.mrc:636441290:1277
             if tag_line[1:8] == b'{llig}\x1f':
                 tag_line = tag_line[0] + '\uFE20' + tag_line[7:]

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -66,7 +66,7 @@ class read_multiget(delegate.page):
             decoded_path = urllib.parse.unquote(raw_path)
 
             m = self.path_re.match(decoded_path)
-            if not len(m.groups()) == 2:
+            if len(m.groups()) != 2:
                 return json.dumps({})
             (brief_or_full, req) = m.groups()
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -239,7 +239,7 @@ class ia_importapi(importapi):
 
         i = web.input()
 
-        require_marc = not (i.get('require_marc') == 'false')
+        require_marc = i.get('require_marc') != 'false'
         force_import = i.get('force_import') == 'true'
         bulk_marc = i.get('bulk_marc') == 'true'
 

--- a/openlibrary/solr/db_load_authors.py
+++ b/openlibrary/solr/db_load_authors.py
@@ -11,9 +11,7 @@ total = 6540759
 
 sizes = dict(name=512, birth_date=256, death_date=256, date=256)
 
-num = 0
-for line in open('author_file'):
-    num += 1
+for num, line in enumerate(open('author_file')):
     if num % 10000 == 0:
         print("%d %d %.2f%%" % (num, total, (float(num) * 100.0) / total))
     src_a = json.loads(line[:-1])

--- a/openlibrary/solr/db_load_works.py
+++ b/openlibrary/solr/db_load_works.py
@@ -8,8 +8,8 @@ db.printing = False
 re_work_key = re.compile(r'^/works/OL(\d+)W$')
 
 total = 13941626
-num = 0
-for line in open('work_file'):
+
+for num, line in enumerate(open('work_file')):
     num += 1
     if num % 10000 == 0:
         print("%d %d %.2f%%" % (num, total, (float(num) * 100.0) / total))

--- a/openlibrary/solr/db_load_works.py
+++ b/openlibrary/solr/db_load_works.py
@@ -10,7 +10,6 @@ re_work_key = re.compile(r'^/works/OL(\d+)W$')
 total = 13941626
 
 for num, line in enumerate(open('work_file')):
-    num += 1
     if num % 10000 == 0:
         print("%d %d %.2f%%" % (num, total, (float(num) * 100.0) / total))
     # src_w = json.loads(line[:-1])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
https://pypi.org/project/flake8-simplify
`SIM201 Use 'len(m.groups()) != 2' instead of 'not len(m.groups()) == 2'`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
