### PR TITLE
Include web book URL in add book form

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add_provider.js
+++ b/openlibrary/plugins/openlibrary/js/add_provider.js
@@ -1,0 +1,30 @@
+export function initAddProviderLink(elem) {
+    elem.addEventListener('click', function() {
+        let index = Number(elem.dataset.index)
+        elem.parentElement.insertBefore(createProviderFieldset(index), elem)
+        this.dataset.index = ++index
+    })
+}
+
+function createProviderFieldset(index) {
+    const fieldset = document.createElement('fieldset')
+    fieldset.classList.add('minor')
+    const innerHtml = `<legend>Provider ${index + 1}</legend>
+      ${createProviderFormElement(index, 'Book URL', 'url')}
+      ${createProviderFormElement(index, 'Access Type', 'access')}
+      ${createProviderFormElement(index, 'File Format', 'format')}
+      ${createProviderFormElement(index, 'Provider Name', 'provider_name')}`
+    fieldset.innerHTML = innerHtml
+    return fieldset
+}
+
+function createProviderFormElement(index, label, type) {
+    const id = `edition--providers--${index}--${type}`
+    return `<div class="formElement">
+      <div class="label">
+          <label for="${id}">${label}</label>
+      </div>
+      <div class="input">
+          <input name="${id}" id="${id}">
+      </div>`
+}

--- a/openlibrary/plugins/openlibrary/js/add_provider.js
+++ b/openlibrary/plugins/openlibrary/js/add_provider.js
@@ -3,6 +3,9 @@ export function initAddProviderRowLink(elem) {
         let index = Number(elem.dataset.index)
         const tbody = document.querySelector('#provider-table-body')
         tbody.appendChild(createProviderRow(index))
+        if (index === 0) {
+            document.querySelector('#provider-table').classList.remove('hidden')
+        }
         this.dataset.index = ++index
     })
 }

--- a/openlibrary/plugins/openlibrary/js/add_provider.js
+++ b/openlibrary/plugins/openlibrary/js/add_provider.js
@@ -1,30 +1,57 @@
-export function initAddProviderLink(elem) {
+export function initAddProviderRowLink(elem) {
     elem.addEventListener('click', function() {
         let index = Number(elem.dataset.index)
-        elem.parentElement.insertBefore(createProviderFieldset(index), elem)
+        const tbody = document.querySelector('#provider-table-body')
+        tbody.appendChild(createProviderRow(index))
         this.dataset.index = ++index
     })
 }
 
-function createProviderFieldset(index) {
-    const fieldset = document.createElement('fieldset')
-    fieldset.classList.add('minor')
-    const innerHtml = `<legend>Provider ${index + 1}</legend>
-      ${createProviderFormElement(index, 'Book URL', 'url')}
-      ${createProviderFormElement(index, 'Access Type', 'access')}
-      ${createProviderFormElement(index, 'File Format', 'format')}
-      ${createProviderFormElement(index, 'Provider Name', 'provider_name')}`
-    fieldset.innerHTML = innerHtml
-    return fieldset
+function createProviderRow(index) {
+    const tr = document.createElement('tr')
+
+    const innerHtml = `${createTextInputDataCell(index, 'url')}
+    ${createSelectDataCell(index, 'access', accessTypeValues)}
+    ${createSelectDataCell(index, 'format', formatValues)}
+    ${createTextInputDataCell(index, 'provider_name')}`
+
+    tr.innerHTML = innerHtml
+    return tr
 }
 
-function createProviderFormElement(index, label, type) {
+function createTextInputDataCell(index, type) {
     const id = `edition--providers--${index}--${type}`
-    return `<div class="formElement">
-      <div class="label">
-          <label for="${id}">${label}</label>
-      </div>
-      <div class="input">
-          <input name="${id}" id="${id}">
-      </div>`
+    return `<td><input name="${id}" id="${id}" ${type === 'url' ? 'type="url"' : ''}></td>`
+}
+
+function createSelectDataCell(index, type, values) {
+    const id = `edition--providers--${index}--${type}`
+    return `<td>
+    <select name="${id}" id="${id}">
+    ${createSelectOptions(values)}
+    </select>
+    </td>`
+}
+
+const accessTypeValues = [
+    {value: '', text: ''},
+    {value: 'read', text: 'Read'},
+    {value: 'listen', text: 'Listen'},
+    {value: 'buy', text: 'Buy'},
+    {value: 'borrow', text: 'Borrow'},
+    {value: 'preview', text: 'Preview'}
+]
+
+const formatValues = [
+    {value: '', text: ''},
+    {value: 'web', text: 'Web'},
+    {value: 'epub', text: 'ePub'},
+    {value: 'pdf', text: 'PDF'}
+]
+function createSelectOptions(values) {
+    let html = ''
+    for (const value of values) {
+        html += `<option value="${value.value}">${value.text}</option>\n`
+    }
+    return html
 }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -444,9 +444,9 @@ jQuery(function () {
     }
 
     // Add new providers in edit edition view:
-    const addProviderLink = document.querySelector('#add-new-provider')
-    if (addProviderLink) {
+    const addProviderRowLink = document.querySelector('#add-new-provider-row')
+    if (addProviderRowLink) {
         import(/* webpackChunkName "add-provider-link" */ './add_provider')
-            .then(module => module.initAddProviderLink(addProviderLink))
+            .then(module => module.initAddProviderRowLink(addProviderRowLink))
     }
 });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -442,4 +442,11 @@ jQuery(function () {
                 }
             })
     }
+
+    // Add new providers in edit edition view:
+    const addProviderLink = document.querySelector('#add-new-provider')
+    if (addProviderLink) {
+        import(/* webpackChunkName "add-provider-link" */ './add_provider')
+            .then(module => module.initAddProviderLink(addProviderLink))
+    }
 });

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -633,8 +633,9 @@ class SaveBookHelper:
             if 'contributors' not in edition_data:
                 self.edition.contributors = []
 
