### PR TITLE
Create distinction between main nav links and hamburger links for analytics

### DIFF
--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -1,9 +1,9 @@
-$def with (props)
+$def with (props, track_prefix=None)
 $# @typedef {Object} DropdownLink
 $# @property {string} text of link
 $# @property {string|null} href of link for HTTP get request
 $# @property {string|null} post when set will be used instead of href and should use HTTP POST request.
-$# @property {string|null} `track` for google analytics
+$# @property {string|null} `track` event label for google analytics
 $#
 $# @param {Object} props template properties
 $# @param {string} props.name unique identifying name for dropdown and distinguishing it from other dropdowns
@@ -16,7 +16,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
 <div class="$(props['name'])-component header-dropdown">
   $if singleton:
     $ link = props['links'][0]
-    $ tracker = link.get('track') and 'data-ol-link-track=%s' % link.get('track') or ''
+    $ tracker = (track_prefix and link.get('track')) and 'data-ol-link-track=%s|%s' % (track_prefix, link.get('track')) or ''
     <a href="$link['href']" $tracker>$(props['label'])</a>
   $else:
     <details>
@@ -44,7 +44,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
       >
         <ul class="dropdown-menu $(props['name'])-dropdown-menu">
           $for link in props['links']:
-            $ tracker = link.get('track') and 'data-ol-link-track=%s' % link.get('track') or ''
+            $ tracker = (track_prefix and link.get('track')) and 'data-ol-link-track=%s|%s' % (track_prefix, link.get('track')) or ''
             $if 'subsection' in link:
               <li class="subsection">
                 $(link['subsection'])

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -16,7 +16,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
 <div class="$(props['name'])-component header-dropdown">
   $if singleton:
     $ link = props['links'][0]
-    $ tracker = (track_prefix and link.get('track')) and 'data-ol-link-track=%s|%s' % (track_prefix, link.get('track')) or ''
+    $ tracker = 'data-ol-link-track=%s|%s' % (track_prefix, link['track']) if (track_prefix and link.get('track')) else ''
     <a href="$link['href']" $tracker>$(props['label'])</a>
   $else:
     <details>
@@ -44,7 +44,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
       >
         <ul class="dropdown-menu $(props['name'])-dropdown-menu">
           $for link in props['links']:
-            $ tracker = (track_prefix and link.get('track')) and 'data-ol-link-track=%s|%s' % (track_prefix, link.get('track')) or ''
+            $ tracker = 'data-ol-link-track=%s|%s' % (track_prefix, link['track']) if (track_prefix and link.get('track')) else ''
             $if 'subsection' in link:
               <li class="subsection">
                 $(link['subsection'])

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -6,38 +6,38 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
 
   $if ctx.user:
     $ loginLinks = [
-    $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MainNav|MyProfile" },
-    $     { "href": homepath() + "/account/loans", "text": _("My Loans"), "track": "MainNav|MyLoans" },
-    $     { "href": "/account/books", "text": _("My Reading Log"), "track": "MainNav|MyReadingLog" },
-    $     { "href": "/account/lists", "text": _("My Lists"), "track": "MainNav|MyLists" },
-    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats"), "track": "MainNav|MyReadingStats" },
-    $     { "href": homepath() + "/account", "text": _("Settings"), "track": "MainNav|MySettings" },
-    $     { "post": "/account/logout", "text": _("Log out"), "track": "MainNav|Logout" },
+    $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MyProfile" },
+    $     { "href": homepath() + "/account/loans", "text": _("My Loans"), "track": "MyLoans" },
+    $     { "href": "/account/books", "text": _("My Reading Log"), "track": "MyReadingLog" },
+    $     { "href": "/account/lists", "text": _("My Lists"), "track": "MyLists" },
+    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats"), "track": "MyReadingStats" },
+    $     { "href": homepath() + "/account", "text": _("Settings"), "track": "MySettings" },
+    $     { "post": "/account/logout", "text": _("Log out"), "track": "Logout" },
     $ ]
       $if is_privileged_user:
