### PR TITLE
Fix for #6294: add a book error with notfound trying to match existing work

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -68,7 +68,6 @@ def get_recaptcha():
 
 def make_work(doc):
     w = web.storage(doc)
-    w.key = "/works/" + w.key
 
     def make_author(key, name):
         key = "/authors/" + key

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -16,6 +16,7 @@ from infogami.utils import delegate
 from infogami.utils.view import safeint, add_flash_message
 from infogami.infobase.client import ClientException
 
+from openlibrary.plugins.upstream.models import Author
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.utils import find_author_olid_in_string, find_work_olid_in_string
@@ -66,21 +67,34 @@ def get_recaptcha():
         return None
 
 
-def make_work(doc):
-    w = web.storage(doc)
+def make_author(key: str, name: str) -> Author:
+    """
+    Use author_key and author_name and return an Author.
 
-    def make_author(key, name):
-        key = "/authors/" + key
-        return web.ctx.site.new(
-            key, {"key": key, "type": {"key": "/type/author"}, "name": name}
-        )
+    >>> make_author("OL123A", "Samuel Clemens")
+    <Author: '/authors/OL123A'>
+    """
+    key = "/authors/" + key
+    return web.ctx.site.new(
+        key, {"key": key, "type": {"key": "/type/author"}, "name": name}
+    )
+
+
+def make_work(doc: dict[str, str | list]) -> web.Storage:
+    """
+    Take a dictionary and make it a work of web.Storage format. This is used as a
+    wrapper for results from solr.select() when adding books from /books/add and
+    checking for existing works or editions.
+    """
+
+    w = web.storage(doc)
 
     w.authors = [
         make_author(key, name)
-        for key, name in zip(doc['author_key'], doc['author_name'])
+        for key, name in zip(doc.get('author_key', []), doc.get('author_name', []))
     ]
-    w.cover_url = "/images/icons/avatar_book-sm.png"
 
+    w.cover_url = "/images/icons/avatar_book-sm.png"
     w.setdefault('ia', [])
     w.setdefault('first_publish_year', None)
     return w

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -388,3 +388,71 @@ class TestSaveBookHelper:
         assert new_work.title == "Original Edition Title"
         # Should ignore edits to work data
         assert web.ctx.site.get("/works/OL100W").title == "Original Work Title"
+
+
+class TestMakeWork:
+    def test_make_author_adds_the_correct_key(self):
+        author_key = "OL123A"
+        author_name = "Samuel Clemens"
+        author = web.ctx.site.new(
+            "/authors/OL123A",
+            {"key": author_key, "type": {"key": "/type/author"}, "name": author_name},
+        )
+        assert addbook.make_author(author_key, author_name) == author
+
+    def test_make_work_does_indeed_make_a_work(self):
+        doc = {
+            "author_key": ["OL123A"],
+            "author_name": ["Samuel Clemens"],
+            "key": "/works/OL123W",
+            "type": "work",
+            "language": ["eng"],
+            "title": "The Celebrated Jumping Frog of Calaveras County",
+        }
+
+        author_key = "OL123A"
+        author_name = "Samuel Clemens"
+        author = web.ctx.site.new(
+            "/authors/OL123A",
+            {"key": author_key, "type": {"key": "/type/author"}, "name": author_name},
+        )
+
+        web_doc = web.Storage(
+            {
+                "author_key": ["OL123A"],
+                "author_name": ["Samuel Clemens"],
+                "key": "/works/OL123W",
+                "type": "work",
+                "language": ["eng"],
+                "title": "The Celebrated Jumping Frog of Calaveras County",
+                "authors": [author],
+                "cover_url": "/images/icons/avatar_book-sm.png",
+                "ia": [],
+                "first_publish_year": None,
+            }
+        )
+
+        assert addbook.make_work(doc) == web_doc
+
+    def test_make_work_handles_no_author(self):
+        doc = {
+            "key": "/works/OL123W",
+            "type": "work",
+            "language": ["eng"],
+            "title": "The Celebrated Jumping Frog of Calaveras County",
+        }
+
+        web_doc = web.Storage(
+            {
+                "key": "/works/OL123W",
+                "type": "work",
+                "language": ["eng"],
+                "title": "The Celebrated Jumping Frog of Calaveras County",
+                "authors": [],
+                "cover_url": "/images/icons/avatar_book-sm.png",
+                "ia": [],
+                "first_publish_year": None,
+            }
+        )
+
+        assert addbook.make_work(doc) == web_doc


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6294

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This fixes the "notfound" error that occurs when adding an existing work, but a new edition, via /books/add.

It also fixes a related `KeyError` that would occur when adding a book via /books/add that exactly matched an existing work and edition.

With respect to the "notfound" error, this happened because `make_work()` in `openlibrary/plugins/upstream/addbook.py` was adding `/works/` to every `doc.key` it processed. `make_work()` is used as a wrapper that processes solr results, all of which already have the "/works/" prefix, so every work was getting a key of `/works//works/OL123W`, as seen in #6294. This PR removes that line, and thereby removes the duplication of the "/works" prefix.

Additionally, this fixes the `KeyError` caused when adding a book via /books/add that is identical to an existing work and edition that also lacks an author. The `KeyError` came from `doc['author_name']` in `make_author()`, when the key didn't exist because there was no author information. The fix here was more sane defaults with `doc.get('author_name', '')`.

