### PR TITLE
Enable work selection on author pages

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -212,7 +212,7 @@ SelectionManager.SELECTION_PROVIDERS = [
      * This selection provider makes books in search results selectable.
      */
     {
-        path: /^(\/search)$/,
+        path: /(\/authors\/OL\d+A.*|\/search)$/,
         selector: '.searchResultItem',
         image: el => $(el).find('.bookcover img')[0].src,
         singular: 'work',


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Enables work selection on author pages using ILE tools.

### Technical
<!-- What should be noted about the implementation? -->
Reinstates original regex used for assigning the Work selection provider, with one change: matches must occur at the end of the string.  Without this change, the original Work regex would match author search pages (`/search/authors`).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as either a `librarian` or `super-librarian`, do the following:
1. Go to an author page and ensure that the ILE blue bar appears.
2. Select some works and ensure that the ILE status message references "works," and that the merge button appears.
3. Go to a work search page and ensure that the ILE blue bar appears.
4. Repeat step 2.
5. Go to an author search page and ensure that the ILE blue bar appears.
6. Select some authors and ensure that the ILE status message references "authors," and that the merge button appears.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
