### PR TITLE
Clicking Book Page Star Ratings summary goes to ratings section

### DIFF
--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -17,7 +17,7 @@ $ form_id = "ratingsForm%s" % id
     $if safeint(page) > 1:
       <input type="hidden" value="$page" name="page"/>
     <input type="hidden" value="$redir_url" name="redir_url"/>
-  <div class="review">
+  <div class="review" id="starRatingSection">
     <div class="stars">
       $ NUM_STARS = 5
       $for star in range(1, NUM_STARS + 1)

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -5,7 +5,7 @@ $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ avg = rating_stats.get('avg_rating')
 
 <ul class="readers-stats" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-  <li class="avg-ratings">
+  <li class="avg-ratings" onclick="location.href='#starRatingSection';">
     $if avg:
       $ stats_decimal = (float(avg))-(int(avg))
       $:('<span class="readers-stats__star">★</span>' * int(avg))
@@ -14,7 +14,7 @@ $ avg = rating_stats.get('avg_rating')
       <span itemprop="ratingValue">$avg</span>
       <span class="dot">·</span>
   </li>
-  <li onclick="location.href='#starRatingSection';">
+  <li>
     <span itemprop="reviewCount">$rating_stats.get('num_ratings', 0)</span> $_("Ratings")
   </li>
   <li class="reading-log-stat">$stats_by_bookshelf.get('want-to-read', 0) $_("Want to read")</li>

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -14,7 +14,7 @@ $ avg = rating_stats.get('avg_rating')
       <span itemprop="ratingValue">$avg</span>
       <span class="dot">·</span>
   </li>
-  <li>
+  <li onclick="location.href='#starRatingSection';">
     <span itemprop="reviewCount">$rating_stats.get('num_ratings', 0)</span> $_("Ratings")
   </li>
   <li class="reading-log-stat">$stats_by_bookshelf.get('want-to-read', 0) $_("Want to read")</li>

--- a/static/css/components/rating-form.less
+++ b/static/css/components/rating-form.less
@@ -20,6 +20,7 @@ html {
 }
 .review {
   display: flex;
+  scroll-margin-top: 100px;
   .review-btn {
     border-left: 1px solid @lighter-grey;
     width: 35px;
@@ -36,21 +37,20 @@ html {
 @keyframes highlight {
   0% {
     border: 1px solid transparent;
-    box-shadow: 0px 0px 10px transparent;
+    box-shadow: 0 0 10px transparent;
   }
   50% {
-    border: 1px solid #02598b;
-    box-shadow: 0px 0px 10px #02598b;
+    border: 1px solid @link-blue;
+    box-shadow: 0 0 10px @link-blue;
   }
   100% {
     border: 1px solid transparent;
-    box-shadow: 0px 0px 10px transparent;
+    box-shadow: 0 0 10px transparent;
   }
 }
 // smooth scrolling and highlighting area after clicking on anchor link
 .review:target {
   animation: highlight 3s;
-  scroll-margin-top: 10rem;
 }
 //changes mouse cursor to 'pointer'
 .avg-ratings{

--- a/static/css/components/rating-form.less
+++ b/static/css/components/rating-form.less
@@ -52,7 +52,10 @@ html {
   animation: highlight 3s;
   scroll-margin-top: 10rem;
 }
-
+//changes mouse cursor to 'pointer'
+.avg-ratings{
+  cursor: pointer;
+}
 .stars {
   background: url(/static/images/stars.png) repeat-x 0 0;
   width: 150px;

--- a/static/css/components/rating-form.less
+++ b/static/css/components/rating-form.less
@@ -14,7 +14,10 @@
   cursor: pointer;
   margin: 0 auto;
 }
-
+// allows smooth scrolling after clicking on anchor link
+html {
+  scroll-behavior: smooth;
+}
 .review {
   display: flex;
   .review-btn {
@@ -22,6 +25,32 @@
     width: 35px;
     height: 35px;
   }
+  // initial setting before clicking on anchor link
+  border: 1px solid transparent;
+  border-radius: 5px;
+  -webkit-transition: all 1s linear;
+  position: sticky;
+  top: 0;
+}
+// highlighting settings
+@keyframes highlight {
+  0% {
+    border: 1px solid transparent;
+    box-shadow: 0px 0px 10px transparent;
+  }
+  50% {
+    border: 1px solid #02598b;
+    box-shadow: 0px 0px 10px #02598b;
+  }
+  100% {
+    border: 1px solid transparent;
+    box-shadow: 0px 0px 10px transparent;
+  }
+}
+// smooth scrolling and highlighting area after clicking on anchor link
+.review:target {
+  animation: highlight 3s;
+  scroll-margin-top: 10rem;
 }
 
 .stars {

--- a/static/css/components/rating-form.less
+++ b/static/css/components/rating-form.less
@@ -52,10 +52,6 @@ html {
 .review:target {
   animation: highlight 3s;
 }
-//changes mouse cursor to 'pointer'
-.avg-ratings{
-  cursor: pointer;
-}
 .stars {
   background: url(/static/images/stars.png) repeat-x 0 0;
   width: 150px;


### PR DESCRIPTION
… redirect user to rate section and highlights this section.

<!-- What issue does this PR close? -->
Closes #7024

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Clicking Book Page Star Ratings summary redirect user to rate section and also highlights this section.

### Technical
<!-- What should be noted about the implementation? -->
In the file "StarRatings.html", div with class="review" now also has an id="starRatingSection".
In the file "StarRatingsStats.html", there is a change that provides clickable link to "rate" section: 
< li onclick="location.href='#starRatingSection';" >

In terms of a design (highlighting), I added detailed comments to the code. (If needed, I can describe changes even more.)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
After picking one of the books and clicking on Book Star Rating, you should be redirected to "rate" section, this section should be also highlighted for a moment.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Alice's adventures in Wonderland (1901 edition) _ Open Library - Google Chrome 2022-11-05 21-41-41_Moment](https://user-images.githubusercontent.com/110251702/200151848-12055690-b95c-488e-974d-337525289b67.jpg)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
