### PR TITLE
Grant `/admin/solr` access to `librarians`

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -82,6 +82,12 @@ class admin(delegate.page):
         if not m:
             raise web.nomethod(cls=cls)
         else:
+            if (
+                context.user
+                and context.user.is_usergroup_member('/usergroup/librarians')
+                and web.ctx.path == '/admin/solr'
+            ):
+                return m(*args)
             if self.is_admin() or (
                 librarians
                 and context.user


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Gives members of the `librarians` usergroup access to Open Library's Solr reindexer.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in with an account that has `librarians` permissions, but does not have `admin` permissions.
2. Ensure that you can access the `/admin/solr` page.
3. Expect a permission denied error to appear if you navigate to any other `/admin/*` page.
4. Ensure that `admin` accounts can still access the `/admin/solr` page.
5. Expect a permission denied error if an unauthenticated patron accesses `/admin/solr`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
