### PR TITLE
Fix reading log is rendered incorrectly in Ukranian and German (#6768)

### DIFF
--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -84,6 +84,14 @@
     margin-bottom: 5px;
   }
 
+  /* stylelint-disable selector-max-specificity */
+  .section-header.section-header-split::after {
+    clear: both;
+    display: block;
+    content: "";
+  }
+  /* stylelint-enable selector-max-specificity */
+
   .section-header.section-header-split {
     padding: 0;
 
@@ -94,7 +102,7 @@
     }
 
     > a {
-      padding: 4px 15px;
+      padding: 4px 15px 4px 1px;
     }
     /* stylelint-enable selector-max-specificity */
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6768 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
Clearfix was applied to .section-header.section-header-split, and the left padding was reduced by two pixels to accommodate the German translation of "LISTS" and "SEE ALL (x)".

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I had a lot of trouble reproducing it, but I was able to do it in Windows 8.1 (64bit) using current versions of Chrome and Edge. 

In more detail:                                                                                          
- I couldn't reproduce in IE 11.0.14 or Firefox 102.0.1 (64-bit)                                                         
- I could reproduce in Chrome 104.0.5112.102 (64-bit) and (unsurprisingly) Edge 104.0.1293.63 (64-bit)                   
- Screen resolution: I tested a number of resolutions from 1024x768 on up, and could only reproduce when the browser wasn't maximized. I don't know enough about CSS to know exactly what's happening, my guess is it relates to the visual scrollbar that suddenly appears in the left-hand menu once the window is no longer maximized. Even if the browser window is far wider than the page, if the browser is not maximized then this issue appears, for me at least (in Chrome and Edge, anyway). 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
All screenshots are Windows 8.1 using the current version of Edge unless noted. I used German because it took up the most space.

Note: when the reading list took only a single digit using padding of `4px 15px 4px 13px` got everything on one line, but as soon as the reading list went to double digits it no longer fit. I tried to look around for further implications of changing the left padding from 15px to 1px, but I couldn't see any. Still, I wanted to draw extra attention to that change.

Before (maximized)
![image](https://user-images.githubusercontent.com/26524678/186039525-e9fbb25c-02e0-4d62-82bd-4d88518414b6.png)

Before (not maximized)
![image](https://user-images.githubusercontent.com/26524678/186039574-935548a7-bffd-4c03-a94f-ba9972c18ac2.png)

After clearfix (maximized)
![image](https://user-images.githubusercontent.com/26524678/186039627-cc3e8539-9e80-47d8-b1f7-e37efe5ae9b3.png)

After clearfix (not maximized)
![image](https://user-images.githubusercontent.com/26524678/186039670-3c78e995-8d87-47d0-8631-d9c9a9ae4d07.png)

After clearfix + padding change (maximized)
![image](https://user-images.githubusercontent.com/26524678/186039764-45064837-d354-48e8-a4fe-348997ccf4f1.png)

After clearfix + padding change (not maximized)
![image](https://user-images.githubusercontent.com/26524678/186039947-15806c48-ac1b-4b66-a152-f07666500e82.png)

Same as before, but in Ukranian for good measure:
![image](https://user-images.githubusercontent.com/26524678/186040033-6560d483-4770-4dab-b213-d2d081be7522.png)

With both changes, Iphone SE
![image](https://user-images.githubusercontent.com/26524678/186040158-ed0171c0-27fc-41f1-9c80-fef1882f6028.png)

Surface Pro 7
![image](https://user-images.githubusercontent.com/26524678/186040203-7bc416ad-1792-4137-b094-44bf204f0625.png)

Current Firefox and Linux:
![image](https://user-images.githubusercontent.com/26524678/186040261-ede8fa3b-d213-4057-8821-73e8f22954ce.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini
@bicolino34 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
