### PR TITLE
cron_watcher: Send Slack message on failure only

### DIFF
--- a/.github/workflows/cron_watcher.yml
+++ b/.github/workflows/cron_watcher.yml
@@ -21,16 +21,20 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install internetarchive slack-sdk
-      - shell: python
+      - run: scripts/cron_watcher.py
+        continue-on-error: true
+        id: cron_watcher_step
+      - if: steps.cron_watcher_step.outcome != 'success'
+        shell: python
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_CHANNEL_ABC_TEAM: ${{ secrets.SLACK_CHANNEL_ABC_TEAM }}
         run: |
-          import os, slack_sdk
+          import os, sys, slack_sdk
           token = os.getenv("SLACK_TOKEN")
           channel = os.getenv("SLACK_CHANNEL_ABC_TEAM")
           if token and channel:
             slack_sdk.WebClient(token=token).chat_postMessage(channel=channel,
-              text="[cron_watcher](https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml) is starting now.",
+              text="[cron_watcher](https://github.com/internetarchive/openlibrary/actions/workflows/cron_watcher.yml) has failed.",
             )
-      - run: scripts/cron_watcher.py
+          sys.exit(1)


### PR DESCRIPTION
https://github.com/cclauss/openlibrary/actions
```
Run scripts/cron_watcher.py
  
files_with_both_prefixes_found = True
```
Slack notification was not sent.