### PR TITLE
Don't show the reading log search when a shelf has < 1 books.

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -100,7 +100,7 @@ export class SearchBar {
             this.facet.write(urlParams.facet);
         }
 
-        if (urlParams.q) {
+        if (urlParams.q && window.location.pathname.match(/^\/search/)) {
             let q = urlParams.q.replace(/\+/g, ' ');
             if (this.facet.read() === 'title' && q.indexOf('title:') !== -1) {
                 const parts = q.split('"');
@@ -127,19 +127,25 @@ export class SearchBar {
         $(window).on('resize', debounce(() => {
             this.toggleCollapsibleModeForSmallScreens($(window).width());
         }, 50));
-        $(document).on('submit','.in-collapsible-mode', event => {
-            if (this.collapsed) {
+
+        const expandAndFocusSearch = (event) => {
+            if (this.inCollapsibleMode && this.collapsed) {
                 event.preventDefault();
                 this.toggleCollapse();
                 this.$input.trigger('focus');
             }
-        });
-        // Collapse search bar when clicking outside of search bar
+        }
+        const expandSelectors = ['.search-component', 'a[href="/search"]'];
+
+        // When clicking on the search bar or a link to /search, expand search if it isn't already.
+        // If clicking elsewhere, collapse search.
+        $(document).on('submit', '.in-collapsible-mode', event => expandAndFocusSearch(event));
         $(document).on('click', event => {
-            if ($(event.target).closest('.search-component').length === 0) {
-                if (!this.collapsed) {
-                    this.toggleCollapse();
-                }
+            const shouldExpand = (item) => $(event.target).closest(item).length === 1;
+            if (expandSelectors.some(shouldExpand)) {
+                expandAndFocusSearch(event);
+            } else {
+                if (!this.collapsed) this.toggleCollapse();
             }
         });
     }

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -24,39 +24,46 @@ $add_metatag(property="og:site_name", content="Open Library")
 $add_metatag(property="og:description", content=og_description)
 $add_metatag(property="og:image", content=meta_photo_url)
 
-<form method="GET" class="olform pagesearchbox">
-  <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
-  <input type="submit"/>
-</form>
+$# The reading log search is only displayed on non-empty shelves because some patrons were confused and searching empty reading lists, perhaps thinking they could add books that way. See #7143.
+$if shelf_count > 0:
+  <form method="GET" class="olform pagesearchbox">
+    <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
+    <input type="submit"/>
+  </form>
 
-<div class="mybooks-list">
-  $if q:
-    <span class="search-results-stats">$ungettext('1 hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
-  $else:
-    <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
-      $if sort_order == 'desc':
-        <strong class="lightgreen">$_("Date Added (newest)")</strong>
-        |
-        <a href="$changequery(sort='asc')">$_("Date Added (oldest)")</a>
-      $else:
-        <a href="$changequery(sort='desc')">$_("Date Added (newest)")</a>
-        |
-        <strong class="lightgreen">$_("Date Added (oldest)")</strong>
-    </span>
-
-  $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
-  <ul class="list-books">
-    $if docs:
-      $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
-      $ doc_number = 1
-      $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
-      $for idx, doc in enumerate(docs):
-        $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=(bookshelf_id == 3 and doc.logged_edition), users_work_read_status=bookshelf_id, remove_on_change=True)
-        $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
-        $:macros.SearchResultsWork(doc, reading_log=dropper, availability=doc.get('availability'), rating=star_rating)
-        $ doc_number = doc_number + 1
+  <div class="mybooks-list">
+    $if q:
+      <span class="search-results-stats">$ungettext('1 hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
     $else:
-      <li>$_('No books are on this shelf')</li>
-  </ul>
-  $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
-</div>
+      <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
+        $if sort_order == 'desc':
+          <strong class="lightgreen">$_("Date Added (newest)")</strong>
+          |
+          <a href="$changequery(sort='asc')">$_("Date Added (oldest)")</a>
+        $else:
+          <a href="$changequery(sort='desc')">$_("Date Added (newest)")</a>
+          |
+          <strong class="lightgreen">$_("Date Added (oldest)")</strong>
+      </span>
+
+    $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
+    <ul class="list-books">
+      $if docs:
+        $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
+        $ doc_number = 1
+        $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
+        $for idx, doc in enumerate(docs):
+          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=(bookshelf_id == 3 and doc.logged_edition), users_work_read_status=bookshelf_id, remove_on_change=True)
+          $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
+          $:macros.SearchResultsWork(doc, reading_log=dropper, availability=doc.get('availability'), rating=star_rating)
+          $ doc_number = doc_number + 1
+    </ul>
+    $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
+  </div>
+$else:
+  <div class="mybooks-list">
+    <ul class="list-books">
+      <p>$_("You haven't added any books to this shelf yet.")</p>
+      <p>$:_('<a href="/search">Search for a book</a> to add to your reading log. <a href="/help/faq/reading-log">Learn more</a> about the reading log.')</p>
+    </ul>
+  </div>

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -13,6 +13,9 @@ describe('SearchBar', () => {
         </div>`;
 
     describe('initFromUrlParams', () => {
+        delete window.location
+        window.location = new URL('https://openlibrary.org/search')
+
         let sb;
         beforeEach(() => {
             sb = new SearchBar($(DUMMY_COMPONENT_HTML));


### PR DESCRIPTION
Additionally, when a reading log shelf has < 1 book, link to /search. On mobile, clicking this link will expand and focus the main search bar at the top.

<!-- What issue does this PR close? -->
Closes #7143

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
This does four things:
- It hides the reading log search when a shelf has < 1 book;
- It adds a link to /search when the reading log search is hidden;
- On mobile, clicking the link to /search will expand the main search bar at the top and focus it.
- It limits the `q` parameter used by `SearchBar.js` to `/search`; this way we can use `q` both for reading log queries and search bar queries -- and possibly other queries in other places.

Edit: I hasten to add this changes functionality on mobile in one minor way. Previously, the search bar at the top would only expand when one clicked on the magnifying glass; this changes it so the search box will expand if anyone clicks where the search box expands to (i.e. within `.search-component`. I figured people might be like me and sometimes have issues clicking smaller magnifying glasses. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Reading log shelves with zero books should not show the reading log search.
- Clicking the link to "search for a book" should on desktop take a user to /search, and on mobile expand the search bar at the top and focus it.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Desktop, viewing a reading log shelf with no books:
![image](https://user-images.githubusercontent.com/26524678/201845222-a638e5e8-ead9-44d4-a811-ded62df8df8a.png)

Mobile, viewing a shelf with no books:
![image](https://user-images.githubusercontent.com/26524678/201845348-3d0c2f5b-8237-4a0f-bcf1-ed9f985c471e.png)

Mobile, after clicking the 'search for a book' link, with the search bar at the top expanded:
![image](https://user-images.githubusercontent.com/26524678/201845462-ca26435e-8647-49d5-bd29-37251d4a704a.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
