### PR TITLE
Check-ins backend

### DIFF
--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,20 +1,31 @@
 from datetime import date, datetime
+from enum import IntEnum
 from . import db
+
+
+class BookshelfEvent(IntEnum):
+    START = 1
+    UPDATE = 2
+    FINISH = 3
+
+    @classmethod
+    def has_key(cls, key: str) -> bool:
+        return key in cls.__members__
 
 
 class BookshelvesEvents:
 
     TABLENAME = 'bookshelves_events'
-    EVENT_TYPES = {
-        'start': 1,
-        'update': 2,
-        'finish': 3,
-    }
 
     # Create methods:
     @classmethod
     def create_event(
-        cls, username, work_id, edition_id, event_date, event_type=EVENT_TYPES['start']
+        cls,
+        username,
+        work_id,
+        edition_id,
+        event_date,
+        event_type=BookshelfEvent.START.value,
     ):
         oldb = db.get_db()
 

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -13,7 +13,7 @@ class BookshelfEvent(IntEnum):
         return key in cls.__members__
 
 
-class BookshelvesEvents:
+class BookshelvesEvents(db.CommonExtras):
 
     TABLENAME = 'bookshelves_events'
 
@@ -39,15 +39,6 @@ class BookshelvesEvents:
         )
 
     # Read methods:
-    @classmethod
-    def select_all_by_username(cls, username):
-        # TODO: how should these be ordered?  edition_id and event_date?
-        oldb = db.get_db()
-
-        where_clause = 'username=$username'
-        where_vars = {'username': username}
-        return list(oldb.select(cls.TABLENAME, where=where_clause, vars=where_vars))
-
     @classmethod
     def select_by_id(cls, pid):
         oldb = db.get_db()

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -38,6 +38,7 @@ class BookshelvesEvents:
         return list(oldb.select(cls.TABLENAME, where=where_clause, vars=where_vars))
 
     # Update methods:
+    @classmethod
     def update_event_date(cls, pid, event_date):
         oldb = db.get_db()
 

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -37,7 +37,31 @@ class BookshelvesEvents:
         where_vars = {'username': username}
         return list(oldb.select(cls.TABLENAME, where=where_clause, vars=where_vars))
 
+    @classmethod
+    def select_by_id(cls, pid):
+        oldb = db.get_db()
+
+        return list(oldb.select(cls.TABLENAME, where='id=$id', vars={'id': pid}))
+
     # Update methods:
