### PR TITLE
oldump.sh: Use log, not echo

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -230,7 +230,8 @@ def make_index(dump_file):
     """Make index with "path", "title", "created" and "last_modified" columns."""
     log(f"make_index({dump_file})")
     start_time = datetime.now()
-    for i, type, key, revision, timestamp, json_data in enumerate(read_tsv(dump_file)):
+    for i, line in enumerate(read_tsv(dump_file)):
+        type, key, revision, timestamp, json_data = line
         data = json.loads(json_data)
         if type in ("/type/edition", "/type/work"):
             title = data.get("title", "untitled")

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -154,11 +154,11 @@ then
   log "=== Step 5 ==="
   if [[ ! -f $(compgen -G "ol_dump_*.txt.gz") ]]
   then
-      echo "generating the dump -- takes approx. 485 minutes for 173,000,000+ records..."
+      log "generating the dump -- takes approx. 485 minutes for 173,000,000+ records..."
       time gzip -cd $(compgen -G "ol_cdump_$yyyymm*.txt.gz") | python $SCRIPTS/oldump.py sort --tmpdir $TMPDIR | python $SCRIPTS/oldump.py dump | gzip -c > $dump.txt.gz
-      echo "generated $dump.txt.gz"
+      log "generated $dump.txt.gz"
   else
-      echo "Skipping: $(compgen -G "ol_dump_$yyyymm*.txt.gz")"
+      log "Skipping: $(compgen -G "ol_dump_$yyyymm*.txt.gz")"
   fi
 
 
@@ -166,11 +166,11 @@ then
   if [[ ! -f $(compgen -G "ol_dump_*_$yyyymm*.txt.gz") ]]
   then
       mkdir -p $TMPDIR/oldumpsort
-      echo "splitting the dump: ol_dump_%s_$yyyymmdd.txt.gz -- takes approx. 85 minutes for 68,000,000+ records..."
+      log "splitting the dump: ol_dump_%s_$yyyymmdd.txt.gz -- takes approx. 85 minutes for 68,000,000+ records..."
       time gzip -cd $dump.txt.gz | python $SCRIPTS/oldump.py split --format ol_dump_%s_$yyyymmdd.txt.gz
       rm -rf $TMPDIR/oldumpsort
   else
-      echo "Skipping $(compgen -G "ol_dump_*_$yyyymm*.txt.gz")"
+      log "Skipping $(compgen -G "ol_dump_*_$yyyymm*.txt.gz")"
   fi
 
   mkdir -p $dump $cdump


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In `scripts/oldump.sh` we tend to use the `log` command which writes to `stderr` and the Docker error logs instead of the `echo` command which writes to `stdout`.  This is done to keep `stdout` clear because this script often pipes data from one command to the next.

The change to the `make_index()` function of `openlibrary/data/dump.py` may not be important because I am unable to find anywhere that this function is called but still it is better to fix this logic error.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
