### PR TITLE
Close dropper consistently on shelf change

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -259,6 +259,7 @@ function addReadingLogButtonClickListener(button) {
             // If there is a check-in modal, then a `.check-in-prompt` component may exist:
             const datePrompt = modal ? document.querySelector(`#prompt-${workOlid}`) : null
 
+            // Prompt for check-in date:
             if (datePrompt) {
                 if (actionInput.value === 'add') {
                     const bookshelfValue = form.querySelector('input[name=bookshelf_id]').value
@@ -276,6 +277,7 @@ function addReadingLogButtonClickListener(button) {
                     datePrompt.classList.add('hidden')
                 }
             }
+            // Update list widget on reading log shelf change:
             if (button.classList.contains('want-to-read')) {
                 // Primary button pressed
                 // Toggle checkmark
@@ -301,12 +303,8 @@ function addReadingLogButtonClickListener(button) {
 
                 button.children[1].innerText = initialText
 
-                // Close dropper if expanded:
-                if ($(dropper).find('.arrow').first().hasClass('up')) {
-                    toggleDropper(dropper)
-                }
+
             } else {
-                toggleDropper(dropper)
                 // Secondary button pressed
 
                 // Change primary button's text to new value:
@@ -334,6 +332,10 @@ function addReadingLogButtonClickListener(button) {
                     btn.classList.remove('hidden')
                 }
                 button.classList.add('hidden')
+            }
+            // Close dropper if expanded:
+            if ($(dropper).find('.arrow').first().hasClass('up')) {
+                toggleDropper(dropper)
             }
         }
 

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -128,8 +128,10 @@ function addListClickListener(elem, parentDropper) {
                 }
             }
 
-            // close dropper
-            toggleDropper(parentDropper)
+            // Close dropper if expanded:
+            if ($(parentDropper).find('.arrow').first().hasClass('up')) {
+                toggleDropper(parentDropper)
+            }
         }
 
         addToList(listKey, seed, successCallback)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6530

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Simplifies logic that closes the reading log dropper on shelf change.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
