### PR TITLE
Fix edit button layout

### DIFF
--- a/openlibrary/macros/databarEdit.html
+++ b/openlibrary/macros/databarEdit.html
@@ -1,7 +1,7 @@
 $def with (page)
 
 
-<div id="editTools" class="edit inline-block">
+<div id="editTools" class="edit">
     <div id="editHistory">
         <a class="linkButton larger" href="$page.key?m=history" title="View the editing history of this page">$_("History")</a>
     </div>

--- a/static/css/components/edit-toolbar--tablet.less
+++ b/static/css/components/edit-toolbar--tablet.less
@@ -4,6 +4,13 @@
  */
 
 /* stylelint-disable selector-max-specificity */
+div#editTools,
+div.editButton,
+div#editHistory {
+  padding: 3px 1px 0 20px;
+  float: right;
+}
+
 div#editInfo {
   margin-top: 3px;
   float: right;
@@ -13,9 +20,4 @@ div#editTools {
   display: flex;
   margin-top: 1px;
   max-width: 280px;
-
-  &.inline-block {
-    display: inline-block;
-    max-width: 50%;
-  }
 }

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -7,11 +7,6 @@
 div#editTools,
 div#editHistory {
   width: auto;
-
-  &.inline-block {
-    display: inline-block;
-    max-width: 50%;
-  }
 }
 
 div.editButton {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7188

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Reverts layout changes made in #7157.

Previous layout changes were made in order to align the author page delete button with the "Cancel" link in mobile views. Reverting these changes causes the delete button to appear to the right of the "Edit Author" heading (see screenshot below).  This change will only affect admins who edit in mobile views.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-11-23 12-58-20](https://user-images.githubusercontent.com/28732543/203645005-748ab2e8-352e-45a0-9ec9-b2f45e7aef2e.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
