### PR TITLE
Make optional type hints explicit, per PEP 484

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     - id: cython-lint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.991'
+    rev: 'v0.982'
     hooks:
       - id: mypy  # See pyproject.toml for args
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     - id: cython-lint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.982'
+    rev: 'v0.991'
     hooks:
       - id: mypy  # See pyproject.toml for args
         additional_dependencies:

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -29,7 +29,7 @@ from openlibrary.core.edits import CommunityEditsQueue
 try:
     from simplejson.errors import JSONDecodeError
 except ImportError:
-    from json.decoder import JSONDecodeError  # type: ignore[misc]
+    from json.decoder import JSONDecodeError  # type: ignore[misc, assignment]
 
 logger = logging.getLogger("openlibrary.account.model")
 

--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -199,7 +199,7 @@ class OpenLibrary:
             response = self._request("/query.json", params=dict(query=json.dumps(q)))
             return unmarshal(response.json())
 
-    def search(self, query, limit=10, offset=0, fields: list[str] = None):
+    def search(self, query, limit=10, offset=0, fields: list[str] | None = None):
         return self._request(
             '/search.json',
             params={

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -86,7 +86,7 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
             self.get_template_path('read_button'), self.get_best_identifier(ed_or_solr)
         )
 
-    def render_download_options(self, edition: Edition, extra_args: list = None):
+    def render_download_options(self, edition: Edition, extra_args: list | None = None):
         return render_template(
             self.get_template_path('download_options'),
             self.get_best_identifier(edition),
@@ -100,7 +100,7 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
     def get_access(
         self,
         edition: dict,
-        metadata: TProviderMetadata = None,
+        metadata: TProviderMetadata | None = None,
     ) -> EbookAccess:
         """
         Return the access level of the edition.
@@ -138,7 +138,7 @@ class InternetArchiveProvider(AbstractBookProvider[IALiteMetadata]):
     def is_own_ocaid(self, ocaid: str) -> bool:
         return True
 
-    def render_download_options(self, edition: Edition, extra_args: list = None):
+    def render_download_options(self, edition: Edition, extra_args: list | None = None):
         if edition.is_access_restricted() or not edition.ia_metadata:
             return ''
 
@@ -158,7 +158,9 @@ class InternetArchiveProvider(AbstractBookProvider[IALiteMetadata]):
         else:
             return ''
 
-    def get_access(self, edition: dict, metadata: IALiteMetadata = None) -> EbookAccess:
+    def get_access(
+        self, edition: dict, metadata: IALiteMetadata | None = None
+    ) -> EbookAccess:
         if not metadata:
             if edition.get('ocaid'):
                 return EbookAccess.UNCLASSIFIED
@@ -182,7 +184,7 @@ class LibriVoxProvider(AbstractBookProvider):
     short_name = 'librivox'
     identifier_key = 'librivox'
 
-    def render_download_options(self, edition: Edition, extra_args: list = None):
+    def render_download_options(self, edition: Edition, extra_args: list | None = None):
         # The template also needs the ocaid, since some of the files are hosted on IA
         return super().render_download_options(edition, [edition.get('ocaid')])
 

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -44,7 +44,9 @@ class Bookshelves(db.CommonExtras):
         }
 
     @classmethod
-    def total_books_logged(cls, shelf_ids: list[str] = None, since: date = None) -> int:
+    def total_books_logged(
+        cls, shelf_ids: list[str] | None = None, since: date | None = None
+    ) -> int:
         """Returns (int) number of books logged across all Reading Log shelves (e.g. those
         specified in PRESET_BOOKSHELVES). One may alternatively specify a
         `list` of `shelf_ids` to isolate or span multiple
@@ -72,7 +74,7 @@ class Bookshelves(db.CommonExtras):
         return results[0]
 
     @classmethod
-    def total_unique_users(cls, since: date = None) -> int:
+    def total_unique_users(cls, since: date | None = None) -> int:
         """Returns the total number of unique users who have logged a
         book. `since` may be provided to only return the number of users after
         a certain datetime.date.
@@ -86,7 +88,7 @@ class Bookshelves(db.CommonExtras):
 
     @classmethod
     def most_logged_books(
-        cls, shelf_id='', limit=10, since: date = None, page=1, fetch=False
+        cls, shelf_id='', limit=10, since: date | None = None, page=1, fetch=False
     ) -> list:
         """Returns a ranked list of work OLIDs (in the form of an integer --
         i.e. OL123W would be 123) which have been most logged by
@@ -136,7 +138,7 @@ class Bookshelves(db.CommonExtras):
 
     @classmethod
     def count_total_books_logged_by_user(
-        cls, username: str, bookshelf_ids: list[str] = None
+        cls, username: str, bookshelf_ids: list[str] | None = None
     ) -> int:
         """Counts the (int) total number of books logged by this `username`,
         with the option of limiting the count to specific bookshelves
@@ -150,7 +152,7 @@ class Bookshelves(db.CommonExtras):
 
     @classmethod
     def count_total_books_logged_by_user_per_shelf(
-        cls, username: str, bookshelf_ids: list[str] = None
+        cls, username: str, bookshelf_ids: list[str] | None = None
     ) -> dict[int, int]:
         """Returns a dict mapping the specified user's bookshelves_ids to the
         number of number of books logged per each shelf, i.e. {bookshelf_id:
@@ -523,7 +525,7 @@ class Bookshelves(db.CommonExtras):
             )
 
     @classmethod
-    def remove(cls, username: str, work_id: str, bookshelf_id: str = None):
+    def remove(cls, username: str, work_id: str, bookshelf_id: str | None = None):
         oldb = db.get_db()
         where = {'username': username, 'work_id': int(work_id)}
         if bookshelf_id:

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -64,7 +64,7 @@ class CommunityEditsQueue:
         limit: int = 50,
         page: int = 1,
         mode: str = 'all',
-        order: str = None,
+        order: str | None = None,
         **kwargs,
     ):
         oldb = db.get_db()
@@ -163,11 +163,11 @@ class CommunityEditsQueue:
         cls,
         url: str,
         submitter: str,
-        reviewer: str = None,
+        reviewer: str | None = None,
         status: int = STATUS['PENDING'],
-        comment: str = None,
-        title: str = None,
-        mr_type: int = None,
+        comment: str | None = None,
+        title: str | None = None,
+        mr_type: int | None = None,
     ):
         """
         Inserts a new record into the table.
@@ -242,7 +242,7 @@ class CommunityEditsQueue:
 
     @classmethod
     def update_request_status(
-        cls, rid: int, status: int, reviewer: str, comment: str = None
+        cls, rid: int, status: int, reviewer: str, comment: str | None = None
     ) -> int:
         """
         Changes the status of the request with the given rid.

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -109,12 +109,12 @@ def cached_work_authors_and_subjects(work_id):
 
 @public
 def compose_ia_url(
-    limit: int = None,
+    limit: int | None = None,
     page: int = 1,
     subject=None,
     query=None,
     work_id=None,
-    _type: Literal['authors', 'subjects'] = None,
+    _type: Literal['authors', 'subjects'] | None = None,
     sorts=None,
     advanced=True,
     rate_limit_exempt=True,

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -114,7 +114,7 @@ class AmazonAPI:
         asins: list | str,
         serialize: bool = False,
         marketplace: str = 'www.amazon.com',
-        resources: Any = None,
+        resources: Any | None = None,
         **kwargs,
     ) -> list | None:
         """
@@ -289,7 +289,7 @@ def get_amazon_metadata(
     return cached_get_amazon_metadata(id_, id_type=id_type, resources=resources)
 
 
-def search_amazon(title: str = '', author: str = '') -> dict:
+def search_amazon(title: str = '', author: str = '') -> dict:  # type: ignore[empty-body]
     """Uses the Amazon Product Advertising API ItemSearch operation to search for
     books by author and/or title.
     https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
