### PR TITLE
import promise items batch

### DIFF
--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import requests
 import logging
 
-from infogami import config  # noqa: F401                                                                                                                                                                                                                                                                                      
+from infogami import config  # noqa: F401
 from openlibrary.config import load_config
 from openlibrary.core.imports import Batch
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
@@ -33,7 +33,7 @@ def map_book_to_olbook(book):
         'author': [{"name": book['ProductJSON'].get('Author') or '????'}],
         'publishers': [book['ProductJSON'].get('Publisher') or '????';],
         'source_records': ["promise:bwb_daily_pallets_2022-10-20"],
-        # format_date adds hyphens between YYYY-MM-DD                                                                                                                                                                                                                                                                          
+        # format_date adds hyphens between YYYY-MM-DD
         'publish_date': publish_date and format_date(publish_date) or '????'
     }
     if not olbook['identifiers']:
@@ -52,7 +52,7 @@ def batch_import(promise_id):
             'data': b
         } for b in olbooks]
         print(batch_items)  # XXX
-        #batch.add_items(batch_items)                                                                                                                                                                                                                                                                                          
+        #batch.add_items(batch_items)
 
 def get_promise_items():
     url = "https://archive.org/advancedsearch.php"
@@ -68,7 +68,7 @@ def main(ol_config: str):
     promise_ids = get_promise_items()
     for promise_id in promise_ids:
         batch_import(promise_id)
-        return # XXX try 1 and quit                                                                                                                                                                                                                                                                                            
+        return # XXX try 1 and quit
 
 if __name__ == '__main__':
     FnToCLI(main).run()

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -40,7 +40,7 @@ def map_book_to_olbook(book, promise_id):
         **({'title': title} if title else {}),
         'author': [{"name": book['ProductJSON'].get('Author') or '????'}],
         'publishers': [book['ProductJSON'].get('Publisher') or '????'],
-        'source_records': [promise_id],
+        'source_records': [f"promise:{promise_id}"],
         # format_date adds hyphens between YYYY-MM-DD
         'publish_date': publish_date and format_date(publish_date) or '????',
     }

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -31,7 +31,7 @@ def map_book_to_olbook(book):
         **({'isbn_10': [book.get('ASIN')]} if asin_is_isbn_10 else {}),
         **({'title': title} if title else {}),
         'author': [{"name": book['ProductJSON'].get('Author') or '????'}],
-        'publishers': [book['ProductJSON'].get('Publisher') or '????';],
+        'publishers': [book['ProductJSON'].get('Publisher') or '????'],
         'source_records': ["promise:bwb_daily_pallets_2022-10-20"],
         # format_date adds hyphens between YYYY-MM-DD
         'publish_date': publish_date and format_date(publish_date) or '????'

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -38,7 +38,7 @@ def map_book_to_olbook(book, promise_id):
         ),
         **({'isbn_10': [book.get('ASIN')]} if asin_is_isbn_10 else {}),
         **({'title': title} if title else {}),
-        'author': [{"name": book['ProductJSON'].get('Author') or '????'}],
+        'authors': [{"name": book['ProductJSON'].get('Author') or '????'}],
         'publishers': [book['ProductJSON'].get('Publisher') or '????'],
         'source_records': [f"promise:{promise_id}"],
         # format_date adds hyphens between YYYY-MM-DD

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+import requests
+import logging
+
+from infogami import config  # noqa: F401                                                                                                                                                                                                                                                                                      
+from openlibrary.config import load_config
+from openlibrary.core.imports import Batch
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
+
+logger = logging.getLogger("openlibrary.importer.promises")
+
+def format_date(date: str) -> str:
+    y = date[0:4]
+    m = date[4:6]
+    d = date[6:8]
+    return f"{y}-{m}-{d}"
+
+def map_book_to_olbook(book):
+    asin_is_isbn_10 = book.get('ASIN')[0].isdigit()
+    publish_date = book['ProductJSON'].get('PublicationDate')
+    title = book['ProductJSON'].get('Title')
+    olbook = {
+        'local_id': [
+            f"urn:bwbsku:{book['BookSKUB']}"
+        ],
+        'identifiers': {
+            **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
+            **({'better_world_books': [book.get('ISBN')]} if not book.get('ISBN', ' ')[0].isdigit() else {}),
+        },
+        **({'isbn_13': [book.get('ISBN')]} if book.get('ISBN', ' ')[0].isdigit() else {}),
+        **({'isbn_10': [book.get('ASIN')]} if asin_is_isbn_10 else {}),
+        **({'title': title} if title else {}),
+        'author': [{"name": book['ProductJSON'].get('Author') or '????'}],
+        'publishers': [book['ProductJSON'].get('Publisher') or '????';],
+        'source_records': ["promise:bwb_daily_pallets_2022-10-20"],
+        # format_date adds hyphens between YYYY-MM-DD                                                                                                                                                                                                                                                                          
+        'publish_date': publish_date and format_date(publish_date) or '????'
+    }
+    if not olbook['identifiers']:
+        del olbook['identifiers']
+    return olbook
+
+def batch_import(promise_id):
+    url = "https://archive.org/download/"
+    date = promise_id.split("_")[-1]
+    books = requests.get(f"{url}{promise_id}/DailyPallets__{date}.json").json()
+    batch = Batch.find(promise_id) or Batch.new(promise_id)
+    if batch.count_items != len(books):
+        olbooks = [map_book_to_olbook(book) for book in books]
+        batch_items = [{
+            'ia_id': b['local_id'][0],
+            'data': b
+        } for b in olbooks]
+        print(batch_items)  # XXX
+        #batch.add_items(batch_items)                                                                                                                                                                                                                                                                                          
+
+def get_promise_items():
+    url = "https://archive.org/advancedsearch.php"
+    q = "collection%3Abookdonationsfrombetterworldbooks+identifier%3Abwb_daily_pallets_*"
+    sorts = "sort%5B%5D=addeddate+desc&sort%5B%5D=&sort%5B%5D="
+    fields = "fl%5B%5D=identifier"
+    rows = 5000
+    r = requests.get(f"{url}?q={q}&{fields}&{sorts}&rows={rows}&page=1&output=json")
+    return [d['identifier'] for d in r.json()['response']['docs']]
+
+def main(ol_config: str):
+    load_config(ol_config)
+    promise_ids = get_promise_items()
+    for promise_id in promise_ids:
+        batch_import(promise_id)
+        return # XXX try 1 and quit                                                                                                                                                                                                                                                                                            
+
+if __name__ == '__main__':
+    FnToCLI(main).run()


### PR DESCRIPTION
Run on ol-home0 cron container as
`su openlibrary -c 'PYTHONPATH="/openlibrary" python3 /openlibrary/scripts/promise_batch_imports.py /olsystem/etc/openlibrary.yml'`

<!-- What issue does this PR close? -->
Addresses #7132

The imports can be monitored for their statuses and rolled up / counted using this query on `ol-db1`:

```
openlibrary=# select count(*) from import_item where batch_id in (select id from import_batch where name like 'bwb_daily_pallets_%');
```
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

Relies on #7131 draft

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@judec @brewsterkahle @hornc 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
