### PR TITLE
Disable gitpod master branch prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,6 +25,8 @@ tasks:
 
 github:
   prebuilds:
+    # Disable master prebuilds ; it's not faster and often errors
+    master: false
     # Don't prebuild for PRs coming from this repo
     # Don't need this running on all renovatebot's PRs; it's slow
     pullRequests: false


### PR DESCRIPTION
https://gitpod.io/#https://github.com/internetarchive/openlibrary/ always errors :/ Disable the prebuild.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Won't be able to test until merged.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@cclauss @RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
