### PR TITLE
Adds ability to search/filter one's reading log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,14 @@ services:
       # Hard commit less frequently to avoid performance impact, but avoid
       # having very large transaction log
       # https://solr.apache.org/guide/solr/latest/configuration-guide/commits-transaction-logs.html
-      - SOLR_OPTS=-Dsolr.autoSoftCommit.maxTime=60000 -Dsolr.autoCommit.maxTime=120000
+      # Enlarge the max boolean clauses so that we can large intersections
+      # between books in reading logs and solr.
+      # Should be in sync with the value in openlibrary/core/bookshelves.py ,
+      # eg key:(/works/OL1W OR /works/OL2W OR ...)
+      - SOLR_OPTS=
+        -Dsolr.autoSoftCommit.maxTime=60000
+        -Dsolr.autoCommit.maxTime=120000
+        -Dsolr.max.booleanClauses=30000
     volumes:
       - solr-data:/var/solr/data
       - ./conf/solr:/opt/solr/server/solr/configsets/olconfig:ro

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -234,8 +234,6 @@ class Bookshelves(db.CommonExtras):
                         web.storage(
                             {
                                 "key": work_key,
-                                "author_name": ["Unknown author"],
-                                "title": "",
                             }
                         ),
                     )

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -401,7 +401,6 @@ class Bookshelves(db.CommonExtras):
             return get_filtered_reading_log_books(
                 q=q, query_params=query_params, filter_book_limit=FILTER_BOOK_LIMIT
             )
-
         else:
             return get_sorted_reading_log_books(query_params=query_params, sort=sort)
 

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -111,12 +111,13 @@ class Ratings(db.CommonExtras):
         return list(oldb.query(query, vars={'work_id': int(work_id)}))
 
     @classmethod
-    def get_users_rating_for_work(cls, username, work_id):
+    def get_users_rating_for_work(cls, username: str, work_id: str | int) -> int | None:
+        """work_id must be convertible to int."""
         oldb = db.get_db()
         data = {'username': username, 'work_id': int(work_id)}
         query = 'SELECT * from ratings where username=$username AND work_id=$work_id'
         results = list(oldb.query(query, vars=data))
-        rating = results[0].rating if results else None
+        rating: int | None = results[0].rating if results else None
         return rating
 
     @classmethod

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -26,11 +26,11 @@ $code:
   if doc_type == 'infogami_edition' and 'works' in doc:
     edition_work = doc['works'][0]
 
-  full_title = selected_ed.title + (': ' + selected_ed.subtitle if selected_ed.get('subtitle') else '')
+  full_title = selected_ed.get('title', '') + (': ' + selected_ed.subtitle if selected_ed.get('subtitle') else '')
   if doc_type == 'infogami_edition' and edition_work:
-    full_work_title = edition_work.title + (': ' + edition_work.subtitle if edition_work.get('subtitle') else '')
+    full_work_title = edition_work.get('title', '') + (': ' + edition_work.subtitle if edition_work.get('subtitle') else '')
   else:
-    full_work_title = doc.title + (': ' + doc.subtitle if doc.get('subtitle') else '')
+    full_work_title = doc.get('title', '') + (': ' + doc.subtitle if doc.get('subtitle') else '')
 
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
   <span class="bookcover">

--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -1,8 +1,8 @@
 $def with (work, edition=None, redir_url=None, id='', rating=None)
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
-$if rating is None:
-  $ rating = work and username and work.get_users_rating(username)
+$if rating is None and work and username:
+  $ rating = work.get_users_rating(username)
 $ edition_key = edition.key if edition else ""
 $ form_id = "ratingsForm%s" % id
 

--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -1,6 +1,8 @@
-$def with (work, edition=None, redir_url=None, id='')
+$def with (work, edition=None, redir_url=None, id='', rating=None)
+
 $ username = ctx.user and ctx.user.key.split('/')[-1]
-$ rating = work and username and work.get_users_rating(username)
+$if rating is None:
+  $ rating = work and username and work.get_users_rating(username)
 $ edition_key = edition.key if edition else ""
 $ form_id = "ratingsForm%s" % id
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -74,7 +74,7 @@ class public_my_books_json(delegate.page):
                         'author_keys': [
                             '/authors/' + key for key in w.get('author_key', [])
                         ],
-                        'author_names': w.get('author_name'),
+                        'author_names': w.get('author_name', []),
                         'first_publish_year': w.get('first_publish_year') or None,
                         'lending_edition_s': (w.get('lending_edition_s') or None),
                         'edition_key': (w.get('edition_key') or None),

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -32,6 +32,7 @@ from openlibrary.plugins.upstream.utils import (
     get_language_name,
     urlencode,
 )
