### PR TITLE
Prevent reordering of work records in merge UI

### DIFF
--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -95,18 +95,13 @@ export default {
                 await Promise.all(olids_sorted.map(fetchRecord)),
                 record => record.type.key, 'desc');
 
-            // Ensure that primary record is the first record
+            let masterIndex = 0
             if (this.primary) {
                 const primaryKey = `/works/${this.primary}`
-                const primaryIndex = records.findIndex(elem => elem.key === primaryKey)
-                if (primaryIndex > 0) {
-                    const primaryRecord = records[primaryIndex]
-                    records.splice(primaryIndex, 1)
-                    records.unshift(primaryRecord)
-                }
+                masterIndex = records.findIndex(elem => elem.key === primaryKey)
             }
 
-            this.master_key = records[0].key
+            this.master_key = records[masterIndex].key
             this.selected = _.fromPairs(records.map(record => [record.key, record.type.key.includes('work')]));
 
             return records;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7120

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
If a primary record has been selected, the work records are not reordered.  Instead, the chosen primary record is selected as the main record.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
