### PR TITLE
Change simple 200 raise to return

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -402,15 +402,9 @@ class robotstxt(delegate.page):
 
     def GET(self):
         web.header('Content-Type', 'text/plain')
-        try:
-            is_dev = (
-                'dev' in infogami.config.features or web.ctx.host != 'openlibrary.org'
-            )
-            robots_file = 'norobots.txt' if is_dev else 'robots.txt'
-            data = open('static/' + robots_file).read()
-            raise web.HTTPError('200 OK', {}, data)
-        except OSError:
-            raise web.notfound()
+        is_dev = 'dev' in infogami.config.features or web.ctx.host != 'openlibrary.org'
+        robots_file = 'norobots.txt' if is_dev else 'robots.txt'
+        return web.ok(open(f'static/{robots_file}').read())
 
 
 @web.memoize
@@ -423,7 +417,7 @@ class ia_js_cdn(delegate.page):
 
     def GET(self, filename):
         web.header('Content-Type', 'text/javascript')
-        raise web.HTTPError('200 OK', {}, fetch_ia_js(filename))
+        return web.ok(fetch_ia_js(filename))
 
 
 class serviceworker(delegate.page):
@@ -431,25 +425,15 @@ class serviceworker(delegate.page):
 
     def GET(self):
         web.header('Content-Type', 'text/javascript')
-        try:
-            data = open('static/build/sw.js').read()
-            raise web.HTTPError('200 OK', {}, data)
-        except OSError:
-            raise web.notfound()
+        return web.ok(open('static/build/sw.js').read())
 
 
 class assetlinks(delegate.page):
-    """To verify the TWA, currently serves dummy data"""
-
     path = '/.well-known/assetlinks'
 
     def GET(self):
         web.header('Content-Type', 'application/json')
-        try:
-            data = open('static/.well-known/assetlinks.json').read()
-            raise web.HTTPError('200 OK', {}, data)
-        except OSError:
-            raise web.notfound()
+        return web.ok(open('static/.well-known/assetlinks.json').read())
 
 
 class opensearchxml(delegate.page):
@@ -457,11 +441,7 @@ class opensearchxml(delegate.page):
 
     def GET(self):
         web.header('Content-Type', 'text/plain')
-        try:
-            data = open('static/opensearch.xml').read()
-            raise web.HTTPError('200 OK', {}, data)
-        except OSError:
-            raise web.notfound()
+        return web.ok(open('static/opensearch.xml').read())
 
 
 class health(delegate.page):
@@ -469,7 +449,7 @@ class health(delegate.page):
 
     def GET(self):
         web.header('Content-Type', 'text/plain')
-        raise web.HTTPError('200 OK', {}, 'OK')
+        return web.ok('OK')
 
 
 class isbn_lookup(delegate.page):


### PR DESCRIPTION
Refactor. We could do this in more places, but these are the most hit endpoints.

- This improves Sentry, since this will no longer show as "failed"
- Also remove some unhelpful try/excepts. We _do_ want it to error if those files are missing for some reason!



### Technical
<!-- What should be noted about the implementation? -->

### Testing
- URLs still work:
    - https://testing.openlibrary.org/health

### Screenshot
See the failure rate plummet!
![image](https://user-images.githubusercontent.com/6251786/202843331-75fe9ef8-0d51-4094-99af-1d1680e79ebc.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
