### PR TITLE
Merge request unassignment

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -315,9 +315,9 @@ class CommunityEditsQueue:
 
 
 @public
-def cached_get_counts_by_mode(mode='all', **kwargs):
+def cached_get_counts_by_mode(mode='all', reviewer='', **kwargs):
     return cache.memcache_memoize(
         CommunityEditsQueue.get_counts_by_mode,
         f"librarian_queue_counts_{mode}",
         timeout=dateutil.MINUTE_SECS,
-    )(mode, **kwargs)
+    )(mode=mode, reviewer=reviewer, **kwargs)

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -212,6 +212,12 @@ async function claim(mrid) {
                 const reviewerHtml = `${data.reviewer}
                     <span class="mr-unassign" data-mrid="${mrid}">&times;</span>`
                 updateRow(mrid, data.newStatus, reviewerHtml)
+
+                // Hide the row's merge link:
+                const mergeLink = document.querySelector(`#mr-resolve-link-${mrid}`)
+                if (!mergeLink.classList.contains('hidden')) {
+                    toggleMergeLink(mergeLink)
+                }
             }
         })
 }
@@ -251,6 +257,23 @@ async function unassign(mrid) {
         .then(data => {
             if (data.status === 'ok') {
                 updateRow(mrid, data.newStatus, ' ')
+
+                // Display the row's merge link:
+                const mergeLink = document.querySelector(`#mr-resolve-link-${mrid}`)
+                if (mergeLink.classList.contains('hidden')) {
+                    toggleMergeLink(mergeLink)
+                }
             }
         })
+}
+
+/**
+ * Toggles 'hidden' class for element with given ID.
+ *
+ * @param {HTMLElement} mergeLink Reference to a merge link element
+ */
+function toggleMergeLink(mergeLink) {
+    if (mergeLink) {
+        mergeLink.classList.toggle('hidden')
+    }
 }

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -97,8 +97,10 @@ $ page = int(input(page=1).page)
                 </div>
             </td>
             <td id="reviewer-cell-$(r['id'])">
-              $if can_merge and is_open and r.get('reviewer') == username:
+              $if can_merge and is_open and r.get('reviewer'):
                 $r['reviewer'] <span class="mr-unassign" data-mrid="$r['id']" data-merge-type="$r['mr_type']">&times;</span>
+                <br>
+                $datestr(r['updated'])
               $elif r.get('reviewer'):
                 $r['reviewer']
             </td>
@@ -106,8 +108,10 @@ $ page = int(input(page=1).page)
               $if is_open:
                 $if is_submitter:
                   <a class="mr-close-link" data-mrid="$r['id']" data-merge-type="$r['mr_type']" href="javascript:;">$_('Close')</a>
-                $elif can_merge and (not r.get('reviewer') or r.get('reviewer') == username):
-                  <a class="mr-resolve-link" data-mrid="$r['id']" data-merge-type="$r['mr_type']" href="$url" target="_blank">$_('Merge')</a>
+                $elif can_merge:
+                  $ show_link = not r.get('reviewer') or r.get('reviewer') == username
+                  $ extra_classes = '' if show_link else ' hidden'
+                  <a class="mr-resolve-link$extra_classes" id="mr-resolve-link-$r['id']" data-mrid="$r['id']" data-merge-type="$r['mr_type']" href="$url" target="_blank">$_('Merge')</a>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR does the following:
1. Modifies badge count such that only unassigned pending requests are counted.
2. Adds an assignment date to the merge request table.
3. Allows others with merge capabilities to unassign a person from a merge request.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![reassign](https://user-images.githubusercontent.com/28732543/187563101-16018b17-efea-4e74-9de6-357b00b62601.gif)
_Unassigning `openlibrary` as User `admin`_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
