### PR TITLE
6660 duplicate the pagination widget for lists

### DIFF
--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -190,7 +190,7 @@ $def seed_attrs(seed):
 
         $if list.description:
             $:format(list.description)
-        
+
         $:macros.Pager(page+1, len(list.seeds), page_size)
         <div class="clearfix"></div>
 

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -190,6 +190,9 @@ $def seed_attrs(seed):
 
         $if list.description:
             $:format(list.description)
+        
+        $:macros.Pager(page+1, len(list.seeds), page_size)
+        <div class="clearfix"></div>
 
         <ul id="listResults" class="list-books clearfix">
             $ component_times['get_seeds'] = time()
@@ -230,7 +233,6 @@ $def seed_attrs(seed):
                 </li>
         </ul>
     </div>
-
     <div class="contentOnethird" style="margin-bottom:0;">
 
         $:render_template("type/list/exports", list)

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -175,6 +175,7 @@ $ )
         $# this commit to revert.
         <center>
           <div class="red">$_("No results found.")</div>
+          <div>$_("Did you mean X ?")</div> <!-- where X is add spellchecked answer and link to search for that-->
           <hr>
           <div>
             <a href="/search/inside?$urlencode(dict(q=query))">$_('Search for books containing the phrase "%s"?' % query)</a>


### PR DESCRIPTION
Closes #6660

This PR achieves a feature where clicking on lists now has pagination at the top and bottom of the lists. 

### Technical

In the “view_body.html” in templates/type/list, the div with class “mybooks-list” now has a macros pager and an additional div with class “clearfix”. This is done so the presentation of the pagination elements remains consistent at the top and bottom of the lists page.  

### Testing
To reproduce or verify what this PR fixes, one should create or access a list of over 50 items (so there are enough items to present pagination). After completing the above one should look at the people/username/lists/list_id/list_name page and find that pagination is present on the top and the bottom. 


### Screenshot
<img width="1440" alt="6660_evidence" src="https://user-images.githubusercontent.com/97415505/201463087-bdef3368-eed7-4db1-ba4e-1353bedd7b6e.png">


### Stakeholders
@seabelis  @cdrini @mekarpeles 