+    @classmethod
+    def update_event(cls, pid, event_date=None, data=None):
+        oldb = db.get_db()
+        updates = {}
+        if event_date:
+            updates['event_date'] = event_date
+        if data:
+            updates['data'] = data
+        if updates:
+            return oldb.update(
+                cls.TABLENAME,
+                where='id=$id',
+                vars={'id': pid},
+                updated=datetime.utcnow(),
+                **updates,
+            )
+        return 0
+
     @classmethod
     def update_event_date(cls, pid, event_date):
         oldb = db.get_db()

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,0 +1,88 @@
+from datetime import date, datetime
+from . import db
+
+
+class BookshelvesEvents:
+
+    TABLENAME = 'bookshelves_events'
+    EVENT_TYPES = {
+        'start': 1,
+        'update': 2,
+        'finish': 3,
+    }
+
+    # Create methods:
+    @classmethod
+    def create_event(
+        cls, username, work_id, edition_id, event_date, event_type=EVENT_TYPES['start']
+    ):
+        oldb = db.get_db()
+
+        return oldb.insert(
+            cls.TABLENAME,
+            username=username,
+            work_id=work_id,
+            edition_id=edition_id,
+            event_type=event_type,
+            event_date=event_date,
+        )
+
+    # Read methods:
+    @classmethod
+    def select_all_by_username(cls, username):
+        # TODO: how should these be ordered?  edition_id and event_date?
+        oldb = db.get_db()
+
+        where_clause = 'username=$username'
+        where_vars = {'username': username}
+        return list(oldb.select(cls.TABLENAME, where=where_clause, vars=where_vars))
+
+    # Update methods:
+    def update_event_date(cls, pid, event_date):
+        oldb = db.get_db()
+
+        where_clause = 'id=$id'
+        where_vars = {'id': pid}
+        update_time = datetime.utcnow()
+
+        return oldb.update(
+            cls.TABLENAME,
+            where=where_clause,
+            vars=where_vars,
+            updated=update_time,
+            event_date=event_date,
+        )
+
+    def update_event_data(cls, pid, data):
+        oldb = db.get_db()
+
+        where_clause = 'id=$id'
+        where_vars = {'id': pid}
+        update_time = datetime.utcnow()
+
+        return oldb.update(
+            cls.TABLENAME,
+            where=where_clause,
+            vars=where_vars,
+            updated=update_time,
+            data=data,
+        )
+
+    # Delete methods:
+    @classmethod
+    def delete_by_id(cls, pid):
+        oldb = db.get_db()
+
+        where_clause = 'id=$id'
+        where_vars = {'id': pid}
+
+        return oldb.delete(cls.TABLENAME, where=where_clause, vars=where_vars)
+
+    @classmethod
+    def delete_by_username(cls, username):
+        oldb = db.get_db()
+
+        where_clause = 'username=$username'
+        where_vars = {'username': username}
+
+        return oldb.delete(cls.TABLENAME, where=where_clause, vars=where_vars)

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -52,6 +52,17 @@ INSERT INTO bookshelves (name, description) VALUES ('Want to Read', 'A list of b
 INSERT INTO bookshelves (name, description) VALUES ('Currently Reading', 'A list of books I am currently reading');
 INSERT INTO bookshelves (name, description) VALUES ('Already Read', 'A list of books I have finished reading');
 
+CREATE TABLE bookshelves_events (
+    id serial primary key,
+    username text not null,
+    work_id integer not null,
+    edition_id integer not null,
+    event_type integer not null,
+    event_date text not null,
+    data json,
+    updated timestamp without time zone default (current_timestamp at time zone 'utc'),
+    created timestamp without time zone default (current_timestamp at time zone 'utc')
+);
 
 CREATE TABLE observations (
     work_id INTEGER not null,

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -75,7 +75,7 @@ class check_ins(delegate.page):
 
 
 class patron_check_ins(delegate.page):
-    path = r'/check-ins/people/([^/]+)'
+    path = r'/people/([^/]+)/checkins'
     encoding = 'json'
 
     @authorized_for('/usergroup/admin')
@@ -116,11 +116,7 @@ class patron_check_ins(delegate.page):
         a. Missing an 'id'
         b. Does not have either 'year' or 'data'
         """
-        if not 'id' in data:
-            return False
-        if not any(key in data for key in ('data', 'year')):
-            return False
-        return True
+        return 'id' in data and 'data' in data and 'year' in data
 
 
 def setup():

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -66,17 +66,6 @@ class check_ins(delegate.page):
 
         Month and day can be None.  If the month is None, only the year is returned.
         If there is a month but day is None, the year and month are returned.
-
-        >>> check_ins.make_date_string(1999, 12, 22)
-        '1999-12-22'
-        >>> check_ins.make_date_string(1999, 2, 2)
-        '1999-02-02'
-        >>> check_ins.make_date_string(1999, 2, None)
-        '1999-02'
-        >>> check_ins.make_date_string(1999, None, None)
-        '1999'
-        >>> check_ins.make_date_string(1999, None, 2)
-        '1999'
         """
         result = f'{year}'
         if month:

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -17,10 +17,11 @@ from openlibrary.utils.decorators import authorized_for
 class check_ins(delegate.page):
     path = r'/check-ins/OL(\d+)W'
 
+    @authorized_for('/usergroup/admin')
     def GET(self, work_id):
-        pass
+        return render_template('check_ins/test_form')
 
-    @authorized_for('/usergroup/beta-testers', '/usergroup/admin')
+    @authorized_for('/usergroup/admin')
     def POST(self, work_id):
         """Creates a check-in for the given work.
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -78,6 +78,7 @@ class patron_check_ins(delegate.page):
     path = r'/check-ins/people/([^/]+)'
     encoding = 'json'
 
+    @authorized_for('/usergroup/admin')
     def POST(self, username):
         data = json.loads(web.data())
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -1,0 +1,89 @@
+"""Reading log check-ins handler and services.
+"""
+import json
+import web
+
+from typing import Optional
+
+from infogami.utils import delegate
+from infogami.utils.view import render_template
+
+from openlibrary.accounts import get_current_user
+from openlibrary.utils import extract_numeric_id_from_olid
+from openlibrary.core.bookshelves_events import BookshelvesEvents
+from openlibrary.utils.decorators import authorized_for
+
+
+class check_ins(delegate.page):
+    path = r'/check-ins/OL(\d+)W'
+
+    def GET(self, work_id):
+        pass
+
+    @authorized_for('/usergroup/beta-testers', '/usergroup/admin')
+    def POST(self, work_id):
+        """Creates a check-in for the given work.
+
+        Additional data is expected to be sent as JSON in the body, and will
+        have the following keys:
+        edition_olid : str,
+        event_type : str,
+        year : integer,
+        month : integer [optional],
+        day : integer [optional]
+        """
+        data = json.loads(web.data())
+        valid_request = self.is_valid(data)
+        user = get_current_user()
+        username = user['key'].split('/')[-1]
+
+        if valid_request and username:
+            edition_id = extract_numeric_id_from_olid(data['edition_olid'])
+            date_str = self.make_date_string(
+                data['year'], data.get('month', None), data.get('day', None)
+            )
+            event_type = BookshelvesEvents.EVENT_TYPES[data['event_type']]
+            BookshelvesEvents.create_event(
+                username, work_id, edition_id, date_str, event_type=event_type
+            )
+        else:
+            return web.badrequest(message="Invalid request")
+        return delegate.RawText(json.dumps({'status': 'ok'}))
+
+    def is_valid(self, data: dict) -> bool:
+        """Validates POSTed check-in data."""
+        if not all(key in data for key in ('edition_olid', 'year', 'event_type')):
+            return False
+        if data['event_type'] not in BookshelvesEvents.EVENT_TYPES:
+            return False
+        return True
+
+    def make_date_string(
+        self, year: int, month: Optional[int], day: Optional[int]
+    ) -> str:
+        """Creates a date string in 'YYYY-MM-DD' format, given the year, month, and day.
+
+        Month and day can be None.  If the month is None, only the year is returned.
+        If there is a month but day is None, the year and month are returned.
+
+        >>> check_ins.make_date_string(1999, 12, 22)
+        '1999-12-22'
+        >>> check_ins.make_date_string(1999, 2, 2)
+        '1999-02-02'
+        >>> check_ins.make_date_string(1999, 2, None)
+        '1999-02'
+        >>> check_ins.make_date_string(1999, None, None)
+        '1999'
+        >>> check_ins.make_date_string(1999, None, 2)
+        '1999'
+        """
+        result = f'{year}'
+        if month:
+            result += f'-{month:02}'
+            if day:
+                result += f'-{day:02}'
+        return result
+
+
+def setup():
+    pass

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -10,7 +10,7 @@ from infogami.utils.view import render_template
 
 from openlibrary.accounts import get_current_user
 from openlibrary.utils import extract_numeric_id_from_olid
-from openlibrary.core.bookshelves_events import BookshelvesEvents
+from openlibrary.core.bookshelves_events import BookshelvesEvents, BookshelfEvent
 from openlibrary.utils.decorators import authorized_for
 
 
@@ -57,7 +57,7 @@ class check_ins(delegate.page):
             date_str = make_date_string(
                 data['year'], data.get('month', None), data.get('day', None)
             )
-            event_type = BookshelvesEvents.EVENT_TYPES[data['event_type']]
+            event_type = BookshelfEvent[data['event_type']].value
             BookshelvesEvents.create_event(
                 username, work_id, edition_id, date_str, event_type=event_type
             )
@@ -69,7 +69,7 @@ class check_ins(delegate.page):
         """Validates POSTed check-in data."""
         if not all(key in data for key in ('edition_olid', 'year', 'event_type')):
             return False
-        if data['event_type'] not in BookshelvesEvents.EVENT_TYPES:
+        if not BookshelfEvent.has_key(data['event_type']):
             return False
         return True
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -23,6 +23,7 @@ from openlibrary.plugins.upstream import addbook, covers, models, utils
 from openlibrary.plugins.upstream import spamcheck
 from openlibrary.plugins.upstream import merge_authors
 from openlibrary.plugins.upstream import edits
+from openlibrary.plugins.upstream import checkins
 from openlibrary.plugins.upstream import borrow, recentchanges  # TODO: unused imports?
 from openlibrary.plugins.upstream.utils import render_component
 
@@ -351,6 +352,7 @@ def setup():
     merge_authors.setup()
     # merge_works.setup() # ILE code
     edits.setup()
+    checkins.setup()
 
     from openlibrary.plugins.upstream import data, jsdef
 

--- a/openlibrary/plugins/upstream/tests/test_checkins.py
+++ b/openlibrary/plugins/upstream/tests/test_checkins.py
@@ -1,0 +1,82 @@
+from openlibrary.plugins.upstream.checkins import check_ins
+
+
+class TestMakeDateString:
+    def setup_method(self):
+        self.checkins = check_ins()
+
+    def test_formatting(self):
+        date_str = self.checkins.make_date_string(2000, 12, 22)
+        assert date_str == "2000-12-22"
+
+    def test_zero_padding(self):
+        date_str = self.checkins.make_date_string(2000, 2, 2)
+        split_date = date_str.split('-')
+        assert len(split_date) == 3
+        # Year has four characters:
+        assert len(split_date[0]) == 4
+        # Month has two characters:
+        assert len(split_date[1]) == 2
+        # Day has two characters:
+        assert len(split_date[2]) == 2
+
+    def test_partial_dates(self):
+        year_resolution = self.checkins.make_date_string(1998, None, None)
+        assert year_resolution == "1998"
+        month_resolution = self.checkins.make_date_string(1998, 10, None)
+        assert month_resolution == "1998-10"
+        missing_month = self.checkins.make_date_string(1998, None, 10)
+        assert missing_month == "1998"
+
+
+class TestIsValid:
+    def setup_method(self):
+        self.checkins = check_ins()
+        self.valid_data = {
+            'edition_olid': 'OL1234M',
+            'event_type': 'start',
+            'year': 2000,
+            'month': 3,
+            'day': 7,
+        }
+
+    def test_required_fields(self):
+        assert self.checkins.is_valid(self.valid_data) == True
+
+        missing_edition = {
+            'event_type': 'start',
+            'year': 2000,
+            'month': 3,
+            'day': 7,
+        }
+        missing_event_type = {
+            'edition_olid': 'OL1234M',
+            'year': 2000,
+            'month': 3,
+            'day': 7,
+        }
+        missing_year = {
+            'edition_olid': 'OL1234M',
+            'event_type': 'start',
+            'month': 3,
+            'day': 7,
+        }
+        missing_all = {
+            'month': 3,
+            'day': 7,
+        }
+        assert self.checkins.is_valid(missing_edition) == False
+        assert self.checkins.is_valid(missing_event_type) == False
+        assert self.checkins.is_valid(missing_year) == False
+        assert self.checkins.is_valid(missing_all) == False
+
+    def test_event_type_values(self):
+        assert self.checkins.is_valid(self.valid_data) == True
+        unknown_event_type = {
+            'edition_olid': 'OL1234M',
+            'event_type': 'sail-the-seven-seas',
+            'year': 2000,
+            'month': 3,
+            'day': 7,
+        }
+        assert self.checkins.is_valid(unknown_event_type) == False

--- a/openlibrary/plugins/upstream/tests/test_checkins.py
+++ b/openlibrary/plugins/upstream/tests/test_checkins.py
@@ -34,7 +34,7 @@ class TestIsValid:
         self.checkins = check_ins()
         self.valid_data = {
             'edition_olid': 'OL1234M',
-            'event_type': 'start',
+            'event_type': 'START',
             'year': 2000,
             'month': 3,
             'day': 7,
@@ -44,7 +44,7 @@ class TestIsValid:
         assert self.checkins.is_valid(self.valid_data) == True
 
         missing_edition = {
-            'event_type': 'start',
+            'event_type': 'START',
             'year': 2000,
             'month': 3,
             'day': 7,
@@ -57,7 +57,7 @@ class TestIsValid:
         }
         missing_year = {
             'edition_olid': 'OL1234M',
-            'event_type': 'start',
+            'event_type': 'START',
             'month': 3,
             'day': 7,
         }

--- a/openlibrary/plugins/upstream/tests/test_checkins.py
+++ b/openlibrary/plugins/upstream/tests/test_checkins.py
@@ -1,4 +1,4 @@
-from openlibrary.plugins.upstream.checkins import check_ins
+from openlibrary.plugins.upstream.checkins import check_ins, make_date_string
 
 
 class TestMakeDateString:
@@ -6,11 +6,11 @@ class TestMakeDateString:
         self.checkins = check_ins()
 
     def test_formatting(self):
-        date_str = self.checkins.make_date_string(2000, 12, 22)
+        date_str = make_date_string(2000, 12, 22)
         assert date_str == "2000-12-22"
 
     def test_zero_padding(self):
-        date_str = self.checkins.make_date_string(2000, 2, 2)
+        date_str = make_date_string(2000, 2, 2)
         split_date = date_str.split('-')
         assert len(split_date) == 3
         # Year has four characters:
@@ -21,11 +21,11 @@ class TestMakeDateString:
         assert len(split_date[2]) == 2
 
     def test_partial_dates(self):
-        year_resolution = self.checkins.make_date_string(1998, None, None)
+        year_resolution = make_date_string(1998, None, None)
         assert year_resolution == "1998"
-        month_resolution = self.checkins.make_date_string(1998, 10, None)
+        month_resolution = make_date_string(1998, 10, None)
         assert month_resolution == "1998-10"
-        missing_month = self.checkins.make_date_string(1998, None, 10)
+        missing_month = make_date_string(1998, None, 10)
         assert missing_month == "1998"
 
 

--- a/openlibrary/templates/check_ins/test_form.html
+++ b/openlibrary/templates/check_ins/test_form.html
@@ -1,0 +1,63 @@
+$def with()
+
+<div style="padding: 10px;">
+  <h2>Submit a new check-in</h2>
+  <form name="check-in">
+    <label>
+      Year:
+      <input type="number" name="ci-year">
+    </label>
+    <label>
+      Month:
+      <input type="number" name="ci-month">
+    </label>
+    <label>
+      Day:
+      <input type="number" name="ci-day">
+    </label>
+    <br>
+    <label>
+      Edition OLID:
+      <input type="text" name="ci-edition-olid">
+    </label>
+    <br>
+    <label>
+      Event Type:
+      <input type="text" name="ci-event-type">
+    </label>
+    <button type="button" onclick="submitCheckIn()">Submit</button>
+  </form>
+  <hr>
+  <div id="ci-results">
+
+  </div>
+  <script>
+    const resultsDiv = document.querySelector('#ci-results')
+
+    function submitCheckIn() {
+      const form = document.forms['check-in']
+      data = {
+        event_type: form['ci-event-type'].value,
+        edition_olid: form['ci-edition-olid'].value,
+        year: Number(form['ci-year'].value),
+        month: Number(form['ci-month'].value),
+        day: Number(form['ci-day'].value)
+      }
+      console.log(data)
+      \$.ajax({
+        method: 'POST',
+        dataType: 'json',
+        data: JSON.stringify(data)
+      })
+        .done(function(data){
+          resultsDiv.innerHTML = 'Success!'
+        })
+        .fail(function(data) {
+          resultsDiv.innerHTML = '<span style="color:red;">Something went wrong...</span>'
+        })
+        .always(function(data) {
+          console.log(data)
+        })
+    }
+  </script>
+</div>

--- a/openlibrary/utils/decorators.py
+++ b/openlibrary/utils/decorators.py
@@ -1,0 +1,30 @@
+import web
+
+from functools import wraps
+
+from openlibrary.accounts import get_current_user
+
+
+def authorized_for(*expected_args):
+    """Check for membership in any given usergroup before proceeding."""
+
+    def decorator_authorized(func):
+        @wraps(func)
+        def wrapper_authorized(*args, **kwargs):
+            user = get_current_user()
+            if not user:
+                raise web.unauthorized(message='Requires log-in.')
+
+            authorized = False
+            for usergroup in expected_args:
+                if user.is_usergroup_member(usergroup):
+                    authorized = True
+
+            if not authorized:
+                # Throw some authorization error
+                raise web.forbidden(message='Requires elevated permissions.')
+            return func(*args, *kwargs)
+
+        return wrapper_authorized
+
+    return decorator_authorized


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6662

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds new DB table for tracking check-in events, and creates the persistence layer for the new table.  Creates two check-in event handlers: one for creating events (`/check-ins/{work_olid}`, and one for updating existing events (`/check-ins/{username}`.  Adds a __temporary__ UI from which to create new check-in events.  New UI is only available to `admin`s.

### Technical
<!-- What should be noted about the implementation? -->
For convenience, the new UI has inline styling and Javascript.  I figure that is okay, as we will not be surfacing this __temporary__ UI to patrons.  The purpose of the UI is for admins to quickly add new events to their dev instances, and to give an example of how to construct a valid payload client-side.  The test UI can be viewed at `/check-ins/{work_olid}` (work OLID need not be valid).

Any updates to the `data` field will overwrite the previous value.  I'm not quite sure what goes in `data` yet, so I don't know if it makes sense to overwrite `data` or to update the object with the new keys.

The endpoints don't really make sense now.  The event creation endpoint has the work OLID in the path, but these events are edition-level.  The endpoint for updating events has a `username` in the path, but we probably want to get the username from `accounts.get_current_user()` to more easily ensure that the request was POSTed by the owner the event (meaning one should only be able to update one's own events).

A new `@authorized_for` decorator has been created in support of this PR.  It does the following:
1. Checks to see if the patron is logged in. If not, a `401` error is returned.
2. Checks to see if the patron is a member of any of the given usergroups.  If not, a `403` error is returned.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
