### PR TITLE
My Books summary desktop redesign

### DIFF
--- a/openlibrary/macros/FormatExpiry.html
+++ b/openlibrary/macros/FormatExpiry.html
@@ -1,11 +1,24 @@
 $def with(expiry)
 
 $if expiry:
+    $if render_once('expire-dates-js'):
+        <script type="text/javascript">
+        <!--
+        window.q.push(function(){
+            \$(".localize-time").each(function() {
+                var expiry_utc = \$(this).attr("data-expiry-utc");
+                var options = {hour: '2-digit', minute:'2-digit', month:'2-digit', day:'2-digit', year:'numeric'};
+                \$(this).html((new Date(expiry_utc)).toLocaleString([], options));
+            });
+        });
+        //-->
+        </script>
+
     $ expiry_datetime = datetime_from_isoformat(expiry)
-    <div class="local-date-time" data-expiry-utc="$datetimestr_utc(expiry_datetime)">
-     Expires $datestr(expiry_datetime) at
-     $expiry_datetime.strftime("%I:%M %p")
+    <div class="local-date-time">
+      $_('Expires')
+      <span class="localize-time"
+	    data-expiry-utc="$datetimestr_utc(expiry_datetime)">
+	$datetimestr_utc(expiry_datetime)
+      </span>
     </div>
-$else:
-    $# Not yet fulfilled
-    <span class="red">Not yet downloaded</span>

--- a/openlibrary/macros/FormatExpiry.html
+++ b/openlibrary/macros/FormatExpiry.html
@@ -1,8 +1,11 @@
 $def with(expiry)
 
-$if expiry is None or expiry == False:
+$if expiry:
+    $ expiry_datetime = datetime_from_isoformat(expiry)
+    <div class="local-date-time" data-expiry-utc="$datetimestr_utc(expiry_datetime)">
+     Expires $datestr(expiry_datetime) at
+     $expiry_datetime.strftime("%I:%M %p")
+    </div>
+$else:
     $# Not yet fulfilled
     <span class="red">Not yet downloaded</span>
-$else:
-    $ expiry_datetime = datetime_from_isoformat(expiry)
-    <div class="darkgreen local-date-time" data-expiry-utc="$datetimestr_utc(expiry_datetime)">$datetimestr_utc(expiry_datetime)</div>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -49,7 +49,7 @@ $if user_loan:
     <form action="$return_url" method="post"
           class="waitinglist-form return-book">
       <input type="hidden" name="action" value="return" />
-      <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--vanilla" id="return_ebook"/>
+      <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--shell" id="return_ebook"/>
     </form>
     $if render_once('LoanStatus:return-book-js'):
       <script type="text/javascript">

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -36,29 +36,31 @@ $ borrow_link = '/borrow/ia/%s' % ocaid
 
 $# Checks to see if patron has actively loan / waitlist for this book
 $ get_loan_for_start_time = time()
-$ user_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid)
+$ user_loan = doc.get('loan') or (check_loan_status and ocaid and ctx.user and ctx.user.get_loan_for(ocaid))
 $ get_loan_for_total_time = time() - get_loan_for_start_time
 
 $ is_edition = doc.key.split('/')[1] == 'books'
 
