### PR TITLE
Updating order of Old English to ease editing

### DIFF
--- a/openlibrary/plugins/openlibrary/pages/languages.page
+++ b/openlibrary/plugins/openlibrary/pages/languages.page
@@ -91,12 +91,6 @@
     "key": "/languages/amh"
   },
   {
-    "code": "ang",
-    "type": "/type/language",
-    "name": "English, Old (ca. 450-1100)",
-    "key": "/languages/ang"
-  },
-  {
     "code": "apa",
     "type": "/type/language",
     "name": "Apache languages",
@@ -675,6 +669,12 @@
     "type": "/type/language",
     "name": "English, Middle (1100-1500)",
     "key": "/languages/enm"
+  },
+  {
+    "code": "ang",
+    "type": "/type/language",
+    "name": "English, Old (ca. 450-1100)",
+    "key": "/languages/ang"
   },
   {
     "code": "epo",


### PR DESCRIPTION
This is addressing https://github.com/internetarchive/openlibrary/issues/7054

With other languages such as French and German, the list order in _languages.page_ is shown to be the same as the display order (French, Middle French, Old French), so reordering Old English to after Middle English should resolve this issue.

<!-- What issue does this PR close? -->
Closes #7054 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix, reorders display order of autofill options.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Edit a book in Openlibrary, and edit or add a language, typing out "English". It should display: English; English Middle (1100-1500); English Old (450-1100).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
