### PR TITLE
Sort merge requests by last updated

### DIFF
--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -41,7 +41,7 @@ class community_edits_queue(delegate.page):
             mode=i.mode,
             submitter=i.submitter,
             reviewer=i.reviewer,
-            order=f'created {i.order}',
+            order=f'updated {i.order}',
         ).list()
 
         total_found = {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6927

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Entries in the merge request table are now sorted by last updated date, descending.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
