### PR TITLE
Improvements to solr performance

### DIFF
--- a/conf/solr/conf/solrconfig.xml
+++ b/conf/solr/conf/solrconfig.xml
@@ -418,10 +418,10 @@
                       to occupy. Note that when this option is specified, the size
                       and initialSize parameters are ignored.
       -->
-    <filterCache class="solr.FastLRUCache"
+    <filterCache class="solr.CaffeineCache"
                  size="512"
                  initialSize="512"
-                 autowarmCount="0"/>
+                 autowarmCount="128"/>
 
     <!-- Query Result Cache
 
@@ -431,10 +431,10 @@
             maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
                        to occupy
       -->
-    <queryResultCache class="solr.LRUCache"
+    <queryResultCache class="solr.CaffeineCache"
                       size="512"
                       initialSize="512"
-                      autowarmCount="0"/>
+                      autowarmCount="128"/>
 
     <!-- Document Cache
 
@@ -442,14 +442,14 @@
          document).  Since Lucene internal document ids are transient,
          this cache will not be autowarmed.
       -->
-    <documentCache class="solr.LRUCache"
+    <documentCache class="solr.CaffeineCache"
                    size="512"
                    initialSize="512"
                    autowarmCount="0"/>
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
-           class="solr.search.LRUCache"
+           class="solr.CaffeineCache"
            size="10"
            initialSize="0"
            autowarmCount="10"
@@ -621,6 +621,7 @@
          will block until the first searcher is done warming.
       -->
     <useColdSearcher>false</useColdSearcher>
+    <maxWarmingSearchers>4</maxWarmingSearchers>
 
   </query>
 

--- a/conf/solr/conf/solrconfig.xml
+++ b/conf/solr/conf/solrconfig.xml
@@ -552,10 +552,55 @@
       -->
     <listener event="newSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
