### PR TITLE
Passing the missing param - sort_order in mybooks

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -248,7 +248,7 @@ class MyBooksTemplate:
                 lists=self.lists,
                 public=is_public,
                 owners_page=is_logged_in_user,
-                sort_order=sort
+                sort_order=sort,
             )
 
         raise web.seeother(self.user.key)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -248,6 +248,7 @@ class MyBooksTemplate:
                 lists=self.lists,
                 public=is_public,
                 owners_page=is_logged_in_user,
+                sort_order=sort
             )
 
         raise web.seeother(self.user.key)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6891

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds a missing param named sort_order in mybooks.py which is being passed to reading_log.html.


### Testing
1. Log in
2. Add a few books to your "Want to read" list
3. Go to "My Reading Log" page from the user menu
4. Click on the filters given to sort the list

### Screenshot
Added the screenshots. Active selection turn green as expected
<img width="1724" alt="Screenshot 2022-08-20 at 1 21 20 AM" src="https://user-images.githubusercontent.com/15162221/185697008-4c87e228-09ab-45e3-89fd-2b31e453ec86.png">

<img width="1728" alt="Screenshot 2022-08-20 at 1 21 37 AM" src="https://user-images.githubusercontent.com/15162221/185696886-25c66b92-bd5d-4ec1-a3b7-d7425982ed96.png">


### Stakeholders
@bicolino34 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code wh
<img width="1724" alt="Screenshot 2022-08-20 at 1 21 20 AM" src="https://user-images.githubusercontent.com/15162221/185696868-f6af70b7-acb0-46e2-bc34-403c32f58780.png">
ich substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