-$if user_loan:
+$if user_loan:  
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
-  $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
-  <form action="$return_url" method="post" class="waitinglist-form return-book">
-    <input type="hidden" name="action" value="return" />
-    <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--available" id="return_ebook"/>
-  </form>
-
-  $if render_once('LoanStatus:return-book-js'):
-    <script type="text/javascript">
-      window.q.push(function() {
-        \$('.return-book').on('submit', function(event) {
-          if (!confirm("$_('Really return this book?')")) {
-            event.preventDefault();
-          }
+  $:macros.FormatExpiry(user_loan['expiry'])
+  $if secondary_action:
+    $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
+    <form action="$return_url" method="post"
+          class="waitinglist-form return-book">
+      <input type="hidden" name="action" value="return" />
+      <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--vanilla" id="return_ebook"/>
+    </form>
+    $if render_once('LoanStatus:return-book-js'):
+      <script type="text/javascript">
+        window.q.push(function() {
+          \$('.return-book').on('submit', function(event) {
+            if (!confirm("$_('Really return this book?')")) {
+              event.preventDefault();
+            }
+          });
         });
-      });
-    </script>
+      </script>
 
 $elif book_provider and book_provider.short_name != 'ia':
   $# Partner Trusted Book Provider Read Buttons

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -41,7 +41,7 @@ $ get_loan_for_total_time = time() - get_loan_for_start_time
 
 $ is_edition = doc.key.split('/')[1] == 'books'
 
-$if user_loan:  
+$if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
   $:macros.FormatExpiry(user_loan['expiry'])
   $if secondary_action:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -403,7 +403,7 @@ class account_login(delegate.page):
             "/account/create",
         ]
         if i.redirect == "" or any([path in i.redirect for path in blacklist]):
-            i.redirect = "/account/loans"
+            i.redirect = "/account/books"
         raise web.seeother(i.redirect)
 
     def POST_resend_verification_email(self, i):

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -289,13 +289,13 @@ class MyBooksTemplate:
             # Ideally, do all 3 lookups in one add_availability call
             want_to_read.docs = add_availability(
                 [d for d in want_to_read.docs if d.get('title')]
-            )[:4]
+            )[:5]
             currently_reading.docs = add_availability(
                 [d for d in currently_reading.docs if d.get('title')]
-            )[:4]
+            )[:5]
             already_read.docs = add_availability(
                 [d for d in already_read.docs if d.get('title')]
-            )[:4]
+            )[:5]
 
             # Marshal loans into homogeneous data that carousel can render
             loans = get_loans_of_user(logged_in_user.key)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -312,7 +312,6 @@ class MyBooksTemplate:
                 'already-read': already_read,
             }
         elif self.key == 'loans':
-            # logged_in_user.update_loan_status()
             return get_loans_of_user(logged_in_user.key)
         elif self.key == 'waitlist':
             return {}

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -289,13 +289,13 @@ class MyBooksTemplate:
             # Ideally, do all 3 lookups in one add_availability call
             want_to_read.docs = add_availability(
                 [d for d in want_to_read.docs if d.get('title')]
-            )[:5]
+            )[:4]
             currently_reading.docs = add_availability(
                 [d for d in currently_reading.docs if d.get('title')]
-            )[:5]
+            )[:4]
             already_read.docs = add_availability(
                 [d for d in already_read.docs if d.get('title')]
-            )[:5]
+            )[:4]
 
             # Marshal loans into homogeneous data that carousel can render
             loans = get_loans_of_user(logged_in_user.key)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -282,15 +282,22 @@ class MyBooksTemplate:
             return self.readlog.get_works(
                 key=name, page=page, limit=6, sort='created', sort_order='asc'
             )
+
         if self.key == 'mybooks':
             want_to_read = get_shelf('want-to-read', page=page)
             currently_reading = get_shelf('currently-reading', page=page)
             already_read = get_shelf('already-read', page=page)
 
             # Ideally, do all 3 lookups in one add_availability call
-            want_to_read.docs = add_availability([d for d in want_to_read.docs if d.get('title')])[:4]
-            currently_reading.docs = add_availability([d for d in currently_reading.docs if d.get('title')])[:4]
-            already_read.docs = add_availability([d for d in already_read.docs if d.get('title')])[:4]
+            want_to_read.docs = add_availability(
+                [d for d in want_to_read.docs if d.get('title')]
+            )[:4]
+            currently_reading.docs = add_availability(
+                [d for d in currently_reading.docs if d.get('title')]
+            )[:4]
+            already_read.docs = add_availability(
+                [d for d in already_read.docs if d.get('title')]
+            )[:4]
 
             return {
                 'loans': borrow.get_loans(logged_in_user),

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -282,17 +282,29 @@ class MyBooksTemplate:
             return {
                 'loans': borrow.get_loans(logged_in_user),
                 'want-to-read': self.readlog.get_works(
-                    key='want-to-read', page=page, limit=5, sort='created', sort_order='asc'
+                    key='want-to-read',
+                    page=page,
+                    limit=5,
+                    sort='created',
+                    sort_order='asc',
                 ),
                 'currently-reading': self.readlog.get_works(
-                    key='currently-reading', page=page, limit=5, sort='created', sort_order='asc'
+                    key='currently-reading',
+                    page=page,
+                    limit=5,
+                    sort='created',
+                    sort_order='asc',
                 ),
                 'already-read': self.readlog.get_works(
-                    key='already-read', page=page, limit=5, sort='created', sort_order='asc'
+                    key='already-read',
+                    page=page,
+                    limit=5,
+                    sort='created',
+                    sort_order='asc',
                 ),
             }
         elif self.key == 'loans':
-            #logged_in_user.update_loan_status()
+            # logged_in_user.update_loan_status()
             return borrow.get_loans(logged_in_user)
         elif self.key == 'waitlist':
             return {}

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -299,10 +299,7 @@ class MyBooksTemplate:
 
             # Marshal loans into homogenous data that carousel can render
             loans = get_loans_of_user(logged_in_user.key)
-            myloans = web.Storage({
-                "docs": [],
-                "total_results": len(loans)
-            })
+            myloans = web.Storage({"docs": [], "total_results": len(loans)})
             for loan in loans:
                 book = web.ctx.site.get(loan['book'])
                 book.loan = loan

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -297,7 +297,7 @@ class MyBooksTemplate:
                 [d for d in already_read.docs if d.get('title')]
             )[:4]
 
