### PR TITLE
Hotfix/resolve redirects

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -632,7 +632,9 @@ class Work(Thing):
                 r['updates']['readinglog'] = Bookshelves.update_work_id(
                     olid, new_olid, _test=test
                 )
-                r['updates']['ratings'] = Ratings.update_work_id(olid, new_olid, _test=test)
+                r['updates']['ratings'] = Ratings.update_work_id(
+                    olid, new_olid, _test=test
+                )
                 r['updates']['booknotes'] = Booknotes.update_work_id(
                     olid, new_olid, _test=test
                 )
@@ -640,9 +642,8 @@ class Work(Thing):
                     olid, new_olid, _test=test
                 )
                 summary['modified'] = summary['modified'] or any(
-                    any(r['updates'][group].values()) for group in [
-                        'readinglog', 'ratings', 'booknotes', 'observations'
-                    ]
+                    any(r['updates'][group].values())
+                    for group in ['readinglog', 'ratings', 'booknotes', 'observations']
                 )
 
         return summary
@@ -701,7 +702,7 @@ class Work(Thing):
                 else:
                     chain = Work.resolve_redirect_chain(work.key, test=test)
                     if chain['modified']:
-                        fixed +=1
+                        fixed += 1
                         logger.info(
                             f"[update-redirects] Update: #{pos} fix#{fixed} <{work.key}> {chain}"
                         )

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -224,11 +224,15 @@ class resolve_redirects:
     def main(self, test=False):
         params = web.input(key='', test='')
 
+        # Provide an escape hatch to let GET requests resolve
+        if test is True and params.test == 'false':
+            test = False
+
         # Provide an escape hatch to let POST requests preview
-        if test is False and params.test:
+        elif test is False and params.test:
             test = True
 
-        summary = Work.get_redirect_chain(params.key, test=test)
+        summary = Work.resolve_redirect_chain(params.key, test=test)
 
         return delegate.RawText(json.dumps(summary), content_type="application/json")
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

1. Repairs the /admin/resolve-redirects endpoint
  * Allows ?test=false for GET
  * Fixes the call to resolve redirects (outdated invocation)
2. Upgrades resolve_redirect_chain
  * Doesn't attempt unnecessary table updates on the latest resolved_work
  * Returns a value `modified` for whether the chain has performed updates
3. Upgrades bulk_redirects
  * Shows number of fixes
  * Only shows json `{chain}` for chains which underwent updates

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
