### PR TITLE
Type hints from type annotations, batch 6

### DIFF
--- a/openlibrary/catalog/merge/normalize.py
+++ b/openlibrary/catalog/merge/normalize.py
@@ -6,12 +6,10 @@ re_normalize = re.compile('[^[:alpha:] ]', re.I)
 re_whitespace_and_punct = re.compile(r'[-\s,;:.]+')
 
 
-def normalize(s):
+def normalize(s: str) -> str:
     """
     Normalizes title by lowercasing, unicode -> NFC,
     stripping extra whitespace and punctuation, and replacing ampersands.
-    :param str s:
-    :rtype: str
     """
 
     if isinstance(s, str):

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -1,4 +1,5 @@
 import re
+from re import Match
 import web
 from unicodedata import normalize
 import openlibrary.catalog.merge.normalize as merge
@@ -36,7 +37,7 @@ def key_int(rec):
     return int(web.numify(rec['key']))
 
 
-def author_dates_match(a, b):
+def author_dates_match(a: dict, b: dict) -> bool:
     """
     Checks if the years of two authors match. Only compares years,
     not names or keys. Works by returning False if any year specified in one record
@@ -45,7 +46,6 @@ def author_dates_match(a, b):
 
     :param dict a: Author import dict {"name": "Some One", "birth_date": "1960"}
     :param dict b: Author import dict {"name": "Some One"}
-    :rtype: bool
     """
     for k in ['birth_date', 'death_date', 'date']:
         if k not in a or a[k] is None or k not in b or b[k] is None:
@@ -62,14 +62,13 @@ def author_dates_match(a, b):
     return True
 
 
-def flip_name(name):
+def flip_name(name: str) -> str:
     """
     Flip author name about the comma, stripping the comma, and removing non
     abbreviated end dots. Returns name with end dot stripped if no comma+space found.
     The intent is to convert a Library indexed name to natural name order.
 
     :param str name: e.g. "Smith, John." or "Smith, J."
-    :rtype: str
     :return: e.g. "John Smith" or "J. Smith"
     """
 
@@ -79,7 +78,10 @@ def flip_name(name):
     if name.find(', ') == -1:
         return name
     m = re_marc_name.match(name)
-    return m.group(2) + ' ' + m.group(1)
+    if isinstance(m, Match):
+        return m.group(2) + ' ' + m.group(1)
+
+    return ""
 
 
 def remove_trailing_number_dot(date):
@@ -265,13 +267,12 @@ def get_title(e):
     return title
 
 
-def mk_norm(s):
+def mk_norm(s: str) -> str:
     """
     Normalizes titles and strips ALL spaces and small words
     to aid with string comparisons of two titles.
 
     :param str s: A book title to normalize and strip.
-    :rtype: str
     :return: a lowercase string with no spaces, containing the main words of the title.
     """
 

--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -2,7 +2,7 @@ import logging
 import web
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Literal, Optional, cast, Any, Final
+from typing import Literal, cast, Any, Final
 from collections.abc import Iterable
 from openlibrary.plugins.worksearch.search import get_solr
 
@@ -88,7 +88,12 @@ class Bookshelves(db.CommonExtras):
 
     @classmethod
     def most_logged_books(
-        cls, shelf_id='', limit=10, since: date | None = None, page=1, fetch=False
+        cls,
+        shelf_id: str = '',
+        limit: int = 10,
+        since: date | None = None,
+        page: int = 1,
+        fetch: bool = False,
     ) -> list:
         """Returns a ranked list of work OLIDs (in the form of an integer --
         i.e. OL123W would be 123) which have been most logged by
@@ -437,10 +442,10 @@ class Bookshelves(db.CommonExtras):
     @classmethod
     def get_recently_logged_books(
         cls,
-        bookshelf_id=None,
-        limit=50,
-        page=1,
-        fetch=False,
+        bookshelf_id: str | None = None,
+        limit: int = 50,
+        page: int = 1,
+        fetch: bool = False,
     ) -> list:
         oldb = db.get_db()
         page = int(page or 1)
@@ -458,9 +463,7 @@ class Bookshelves(db.CommonExtras):
         return cls.fetch(logged_books) if fetch else logged_books
 
     @classmethod
-    def get_users_read_status_of_work(
-        cls, username: str, work_id: str
-    ) -> Optional[str]:
+    def get_users_read_status_of_work(cls, username: str, work_id: str) -> str | None:
         """A user can mark a book as (1) want to read, (2) currently reading,
         or (3) already read. Each of these states is mutually
         exclusive. Returns the user's read state of this work, if one

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -5,6 +5,7 @@ import string
 import time
 import threading
 import functools
+from typing import Callable, Literal
 
 import memcache
 import json
@@ -50,7 +51,13 @@ class memcache_memoize:
     :param prethread: Function to call on the new thread to set it up
     """
 
-    def __init__(self, f, key_prefix=None, timeout=MINUTE_SECS, prethread=None):
+    def __init__(
+        self,
+        f: Callable,
+        key_prefix: str | None = None,
+        timeout: int = MINUTE_SECS,
+        prethread: Callable | None = None,
+    ):
         """Creates a new memoized function for ``f``."""
         self.f = f
         self.key_prefix = key_prefix or self._generate_key_prefix()
@@ -59,7 +66,7 @@ class memcache_memoize:
         self._memcache = None
 
         self.stats = web.storage(calls=0, hits=0, updates=0, async_updates=0)
-        self.active_threads = {}
+        self.active_threads: dict = {}
         self.prethread = prethread
 
     def _get_memcache(self):
@@ -456,7 +463,12 @@ class memoize:
     """
 
     def __init__(
-        self, engine="memory", key=None, expires=0, background=False, cacheable=None
+        self,
+        engine: Literal["memory", "memcache", "request"] = "memory",
+        key=None,
+        expires: int = 0,
+        background: bool = False,
+        cacheable: Callable | None = None,
     ):
         self.cache = _get_cache(engine)
         self.keyfunc = self._make_key_func(key)
