### PR TITLE
Make solr restarter wait longer before restarting solr

### DIFF
--- a/scripts/solr_restarter/index.js
+++ b/scripts/solr_restarter/index.js
@@ -23,7 +23,7 @@ class SolrRestarter {
     /** Don't restart twice in 10 minutes */
     MAX_RESTART_WIN = 10*60*1000;
     /** Must be unhealthy for this many minutes to trigger a refresh */
-    UNHEALTHY_DURATION = 2*60*1000;
+    UNHEALTHY_DURATION = 4*60*1000;
     /** Check every minute */
     CHECK_FREQ = 60*1000;
     /** How many times we're aloud to try restarting without going healthy before giving up */


### PR DESCRIPTION
Makes it less noisy, and avoids it restarting too aggressively.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
