### PR TITLE
removing profile and settings links from My Books nav because they are in the sitewide nav also

### DIFF
--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -11,10 +11,7 @@ $ counts = counts or pa.get_sidebar_counts
   <div class="mybooks-menu">
     <ul class="sidebar-section">
       <li class="section-header">$username</li>
-      <li><a href="/people/$username" data-ol-link-track="MyBooksSidebar|Profile" $('class=selected' if key == 'profile' else '')>$_('Profile Page')</a></li>
       $if owners_page:
-        <li><a href="/account" data-ol-link-track="MyBooksSidebar|Settings" $('class=selected' if key == 'settings' else '')>$_('Settings & Privacy')</a></li>
-        <hr/>
         <li><a href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('Loans')</a></li>
         <li><a class="external-link" data-ol-link-track="MyBooksSidebar|LoanHistory" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a></li>
     </ul>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7020 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Remove profile and settings links from My Books nav, because they were redundant

### Technical
<!-- What should be noted about the implementation? -->
Three lines deleted

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
go to My Books page and review the top few links of the menu

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="813" alt="Screen Shot 2022-09-27 at 6 28 17 PM" src="https://user-images.githubusercontent.com/69476557/192648854-0ad89ac7-b04b-40ae-a1b9-d988a5fdbecd.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
