### PR TITLE
Change trending to hourly API

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -70,9 +70,11 @@ class trending_books_api(delegate.page):
         from openlibrary.views.loanstats import SINCE_DAYS
 
         period = period[1:]  # remove slash
-        i = web.input(page=1, limit=100)
+        i = web.input(page=1, limit=100, days=0, hours=0)
+        days = SINCE_DAYS.get(period, int(i.days))
         works = get_trending_books(
-            since_days=SINCE_DAYS[period],
+            since_days=days,
+            since_hours=int(i.hours),
             limit=int(i.limit),
             page=int(i.page),
             books_only=True,
@@ -80,6 +82,8 @@ class trending_books_api(delegate.page):
         result = {
             'query': f"/trending/{period}",
             'works': [dict(work) for work in works],
+            'days': days,
+            'hours': i.hours,
         }
         return delegate.RawText(json.dumps(result), content_type="application/json")
 

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -20,7 +20,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
   $:render_template("home/welcome", test=test)
 
   $if not test:
-    $:render_template("books/custom_carousel", books=get_trending_books(books_only=True), title=_('Trending Books'), url="/trending/daily", test=test, load_more={"url": "/trending/daily.json", "mode": "page", "limit": 18})
+    $:render_template("books/custom_carousel", books=get_trending_books(books_only=True), title=_('Trending Books'), url="/trending/daily", test=test, load_more={"url": "/trending/hours.json?hours=1", "mode": "page", "limit": 18})
 
     $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly')
 

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -22,7 +22,7 @@ def days_in_current_month():
 
 
 def todays_date_minus(**kwargs):
-    return (datetime.date.today() - datetime.timedelta(**kwargs))
+    return datetime.date.today() - datetime.timedelta(**kwargs)
 
 
 def date_n_days_ago(n=None, start=None):

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -21,6 +21,10 @@ def days_in_current_month():
     return calendar.monthrange(now.year, now.month)[1]
 
 
+def todays_date_minus(**kwargs):
+    return (datetime.date.today() - datetime.timedelta(**kwargs))
+
+
 def date_n_days_ago(n=None, start=None):
     """
     Args:

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -47,12 +47,12 @@ cached_reading_log_summary = cache.memcache_memoize(
 
 
 @public
-def get_trending_books(since_days=1, limit=18, page=1, books_only=False):
+def get_trending_books(since_days=1, since_hours=0, limit=18, page=1, books_only=False):
     logged_books = (
         Bookshelves.fetch(get_activity_stream(limit=limit, page=page))  # i.e. "now"
-        if since_days == 0
+        if (since_days == 0 and since_hours == 0)
         else Bookshelves.most_logged_books(
-            since=dateutil.date_n_days_ago(since_days),
+            since=dateutil.todays_date_minus(days=since_days, hours=since_hours),
             limit=limit,
             page=page,
             fetch=True,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6674

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This PR still needs to be updated so the header link goes to some sort of hourly view. Currently `hourly.json` has no UI. 
https://github.com/internetarchive/openlibrary/issues/6674#issuecomment-1160791270

After review, we may just want to use the /now.json endpoint (and not aggregate by time)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
