### PR TITLE
Restrict some features to lead librarians

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -83,7 +83,9 @@ class admin(delegate.page):
             raise web.nomethod(cls=cls)
         else:
             if self.is_admin() or (
-                librarians and context.user and context.user.is_librarian()
+                librarians
+                and context.user
+                and context.user.is_usergroup_member('/usergroup/super-librarians')
             ):
                 return m(*args)
             else:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -536,7 +536,10 @@ class SaveBookHelper:
         user = accounts.get_current_user()
         delete = (
             user
-            and (user.is_admin() or user.is_librarian())
+            and (
+                user.is_admin()
+                or user.is_usergroup_member('/usergroup/super-librarians')
+            )
             and formdata.pop('_delete', '')
         )
 
@@ -756,7 +759,9 @@ class SaveBookHelper:
     def _prevent_ocaid_deletion(self, edition):
         # Allow admins to modify ocaid
         user = accounts.get_current_user()
-        if user and (user.is_admin() or user.is_librarian()):
+        if user and (
+            user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
+        ):
             return
 
         # read ocaid from form data

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -256,9 +256,11 @@ def setup_jquery_urls():
     web.template.Template.globals['use_google_cdn'] = config.get('use_google_cdn', True)
 
 
-def user_is_admin_or_librarian():
+def user_can_revert_records():
     user = web.ctx.site.get_user()
-    return user and (user.is_admin() or user.is_librarian())
+    return user and (
+        user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
+    )
 
 
 @public
@@ -286,7 +288,7 @@ class revert(delegate.mode):
         if v is None:
             raise web.seeother(web.changequery({}))
 
-        if not web.ctx.site.can_write(key) or not user_is_admin_or_librarian():
+        if not web.ctx.site.can_write(key) or not user_can_revert_records():
             return render.permission_denied(
                 web.ctx.fullpath, "Permission denied to edit " + key + "."
             )

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -16,6 +16,7 @@ def mock_user():
         {
             'is_admin': lambda slf: False,
             'is_librarian': lambda slf: False,
+            'is_usergroup_member': lambda slf, grp: False,
         },
     )()
 

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -51,7 +51,7 @@ $var title: $_("Add a book")
             </div>
         </div>
 
-        $ admin_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
+        $ admin_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
         <div class="formElement">
             <div class="label"><label for="id_value">$:_("And optionally, an ID number &#151; like an ISBN &#151; would be helpful...")</label></div>
                 <label for="id_name" class="hidden">$_("ID Type")</label>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -39,7 +39,7 @@ $# the default "enter" action.
             title = _("Editing...")
             note = ""
     <h2 class="editFormTitle">$:title</h2>
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
                 <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -1,7 +1,7 @@
 $def with (work, book)
 
 $ edition_config = get_edition_config()
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 
 $def radiobuttons(name, options, value):
     $for v in options:
@@ -404,7 +404,6 @@ $jsdef render_work_autocomplete_item(item):
     </div>
 
 </fieldset>
-$ admin_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 $ config = ({'Please select an identifier.': _('Please select an identifier.'), 'You need to give a value to ID.': _('You need to give a value to ID.'), 'ID ids cannot contain whitespace.': _('ID ids cannot contain whitespace.'), 'ID must be exactly 10 characters [0-9] or X.': _('ID must be exactly 10 characters [0-9] or X.'), 'That ISBN already exists for this edition.': _('That ISBN already exists for this edition.'), 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4': _('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4')})
 <fieldset class="major" id="identifiers" data-config="$dumps(config)">
     <legend>$_("ID Numbers")</legend>
@@ -424,7 +423,7 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
                             $ id_labels = dict((d.name, d.label) for d in edition_config.identifiers)
                             $ id_dict = dict((id.name, id) for id in edition_config.identifiers)
                             $ popular = ["ocaid", "isbn_10", "isbn_13", "lccn", "oclc_numbers", "goodreads", "librarything"]
-                            $if admin_user:
+                            $if is_privileged_user:
                                 $ exclude = []
                             $else:
                                 $ exclude = ["ocaid"]
@@ -472,7 +471,7 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
                                 <input type="hidden" name="edition--identifiers--${i}--value" value="$id.value" class="$id.name"/>
                             </td>
                             $# Disable removing ocaid for regular users.
-                            $if id.name == "ocaid" and not admin_user:
+                            $if id.name == "ocaid" and not is_privileged_user:
                                 <td></td>
                             $else:
                                 <td><a href="javascript:;" class="repeat-remove red plain" title="Remove this identifier">[x]</a></td>

--- a/openlibrary/templates/showmarc.html
+++ b/openlibrary/templates/showmarc.html
@@ -45,7 +45,7 @@ $var title: $title
     $else:
         <p><b>LEADER:</b> <code>$record.leader</code><br/>
         $:record.html()</p>
-   $if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
+   $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
        <div>
           <a href="$next_url" class="slick-next adminOnly right">$_("Next")</a>
        </div>

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $ v = query_param("v", None)
 
-$if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
+$if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
     $if v and not page.key.startswith("/books/ia:"):
         <div id="revertNotice">
             <form name="revert" method="POST" action="$changequery(m='revert')">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6940

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restricts a number of features previously available to members of usergroup `librarians` to `super-librarians`.

Once merged, `librarians` will no longer have access to the following:
- Viewing `/admin` pages
- Deleting records via edit form
- Modification of OCAIDS (including deletion)
- Reverting records to a previous version
- The "Next" button on MARC record pages
- Including an Internet Archive ID when adding a book
- Moving editions to another work
 
The following functionality remains unchanged by this PR:
- Recaptcha exemption when adding books
- Access to merge UIs and ILE blue bar
- Bypassing `is_spam()` spam checks
- OCAID and ISBNs rendered in book details page omnibar

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Post-Merge Tasks
- [ ] Review `/usergroup/librarians` description, and update if necessary
- [ ] Review librarian/developer documentation, updating permissions information as needed
- [ ] Add new librarians to the `librarians` usergroup

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
