### PR TITLE
Add delete button to author edit page

### DIFF
--- a/openlibrary/macros/HiddenSaveButton.html
+++ b/openlibrary/macros/HiddenSaveButton.html
@@ -1,7 +1,7 @@
-$def with ()
+$def with (form_ref)
 
 $# Forms will bind the "enter" key to the first submit button ; in the case
 $# we show the delete button for librarians, that becomes the first submit
 $# button! So we duplicate the save button here to make sure that it's always
 $# the default "enter" action.
-<button type="submit" class="hidden" name="_save" form="addWork" tabindex="-1"></button>
+<button type="submit" class="hidden" name="_save" form="$form_ref" tabindex="-1"></button>

--- a/openlibrary/macros/HiddenSaveButton.html
+++ b/openlibrary/macros/HiddenSaveButton.html
@@ -1,0 +1,7 @@
+$def with ()
+
+$# Forms will bind the "enter" key to the first submit button ; in the case
+$# we show the delete button for librarians, that becomes the first submit
+$# button! So we duplicate the save button here to make sure that it's always
+$# the default "enter" action.
+<button type="submit" class="hidden" name="_save" form="addWork" tabindex="-1"></button>

--- a/openlibrary/macros/databarEdit.html
+++ b/openlibrary/macros/databarEdit.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 
-<div id="editTools" class="edit">
+<div id="editTools" class="edit inline-block">
     <div id="editHistory">
         <a class="linkButton larger" href="$page.key?m=history" title="View the editing history of this page">$_("History")</a>
     </div>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -5,11 +5,7 @@ $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) e
 $var title: $this_title
 $putctx("robots", "noindex,nofollow")
 
-$# Forms will bind the "enter" key to the first submit button ; in the case
-$# we show the delete button for librarians, that becomes the first submit
-$# button! So we duplicate the save button here to make sure that it's always
-$# the default "enter" action.
-<button type="submit" class="hidden" name="_save" form="addWork" tabindex="-1"></button>
+$:macros.HiddenSaveButton()
 
 <div id="contentHead" class="editFormHead">
     $code:

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -5,7 +5,7 @@ $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) e
 $var title: $this_title
 $putctx("robots", "noindex,nofollow")
 
-$:macros.HiddenSaveButton()
+$:macros.HiddenSaveButton("addWork")
 
 <div id="contentHead" class="editFormHead">
     $code:

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -4,7 +4,7 @@ $var title: $page.name
 
 $putctx("robots", "noindex,nofollow")
 
-$:macros.HiddenSaveButton()
+$:macros.HiddenSaveButton("addAuthor")
 
 <div id="contentHead">
     $:macros.databarEdit(page)

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -4,8 +4,14 @@ $var title: $page.name
 
 $putctx("robots", "noindex,nofollow")
 
+$:macros.HiddenSaveButton()
+
 <div id="contentHead">
     $:macros.databarEdit(page)
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+        <span class="adminOnly right">
+            <button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete" form="addAuthor">$_("Delete Record")</button>
+        </span>
     <h1>$_("Edit Author")</h1>
     $if not ctx.user:
         $:render_template("lib/not_logged")

--- a/static/css/components/edit-toolbar--tablet.less
+++ b/static/css/components/edit-toolbar--tablet.less
@@ -4,13 +4,6 @@
  */
 
 /* stylelint-disable selector-max-specificity */
-div#editTools,
-div.editButton,
-div#editHistory {
-  padding: 3px 1px 0 20px;
-  float: right;
-}
-
 div#editInfo {
   margin-top: 3px;
   float: right;
@@ -20,4 +13,9 @@ div#editTools {
   display: flex;
   margin-top: 1px;
   max-width: 280px;
+
+  &.inline-block {
+    display: inline-block;
+    max-width: 50%;
+  }
 }

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -7,6 +7,11 @@
 div#editTools,
 div#editHistory {
   width: auto;
+
+  &.inline-block {
+    display: inline-block;
+    max-width: 50%;
+  }
 }
 
 div.editButton {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6583

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds delete button to the top of the author edit page for admins and super-librarians.  Adds hidden "Save" button before the delete button in order to prevent accidental deletions when the enter button is pressed (see: #6472).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-11-14 23-54-24](https://user-images.githubusercontent.com/28732543/201866118-09055065-27e9-4f8e-a600-0a107d50a6c8.png)
_Desktop view_

![Screenshot from 2022-11-14 23-53-59](https://user-images.githubusercontent.com/28732543/201866138-96dea270-0984-4be6-86c3-c072aa7900ca.png)
_Mobile view_


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