@@ -513,9 +513,9 @@ def _get_betterworldbooks_metadata(isbn: str) -> dict | None:
 
 def betterworldbooks_fmt(
     isbn: str,
-    qlt: str = None,
-    price: str = None,
-    market_price: list[str] = None,
+    qlt: str | None = None,
+    price: str | None = None,
+    market_price: list[str] | None = None,
 ) -> dict | None:
     """Defines a standard interface for returning bwb price info
 

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -57,7 +57,7 @@ def get_work_iaids(wkey):
 def get_solr_fields_for_works(
     field: str,
     wkeys: list[str],
-    clip_limit: int = None,
+    clip_limit: int | None = None,
 ) -> dict[str, list[str]]:
     from openlibrary.plugins.worksearch.search import get_solr
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -816,7 +816,7 @@ def csv_header_and_format(row: Mapping[str, Any]) -> tuple[str, str]:
 
 
 @elapsed_time("csv_string")
-def csv_string(source: Iterable[Mapping], row_formatter: Callable = None) -> str:
+def csv_string(source: Iterable[Mapping], row_formatter: Callable | None = None) -> str:
     """
     Given an list of dicts, generate comma separated values where each dict is a row.
     An optional reformatter function can be provided to transform or enrich each dict.

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -345,13 +345,13 @@ class addbook(delegate.page):
 
     def try_edition_match(
         self,
-        work: web.Storage = None,
-        title: str = None,
-        author_key: str = None,
-        publisher: str = None,
-        publish_year: str = None,
-        id_name: str = None,
-        id_value: str = None,
+        work: web.Storage | None = None,
+        title: str | None = None,
+        author_key: str | None = None,
+        publisher: str | None = None,
+        publish_year: str | None = None,
+        id_name: str | None = None,
+        id_value: str | None = None,
     ) -> None | Edition | list[web.Storage]:
         """
         Searches solr for potential edition matches.

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -69,8 +69,8 @@ class community_edits_queue(delegate.page):
         action='',
         mr_type=None,
         olids='',
-        comment: str = None,
-        primary: str = None,
+        comment: str | None = None,
+        primary: str | None = None,
     ):
         def is_valid_action(action):
             return action in ('create-pending', 'create-merged')
@@ -165,7 +165,7 @@ class community_edits_queue(delegate.page):
         return resp
 
     @staticmethod
-    def create_url(mr_type: int, olids: list[str], primary: str = None) -> str:
+    def create_url(mr_type: int, olids: list[str], primary: str | None = None) -> str:
         if mr_type == CommunityEditsQueue.TYPE['WORK_MERGE']:
             primary_param = f'&primary={primary}' if primary else ''
             return f'/works/merge?records={",".join(olids)}{primary_param}'

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -138,7 +138,7 @@ def kebab_case(upper_camel_case: str) -> str:
 
 
 @public
-def render_component(name: str, attrs: dict = None, json_encode: bool = True):
+def render_component(name: str, attrs: dict | None = None, json_encode: bool = True):
     """
     :param str name: Name of the component (excluding extension)
     :param dict attrs: attributes to add to the component element
