### PR TITLE
Donate Button Changes

### DIFF
--- a/openlibrary/macros/DonateModal.html
+++ b/openlibrary/macros/DonateModal.html
@@ -1,9 +1,9 @@
-$def with(book, size="M", ids={})
+$def with(book, id, ids={})
 
 $ title = book.title
 
 <div class="hidden">
-  <div class="coverFloat" id="seeDonate">
+  <div class="coverFloat" id=$id>
     <div class="coverFloatHead">
       <h2 class="donation__override">
         Donate this book to the <a href="https://archive.org">Internet Archive</a> library.

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -131,6 +131,8 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
         $_("We don't have this book yet. Can you donate it to the Lending Library?")
         <a href="https://openlibrary.org/bookdrive" target="_blank">$_('Learn More')</a>
       </p>
+  $else:
+    $:macros.NotInLibrary(work_key)
 
 $elif ocaid and availability.get('is_previewable') and book_provider.short_name == 'ia':
   $:macros.BookPreview(ocaid, linkback=not no_index)
@@ -138,10 +140,7 @@ $elif ocaid and availability.get('is_previewable') and book_provider.short_name 
       $:macros.BookSearchInside(ocaid)
 
 $else:
-  <div class="cta-button-group">
-    <a href="$work_key" class="cta-btn cta-btn--missing"
-       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
-  </div>
+  $:macros.NotInLibrary(work_key)
 
 $:post
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -122,10 +122,25 @@ $elif availability.get('is_lendable'):
 $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availability.get('is_lendable')):
   $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc, donate_only=True)
   $if sponsorship.get('is_eligible'):
+    $ btn_count = ctx.get('donate_count', 1)
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor dialog--open"
        aria-controls="seeDonate"
+       data-id-num="$btn_count"
        data-ol-link-track="CTAClick|Sponsor">$_('Donate Book')</a>
+    $ isbn_13 = doc.get_isbn13()
+    $ asin = None
+    $if doc.get('identifiers'):
+      $if doc.identifiers.get('amazon'):
+        $ asin = doc.identifiers.amazon[0]
+
+    $if not asin:
+      $ asin = doc.get_isbn10()
+
+    $ modal_id = "donate-modal-%d" % btn_count
+
+    $:macros.DonateModal(doc, modal_id, ids={'isbn': isbn_13, 'asin': asin, 'prices': True})
+    $putctx('donate_count', btn_count + 1)
     $if sponsorship_help:
       <p>
         $_("We don't have this book yet. Can you donate it to the Lending Library?")

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -38,6 +38,9 @@ $# Checks to see if patron has actively loan / waitlist for this book
 $ get_loan_for_start_time = time()
 $ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
 $ get_loan_for_total_time = time() - get_loan_for_start_time
+
+$ is_edition = doc.key.split('/')[1] == 'books'
+
 $if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
@@ -119,7 +122,7 @@ $elif availability.get('is_lendable'):
   $if secondary_action:
     $:macros.BookPreview(ocaid, linkback=not no_index)
 
-$elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availability.get('is_lendable')):
+$elif is_edition and (('eligibility' in doc) or (check_sponsorship and not ocaid and not availability.get('is_lendable'))):
   $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc, donate_only=True)
   $if sponsorship.get('is_eligible'):
     $ btn_count = ctx.get('donate_count', 1)

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -123,9 +123,10 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
   $ sponsorship = doc.get('eligibility') if 'eligibility' in doc else qualifies_for_sponsorship(doc, donate_only=True)
   $if sponsorship.get('is_eligible'):
     $ btn_count = ctx.get('donate_count', 1)
+    $ modal_id = "donate-modal-%d" % btn_count
     <a href="$(sponsorship['sponsor_url'])"
        class="cta-btn cta-btn--sponsor dialog--open"
-       aria-controls="seeDonate"
+       aria-controls="$modal_id"
        data-id-num="$btn_count"
        data-ol-link-track="CTAClick|Sponsor">$_('Donate Book')</a>
     $ isbn_13 = doc.get_isbn13()
@@ -136,8 +137,6 @@ $elif ('eligibility' in doc) or (check_sponsorship and not ocaid and not availab
 
     $if not asin:
       $ asin = doc.get_isbn10()
-
-    $ modal_id = "donate-modal-%d" % btn_count
 
     $:macros.DonateModal(doc, modal_id, ids={'isbn': isbn_13, 'asin': asin, 'prices': True})
     $putctx('donate_count', btn_count + 1)

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,0 +1,6 @@
+$def with(work_key)
+
+<div class="cta-button-group">
+  <a href="$work_key" class="cta-btn cta-btn--missing"
+     data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+</div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -50,10 +50,6 @@ $if isbn_10 and not asin:
              $:summary
           </div>
 
-        $ render_times['databarWork: DonateModal'] = time()
-        $:macros.DonateModal(page, ids={'isbn': isbn_13, 'asin': asin, 'prices': True})
-        $ render_times['databarWork: DonateModal'] = time() - render_times['databarWork: DonateModal']
-
         $ work = (page.works and page.works[0]) or page
         $ edition = page.works and page
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following changes to our donate button logic:
1. Renders a "Not in Library" button if we enter the "Donate" button block of code and find that the book is not eligible.
2. Renders a new, uniquely identified donation modal content element with every "Donate" button, allowing multiple "Donate" buttons per page.
3. Checks if the record is an `Edition` before attempting to render a donate button (edition-level data is required for the donate modal macro)

### Technical
<!-- What should be noted about the implementation? -->
A count of donate buttons is stored in the web context object.  This count is used to uniquely identify individual "Donate" buttons on a single page.  There is a risk that this approach may not work with asynchronously fetched partials (like carousel items).

`Edition`-level methods `get_isbn10` and `get_isbn13` are required to get the price information for the donate modal.

Unless an `Edition` has been enriched with `eligibility`, "Donate" buttons will not appear in search results or carousels unless `check_sponsorship=True` is passed to `LoanStatus.html`.

Styling of the modal content appears differently on search results pages (as opposed to its appearance on a book page).  Neither one seems exactly correct, so no attempt to change the CSS has been made in this PR.  We should discuss how the modal should appear before merging this (if this type of solution is approved).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This has been deployed to both `testing` and `ol-jchamp` (port 8600).  The difference between the two instances is that `check_sponsorship` is defaulted to `True` in `LoanStatus` on `ol-jchamp`.  This list containing editions that we'd like donated has donate buttons on `ol-jchamp`, but not in testing:

/people/jachamp/lists/OL212635L

Check that our in both instances, and browse around looking for missing buttons.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![multi-donate](https://user-images.githubusercontent.com/28732543/188247009-26e9e04a-94fa-422d-845d-731bb0836e07.gif)
_Multiple "Donate" buttons on a search results page._

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
