### PR TITLE
Prevent calls to `list(None)` for edition weights and dimensions

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -717,11 +717,13 @@ class SaveBookHelper:
 
         edition = trim_doc(edition)
 
-        if list(edition.get('physical_dimensions', [])) == ['units']:
-            edition.physical_dimensions = None
+        if physical_dimensions := (edition.get('physical_dimensions', [])):
+            if list(physical_dimensions) == ['units']:
+                edition.physical_dimensions = None
 
-        if list(edition.get('weight', [])) == ['units']:
-            edition.weight = None
+        if weight := (edition.get('weight', [])):
+            if list(weight) == ['units']:
+                edition.weight = None
 
         for k in ['roles', 'identifiers', 'classifications']:
             edition[k] = edition.get(k) or []


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7075 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

Stops `TypeError` `'NoneType'is not iterable` when removing the weight or physical dimensions from an edition and saving, when the edition originally had:
1. a weight but no weight unit, or
2. a physical dimension but no physical dimension unit.

Though the scope of the issue was only weights, the same issue was present with the `physical_dimensions` value and the fix was the same.

### Technical
<!-- What should be noted about the implementation? -->
If `edition.weight` or `edition.physical_dimensions` was an empty string, e.g. because a librarian had deleted a bad weight value, `trim_doc()` would set the values to `None`, which caused calls to `list(None)` a few lines later in `process_edition()`.

It would have been possible to simply move `edition = trim_doc(edition)` below the `list(edition.get('physical_dimensions', []))` and `list(edition.get('weight', []))` call, as `trim_doc(edition)` is what was adding `None` values. However, if for some reason `None` still made it through to those `if` clauses, the error would occur anyway. So even though this added more indentation, I think it better protects against a similar error in the future.

If it's preferable to simply move `edition = trim_doc(edition)` below the `if` clauses, just let me know.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Visit https://openlibrary.org/works/OL27130932W/
- Remove the weight
- Save
- See, hopefully, no error messages.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles, @onnotasler.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
