### PR TITLE
fix text selection for selectable items

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -57,6 +57,9 @@ export default class SelectionManager {
      * @param {MouseEvent & { currentTarget: HTMLElement }} clickEvent
      */
     toggleSelected(clickEvent) {
+        // If there is text selection, dont do anything
+        if (window.getSelection()?.toString() !== '') return;
+
         const el = clickEvent.currentTarget;
         el.classList.toggle('ile-selected');
         const selected = el.classList.contains('ile-selected');


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6696

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix

### Technical
<!-- What should be noted about the implementation? -->
In the click handler that adds the selection fires, it will do nothing if there is a text selection.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
When logged in as a `librarian`, `super-librarian`, or `admin`:
- Go to an author's page (e.g. http://localhost:8080/authors/OL18319A/Mark_Twain)
- Try to copy the text (title, author, date) of a book
- Result: Text is selected but the book is not selected (not highlighted in blue)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![demo](https://user-images.githubusercontent.com/59118459/191911563-f00daa18-fae1-4b04-9346-44c70ba3d1e9.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
