### PR TITLE
Covers to webp

### DIFF
--- a/scripts/covers_to_webp.py
+++ b/scripts/covers_to_webp.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+Utility script to be run on ol-home0 to convert some cover images from jpeg to webp.
+It demonstrates how to:
+1. read cover jpeg files from existing zip files on /1/var/tmp/imports,
+2. how to get the size in bytes of image files,
+3. convert jpeg images to webp
+
+Sample output:
+Cover filename      jpeg    webp    delta
+-----------------  ------  ------  ------
+9780000528742.jpg  13,252   8,534  64.40%
+9780006499268.jpg  21,520  18,184  84.50%
+9780006499305.jpg  20,648  17,552  85.01%
+9780007217410.jpg  25,793  20,080  77.85%
+9780007217427.jpg  30,450  24,568  80.68%
+"""
+
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+from PIL import Image
+
+COVERS_DIR = "/1/var/tmp/imports/2022/covers/"
+
+
+def main(debug: bool = False):
+    """Convert all images in the current directory to webp."""
+    with ZipFile(COVERS_DIR + "Apr2022_1_lc_13.zip") as in_file:
+        for i, cover_file in enumerate(sorted(in_file.namelist())):
+            if cover_file.endswith(".jpg"):
+                image = Image.open(in_file.open(cover_file))
+                with BytesIO() as jpeg_file:
+                    image.save(jpeg_file, "jpeg")
+                    src_image_size = jpeg_file.tell()
+                with BytesIO() as webp_file:
+                    image.save(webp_file, "webp")
+                    dst_image_size = webp_file.tell()
+                del image
+                print(
+                    f"{cover_file}  {src_image_size:,}  {dst_image_size:>6,}  "
+                    f"{dst_image_size/src_image_size:.2%}"
+                )
+                if debug and i > 20:
+                    break
+
+
+if __name__ == "__main__":
+    main(debug=True)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Utility script to be run on `ol-home0` to convert some cover images from `jpeg` to `webp`.
It demonstrates how to:
1. read cover `jpeg` files from existing zip files on `/1/var/tmp/imports`,
2. how to get the size in bytes of image files,
3. convert `jpeg` images to `webp`.

Sample output:
```
Cover filename      jpeg    webp    delta
-----------------  ------  ------  ------
9780000528742.jpg  13,252   8,534  64.40%
9780006499268.jpg  21,520  18,184  84.50%
9780006499305.jpg  20,648  17,552  85.01%
9780007217410.jpg  25,793  20,080  77.85%
9780007217427.jpg  30,450  24,568  80.68%
```
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
