### PR TITLE
Add sentry transactions to OL python

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -180,6 +180,7 @@ sentry:
     enabled: false
     # Dummy endpoint; where sentry logs are sent to
     dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    traces_sample_rate: 1.0
     environment: 'local'
 
 sentry_cron_jobs:

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import infogami
 from infogami.utils import delegate
-from openlibrary.utils.sentry import Sentry
+from openlibrary.utils.sentry import Sentry, SentryProcessor
 
 sentry: Optional[Sentry] = None
 
@@ -14,3 +14,4 @@ def setup():
     if sentry.enabled:
         sentry.init()
         delegate.add_exception_hook(lambda: sentry.capture_exception_webpy())
+        delegate.app.add_processor(SentryProcessor())


### PR DESCRIPTION
We've been getting more traffic lately, and as a result the system has been struggling. To get more visibility into places we can squeeze out some more performance, let's use sentry's performance tools!


### Technical
- Some of the routes aren't being picked up correctly, but those can be fixed later. eg: profile pages (/people/Foo) show up as <other>, admin pages are all grouped together.
- Throttled to 20% of traffic on prod, 100% on testing
- TODO in future PR: Add to covers, which is currently experiencing the most strain!
- TODO in future PR: Add to infobase

### Testing
Try it at https://sentry.archive.org/organizations/ia-ux/performance/?breakdown=none&environment=ol-dev&isDefaultQuery=false&metricSearchSetting=transactionsOnly&project=7&showTransactions=p95&sort=-timestamp&statsPeriod=24h 

### Screenshot
The metrics are _amazing_!
![image](https://user-images.githubusercontent.com/6251786/201034619-1d98580b-d596-4be0-bf7c-153e6c2d05e5.png)

* TPM: Transactions per minute
* p50: 50% of all requests took less than the provided time
* p95: 95% of all requests took less than the provided time

You can further dive into a specific transaction's events to see sub-spans. Currently only other http calls work, but we could eg add db calls, etc here.

Here's a slow /books/OL*M request:
![image](https://user-images.githubusercontent.com/6251786/201035437-1658e366-bfde-4e89-a6f2-66bb5df28ace.png)


### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