-            if 'provider' in edition_data:
-                self.edition.set_provider_data(edition_data.pop('provider'))
+            providers = edition_data.pop('providers', [])
+            self.edition.set_providers(providers)
+
             self.edition.update(edition_data)
             saveutil.save(self.edition)
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -219,6 +219,7 @@ class addbook(delegate.page):
             publish_date="",
             id_name="",
             id_value="",
+            webbook_url="",
             _test="false",
         )
 
@@ -255,6 +256,8 @@ class addbook(delegate.page):
 
         elif match and match.key.startswith('/books'):
             # work match and edition match, match is an Edition
+            if i.webbook_url:
+                match.provider = [dict(url=i.webbook_url)]
             return self.work_edition_match(match)
 
         elif match and match.key.startswith('/works'):
@@ -475,6 +478,8 @@ class addbook(delegate.page):
             publishers=[i.publisher],
             publish_date=i.publish_date,
         )
+        if i.get('webbook_url'):
+            edition.set_provider_data(dict(url=i.webbook_url))
         if i.get("id_name") and i.get("id_value"):
             edition.set_identifiers([dict(name=i.id_name, value=i.id_value)])
         return edition
@@ -628,6 +633,8 @@ class SaveBookHelper:
             if 'contributors' not in edition_data:
                 self.edition.contributors = []
 
+            if 'provider' in edition_data:
+                self.edition.set_provider_data(edition_data.pop('provider'))
             self.edition.update(edition_data)
             saveutil.save(self.edition)
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -219,7 +219,7 @@ class addbook(delegate.page):
             publish_date="",
             id_name="",
             id_value="",
-            webbook_url="",
+            web_book_url="",
             _test="false",
         )
 
@@ -256,8 +256,8 @@ class addbook(delegate.page):
 
         elif match and match.key.startswith('/books'):
             # work match and edition match, match is an Edition
-            if i.webbook_url:
-                match.provider = [dict(url=i.webbook_url)]
+            if i.web_book_url:
+                match.provider = [dict(url=i.web_book_url)]
             return self.work_edition_match(match)
 
         elif match and match.key.startswith('/works'):