+from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.solr.solr_types import SolrDocument
 from openlibrary.solr.query_utils import (
     EmptyTreeError,
@@ -432,9 +433,6 @@ def build_q_from_params(param: dict[str, str]) -> str:
     return ' AND '.join(q_list)
 
 
-solr_session = requests.Session()
-
-
 def execute_solr_query(
     solr_path: str, params: Union[dict, list[tuple[str, Any]]]
 ) -> Optional[Response]:
@@ -445,7 +443,7 @@ def execute_solr_query(
 
     stats.begin("solr", url=url)
     try:
-        response = solr_session.get(url, timeout=10)
+        response = get_solr().raw_request(solr_path, urlencode(params))
         response.raise_for_status()
     except requests.HTTPError:
         logger.exception("Failed solr query")

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -1,12 +1,13 @@
-$def with (items, key, counts, lists=None, user=None, logged_in_user=None, public=False, sort_order='desc', owners_page=False)
+$def with (docs, key, shelf_counts, doc_count, lists=None, user=None, logged_in_user=None, public=False, sort_order='desc', owners_page=False, q="", results_per_page=25, ratings=[])
 
 $# Displays a user's reading log
-$# :param list items:
+$# :param list docs:
 $# :param Literal['currently-reading', 'want-to-read', 'already-read', 'sponsorships', 'loans', 'notes', 'observations'] key:
-$# :param Dict[str: int] counts:
+$# :param Dict[str: int] shelf_counts:
 $# :param list? lists:
 $# :param user:
 $# :param bool public:
+$# :param str q: search term.
 
 $ component_times = {}
 $ component_times['TotalTime'] = time()
@@ -14,7 +15,7 @@ $ component_times['TotalTime'] = time()
 $ username = user.key.split('/')[-1]
 
 $ current_page = int(input(page=1).page)
-$ total_items = counts.get(key, None)
+$ total_docs = shelf_counts.get(key, None)
 
 $ userDisplayName = user.displayname or ctx.user.displayname
 $ userKey = user.key or ctx.user.key
@@ -42,7 +43,7 @@ $if not header_title:
   $elif key == 'lists':
     $ header_title = _('My Lists')
   $elif key == 'list':
-    $ header_title = items.get('name', 'List')
+    $ header_title = docs.get('name', 'List')
   $else:
     $ header_title = key
   $ breadcrumb = header_title
@@ -50,7 +51,7 @@ $var title: $header_title
 
 <div class="mybooks">
 
-  $:render_template("account/sidebar", user, key=key, public=public, owners_page=owners_page, counts=counts, lists=lists, component_times=component_times)
+  $:render_template("account/sidebar", user, key=key, public=public, owners_page=owners_page, counts=shelf_counts, lists=lists, component_times=component_times)
 
   <div class="mybooks-details">
     $ component_times['Details header'] = time()
@@ -89,28 +90,28 @@ $var title: $header_title
       </div>
       $if key == 'list':
         <div>
-          $:macros.databarView(items)
+          $:macros.databarView(docs)
         </div>
     </header>
     $ component_times['Details header'] = time() - component_times['Details header']
     $ component_times['Details content'] = time()
     <div class="details-content">
     $if key == 'loans':
-      $:render_template('account/loans', logged_in_user, items)
+      $:render_template('account/loans', logged_in_user, docs)
     $elif key == 'notes':
-      $:render_template('account/notes', items, user, counts['notes'], page=current_page)
+      $:render_template('account/notes', docs, user, shelf_counts['notes'], page=current_page)
     $elif key == 'observations':
-      $:render_template('account/observations', items, user, counts['observations'], page=current_page)
+      $:render_template('account/observations', docs, user, shelf_counts['observations'], page=current_page)
     $elif key == 'imports':
       $:render_template('account/import')
     $elif key == 'lists':
-      $:render_template('lists/lists', items, lists, show_header=False)
+      $:render_template('lists/lists', docs, lists, show_header=False)
     $elif key == 'already-read':
-      $:render_template('account/reading_log', items, key, counts[key], owners_page, current_page, sort_order=sort_order, user=user, include_ratings=owners_page)
+      $:render_template('account/reading_log', docs, key, shelf_counts[key], doc_count, owners_page, current_page, sort_order=sort_order, user=user, include_ratings=owners_page, q=q, results_per_page=results_per_page, ratings=ratings)
     $elif key in {'currently-reading', 'want-to-read', 'sponsorships'}:
-      $:render_template('account/reading_log', items, key, counts[key], owners_page, current_page, sort_order=sort_order, user=user)
+      $:render_template('account/reading_log', docs, key, shelf_counts[key], doc_count, owners_page, current_page, sort_order=sort_order, user=user, q=q, results_per_page=results_per_page)
     $else:
-      $:render_template('type/list/view', items, check_owner=False, owns_page=True)
+      $:render_template('type/list/view', docs, check_owner=False, owns_page=True)
     </div>
     $ component_times['Details content'] = time() - component_times['Details content']
   </div>

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -1,4 +1,4 @@
-$def with (items, key, total_items, owners_page, current_page, sort_order='desc', user=None, include_ratings=False)
+$def with (docs, key, shelf_count, doc_count, owners_page, current_page, sort_order='desc', user=None, include_ratings=False, q=None, results_per_page=25, ratings=[])
 
 $ username = user.key.split('/')[-1]
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
@@ -6,16 +6,16 @@ $ userDisplayName = user.displayname or ctx.user.displayname
 
 $if key == 'currently-reading':
   $ og_title = _("Books %(username)s is reading", username=userDisplayName)
-  $ og_description = _("%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading.", username=userDisplayName, total=total_items)
+  $ og_description = _("%(username)s is reading %(total)d books. Join %(username)s on OpenLibrary.org and tell the world what you're reading.", username=userDisplayName, total=shelf_count)
 $elif key == 'want-to-read':
   $ og_title = _("Books %(username)s wants to read", username=userDisplayName)
-  $ og_description = _("%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!", username=userDisplayName, total=total_items)
+  $ og_description = _("%(username)s wants to read %(total)d books. Join %(username)s on OpenLibrary.org and share the books that you'll soon be reading!", username=userDisplayName, total=shelf_count)
 $elif key == 'already-read':
   $ og_title = _("Books %(username)s has read", username=userDisplayName)
-  $ og_description = _("%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about.", username=userDisplayName, total=total_items)
+  $ og_description = _("%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about.", username=userDisplayName, total=shelf_count)
 $elif key == 'sponsorships':
   $ og_title = _("Books %(userdisplayname)s is sponsoring", userdisplayname=userDisplayName)
-  $ og_description = "{username} is sponsoring {total} books. Join {username} on OpenLibrary.org and share the books that you'll soon be reading!".format(username=userDisplayName, total=total_items)
+  $ og_description = "{username} is sponsoring {total} books. Join {username} on OpenLibrary.org and share the books that you'll soon be reading!".format(username=userDisplayName, total=shelf_count)
 
 $putctx("description", og_description)
 $add_metatag(property="og:title", content=og_title)
@@ -24,32 +24,39 @@ $add_metatag(property="og:site_name", content="Open Library")
 $add_metatag(property="og:description", content=og_description)
 $add_metatag(property="og:image", content=meta_photo_url)
 
-<div class="mybooks-list">
-  <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
-    $if sort_order == 'desc':
-      <strong class="lightgreen">$_("Date Added (newest)")</strong>
-      |
-      <a href="$ctx.path?sort=asc">$_("Date Added (oldest)")</a>
-    $else:
-      <a href="$ctx.path?sort=desc">$_("Date Added (newest)")</a>
-      |
-      <strong class="lightgreen">$_("Date Added (oldest)")</strong>
-  </span>
+<form method="GET" class="olform pagesearchbox">
+  <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
+  <input type="submit"/>
+</form>
 
-  $:macros.Pager(current_page, total_items, results_per_page=25)
+<div class="mybooks-list">
+  $if q:
+    <span class="search-results-stats">$ungettext('1 hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
+  $else:
+    <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
+      $if sort_order == 'desc':
+        <strong class="lightgreen">$_("Date Added (newest)")</strong>
+        |
+        <a href="$changequery(sort='asc')">$_("Date Added (oldest)")</a>
+      $else:
+        <a href="$changequery(sort='desc')">$_("Date Added (newest)")</a>
+        |
+        <strong class="lightgreen">$_("Date Added (oldest)")</strong>
+    </span>
+
+  $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
   <ul class="list-books">
-    $if items:
+    $if docs:
       $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
-      $ solr_works = get_solr_works(work['key'] for work in items)
-      $ item_number = 1
-      $for item in items:
-        $ work = solr_works.get(item['key']) or item
-        $ decorations = (bookshelf_id and owners_page) and macros.ReadingLogButton(work, read_status=bookshelf_id)
-        $ star_rating = macros.StarRatings(item, redir_url='/account/books/already-read', id=item_number) if include_ratings else None
-        $:macros.SearchResultsWork(work, decorations=decorations, availability=item.get('availability'), rating=star_rating)
-        $ item_number = item_number + 1
+      $ doc_number = 1
+      $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
+      $for idx, doc in enumerate(docs):
+        $ decorations = (bookshelf_id and owners_page) and macros.ReadingLogButton(doc, read_status=bookshelf_id)
+        $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
+        $:macros.SearchResultsWork(doc, decorations=decorations, availability=doc.get('availability'), rating=star_rating)
+        $ doc_number = doc_number + 1
     $else:
       <li>$_('No books are on this shelf')</li>
   </ul>
-  $:macros.Pager(current_page, total_items, results_per_page=25)
+  $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
 </div>

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -114,7 +114,7 @@ class Solr:
 
         json_data = self.raw_request(
             'select',
-            urlencode(params, doSeq=True),
+            urlencode(params, doseq=True),
         ).json()
         return self._parse_solr_result(
             json_data, doc_wrapper=doc_wrapper, facet_wrapper=facet_wrapper


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5080. This may need significantly more work, however.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds basic capacity to filter/search one's reading log.

### Technical
<!-- What should be noted about the implementation? -->
#### What this does, in theory
This draft PR likely needs some work, but before getting the problems, first comes an explanation of how this theoretically works:
- From the [Reading Log](http://localhost:8080/people/openlibrary/books/want-to-read) one can enter a 3+ character search term and search (1) up to 1000 of their logged books to see (2) up to 100 matching results within that 1000.
- Currently, searching is not limited to title or author, but rather the defaults from `do_search`. This would be easy enough to change I think by switching to `run_solr_query` (unless it's possible to specify fields in `do_search`.

#### Issues
- Because I could not figure out a good way to filter the results, there is the possibility for a fairly hefty pair of queries to occur. *When a user enters a query of 3+ characters*, this:
  1. requests up to 1000 of the user's logged books from the current shelf (e.g. "Want to Read") via `get_users_logged_books` in `core/bookshelves.py`;
  2. searches Solr for those work IDs *and* any matches for the search term (currently *not* limited to author/title); and
  3. returns only logged books that match the work IDs in the Solr search results -- meaning that only logged works that match the search term are returned and passed on to `process_logged_books` in `upstream/mybooks.py`, etc.
- This requires new page loads for each search.
- I have not tested this with more than 29 books in one shelf.
- To avoid a circular imports issue in `bookshelves.py`, `do_search` is conditionally imported. This likely will need a better solution, though I didn't put any time into it on the theory that maybe this implementation has no future.
- There is no pagination. The number of results on a page is limited to the number of filtered results, which is up to 100. Owing to the need to do two queries and 'merge' the results, I couldn't figure out a way to use query offsets effectively (which isn't to say there isn't an easy and obvious way). Additionally, I was thinking that if this is limited to a certain number of characters and/or title/author, not many searches would go near 100 results. I am unsure of the performance implications of this, or the reality of my supposition.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Visit the [Reading Log](http://localhost:8080/people/openlibrary/books/want-to-read) and try filtering via the search box for "Currently Reading", "Want to Read", and "Already Read".
- Verify that the results appear correct and that sorting by date added works.
- Try searching for <= 2 characters and see if that does anything, both through the search box and via a GET request in the URL bar. With the direct GET, the search should just be ignored.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Already Read, without any filtering:
![image](https://user-images.githubusercontent.com/26524678/193938148-3baf3aa8-9929-4387-94af-23dea29e28ee.png)

Searching for 'twain':
![image](https://user-images.githubusercontent.com/26524678/193938202-716b46b3-7ce6-4086-99ef-8f5045d1a22d.png)

Same search, but with the sort order showing oldest-added first:
![image](https://user-images.githubusercontent.com/26524678/193938261-79efd46c-20d9-4065-bf4f-b143f2c04a5b.png)

Searching a shelf of 29 books for the phrase "web":
![image](https://user-images.githubusercontent.com/26524678/193938345-1872a553-2b8b-4fd6-8370-2b67a1f875c2.png)

A not very good screenshot of trying to enter < 3 characters into the search:
![IMG_1516](https://user-images.githubusercontent.com/26524678/193938875-503f825a-9bcb-4632-8793-57b370e3bb93.jpg)

Doing a GET request for a search of <= 2 characters just returns everything on the shelf, with the usual pagination and no filtering. (Though there is no indication that the search didn't work, aside from not mentioning results):
![image](https://user-images.githubusercontent.com/26524678/193939072-eb02544b-7f97-453e-b098-1e6ab4ee3d73.png)

### Thanks to
@cdrini for walking me through a lot of it, and @mekarpeles for the detailed explanation of the steps.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles, @cdrini


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
