### PR TITLE
Added Google analytics tracking html to facets

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -16,7 +16,26 @@ $code:
             return changequery(page=None,**{k:None})
 
     def add_track(k):
-        return "SearchFacet|" + k
+        match k:
+            case "has_fulltext":
+                facet = "Ebook"
+            case "author_key":
+                facet = "Author"
+            case "subject_facet":
+                facet = "Subjects"
+            case "person_facet":
+                facet = "People"
+            case "place_facet":
+                facet = "Places"
+            case "time_facet":
+                facet = "Times"
+            case "first_publisher_year":
+                facet = "FirstPublished"
+            case "publisher_facet":
+                facet = "Publisher"
+            case "language_facet":
+                facet = "Language"
+        return "SearchFacet|" + facet
 
 $ param = {}
 $for p in ['q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor', 'publish_place', 'lccn', 'ia', 'first_sentence', 'publisher', 'author_key', 'debug', 'subject', 'place', 'person', 'time'] + facet_fields:

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -15,6 +15,9 @@ $code:
         else:
             return changequery(page=None,**{k:None})
 
+    def add_track(k):
+        return "SearchFacet|" + k
+
 $ param = {}
 $for p in ['q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor', 'publish_place', 'lccn', 'ia', 'first_sentence', 'publisher', 'author_key', 'debug', 'subject', 'place', 'person', 'time'] + facet_fields:
     $if p in input and input[p]:
@@ -229,9 +232,9 @@ $elif param and len(docs):
                        $ display = _('yes')
                     $else:
                        $ display = _('no')
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')" data-ol-link-track="$add_track(header)" >$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 $else:
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)" data-ol-link-track="$add_track(header)">$display </a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
                 <div class="facetMoreLess">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -29,7 +29,7 @@ $code:
                 facet = "Places"
             case "time_facet":
                 facet = "Times"
-            case "first_publisher_year":
+            case "first_publish_year":
                 facet = "FirstPublished"
             case "publisher_facet":
                 facet = "Publisher"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6938

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Google analytics attributes are added to search facets, allowing for the tracking of their popularity when clicked.

### Technical
<!-- What should be noted about the implementation? -->
`work_search.html` now contains the `data-ol-link-track` attribute when headers are clicked, which uses the `add_track` function to get the value.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