@@ -478,8 +478,8 @@ class addbook(delegate.page):
             publishers=[i.publisher],
             publish_date=i.publish_date,
         )
-        if i.get('webbook_url'):
-            edition.set_provider_data(dict(url=i.webbook_url))
+        if i.get('web_book_url'):
+            edition.set_provider_data(dict(url=i.web_book_url))
         if i.get("id_name") and i.get("id_value"):
             edition.set_identifiers([dict(name=i.id_name, value=i.id_value)])
         return edition

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -257,7 +257,7 @@ class addbook(delegate.page):
         elif match and match.key.startswith('/books'):
             # work match and edition match, match is an Edition
             if i.web_book_url:
-                match.provider = [dict(url=i.web_book_url)]
+                match.provider = [dict(url=i.web_book_url, format="web")]
             return self.work_edition_match(match)
 
         elif match and match.key.startswith('/works'):
@@ -479,7 +479,7 @@ class addbook(delegate.page):
             publish_date=i.publish_date,
         )
         if i.get('web_book_url'):
-            edition.set_provider_data(dict(url=i.web_book_url))
+            edition.set_provider_data(dict(url=i.web_book_url, format="web"))
         if i.get("id_name") and i.get("id_value"):
             edition.set_identifiers([dict(name=i.id_name, value=i.id_value)])
         return edition

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -478,9 +478,9 @@ class Edition(models.Edition):
         return "/ia:" in self.key
 
     def set_provider_data(self, data):
-        if not self.provider:
-            self.provider = []
-        self.provider.append(data)
+        if not self.providers:
+            self.providers = []
+        self.providers.append(data)
 
 
 class Author(models.Author):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -482,6 +482,9 @@ class Edition(models.Edition):
             self.providers = []
         self.providers.append(data)
 
