### PR TITLE
Display vendor beneath omnibar on mobile book page views

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -89,7 +89,7 @@ $if isbn_10 and not asin:
 
     $if isbn_10 and not asin:
         $ asin = isbn_10
-    <div class="panel">
+    <div class="panel desktop-vendor">
       <div class="btn-notice">
         $:macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -262,6 +262,32 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
           </div>
       </div>
 
+      $ prices = page.key.startswith('/books/')
+
+      $ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
+      $ isbn_13 = page.get_isbn13()
+      $ isbn_10 = page.get_isbn10()
+
+      $ asin = None
+      $if page.get('identifiers'):
+          $if page.identifiers.get('amazon'):
+              $ asin = page.identifiers.amazon[0]
+
+      $if isbn_10 and not asin:
+          $ asin = isbn_10
+      <div class="Tools">
+        <div class="panel mobile-vendor">
+          <div class="btn-notice">
+            $:macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+
+            <div class="cta-section">
+              <p class="cta-section-title">$_('Buy this book')</p>
+              $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+            </div>
+          </div>
+        </div>
+      </div>
+
       $ seen = set()
       $if previews and any([len(e.languages) for e in previews]):
         <p class="preview-languages">

--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -13,6 +13,10 @@
   font-size: 12px;
 }
 
+.mobile-vendor {
+  display: none;
+}
+
 .read-options,
 .Tools .btn-notice {
   line-height: 1.5em;
@@ -121,6 +125,13 @@
 @media only screen and (max-width: @width-breakpoint-desktop){
   .mobile-book-header{
     display: inline;
+  }
+
+  .mobile-vendor {
+    display: inline;
+  }
+  .desktop-vendor {
+    display: none;
   }
 }
 // For the button at the top


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7009 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: `Display vendor beneath omnibar on mobile book page views`

### Technical
<!-- What should be noted about the implementation? -->
Tried this method suggested in the issue:
> It's probably best to pass an optional string to the template containing any additional classes that will be needed to display the correct vendor section. You can add the new classes the the ul element in AffiliateLinks.html.

Inside `AffiliateLinks.html`
```html
$def with (page, opts, classes='')
...
<ul class="buy-options-table $_(classes)">
```

Inside `view.html`
```python
$:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices}, 'mobile-vendor')
```

Inside `read-panel.less`
```css
.mobile-vendor {
  display: none;
}
...
@media only screen and (max-width: @width-breakpoint-desktop){
  .mobile-vendor {
    display: inline;
  }
  .desktop-vendor {
    display: none;
  }
}
```

**Result:**
![image](https://user-images.githubusercontent.com/59118459/194995299-444ad8b0-b518-4b36-90cd-81620744d982.png)

> Only the `ul` is hidden but the `Buy this book` and its container is still visible.

So, instead of applying it to the `AffliateLinks.html` template, I applied it to its container in `view.html` and `databarWork.html`.
```html
<div class="panel mobile-vendor">   <!-- view.html -->
<div class="panel desktop-vendor"> <!-- databarWork.html -->
```
The result is shown in the screenshots below.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to one of the book pages (e.g. http://localhost:8080/works/OL118420W/Flatland)
1. View the page in desktop view (only the vendor on the side should be visible)
1. View the page in mobile view (only the vendor below the omibar should be visible)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/59118459/194995236-147d6dbc-cf06-4935-a42b-3e9907c000d5.png)
![image](https://user-images.githubusercontent.com/59118459/194995935-7eb6eed5-e677-488c-85ab-9ba124a44001.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
