### PR TITLE
Export PYTHONUNBUFFERED=1 so console output is not buffered (#7186)

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,8 @@ services:
     depends_on:
       - db
       - infobase
+    environment:
+      - PYTHONUNBUFFERED=1
 
   solr:
     ports:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7186 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
This changes the development docker-compose configuration to export `PYTHONUNBUFFERED=1` so that console output is not buffered (e.g. `print()` statements.)

See this Stack Overflow question for more: https://stackoverflow.com/questions/59812009/what-is-the-use-of-pythonunbuffered-in-docker-file

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Put a print statement immediately before a line that an error and the print statement should show up in the docker console or docker log immediately before the error, rather than at some later point once the buffer fills:

The output should look like this:
```
openlibrary-web-1           | Print statement just before a line that causes an error.
openlibrary-web-1           | Traceback (most recent call last):
openlibrary-web-1           |   File "/home/openlibrary/.local/lib/python3.10/site-packages/web/application.py", line 280, in process
openlibrary-web-1           |     return self.handle()
[...omitted for brevity...]
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 724, in process_edition
openlibrary-web-1           |     if list(edition.get('weight', [])) == ['units']:
openlibrary-web-1           | TypeError: 'NoneType' object is not iterable
openlibrary-web-1           |
openlibrary-web-1           | error saved to /var/log/openlibrary/ol-errors/2022-11-23/060327727207.html
```

And not like this:
```
openlibrary-web-1           | 0.0 (3): SELECT id, key FROM thing where id in (525, 527, 20, 669)
openlibrary-web-1           | Traceback (most recent call last):
openlibrary-web-1           |   File "/home/openlibrary/.local/lib/python3.10/site-packages/web/application.py", line 280, in process
openlibrary-web-1           |     return self.handle()
[...omitted for brevity...]
openlibrary-web-1           |   File "/openlibrary/openlibrary/plugins/upstream/addbook.py", line 724, in process_edition
openlibrary-web-1           |     if list(edition.get('weight', [])) == ['units']:
openlibrary-web-1           | TypeError: 'NoneType' object is not iterable
openlibrary-web-1           |
openlibrary-web-1           | error saved to /var/log/openlibrary/ol-errors/2022-11-23/060537676065.html
openlibrary-web-1           | 0.0 (1): SELECT * FROM store WHERE key='account/openlibrary'
openlibrary-infobase-1      | 172.27.0.5:44152 - - [23/Nov/2022 06:05:40] "HTTP/1.1 GET /openlibrary.org/log/2022-11-23:122974" - 200 OK
openlibrary-infobase-1      | 172.27.0.5:42598 - - [23/Nov/2022 06:05:45] "HTTP/1.1 GET /openlibrary.org/log/2022-11-23:122974" - 200 OK
[...omitted for brevity...]
openlibrary-web-1           | 0.0 (1): SELECT * FROM thing WHERE key='/works/OL451768W'
openlibrary-web-1           | 0.0 (1): SELECT data FROM data WHERE thing_id=2445 AND revision=1
openlibrary-web-1           | Print statement just before a line that causes an error.
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
