### PR TITLE
Filter merge requests by reviewer

### DIFF
--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -23,7 +23,14 @@ $else:
   <h1>$_('Community Edit Requests')</h1>
 
   <div class="description">
-    $desc <a href="$href">$link_text</a>
+    $if can_merge:
+      <span class="reviewer-filter">
+        $if reviewer:
+          $_("Showing requests reviewed by %(reviewer)s only.", reviewer=reviewer) <a href="$changequery(reviewer=None, page=None)">$_("Remove reviewer filter")</a>
+        $else:
+          <a href="$changequery(reviewer=username, page=None)">$_("Show requests that I've reviewed")</a>
+      </span>
+    <span>$desc <a href="$href">$link_text</a></span>
   </div>
 
 $ page = int(input(page=1).page)

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -13,7 +13,7 @@ $ mode = query_param('mode', 'open')
 $if submitter:
   $ desc = _("Showing %(username)s's requests only.", username=submitter)
   $ link_text = _('Show all requests')
-  $ href = changequery(submitter=None)
+  $ href = changequery(submitter=None, page=None)
 $else:
   $ desc = _('Showing all requests.')
   $ link_text = _('Show my requests') if username else ''

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -2,7 +2,13 @@
   padding: 0 10px 10px;
 
   .description {
+    display: flex;
+    flex-direction: column;
     margin-bottom: 10px;
+
+    .reviewer-filter {
+      margin-bottom: 10px;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds ability to filter merge requests that were reviewed by oneself.  This option will only be available to `super-librarians`.

This PR also corrects bug where clicking "Show all requests" does not remove `page` from the URL search params.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