-        $ loginLinks.insert(1,{ "href": homepath() + "/merges", "text": _("Pending Requests"),"track": "MainNav|MyRequests" })
+        $ loginLinks.insert(1,{ "href": homepath() + "/merges", "text": _("Pending Requests"),"track": "MyRequests" })
   $else:
     $ loginLinks = [
     $     { "loginClass": "login-links" }
     $ ]
   $ myBooksLinks = [
-  $     { "href": homepath() + "/account/loans", "text": _("My Books"), "track": "MainNav|MyBooks" },
+  $     { "href": homepath() + "/account/loans", "text": _("My Books"), "track": "MyBooks" },
   $ ]
   $ browseLinks = [
-  $     { "href": "/subjects", "text": _("Subjects"), "track": "MainNav|Subjects" },
-  $     { "href": "/trending", "text": _("Trending"), "track": "MainNav|Trending" },
-  $     { "href": "/explore", "text": _("Library Explorer"), "track": "MainNav|Explore" },
-  $     { "href": "/lists", "text": _("Lists"), "track": "MainNav|Lists" },
-  $     { "href": "/collections", "text": _("Collections"), "track": "MainNav|Collections" },
-  $     { "href": "/k-12", "text": _("K-12 Student Library"), "track": "MainNav|K12Library" },
-  $     { "href": "/random", "text": _("Random Book"), "track": "MainNav|RandomBook" },
-  $     { "href": "/advancedsearch", "text": _("Advanced Search"), "track": "MainNav|AdvancedSearch" }
+  $     { "href": "/subjects", "text": _("Subjects"), "track": "Subjects" },
+  $     { "href": "/trending", "text": _("Trending"), "track": "Trending" },
+  $     { "href": "/explore", "text": _("Library Explorer"), "track": "Explore" },
+  $     { "href": "/lists", "text": _("Lists"), "track": "Lists" },
+  $     { "href": "/collections", "text": _("Collections"), "track": "Collections" },
+  $     { "href": "/k-12", "text": _("K-12 Student Library"), "track": "K12Library" },
+  $     { "href": "/random", "text": _("Random Book"), "track": "RandomBook" },
+  $     { "href": "/advancedsearch", "text": _("Advanced Search"), "track": "AdvancedSearch" }
   $ ]
   $ moreLinks = [
-  $     { "href": "/books/add", "text": _("Add a Book"), "track": "MainNav|AddBook" },
-  $     { "href": "/recentchanges", "text": _("Recent Community Edits"), "track": "MainNav|RecentEdits" },
-  $     { "href": "/developers", "text": _("Developer Center"), "track": "MainNav|Developers" },
-  $     { "href": "/help", "text": _("Help & Support"), "track": "MainNav|Help" }
+  $     { "href": "/books/add", "text": _("Add a Book"), "track": "AddBook" },
+  $     { "href": "/recentchanges", "text": _("Recent Community Edits"), "track": "RecentEdits" },
+  $     { "href": "/developers", "text": _("Developer Center"), "track": "Developers" },
+  $     { "href": "/help", "text": _("Help & Support"), "track": "Help" }
   $ ]
   $ hamburgerProps = {
   $  'name': 'hamburger',
@@ -77,8 +77,8 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
   $   'links': myBooksLinks
   $ }
   <ul class="navigation-component">
-    <li>$:render_template("lib/header_dropdown", myBooksProps )</li>
-    <li>$:render_template("lib/header_dropdown", browseProps )</li>
+    <li>$:render_template("lib/header_dropdown", myBooksProps, track_prefix="MainNav")</li>
+    <li>$:render_template("lib/header_dropdown", browseProps, track_prefix="MainNav")</li>
   </ul>
 
   <div class="search-component">
@@ -119,12 +119,12 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
       <li><a class="btn primary" href="/account/create">$_("Sign Up")</a></li>
     </ul>
 
-  $:render_template("lib/header_dropdown", hamburgerProps )
+  $:render_template("lib/header_dropdown", hamburgerProps, track_prefix="Hamburger")
 
 </header>
 <header class="header-bar mobile">
   <ul class="navigation-component mobile">
-    <li>$:render_template("lib/header_dropdown", myBooksProps )</li>
-    <li>$:render_template("lib/header_dropdown", browseProps )</li>
+    <li>$:render_template("lib/header_dropdown", myBooksProps, track_prefix="MainNav")</li>
+    <li>$:render_template("lib/header_dropdown", browseProps, track_prefix="MainNav")</li>
   </ul>
 </header>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates distinction between main navigation links and hamburger links for our Google Analytics.
Main navigation link event name: "MainNav" 
Hamburger link event name: "Hamburger"

### Technical
<!-- What should be noted about the implementation? -->
Event name is now passed as keyword argument `tracker_prefix` to `header_dropdown.html`.  The tracker property is created and rendered if both `tracker_prefix` and `link.track` exist.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
