### PR TITLE
Update authors.html

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -20,7 +20,7 @@ $var title: Search Open Library for "$q"
 
   <form class="siteSearch olform" action="">
     <input type="text" class="larger" name="q" size="100" value="$q"/>
-    <input type="submit"  class="large" value="$_('Search')"/>
+    <input type="submit"  class="larger" value="$_('Search')"/>
   </form>
 </div>
 


### PR DESCRIPTION
Make "Authors" tab search button have the same format as the "Books" tab search button.

<!-- What issue does this PR close? -->
Closes #6728 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This search button under the "Authors" tab will now have the same stylization as the "Books" tab.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Search > Authors tab

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/70588786/191162847-1ebebfc8-bb5a-4a43-a2dd-f969d47ed7ab.png)

to

![image](https://user-images.githubusercontent.com/70588786/191162808-3c83776c-62ae-40d9-a63c-7648390596e1.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
