### PR TITLE
Update copy for registration form

### DIFF
--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -87,7 +87,9 @@ class RegisterForm(Form):
         ),
         Textbox(
             'username',
-            description=_('Choose a screen name'),
+            description=_(
+                "Choose a screen name. Screen names are public and cannot be changed later."
+            ),
             klass='required',
             help=_("Letters and numbers only please, and at least 3 characters."),
             autocapitalize="off",


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the copy for the username field in our registration form.

__Old Copy__: Choose a screen name
__New Copy__: Choose a screen name. Screen names are public and cannot be changed later.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-09-21 17-45-01](https://user-images.githubusercontent.com/28732543/191617155-3f130ecc-fd23-4412-a73d-c154fd8ff721.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
