### PR TITLE
Redirect to merge request table on merge request submission

### DIFF
--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -114,6 +114,13 @@ export default {
                 const splitKey = master.key.split('/')
                 const primaryRecord = splitKey[splitKey.length - 1]
                 await createMergeRequest(workIds, primaryRecord, 'create-pending', this.comment)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.status === 'ok') {
+                            // Redirect to merge table on success:
+                            window.location.replace(`/merges#mrid-${data.id}`)
+                        }
+                    })
             }
             this.mergeStatus = 'Done';
         },

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -333,9 +333,16 @@ class merge_authors(delegate.page):
             if i.comment:
                 data['comment'] = i.comment
 
-            process_merge_request('create-request', data)
+            result = process_merge_request('create-request', data)
+            mrid = result.get('id', None)
 
-            raise web.seeother('/search/authors')
+            username = user.get('key').split('/')[-1]
+
+            redir_url = f'/merges?submitter={username}'
+            if mrid:
+                redir_url = f'{redir_url}#mrid-{mrid}'
+
+            raise web.seeother(redir_url)
         else:
             # redirect to the master. The master will display a progressbar and call the merge_authors_json to trigger the merge.
             redir_url = (


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When `librarians` submit merge requests today, it's somewhat unclear that they have submitted a request.  This PR redirects to the new merge table entry on successful submission.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a `librarian` (but not an `admin` nor `super-librarian`):
1. Submit an author merge request.  Ensure that you are redirected to the merge request table.
2. Submit a work merge request.  Ensure that you are redirected to the merge request table.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
