### PR TITLE
Improve check-in event validation

### DIFF
--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -3,15 +3,14 @@ from enum import IntEnum, EnumMeta
 from . import db
 
 
-class BookshelfEventMeta(EnumMeta):
-    def __contains__(cls, item):
-        return item in cls.__members__.values()
-
-
-class BookshelfEvent(IntEnum, metaclass=BookshelfEventMeta):
+class BookshelfEvent(IntEnum):
     START = 1
     UPDATE = 2
     FINISH = 3
+
+    @classmethod
+    def has_value(cls, value: int) -> bool:
+        return value in (item.value for item in BookshelfEvent.__members__.values())
 
 
 class BookshelvesEvents(db.CommonExtras):

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,16 +1,17 @@
-from datetime import date, datetime
-from enum import IntEnum
+from datetime import datetime
+from enum import IntEnum, EnumMeta
 from . import db
 
 
-class BookshelfEvent(IntEnum):
+class BookshelfEventMeta(EnumMeta):
+    def __contains__(cls, item):
+        return item in cls.__members__.values()
+
+
+class BookshelfEvent(IntEnum, metaclass=BookshelfEventMeta):
     START = 1
     UPDATE = 2
     FINISH = 3
-
-    @classmethod
-    def has_key(cls, key: str) -> bool:
-        return key in cls.__members__
 
 
 class BookshelvesEvents(db.CommonExtras):

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import IntEnum, EnumMeta
+from enum import IntEnum
 from . import db
 
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -118,7 +118,7 @@ class patron_check_ins(delegate.page):
         if 'event_type' not in data:
             return False
 
-        if not data.get('event_type') in BookshelfEvent:
+        if not BookshelfEvent.has_value(data.get('event_type')):
             return False
 
         # Date must be valid:

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -118,6 +118,9 @@ class patron_check_ins(delegate.page):
         if 'event_type' not in data:
             return False
 
+        if not data.get('event_type') in BookshelfEvent:
+            return False
+
         # Date must be valid:
         if not is_valid_date(
             data.get('year', None),

--- a/openlibrary/plugins/upstream/tests/test_checkins.py
+++ b/openlibrary/plugins/upstream/tests/test_checkins.py
@@ -65,8 +65,16 @@ class TestValidateData:
             'month': 3,
             'day': 7,
         }
+        self.unknown_event = {
+            'edition_key': '/books/OL1234M',
+            'event_type': 54321,
+            'year': 2000,
+            'month': 3,
+            'day': 7,
+        }
 
     def test_validate_data(self):
         assert self.checkins.validate_data(self.valid_data) is True
         assert self.checkins.validate_data(self.missing_event) is False
         assert self.checkins.validate_data(self.invalid_date) is False
+        assert self.checkins.validate_data(self.unknown_event) is False


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Validates POSTed check-in events (specifically the `event_type` property).  Also replaces the `has_key` enum method with a `__contains__` method (as per this [review note](https://github.com/internetarchive/openlibrary/pull/6987/files#r985286665))

### Technical
<!-- What should be noted about the implementation? -->
Our backend check-in service expects `event_type` to be one of the values in the `BookshelfEvent` enum (1, 2, or 3).  This code checks if the value of `event_type` is included in `BookshelfEvent`. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
