### PR TITLE
Make edition table covers loading=lazy

### DIFF
--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -30,7 +30,12 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
     <td class="book">
       <span class="hidden sort-key">$edition_sort_key</span>
       <div class="cover">
-          <a href="$book.url()"><img src="$url" alt="$_('Cover of: %(title)s', title=book.title)" title="$_('Cover of: %(title)s', title=book.title)"/></a>
+          <a href="$book.url()"><img
+            src="$url"
+            alt="$_('Cover of: %(title)s', title=book.title)"
+            title="$_('Cover of: %(title)s', title=book.title)"
+            loading="lazy"
+          /></a>
       </div>
 
       <div class="title">


### PR DESCRIPTION
These images are below the fold, so we don't need them to be fetched as soon as the page is visible.



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
