### PR TITLE
Fix various editions search bug + make edition search the default

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -219,7 +219,7 @@ def run_solr_query(
             solr_fields.remove('editions')
             solr_fields.add('editions:[subquery]')
         params.append(('fl', ','.join(solr_fields)))
-        params += scheme.q_to_solr_params(q, solr_fields)
+        params += scheme.q_to_solr_params(q, solr_fields, params)
 
     if sort:
         params.append(('sort', scheme.process_user_sort(sort)))

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -103,5 +103,10 @@ class SearchScheme:
     def build_q_from_params(self, params: dict) -> Optional[str]:
         return None
 
-    def q_to_solr_params(self, q: str, solr_fields: set[str]) -> list[tuple[str, str]]:
+    def q_to_solr_params(
+        self,
+        q: str,
+        solr_fields: set[str],
+        cur_solr_params: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
         return [('q', q)]

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -40,7 +40,12 @@ class AuthorSearchScheme(SearchScheme):
     }
     facet_rewrites: dict[tuple[str, str], str] = {}
 
-    def q_to_solr_params(self, q: str, solr_fields: set[str]) -> list[tuple[str, str]]:
+    def q_to_solr_params(
+        self,
+        q: str,
+        solr_fields: set[str],
+        cur_solr_params: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
         return [
             ('q', q),
             ('q.op', 'AND'),

--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -33,7 +33,12 @@ class SubjectSearchScheme(SearchScheme):
     }
     facet_rewrites: dict[tuple[str, str], str] = {}
 
-    def q_to_solr_params(self, q: str, solr_fields: set[str]) -> list[tuple[str, str]]:
+    def q_to_solr_params(
+        self,
+        q: str,
+        solr_fields: set[str],
+        cur_solr_params: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
         return [
             ('q', q),
             ('q.op', 'AND'),

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -272,6 +272,7 @@ class WorkSearchScheme(SearchScheme):
                 'title': 'title',
                 'title_suggest': 'title_suggest',
                 'subtitle': 'subtitle',
+                # TODO: Change to alternative_title after full reindex
                 'alternative_title': 'title',
                 'alternative_subtitle': 'subtitle',
                 'cover_i': 'cover_i',

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -551,4 +551,4 @@ def has_solr_editions_enabled():
     if cookie_value is not None:
         return cookie_value == 'true'
 
-    return False
+    return True

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -340,7 +340,12 @@ class WorkSearchScheme(SearchScheme):
                             parent = parents[-1] if parents else None
                             # Prefixing with + makes the field mandatory
                             if isinstance(
-                                parent, (luqum.tree.Not, luqum.tree.Prohibit)
+                                parent,
+                                (
+                                    luqum.tree.Not,
+                                    luqum.tree.Prohibit,
+                                    luqum.tree.OrOperation,
+                                ),
                             ):
                                 node.name = new_name
                             else:

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -32,6 +32,19 @@ def luqum_remove_child(child: Item, parents: list[Item]):
         raise ValueError("Not supported for generic class Item")
 
 
+def luqum_replace_child(parent: Item, old_child: Item, new_child: Item):
+    """
+    Replaces a child in a luqum parse tree.
+    """
+    if isinstance(parent, (BaseOperation, Group, Unary)):
+        new_children = tuple(
+            new_child if c == old_child else c for c in parent.children
+        )
+        parent.children = new_children
+    else:
+        raise ValueError("Not supported for generic class Item")
+
+
 def luqum_traverse(item: Item, _parents: list[Item] | None = None):
     """
     Traverses every node in the parse tree in depth-first order.

--- a/openlibrary/solr/update_edition.py
+++ b/openlibrary/solr/update_edition.py
@@ -45,6 +45,21 @@ class EditionSolrBuilder:
         return self.get('subtitle')
 
     @property
+    def alternative_title(self) -> set[str]:
+        """Get titles from the editions as alternative titles."""
+        result: set[str] = set()
+        full_title = self.get('title')
+        if not full_title:
+            return result
+        if self.get('subtitle'):
+            full_title += ': ' + self.get('subtitle')
+        result.add(full_title)
+        result.update(self.get('work_titles', []))
+        result.update(self.get('other_titles', []))
+
+        return result
+
+    @property
     def cover_i(self) -> Optional[int]:
         return next(
             (cover_id for cover_id in self.get('covers', []) if cover_id != -1), None
@@ -177,6 +192,7 @@ def build_edition_data(
             # Display data
             'title': ed.title,
             'subtitle': ed.subtitle,
+            'alternative_title': list(ed.alternative_title),
             'cover_i': ed.cover_i,
             'language': ed.languages,
             # Misc useful data

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -615,20 +615,11 @@ class SolrProcessor:
 
     @staticmethod
     def get_alternate_titles(books: Iterable[dict]) -> set[str]:
-        """Get titles from the editions as alternative titles."""
-        result = set()
-        for bookish in books:
-            full_title = bookish.get('title')
-            if not full_title:
-                # None would've got in if any of the editions has no title.
-                continue
-            if bookish.get('subtitle'):
-                full_title += ': ' + bookish['subtitle']
-            result.add(full_title)
-            result.update(bookish.get('work_titles', []))
-            result.update(bookish.get('other_titles', []))
-
-        return result
+        return {
+            title
+            for bookish in books
+            for title in EditionSolrBuilder(bookish).alternative_title
+        }
 
     @staticmethod
     def get_alternate_subtitles(books: Iterable[dict]) -> set[str]:

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -329,9 +329,10 @@ class Test_build_data:
     def test_get_alternate_titles(self):
         f = SolrProcessor.get_alternate_titles
 
-        no_title = {}
-        only_title = {'title': 'foo'}
-        with_subtitle = {'title': 'foo 2', 'subtitle': 'bar'}
+        no_title = make_work()
+        del no_title['title']
+        only_title = make_work(title='foo')
+        with_subtitle = make_work(title='foo 2', subtitle='bar')
 
         assert f([]) == set()
         assert f([no_title]) == set()


### PR DESCRIPTION
Makes edition search the default. It can still be disabled via cookies by the librarian/admin toggle.


### Technical
- Known issues: searching for author. But I figure with the search nav, it's easy enough for people to switch to author search.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
