### PR TITLE
covers.py: URLs should be str, not bytes

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -45,6 +45,8 @@ class add_cover(delegate.page):
         coverid = data.get('id')
 
         if coverid:
+            if isinstance(i.url, bytes):
+                i.url = i.url.decode("utf-8")
             self.save(book, coverid, url=i.url)
             cover = Image(web.ctx.site, "b", coverid)
             return render_template("covers/saved", cover)


### PR DESCRIPTION
Fixes https://sentry.archive.org/organizations/ia-ux/issues/50747

<!-- What issue does this PR close? -->
Closes https://sentry.archive.org/organizations/ia-ux/issues/50747

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Converts a bytes URL into a string.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
