### PR TITLE
Switch RelatedWorksCarousel to use solr

### DIFF
--- a/openlibrary/templates/books/RelatedWorksCarousel.html
+++ b/openlibrary/templates/books/RelatedWorksCarousel.html
@@ -1,11 +1,23 @@
 $def with(work)
 
 $if work and not is_bot():
-    $ work_subjects_authors = cached_work_authors_and_subjects(work.key)
     <div class="related-books">
-        $if work_subjects_authors.get('subjects'):
-            $:render_template("home/custom_ia_carousel", title="You might also like", key="related-subjects-carousel", work_id=work.key, _type="subjects", limit=42, min_books=1)
-        $if work_subjects_authors.get('authors'):
-            $ authors = ', '.join([author if isinstance(author, basestring) else author.name for author in work_subjects_authors['authors']])
-            $:render_template("home/custom_ia_carousel", title="More by %s" % (authors or "this author"), key="related-authors-carousel", work_id=work.key, _type="authors", limit=42, min_books=1)
+        $ subjects = work.get_related_books_subjects()
+        $ author_keys = [a.key.split('/')[-1] for a in work.get_authors()]
+
+        $if subjects:
+            $ query = 'ebook_access:[borrowable TO *] -key:"%s" subject:(%s)' % (
+            $    work.key,
+            $    ' OR '.join(['"%s"' % s for s in subjects]),
+            $ )
+            $if author_keys:
+                $ query += ' -author_key:(%s)' % ' OR '.join(['%s' % a for a in author_keys])
+            $:macros.QueryCarousel(query=query, title=_("You might also like"), key="related-subjects-carousel", limit=12)
+        $if author_keys:
+            $ query = 'ebook_access:[borrowable TO *] -key:"%s" author_key:(%s)' % (
+            $    work.key,
+            $    ' OR '.join(['%s' % a for a in author_keys]),
+            $ )
+            $ title = ungettext("More by this author", "More by these authors", len(author_keys))
+            $:macros.QueryCarousel(query=query, title=title, key="related-authors-carousel", limit=12)
     </div>


### PR DESCRIPTION
Fix. Performance and unnecessary hits to IA metadata. Closes #7136 .

Removes 10s of archive.org metadata API calls per OL book page load!

### Technical
- We can delete a good chunk of code after this as well: #7138 . Separating to get this out sooner.

### Testing
- Books without subjects work
- Books in results are comparable (see screenshots)

The timing improvements on testing are quite promising!

![image](https://user-images.githubusercontent.com/6251786/201030300-b04c213b-f791-4562-b3b1-316475bb7dc9.png)

The line ~15:00 is when this PR was deployed to testing.

### Screenshot

Results look better or comparable:

![image](https://user-images.githubusercontent.com/6251786/200925524-328f5aed-e5a1-44d0-a43f-ed64c787a3b1.png)

![image](https://user-images.githubusercontent.com/6251786/200925741-ff2ab2b3-a502-49e2-a1d9-6e75f73d8965.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
