### PR TITLE
Refactor ISBN checksum validation

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -103,30 +103,15 @@ function isFormatValidIsbn10(isbn) {
  * @returns {boolean}  true if ISBN string is a valid ISBN 10
  */
 export function isChecksumValidIsbn10(isbn) {
-    const chars = isbn.split('');
-    let last = chars.pop();
-    let check;
+    const chars = isbn.replace('X', 'A').split('');
 
-    // With ISBN 10, the last character can be [0-9] or string 'X'.
-    if (last !== 'X') {
-        last = parseInt(last);
-    }
-
-    // Compute the ISBN-10 check digit
     chars.reverse();
     const sum = chars
-        .map((char, idx) => ((idx + 2) * parseInt(char, 10)))
-        .reduce((acc, sum) => acc + sum, 0)
+        .map((char, idx) => ((idx + 1) * parseInt(char, 16)))
+        .reduce((acc, sum) => acc + sum, 0);
 
-    check = 11 - (sum % 11);
-    if (check === 10) {
-        check = 'X';
-    } else if (check === 11) {
-        check = 0;
-    }
-
-    // The ISBN 10 is valid if the check digit and last digit match.
-    return check === last;
+    // The ISBN 10 is valid if the checksum mod 11 is 0.
+    return sum % 11 === 0;
 }
 
 /**
@@ -148,21 +133,12 @@ function isFormatValidIsbn13(isbn) {
  */
 export function isChecksumValidIsbn13(isbn) {
     const chars = isbn.split('');
-    // Remove the final ISBN digit from `chars`, and assign it to `last` for comparison.
-    const last = parseInt(chars.pop());
-    let check;
-
     const sum = chars
         .map((char, idx) => ((idx % 2 * 2 + 1) * parseInt(char, 10)))
         .reduce((sum, num) => sum + num, 0);
 
-    check = 10 - (sum % 10);
-    if (check === 10) {
-        check = 0;
-    }
-
-    // The ISBN 13 is valid if the check digit and last digit match.
-    return check === last;
+    // The ISBN 13 is valid if the checksum mod 10 is 0.
+    return sum % 10 === 0;
 }
 
 /**

--- a/tests/unit/js/editionsEditPage.test.js
+++ b/tests/unit/js/editionsEditPage.test.js
@@ -75,14 +75,14 @@ beforeEach(() => {
 // Per the test data used, and beforeEach(), the length always starts out at 5.
 describe('initIdentifierValidation', () => {
     // ISBN 10
-    it('it does add a valid ISBN 10 ending in X', () => {
+    it('does add a valid ISBN 10 ending in X', () => {
         $('#select-id').val('isbn_10');
         $('#id-value').val('0-8044-2957-X');
         $('.repeat-add').trigger('click');
         expect($('.repeat-item').length).toBe(6);
     });
 
-    it('it does add a valid ISBN 10 NOT ending in X', () => {
+    it('does add a valid ISBN 10 NOT ending in X', () => {
         $('#select-id').val('isbn_10');
         $('#id-value').val('0596520689');
         $('.repeat-add').trigger('click');
@@ -96,7 +96,7 @@ describe('initIdentifierValidation', () => {
         expect($('.repeat-item').length).toBe(5);
     });
 
-    it('it does NOT prompt to add a formally invalid ISBN 10', () => {
+    it('does NOT prompt to add a formally invalid ISBN 10', () => {
         $('#select-id').val('isbn_10');
         $('#id-value').val('12345');
         $('.repeat-add').trigger('click');
@@ -136,7 +136,7 @@ describe('initIdentifierValidation', () => {
         expect($('.repeat-item').length).toBe(6);
     })
 
-    it('it does count identical stripped and unstripped ISBN 10s as the same ISBN', () => {
+    it('does count identical stripped and unstripped ISBN 10s as the same ISBN', () => {
         $('#select-id').val('isbn_10');
         $('#id-value').val(' 144--93-55730 ');
         $('.repeat-add').trigger('click');
@@ -147,7 +147,7 @@ describe('initIdentifierValidation', () => {
     });
 
     // ISBN 13
-    it('it does add a valid ISBN 13', () => {
+    it('does add a valid ISBN 13', () => {
         $('#select-id').val('isbn_13');
         $('#id-value').val('9781789801217');
         $('.repeat-add').trigger('click');
@@ -161,7 +161,7 @@ describe('initIdentifierValidation', () => {
         expect($('.repeat-item').length).toBe(5);
     });
 
-    it('it does NOT prompt to add a formally invalid ISBN 13', () => {
+    it('does NOT prompt to add a formally invalid ISBN 13', () => {
         $('#select-id').val('isbn_13');
         $('#id-value').val('12345');
         $('.repeat-add').trigger('click');
@@ -201,7 +201,7 @@ describe('initIdentifierValidation', () => {
         expect($('.repeat-item').length).toBe(6);
     })
 
-    it('it does count identical stripped and unstripped ISBN 13s as the same ISBN', () => {
+    it('does count identical stripped and unstripped ISBN 13s as the same ISBN', () => {
         $('#select-id').val('isbn_13');
         $('#id-value').val('-979-86 -64653403   ');
         $('.repeat-add').trigger('click');


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

I thought there was a problem with ISBN hyphenation is some cases, but it was just a problem with me not re-building assets in docker.

By the time I realised, I'd already made these refactoring changes. :)



<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

* Uses checksum validation directly, rather than calculating a check digit and comparing the last digit.


### Technical
<!-- What should be noted about the implementation? -->
* Uses a trick of converting X -> A and parsing as base-16 to handle X = 10 for ISBN 10

Not sure if the the comments  "Adapted from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s13.html" still apply;, the nice map reduce seems to be from @scottbarnes , and I have pretty much changed the rest.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
* The tests/unit/js/editionsEditPage.test.js ISBN tests pass or fail based on whether the checkdigit code is correct.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
