### PR TITLE
Open merge UIs to `librarians`

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -65,7 +65,7 @@ features:
     lists: enabled
     merge-authors:
         filter: usergroup
-        usergroup: /usergroup/super-librarians
+        usergroup: /usergroup/librarians
     merge-editions: admin
     publishers: enabled
     recentchanges_v2: enabled

--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <MergeTable :olids="olids" :show_diffs="show_diffs" ref="mergeTable"/>
+    <MergeTable :olids="olids" :show_diffs="show_diffs" :primary="primary" ref="mergeTable"/>
     <div class="action-bar">
         <div class="comment-input">
             <label for="comment">Comment: </label>
@@ -111,7 +111,9 @@ export default {
             } else {
                 // Create a new merge request with "pending" status
                 const workIds = [master.key].concat(Array.from(dupes, item => item.key))
-                await createMergeRequest(workIds, 'create-pending', this.comment)
+                const splitKey = master.key.split('/')
+                const primaryRecord = splitKey[splitKey.length - 1]
+                await createMergeRequest(workIds, primaryRecord, 'create-pending', this.comment)
             }
             this.mergeStatus = 'Done';
         },

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -82,7 +82,8 @@ export default {
     },
     props: {
         olids: Array,
-        show_diffs: Boolean
+        show_diffs: Boolean,
+        primary: String
     },
     asyncComputed: {
         async records() {
@@ -93,8 +94,21 @@ export default {
             const records = _.orderBy(
                 await Promise.all(olids_sorted.map(fetchRecord)),
                 record => record.type.key, 'desc');
+
+            // Ensure that primary record is the first record
+            if (this.primary) {
+                const primaryKey = `/works/${this.primary}`
+                const primaryIndex = records.findIndex(elem => elem.key === primaryKey)
+                if (primaryIndex > 0) {
+                    const primaryRecord = records[primaryIndex]
+                    records.splice(primaryIndex, 1)
+                    records.unshift(primaryRecord)
+                }
+            }
+
             this.master_key = records[0].key
             this.selected = _.fromPairs(records.map(record => [record.key, record.type.key.includes('work')]));
+
             return records;
         },
 

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -164,15 +164,16 @@ export function update_merge_request(mrid, action, comment) {
 }
 
 /**
- * Composes and POSTs a merge request with status "Merged"
+ * Composes and POSTs a new merge request.
  *
  * @param {Array<string>} workIds Un-normalized work OLIDs
+ * @param {'create-merged'|'create-pending'} action Determines the status code of the new request
  *
  * @returns {Promise<Response>}
  */
-export function createMergeRequest(workIds) {
+export function createMergeRequest(workIds, action = 'create-merged', comment = null) {
     const normalizedIds = prepareIds(workIds).join(',')
-    return createRequest(normalizedIds, 'create-merged', REQUEST_TYPES['WORK_MERGE'])
+    return createRequest(normalizedIds, action, REQUEST_TYPES['WORK_MERGE'], comment)
 }
 
 /**

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -167,13 +167,15 @@ export function update_merge_request(mrid, action, comment) {
  * Composes and POSTs a new merge request.
  *
  * @param {Array<string>} workIds Un-normalized work OLIDs
+ * @param {string} primaryRecord The record in which to merge other records
  * @param {'create-merged'|'create-pending'} action Determines the status code of the new request
+ * @param {string} comment Optional comment from request submitter
  *
  * @returns {Promise<Response>}
  */
-export function createMergeRequest(workIds, action = 'create-merged', comment = null) {
+export function createMergeRequest(workIds, primaryRecord, action = 'create-merged', comment = null) {
     const normalizedIds = prepareIds(workIds).join(',')
-    return createRequest(normalizedIds, action, REQUEST_TYPES['WORK_MERGE'], comment)
+    return createRequest(normalizedIds, action, REQUEST_TYPES['WORK_MERGE'], comment, primaryRecord)
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/dialog.js
+++ b/openlibrary/plugins/openlibrary/js/dialog.js
@@ -34,23 +34,27 @@ export function confirmDialog(callback, options) {
 function initConfirmationDialogs() {
     const CONFIRMATION_PROMPT_DEFAULTS = { autoOpen: false, modal: true };
     $('#noMaster').dialog(CONFIRMATION_PROMPT_DEFAULTS);
-    $('#confirmMerge').dialog(
-        $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
-            buttons: {
-                'Yes, Merge': function() {
-                    const commentInput = document.querySelector('#author-merge-comment')
-                    if (commentInput.value) {
-                        document.querySelector('#hidden-comment-input').value = commentInput.value
+
+    const $confirmMerge = $('#confirmMerge')
+    if ($confirmMerge.length) {
+        $confirmMerge.dialog(
+            $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
+                buttons: {
+                    'Yes, Merge': function() {
+                        const commentInput = document.querySelector('#author-merge-comment')
+                        if (commentInput.value) {
+                            document.querySelector('#hidden-comment-input').value = commentInput.value
+                        }
+                        $('#mergeForm').trigger('submit');
+                        $(this).parents().find('button').attr('disabled','disabled');
+                    },
+                    'No, Cancel': function() {
+                        $(this).dialog('close');
                     }
-                    $('#mergeForm').trigger('submit');
-                    $(this).parents().find('button').attr('disabled','disabled');
-                },
-                'No, Cancel': function() {
-                    $(this).dialog('close');
                 }
-            }
-        })
-    );
+            })
+        );
+    }
     $('#leave-waitinglist-dialog').dialog(
         $.extend({}, CONFIRMATION_PROMPT_DEFAULTS, {
             width: 450,

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/MergeRequestService.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/MergeRequestService.js
@@ -4,7 +4,7 @@ export const REQUEST_TYPES = {
     AUTHOR_MERGE: 2
 }
 
-export async function createRequest(olids, action, type, comment = null) {
+export async function createRequest(olids, action, type, comment = null, primary = null) {
     const data = {
         rtype: 'create-request',
         action: action,
@@ -13,6 +13,9 @@ export async function createRequest(olids, action, type, comment = null) {
     }
     if (comment) {
         data['comment'] = comment
+    }
+    if (primary) {
+        data['primary'] = primary
     }
 
     return fetch('/merges', {

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -3,10 +3,13 @@ import { declineRequest } from './merge-request-table/MergeRequestService';
 export function initAuthorMergePage() {
     $('#save').on('click', function () {
         const n = $('#mergeForm input[type=radio]:checked').length;
+        const confirmMergeButton = document.querySelector('#confirmMerge')
         if (n === 0) {
             $('#noMaster').dialog('open');
-        } else {
+        } else if (confirmMergeButton) {
             $('#confirmMerge').dialog('open');
+        } else {
+            $('#mergeForm').trigger('submit')
         }
         return false;
     });
@@ -40,12 +43,15 @@ export function initAuthorMergePage() {
 
 function initRejectButton() {
     const rejectButton = document.querySelector('#reject-author-merge-btn')
-    rejectButton.addEventListener('click', function() {
-        rejectMerge()
-        rejectButton.disabled = true
-        const approveButton = document.querySelector('#save')
-        approveButton.disabled = true
-    })
+    console.log(rejectButton)
+    if(rejectButton) {
+        rejectButton.addEventListener('click', function() {
+            rejectMerge()
+            rejectButton.disabled = true
+            const approveButton = document.querySelector('#save')
+            approveButton.disabled = true
+        })
+    }
 }
 
 function rejectMerge() {

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -43,8 +43,7 @@ export function initAuthorMergePage() {
 
 function initRejectButton() {
     const rejectButton = document.querySelector('#reject-author-merge-btn')
-    console.log(rejectButton)
-    if(rejectButton) {
+    if (rejectButton) {
         rejectButton.addEventListener('click', function() {
             rejectMerge()
             rejectButton.disabled = true

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -104,7 +104,7 @@ class merge_work(delegate.page):
     path = "/works/merge"
 
     def GET(self):
-        i = web.input(records='', mrid=None)
+        i = web.input(records='', mrid=None, primary=None)
         user = web.ctx.site.get_user()
         has_access = user and (
             (user.is_admin() or user.is_librarian())
@@ -119,7 +119,9 @@ class merge_work(delegate.page):
         ):
             optional_kwargs['can_merge'] = 'false'
 
-        return render_template('merge/works', mrid=i.mrid, **optional_kwargs)
+        return render_template(
+            'merge/works', mrid=i.mrid, primary=i.primary, **optional_kwargs
+        )
 
 
 @web.memoize

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -29,6 +29,10 @@ from openlibrary.plugins.upstream.utils import render_component
 if not config.get('coverstore_url'):
     config.coverstore_url = "https://covers.openlibrary.org"  # type: ignore[attr-defined]
 
+import logging
+
+logger = logging.getLogger('openlibrary.plugins.upstream.code')
+
 
 class static(delegate.page):
     path = "/images/.*"
@@ -104,12 +108,18 @@ class merge_work(delegate.page):
         user = web.ctx.site.get_user()
         has_access = user and (
             (user.is_admin() or user.is_librarian())
-            and user.is_usergroup_member('/usergroup/super-librarians')
+            or user.is_usergroup_member('/usergroup/super-librarians')
         )
         if not has_access:
             raise web.HTTPError('403 Forbidden')
 
-        return render_template('merge/works', mrid=i.mrid)
+        optional_kwargs = {}
+        if not (
+            user.is_usergroup_member('/usergroup/super-librarians') or user.is_admin()
+        ):
+            optional_kwargs['can_merge'] = 'false'
+
+        return render_template('merge/works', mrid=i.mrid, **optional_kwargs)
 
 
 @web.memoize

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -15,7 +15,6 @@ def response(status='ok', **kwargs):
 
 
 def process_merge_request(rtype, data):
-
     user = accounts.get_current_user()
     username = user['key'].split('/')[-1]
     # Request types can be: create-request, update-request
@@ -66,7 +65,12 @@ class community_edits_queue(delegate.page):
 
     @staticmethod
     def create_request(
-        username, action='', mr_type=None, olids='', comment: str = None
+        username,
+        action='',
+        mr_type=None,
+        olids='',
+        comment: str = None,
+        primary: str = None,
     ):
         def is_valid_action(action):
             return action in ('create-pending', 'create-merged')
@@ -81,7 +85,7 @@ class community_edits_queue(delegate.page):
             olid_list = olids.split(',')
 
             title = community_edits_queue.create_title(mr_type, olid_list)
-            url = community_edits_queue.create_url(mr_type, olid_list)
+            url = community_edits_queue.create_url(mr_type, olid_list, primary=primary)
 
             # Validate URL
             is_valid_url = True
@@ -161,9 +165,10 @@ class community_edits_queue(delegate.page):
         return resp
 
     @staticmethod
-    def create_url(mr_type: int, olids: list[str]) -> str:
+    def create_url(mr_type: int, olids: list[str], primary: str = None) -> str:
         if mr_type == CommunityEditsQueue.TYPE['WORK_MERGE']:
-            return f'/works/merge?records={",".join(olids)}'
+            primary_param = f'&primary={primary}' if primary else ''
+            return f'/works/merge?records={",".join(olids)}{primary_param}'
         elif mr_type == CommunityEditsQueue.TYPE['AUTHOR_MERGE']:
             return f'/authors/merge?key={"&key=".join(olids)}'
         return ''

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -1,4 +1,4 @@
-$def with (keys, top_books_from_author, formdata=None, mrid=None)
+$def with (keys, top_books_from_author, formdata=None, mrid=None, can_merge=False)
 
 $var title: $_("Merge Authors")
 
@@ -35,15 +35,16 @@ $if formdata:
     <p>$_('You must select a primary record to point the duplicates toward.')</p>
 </div>
 
-<div id="confirmMerge" title="$_('Please Be Careful...')" style="text-align:left;">
-    <p class="merge">$:_('<b>Are you sure</b> you want to merge these records?')</p>
-</div>
+$if can_merge:
+    <div id="confirmMerge" title="$_('Please Be Careful...')" style="text-align:left;">
+        <p class="merge">$:_('<b>Are you sure</b> you want to merge these records?')</p>
+    </div>
 
-<form method="POST" id="mergeForm" name="mergeForm">
+<form method="POST" id="mergeForm" name="mergeForm" action="/authors/merge" method="POST">
     <input type="hidden" name="merge" value="true"/>
     $if mrid:
         <input type="hidden" id="mrid-input" name="mrid" value="$mrid"/>
-        <input type="hidden" id="hidden-comment-input" name="comment" value=""/>
+    <input type="hidden" id="hidden-comment-input" name="comment" value=""/>
     <div class="merge" id="include">
 
         <div class="entry header">
@@ -91,9 +92,9 @@ $if formdata:
     </div>
 
     <div class="merge-feedback">
-        <label for="merge-comment">$_('Comment:') <input type="text" id="author-merge-comment" name="merge-comment" placeholder="$_('Comment...')"></label>
+        <label for="merge-comment">$_('Comment:') <input type="text" id="author-merge-comment" name="comment" placeholder="$_('Comment...')"></label>
         <div class="merge-feedback__buttons">
-            <button id="save" class="larger merge-feedback__submit" value="Merge Authors">$_('Merge Authors')</button>
+            <button id="save" class="larger merge-feedback__submit" value="Merge Authors" type="submit">$_('Merge Authors')</button>
             $if mrid:
                 <button id="reject-author-merge-btn" type="button" class="larger merge-feedback__reject">$_('Reject Merge')</button>
             $else:

--- a/openlibrary/templates/merge/works.html
+++ b/openlibrary/templates/merge/works.html
@@ -1,9 +1,13 @@
-$def with (mrid=None)
+$def with (mrid=None, can_merge='true')
+$# mrid : int : Reference to entry in merge requests table
+
 $var title: $_('Merge Works')
 
 $ bodyclass = ctx.setdefault('bodyclass', [])
 $ bodyclass.append('full-width')
 
-$ attrs = dict(mrid=mrid) if mrid else {}
+$ attrs = dict(canmerge=can_merge)
+$if mrid:
+  $ attrs['mrid'] = mrid
 
 $:render_component('MergeUI', attrs=attrs)

--- a/openlibrary/templates/merge/works.html
+++ b/openlibrary/templates/merge/works.html
@@ -1,5 +1,6 @@
-$def with (mrid=None, can_merge='true')
+$def with (mrid=None, can_merge='true', primary=None)
 $# mrid : int : Reference to entry in merge requests table
+$# primary : string : Specifies a specific work as the primary record
 
 $var title: $_('Merge Works')
 
@@ -9,5 +10,7 @@ $ bodyclass.append('full-width')
 $ attrs = dict(canmerge=can_merge)
 $if mrid:
   $ attrs['mrid'] = mrid
+$if primary:
+  $ attrs['primary'] = primary
 
 $:render_component('MergeUI', attrs=attrs)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6883

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Permits members of `/usergroup/librarians` to access author and work merge views.  `librarians` now submit merge requests (MRs) from these UIs, instead of search results pages.

The primary work ID can now be included for work MRs.  If a work merge URL has a `primary` ID, that record will appear first in the list of all records.

### Technical
<!-- What should be noted about the implementation? -->

### Special Deployment Instructions
The `openlibrary.yml` configuration files must be updated in production, testing, and staging before this is deployed.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