To expand on this a bit, `make_work()` is run as a wrapper on solr results during the duplicate check. This error manifested itself when someone used /books/add to add a book that exactly matched a work and edition that lacked an author; solr would return book matches, run the wrapper (line 169 in `/openlibrary/utils/solr.py`), and cause a `KeyError` because `author_name` didn't exist. I've attached a log of this error as a zip, but here's a screenshot for potentially quicker skimming:
![image](https://user-images.githubusercontent.com/26524678/191131436-e16d89cb-daf9-4583-b955-100ff881933a.png)
[blob_040354495265.html.zip](https://github.com/internetarchive/openlibrary/files/9602738/blob_040354495265.html.zip)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I've included tests, but here is some before and after to help illustrate before and after.

As mentioned in #6294, adding a new book that matched an existing work, but not an edition, would cause a "notfound" error. That no longer happens.

Here's an example using Robinson Crusoe, which to begin with has only the 1920 G.W. Jacobs and Co. edition:
![image](https://user-images.githubusercontent.com/26524678/191132204-18a9b492-18e6-45c7-8a3d-a05a7b364e78.png)

And here's adding a new 1921 edition via /books/add:
![image](https://user-images.githubusercontent.com/26524678/191132284-69f908ac-eed0-415e-be30-908ea20ea3d4.png)

Now there are two editions: 1920, and 1921:
![image](https://user-images.githubusercontent.com/26524678/191132417-77b4f59c-0be2-414b-98a2-c9b1e25576d1.png)

And here's trying to add an identical 1920 G.W. Jacobs and Co. edition, which picks up where we left off with the 1920 and 1921 editions:
![image](https://user-images.githubusercontent.com/26524678/191132464-b0b53381-34a1-4984-8f99-455e6028acca.png)

After submission, this displays:
![image](https://user-images.githubusercontent.com/26524678/191132483-65d47ec6-71df-429e-b14d-6091aabaa17f.png)

Behind the scenes, this is the error (a zip of the logged error is included below the text output)
```
openlibrary-web-1           | 2022-09-19 21:44:58 [openlibrary.logger] [INFO] solr request: http://solr:8983/solr/openlibrary/select?wt=json&q.op=AND&q=title%3A%22Robinson+Crusoe%22+AND+author_key%3A%22OL18283A%22+AND+publisher%3A%22G.W.+Jacobs+and+Co.%22+AND+publish_date%3A%221920%22&start=0
openlibrary-solr-1          | 2022-09-19 21:44:58.755 INFO  (qtp988850650-28) [   x:openlibrary] o.a.s.c.S.Request [openlibrary]  webapp=/solr path=/select params={q=title:"Robinson+Crusoe"+AND+author_key:"OL18283A"+AND+publisher:"G.W.+Jacobs+and+Co."+AND+publish_date:"1920"&start=0&q.op=AND&wt=json} hits=1 status=0 QTime=2
openlibrary-web-1           | Traceback (most recent call last):
openlibrary-web-1           |   File "/home/openlibrary/.local/lib/python3.10/site-packages/web/application.py", line 280, in process
openlibrary-web-1           |     return self.handle()
openlibrary-web-1           |   File "/home/openlibrary/.local/lib/python3.10/site-packages/web/application.py", line 271, in handle
openlibrary-web-1           |     return self._delegate(fn, self.fvars, args)
openlibrary-web-1           |   File "/home/openlibrary/.local/lib/python3.10/site-packages/web/application.py", line 517, in _delegate
openlibrary-web-1           |     return handle_class(cls)
openlibrary-web-1           |   File "/home/openlibrary/.local/lib/python3.10/site-packages/web/application.py", line 495, in handle_class
openlibrary-web-1           |     return tocall(*args)
openlibrary-web-1           |   File "/openlibrary/infogami/utils/app.py", line 200, in <lambda>
openlibrary-web-1           |     HEAD = GET = POST = PUT = DELETE = lambda self: delegate()
openlibrary-web-1           |   File "/openlibrary/infogami/utils/app.py", line 220, in delegate
openlibrary-web-1           |     return getattr(cls(), method)(*args)
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 232, in POST
openlibrary-web-1           |     match = None if created_author else self.find_matches(i)
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 291, in find_matches
openlibrary-web-1           |     edition = self.try_edition_match(
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 377, in try_edition_match
openlibrary-web-1           |     result = solr.select(q, doc_wrapper=make_work, q_op="AND")
openlibrary-web-1           |   File "/openlibrary/openlibrary/utils/solr.py", line 155, in select
openlibrary-web-1           |     return self._parse_solr_result(
openlibrary-web-1           |   File "/openlibrary/openlibrary/utils/solr.py", line 169, in _parse_solr_result
openlibrary-web-1           |     d.docs = [doc_wrapper(doc) for doc in response['docs']]
openlibrary-web-1           |   File "/openlibrary/openlibrary/utils/solr.py", line 169, in <listcomp>
openlibrary-web-1           |     d.docs = [doc_wrapper(doc) for doc in response['docs']]
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 94, in make_work
openlibrary-web-1           |     for key, name in zip(doc.get['author_key'], doc.get['author_name'])
openlibrary-web-1           | TypeError: 'builtin_function_or_method' object is not subscriptable
openlibrary-web-1           |
openlibrary-web-1           | error saved to /var/log/openlibrary/ol-errors/2022-09-19/214458761978.html
```
[duplicate_edition_214458761978.html.zip](https://github.com/internetarchive/openlibrary/files/9602787/duplicate_edition_214458761978.html.zip)

After the change, again, entering matching 1920 G.W. Jacobs and Co. edition information:
![image](https://user-images.githubusercontent.com/26524678/191133052-dfee97f1-3321-4e7a-8b46-95dd64039e11.png)

And finally, no new 1920 edition has been added:
![image](https://user-images.githubusercontent.com/26524678/191133080-c8030a84-118c-4e6c-868e-74918b3de359.png)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
