### PR TITLE
Partial fix for #6755. Create more python type hints: 48-52.

### DIFF
--- a/openlibrary/utils/lcc.py
+++ b/openlibrary/utils/lcc.py
@@ -84,6 +84,7 @@ But it works for subject-related range queries, so we consider it sufficient.
 [1]: https://www.terkko.helsinki.fi/files/9666/classify_trnee_manual.pdf
 [2]: https://ejournals.bc.edu/index.php/ital/article/download/11585/9839/
 """
+from __future__ import annotations
 import re
 from collections.abc import Iterable
 
@@ -109,11 +110,11 @@ LCC_PARTS_RE = re.compile(
 )
 
 
-def short_lcc_to_sortable_lcc(lcc):
+def short_lcc_to_sortable_lcc(lcc: str) -> str | None:
     """
     See Sorting section of doc above
     :param str lcc: unformatted lcc
-    :rtype: basestring|None
+    :return: basestring|None
     """
     m = LCC_PARTS_RE.match(clean_raw_lcc(lcc))
     if not m:
@@ -135,11 +136,11 @@ def short_lcc_to_sortable_lcc(lcc):
     return '%(letters)s%(number)013.8f%(cutter1)s%(rest)s' % parts
 
 
-def sortable_lcc_to_short_lcc(lcc):
+def sortable_lcc_to_short_lcc(lcc: str) -> str:
     """
     As close to the inverse of make_sortable_lcc as possible
     :param basestring lcc:
-    :rtype: basestring
+    :return: basestring
     """
     m = LCC_PARTS_RE.match(lcc)
     assert m, f'Unable to parse LCC "{lcc}"'
@@ -152,11 +153,11 @@ def sortable_lcc_to_short_lcc(lcc):
     return '%(letters)s%(number)s%(cutter1)s%(rest)s' % parts
 
 
-def clean_raw_lcc(raw_lcc):
+def clean_raw_lcc(raw_lcc: str) -> str:
     """
     Remove noise in lcc before matching to LCC_PARTS_RE
     :param basestring raw_lcc:
-    :rtype: basestring
+    :return: basestring
     """
     lcc = collapse_multiple_space(raw_lcc.replace('\\', ' ').strip(' '))
     if (lcc.startswith('[') and lcc.endswith(']')) or (
@@ -166,11 +167,11 @@ def clean_raw_lcc(raw_lcc):
     return lcc
 
 
-def normalize_lcc_prefix(prefix):
+def normalize_lcc_prefix(prefix: str) -> str | None:
     """
     :param str prefix: An LCC prefix
     :return: Prefix transformed to be a prefix for sortable LCC
-    :rtype: str|None
+    :return: str|None
 
     >>> normalize_lcc_prefix('A123')
     'A--0123'
@@ -203,12 +204,11 @@ def normalize_lcc_prefix(prefix):
             return None
 
 
