### PR TITLE
Deal with query param['q'] being only whitespace

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -759,7 +759,7 @@ class search_json(delegate.page):
         )
 
         # If the query is a /list/ key, create custom list_editions_query
-        q = query.get('q', '')
+        q = query.get('q', '').strip()
         query['q'], page, offset, limit = rewrite_list_query(q, page, offset, limit)
         response = work_search(
             query,


### PR DESCRIPTION
[Ply](https://pypi.org/project/ply) is throwing `ParseSyntaxError` when param['q'] one or more space characters.
We do not want to `process_user_query(" ")` so let's instead use `build_q_from_params(param)`.

<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/organizations/ia-ux/projects/ol-web/?issuesType=all&project=7&query=ParseSyntaxError

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
