### PR TITLE
Fix handling for edition records in merge requests

### DIFF
--- a/openlibrary/components/MergeUI/MergeRowReferencesField.vue
+++ b/openlibrary/components/MergeUI/MergeRowReferencesField.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="record.key.includes('works') && (!merged || (merged && record != merged.record))">
+    <div v-if="record.type.key === '/type/work' && (!merged || (merged && record != merged.record))">
         <div class="list-counts" v-if="lists">
         <a :href="`${record.key}/-/lists`">{{lists[record.key].size}} list{{lists[record.key].size == 1 ? '' : 's'}}</a>
         </div>

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -122,7 +122,7 @@ export default {
 
             // We only need the count, so set limit=0 (waaaay faster!)
             const promises = await Promise.all(
-                this.records.map(r => get_lists(r.key, 0))
+                this.records.map(r => (r.type.key === '/type/work') ? get_lists(r.key, 0) : {})
             );
             const responses = promises.map(p => p.value || p);
             return _.fromPairs(
@@ -133,7 +133,7 @@ export default {
             if (!this.records) return null;
 
             const promises = await Promise.all(
-                this.records.map(r => get_bookshelves(r.key))
+                this.records.map(r => (r.type.key === '/type/work') ? get_bookshelves(r.key) : {})
             );
             const responses = promises.map(p => p.value || p);
             return _.fromPairs(
@@ -145,7 +145,7 @@ export default {
             if (!this.records) return null;
 
             const promises = await Promise.all(
-                this.records.map(r => get_ratings(r.key))
+                this.records.map(r => (r.type.key === '/type/work') ? get_ratings(r.key) : {})
             );
             const responses = promises.map(p => p.value || p);
             return _.fromPairs(
@@ -158,17 +158,17 @@ export default {
                 return undefined;
 
             const master = this.records.find(r => r.key === this.master_key);
-            const dupes = this.records
+            const all_dupes = this.records
                 .filter(r => this.selected[r.key])
                 .filter(r => r.key !== this.master_key);
-            const work_dupes = dupes.filter(r => r.type.key === '/type/work');
-            const records = [master, ...dupes];
+            const dupes = all_dupes.filter(r => r.type.key === '/type/work');
+            const records = [master, ...all_dupes];
             const editions_to_move = _.flatMap(
-                dupes,
+                all_dupes,
                 work => this.editions[work.key].entries
             );
 
-            const [record, sources] = merge(master, work_dupes);
+            const [record, sources] = merge(master, dupes);
 
             const extras = {
                 edition_count: _.sum(records.map(r => this.editions[r.key].size)),


### PR DESCRIPTION
Late changes to the MergeUI updates PR broke handling of orphaned edition records sent to the MergeUI. This fixes that and allows the MergeUI to fix orphans correctly.

### Technical
This PR does two things: 
- Only requests and displays lists/reading logs/ratings for valid work records, so the merge isn't blocked by missing data errors
- Correctly returns the filtered list of duplicate works from MergeTable.merge so that edition records aren't changed into redirects when the merge is done

### Testing
Try a merge like this with some works and an edition:

https://testing.openlibrary.org/works/merge?records=OL99529W,OL27145882W,OL38495188M

(That's not a real orphaned edition, but it's a junk record. You can move the edition back to its work (OL28124291W) when you're done if you like.)


### Stakeholders
@mheiman @cdrini

