### PR TITLE
Small `/admin/people` improvements

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "static/build/admin.*.js",
-      "maxSize": "1KB"
+      "maxSize": "1.3KB"
     },
     {
       "path": "static/build/search.*.js",

--- a/openlibrary/plugins/openlibrary/js/admin.js
+++ b/openlibrary/plugins/openlibrary/js/admin.js
@@ -32,3 +32,20 @@ export function initAnonymizationButton(button) {
         }
     })
 }
+
+/**
+ * Adds click listener to each given button.  When the button is clicked,
+ * the patron is prompted to confirm the action via a dialog.
+ *
+ * @param {NodeList<HTMLButtonElement>} buttons
+ */
+export function initConfirmationButtons(buttons) {
+    const confirmMessage = 'Are you sure?'
+    for (const button of buttons) {
+        button.addEventListener('click', function(event) {
+            if (!confirm(confirmMessage)) {
+                event.preventDefault();
+            }
+        })
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/admin.js
+++ b/openlibrary/plugins/openlibrary/js/admin.js
@@ -25,7 +25,7 @@ export function initAdmin() {
 
 export function initAnonymizationButton(button) {
     const displayName = button.dataset.displayName;
-    const confirmMessage = `Really anonymize ${displayName}'s account? This will delete ${displayName}'s profile page and booknotes, and anonymize ${displayName}'s reading log, reviews, and star ratings.`;
+    const confirmMessage = `Really anonymize ${displayName}'s account? This will delete ${displayName}'s profile page and booknotes, and anonymize ${displayName}'s reading log, reviews, star ratings, and merge request submissions.`;
     button.addEventListener('click', function(event) {
         if (!confirm(confirmMessage)) {
             event.preventDefault();

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -312,7 +312,8 @@ jQuery(function () {
     }
     const anonymizationButton = document.querySelector('.account-anonymization-button')
     const adminLinks = document.getElementById('adminLinks')
-    if (adminLinks || anonymizationButton) {
+    const confirmButtons = document.querySelectorAll('.do-confirm')
+    if (adminLinks || anonymizationButton || confirmButtons.length) {
         import(/* webpackChunkName: "admin" */ './admin')
             .then(module => {
                 if (adminLinks) {
@@ -320,6 +321,9 @@ jQuery(function () {
                 }
                 if (anonymizationButton) {
                     module.initAnonymizationButton(anonymizationButton);
+                }
+                if (confirmButtons.length) {
+                    module.initConfirmationButtons(confirmButtons);
                 }
             });
     }

--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -110,8 +110,8 @@ $ has_profile = person.get_user() is not None
             Status: <span class="status">$person.status</span>
 
         $if person.status in ['active', 'verified']:
-            <button type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">block and revert all edits</button>
-            <button type="submit" name="action" value="block_account">block this account</button>
+            <button class="do-confirm" type="submit" name="action" value="block_account_and_revert" style="float: right; background: #ffbbbb;">block and revert all edits</button>
+            <button class="do-confirm" type="submit" name="action" value="block_account">block this account</button>
             &nbsp;&nbsp;<button type="submit" name="action" value="send_password_reset_email">send password reset email</button>
             <br/>
             <br/>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR makes two improvements to the `/admin/people/{username}` page:
1. Adds merge requests to the patron anonymization confirm dialog.  This was overlooked when #6834 was created.
2. Adds a confirmation dialog to the "block patron" buttons.

### Technical
<!-- What should be noted about the implementation? -->
The `initConfimationButtons()` function seems like it could be used on many other pages.  We can further generalize this function by passing the confirmation message as a parameter, and move this function into another, more appropriate, file.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
__Warning:__ Testing involves clicking the "block and revert all edits" button.  Recommend testing this on a local instance, or with a test account that has no meaningful edits.

1. While logged in as an `admin`, navigate to a patron's admin page.
2. Click the "Anonymize Account" button.  Confirm that merge requests are listed among the data to be anonymized in the confirmation dialog.  Click cancel.
3. Click each of the account blocking buttons ("block this account" and "block and revert all edits"). Verify that a confirmation dialog appears.  Click "Cancel" and verify that the account has not been blocked.
4. Repeat step 3, clicking "OK" when the confirmation dialog appears.  Verify that the account has been blocked.  Click the "unblock this account" button.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
