### PR TITLE
Add format field to solr works/editions

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -170,6 +170,7 @@
     <field name="contributor" type="text_general" multiValued="true"/>
     <field name="publish_place" type="text_en_splitting" multiValued="true"/>
     <field name="publisher" type="text_en_splitting" multiValued="true"/>
+    <field name="format" type="text_en_splitting" multiValued="true"/>
     <field name="publisher_facet" type="string" stored="false" multiValued="true"/>
     <field name="first_sentence" type="text_en_splitting" multiValued="true"/>
     <field name="author_key" type="string" multiValued="true"/>

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -46,6 +46,7 @@ class WorkSearchScheme(SearchScheme):
         "ebook_access",
         "edition_count",
         "edition_key",
+        "format",
         "by_statement",
         "publish_date",
         "lccn",
@@ -308,6 +309,7 @@ class WorkSearchScheme(SearchScheme):
                 'alternative_subtitle': 'subtitle',
                 'cover_i': 'cover_i',
                 # Misc useful data
+                'format': 'format',
                 'language': 'language',
                 'publisher': 'publisher',
                 'publisher_facet': 'publisher_facet',

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -41,6 +41,7 @@ class SolrDocument(TypedDict):
     contributor: Optional[list[str]]
     publish_place: Optional[list[str]]
     publisher: Optional[list[str]]
+    format: Optional[list[str]]
     publisher_facet: Optional[list[str]]
     first_sentence: Optional[list[str]]
     author_key: Optional[list[str]]

--- a/openlibrary/solr/update_edition.py
+++ b/openlibrary/solr/update_edition.py
@@ -90,6 +90,10 @@ class EditionSolrBuilder:
             return None
 
     @property
+    def format(self) -> str | None:
+        return self.get('physical_format')
+
+    @property
     def isbn(self) -> list[str]:
         """
         Get all ISBNs of the given edition. Calculates complementary ISBN13 for each
@@ -201,6 +205,7 @@ def build_edition_data(
             'language': ed.languages,
             # Misc useful data
             'publisher': ed.publisher,
+            'format': [ed.format] if ed.format else None,
             'publish_date': [ed.publish_date] if ed.publish_date else None,
             'publish_year': [ed.publish_year] if ed.publish_year else None,
             # Identifiers

--- a/openlibrary/solr/update_edition.py
+++ b/openlibrary/solr/update_edition.py
@@ -191,6 +191,8 @@ def build_edition_data(
     Build the solr document for the given edition to store as a nested
     document
     """
+    from openlibrary.solr.update_work import get_solr_next
+
     ed = EditionSolrBuilder(edition, ia_metadata)
     solr_doc: SolrDocument = cast(
         SolrDocument,
@@ -205,7 +207,11 @@ def build_edition_data(
             'language': ed.languages,
             # Misc useful data
             'publisher': ed.publisher,
-            'format': [ed.format] if ed.format else None,
+            **(
+                {'format': [ed.format] if ed.format else None}
+                if get_solr_next()
+                else {}
+            ),
             'publish_date': [ed.publish_date] if ed.publish_date else None,
             'publish_year': [ed.publish_year] if ed.publish_year else None,
             # Identifiers

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -832,6 +832,12 @@ def build_data2(
         },
     )
 
+    add_field_list(
+        doc,
+        'format',
+        {format for ed in editions if (format := EditionSolrBuilder(ed).format)},
+    )
+
     languages: list[str] = []
     ia_loaded_id = set()
     ia_box_id = set()

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -832,11 +832,12 @@ def build_data2(
         },
     )
 
-    add_field_list(
-        doc,
-        'format',
-        {format for ed in editions if (format := EditionSolrBuilder(ed).format)},
-    )
+    if get_solr_next():
+        add_field_list(
+            doc,
+            'format',
+            {format for ed in editions if (format := EditionSolrBuilder(ed).format)},
+        )
 
     languages: list[str] = []
     ia_loaded_id = set()


### PR DESCRIPTION
In order to support our implementation of web books, we wanted to add an ability to search by `format` . This adds that ability.

### Technical
<!-- What should be noted about the implementation? -->

### Testing

You'll have to reset your local solr:

```sh
docker compose down
docker volume rm openlibrary_solr-data openlibrary_solr-updater-data
docker compose up -d

# Add a web book
docker compose exec web bash -c 'PYTHONPATH=. ./scripts/copydocs.py /books/OL40066166M'
```

- ✅ Searching for `format: web book` or `format:audio` or `format:ebook` works
- ✅ Selects editions of said format
- ✅ Appears correctly in search.json endpoint

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

To deploy: Copy the manage-schema into the running solr docker container _before_ deploying