### PR TITLE
Check-ins: Ensure last read year is selected by default in edit form

### DIFF
--- a/openlibrary/templates/check_ins/modal_form.html
+++ b/openlibrary/templates/check_ins/modal_form.html
@@ -40,7 +40,7 @@ $if last_read_date:
         <select class="check-in__select" name="year">
           <option value="">$_('Year')</option>
           $for i in range(120):
-            $ is_selected = i == year_read
+            $ is_selected = year - i == year_read
             <option value="$(year - i)" $cond(is_selected, 'selected', '')>$(year - i)</option>
         </select>
       </span>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
If a patron sets the last read page of a book and later views the book's page, a prompt to edit the last read date appears below the reading log dropper.  Pressing the edit button displays a form that should be populated with the last read date, but the logic that sets the selected year is incorrect.  This PR corrects this issue.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![read_date_before](https://user-images.githubusercontent.com/28732543/203655602-46ad2e6f-7883-4674-9b9f-6fc624431cd2.png)
_Before: Year is not selected by default.  Pressing the "Submit" button before setting the year would send an invalid date to the server_

![read_date_after](https://user-images.githubusercontent.com/28732543/203655720-77d5a382-1183-4fad-bf0f-b23b602246b5.png)
_After: Year is correctly pre-populated_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
