### PR TITLE
Partial fix for #6755. Batch three of type hints from type comments.

### DIFF
--- a/openlibrary/utils/ddc.py
+++ b/openlibrary/utils/ddc.py
@@ -6,9 +6,9 @@ Known issues
 ## Further Reading
 https://www.oclc.org/bibformats/en/0xx/082.html
 """
+from __future__ import annotations
 import re
 from string import printable
-from typing import List
 from collections.abc import Iterable
 
 MULTIPLE_SPACES_RE = re.compile(r'\s+')
@@ -123,18 +123,16 @@ def normalize_ddc(ddc: str) -> list[str]:
     return results
 
 
-def normalize_ddc_range(start, end):
+def normalize_ddc_range(start: str, end: str) -> list[str | None]:
     """
     Normalizes the pieces of a lucene (i.e. solr)-style range.
     E.g. ('23.23', '*')
-    :param str start:
-    :param str end:
 
     >>> normalize_ddc_range('23.23', '*')
     ['023.23', '*']
     """
 
-    ddc_range_norm = []
+    ddc_range_norm: list[str | None] = []
     for ddc in start, end:
         if ddc == '*':
             ddc_range_norm.append('*')

--- a/openlibrary/utils/isbn.py
+++ b/openlibrary/utils/isbn.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from isbnlib import canonical
 
 
@@ -60,13 +61,11 @@ def isbn_10_to_isbn_13(isbn_10):
     return isbn_13 + check_digit_13(isbn_13)
 
 
-def to_isbn_13(isbn):
+def to_isbn_13(isbn: str) -> str | None:
     """
     Tries to make an isbn into an isbn13; regardless of input isbn type
-    :param str isbn:
-    :rtype: str|None
     """
-    isbn = normalize_isbn(isbn)
+    isbn = normalize_isbn(isbn) or isbn
     return isbn and (isbn if len(isbn) == 13 else isbn_10_to_isbn_13(isbn))
 
 
@@ -77,13 +76,10 @@ def opposite_isbn(isbn):  # ISBN10 -> ISBN13 and ISBN13 -> ISBN10
             return alt
 
 
-def normalize_isbn(isbn):
+def normalize_isbn(isbn: str) -> str | None:
     """
-    Keep only numbers and X/x to return an ISBN-like string.
+    Takes an isbn-like string, keeps only numbers and X/x, and returns an ISBN-like
+    string or None.
     Does NOT validate length or checkdigits.
-
-    :param: str isbn: An isbnlike string to normalize
-    :rtype: str|None
-    :return: isbnlike string containing only valid ISBN characters, or None
     """
     return isbn and canonical(isbn) or None


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially closes #6755 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->
This batch entered the Solar system and required some use of `is not None` and `isinstance(x, y)` such that output could be changed. I... hope it has not changed.

I can see how reasonable people might disagree about whether or not some of the `:param:` comments add anything. I was trying to imagine myself in the situation of someone unfamiliar with the code base, as I am, and whether the `:param:` comments added something useful beyond the type hints and parameter names. I have no idea how much I can generalize from my own experience, if that’s even the right approach, though.

Some additional things to note:
- in `openlibrary/tests/solr/test_update_work.py`: the use of `Any` in the various functions to make make authors, editions, etc.
- in `openlibrary/solr/update_work.py`:
    - `get_last_modified()` (line 630). I wasn’t able to satisfy mypy using the comprehension format. Maybe there is a better way than a `for` loop to deal with the possibility of `datetimestr_to_int()` having None as an argument.
    - `update_author()` (line 1246). I am not sure about the approach of raising a `TypeError`. If `a` is `None`, or at least not a `dict`, an AttributeError will be raised shortly anyway I think, but this way mypy can type check it more thoroughly. I also saw the caller will log an error if an exception is raised.
- in `openlibrary/core/vendors.py`:
    - I made `resources` `Any` on line 117. After briefly consulting https://webservices.amazon.com/paapi5/documentation/get-items.html#resources-parameter it wasn’t clear to me what `resources` would be.
    - Similarly, with `serialize()` on line 155, I made `products` `Any` as I couldn’t figure out what sort of object was being returned from the API, and it looked as if I had have a reviewed and approved Amazon Associate account I could register to use the API.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ideally no behavior should change and mypy should pass.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
