### PR TITLE
Delete old subject carousel code

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -84,37 +84,12 @@ def setup(config):
     config_http_request_timeout = config.get('http_request_timeout')
 
 
-def get_work_authors_and_related_subjects(work_id):
-    if 'env' not in web.ctx:
-        delegate.fakeload()
-    work = web.ctx.site.get(work_id)
-    return {
-        'authors': work.get_author_names(blacklist=['anonymous']) if work else [],
-        'subjects': work.get_related_books_subjects() if work else [],
-    }
-
-
-@public
-def cached_work_authors_and_subjects(work_id):
-    try:
-        return cache.memcache_memoize(
-            get_work_authors_and_related_subjects,
-            'works_authors_and_subjects',
-            timeout=dateutil.HALF_DAY_SECS,
-        )(work_id)
-    except AttributeError:
-        logger.exception("cached_work_authors_and_subjects(%s)" % work_id)
-        return {'authors': [], 'subject': []}
-
-
 @public
 def compose_ia_url(
     limit: int = None,
     page: int = 1,
     subject=None,
     query=None,
-    work_id=None,
-    _type: Literal['authors', 'subjects'] = None,
     sorts=None,
     advanced=True,
     rate_limit_exempt=True,
@@ -155,27 +130,6 @@ def compose_ia_url(
         q += " AND " + query
     if subject:
         q += " AND openlibrary_subject:" + subject
-
-    if work_id and _type in ("authors", "subjects"):
-        _q = None
-        works_authors_and_subjects = cached_work_authors_and_subjects(work_id)
-        if _type == "authors":
-            authors = works_authors_and_subjects.get('authors', [])
-            if not authors:
-                return None
-            name_variations = [
-                variation
-                for name in authors
-                for variation in (name, ','.join(name.split(' ', 1)[::-1]))
-            ]
-
-            _q = ' OR '.join(f'creator:"{name}"' for name in name_variations)
-        elif _type == "subjects":
-            subjects = works_authors_and_subjects.get('subjects', [])
-            if not subjects:
-                return None
-            _q = ' OR '.join(f'subject:"{subject}"' for subject in subjects)
-        q += ' AND ({}) AND !openlibrary_work:({})'.format(_q, work_id.split('/')[-1])
 
     if not advanced:
         _sort = sorts[0] if sorts else ''
@@ -270,8 +224,6 @@ def get_available(
     page=1,
     subject=None,
     query=None,
-    work_id=None,
-    _type=None,
     sorts=None,
     url=None,
 ):
@@ -289,8 +241,6 @@ def get_available(
         page=page,
         subject=subject,
         query=query,
-        work_id=work_id,
-        _type=_type,
         sorts=sorts,
     )
     if not url:
@@ -301,8 +251,6 @@ def get_available(
                 'page': page,
                 'subject': subject,
                 'query': query,
-                'work_id': work_id,
-                'type': _type,
                 'sorts': sorts,
             },
         )

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -89,9 +89,7 @@ class browse(delegate.page):
     encoding = "json"
 
     def GET(self):
-        i = web.input(
-            q='', page=1, limit=100, subject='', work_id='', _type='', sorts=''
-        )
+        i = web.input(q='', page=1, limit=100, subject='', sorts='')
         sorts = i.sorts.split(',')
         page = int(i.page)
         limit = int(i.limit)
@@ -100,8 +98,6 @@ class browse(delegate.page):
             limit=limit,
             page=page,
             subject=i.subject,
-            work_id=i.work_id,
-            _type=i._type,
             sorts=sorts,
         )
         works = lending.get_available(url=url) if url else []

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -663,9 +663,7 @@ class random_book(delegate.page):
         raise web.seeother("/")
 
 
-def get_ia_carousel_books(
-    query=None, subject=None, work_id=None, sorts=None, _type=None, limit=None
-):
+def get_ia_carousel_books(query=None, subject=None, sorts=None, limit=None):
     if 'env' not in web.ctx:
         delegate.fakeload()
 
@@ -676,8 +674,6 @@ def get_ia_carousel_books(
     books = lending.get_available(
         limit=limit,
         subject=subject,
-        work_id=work_id,
-        _type=_type,
         sorts=sorts,
         query=query,
     )
@@ -730,8 +726,6 @@ def get_cached_featured_subjects():
 def generic_carousel(
     query=None,
     subject=None,
-    work_id=None,
-    _type=None,
     sorts=None,
     limit=None,
     timeout=None,
@@ -745,8 +739,6 @@ def generic_carousel(
     books = cached_ia_carousel_books(
         query=query,
         subject=subject,
-        work_id=work_id,
-        _type=_type,
         sorts=sorts,
         limit=limit,
     )
@@ -754,8 +746,6 @@ def generic_carousel(
         books = cached_ia_carousel_books.update(
             query=query,
             subject=subject,
-            work_id=work_id,
-            _type=_type,
             sorts=sorts,
             limit=limit,
         )[0]

--- a/openlibrary/templates/home/custom_ia_carousel.html
+++ b/openlibrary/templates/home/custom_ia_carousel.html
@@ -1,7 +1,7 @@
-$def with(title, key, query='', subject='', work_id='', _type='', sorts='', limit=None, min_books=7, test=False, compact_mode=False)
+$def with(title, key, query='', subject='', sorts='', limit=None, min_books=7, test=False, compact_mode=False)
 
-$ url = compose_ia_url(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit, advanced=False)
-$ books = generic_carousel(query=query, subject=subject, work_id=work_id, _type=_type, sorts=sorts, limit=limit) if not test else []
+$ url = compose_ia_url(query=query, subject=subject, sorts=sorts, limit=limit, advanced=False)
+$ books = generic_carousel(query=query, subject=subject, sorts=sorts, limit=limit) if not test else []
 $ sorts = ','.join(sorts) if sorts else ''
-$ load_more_url = '/browse.json?q=%s&subject=%s&work_id=%s&_type=%s&sorts=%s' % (query, subject, work_id, _type, sorts)
+$ load_more_url = '/browse.json?q=%s&subject=%s&sorts=%s' % (query, subject, sorts)
 $:render_template("books/custom_carousel", books, title=title, url=url, key=key, min_books=min_books, load_more={"url": load_more_url, "mode": "page", "limit": limit}, test=test, compact_mode=compact_mode)


### PR DESCRIPTION
Refactor. Delete no longer used methods now that RelatedWorkCarousel uses solr.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Related carousels still work. We shouldn't be using these anywhere else?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