-def normalize_lcc_range(start, end):
+def normalize_lcc_range(start: str, end: str) -> list[str | None]:
     """
     :param str start: LCC prefix to start range
     :param str end: LCC prefix to end range
     :return: range with prefixes being prefixes for sortable LCCs
-    :rtype: [str, str]
     """
     return [
         lcc if lcc == '*' else short_lcc_to_sortable_lcc(lcc) for lcc in (start, end)

--- a/openlibrary/utils/lcc.py
+++ b/openlibrary/utils/lcc.py
@@ -139,8 +139,6 @@ def short_lcc_to_sortable_lcc(lcc: str) -> str | None:
 def sortable_lcc_to_short_lcc(lcc: str) -> str:
     """
     As close to the inverse of make_sortable_lcc as possible
-    :param basestring lcc:
-    :return: basestring
     """
     m = LCC_PARTS_RE.match(lcc)
     assert m, f'Unable to parse LCC "{lcc}"'
@@ -156,8 +154,6 @@ def sortable_lcc_to_short_lcc(lcc: str) -> str:
 def clean_raw_lcc(raw_lcc: str) -> str:
     """
     Remove noise in lcc before matching to LCC_PARTS_RE
-    :param basestring raw_lcc:
-    :return: basestring
     """
     lcc = collapse_multiple_space(raw_lcc.replace('\\', ' ').strip(' '))
     if (lcc.startswith('[') and lcc.endswith(']')) or (
@@ -171,7 +167,6 @@ def normalize_lcc_prefix(prefix: str) -> str | None:
     """
     :param str prefix: An LCC prefix
     :return: Prefix transformed to be a prefix for sortable LCC
-    :return: str|None
 
     >>> normalize_lcc_prefix('A123')
     'A--0123'

--- a/openlibrary/utils/lcc.py
+++ b/openlibrary/utils/lcc.py
@@ -114,7 +114,6 @@ def short_lcc_to_sortable_lcc(lcc: str) -> str | None:
     """
     See Sorting section of doc above
     :param str lcc: unformatted lcc
-    :return: basestring|None
     """
     m = LCC_PARTS_RE.match(clean_raw_lcc(lcc))
     if not m:

--- a/openlibrary/utils/processors.py
+++ b/openlibrary/utils/processors.py
@@ -9,13 +9,14 @@ __all__ = ["RateLimitProcessor"]
 class RateLimitProcessor:
     """Application processor to ratelimit the access per ip."""
 
-    def __init__(self, limit, window_size=600, path_regex="/.*"):
+    def __init__(self, limit: int, window_size: int = 600, path_regex: str = "/.*"):
         """Creates a rate-limit processor to limit the number of
         requests/ip in the time frame.
 
-        :param limit: the maximum number of requests allowed in the given time window.
-        :param window_size: the time frame in seconds during which the requests are measured.
-        :param path_regex: regular expression to specify which urls are rate-limited.
+        :param int limit: the maximum number of requests allowed in the given time window.
+        :param int window_size: the time frame in seconds during which the requests are measured.
+        :param int path_regex: regular expression to specify which urls are rate-limited.
+        :return None:
         """
         self.path_regex = web.re_compile(path_regex)
         self.limit = limit

--- a/openlibrary/utils/processors.py
+++ b/openlibrary/utils/processors.py
@@ -9,14 +9,13 @@ __all__ = ["RateLimitProcessor"]
 class RateLimitProcessor:
     """Application processor to ratelimit the access per ip."""
 
-    def __init__(self, limit: int, window_size: int = 600, path_regex: str = "/.*"):
+    def __init__(self, limit: int, window_size: int = 600, path_regex: str = "/.*") -> None:
         """Creates a rate-limit processor to limit the number of
         requests/ip in the time frame.
 
         :param int limit: the maximum number of requests allowed in the given time window.
         :param int window_size: the time frame in seconds during which the requests are measured.
         :param int path_regex: regular expression to specify which urls are rate-limited.
-        :return None:
         """
         self.path_regex = web.re_compile(path_regex)
         self.limit = limit

--- a/openlibrary/utils/processors.py
+++ b/openlibrary/utils/processors.py
@@ -9,7 +9,9 @@ __all__ = ["RateLimitProcessor"]
 class RateLimitProcessor:
     """Application processor to ratelimit the access per ip."""
 
-    def __init__(self, limit: int, window_size: int = 600, path_regex: str = "/.*") -> None:
+    def __init__(
+        self, limit: int, window_size: int = 600, path_regex: str = "/.*"
+    ) -> None:
         """Creates a rate-limit processor to limit the number of
         requests/ip in the time frame.
 

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
+from __future__ import annotations
 from collections import namedtuple
 
 import json
 import os
 import sys
 from typing import Union
+from collections.abc import Iterator
 
 import web
 
@@ -12,6 +14,7 @@ from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 sys.path.insert(0, ".")  # Enable scripts/copydocs.py to be run.
 import scripts._init_path  # noqa: E402,F401
+import scripts.tests.test_copydocs
 from openlibrary.api import OpenLibrary, marshal  # noqa: E402
 
 __version__ = "0.2"
@@ -27,35 +30,17 @@ def find(server, prefix):
     return [str(x) for x in server.query(q)]
 
 
-def expand(server, keys):
-    """
-    Expands keys like "/templates/*" to be all template keys.
-
-    :param Disk or OpenLibrary server:
-    :param typing.Iterable[str] keys:
-    :rtype: typing.Iterator[str]
-    """
-    if isinstance(server, Disk):
-        yield from keys
-    else:
-        for key in keys:
-            if key.endswith('*'):
-                yield from find(server, key)
-            else:
-                yield key
-
-
 class Disk:
     """Lets us copy templates from and records to the disk as files"""
 
     def __init__(self, root):
         self.root = root
 
-    def get_many(self, keys):
+    def get_many(self, keys: list[str]) -> dict:
         """
         Only gets templates
         :param typing.List[str] keys:
-        :rtype: dict
+        :return: dict
         """
 
         def f(k):
@@ -70,11 +55,12 @@ class Disk:
 
         return {k: f(k) for k in keys}
 
-    def save_many(self, docs, comment=None):
+    def save_many(self, docs: list[dict | web.storage], comment: str = None) -> None:
         """
 
         :param typing.List[dict or web.storage] docs:
         :param str or None comment: only here to match the signature of OpenLibrary api
+        :return None:
         """
 
         def write(path, text):
@@ -106,6 +92,24 @@ class Disk:
                 write(path, json.dumps(doc, indent=2))
 
 
+def expand(server: Disk | OpenLibrary, keys: Iterator):
+    """
+    Expands keys like "/templates/*" to be all template keys.
+
+    :param Disk or OpenLibrary server:
+    :param typing.Iterable[str] keys:
+    :return: typing.Iterator[str]
+    """
+    if isinstance(server, Disk):
+        yield from keys
+    else:
+        for key in keys:
+            if key.endswith('*'):
+                yield from find(server, key)
+            else:
+                yield key
+
+
 def read_lines(filename):
     try:
         return [line.strip() for line in open(filename)]
@@ -133,10 +137,10 @@ class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
     """Helper class to store uri's like /works/OL1W?v=2"""
 
     @staticmethod
-    def from_uri(uri):
+    def from_uri(uri: str) -> KeyVersionPair:
         """
         :param str uri: either something like /works/OL1W, /books/OL1M?v=3, etc.
-        :rtype: KeyVersionPair
+        :return: KeyVersionPair
         """
 
         if '?v=' in uri:
@@ -145,9 +149,9 @@ class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
             key, version = uri, None
         return KeyVersionPair._make([key, version])
 
-    def to_uri(self):
+    def to_uri(self) -> str:
         """
-        :rtype: str
+        :return: str
         """
         uri = self.key
         if self.version:
@@ -159,15 +163,15 @@ class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
 
 
 def copy(
-    src: Union[Disk, OpenLibrary],
-    dest: Union[Disk, OpenLibrary],
+    src: Disk | OpenLibrary,
+    dest: Disk | OpenLibrary,
     keys: list[str],
     comment: str,
-    recursive=False,
-    editions=False,
+    recursive: bool = False,
+    editions: bool = False,
     saved: set[str] = None,
     cache: dict = None,
-):
+) -> None:
     """
     :param src: where we'll be copying form
     :param dest: where we'll be saving to
@@ -175,6 +179,7 @@ def copy(
     :param recursive: Whether to recursively fetch an referenced docs
     :param editions: Whether to fetch editions of works as well
     :param saved: keys saved so far
+    :return None:
     """
     if saved is None:
         saved = set()
@@ -194,12 +199,16 @@ def copy(
 
         return docs
 
-    def fetch(uris):
+    def fetch(uris: list[str]) -> list[dict | web.storage]:
         """
         :param typing.List[str] uris:
-        :rtype: typing.List[dict or web.storage]
+        :return: typing.List[dict or web.storage]
         """
-        docs = []
+        docs: list = []
+
+        # The remaining code relies on cache being a dict.
+        if not isinstance(cache, dict):
+            return docs
 
         key_pairs = list(map(KeyVersionPair.from_uri, uris))
 
@@ -219,6 +228,12 @@ def copy(
         # Do versioned second so they can overwrite if necessary
         if versioned_to_get:
             print("fetching versioned", versioned_to_get)
+            # src is type Disk | OpenLibrary, and here must be OpenLibrary for the get()
+            # method, But using isinstance(src, OpenLibrary) causes pytest to fail
+            # because TestServer is type scripts.tests.test_copydocs.FakeServer.
+            assert isinstance(
+                src, (OpenLibrary, scripts.tests.test_copydocs.FakeServer)
+            ), "fetching editions only works with OL src"
             docs2 = [src.get(pair.key, int(pair.version)) for pair in versioned_to_get]
             cache.update((doc['key'], doc) for doc in docs2)
             docs.extend(docs2)
@@ -325,15 +340,15 @@ def copy_list(src, dest, list_key, comment):
 
 def main(
     keys: list[str],
-    src="http://openlibrary.org/",
-    dest="http://localhost:8080",
-    comment="",
-    recursive=True,
-    editions=True,
+    src: str = "http://openlibrary.org/",
+    dest: str = "http://localhost:8080",
+    comment: str = "",
+    recursive: bool = True,
+    editions: bool = True,
     lists: list[str] = None,
     search: str = None,
     search_limit: int = 10,
-):
+) -> None:
     """
     Script to copy docs from one OL instance to another.
     Typically used to copy templates, macros, css and js from
@@ -354,6 +369,7 @@ def main(
     :param editions: Also fetch all the editions of works
     :param lists: Copy docs from list(s)
     :param search: Run a search on open library and copy docs from the results
+    :return None:
     """
 
     # Mypy doesn't handle union-ing types across if statements -_-

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -39,8 +39,6 @@ class Disk:
     def get_many(self, keys: list[str]) -> dict:
         """
         Only gets templates
-        :param typing.List[str] keys:
-        :return: dict
         """
 
         def f(k):
@@ -60,7 +58,6 @@ class Disk:
 
         :param typing.List[dict or web.storage] docs:
         :param str or None comment: only here to match the signature of OpenLibrary api
-        :return None:
         """
 
         def write(path, text):
@@ -140,7 +137,6 @@ class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
     def from_uri(uri: str) -> KeyVersionPair:
         """
         :param str uri: either something like /works/OL1W, /books/OL1M?v=3, etc.
-        :return: KeyVersionPair
         """
 
         if '?v=' in uri:
@@ -151,7 +147,6 @@ class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
 
     def to_uri(self) -> str:
         """
-        :return: str
         """
         uri = self.key
         if self.version:
@@ -179,7 +174,6 @@ def copy(
     :param recursive: Whether to recursively fetch an referenced docs
     :param editions: Whether to fetch editions of works as well
     :param saved: keys saved so far
-    :return None:
     """
     if saved is None:
         saved = set()
@@ -200,10 +194,6 @@ def copy(
         return docs
 
     def fetch(uris: list[str]) -> list[dict | web.storage]:
-        """
-        :param typing.List[str] uris:
-        :return: typing.List[dict or web.storage]
-        """
         docs: list = []
 
         # The remaining code relies on cache being a dict.
@@ -369,7 +359,6 @@ def main(
     :param editions: Also fetch all the editions of works
     :param lists: Copy docs from list(s)
     :param search: Run a search on open library and copy docs from the results
-    :return None:
     """
 
     # Mypy doesn't handle union-ing types across if statements -_-

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -146,8 +146,7 @@ class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
         return KeyVersionPair._make([key, version])
 
     def to_uri(self) -> str:
-        """
-        """
+        """ """
         uri = self.key
         if self.version:
             uri += '?v=' + self.version

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -136,7 +136,6 @@ def import_job(
     """
     :param str ol_config: Path to openlibrary.yml file
     :param bool dry_run: If true, only print out records to import
-    :return: None
     """
     load_config(ol_config)
 

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -131,11 +131,12 @@ def filter_modified_since(
 
 def import_job(
     ol_config: str,
-    dry_run=False,
+    dry_run: bool = False,
 ) -> None:
     """
-    :param ol_config: Path to openlibrary.yml file
-    :param dry_run: If true, only print out records to import
+    :param str ol_config: Path to openlibrary.yml file
+    :param bool dry_run: If true, only print out records to import
+    :return: None
     """
     load_config(ol_config)
 

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -35,9 +35,6 @@ def run_piped(cmds: list[list[str]], stdin: IO = None):
 def store_data(data: dict, day: datetime) -> None:
     """
     Store stats data about the provided date.
-    :param dict data:
-    :param datetime day:
-    :return: None
     """
     uid = day.strftime("counts-%Y-%m-%d")
     doc = web.ctx.site.store.get(uid) or {}
@@ -50,8 +47,6 @@ def count_unique_ips_for_day(day: datetime) -> int:
     """
     Get the number of unique visitors for the given day.
     Throws an IndexError if missing log for the given day.
-    :param datetime day:
-    :return: an int
     """
     basedir = "/var/log/nginx/"
 
@@ -83,9 +78,6 @@ def main(config: str, start: datetime, end: datetime):
     """
     Get the unique visitors per day between the 2 dates (inclusive) and store them
     in the infogami database. Ignores errors
-    :param datetime start:
-    :param datetime end:
-    :return: None
     """
     load_config(config)  # loads config for psql db under the hood
     infogami._setup()

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -15,15 +15,15 @@ import web
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 import infogami  # must be after _init_path
 from openlibrary.config import load_config
+from typing import Dict, IO, List
 
 
-def run_piped(cmds, stdin=None):
+def run_piped(cmds: list[list[str]], stdin: IO = None):
     """
     Run the commands piping one's output to the next's input.
     :param list[list[str]] cmds:
     :param file stdin: The stdin to supply the first command of the pipe
     :return: the stdout of the last command
-    :rtype: file
     """
     prev_stdout = stdin
     for cmd in cmds:
@@ -32,12 +32,12 @@ def run_piped(cmds, stdin=None):
     return prev_stdout
 
 
-def store_data(data, day):
+def store_data(data: dict, day: datetime) -> None:
     """
     Store stats data about the provided date.
     :param dict data:
     :param datetime day:
-    :return:
+    :return: None
     """
     uid = day.strftime("counts-%Y-%m-%d")
     doc = web.ctx.site.store.get(uid) or {}
@@ -46,13 +46,12 @@ def store_data(data, day):
     web.ctx.site.store[uid] = doc
 
 
-def count_unique_ips_for_day(day):
+def count_unique_ips_for_day(day: datetime) -> int:
     """
     Get the number of unique visitors for the given day.
     Throws an IndexError if missing log for the given day.
     :param datetime day:
-    :return: A dict of the form `{visitors: int}`
-    :rtype: int
+    :return: an int
     """
     basedir = "/var/log/nginx/"
 
@@ -80,13 +79,13 @@ def count_unique_ips_for_day(day):
     return int(out.read())
 
 
-def main(config, start, end):
+def main(config: str, start: datetime, end: datetime):
     """
     Get the unique visitors per day between the 2 dates (inclusive) and store them
     in the infogami database. Ignores errors
     :param datetime start:
     :param datetime end:
-    :return:
+    :return: None
     """
     load_config(config)  # loads config for psql db under the hood
     infogami._setup()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially closes #6755 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor to include more type hints.

### Technical
<!-- What should be noted about the implementation? -->
`fetch()` from `scripts/test_copydocs.py` is a bit of a question mark. There is a comment that explains it, but the code in production requires `src` to be of type `OpenLibrary`, but pytest uses `FakeServer`. I saw `assert` was used in there to deal with specifically with thte issue of the type for `src`, though admittedly this is rather like using `assert` for flow control.

I also struggled a bit with the best way to narrow the type of `cache`, as the function expects it not to be None, but the type is controlled by a parent function.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
