### PR TITLE
Add edition info to book details section

### DIFF
--- a/openlibrary/templates/type/edition/publisher_line.html
+++ b/openlibrary/templates/type/edition/publisher_line.html
@@ -1,0 +1,27 @@
+$def with (edition)
+
+$if edition:
+  <h4 class="publisher">
+  $if edition.publish_date or edition.publishers or edition.publish_places:
+    <!-- TODO: this handcrafted concatenation will be difficult to internationalize -->
+    $_('This edition was published')
+      $if edition.publish_date:
+        $_('in') <strong itemprop="datePublished">$edition.publish_date</strong>
+      $if edition.publishers:
+          $_('by')
+          $for p in edition.publishers:
+              $if "publishers" in ctx.features:
+                <a itemprop="publisher" href="/publishers/$p.replace(' ', '_')"
+                   title="$_('Show other books from %(publisher)s', publisher=p)"
+                   >$p</a>$cond(loop.last, "", ", ")
+              $else:
+                <a itemprop="publisher" href="/search?publisher_facet=$p.replace('&','%26')"
+                   title="$_('Search for other books from %(publisher)s', publisher=p)"
+                   >$p</a>$cond(loop.last, "", ", ")
+      $if edition.publish_places:
+        $_('in')
+        $for p in edition.publish_places:
+           <a href="/search/subjects?q=$p.replace('&','%26').replace(' ','%20')"
+              title="$_('Search for subjects about %(place)s', place=p)"
+              >$p</a>$cond(loop.last, "", ", ")<span class="adjust">.</span>
+  </h4>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -312,7 +312,18 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
         $if edition:
           <h2 class="details-title" itemprop="name">$_("Book Details")</h2>
           <hr>
-          $if edition.publish_places:
+          $if is_privileged_user:
+            <h3 class="work-title" itemprop="name">$book_title</h3>
+            $if edition.subtitle:
+              <h3>
+                $edition.subtitle
+              </h3>
+            $if edition.edition_name:
+              <div class="work-line">
+                $edition.edition_name
+              </div>
+            $:render_template("type/edition/publisher_line", edition)
+          $if edition.publish_places and not is_privileged_user:
             <div class="section">
               <h3 class="edition-header">$_('Published in')</h3>
               <p>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7101

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Displays some edition information in the book details section for admins and super-librarians.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