@@ -1082,7 +1082,7 @@ class HTMLTagRemover(HTMLParser):
 
 
 @public
-def reformat_html(html_str: str, max_length: int = None) -> str:
+def reformat_html(html_str: str, max_length: int | None = None) -> str:
     """
     Reformats an HTML string, removing all opening and closing tags.
     Adds a line break element between each set of text content.

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -480,10 +480,10 @@ def run_solr_query(
     param: Optional[dict] = None,
     rows=100,
     page=1,
-    sort: str = None,
+    sort: str | None = None,
     spellcheck_count=None,
     offset=None,
-    fields: Union[str, list[str]] = None,
+    fields: Union[str, list[str]] | None = None,
     facet: Union[bool, Iterable[str]] = True,
     allowed_filter_params=FACET_FIELDS,
     extra_params: Optional[list[tuple[str, Any]]] = None,
@@ -1005,7 +1005,7 @@ def works_by_author(
     rows=100,
     facet=False,
     has_fulltext=False,
-    query: str = None,
+    query: str | None = None,
 ):
     param = {'q': query or '*:*'}
     if has_fulltext:
@@ -1313,13 +1313,13 @@ def rewrite_list_query(q, page, offset, limit):
 @public
 def work_search(
     query: dict,
-    sort: str = None,
+    sort: str | None = None,
     page: int = 1,
     offset: int = 0,
     limit: int = 100,
     fields: str = '*',
     facet: bool = True,
-    spellcheck_count: int = None,
+    spellcheck_count: int | None = None,
 ) -> dict:
     """
     :param sort: key of SORTS dict at the top of this file

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -330,8 +330,8 @@ class ExternalDataProvider(DataProvider):
 class BetterDataProvider(LegacyDataProvider):
     def __init__(
         self,
-        site: Site = None,
-        db: DB = None,
+        site: Site | None = None,
+        db: DB | None = None,
     ):
         """Test with
         import web; import infogami

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -32,7 +32,7 @@ def luqum_remove_child(child: Item, parents: list[Item]):
         raise ValueError("Not supported for generic class Item")
 
 
-def luqum_traverse(item: Item, _parents: list[Item] = None):
+def luqum_traverse(item: Item, _parents: list[Item] | None = None):
     """
     Traverses every node in the parse tree in depth-first order.
 
