### PR TITLE
Parallel process importbot imports to increase throughput + bug fixes

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -449,6 +449,8 @@ def early_exit(rec):
     # only searches for the first value from these lists
     for f in 'source_records', 'oclc_numbers', 'lccn':
         if rec.get(f):
+            if f == 'source_records' and not rec[f][0].startswith('ia:'):
+                continue
             ekeys = editions_matched(rec, f, rec[f][0])
             if ekeys:
                 return ekeys[0]

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -104,7 +104,7 @@ class ImportItem(web.storage):
     @staticmethod
     def find_pending(limit=1000):
         result = db.where("import_item", status="pending", order="id", limit=limit)
-        return [ImportItem(row) for row in result]
+        return map(ImportItem, result)
 
     @staticmethod
     def find_by_identifier(identifier):

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -27,13 +27,13 @@ def map_book_to_olbook(book, promise_id):
             **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
             **(
                 {'better_world_books': [book.get('ISBN')]}
-                if not book.get('ISBN', ' ')[0].isdigit()
+                if book.get('ISBN') and not book.get('ISBN')[0].isdigit()
                 else {}
             ),
         },
         **(
             {'isbn_13': [book.get('ISBN')]}
-            if book.get('ISBN', ' ')[0].isdigit()
+            if book.get('ISBN') and book.get('ISBN')[0].isdigit()
             else {}
         ),
         **({'isbn_10': [book.get('ASIN')]} if asin_is_isbn_10 else {}),


### PR DESCRIPTION
Closes #7215 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
- Runs 10 workers in parallel
- Fixes bug where `source_record` field would be deemed sufficient to create a "match" on import!
- Corresponding haproxy changes: https://github.com/internetarchive/olsystem/pull/166
### Testing
- Observe increased throughput in https://openlibrary.org/people/ImportBot

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
