### PR TITLE
allow overriding import authors + publishers

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -131,7 +131,7 @@ class importapi:
             edition, format = parse_data(data)
             # Validation requires valid publishers and authors.
             # If data unavailable, provide throw-away data which validates
-            # We use ["????"] as an override pattern  
+            # We use ["????"] as an override pattern
             if data.get('publishers') == ["????"]:
                 data.pop('publishers')
             if data.get('authors') == ["????"]:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -132,10 +132,10 @@ class importapi:
             # Validation requires valid publishers and authors.
             # If data unavailable, provide throw-away data which validates
             # We use ["????"] as an override pattern
-            if data.get('publishers') == ["????"]:
-                data.pop('publishers')
-            if data.get('authors') == [{"name": "????"}]:
-                data.pop('authors')
+            if edition.get('publishers') == ["????"]:
+                edition.pop('publishers')
+            if edition.get('authors') == [{"name": "????"}]:
+                edition.pop('authors')
         except DataError as e:
             return self.error(str(e), 'Failed to parse import data')
         except ValidationError as e:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -134,7 +134,7 @@ class importapi:
             # We use ["????"] as an override pattern
             if data.get('publishers') == ["????"]:
                 data.pop('publishers')
-            if data.get('authors') == ["????"]:
+            if data.get('authors') == [{"name": "????"}]:
                 data.pop('authors')
         except DataError as e:
             return self.error(str(e), 'Failed to parse import data')

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -129,6 +129,13 @@ class importapi:
 
         try:
             edition, format = parse_data(data)
+            # Validation requires valid publishers and authors.
+            # If data unavailable, provide throw-away data which validates
+            # We use ["????"] as an override pattern  
+            if data.get('publishers') == ["????"]:
+                data.pop('publishers')
+            if data.get('authors') == ["????"]:
+                data.pop('authors')
         except DataError as e:
             return self.error(str(e), 'Failed to parse import data')
         except ValidationError as e:


### PR DESCRIPTION
This is needed for importing `promise` item json because some records have no publisher or author.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
