### PR TITLE
Don't import from partner data where publish_date is a future year

### DIFF
--- a/scripts/tests/test_partner_batch_imports.py
+++ b/scripts/tests/test_partner_batch_imports.py
@@ -1,5 +1,12 @@
+from datetime import datetime
+
 import pytest
-from ..partner_batch_imports import Biblio, is_low_quality_book
+
+from ..partner_batch_imports import (
+    Biblio,
+    is_low_quality_book,
+    is_published_in_future_year,
+)
 
 csv_row = "USA01961304|0962561851||9780962561856|AC|I|TC||B||Sutra on Upasaka Precepts|The||||||||2006|20060531|Heng-ching, Shih|TR||||||||||||||226|ENG||0.545|22.860|15.240|||||||P|||||||74474||||||27181|USD|30.00||||||||||||||||||||||||||||SUTRAS|BUDDHISM_SACRED BOOKS|||||||||REL007030|REL032000|||||||||HRES|HRG|||||||||RB,BIP,MIR,SYN|1961304|00|9780962561856|67499962||PRN|75422798|||||||BDK America||1||||||||10.1604/9780962561856|91-060120||20060531|||||REL007030||||||"  # noqa: E501
 
@@ -87,3 +94,21 @@ def test_is_low_quality_book():
             'publishers': ['Independently Published'],
         }
     )
+
+
+def test_is_published_in_future_year() -> None:
+    last_year = str(datetime.now().year - 1)
+    last_year_book = {'publish_date': last_year}
+    assert is_published_in_future_year(last_year_book) is False
+
+    this_year = str(datetime.now().year)
+    this_year_book = {'publish_date': this_year}
+    assert is_published_in_future_year(this_year_book) is False
+
+    next_year = str(datetime.now().year + 1)
+    next_year_book = {'publish_date': next_year}
+    assert is_published_in_future_year(next_year_book) is True
+
+    # No publication year
+    no_year_book = {'publish_date': '0'}
+    assert is_published_in_future_year(no_year_book) is False


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7201

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This prevents importing books from partner data where the `publish_date` is for a future year.

### Technical
<!-- What should be noted about the implementation? -->
This just checks if a book's `publish_date` is for a future year; if it is, it won't import it via `batch_import`.

To satisfy mypy `cast` is used, as I wasn't sure of the data schema. I'd like to address this if I can before merging.

I am testing if `publish_date` is a future year by adding +1 to the current year, and I don't know enough about the publishing industry to know if this is a problem.

For example, if publishers submit data to Open Library partners in the last week of December for books published in January of the coming year, this PR treats that data as bad.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Take a look at the new tests in `scripts/tests/test_partner_batch_imports.py`, make sure they cover the use cases, and run the tests.

NOTE: Though the added `is_published_in_future_year()` should return 'proper' results, I wasn't fully sure how to test whether I integrated this properly into `batch_import`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles, @cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
