### PR TITLE
fix ile bar obstructing drawer

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.less
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.less
@@ -3,7 +3,7 @@
 @ile-toolbar-background: #0067d5;
 @ile-toolbar-text-color: white;
 // Not sure where to put this...
-@ile-toolbar-z-index: 99999;
+@ile-toolbar-z-index: 1;
 
 .ile-drag-over {
   box-shadow: 0 0 10px 2px inset @selection-outline;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6942

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix

### Technical
<!-- What should be noted about the implementation? -->
The `.app-drawer` is the child element of `#header-bar`, which has a `z-index` of `2`, while the `#ile-toolbar` has a `z-index` of `99999`. This causes the `#ile-toolbar` to obstruct the `.app-drawer`.
- This can be fixed through css by 
    - increasing the `z-index` of `#header-bar`
    - decreasing the `z-index` of `#ile-toolbar`
    - adding a bottom padding to the `.app-drawer`

Increasing the `z-index` of header bar would affect other components, like obstructing the language drop down component. Adding a bottom padding to the app drawer would not look good when there is no ile toolbar.
Hence, I decided to decrease the `z-index` of the ile toolbar.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
When logged in as a `librarian`, `super-librarian`, or `admin`:
- Go to a search results page.
- Display the drawer by clicking on the hamburger icon located on the right side of the navigation menu.
- Observe the "Help & Support" link (it's the last link)
- The link should not be unobstructed

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/59118459/190072352-5b94f2f7-a74c-4a2e-944e-dfd239b45f63.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
