### PR TITLE
json endpoint for api manifest

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -31,6 +31,21 @@ from openlibrary.core.vendors import (
 )
 
 
+class json_api_listing(delegate.page):
+    encoding = "json"
+
+    def GET(self):
+        return delegate.RawText(json.dumps({
+            "search": {
+                "url": "/search.json",
+                "docs": "/dev/docs/api/search"
+            },
+            "isbn": {
+                "url": "/isbn/{isbn}.json",
+                "docs": "https://openlibrary.org/dev/docs/api/books#isbn_api"
+            }
+        }), content_type="application/json")
+
 class book_availability(delegate.page):
     path = "/availability/v2"
 

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -35,16 +35,19 @@ class json_api_listing(delegate.page):
     encoding = "json"
 
     def GET(self):
-        return delegate.RawText(json.dumps({
-            "search": {
-                "url": "/search.json",
-                "docs": "/dev/docs/api/search"
-            },
-            "isbn": {
-                "url": "/isbn/{isbn}.json",
-                "docs": "https://openlibrary.org/dev/docs/api/books#isbn_api"
-            }
-        }), content_type="application/json")
+        return delegate.RawText(
+            json.dumps(
+                {
+                    "search": {"url": "/search.json", "docs": "/dev/docs/api/search"},
+                    "isbn": {
+                        "url": "/isbn/{isbn}.json",
+                        "docs": "https://openlibrary.org/dev/docs/api/books#isbn_api",
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+
 
 class book_availability(delegate.page):
     path = "/availability/v2"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Calling for a swagger like endpoint (which will eventually live here) to list out all our APIs and links to docs.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
