### PR TITLE
Subjects searchbttn

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -20,7 +20,7 @@ $var title: Search Open Library for "$q"
 
   <form class="siteSearch olform" action="">
     <input type="text" class="larger" name="q" size="100" value="$q"/>
-    <input type="submit"  class="large" value="$_('Search')"/>
+    <input type="submit"  class="larger" value="$_('Search')"/>
   </form>
 </div>
 

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -21,7 +21,7 @@ $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
     <div class="section">
         <form class="siteSearch olform" action="">
             <input type="text" class="larger" name="q" size="100" value="$q"/>
-            <input type="submit" class="large" value="$_('Search')"/>
+            <input type="submit" class="larger" value="$_('Search')"/>
         </form>
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6728 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This changes the "Subjects" search button to match the "Books" search buttons

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Search > Subjects tab

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/70588786/191161203-9b85d18f-435f-4691-9322-8584a85dd607.png)

to

![image](https://user-images.githubusercontent.com/70588786/191161251-4d3613f4-ca92-4808-8132-00a14e965672.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
