### PR TITLE
Add timeout to DWWI request to fix sometimes being 50s

### DIFF
--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -107,7 +107,7 @@ def do_we_want_it(isbn):
         dwwi = data.get('response', 0)
         return dwwi == 1, data.get('books', [])
     except requests.exceptions.Timeout:
-        logger.error('DWWI Timeout')
+        logger.exception('DWWI Timeout')
         return False, []
     except:
         logger.error("DWWI Failed for isbn %s" % isbn, exc_info=True)

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -107,7 +107,7 @@ def do_we_want_it(isbn):
         dwwi = data.get('response', 0)
         return dwwi == 1, data.get('books', [])
     except requests.exceptions.Timeout:
-        logger.exception('DWWI Timeout')
+        logger.error('DWWI Timeout')
         return False, []
     except:
         logger.error("DWWI Failed for isbn %s" % isbn, exc_info=True)

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -103,9 +103,12 @@ def do_we_want_it(isbn):
     }
     url = '%s/book/marc/ol_dedupe.php' % lending.config_ia_domain
     try:
-        data = requests.get(url, params=params).json()
+        data = requests.get(url, params=params, timeout=2).json()
         dwwi = data.get('response', 0)
         return dwwi == 1, data.get('books', [])
+    except requests.exceptions.Timeout:
+        logger.exception(f'DWWI Timeout')
+        return False, []
     except:
         logger.error("DWWI Failed for isbn %s" % isbn, exc_info=True)
     # err on the side of false negative

--- a/openlibrary/core/sponsorships.py
+++ b/openlibrary/core/sponsorships.py
@@ -107,7 +107,7 @@ def do_we_want_it(isbn):
         dwwi = data.get('response', 0)
         return dwwi == 1, data.get('books', [])
     except requests.exceptions.Timeout:
-        logger.exception(f'DWWI Timeout')
+        logger.exception('DWWI Timeout')
         return False, []
     except:
         logger.error("DWWI Failed for isbn %s" % isbn, exc_info=True)


### PR DESCRIPTION
**SQUASH ME**

Unclear why, but this IA request is sometimes taking 50s. Elevated to appropriate people on IA side, but on our side we should have a timeout here.


### Technical
- Added a custom exception log so we can see timeout in sentry separate from other errors.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
