### PR TITLE
Affiliate service: Fix two issues related to None

### DIFF
--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -216,9 +216,13 @@ class AmazonAPI:
             and item_info.classifications.product_group.display_value
         )
         try:
-            publish_date = edition_info and isoparser.parse(
-                edition_info.publication_date.display_value
-            ).strftime('%b %d, %Y')
+            publish_date = (
+                edition_info
+                and edition_info.publication_date
+                and isoparser.parse(
+                    edition_info.publication_date.display_value
+                ).strftime('%b %d, %Y')
+            )
         except Exception:
             logger.exception(f"serialize({product})")
             publish_date = None
@@ -247,7 +251,7 @@ class AmazonAPI:
                 else None
             ),
             'authors': attribution
-            and [{'name': contrib.name} for contrib in attribution.contributors],
+            and [{'name': contrib.name} for contrib in attribution.contributors or []],
             'publishers': list({p for p in (brand, manufacturer) if p}),
             'number_of_pages': (
                 edition_info


### PR DESCRIPTION
<!-- What issue does this PR close? -->

When looking at the logs of the affiliate service, we noticed two exceptions being thrown:
% `ol-home0% docker logs -f --tail 10 openlibrary_affiliate-server_1`
```
Traceback (most recent call last):
  File "/openlibrary/openlibrary/core/vendors.py", line 220, in serialize
    edition_info.publication_date.display_value
AttributeError: 'NoneType' object has no attribute 'display_value'
```
```
Traceback (most recent call last):
  [ ... ]
  File "/openlibrary/openlibrary/core/vendors.py", line 250, in serialize
    and [{'name': contrib.name} for contrib in attribution.contributors],
TypeError: 'NoneType' object is not iterable
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->
https://github.com/internetarchive/openlibrary/wiki/Deployment-Guide#recovering-from-restart-loops
`docker exec -it openlibrary_affiliate-server_1 bash`
* `vi openlibrary/core/vendors.py`
* `exit`

`docker restart openlibrary_affiliate-server_1`
`docker logs -f --tail 10 openlibrary_affiliate-server_1 2>&1 | grep Error`
All quiet on the western front.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
