### PR TITLE
Fixed excessive scrolling issue w/ Related Books tab

### DIFF
--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -306,7 +306,7 @@ div.editionTools {
 .edition-omniline {
   display: flex;
   flex-direction: column;
-  padding: 20px;
+  padding: 10px;
   border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
   background: @grey-fafafa;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -227,6 +227,7 @@ h2.edition-byline {
 }
 
 a.section-anchor {
+  scroll-margin-top: 70px;
   height: 20px;
   display: block;
 }
@@ -305,7 +306,7 @@ div.editionTools {
 .edition-omniline {
   display: flex;
   flex-direction: column;
-  padding: 10px;
+  padding: 20px;
   border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
   background: @grey-fafafa;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6536 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR fixes the UI issue that was caused when clicking a subsection on the navbar which jumped down too far.

### Technical
<!-- What should be noted about the implementation? -->
I added margin to the scrolling on top of the anchor points so that when the page jumps it stops right above the anchor point. The problem was that the jump did not account for the nav bar and title staying at the top of the page while scrolling down.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To test my code, simply apply the changes and run the developer mode. Go to any edition or work page and click on the navbar link. Observe the page after scrolling has stopped.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![ezgif-5-adc1fa0464](https://user-images.githubusercontent.com/88256186/193381945-517c76b0-fb5e-43ca-a2e7-c0d589374f6f.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
