### PR TITLE
Update hamburger menu

### DIFF
--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -4,6 +4,7 @@ $# @property {string} text of link
 $# @property {string|null} href of link for HTTP get request
 $# @property {string|null} post when set will be used instead of href and should use HTTP POST request.
 $# @property {string|null} `track` event label for google analytics
+$# @property {string|null} subheading that will appear below the link text
 $#
 $# @param {Object} props template properties
 $# @param {string} props.name unique identifying name for dropdown and distinguishing it from other dropdowns
@@ -69,6 +70,9 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
                     <span>$(link['text'])</span><span class="app-drawer__badge">$_('New!')</span>
                   $else:
                     $(link['text'])
+                    $if 'subheading' in link:
+                      <br>
+                      <i class="subheading">$(link['subheading'])</i>
                 </a>
               </li>
         </ul>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -12,7 +12,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
     $     { "post": "/account/logout", "text": _("Log out"), "track": "Logout" },
     $ ]
       $if is_privileged_user:
-        $ loginLinks.insert(2, { "href": homepath() + "/merges", "text": _("Pending Requests"),"track": "MyRequests" })
+        $ loginLinks.insert(2, { "href": homepath() + "/merges", "text": _("Pending Merge Requests"),"track": "MyRequests" })
   $else:
     $ loginLinks = [
     $     { "loginClass": "login-links" }
@@ -32,11 +32,12 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
   $ ]
   $ contributeLinks = [
   $     { "href": "/books/add", "text": _("Add a Book"), "track": "AddBook" },
-  $     { "href": "/recentchanges", "text": _("Recent Community Edits"), "track": "RecentEdits" },
-  $     { "href": "/developers", "text": _("Developer Center"), "track": "Developers" }
+  $     { "href": "/recentchanges", "text": _("Recent Community Edits"), "track": "RecentEdits" }
   $ ]
   $ resourceLinks = [
-  $     { "href": "/help", "text": _("Help & Support"), "track": "Help" }
+  $     { "href": "/help", "text": _("Help & Support"), "track": "Help" },
+  $     { "href": "/developers", "text": _("Developer Center"), "track": "DevelopersHelp" },
+  $     { "href": "/librarians", "text": _("Librarians Portal"), "track": "LibrariansHelp" }
   $ ]
   $ hamburgerProps = {
   $  'name': 'hamburger',

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -6,16 +6,13 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
 
   $if ctx.user:
     $ loginLinks = [
+    $     { "href": "/account/loans", "text": _("My Books"), "track": "MyBooks", "subheading": _("Loans, Reading Log, Lists, Stats") },
     $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MyProfile" },
-    $     { "href": homepath() + "/account/loans", "text": _("My Loans"), "track": "MyLoans" },
-    $     { "href": "/account/books", "text": _("My Reading Log"), "track": "MyReadingLog" },
-    $     { "href": "/account/lists", "text": _("My Lists"), "track": "MyLists" },
-    $     { "href": "/account/books/already-read/stats", "text": _("My Reading Stats"), "track": "MyReadingStats" },
     $     { "href": homepath() + "/account", "text": _("Settings"), "track": "MySettings" },
     $     { "post": "/account/logout", "text": _("Log out"), "track": "Logout" },
     $ ]
       $if is_privileged_user:
-        $ loginLinks.insert(1,{ "href": homepath() + "/merges", "text": _("Pending Requests"),"track": "MyRequests" })
+        $ loginLinks.insert(2, { "href": homepath() + "/merges", "text": _("Pending Requests"),"track": "MyRequests" })
   $else:
     $ loginLinks = [
     $     { "loginClass": "login-links" }
@@ -33,16 +30,20 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
   $     { "href": "/random", "text": _("Random Book"), "track": "RandomBook" },
   $     { "href": "/advancedsearch", "text": _("Advanced Search"), "track": "AdvancedSearch" }
   $ ]
-  $ moreLinks = [
+  $ contributeLinks = [
   $     { "href": "/books/add", "text": _("Add a Book"), "track": "AddBook" },
   $     { "href": "/recentchanges", "text": _("Recent Community Edits"), "track": "RecentEdits" },
-  $     { "href": "/developers", "text": _("Developer Center"), "track": "Developers" },
+  $     { "href": "/developers", "text": _("Developer Center"), "track": "Developers" }
+  $ ]
+  $ resourceLinks = [
   $     { "href": "/help", "text": _("Help & Support"), "track": "Help" }
   $ ]
   $ hamburgerProps = {
   $  'name': 'hamburger',
   $  'links': [ { "subsection": _("My Open Library") } ] + loginLinks +
-  $     [ { "subsection": _("Browse") } ] + browseLinks + [ { "subsection": _("More") } ] + moreLinks,
+  $     [ { "subsection": _("Browse") } ] + browseLinks +
+  $     [ { "subsection": _("Contribute") } ] + contributeLinks +
+  $     [ { "subsection": _("Resources") } ] + resourceLinks,
   $  'image': '/static/images/hamburger-icon.svg',
   $  'image-class': 'hamburger__icon',
   $  'label': 'additional options menu',
@@ -63,12 +64,6 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
   $   'name': 'browse',
   $   'label': _('Browse'),
   $   'links': browseLinks
-  $ }
-
-  $ moreProps = {
-  $   'name': 'more',
-  $   'label': _('More'),
-  $   'links': moreLinks
   $ }
 
   $ myBooksProps = {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7021

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following updates to the hamburger menu:
1. Replace "My Loans", "My Reading Log", "My Lists", and "My Reading Stats" links with single "My Books" link which references the loans page.
2. Split "More" section into "Contribute" and "Resources" section.

### Technical
<!-- What should be noted about the implementation? -->
Unreferenced `moreProps` have been removed from `nav_head.html`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-11-15 13-25-17](https://user-images.githubusercontent.com/28732543/202028580-225f38fb-7977-4809-b836-b00279888a75.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@danafein
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
