### PR TITLE
Fix openlibrary/core/lending.py: Fix duplicate enties in a dict

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -721,11 +721,9 @@ class Loan(dict):
                 'ocaid': identifier,
                 'expiry': expiry,
                 'uuid': _uuid,
-                'resource_type': 'bookreader',  # noqa: F601
-                'resource_id': 'bookreader:%s' % identifier,  # noqa: F601
                 'loaned_at': loaned_at,
-                'resource_type': resource_type,  # noqa: F601
-                'resource_id': resource_id,  # noqa: F601
+                'resource_type': resource_type,
+                'resource_id': resource_id,
                 'loan_link': loan_link,
             }
         )


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7065

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
There are duplicate keys in the definition of a dict.  This PR eliminates the first entries and leaves the second entries in place which is exactly what Python has been doing by default.  The `resource_type` value that is being preserved is passed into this function.  The `resource_id` is being created in this function.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
