### PR TITLE
Fix visual alignment of author search results

### DIFF
--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1198,7 +1198,7 @@ div#searchResults {
     color: @grey;
   }
   .cover {
-    width: 120px;
+    max-width: 120px;
     border-radius: 4px;
   }
 }


### PR DESCRIPTION
The results of an author search are visually ragged, because the space allocated for the author image becomes flexible if no image is preset. The effect is unpleasant:

<img width="783" alt="Screen Shot 2022-08-14 at 8 36 43 PM" src="https://user-images.githubusercontent.com/886889/184565116-eaf76582-b8a2-4901-aa55-6e02ec6bb9c7.png">


### Technical
This is a tiny fix — changing the css on the image slot from width to max-width allows results with no image to use the entire space.

### Screenshot
The result of the fix:

<img width="764" alt="Screen Shot 2022-08-14 at 8 37 27 PM" src="https://user-images.githubusercontent.com/886889/184565219-defb2966-d83b-4347-aa51-f8df9a7729e6.png">


### Stakeholders
@mheiman
