### PR TITLE
Fix cache=True logic for ia.get_metadata

### DIFF
--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -52,7 +52,7 @@ def get_metadata_direct(itemid, only_metadata=True, cache=True):
     """
     url = f'{IA_BASE_URL}/metadata/{web.safestr(itemid.strip())}'
     params = {}
-    if cache:
+    if cache is False:
         params['dontcache'] = 1
     full_json = get_api_response(url, params)
     return extract_item_metadata(full_json) if only_metadata else full_json


### PR DESCRIPTION
This was being called with dontcache=True waaaay too often!

Here's an example load graph from our works pages:


![tmp (2)](https://user-images.githubusercontent.com/6251786/200908519-09e805b9-01ea-4af3-9cfc-59896aa717f5.jpg)


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
