### PR TITLE
Flake8: Go from a select list to an exclude list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ lint-diff:
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --extend-ignore=E203,E402,E722,F811,F841,W504 --max-complexity=48 --max-line-length=88 --show-source --statistics
+	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --extend-ignore=E203,E402,E722,F401,F811,F841,W504 \
+	    --max-complexity=48 --max-line-length=$(GITHUB_EDITOR_WIDTH) --show-source --statistics
 
 test-py:
 	pytest . --ignore=tests/integration --ignore=infogami --ignore=vendor --ignore=node_modules

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,7 @@ lint-diff:
 
 lint:
 	# stop the build if there are Python syntax errors or undefined names
-	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --select=E9,F63,F7,F82 --show-source --statistics
-ifndef CI
-	# exit-zero treats all errors as warnings, only run this in local dev while fixing issue, not CI as it will never fail.
-	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --exit-zero --max-complexity=10 --max-line-length=$(GITHUB_EDITOR_WIDTH) --statistics
-endif
+	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --extend-ignore=E203,E402,E722,F811,F841,W504 --max-complexity=48 --max-line-length=88 --show-source --statistics
 
 test-py:
 	pytest . --ignore=tests/integration --ignore=infogami --ignore=vendor --ignore=node_modules

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 
 BUILD=static/build
 ACCESS_LOG_FORMAT='%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
