### PR TITLE
Solves #6660 whole issue of duplicating pagination for user lists

### DIFF
--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -190,6 +190,9 @@ $def seed_attrs(seed):
 
         $if list.description:
             $:format(list.description)
+        
+        $:macros.Pager(page+1, len(list.seeds), page_size)
+        <div class="clearfix"></div>
 
         <ul id="listResults" class="list-books clearfix">
             $ component_times['get_seeds'] = time()

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -190,7 +190,7 @@ $def seed_attrs(seed):
 
         $if list.description:
             $:format(list.description)
-        
+
         $:macros.Pager(page+1, len(list.seeds), page_size)
         <div class="clearfix"></div>
 


### PR DESCRIPTION
Closes #6660

This PR achieves a feature where clicking on lists now has pagination at the top and bottom of the lists. 

### Technical

In the “view_body.html” in templates/type/list, the div with class “mybooks-list” now has a macros pager and an additional div with class “clearfix”. This is done so the presentation of the pagination elements remains consistent at the top and bottom of the lists page.  

### Testing
To reproduce or verify what this PR fixes, one should create or access a list of over 50 items (so there are enough items to present pagination). After completing the above one should look at the people/username/lists/list_id/list_name page and find that pagination is present on the top and the bottom. 


### Screenshot
<img width="1440" alt="6660_evidence" src="https://user-images.githubusercontent.com/97415505/201465059-f1b8f629-195c-483e-82d5-ffc985434591.png">


### Stakeholders
@seabelis  @cdrini @mekarpeles 
