### PR TITLE
NoneType object has no attribute author

### DIFF
--- a/openlibrary/templates/diff.html
+++ b/openlibrary/templates/diff.html
@@ -32,7 +32,7 @@ $def display_revision(page):
     <div class="small sansserif">
         <a href="$changequery({}, v=page.revision)"><span class="uppercase"><strong>$_("Revision %d", page.revision)</strong></span></a>
         $ v = get_version(page.key, page.revision)
-        $if v.author:
+        $if v and v.author:
             <span class="brown">$_('by') <a href="$v.author.key">$v.author.displayname</a> $datestr(v.created)</span>
         $else:
             <span class="brown">$_('by Anonymous') $datestr(v.created)</span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes [Sentry OL-WEB-88](https://sentry.archive.org/organizations/ia-ux/issues/81) which has been happening for 7 months and happened 17k times in the past 30 days and 1.1k times in the past 24 hours.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When `get_version(page.key, page.revision)` returns `None`, properly display the page instead of raising the exception `AttributeError: 'NoneType' object has no attribute 'author'`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with essential attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
