### PR TITLE
Block more words from auto-imports

### DIFF
--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -59,7 +59,6 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
         'illustrated',
         'Illustrée',
         'summary',
-
         # Not a book
         'calendar',
         'diary',

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -56,13 +56,17 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
         'annoté',
         'classic',
         'classics',
+        'illustrated',  # Some books have typos in their titles!
         'illustrated',
         'Illustrée',
+        'original',
         'summary',
+        'version',
         # Not a book
         'calendar',
         'diary',
         'journal',
+        'logbook',
         'notebook',
         'notizbuch',
         'planner',

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -56,7 +56,7 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
         'annoté',
         'classic',
         'classics',
-        'illustrated',  # Some books have typos in their titles!
+        'illustarted',  # Some books have typos in their titles!
         'illustrated',
         'Illustrée',
         'original',

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -54,6 +54,7 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
         # Noisy classic re-prints
         'annotated',
         'annoté',
+        'classic',
         'classics',
         'illustrated',
         'Illustrée',
@@ -61,6 +62,7 @@ EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
 
         # Not a book
         'calendar',
+        'diary',
         'journal',
         'notebook',
         'notizbuch',

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -51,11 +51,21 @@ EXCLUDED_AUTHORS = {
 EXCLUDED_INDEPENDENTLY_PUBLISHED_TITLES = {
     x.casefold()
     for x in (
+        # Noisy classic re-prints
         'annotated',
         'annoté',
+        'classics',
         'illustrated',
         'Illustrée',
+        'summary',
+
+        # Not a book
+        'calendar',
+        'journal',
         'notebook',
+        'notizbuch',
+        'planner',
+        'sketchbook',
     )
 }
 


### PR DESCRIPTION
**SQUASH ME**

I've added a bunch of new words to the block list for automatic imports

Note these will probably catch a few valid books, but there's sooooo many bad imports right now; and we can always manually import something that gets incorrectly excluded

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Here are the corresponding searches
- [classics](https://testing.openlibrary.org/search?q=title%3Aclassics+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [summary](https://testing.openlibrary.org/search?q=title%3Asummary+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [calendar](https://testing.openlibrary.org/search?q=title%3Acalendar+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [journal](https://testing.openlibrary.org/search?q=title%3Ajournal+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [notizbuch](https://testing.openlibrary.org/search?q=title%3Anotizbuch+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [planner](https://testing.openlibrary.org/search?q=title%3Aplanner+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [sketchbook](https://testing.openlibrary.org/search?q=title%3Asketchbook+publisher%3A%22independently+published%22&mode=everything&editions=true)
- [diary](https://testing.openlibrary.org/search?q=title%3Adiary+publisher%3A%22independently+published%22&mode=everything&editions=true)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@seabelis  @jimman2003 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
