### PR TITLE
Partial fix for #6755. Batch four of type hints from type annotations.

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -1,9 +1,10 @@
 """Merge authors.
 """
 import re
-
 import json
 import web
+
+from typing import Any
 
 from infogami.infobase.client import ClientException
 from infogami.utils import delegate
@@ -20,12 +21,7 @@ class BasicRedirectEngine:
     to the newly identified canonical record.
     """
 
-    def make_redirects(self, master, duplicates):
-        """
-        :param str master:
-        :param list of str duplicates:
-        :rtype: list of dict
-        """
+    def make_redirects(self, master: str, duplicates: list[str]) -> list[dict]:
         # Create the actual redirect objects
         docs_to_save = [make_redirect_doc(key, master) for key in duplicates]
 
@@ -50,14 +46,9 @@ class BasicRedirectEngine:
         refs = {ref for key in keys for ref in self.find_references(key)}
         return list(refs)
 
-    def update_references(self, doc, master, duplicates):
+    def update_references(self, doc: Any, master: str, duplicates: list[str]) -> Any:
         """
         Converts references to any of the duplicates in the given doc to the master.
-
-        :param doc:
-        :param str master:
-        :param list of str duplicates:
-        :rtype: Any
         """
         if isinstance(doc, dict):
             if list(doc) == ['key']:
@@ -89,12 +80,11 @@ class BasicMergeEngine:
         docs = self.do_merge(master, duplicates)
         return self.save(docs, master, duplicates)
 
-    def do_merge(self, master, duplicates):
+    def do_merge(self, master: str, duplicates: list[str]) -> list:
         """
         Performs the merge and returns the list of docs to save.
         :param str master: key of master doc
         :param list of str duplicates: keys of duplicates
-        :rtype: dict
         :return: Document to save
         """
         docs_to_save = []
@@ -212,10 +202,9 @@ def name_eq(n1, n2):
     return space_squash_and_strip(n1) == space_squash_and_strip(n2)
 
 
-def fix_table_of_contents(table_of_contents):
+def fix_table_of_contents(table_of_contents: list[str | dict]) -> list:
     """
     Some books have bad table_of_contents--convert them in to correct format.
-    :param typing.List[typing.Union[str, dict]] table_of_contents:
     """
 
     def row(r):
@@ -241,12 +230,7 @@ def fix_table_of_contents(table_of_contents):
     return [row for row in map(row, table_of_contents) if any(row.values())]
 
 
-def get_many(keys):
-    """
-    :param list of str keys:
-    :rtype: list of dict
-    """
-
+def get_many(keys: list[str]) -> list[dict]:
     def process(doc):
         # some books have bad table_of_contents. Fix them to avoid failure on save.
         if doc['type']['key'] == "/type/edition" and 'table_of_contents' in doc:

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -702,13 +702,13 @@ class Work(models.Work):
     def get_related_books_subjects(self, filter_unicode=True):
         return self.filter_problematic_subjects(self.get_subjects(), filter_unicode)
 
-    def get_representative_edition(self):
+    def get_representative_edition(self) -> str | None:
         """When we have confidence we can direct patrons to the best edition
         of a work (for them), return qualifying edition key. Attempts
         to find best (most available) edition of work using
         archive.org work availability API. May be extended to support language
 
-        :rtype str: infogami edition key or url which resolves to an edition
+        :rtype str: infogami edition key or url which resolves to an edition or None
         """
         work_id = self.key.replace('/works/', '')
         availability = lending.get_work_availability(work_id)
@@ -716,13 +716,14 @@ class Work(models.Work):
             if 'openlibrary_edition' in availability[work_id]:
                 return '/books/%s' % availability[work_id]['openlibrary_edition']
 
-    def get_sorted_editions(self, ebooks_only=False, limit=None, keys=None):
+        return None
+
+    def get_sorted_editions(
+        self, ebooks_only: bool = False, limit: int = None, keys: list[str] = None
+    ) -> list[Edition]:
         """
         Get this work's editions sorted by publication year
-        :param bool ebooks_only:
-        :param int limit:
         :param list[str] keys: ensure keys included in fetched editions
-        :rtype: list[Edition]
         """
         db_query = {"type": "/type/edition", "works": self.key}
         db_query['limit'] = limit or 10000

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1,5 +1,5 @@
 import functools
-from typing import List, Union, Tuple, Any
+from typing import Any
 from collections.abc import Iterable
 import unicodedata
 
@@ -16,7 +16,6 @@ import xml.etree.ElementTree as etree
 import datetime
 import logging
 from html.parser import HTMLParser
-from typing import Optional
 
 import requests
 
@@ -124,7 +123,7 @@ def render_template(name, *a, **kw):
     return render[name](*a, **kw)
 
 
-def kebab_case(upper_camel_case):
+def kebab_case(upper_camel_case: str) -> str:
     """
     :param str upper_camel_case: Text in upper camel case (e.g. "HelloWorld")
     :return: text in kebab case (e.g. 'hello-world')
@@ -139,7 +138,7 @@ def kebab_case(upper_camel_case):
 
 
 @public
-def render_component(name, attrs=None, json_encode=True):
+def render_component(name: str, attrs: dict = None, json_encode: bool = True):
     """
     :param str name: Name of the component (excluding extension)
     :param dict attrs: attributes to add to the component element
@@ -515,7 +514,7 @@ def url_quote(text):
 
 
 @public
-def urlencode(dict_or_list_of_tuples: Union[dict, list[tuple[str, Any]]]) -> str:
+def urlencode(dict_or_list_of_tuples: dict | list[tuple[str, Any]]) -> str:
     """
     You probably want to use this, if you're looking to urlencode parameters. This will
     encode things to utf8 that would otherwise cause urlencode to error.
@@ -684,7 +683,7 @@ def autocomplete_languages(prefix: str):
             continue
 
 
-def get_language(lang_or_key: Union[Thing, str]) -> Optional[Thing]:
+def get_language(lang_or_key: Thing | str) -> Thing | None:
     if isinstance(lang_or_key, str):
         return get_languages().get(lang_or_key)
     else:
@@ -692,7 +691,7 @@ def get_language(lang_or_key: Union[Thing, str]) -> Optional[Thing]:
 
 
 @public
-def get_language_name(lang_or_key: Union[Thing, str]):
+def get_language_name(lang_or_key: Thing | str):
     if isinstance(lang_or_key, str):
         lang = get_language(lang_or_key)
         if not lang:
@@ -705,7 +704,7 @@ def get_language_name(lang_or_key: Union[Thing, str]):
 
 
 @functools.cache
-def convert_iso_to_marc(iso_639_1: str) -> Optional[str]:
+def convert_iso_to_marc(iso_639_1: str) -> str | None:
     """
     e.g. 'en' -> 'eng'
     """
@@ -1083,7 +1082,7 @@ class HTMLTagRemover(HTMLParser):
 
 
 @public
-def reformat_html(html_str: str, max_length: Optional[int] = None) -> str:
+def reformat_html(html_str: str, max_length: int = None) -> str:
     """
     Reformats an HTML string, removing all opening and closing tags.
     Adds a line break element between each set of text content.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partial fix for #6755 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor

### Technical
<!-- What should be noted about the implementation? -->
Added more type hints from type annotations.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Although there is an `assert` at line 573 in `addbook.py`, this should not change runtime behavior because Mypy doesn't understand that `self.edition` won't be `None` in that branch of code, as if `edition_data` is not `None`, then `self.edition` is not `None`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
