### PR TITLE
adding book image carousels for loans and reading logs, title URLs

### DIFF
--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -47,4 +47,3 @@ $else:
   }
 </style>
 
-<!-- $mybooks -->

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -5,6 +5,39 @@ $ component_times['TotalTime'] = time()
 
 $ username = user.key.split('/')[-1]
 
+$if len(mybooks['loans']) == 0:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="loans" href="/account/loans">$_('Loans (0)')</a></h2>
+  </div>
+  <div><em>$_("You've not checked out any books at this moment.")</em></div>
+  <br>
+$else:
+  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans")
+
+$if mybooks['currently-reading'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
+$if mybooks['want-to-read'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
+$if mybooks['already-read'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
 <style type="text/css">
   .item {
   background-color: #ddd;
@@ -14,4 +47,4 @@ $ username = user.key.split('/')[-1]
   }
 </style>
 
-$mybooks
+<!-- $mybooks -->


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7053 First step of My Books page redesign process 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Create a new page at /account/books (technically /people/username/books) with new My Books desktop interface

### Technical
<!-- What should be noted about the implementation? -->
Carousels are custom_carousels, I was unable to test with books in the loans carousel as yet

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
go to /account/books at your local instance and click through the carousels to see what it does. if there aren't any books in your testing instance, add some books to reading logs or borrow some books if possible

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![localhost_8080_people_openlibrary_books (1)](https://user-images.githubusercontent.com/69476557/202358002-4283d624-4600-4b54-a511-bbf2bd31e31c.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jimchamp @cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