@@ -488,7 +500,7 @@ class memoize:
 
         return func
 
-    def cache_get(self, key):
+    def cache_get(self, key: str | tuple):
         """Reads value of a key from the cache.
 
         When key is a string, this is equvivalant to::
@@ -507,7 +519,7 @@ class memoize:
         else:
             return self.cache.get(key)
 
-    def cache_set(self, key, value):
+    def cache_set(self, key: str | tuple, value):
         """Sets a key to a given value in the cache.
 
         When key is a string, this is equvivalant to::

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -20,13 +20,11 @@ IA_BASE_URL = config.get('ia_base_url', 'https://archive.org')
 VALID_READY_REPUB_STATES = ['4', '19', '20', '22']
 
 
-def get_api_response(url, params=None):
+def get_api_response(url: str, params: dict | None = None) -> dict:
     """
     Makes an API GET request to archive.org, collects stats
     Returns a JSON dict.
-    :param str url:
     :param dict params: url parameters
-    :rtype: dict
     """
     api_response = {}
     stats.begin('archive.org', url=url)
@@ -42,13 +40,13 @@ def get_api_response(url, params=None):
     return api_response
 
 
-def get_metadata_direct(itemid, only_metadata=True, cache=True):
+def get_metadata_direct(
+    itemid: str, only_metadata: bool = True, cache: bool = True
+) -> dict:
     """
     Fetches metadata by querying the archive.org metadata API, without local caching.
-    :param str itemid:
     :param bool cache: if false, requests uncached metadata from archive.org
     :param bool only_metadata: whether to get the metadata without any processing
-    :rtype: dict
     """
     url = f'{IA_BASE_URL}/metadata/{web.safestr(itemid.strip())}'
     params = {}

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -66,7 +66,7 @@ class Batch(web.storage):
             for item in items
         ]
 
-    def add_items(self, items):
+    def add_items(self, items: list[str] | list[dict]) -> None:
         """
         :param items: either a list of `ia_id`  (legacy) or a list of dicts
             containing keys `ia_id` and book `data`. In the case of
@@ -74,7 +74,7 @@ class Batch(web.storage):
             i.e. of a format id_type:value which cannot be a valid IA id.
         """
         if not items:
-            return
+            return None
 
         logger.info("batch %s: adding %d items", self.name, len(items))
 
@@ -92,6 +92,8 @@ class Batch(web.storage):
                     except UniqueViolation:
                         pass
             logger.info("batch %s: added %d items", self.name, len(items))
+
+        return None
 
     def get_items(self, status="pending"):
         result = db.where("import_item", batch_id=self.id, status=status)

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1,6 +1,6 @@
 """Module for providing core functionality of lending on Open Library.
 """
-from typing import Literal, Optional
+from typing import Literal
 
 import web
 import datetime
@@ -91,9 +91,9 @@ def compose_ia_url(
     subject=None,
     query=None,
     sorts=None,
-    advanced=True,
-    rate_limit_exempt=True,
-) -> Optional[str]:
+    advanced: bool = True,
+    rate_limit_exempt: bool = True,
+) -> str | None:
     """This needs to be exposed by a generalized API endpoint within
     plugins/api/browse which lets lazy-load more items for
     the homepage carousel and support the upcoming /browse view
@@ -263,11 +263,10 @@ def get_available(
         return {'error': 'request_timeout'}
 
 
-def get_availability(key, ids):
+def get_availability(key: str, ids: list[str]) -> dict:
     """
     :param str key: the type of identifier
     :param list of str ids:
-    :rtype: dict
     """
     ids = [id_ for id_ in ids if id_]  # remove infogami.infobase.client.Nothing
     if not ids:
@@ -394,11 +393,9 @@ def get_availability_of_ocaid(ocaid):
     return get_availability('identifier', [ocaid])
 
 
-def get_availability_of_ocaids(ocaids):
+def get_availability_of_ocaids(ocaids: list[str]) -> dict:
     """
     Retrieves availability based on ocaids/archive.org identifiers
-    :param list[str] ocaids:
-    :rtype: dict
     """
     return get_availability('identifier', ocaids)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially #6755 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor.

### Technical
<!-- What should be noted about the implementation? -->
Here's the next batch of type hints from type annotations. I will attempt to preemptively explain my rationale for some of the changes to help shorten the feedback cycle:

- `/core/lending.py`: I didn't update `s3_loan_api()` because the default value doesn't match what's in the comments, and after a few minutes I couldn't find the actual values from Internet Archive.
- `/core/cache.py`: in `class memoize` it wasn't immediately apparent what types `key` could be, though the docstrings mention at least two types are `str` and a `Callable`, as well as the default `None`.
- `catolog/utils/__init__.py`: In `flip_name()` mypy took issue with `m.group(2) + ' ' + m.group(1)` because it is possible there is no match. I added an `isinstance(m, Match)`, but that meant the function might return `None` rather than a string, so I had it return an empty string if for some reason there is no match.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
mypy should pass, the tests should pass, and functionality should remain the same.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
