### PR TITLE
Prevent showing date prompt if read date exists

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -258,6 +258,7 @@ function addReadingLogButtonClickListener(button) {
             const modal = document.querySelector(`#check-in-dialog-${workOlid}`)
             // If there is a check-in modal, then a `.check-in-prompt` component may exist:
             const datePrompt = modal ? document.querySelector(`#prompt-${workOlid}`) : null
+            const dateDisplay = document.querySelector(`#check-in-display-${workOlid}`)
 
             if (datePrompt) {
                 if (actionInput.value === 'add') {
@@ -267,7 +268,10 @@ function addReadingLogButtonClickListener(button) {
                         const checkInForm = modal.querySelector('.check-in')
                         checkInForm.dataset.eventType = CheckInEvent.FINISH
 
-                        datePrompt.classList.remove('hidden')
+                        // Show date prompt only if no date has been submitted already:
+                        if (dateDisplay.classList.contains('hidden')) {
+                            datePrompt.classList.remove('hidden')
+                        }
                     }
                     else {
                         datePrompt.classList.add('hidden')


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Today, the last read date prompt is displayed whenever a book has been marked "Already Read", regardless of whether a date has been set or not.  This can sometimes cause the date display and the date prompt to appear concurrently:

![Screenshot from 2022-11-28 14-52-53](https://user-images.githubusercontent.com/28732543/204369419-ac8d887d-66ed-400f-b632-537d5f5d912c.png)

This PR checks if the date display is visible before displaying the prompt on "Already Read" clicks.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
