### PR TITLE
setting compact_mode=True in the loans and logs carousels to improve responsiveness

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -282,17 +282,29 @@ class MyBooksTemplate:
             return {
                 'loans': borrow.get_loans(logged_in_user),
                 'want-to-read': self.readlog.get_works(
-                    key='want-to-read', page=page, limit=5, sort='created', sort_order='asc'
+                    key='want-to-read',
+                    page=page,
+                    limit=5,
+                    sort='created',
+                    sort_order='asc',
                 ),
                 'currently-reading': self.readlog.get_works(
-                    key='currently-reading', page=page, limit=5, sort='created', sort_order='asc'
+                    key='currently-reading',
+                    page=page,
+                    limit=5,
+                    sort='created',
+                    sort_order='asc',
                 ),
                 'already-read': self.readlog.get_works(
-                    key='already-read', page=page, limit=5, sort='created', sort_order='asc'
+                    key='already-read',
+                    page=page,
+                    limit=5,
+                    sort='created',
+                    sort_order='asc',
                 ),
             }
         elif self.key == 'loans':
-            #logged_in_user.update_loan_status()
+            # logged_in_user.update_loan_status()
             return borrow.get_loans(logged_in_user)
         elif self.key == 'waitlist':
             return {}

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -12,10 +12,10 @@ $if len(mybooks['loans']) == 0:
   <div><em>$_("You've not checked out any books at this moment.")</em></div>
   <br>
 $else:
-  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans")
+  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans", min_books=1, load_more=None, test=False, compact_mode=True)
 
 $if mybooks['currently-reading'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading")
+  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading", min_books=1, load_more=None, test=False, compact_mode=True)
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
@@ -23,7 +23,7 @@ $else:
   <li>$_('No books are on this shelf')</li>
 
 $if mybooks['want-to-read'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read")
+  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read", min_books=1, load_more=None, test=False, compact_mode=True)
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
@@ -31,7 +31,7 @@ $else:
   <li>$_('No books are on this shelf')</li>
 
 $if mybooks['already-read'].docs:
-  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read")
+  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read", min_books=1, load_more=None, test=False, compact_mode=True)
 $else:
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -5,6 +5,39 @@ $ component_times['TotalTime'] = time()
 
 $ username = user.key.split('/')[-1]
 
+$if len(mybooks['loans']) == 0:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="loans" href="/account/loans">$_('Loans (0)')</a></h2>
+  </div>
+  <div><em>$_("You've not checked out any books at this moment.")</em></div>
+  <br>
+$else:
+  $:render_template("books/custom_carousel", books=mybooks['loans'], title=_('Loans')+" ("+str(len(mybooks['loans']))+")", url="/account/loans", key="loans")
+
+$if mybooks['currently-reading'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['currently-reading'].docs, title=_('Currently Reading')+" ("+str(mybooks['currently-reading'].total_results)+")", url="/account/books/currently-reading", key="currently-reading")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="currently-reading" href="/account/books/currently-reading">$_('Currently Reading (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
+$if mybooks['want-to-read'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['want-to-read'].docs, title=_('Want to Read')+" ("+str(mybooks['want-to-read'].total_results)+")", url="/account/books/want-to-read", key="want-to-read")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="want-to-read" href="/account/books/want-to-read">$_('Want to Read (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
+$if mybooks['already-read'].docs:
+  $:render_template("books/custom_carousel", books=mybooks['already-read'].docs, title=_('Already Read')+" ("+str(mybooks['already-read'].total_results)+")", url="/account/books/already-read", key="already-read")
+$else:
+  <div class="carousel-section-header">
+    <h2 class="home-h2"><a name="already-read" href="/account/books/already-read">$_('Already Read (0)')</a></h2>
+  </div>
+  <li>$_('No books are on this shelf')</li>
+
 <style type="text/css">
   .item {
   background-color: #ddd;
@@ -14,4 +47,4 @@ $ username = user.key.split('/')[-1]
   }
 </style>
 
-$mybooks
+<!-- $mybooks -->


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7053 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes responsiveness bug with carousel design for My Books page with sidebar

### Technical
<!-- What should be noted about the implementation? -->
set compact_mode=True for each of the carousels

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try looking at carousels with different numbers of books (1 or 2 books vs 5 vs 10)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![localhost_8080_people_openlibrary_books(Surface Pro 7)](https://user-images.githubusercontent.com/69476557/202768963-ced588b8-16cb-41c6-ab10-094fc5164465.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jimchamp @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