-            # Marshal loans into homogenous data that carousel can render
+            # Marshal loans into homogeneous data that carousel can render
             loans = get_loans_of_user(logged_in_user.key)
             myloans = web.Storage({"docs": [], "total_results": len(loans)})
             for loan in loans:

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -278,30 +278,25 @@ class MyBooksTemplate:
         page=1,
         username=None,
     ):
+        def get_shelf(name, page=1):
+            return self.readlog.get_works(
+                key=name, page=page, limit=6, sort='created', sort_order='asc'
+            )
         if self.key == 'mybooks':
+            want_to_read = get_shelf('want-to-read', page=page)
+            currently_reading = get_shelf('currently-reading', page=page)
+            already_read = get_shelf('already-read', page=page)
+
+            # Ideally, do all 3 lookups in one add_availability call
+            want_to_read.docs = add_availability([d for d in want_to_read.docs if d.get('title')])[:4]
+            currently_reading.docs = add_availability([d for d in currently_reading.docs if d.get('title')])[:4]
+            already_read.docs = add_availability([d for d in already_read.docs if d.get('title')])[:4]
+
             return {
                 'loans': borrow.get_loans(logged_in_user),
-                'want-to-read': self.readlog.get_works(
-                    key='want-to-read',
-                    page=page,
-                    limit=5,
-                    sort='created',
-                    sort_order='asc',
-                ),
-                'currently-reading': self.readlog.get_works(
-                    key='currently-reading',
-                    page=page,
-                    limit=5,
-                    sort='created',
-                    sort_order='asc',
-                ),
-                'already-read': self.readlog.get_works(
-                    key='already-read',
-                    page=page,
-                    limit=5,
-                    sort='created',
-                    sort_order='asc',
-                ),
+                'want-to-read': want_to_read,
+                'currently-reading': currently_reading,
+                'already-read': already_read,
             }
         elif self.key == 'loans':
             # logged_in_user.update_loan_status()

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -21,11 +21,26 @@ from openlibrary.core.models import LoggedBooksData
 RESULTS_PER_PAGE: Final = 25
 
 
-class my_books_redirect(delegate.page):
+class my_books_home(delegate.page):
     path = "/people/([^/]+)/books"
 
     def GET(self, username):
-        raise web.seeother('/people/%s/books/want-to-read' % username)
+        """
+        The other way to get to this page is /account/books which is defined
+        in /plugins/account.py account_my_books. But we don't need to update that redirect
+        because it already just redirects here.
+        """
+        user = web.ctx.site.get('/people/%s' % username)
+        is_public = user.preferences().get('public_readlog', 'no') == 'yes'
+        if is_public: # or current_user == user:
+            #user.update_loan_status()
+            mybooks = ReadingLog(user=user)
+            mybooks.loans = borrow.get_loans(user)
+
+            # TODO:
+            # Render a "account/books.html" view which uses the account/mybooks as its template
+            #return MyBooksTemplate(username, key).render(page="books")
+            return render['account/mybooks'](user, mybooks)
 
 
 class my_books_view(delegate.page):

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -23,7 +23,9 @@ $ userKey = user.key or ctx.user.key
 $ breadcrumb = _("Reading Log")
 $ header_title = ""
 
