### PR TITLE
Improve statsd name ol.affiliate.amazon.queue_size

### DIFF
--- a/scripts/affiliate-server
+++ b/scripts/affiliate-server
@@ -170,7 +170,8 @@ class Submit:
         if isbn10 not in web.amazon_queue.queue:
             web.amazon_queue.put_nowait(isbn10)
         qsize = web.amazon_queue.qsize()
-        stats.put("Amazon queue qsize", qsize, 0.05)  # send one sample in 20 to statsd
+        # send one sample in 20 to statsd
+        stats.put("ol.affiliate.amazon.queue_size", qsize, 0.05)
         return json.dumps({"status": "submitted", "queue": qsize})
 
 


### PR DESCRIPTION
The current string is not useful for reporting from statsd.

For current statsd names used in the codebase, see: `git grep increment`

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
