### PR TITLE
Drop setup.cfg in favor of pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,9 @@ repos:
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
-      - id: codespell  # See setup.cfg for args
+      - id: codespell  # See pyproject.toml for args
+        additional_dependencies:
+          - tomli
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.982'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-# Minimal configuration to ensure that Black does not convert quotes.
-# Black does not support reading its configuration from `setup.cfg`.
-# This file can be deleted when we convert to favoring double quotes.
-# https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html
-
 # NOTE: You have to use single-quoted strings in TOML for regular expressions.
 # It's the equivalent of r-strings in Python.  Multiline strings are treated as
 # verbose regular expressions by Black.  Use [ ] to denote a significant space
@@ -11,6 +6,10 @@
 [tool.black]
 skip-string-normalization = true
 target-version = ["py39", "py310"]
+
+[tool.codespell]
+ignore-words-list = "beng,curren,datas,furst,nd,nin,ot,ser,spects,te,tha,ue,upto"
+skip = "./.*,*/ocm00400866,*/read_toc.py,*.it,*.js,*.json,*.mrc,*.page,*.pg_dump,*.po,*.txt,*.xml,*.yml"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-# https://github.com/codespell-project/codespell
-[codespell]
-count =
-ignore-words-list = ba,beng,curren,datas,furst,nd,nin,ot,ser,spects,te,tha,ue,upto
-skip = ./.*,*/ocm00400866,*/read_toc.py,*.it,*.js,*.json,*.mrc,*.page,*.pg_dump,*.po,*.txt,*.xml,*.yml


### PR DESCRIPTION
<!-- What issue does this PR close? -->
`codespell`'s latest [release](https://github.com/codespell-project/codespell/releases) adds support for reading its configuration from `pyproject.toml`.  This pull request drops `setup.cfg` and consolidates our configs for `psf/black, `codespell`, `mypy`, and `pytest` in our `pyproject.toml` file.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`codespell` runs in pre-commit so this is tested on both local commits and on pre-commit.ci

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