-$if key == 'currently-reading':
+$if key == 'mybooks':
+  $ header_title = _("My Books")
+$elif key == 'currently-reading':
   $ header_title = _("Currently Reading")
 $elif key == 'want-to-read':
   $ header_title = _("Want To Read")
@@ -46,7 +48,8 @@ $if not header_title:
     $ header_title = docs.get('name', 'List')
   $else:
     $ header_title = key
-  $ breadcrumb = header_title
+
+$ breadcrumb = header_title
 $var title: $header_title
 
 <div class="mybooks">
@@ -96,7 +99,9 @@ $var title: $header_title
     $ component_times['Details header'] = time() - component_times['Details header']
     $ component_times['Details content'] = time()
     <div class="details-content">
-    $if key == 'loans':
+    $if key == 'mybooks':
+      $:render_template('account/mybooks', logged_in_user, docs, public=public, owners_page=owners_page, counts=shelf_counts, lists=lists,)
+    $elif key == 'loans':
       $:render_template('account/loans', logged_in_user, docs)
     $elif key == 'notes':
       $:render_template('account/notes', docs, user, shelf_counts['notes'], page=current_page)

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -45,18 +45,6 @@ th.status {
 
 </style>
 
-<script type="text/javascript">
-<!--
-window.q.push(function(){
-    \$(".local-date-time").each(function() {
-        var expiry_utc = \$(this).attr("data-expiry-utc");
-        var options = {hour: '2-digit', minute:'2-digit', month:'2-digit', day:'2-digit', year:'numeric'};
-        \$(this).html((new Date(expiry_utc)).toLocaleString([], options));
-    });
-});
-//-->
-</script>
-
 <div>
   $if len(loans) == 0:
     <div><em>$_("You've not checked out any books at this moment.")</em></div>

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,8 +1,5 @@
 $def with (user, mybooks, public=False, owners_page=False, counts=None, lists=None)
 
-$ component_times = {}
-$ component_times['TotalTime'] = time()
-
 $ username = user.key.split('/')[-1]
 
 <div class="chip-group">

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,4 +1,4 @@
-$def with (user, mybooks)
+$def with (user, mybooks, public=False, owners_page=False, counts=None, lists=None)
 
 $ component_times = {}
 $ component_times['TotalTime'] = time()
@@ -14,27 +14,4 @@ $ username = user.key.split('/')[-1]
   }
 </style>
 
-<h1>My Books</h1>
-
-<div class="item">
-  <a href="/account/loans">My Loans &amp; Holds ($len(mybooks.loans))</a>
-</div>
-
-<div class="item">
-  <a href="/account/books/want-to-read">Want to Read ($mybooks.reading_log_counts['want-to-read'])</a>
-
-</div>
-<div class="item">
-  <a href="/account/books/currently-reading">Currently Reading ($mybooks.reading_log_counts['currently-reading'])</a>
-</div>
-<div class="item">
-  <a href="/account/books/already-read">Already Read ($mybooks.reading_log_counts['already-read'])</a>
-</div>
-
-<div class="item">
-  <a href="/account/lists">My Lists ($(len(mybooks.lists)))</a>
-</div>
-
-<div class="item">
-  <a href="/account/books/already-read/stats">My Reading Stats</a>
-</div>
+$mybooks

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -5,18 +5,37 @@ $ component_times['TotalTime'] = time()
 
 $ username = user.key.split('/')[-1]
 
