### PR TITLE
scrubs IPs from ?m=history json api

### DIFF
--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -11,6 +11,9 @@ import web
 
 from infogami import config
 from infogami.core import code as core
+from infogami.plugins.api.code import jsonapi, make_query
+from infogami.plugins.api.code import request as infogami_request
+
 from infogami.infobase import client
 from infogami.utils import delegate, app, types
 from infogami.utils.view import public, safeint, render
@@ -40,6 +43,25 @@ class static(delegate.page):
     def GET(self):
         host = 'https://%s' % web.ctx.host if 'openlibrary.org' in web.ctx.host else ''
         raise web.seeother(host + '/static' + web.ctx.path)
+
+
+class history(delegate.mode):
+    """Overwrite ?m=history to remove IP"""
+
+    encoding = "json"
+
+    @jsonapi
+    def GET(self, path):
+        query = make_query(web.input(), required_keys=['author', 'offset', 'limit'])
+        query['key'] = path
+        query['sort'] = '-created'
+        # Possibly use infogami.plugins.upstream.utils get_changes to avoid json load/dump?
+        history = json.loads(
+            infogami_request('/versions', data=dict(query=json.dumps(query)))
+        )
+        for i, row in enumerate(history):
+            history[i].pop("ip")
+        return json.dumps(history)
 
 
 class edit(core.edit):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7039

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

There may be a better way to do this (calling the API directly and using a specific json decoder for the datetime) which doesn't require us fetching the raw text via the API, loading as json, and then dumping json again (which seems like a wasteful performance hit). I imagine it's being called relatively infrequently and so may be OK.

**Another technical note, we may want to simply REDACT the `ip` (leaving the field) in case anything relies on the key being present**

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

https://testing.openlibrary.org/authors/OL117575A.json?m=history&debug=true

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tfmorris @cdrini @jimchamp @bfalling 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
