### PR TITLE
unbreak data dumps (prevent log pollution)

### DIFF
--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -25,13 +25,13 @@ if __name__ == "__main__":
     from openlibrary.data import dump
     from openlibrary.utils.sentry import Sentry
 
-    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.10.4                                                                          
+    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.10.4
 
     ol_config = os.getenv("OL_CONFIG")
     if ol_config:
         logger.info(f"loading config from {ol_config}")
-        # Squelch output from infobase (needed for sentry setup)                                                                                               
-        # So it doesn't end up in our data dumps body                                                                                                          
+        # Squelch output from infobase (needed for sentry setup)
+        # So it doesn't end up in our data dumps body
         with open(os.devnull, 'w') as devnull:
             with redirect_stdout(devnull):
                 load_config(ol_config)

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -19,17 +19,22 @@ def log(*args) -> None:
 
 
 if __name__ == "__main__":
+    from contextlib import redirect_stdout
     from infogami import config
     from openlibrary.config import load_config
     from openlibrary.data import dump
     from openlibrary.utils.sentry import Sentry
 
-    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.10.4
+    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.10.4                                                                          
 
     ol_config = os.getenv("OL_CONFIG")
     if ol_config:
         logger.info(f"loading config from {ol_config}")
-        load_config(ol_config)
+        # Squelch output from infobase (needed for sentry setup)                                                                                               
+        # So it doesn't end up in our data dumps body                                                                                                          
+        with open(os.devnull, 'w') as devnull:
+            with redirect_stdout(devnull):
+                load_config(ol_config)
         sentry = Sentry(getattr(config, "sentry_cron_jobs", {}))
         if sentry.enabled:
             sentry.init()


### PR DESCRIPTION
Sentry requires infobase config to load which invokes logging that is polluting our monthly data dumps during the cdump stage, printing startup messages like the following to stdout (instead of using stderr logging) and thus polluting (i.e. getting added into the output of this script which then goes into) our cdumps

```
2022-08-25 16:10:09 [11337] [infobase.ol] [INFO] logging initialized                                                                                           
2022-08-25 16:10:09 [11337] [openlibrary.olbase] [INFO] setting up infobase events for Open Library
```

<!-- What issue does this PR close? -->
Closes #5402 #6319 #6825 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