-$if len(mybooks['loans']) == 0:
-  <div class="carousel-section-header">
-    <h2 class="home-h2"><a name="loans" href="/account/loans">$_('Loans (0)')</a></h2>
-  </div>
-  <div><em>$_("You've not checked out any books at this moment.")</em></div>
-  <br>
-$else:
-  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans", min_books=1, load_more=None, test=False, compact_mode=True)
+<div class="mybooks-options">
+  <span class="chip value-chip chip--selectable">
+    <a data-ol-link-track="MyBooksSidebar|ReadingStats"
+       href="/account/books/already-read/stats">$_('My Reading Stats')</a>
+  </span>
+  <span class="chip value-chip chip--selectable">
+    <a data-ol-link-track="MyBooksSidebar|ImportExport"
+       href="/account/import">$_("Import & Export Options")</a>
+  </span>
+</div>
+
+$code:
+    def compact_carousel(key, title, url):
+        books = mybooks[key].docs
+        count = mybooks[key].total_results
+        return render_template("books/custom_carousel", **{
+            "books": books,
+            "title": "%s (%d)" % (title, count),
+            "url": url,
+            "key": key,
+            "min_books": 1,
+            "load_more": None,
+            "compact_mode": True,
+            "test": False
+        })
+
+$if mybooks['loans'].docs:
+  $:compact_carousel("loans", _('My Loans'), url="/account/loans")
 
 $if mybooks['currently-reading'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading", min_books=1, load_more=None, test=False, compact_mode=True)
-
+  $:compact_carousel("currently-reading", _('Currently Reading'), url="/account/books/currently-reading")
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
@@ -24,7 +43,7 @@ $else:
   <li>$_('No books are on this shelf')</li>
 
 $if mybooks['want-to-read'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read", min_books=1, load_more=None, test=False, compact_mode=True)
+  $:compact_carousel("want-to-read", _('Want to Read'), url="/account/books/want-to-read")
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
@@ -32,19 +51,9 @@ $else:
   <li>$_('No books are on this shelf')</li>
 
 $if mybooks['already-read'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read", min_books=1, load_more=None, test=False, compact_mode=True)
+  $:compact_carousel("already-read", _('Already Read'), url="/account/books/already-read")
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>
   </div>
   <li>$_('No books are on this shelf')</li>
-
-<style type="text/css">
-  .item {
-  background-color: #ddd;
-  padding: 5px;
-  font-weight: bold;
-  border-bottom: 1px solid #eee;
-  }
-</style>
-

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,0 +1,40 @@
+$def with (user, mybooks)
+
+$ component_times = {}
+$ component_times['TotalTime'] = time()
+
+$ username = user.key.split('/')[-1]
+
+<style type="text/css">
+  .item {
+  background-color: #ddd;
+  padding: 5px;
+  font-weight: bold;
+  border-bottom: 1px solid #eee;
+  }
+</style>
+
+<h1>My Books</h1>
+
+<div class="item">
+  <a href="/account/loans">My Loans &amp; Holds ($len(mybooks.loans))</a>
+</div>
+
+<div class="item">
+  <a href="/account/books/want-to-read">Want to Read ($mybooks.reading_log_counts['want-to-read'])</a>
+
+</div>
+<div class="item">
+  <a href="/account/books/currently-reading">Currently Reading ($mybooks.reading_log_counts['currently-reading'])</a>
+</div>
+<div class="item">
+  <a href="/account/books/already-read">Already Read ($mybooks.reading_log_counts['already-read'])</a>
+</div>
+
+<div class="item">
+  <a href="/account/lists">My Lists ($(len(mybooks.lists)))</a>
+</div>
+
+<div class="item">
+  <a href="/account/books/already-read/stats">My Reading Stats</a>
+</div>

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -5,19 +5,20 @@ $ component_times['TotalTime'] = time()
 
 $ username = user.key.split('/')[-1]
 
-<div class="mybooks-options">
-  <span class="chip value-chip chip--selectable">
+<div class="chip-group">
+  <span class="chip value-chip category-chip chip--selectable">
     <a data-ol-link-track="MyBooksSidebar|ReadingStats"
        href="/account/books/already-read/stats">$_('My Reading Stats')</a>
   </span>
-  <span class="chip value-chip chip--selectable">
+  <span class="chip value-chip category-chip chip--selectable">
     <a data-ol-link-track="MyBooksSidebar|ImportExport"
-       href="/account/import">$_("Import & Export Options")</a>
+       href="/account/import">$_('Import & Export Options')</a>
   </span>
 </div>
 
 $code:
-    def compact_carousel(key, title, url):
+    def compact_carousel(data):
+        key, title, url = data
         books = mybooks[key].docs
         count = mybooks[key].total_results
         return render_template("books/custom_carousel", **{
@@ -29,31 +30,23 @@ $code:
             "load_more": None,
             "compact_mode": True,
             "test": False
-        })
+        }) if books else None
 
-$if mybooks['loans'].docs:
-  $:compact_carousel("loans", _('My Loans'), url="/account/loans")
-
-$if mybooks['currently-reading'].docs:
-  $:compact_carousel("currently-reading", _('Currently Reading'), url="/account/books/currently-reading")
-$else:
+$def empty_carousel(data):
+  $ key, title, url = data
   <div class="carousel-section-header">
-    <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
+    <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
   </div>
-  <li>$_('No books are on this shelf')</li>
+  <p>$_('No books are on this shelf')</p>
 
-$if mybooks['want-to-read'].docs:
-  $:compact_carousel("want-to-read", _('Want to Read'), url="/account/books/want-to-read")
-$else:
-  <div class="carousel-section-header">
-    <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
-  </div>
-  <li>$_('No books are on this shelf')</li>
+$# Data for carousels
+$ loans = ["loans", _('My Loans'), "/account/loans"]
+$ currently_reading = ["currently-reading", _('Currently Reading'), "/account/books/currently-reading"]
+$ want_to_read = ["want-to-read", _('Want to Read'), "/account/books/want-to-read"]
+$ already_read = ["already-read", _('Already Read'), "/account/books/already-read"]
 
-$if mybooks['already-read'].docs:
-  $:compact_carousel("already-read", _('Already Read'), url="/account/books/already-read")
-$else:
-  <div class="carousel-section-header">
-    <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>
-  </div>
-  <li>$_('No books are on this shelf')</li>
+$# Render carousels
+$:(compact_carousel(loans) or empty_carousel(loans))
+$:(compact_carousel(currently_reading) or empty_carousel(currently_reading))
+$:(compact_carousel(want_to_read) or empty_carousel(want_to_read))
+$:(compact_carousel(already_read) or empty_carousel(already_read))

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -5,6 +5,39 @@ $ component_times['TotalTime'] = time()
 
 $ username = user.key.split('/')[-1]
 
+$if len(mybooks['loans']) == 0:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="loans" href="/account/loans">$_('Loans (0)')</a></h2>
+  </div>
+  <div><em>$_("You've not checked out any books at this moment.")</em></div>
+  <br>
+$else:
+  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans")
+
+$if mybooks['currently-reading'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
+$if mybooks['want-to-read'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
+$if mybooks['already-read'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
 <style type="text/css">
   .item {
   background-color: #ddd;
@@ -14,4 +47,3 @@ $ username = user.key.split('/')[-1]
   }
 </style>
 
-$mybooks

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -12,10 +12,11 @@ $if len(mybooks['loans']) == 0:
   <div><em>$_("You've not checked out any books at this moment.")</em></div>
   <br>
 $else:
-  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans")
+  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans", min_books=1, load_more=None, test=False, compact_mode=True)
 
 $if mybooks['currently-reading'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading")
+  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading", min_books=1, load_more=None, test=False, compact_mode=True)
+
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
@@ -23,7 +24,7 @@ $else:
   <li>$_('No books are on this shelf')</li>
 
 $if mybooks['want-to-read'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read")
+  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read", min_books=1, load_more=None, test=False, compact_mode=True)
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
@@ -31,7 +32,7 @@ $else:
   <li>$_('No books are on this shelf')</li>
 
 $if mybooks['already-read'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read")
+  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read", min_books=1, load_more=None, test=False, compact_mode=True)
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -26,7 +26,7 @@ $ counts = counts or pa.get_sidebar_counts
         <li><a data-ol-link-track="MyBooksSidebar|MyNotes" $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
         <li><a data-ol-link-track="MyBooksSidebar|MyReviews" $('class=selected' if key=='observations' else '') href="/people/$username/books/observations"><span class="li-count">$counts['observations']</span>$_('My Reviews')</a></li>
         <hr>
-        <li><a data-ol-link-track="MyBooksSidebar|ReadingStats" href="/account/books/already-read/stats">$_('Reading Stats')</a></li>
+        <li><a data-ol-link-track="MyBooksSidebar|ReadingStats" href="/account/books/already-read/stats">$_('My Reading Stats')</a></li>
         <li><a data-ol-link-track="MyBooksSidebar|ImportExport" href="/account/import" $('class=selected' if key=='imports' else '')>$_("Import & Export Options")</a></li>
       </ul>
     $if owners_page and ctx.user and ctx.user.in_sponsorship_beta():

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -12,10 +12,11 @@ $def render_carousel_cover(book, lazy):
   $ url = book.get('key') or book.url
   $ title = book.title
 
+  $ cover_id = book.get('cover_id') or book.get('cover_i') or book.get('covers') and book['covers'][0]
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
-  $elif book.get('cover_id') or book.get('cover_i'):
-    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, book.get('cover_id') or book.get('cover_i'))
+  $elif cover_id:
+    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, cover_id)
   $elif book.get('ia'):
     $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
   $elif book.get('cover_edition_key'):
@@ -64,7 +65,7 @@ $def render_carousel_cover(book, lazy):
   </div>
 
 $if test or (books and len(books) >= min_books):
-      <div class="carousel-section">
+    <div class="carousel-section">
       $if title and url:
         <div class="carousel-section-header">
           <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
@@ -83,7 +84,8 @@ $if test or (books and len(books) >= min_books):
           $ config = ['.carousel-' + key, 4, 4, 4, 3, 2, 1, load_more_config ]
         $else:
           $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
-        <div class="carousel carousel-$key carousel--progressively-enhanced"
+        $ compact = "carousel--compact" if compact_mode else ""  
+        <div class="carousel $compact carousel-$key carousel--progressively-enhanced"
           data-config="$json_encode(config)">
           $for index, book in enumerate(books or []):
               $:render_carousel_cover(book, index > 5)

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -84,7 +84,7 @@ $if test or (books and len(books) >= min_books):
           $ config = ['.carousel-' + key, 4, 4, 4, 3, 2, 1, load_more_config ]
         $else:
           $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
-        $ compact = "carousel--compact" if compact_mode else ""  
+        $ compact = "carousel--compact" if compact_mode else ""
         <div class="carousel $compact carousel-$key carousel--progressively-enhanced"
           data-config="$json_encode(config)">
           $for index, book in enumerate(books or []):

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -15,7 +15,7 @@ $def render_carousel_cover(book, lazy):
   $ cover_id = book.get('cover_id') or book.get('cover_i') or book.get('covers') and book['covers'][0]
   $if book.get('cover_url'):
     $ cover_url = book.get('cover_url')
-  $elif cover_id:
+  $elif cover_id and cover_id != -1:
     $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, cover_id)
   $elif book.get('ia'):
     $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -6,7 +6,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
 
   $if ctx.user:
     $ loginLinks = [
-    $     { "href": "/account/loans", "text": _("My Books"), "track": "MyBooks", "subheading": _("Loans, Reading Log, Lists, Stats") },
+    $     { "href": "/account/books", "text": _("My Books"), "track": "MyBooks", "subheading": _("Loans, Reading Log, Lists, Stats") },
     $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MyProfile" },
     $     { "href": homepath() + "/account", "text": _("Settings"), "track": "MySettings" },
     $     { "post": "/account/logout", "text": _("Log out"), "track": "Logout" },
@@ -18,7 +18,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
     $     { "loginClass": "login-links" }
     $ ]
   $ myBooksLinks = [
-  $     { "href": homepath() + "/account/loans", "text": _("My Books"), "track": "MyBooks" },
+  $     { "href": homepath() + "/account/books", "text": _("My Books"), "track": "MyBooks" },
   $ ]
   $ browseLinks = [
   $     { "href": "/subjects", "text": _("Subjects"), "track": "Subjects" },

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -47,7 +47,7 @@ a.hoverlink {
 
 .local-date-time {
   color: @dark-green;
-  font-size: .9em;
+  font-size: .7em;
   text-align: center;
   padding: 5px 0 0;
 }

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -44,3 +44,10 @@ a.hoverlink {
   text-decoration: underline;
   text-decoration-style: dotted;
 }
+
+.local-date-time {
+  color: @dark-green;
+  font-size: 0.9em;
+  text-align: center;
+  padding: 5px 0 0 0;
+}

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -47,7 +47,7 @@ a.hoverlink {
 
 .local-date-time {
   color: @dark-green;
-  font-size: 0.9em;
+  font-size: .9em;
   text-align: center;
-  padding: 5px 0 0 0;
+  padding: 5px 0 0;
 }

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -47,7 +47,7 @@ a.hoverlink {
 
 .local-date-time {
   color: @dark-green;
-  font-size: .7em;
+  font-size: 11px;
   text-align: center;
   padding: 5px 0 0;
 }

--- a/static/css/components/buttonBtn.less
+++ b/static/css/components/buttonBtn.less
@@ -31,7 +31,7 @@ a {
 .chip a{
   text-decoration: none;
 }
-  
+
 .chip--selectable {
   cursor: pointer;
 }

--- a/static/css/components/buttonBtn.less
+++ b/static/css/components/buttonBtn.less
@@ -19,3 +19,34 @@ a {
     text-decoration: none;
   }
 }
+
+/* These should be in their own chip.less file */
+.chip {
+  padding: 4px 12px;
+  border: 1px solid @mid-grey;
+  border-radius: 16px;
+  user-select: none;
+}
+
+.chip a{
+  text-decoration: none;
+}
+  
+.chip--selectable {
+  cursor: pointer;
+}
+
+.chip--selectable:hover {
+  background-color: @grey-e7e7e7;
+}
+
+.chip--selected {
+  background-color: @white;
+  border-color: @primary-blue;
+  color: @primary-blue;
+  background-color: @grey-e7e7e7;
+}
+
+.chip--selected:hover {
+  background-color: @white;
+}

--- a/static/css/components/buttonBtn.less
+++ b/static/css/components/buttonBtn.less
@@ -41,7 +41,6 @@ a {
 }
 
 .chip--selected {
-  background-color: @white;
   border-color: @primary-blue;
   color: @primary-blue;
   background-color: @grey-e7e7e7;
@@ -49,4 +48,14 @@ a {
 
 .chip--selected:hover {
   background-color: @white;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.category-chip {
+  margin-right: 1em;
+  margin-bottom: .5em;
 }

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -173,8 +173,7 @@
   .book .book-cover {
     height: @height-cover-compact;
   }
-
-  .book img.bookcover {
+  .book .bookcover {
     height: @height-cover-compact;
   }
   .carousel__item__blankcover {

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -167,7 +167,6 @@
     font-style: oblique;
   }
 }
-
 @height-cover-compact: 125px;
 .carousel--compact {
   .book .book-cover {
@@ -178,6 +177,8 @@
   }
   .carousel__item__blankcover {
     height: @height-cover-compact;
+    padding: 20% 10px 10px;
+    margin: 0 auto;
   }
 }
 

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -168,6 +168,20 @@
   }
 }
 
+@height-cover-compact: 125px;
+.carousel--compact {
+  .book .book-cover {
+    height: @height-cover-compact;
+  }
+  
+  .book img.bookcover {
+    height: @height-cover-compact;
+  }
+  .carousel__item__blankcover {
+    height: @height-cover-compact;
+  }
+}
+
 .slick {
   // This is a fix for firefox + Librejs
   // because the slick css passed through js

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -173,7 +173,7 @@
   .book .book-cover {
     height: @height-cover-compact;
   }
-  
+
   .book img.bookcover {
     height: @height-cover-compact;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Prototype of #6857

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

https://testing.openlibrary.org/account/books

1. The My Books nav header + My Books hamburger go to a dedicated My Books page
2. compact_mode now not only fixes width issues in My Books but also takes up far less vertical space
3. I borrowed the chip code from @Jim Champ + community reviews to add My Reading Stats at the top of the design
4. My Books is much faster due to removal of logged_in_user.update_loan_status() call
5. I was able to DRY up the code a ton (other than chip and a bit of lazy less placement) 
6. Added bonus: This new My Books view looks significantly better than our existing views in mobile, so it's a great improvement until mobile designs land!

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

http://ol-dev1.us.archive.org:1337/people/mekBot/books?debug=true

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

## With loans

![testing openlibrary org_people_mekBot_books (2)](https://user-images.githubusercontent.com/978325/208228506-064d5f8e-9367-475b-ac7f-0150ba398c7f.png)

## Empty Shelf

![testing openlibrary org_people_mekBot_books (1)](https://user-images.githubusercontent.com/978325/208228509-8c1da377-1cc6-47d3-a375-aa82953900d3.png)
### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
