### PR TITLE
Fetch `User`'s lists only if `User` exists

### DIFF
--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -14,7 +14,7 @@ $code:
         return [get_list_data(list, seed_info['seed']) for list in page.get_lists(sort=False)]
 
 $ seed_info = get_seed_info(page)
-$ user_lists = [] if async_load else get_user_lists(seed_info)
+$ user_lists = [] if async_load or not ctx.user else get_user_lists(seed_info)
 $ page_lists = get_page_lists(page, seed_info)
 $ user_key = ctx.user and ctx.user.key
 $ page_url = page.url()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6884

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Checks for `User` before calling `User` class methods.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