+    def set_providers(self, providers):
+        self.providers = providers
+
 
 class Author(models.Author):
     def get_photos(self):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -477,6 +477,11 @@ class Edition(models.Edition):
         """
         return "/ia:" in self.key
 
+    def set_provider_data(self, data):
+        if not self.provider:
+            self.provider = []
+        self.provider.append(data)
+
 
 class Author(models.Author):
     def get_photos(self):

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -69,6 +69,16 @@ $var title: $_("Add a book")
             </div>
         </div>
 
+        $if admin_user:
+            <div class="formElement">
+                <div class="label">
+                    <label for="webbook_url">$_("Book URL")</label> <span class="tip">$_("Only fill this out if this is a web book")</span></span>
+                </div>
+                <div class="input">
+                    <input type="text" name="webbook_url" class="" id="webbook_url"/>
+                </div>
+            </div>
+
         $if recaptcha and not ctx.user:
             <div class="formElement">
                 <div class="label">$_("Since you are not logged in, please satisfy the reCAPTCHA below.")</div>

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -72,10 +72,10 @@ $var title: $_("Add a book")
         $if admin_user:
             <div class="formElement">
                 <div class="label">
-                    <label for="webbook_url">$_("Book URL")</label> <span class="tip">$_("Only fill this out if this is a web book")</span></span>
+                    <label for="web_book_url">$_("Book URL")</label> <span class="tip">$_("Only fill this out if this is a web book")</span></span>
                 </div>
                 <div class="input">
-                    <input type="text" name="webbook_url" class="" id="webbook_url"/>
+                    <input type="text" name="web_book_url" class="" id="web_book_url"/>
                 </div>
             </div>
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -670,41 +670,7 @@ $if is_privileged_user:
                     </div>
                 </fieldset>
                 $ provider_index = provider_index + 1
-            <fieldset class="minor">
-                <legend>$ungettext('Provider %(count)s', 'Provider %(count)s', provider_index, count=provider_index + 1)</legend>
-                <div class="formElement">
-                    <div class="label">
-                        <label for="edition--providers--${provider_index}--url">$_("Book URL")</label>
-                    </div>
-                    <div class="input">
-                        <input name="edition--providers--${provider_index}--url" id="edition--providers--${provider_index}--url" type="url" value="">
-                    </div>
-                </div>
-                <div class="formElement">
-                    <div class="label">
-                        <label for="edition--providers--${provider_index}--access">$_("Access Type")</label>
-                    </div>
-                    <div class="input">
-                        <input name="edition--providers--${provider_index}--access" id="edition--providers--${provider_index}--access" value="">
-                    </div>
-                </div>
-                <div class="formElement">
-                    <div class="label">
-                        <label for="edition--providers--${provider_index}--format">$_("File Format")</label>
-                    </div>
-                    <div class="input">
-                        <input name="edition--providers--${provider_index}--format" id="edition--providers--${provider_index}--format" value="">
-                    </div>
-                </div>
-                <div class="formElement">
-                    <div class="label">
-                        <label for="edition--providers--${provider_index}--provider_name">$_("Provider Name")</label>
-                    </div>
-                    <div class="input">
-                        <input name="edition--providers--${provider_index}--provider_name" id="edition--providers--${provider_index}--provider_name" value="">
-                    </div>
-                </div>
-            </fieldset>
+            <a href="javascript:;" id="add-new-provider" data-index="$provider_index">Add another provider?</a>
         </div>
     </fieldset>
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -675,8 +675,8 @@ $if is_privileged_user:
                     $ provider_index = provider_index + 1
             </tbody>
         </table>
+        <a href="javascript:;" id="add-new-provider-row" data-index="$provider_index">$_("Add a provider")</a>
     </fieldset>
-    <a href="javascript:;" id="add-new-provider-row" data-index="$provider_index">$_("Add a provider")</a>
 
 $if ctx.user and ctx.user.is_admin():
     <fieldset class="major adminOnly">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -628,12 +628,60 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
 
 </fieldset>
 
+$if is_privileged_user:
+    <fieldset class="major">
+        <legend>$_("Web Book Provider")</legend>
+        <div class="formBack">
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--provider--url">$_("Book URL")</label>
+                </div>
+                <div class="input">
+                    <input name="edition--provider--url" id="edition--provider--url" type="url" value="$book.provider[0].url">
+                </div>
+            </div>
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--provider--access">$_("Access Type")</label>
+                </div>
+                <div class="input">
+                    <input name="edition--provider--access" id="edition--provider--access" value="$book.provider[0].access">
+                </div>
+            </div>
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--provider--format">$_("File Format")</label>
+                </div>
+                <div class="input">
+                    <input name="edition--provider--format" id="edition--provider--format" value="$book.provider[0].format">
+                </div>
+            </div>
+
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--provider--provider_name">$_("Provider Name")</label>
+                </div>
+                <div class="input">
+                    <input name="edition--provider--provider_name" id="edition--provider--provider_name" value="$book.provider[0].provider_name">
+                </div>
+            </div>
+            <!-- <div class="formElement">
+                <div class="label">
+                    <label for="edition--provider--price">$_("Price")</label>
+                </div>
+                <div class="input">
+                    <input name="edition--provider--price" id="edition--provider--price">
+                </div>
+            </div> -->
+        </div>
+    </fieldset>
+
 $if ctx.user and ctx.user.is_admin():
     <fieldset class="major adminOnly">
         <legend>$_("Admin Only")</legend>
         <div class="formElement">
             <div class="label">
-                <label for="edition-first_sentence">$_("Additional Metadata")</label>
+                <label for="additional_metadata">$_("Additional Metadata")</label>
                 <span class="tip">$_('This field can accept arbitrary key:value pairs')</span>
             </div>
             <div class="input">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -628,51 +628,55 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
 
 </fieldset>
 
+$code:
+    def is_selected(actual, selected):
+        if actual == selected:
+            return True
+        return False
+
 $if is_privileged_user:
-    <fieldset class="major">
-        <legend>$_("Web Book Providers")</legend>
-        <div class="formBack">
-            $ provider_index = 0
-            $for i, d in enumerate(book.providers):
-                <fieldset class="minor">
-                    <legend>$ungettext('Provider %(count)s', 'Provider %(count)s', loop.index, count=loop.index)</legend>
-                    <div class="formElement">
-                        <div class="label">
-                            <label for="edition--providers--${i}--url">$_("Book URL")</label>
-                        </div>
-                        <div class="input">
-                            <input name="edition--providers--${i}--url" id="edition--providers--${i}--url" type="url" value="$d.url">
-                        </div>
-                    </div>
-                    <div class="formElement">
-                        <div class="label">
-                            <label for="edition--providers--${i}--access">$_("Access Type")</label>
-                        </div>
-                        <div class="input">
-                            <input name="edition--providers--${i}--access" id="edition--providers--${i}--access" value="$d.access">
-                        </div>
-                    </div>
-                    <div class="formElement">
-                        <div class="label">
-                            <label for="edition--providers--${i}--format">$_("File Format")</label>
-                        </div>
-                        <div class="input">
-                            <input name="edition--providers--${i}--format" id="edition--providers--${i}--format" value="$d.format">
-                        </div>
-                    </div>
-                    <div class="formElement">
-                        <div class="label">
-                            <label for="edition--providers--${i}--provider_name">$_("Provider Name")</label>
-                        </div>
-                        <div class="input">
-                            <input name="edition--providers--${i}--provider_name" id="edition--providers--${i}--provider_name" value="$d.provider_name">
-                        </div>
-                    </div>
-                </fieldset>
-                $ provider_index = provider_index + 1
-            <a href="javascript:;" id="add-new-provider" data-index="$provider_index">Add another provider?</a>
-        </div>
+    $ extra_class = ' hidden' if len(book.providers) == 0 else ''
+    $ provider_index = 0
+    <fieldset class="major $extra_class" id="book-provider-fieldset">
+        <legend>$_('Web Book Providers')</legend>
+        <table class="provider-table">
+            <thead>
+                <tr>
+                    <th>$_("Book URL")</th>
+                    <th>$_("Access Type")</th>
+                    <th>$_("File Format")</th>
+                    <th>$_("Provider Name")</th>
+                </tr>
+            </thead>
+            <tbody id="provider-table-body">
+                $for i, d in enumerate(book.providers):
+                    <tr>
+                        <td><input name="edition--providers--${i}--url" id="edition--providers--${i}--url" type="url" value="$d.url"></td>
+                        <td>
+                            <select name="edition--providers--${i}--access" id="edition--providers--${i}--access" autocomplete="off">
+                                <option value=""></option>
+                                <option value="read" $cond(is_selected(d.access, 'read'), 'selected')>$_("Read")</option>
+                                <option value="listen" $cond(is_selected(d.access, 'listen'), 'selected')>$_("Listen")</option>
+                                <option value="buy" $cond(is_selected(d.access, 'buy'), 'selected')>$_("Buy")</option>
+                                <option value="borrow" $cond(is_selected(d.access, 'borrow'), 'selected')>$_("Borrow")</option>
+                                <option value="preview" $cond(is_selected(d.access, 'preview'), 'selected')>$_("Preview")</option>
+                            </select>
+                        </td>
+                        <td>
+                            <select name="edition--providers--${i}--format" id="edition--providers--${i}--format" autocomplete="off">
+                                <option value=""></option>
+                                <option value="web" $cond(is_selected(d.format, 'web'), 'selected')>$_("Web")</option>
+                                <option value="epub" $cond(is_selected(d.format, 'epub'), 'selected')>$_("ePub")</option>
+                                <option value="pdf" $cond(is_selected(d.format, 'pdf'), 'selected')>$_("PDF")</option>
+                            </select>
+                        </td>
+                        <td><input name="edition--providers--${i}--provider_name" id="edition--providers--${i}--provider_name" value="$d.provider_name"></td>
+                    </tr>
+                    $ provider_index = provider_index + 1
+            </tbody>
+        </table>
     </fieldset>
+    <a href="javascript:;" id="add-new-provider-row" data-index="$provider_index">$_("Add a provider")</a>
 
 $if ctx.user and ctx.user.is_admin():
     <fieldset class="major adminOnly">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -632,39 +632,79 @@ $if is_privileged_user:
     <fieldset class="major">
         <legend>$_("Web Book Providers")</legend>
         <div class="formBack">
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--providers--url">$_("Book URL")</label>
+            $ provider_index = 0
+            $for i, d in enumerate(book.providers):
+                <fieldset class="minor">
+                    <legend>$ungettext('Provider %(count)s', 'Provider %(count)s', loop.index, count=loop.index)</legend>
+                    <div class="formElement">
+                        <div class="label">
+                            <label for="edition--providers--${i}--url">$_("Book URL")</label>
+                        </div>
+                        <div class="input">
+                            <input name="edition--providers--${i}--url" id="edition--providers--${i}--url" type="url" value="$d.url">
+                        </div>
+                    </div>
+                    <div class="formElement">
+                        <div class="label">
+                            <label for="edition--providers--${i}--access">$_("Access Type")</label>
+                        </div>
+                        <div class="input">
+                            <input name="edition--providers--${i}--access" id="edition--providers--${i}--access" value="$d.access">
+                        </div>
+                    </div>
+                    <div class="formElement">
+                        <div class="label">
+                            <label for="edition--providers--${i}--format">$_("File Format")</label>
+                        </div>
+                        <div class="input">
+                            <input name="edition--providers--${i}--format" id="edition--providers--${i}--format" value="$d.format">
+                        </div>
+                    </div>
+                    <div class="formElement">
+                        <div class="label">
+                            <label for="edition--providers--${i}--provider_name">$_("Provider Name")</label>
+                        </div>
+                        <div class="input">
+                            <input name="edition--providers--${i}--provider_name" id="edition--providers--${i}--provider_name" value="$d.provider_name">
+                        </div>
+                    </div>
+                </fieldset>
+                $ provider_index = provider_index + 1
+            <fieldset class="minor">
+                <legend>$ungettext('Provider %(count)s', 'Provider %(count)s', provider_index, count=provider_index + 1)</legend>
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition--providers--${provider_index}--url">$_("Book URL")</label>
+                    </div>
+                    <div class="input">
+                        <input name="edition--providers--${provider_index}--url" id="edition--providers--${provider_index}--url" type="url" value="">
+                    </div>
                 </div>
-                <div class="input">
-                    <input name="edition--providers--url" id="edition--providers--url" type="url" value="$book.providers[0].url">
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition--providers--${provider_index}--access">$_("Access Type")</label>
+                    </div>
+                    <div class="input">
+                        <input name="edition--providers--${provider_index}--access" id="edition--providers--${provider_index}--access" value="">
+                    </div>
                 </div>
-            </div>
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--providers--access">$_("Access Type")</label>
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition--providers--${provider_index}--format">$_("File Format")</label>
+                    </div>
+                    <div class="input">
+                        <input name="edition--providers--${provider_index}--format" id="edition--providers--${provider_index}--format" value="">
+                    </div>
                 </div>
-                <div class="input">
-                    <input name="edition--providers--access" id="edition--providers--access" value="$book.providers[0].access">
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition--providers--${provider_index}--provider_name">$_("Provider Name")</label>
+                    </div>
+                    <div class="input">
+                        <input name="edition--providers--${provider_index}--provider_name" id="edition--providers--${provider_index}--provider_name" value="">
+                    </div>
                 </div>
-            </div>
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--providers--format">$_("File Format")</label>
-                </div>
-                <div class="input">
-                    <input name="edition--providers--format" id="edition--providers--format" value="$book.providers[0].format">
-                </div>
-            </div>
-
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--providers--provider_name">$_("Provider Name")</label>
-                </div>
-                <div class="input">
-                    <input name="edition--providers--provider_name" id="edition--providers--provider_name" value="$book.providers[0].provider_name">
-                </div>
-            </div>
+            </fieldset>
         </div>
     </fieldset>
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -630,49 +630,41 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
 
 $if is_privileged_user:
     <fieldset class="major">
-        <legend>$_("Web Book Provider")</legend>
+        <legend>$_("Web Book Providers")</legend>
         <div class="formBack">
             <div class="formElement">
                 <div class="label">
-                    <label for="edition--provider--url">$_("Book URL")</label>
+                    <label for="edition--providers--url">$_("Book URL")</label>
                 </div>
                 <div class="input">
-                    <input name="edition--provider--url" id="edition--provider--url" type="url" value="$book.provider[0].url">
+                    <input name="edition--providers--url" id="edition--providers--url" type="url" value="$book.providers[0].url">
                 </div>
             </div>
             <div class="formElement">
                 <div class="label">
-                    <label for="edition--provider--access">$_("Access Type")</label>
+                    <label for="edition--providers--access">$_("Access Type")</label>
                 </div>
                 <div class="input">
-                    <input name="edition--provider--access" id="edition--provider--access" value="$book.provider[0].access">
+                    <input name="edition--providers--access" id="edition--providers--access" value="$book.providers[0].access">
                 </div>
             </div>
             <div class="formElement">
                 <div class="label">
-                    <label for="edition--provider--format">$_("File Format")</label>
+                    <label for="edition--providers--format">$_("File Format")</label>
                 </div>
                 <div class="input">
-                    <input name="edition--provider--format" id="edition--provider--format" value="$book.provider[0].format">
+                    <input name="edition--providers--format" id="edition--providers--format" value="$book.providers[0].format">
                 </div>
             </div>
 
             <div class="formElement">
                 <div class="label">
-                    <label for="edition--provider--provider_name">$_("Provider Name")</label>
+                    <label for="edition--providers--provider_name">$_("Provider Name")</label>
                 </div>
                 <div class="input">
-                    <input name="edition--provider--provider_name" id="edition--provider--provider_name" value="$book.provider[0].provider_name">
+                    <input name="edition--providers--provider_name" id="edition--providers--provider_name" value="$book.providers[0].provider_name">
                 </div>
             </div>
-            <!-- <div class="formElement">
-                <div class="label">
-                    <label for="edition--provider--price">$_("Price")</label>
-                </div>
-                <div class="input">
-                    <input name="edition--provider--price" id="edition--provider--price">
-                </div>
-            </div> -->
         </div>
     </fieldset>
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -637,9 +637,9 @@ $code:
 $if is_privileged_user:
     $ extra_class = ' hidden' if len(book.providers) == 0 else ''
     $ provider_index = 0
-    <fieldset class="major $extra_class" id="book-provider-fieldset">
+    <fieldset class="major">
         <legend>$_('Web Book Providers')</legend>
-        <table class="provider-table">
+        <table class="provider-table $extra_class" id="provider-table">
             <thead>
                 <tr>
                     <th>$_("Book URL")</th>

--- a/static/css/components/provider-table.less
+++ b/static/css/components/provider-table.less
@@ -1,0 +1,11 @@
+.provider-table {
+  margin-bottom: 10px;
+  background-color: @lightest-grey;
+
+  th {
+    min-width: 200px;
+  }
+  tbody input {
+    padding: 4px;
+  }
+}

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -42,6 +42,7 @@
 @import (less) "less/font-families.less";
 @import (less) "components/flash-messages.less";
 @import (less) "less/z-index.less";
+@import (less) "components/provider-table.less";
 
 body {
   background-color: @beige;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds field for a web book URL in the add book form.
Also adds a providers table to edition edit forms. New rows can be added to the table dynamically.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-10-13 17-13-53](https://user-images.githubusercontent.com/28732543/195734478-53dc9b7f-bf8a-4034-aed0-d58958257e24.png)

![no_providers](https://user-images.githubusercontent.com/28732543/195736299-7cb5f9fc-3e2e-425e-9e00-dab4b970ada2.gif)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
