### PR TITLE
Fix autodetect of identifiers

### DIFF
--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -103,10 +103,11 @@ export default {
         selectIdentifierByInputValue: function() {
             // Selects the dropdown identifier based on the input value
             // Only supports wikidata and isni because the other identifiers are just numbers
-            const wikiDatas = this.inputValue.match(/Q\d+/i);
+            const wikiDatas = this.inputValue.match(/^Q[1-9]\d*$/i);
+            const isnis = this.inputValue.match(/^\d{15}[\dX]$/i);
             if (wikiDatas?.length > 0){
                 this.selectedIdentifier = 'wikidata';
-            } else if (this.inputValue.length === 16){
+            } else if (isnis?.length > 0){
                 this.selectedIdentifier = 'isni';
             }
         }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7072

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Typing a long VIAF (or any other numerical identifier) with more than 16 digits will still switch the type to ISNI as you pass 16 digits, but pasting or editing a longer string of digits won't trigger the bug.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit a author edit page.
Pasting or typing the following ISNI codes should be automatically detected:

0000000403855362
000000012146438X
000000012146438x

The following Wikidata ids should be autodetected:

Q42
q42
Q461

The following Amazon IDs (or any string with a Q in the middle followed by digits) should not change the type setting to Wikidata when typed or pasted in:

B000AQ51EY

The following librarything ID (or any other string of characters that is 16 long but isn't entirely digits except for the last one which may optionally be an X) should not change the type of setting when typed or pasted in:

LinnemannDiandra
linnemanndiandra

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