@@ -216,8 +216,8 @@ def luqum_parser(query: str) -> Item:
 
 
 def query_dict_to_str(
-    escaped: dict = None,
-    unescaped: dict = None,
+    escaped: dict | None = None,
+    unescaped: dict | None = None,
     op: Literal['AND', 'OR', ''] = '',
 ) -> str:
     """

--- a/openlibrary/solr/update_edition.py
+++ b/openlibrary/solr/update_edition.py
@@ -24,7 +24,7 @@ def is_sine_nomine(pub: str) -> bool:
 
 
 class EditionSolrBuilder:
-    def __init__(self, edition: dict, ia_metadata: bp.IALiteMetadata = None):
+    def __init__(self, edition: dict, ia_metadata: bp.IALiteMetadata | None = None):
         self.edition = edition
         self.ia_metadata = ia_metadata
         self.provider = bp.get_book_provider(edition)
@@ -162,7 +162,7 @@ class EditionSolrBuilder:
 
 def build_edition_data(
     edition: dict,
-    ia_metadata: bp.IALiteMetadata = None,
+    ia_metadata: bp.IALiteMetadata | None = None,
 ) -> SolrDocument:
     """
     Build the solr document for the given edition to store as a nested

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -731,7 +731,7 @@ class SolrProcessor:
 
 async def build_data(
     w: dict,
-    ia_metadata: dict[str, Optional['bp.IALiteMetadata']] = None,
+    ia_metadata: dict[str, Optional['bp.IALiteMetadata']] | None = None,
 ) -> SolrDocument:
     """
     Construct the Solr document to insert into Solr for the given work
@@ -921,7 +921,7 @@ def build_data2(
 
 async def solr_insert_documents(
     documents: list[dict],
-    solr_base_url: str = None,
+    solr_base_url: str | None = None,
     skip_id_check=False,
 ):
     """
@@ -1056,7 +1056,7 @@ class CommitRequest(SolrUpdateRequest):
 def solr_update(
     reqs: list[SolrUpdateRequest],
     skip_id_check=False,
-    solr_base_url: str = None,
+    solr_base_url: str | None = None,
 ) -> None:
     content = '{' + ','.join(r.to_json_command() for r in reqs) + '}'
 
@@ -1585,10 +1585,10 @@ async def main(
     keys: list[str],
     ol_url="http://openlibrary.org",
     ol_config="openlibrary.yml",
-    output_file: str = None,
+    output_file: str | None = None,
     commit=True,
     data_provider: Literal['default', 'legacy', 'external'] = "default",
-    solr_base: str = None,
+    solr_base: str | None = None,
     solr_next=False,
     update: Literal['update', 'print'] = 'update',
 ):

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -37,7 +37,7 @@ class Solr:
     def get(
         self,
         key: str,
-        fields: list[str] = None,
+        fields: list[str] | None = None,
         doc_wrapper: Callable[[dict], T] = web.storage,
     ) -> Optional[T]:
         """Get a specific item from solr"""
@@ -53,7 +53,7 @@ class Solr:
     def get_many(
         self,
         keys: Iterable[str],
-        fields: Iterable[str] = None,
+        fields: Iterable[str] | None = None,
         doc_wrapper: Callable[[dict], T] = web.storage,
     ) -> list[T]:
         if not keys:

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -53,7 +53,9 @@ class Disk:
 
         return {k: f(k) for k in keys}
 
-    def save_many(self, docs: list[dict | web.storage], comment: str = None) -> None:
+    def save_many(
+        self, docs: list[dict | web.storage], comment: str | None = None
+    ) -> None:
         """
 
         :param typing.List[dict or web.storage] docs:
@@ -163,8 +165,8 @@ def copy(
     comment: str,
     recursive: bool = False,
     editions: bool = False,
-    saved: set[str] = None,
-    cache: dict = None,
+    saved: set[str] | None = None,
+    cache: dict | None = None,
 ) -> None:
     """
     :param src: where we'll be copying form
@@ -334,8 +336,8 @@ def main(
     comment: str = "",
     recursive: bool = True,
     editions: bool = True,
-    lists: list[str] = None,
-    search: str = None,
+    lists: list[str] | None = None,
+    search: str | None = None,
     search_limit: int = 10,
 ) -> None:
     """

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -18,7 +18,7 @@ from openlibrary.config import load_config
 from typing import Dict, IO, List
 
 
-def run_piped(cmds: list[list[str]], stdin: IO = None):
+def run_piped(cmds: list[list[str]], stdin: IO | None = None):
     """
     Run the commands piping one's output to the next's input.
     :param list[list[str]] cmds:

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -111,7 +111,7 @@ class LocalPostgresDataProvider(DataProvider):
         self,
         query: str,
         size: int,
