### PR TITLE
Disable all gitpod prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,8 +25,8 @@ tasks:
 
 github:
   prebuilds:
-    # Disable master prebuilds ; it's not faster and often errors
+    # Disable all prebuilds ; it's not faster and often errors
     master: false
-    # Don't prebuild for PRs coming from this repo
-    # Don't need this running on all renovatebot's PRs; it's slow
     pullRequests: false
+    branches: false
+    pullRequestsFromForks: false


### PR DESCRIPTION
Branches should be disabled by default, but were still getting prebuilt for some reason.

It just hangs on this screen indefinitely -_- eg https://gitpod.io/#https://github.com/internetarchive/openlibrary/pull/6922

![image](https://user-images.githubusercontent.com/6251786/187734715-f02e1f03-40ac-4790-ba84-3873505f19d9.png)


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
