### PR TITLE
Fix subject clampers for Firefox

### DIFF
--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -53,7 +53,7 @@ export function initClampers(clampers) {
                 }
 
                 if (up.hasClass('clamp')) {
-                    up.css({ display: up.css('display') === '-webkit-box' ? 'unset' : '-webkit-box' });
+                    clamper.style.display = clamper.style.display === '-webkit-box' || clamper.style.display === '' ? 'unset' : '-webkit-box'
 
                     if (up.attr('data-before') === '\u25BE ') {
                         up.attr('data-before', '\u25B8 ')


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes issue where book page subjects do not expand/collapse in Firefox.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
