### PR TITLE
Use correct call to action for author merge UI button

### DIFF
--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -94,7 +94,11 @@ $if can_merge:
     <div class="merge-feedback">
         <label for="merge-comment">$_('Comment:') <input type="text" id="author-merge-comment" name="comment" placeholder="$_('Comment...')"></label>
         <div class="merge-feedback__buttons">
-            <button id="save" class="larger merge-feedback__submit" value="Merge Authors" type="submit">$_('Merge Authors')</button>
+            $if can_merge:
+                $ cta = _('Merge Authors')
+            $else:
+                $ cta = _('Request Merge')
+            <button id="save" class="larger merge-feedback__submit" value="Merge Authors" type="submit">$cta</button>
             $if mrid:
                 <button id="reject-author-merge-btn" type="button" class="larger merge-feedback__reject">$_('Reject Merge')</button>
             $else:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Today, the author merge UI's submit button reads "Merge Author" regardless of the librarian's permissions.  This PR updates the button's copy to "Request Merge" for members of the `librarians` usergroup.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-09-24 07-46-22](https://user-images.githubusercontent.com/28732543/192096289-f8d5062b-8734-4d85-8dc1-b5cebedaf096.png)
_New copy for librarians._
### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