-        cursor_name: str = None,
+        cursor_name: str | None = None,
         cache_json: bool = False,
     ) -> Iterator:
         """
@@ -284,10 +284,10 @@ async def simple_timeit_async(awaitable: Awaitable):
 
 def build_job_query(
     job: Literal['works', 'orphans', 'authors'],
-    start_at: str = None,
+    start_at: str | None = None,
     offset: int = 0,
-    last_modified: str = None,
-    limit: int = None,
+    last_modified: str | None = None,
+    limit: int | None = None,
 ) -> str:
     """
     :param job: job to complete
@@ -330,14 +330,14 @@ async def main(
     postgres="postgres.ini",
     ol="http://ol/",
     ol_config="../../conf/openlibrary.yml",
-    solr: str = None,
+    solr: str | None = None,
     skip_solr_id_check: bool = True,
-    start_at: str = None,
+    start_at: str | None = None,
     offset=0,
     limit=1,
-    last_modified: str = None,
-    progress: str = None,
-    log_file: str = None,
+    last_modified: str | None = None,
+    progress: str | None = None,
+    log_file: str | None = None,
     log_level=logging.INFO,
     dry_run: bool = False,
 ) -> None:
@@ -414,7 +414,7 @@ async def main(
             cached: str | int | None = None,
             q_ia: str | float | None = None,
             ia_cache: str | int | None = None,
-            next: str = None,
+            next: str | None = None,
         ) -> None:
             """
             :param str or int or None seen:

--- a/scripts/solr_builder/tests/test_fn_to_cli.py
+++ b/scripts/solr_builder/tests/test_fn_to_cli.py
@@ -5,7 +5,7 @@ from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 class TestFnToCLI:
     def test_full_flow(self):
-        def fn(works: list[str], solr_url: str = None):
+        def fn(works: list[str], solr_url: str | None = None):
             """
             Do some magic!
             :param works: These are works

--- a/scripts/solr_updater.py
+++ b/scripts/solr_updater.py
@@ -30,7 +30,7 @@ logger = logging.getLogger("openlibrary.solr-updater")
 args: dict = {}
 
 
-def read_state_file(path, initial_state: str = None):
+def read_state_file(path, initial_state: str | None = None):
     try:
         return open(path).read()
     except OSError:
@@ -45,7 +45,7 @@ def get_default_offset():
 
 
 class InfobaseLog:
-    def __init__(self, hostname: str, exclude: str = None):
+    def __init__(self, hostname: str, exclude: str | None = None):
         """
         :param str hostname:
         :param str|None exclude: if specified, excludes records that include the string
@@ -246,13 +246,13 @@ async def main(
     ol_config: str,
     debugger: bool = False,
     state_file: str = 'solr-update.state',
-    exclude_edits_containing: str = None,
+    exclude_edits_containing: str | None = None,
     ol_url='http://openlibrary.org/',
-    solr_url: str = None,
+    solr_url: str | None = None,
     solr_next: bool = False,
     socket_timeout: int = 10,
     load_ia_scans: bool = False,
-    initial_state: str = None,
+    initial_state: str | None = None,
 ):
     """
     :param debugger: Wait for a debugger to attach before beginning

--- a/scripts/tests/test_copydocs.py
+++ b/scripts/tests/test_copydocs.py
@@ -29,7 +29,7 @@ class FakeServer:
         self.db: dict = {}  # Mapping of key to (Mp of revision to doc)
         self.save_many(docs)
 
-    def get(self, key: str, revision: int = None) -> dict | None:
+    def get(self, key: str, revision: int | None = None) -> dict | None:
         """
         :param str key:
         :param int or None revision:
@@ -52,7 +52,7 @@ class FakeServer:
                 result[k] = self.get(k)
         return result
 
-    def save_many(self, docs: list[dict], comment: str = None) -> None:
+    def save_many(self, docs: list[dict], comment: str | None = None) -> None:
         """
         :param list[dict] docs:
         :param str or None comment:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7169 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Mypy 0.990 disallows implicit optional types by default. This PR
changes hints of the form `i: int = None` into `i: int | None = None`.

### Technical
<!-- What should be noted about the implementation? -->
Although there were 23 files with implicit optional issues, a in 24th, `openlibrary/accounts/model.py`, `mypy` had a problem with `# type: ignore[misc]`, so I changed that to `# type: ignore[misc, assignment]`.

Additionally, I could not commit without `.pre-commit-config.yaml` staged, even though it updated mirrors-mypy to `v0.991`. Please let me know if that is an issue and I'll try to work around that.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