-GITHUB_EDITOR_WIDTH=127
 FLAKE_EXCLUDE=./.*,vendor/*,node_modules/*
 COMPONENTS_DIR=openlibrary/components
 
@@ -72,7 +71,7 @@ lint-diff:
 lint:
 	# stop the build if there are Python syntax errors or undefined names
 	$(PYTHON) -m flake8 . --count --exclude=$(FLAKE_EXCLUDE) --extend-ignore=E203,E402,E722,F401,F811,F841,W504 \
-	    --max-complexity=48 --max-line-length=$(GITHUB_EDITOR_WIDTH) --show-source --statistics
+	    --max-complexity=48 --max-line-length=1195 --show-source --statistics
 
 test-py:
 	pytest . --ignore=tests/integration --ignore=infogami --ignore=vendor --ignore=node_modules

--- a/openlibrary/accounts/__init__.py
+++ b/openlibrary/accounts/__init__.py
@@ -2,10 +2,11 @@ import web
 
 # FIXME: several modules import things from accounts.model
 # directly through openlibrary.accounts
-from .model import *
+from .model import *  # noqa: F403
+from .model import Account, Link
 
 
-## Unconfirmed functions (I'm not sure that these should be here)
+# Unconfirmed functions (I'm not sure that these should be here)
 def get_group(name):
     """
     Returns the group named 'name'.
@@ -43,7 +44,7 @@ class RunAs:
         web.ctx.conn.set_auth_token(self.calling_user_auth_token)
 
 
-## Confirmed functions (these have to be here)
+# Confirmed functions (these have to be here)
 def get_current_user():
     """
     Returns the currently logged in user. None if not logged in.

--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -39,6 +39,7 @@ class NoStats(TypeError):
 
 sqlitefile = None
 
+
 # Utility functions
 def query_single_thing(db, typ, start, end):
     "Query the counts a single type from the things table"

--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -193,7 +193,7 @@ class OpenLibrary:
                     break
                 q['offset'] += len(result)
 
-        if 'limit' in q and q['limit'] == False:
+        if 'limit' in q and q['limit'] is False:
             return unlimited_query(q)
         else:
             response = self._request("/query.json", params=dict(query=json.dumps(q)))

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -119,7 +119,7 @@ class InternetArchiveProvider(AbstractBookProvider[IALiteMetadata]):
 
     @property
     def solr_key(self):
-        return f"ia"
+        return "ia"
 
     def get_identifiers(self, ed_or_solr: Union[Edition, dict]) -> list[str]:
         # Solr work record augmented with availability

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -501,7 +501,7 @@ def find_exact_match(rec, edition_pool):
                     continue
                 if k == 'languages':
                     existing_value = [
-                        str(re_lang.match(l.key).group(1)) for l in existing_value
+                        str(re_lang.match(lang.key).group(1)) for lang in existing_value
                     ]
                 if k == 'authors':
                     existing_value = [dict(a) for a in existing_value]

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -208,11 +208,10 @@ def build_query(rec):
                     book['authors'].append(import_author(author, eastern=east))
             continue
         if k == 'languages':
-            langs = []
-            for l in v:
-                if web.ctx.site.get('/languages/' + l) is None:
-                    raise InvalidLanguage(l)
-            book['languages'] = [{'key': '/languages/' + l} for l in v]
+            for language in v:
+                if web.ctx.site.get('/languages/' + language) is None:
+                    raise InvalidLanguage(language)
+            book['languages'] = [{'key': '/languages/' + language} for language in v]
             continue
         if k in type_map:
             t = '/type/' + type_map[k]

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -141,8 +141,8 @@ def test_load_test_item(mock_site, add_languages, ia_writeback):
     assert e.title == 'Test item'
     assert e.ocaid == 'test_item'
     assert e.source_records == ['ia:test_item']
-    l = e.languages
-    assert len(l) == 1 and l[0].key == '/languages/eng'
+    languages = e.languages
+    assert len(languages) == 1 and languages[0].key == '/languages/eng'
 
     assert reply['work']['status'] == 'created'
     w = mock_site.get(reply['work']['key'])

--- a/openlibrary/catalog/marc/marc_xml.py
+++ b/openlibrary/catalog/marc/marc_xml.py
@@ -39,11 +39,16 @@ class DataField:
         self.element = element
 
     def remove_brackets(self):
-        f = self.element[0]
-        l = self.element[-1]
-        if f.text and l.text and f.text.startswith('[') and l.text.endswith(']'):
-            f.text = f.text[1:]
-            l.text = l.text[:-1]
+        first = self.element[0]
+        last = self.element[-1]
+        if (
+            first.text
+            and last.text
+            and first.text.startswith('[')
+            and last.text.endswith(']')
+        ):
+            first.text = first.text[1:]
+            last.text = last.text[:-1]
 
     def ind1(self):
         return self.element.attrib['ind1']

--- a/openlibrary/catalog/marc/tests/test_marc.py
+++ b/openlibrary/catalog/marc/tests/test_marc.py
@@ -144,7 +144,7 @@ class TestMarcParse(unittest.TestCase):
                     'subjects': ['Great Britain', 'Relations'],
                 },
             ),
-            #'Great Britain -- Relations -- West Indies, British.'),
+            # 'Great Britain -- Relations -- West Indies, British.'),
             (
                 [
                     ('a', 'West Indies, British'),
@@ -156,7 +156,7 @@ class TestMarcParse(unittest.TestCase):
                     'subjects': ['British West Indies', 'Relations'],
                 },
             )
-            #'West Indies, British -- Relations -- Great Britain.')
+            # 'West Indies, British -- Relations -- Great Britain.')
         ]
         for value, expect in data:
             output = subjects_for_work(MockRecord('650', value))

--- a/openlibrary/catalog/marc/tests/test_marc_html.py
+++ b/openlibrary/catalog/marc/tests/test_marc_html.py
@@ -40,7 +40,7 @@ def test_html_line_utf8():
         ),
     ]
     hr = html_record(b'00053Thisais the leader.Now we are beyond the leader.')
-    assert hr.is_marc8 == False
+    assert hr.is_marc8 is False
     for tag, input_, output in samples:
         expect = '<large>{}</large> <code>{}</code>'.format(tag.decode('utf-8'), output)
         assert hr.html_line(tag, input_) == expect

--- a/openlibrary/catalog/merge/test_names.py
+++ b/openlibrary/catalog/merge/test_names.py
@@ -39,7 +39,7 @@ def test_names(amazon, marc):
 
 def test_flip_name():
     assert names.flip_name("Smith, John") == "John Smith"
-    assert names.flip_name("John Smith") == None
+    assert names.flip_name("John Smith") is None
 
 
 def test_compare_part():

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -100,7 +100,7 @@ def remove_trailing_dot(s):
 
 
 def fix_l_in_date(date):
-    if not 'l' in date:
+    if 'l' not in date:
         return date
     return re_l_in_date.sub(lambda m: m.group(1).replace('l', '1'), date)
 

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -721,11 +721,11 @@ class Loan(dict):
                 'ocaid': identifier,
                 'expiry': expiry,
                 'uuid': _uuid,
-                'resource_type': 'bookreader',
-                'resource_id': 'bookreader:%s' % identifier,
+                'resource_type': 'bookreader',  # noqa: F601
+                'resource_id': 'bookreader:%s' % identifier,  # noqa: F601
                 'loaned_at': loaned_at,
-                'resource_type': resource_type,
-                'resource_id': resource_id,
+                'resource_type': resource_type,  # noqa: F601
+                'resource_id': resource_id,  # noqa: F601
                 'loan_link': loan_link,
             }
         )

--- a/openlibrary/core/middleware.py
+++ b/openlibrary/core/middleware.py
@@ -13,7 +13,7 @@ class GZipMiddleware:
 
     def __call__(self, environ, start_response):
         accept_encoding = environ.get("HTTP_ACCEPT_ENCODING", "")
-        if not 'gzip' in accept_encoding:
+        if 'gzip' not in accept_encoding:
             return self.app(environ, start_response)
 
         response = web.storage(compress=False)

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -702,7 +702,7 @@ class Work(Thing):
                         )
             batch += 1
 
-        logger.info(f"[update-redirects] Done")
+        logger.info("[update-redirects] Done")
 
 
 class Author(Thing):

--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -16,7 +16,7 @@ from statsd import StatsClient
 
 from infogami import config
 
-l = logging.getLogger("openlibrary.pystats")
+pystats_logger = logging.getLogger("openlibrary.pystats")
 
 
 def create_stats_client(cfg=config):
@@ -40,7 +40,7 @@ def put(key, value, rate=1.0):
     "Records this ``value`` with the given ``key``. It is stored as a millisecond count"
     global client
     if client:
-        l.debug(f"Putting {value} as {key}")
+        pystats_logger.debug(f"Putting {value} as {key}")
         client.timing(key, value, rate)
 
 
@@ -48,7 +48,7 @@ def increment(key, n=1, rate=1.0):
     "Increments the value of ``key`` by ``n``"
     global client
     if client:
-        l.debug("Incrementing %s" % key)
+        pystats_logger.debug("Incrementing %s" % key)
         for i in range(n):
             try:
                 client.increment(key, sample_rate=rate)

--- a/openlibrary/coverstore/tests/test_code.py
+++ b/openlibrary/coverstore/tests/test_code.py
@@ -54,7 +54,7 @@ class Test_cover:
         monkeypatch.setattr(code, "get_tar_index", _get_tar_index)
         f = code.cover().get_tar_filename
 
-        assert f(42, "s") == None
+        assert f(42, "s") is None
 
         offsets[42] = 1234
         sizes[42] = 567

--- a/openlibrary/mocks/tests/test_mock_memcache.py
+++ b/openlibrary/mocks/tests/test_mock_memcache.py
@@ -18,10 +18,10 @@ class Test_mock_memcache:
     def test_add(self):
         m = mock_memcache.Client([])
 
-        assert m.add("a", 1) == True
+        assert m.add("a", 1) is True
         assert m.get("a") == 1
 
-        assert m.add("a", 2) == False
+        assert m.add("a", 2) is False
 
 
 mc = memcache.Client(servers=[])

--- a/openlibrary/plugins/importapi/import_edition_builder.py
+++ b/openlibrary/plugins/importapi/import_edition_builder.py
@@ -73,7 +73,7 @@ class import_edition_builder:
         return self.edition_dict
 
     def add(self, key, val, restrict_keys=True):
-        if restrict_keys and not key in self.type_dict:
+        if restrict_keys and key not in self.type_dict:
             print('import_edition_builder invalid key: ' + key)
             return
 

--- a/openlibrary/plugins/openlibrary/filters.py
+++ b/openlibrary/plugins/openlibrary/filters.py
@@ -4,7 +4,7 @@ Filters used to check if a certain statistic should be recorded
 import re
 import logging
 
-l = logging.getLogger("openlibrary.stats_filters")
+logger = logging.getLogger("openlibrary.stats_filters")
 
 import web
 from infogami import config
@@ -16,7 +16,7 @@ def all(**params):
 
 
 def url(**params):
-    l.debug("Evaluate url '%s'" % web.ctx.path)
+    logger.debug("Evaluate url '%s'" % web.ctx.path)
     if re.search(params['pattern'], web.ctx.path):
         return True
     else:

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -497,8 +497,8 @@ class list_subjects_json(delegate.page):
 
     def get_subjects(self, lst, limit):
         data = lst.get_subjects(limit=limit)
-        for key, subjects in data.items():
-            data[key] = [self._process_subject(s) for s in subjects]
+        for key, subjects_ in data.items():
+            data[key] = [self._process_subject(s) for s in subjects_]
         return dict(data)
 
     def _process_subject(self, s):

--- a/openlibrary/plugins/openlibrary/opds.py
+++ b/openlibrary/plugins/openlibrary/opds.py
@@ -102,7 +102,7 @@ class OPDS:
     # create_root()
     # ___________________________________________________________________________
     def create_root(self, root_name):
-        ### TODO: add updated element and uuid element
+        # ## TODO: add updated element and uuid element
         opds = ET.Element(OPDS.atom + root_name, nsmap=OPDS.nsmap)
 
         return opds

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -13,14 +13,11 @@ from infogami.utils.app import find_page, find_view, find_mode
 from openlibrary.core import stats as graphite_stats
 import web
 from infogami import config
-from infogami.utils import (
-    delegate,
-    stats,
-)
+from infogami.utils import delegate, stats
 
 import openlibrary.plugins.openlibrary.filters as stats_filters
 
-l = logging.getLogger("openlibrary.stats")
+logger = logging.getLogger("openlibrary.stats")
 TIME_BUCKETS = [10, 100, 1000, 5000, 10000, 20000]  # in ms
 
 filters: dict[str, Any] = {}
@@ -35,7 +32,7 @@ def evaluate_and_store_stat(name, stat, summary):
     try:
         f = filters[stat.filter]
     except KeyError:
-        l.warning("Filter %s not registered", stat.filter)
+        logger.warning("Filter %s not registered", stat.filter)
         return
     try:
         if f(**stat):
@@ -46,10 +43,10 @@ def evaluate_and_store_stat(name, stat, summary):
                 # XXX-Anand: where is the code to update counts?
                 pass
             else:
-                l.warning("No storage item specified for stat %s", name)
+                logger.warning("No storage item specified for stat %s", name)
     except Exception as k:
-        l.warning("Error while storing stats (%s). Complete traceback follows" % k)
-        l.warning(traceback.format_exc())
+        logger.warning("Error while storing stats (%s). Complete traceback follows" % k)
+        logger.warning(traceback.format_exc())
 
 
 def update_all_stats(stats_summary):

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -32,7 +32,7 @@ import urllib
 
 logger = logging.getLogger("openlibrary.borrow")
 
-########## Constants
+# ######### Constants
 
 lending_library_subject = 'Lending library'
 in_library_subject = 'In library'
@@ -69,7 +69,8 @@ except AttributeError:
 
 bookreader_stream_base = f'https://{bookreader_host}/stream'
 
-########## Page Handlers
+
+# ######### Page Handlers
 
 # Handler for /books/{bookid}/{title}/borrow
 class checkout_with_ocaid(delegate.page):
@@ -470,7 +471,7 @@ class ia_borrow_notify(delegate.page):
             waitinglist.on_waitinglist_update(identifier)
 
 
-########## Public Functions
+# ######### Public Functions
 
 
 @public
@@ -522,7 +523,7 @@ def get_bookreader_host():
     return bookreader_host
 
 
-########## Helper Functions
+# ######### Helper Functions
 
 
 def get_all_store_values(**query):

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -297,7 +297,7 @@ class TestAccount:
         assert b.path == "/account"
 
         b.reset()
-        assert self.login(b, "foo", "more_secret") == True
+        assert self.login(b, "foo", "more_secret") is True
 
     def test_change_email(self, ol):
         b = ol.browser()

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -25,8 +25,6 @@ def test_urlencode():
     assert f({'q': 1}) == 'q=1', 'numbers'
     assert f({'q': ['test']}) == 'q=%5B%27test%27%5D', 'list'
     assert f({'q': 'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'unicode without the u'
-    # Can't run this since it's a SyntaxError in python3... But it passes in Python 2
-    # assert f({'q': b'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'byte-string unicode?'
     assert f({'q': 'αβγ'.encode()}) == 'q=%CE%B1%CE%B2%CE%B3', 'uf8 encoded unicode'
     assert f({'q': 'αβγ'}) == 'q=%CE%B1%CE%B2%CE%B3', 'unicode'
 
@@ -88,7 +86,7 @@ def test_set_share_links_unicode():
 def test_item_image():
     assert utils.item_image('//foo') == 'https://foo'
     assert utils.item_image(None, 'bar') == 'bar'
-    assert utils.item_image(None) == None
+    assert utils.item_image(None) is None
 
 
 def test_canonical_url():

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1128,7 +1128,7 @@ def setup():
 
     web.template.Template.globals.update(h.helpers)
 
-    if config.get('use_gzip') == True:
+    if config.get('use_gzip') is True:
         config.middleware.append(GZipMiddleware)
 
 

--- a/openlibrary/records/tests/test_functions.py
+++ b/openlibrary/records/tests/test_functions.py
@@ -27,7 +27,7 @@ def same_dict(a, b):
 
 def populate_infobase(site):
     "Dumps some documents into infobase"
-    ## Create two authors
+    # Create two authors
     atype = '/type/author'
     akey0 = site.new_key(atype)
     a0 = {'name': 'Test author 1', 'type': {'key': atype}, 'key': akey0}
@@ -35,7 +35,7 @@ def populate_infobase(site):
     akey1 = site.new_key(atype)
     a1 = {'name': 'Test author 1', 'type': {'key': atype}, 'key': akey1}
 
-    ## Create a work
+    # Create a work
     wtype = '/type/work'
     wkey = site.new_key(wtype)
     w = {
@@ -46,7 +46,7 @@ def populate_infobase(site):
     }
     site.save(w)
 
-    ## Create two editions for this work
+    # Create two editions for this work
     editions = []
     etype = '/type/edition'
     for i in range(2):
@@ -64,7 +64,7 @@ def populate_infobase(site):
         site.save(e)
         editions.append(ekey)
 
-    ## Now create a work without any edition
+    # Now create a work without any edition
     wkey = site.new_key(wtype)
     w = {
         'title': 'editionless',

--- a/openlibrary/solr/facet_hash.py
+++ b/openlibrary/solr/facet_hash.py
@@ -16,6 +16,7 @@ from hashlib import sha1 as mkhash
 
 facet_token_length = 12
 
+
 # turn v into a str object, by encoding from unicode or numeric
 # if necessary.
 def coerce_str(v):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -445,7 +445,7 @@ class SolrProcessor:
                 # raise AuthorRedirect
                 logger.warning('author redirect error: %s', w['key'])
 
-        ## Consider only the valid authors instead of raising an error.
+        # ## Consider only the valid authors instead of raising an error.
         # assert all(a['type']['key'] == '/type/author' for a in authors)
         authors = [a for a in authors if a['type']['key'] == '/type/author']
 

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -157,8 +157,8 @@ def test_match_with_bad_chars():
         ],
         ['Andrzej Weronski', 'Andrzej Wero\u0144ski', 'Andrzej Weron\u0301ski'],
     ]
-    for l in samples:
-        for a, b in combinations(l, 2):
+    for sample in samples:
+        for a, b in combinations(sample, 2):
             assert match_with_bad_chars(a, b)
 
 

--- a/openlibrary/tests/core/test_processors.py
+++ b/openlibrary/tests/core/test_processors.py
@@ -34,7 +34,7 @@ class MockSite:
 
 def test_MockSite():
     site = MockSite()
-    assert site.get("/books/OL1M") == None
+    assert site.get("/books/OL1M") is None
 
     book = {"key": "/books/OL1M", "type": {"key": "/type/edition"}, "title": "foo"}
     site.add(book)
@@ -72,7 +72,7 @@ def test_get_object():
     assert f("/books/OL1M") == "/books/OL1M"
     assert f("/b/OL1M") == "/books/OL1M"
     assert f("/whatever/OL1M") == "/books/OL1M"
-    assert f("/not-there") == None
+    assert f("/not-there") is None
 
 
 _mock_site = _get_mock_site()

--- a/openlibrary/tests/core/test_processors_invalidation.py
+++ b/openlibrary/tests/core/test_processors_invalidation.py
@@ -114,7 +114,7 @@ class TestInvalidationProcessor:
         p.reload()
 
         # until next 60 seconds, is_timeout must be false.
-        assert p.is_timeout() == False
+        assert p.is_timeout() is False
 
     def test_reload_on_cookie(self, monkeypatch):
         self._monkeypatch_web(monkeypatch)

--- a/openlibrary/tests/core/test_sponsors.py
+++ b/openlibrary/tests/core/test_sponsors.py
@@ -59,17 +59,17 @@ class TestSponsorship:
             sponsorships.requests, 'get', lambda url, **kwargs: {'invalid': 'json'}
         )
         dwwi, matches = do_we_want_it(isbn)
-        assert dwwi == False
+        assert dwwi is False
         assert matches == []
 
         monkeypatch.setattr(sponsorships.requests, 'get', lambda url, **kwargs: None)
         dwwi, matches = do_we_want_it(isbn)
-        assert dwwi == False
+        assert dwwi is False
         assert matches == []
 
         # We need a copy ...
         r = storage({'json': lambda: {"response": 1}})
         monkeypatch.setattr(sponsorships.requests, 'get', lambda url, **kwargs: r)
         dwwi, matches = do_we_want_it(isbn)
-        assert dwwi == True
+        assert dwwi is True
         assert matches == []

--- a/openlibrary/tests/core/test_waitinglist.py
+++ b/openlibrary/tests/core/test_waitinglist.py
@@ -41,4 +41,4 @@ class TestWaitingLoan:
 
     def test_prune_expired(self):
         # prune_expired does nothing now but 'return'
-        assert WaitingLoan.prune_expired() == None
+        assert WaitingLoan.prune_expired() is None

--- a/openlibrary/utils/tests/test_processors.py
+++ b/openlibrary/utils/tests/test_processors.py
@@ -15,8 +15,8 @@ class TestRateLimitProcessor:
         p = RateLimitProcessor(10)
 
         for i in range(10):
-            assert p.check_rate() == True
-        assert p.check_rate() == False
+            assert p.check_rate() is True
+        assert p.check_rate() is False
 
     def test_get_window(self, monkeypatch):
         p = RateLimitProcessor(10, window_size=10)


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Currently, our flake8 tests select a handful of error codes to check. This PR reverses that so we ignore a handful of errors instead.  This has become much easier to do now that we run black and mypy in pre-commit.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with essential attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