-        <!--
-           <lst><str name="q">solr</str><str name="sort">price asc</str></lst>
-           <lst><str name="q">rocks</str><str name="sort">weight asc</str></lst>
-          -->
+        <!-- Work search -->
+        <lst>
+          <str name="workQuery">harry potter</str>
+          <str name="q">({!edismax q.op="AND" qf="text alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$workQuery})</str>
+          <str name="fq">type:work</str>
+          <str name="rows">20</str>
+          <str name="facet">true</str>
+          <str name="facet.field">author_facet</str>
+          <str name="facet.field">first_publish_year</str>
+          <str name="facet.field">has_fulltext</str>
+          <str name="facet.field">language</str>
+          <str name="facet.field">person_facet</str>
+          <str name="facet.field">place_facet</str>
+          <str name="facet.field">publisher_facet</str>
+          <str name="facet.field">subject_facet</str>
+          <str name="facet.field">time_facet</str>
+        </lst>
+        <!-- Author works search -->
+        <lst>
+          <str name="workQuery">*:*</str>
+          <str name="q">({!edismax q.op="AND" qf="text alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$workQuery})</str>
+          <str name="fq">type:work</str>
+          <str name="fq">author_key:OL2162284A</str>
+          <str name="sort">edition_count desc</str>
+          <str name="rows">20</str>
+          <str name="facet">true</str>
+          <str name="facet.limit">25</str>
+          <str name="facet.field">person_facet</str>
+          <str name="facet.field">place_facet</str>
+          <str name="facet.field">subject_facet</str>
+          <str name="facet.field">time_facet</str>
+        </lst>
+        <!-- Ebook only search for carousel -->
+        <lst>
+          <str name="workQuery">subject:"Reading Level-Grade 6"</str>
+          <str name="q">({!edismax q.op="AND" qf="text alternative_title^20 author_name^20" bf="min(100,edition_count)" v=$workQuery})</str>
+          <str name="fq">type:work</str>
+          <str name="fq">ebook_access:[printdisabled TO *]</str>
+          <str name="rows">20</str>
+          <str name="facet">true</str>
+          <str name="facet.field">author_facet</str>
+          <str name="facet.field">first_publish_year</str>
+          <str name="facet.field">language</str>
+          <str name="facet.field">person_facet</str>
+          <str name="facet.field">place_facet</str>
+          <str name="facet.field">publisher_facet</str>
+          <str name="facet.field">subject_facet</str>
+          <str name="facet.field">time_facet</str>
+        </lst>
       </arr>
     </listener>
     <listener event="firstSearcher" class="solr.QuerySenderListener">

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -34,7 +34,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.oldev
     environment:
-      - EXTRA_OPTS= --solr-next
+      - EXTRA_OPTS=--no-commit --solr-next
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -251,6 +251,7 @@ services:
       - OL_URL=https://openlibrary.org/
       - EXTRA_OPTS=--solr-url http://ol-solr0:8984/solr/openlibrary
         --no-solr-next
+        --no-commit
     volumes:
       - ../olsystem:/olsystem
     logging:
@@ -270,7 +271,9 @@ services:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OL_URL=https://openlibrary.org/
       - STATE_FILE=solr-next-update.offset
-      - EXTRA_OPTS=--solr-url http://ol-solr1:8984/solr/openlibrary --solr-next
+      - EXTRA_OPTS=--solr-url http://ol-solr1:8984/solr/openlibrary
+        --solr-next
+        --no-commit
     volumes:
       - solr-updater-data:/solr-updater-data
       - ../olsystem:/olsystem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,12 @@ services:
     image: solr:8.10.1
     expose:
       - 8983
+    environment:
+      # Soft commit frequently to make sure changes are visible in search
+      # Hard commit less frequently to avoid performance impact, but avoid
+      # having very large transaction log
+      # https://solr.apache.org/guide/solr/latest/configuration-guide/commits-transaction-logs.html
+      - SOLR_OPTS=-Dsolr.autoSoftCommit.maxTime=60000 -Dsolr.autoCommit.maxTime=120000
     volumes:
       - solr-data:/var/solr/data
       - ./conf/solr:/opt/solr/server/solr/configsets/olconfig:ro
@@ -40,6 +46,7 @@ services:
       - OL_CONFIG=conf/openlibrary.yml
       - OL_URL=http://web:8080/
       - STATE_FILE=solr-update.offset
+      - EXTRA_OPTS=--no-commit
     volumes:
       - solr-updater-data:/solr-updater-data
     networks:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Work towards #7017

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
- Switch to soft commits instead auto of explicit hard commits
    - Commits are what make user edits visible to search
    - Soft commits make user edits visible to search but do not persist them to disk. The cost of this, is that they stick around in Solr's updateLog until a hard commit is performed.
    - Also soft commits will invalidate active searchers, meaning new searchers need to be warmed
    - But hard commits, which persist updates to disk, are slow
    - We now auto soft commit every minute, and hard commit every 2 minutes
    - Previous we would hard commit by sending explicit commit in solr-updater every minute
    - In a future PR, I will remove some of the code around explicit commits sent by solr-updater, if everything looks good
    - In a future PR, we should also remove `commitWithin` wherever it appears, but commitWithin performs a soft commit, so doesn't really matter.
- Add newSearcher cache warming
    - I noticed that after a soft commit, solr would serve 503s for ~3s. I.e. every minute, there would be 3s of 503s from solr. This is because after a soft commit, the old searchers and their caches are invalidated, and solr need to re-warm up
    - Added newSearcher cache warming, so when a newSearcher is created (ie after a soft commit), it'll run queries to warm up the cache
    - I chose queries we _actually_ use, and which happen frequently (according to Google Analytics). These will need to be updated for edition-aware solr once that's the default, so we get better caching
    - It would be good to actually autogen this section using the functions in worksearch/code.py , so we're guaranteed to be caching the correct queries
- Switched to CaffeineCache
    - This is the default in Solr 9, and the FastLRUCache, the default in solr 8, is removed in solr 9. So thought it might be good.
- Set autoWarmCount on all applicable caches
   - I noticed that the cache warming queries would show "autowarm took 0ms" in solr's docker container logs. That didn't look right. Increasing this number, cause this to be something like "autowarm took 18000ms", so it was actually running and making use of the cache!
   - This is what finally fixed the 503 spike after a soft commit!
![image](https://user-images.githubusercontent.com/6251786/193901344-033bf6fd-b5ab-4e81-a899-c54c0cd0c859.png)
- Increase max warming searchers
    - This was recommended to be slightly greater than 2 for Leader nodes. Since we're not in a cluster, our one and only solr node is a leader! So bumped up

### Testing
Patch deployed onto prod and monitored perf metrics. Performance was unchanged, but 503 errors _drastically_ dropped.

Patch deploying a solrconfig.xml change looks like:

```sh
# On staging solr
docker cp conf/solr/conf/solrconfig.xml solr_builder_solr_1:/var/solr/data/openlibrary/conf/solrconfig.xml
docker restart solr_builder_solr_1

# On prod solr
docker cp conf/solr/conf/solrconfig.xml openlibrary_solr_1:/var/solr/data/openlibrary/conf/solrconfig.xml
docker restart openlibrary_solr_1
```

The process is similar for local environment, which is where I tested first.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
