### PR TITLE
Inside searchbttn

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -20,7 +20,7 @@ $var title: Search Open Library for "$q"
 
   <form class="siteSearch olform" action="">
     <input type="text" class="larger" name="q" size="100" value="$q"/>
-    <input type="submit"  class="large" value="$_('Search')"/>
+    <input type="submit"  class="larger" value="$_('Search')"/>
   </form>
 </div>
 

--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -10,7 +10,7 @@ $var title: $_('Search Open Library for %s', q)
   $:macros.SearchNavigation()
   <form class="siteSearch searchInsideForm" action="/search/inside">
     <input type="text" class="larger" name="q" value="$q"/>
-    <input type="submit" class="generic-button" value="$_('Search')">
+    <input type="submit" class="larger" value="$_('Search')">
   </form>
     $ num_found = 0
     $if q:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6728 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The "Search Inside" search button now is formatted the same as the "Books" Search button.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Search > Search Inside tab

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/70588786/191160971-07af1a71-3415-45dc-add9-4513bf9ca368.png)

to

![image](https://user-images.githubusercontent.com/70588786/191161032-6a1e736f-a25f-4f6e-863e-323a0e6b8780.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
