### PR TITLE
Pin flake8 version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         entry: bash -c 'git diff master -U0 | ./scripts/flake8-diff.sh'
         language: python
         additional_dependencies:
-          - flake8
+          - flake8==5.0.4
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Flake8 removed the `--diff` option in version 6.0.0.  After a recent OS upgrade, I was unable to run `git commit` without either removing the pre-commit hook or pinning the flake8 version in the pre-commit configuration.

This PR pins flake8 to the same version as found in [requirements_test.txt](https://github.com/internetarchive/openlibrary/blob/86e99b37f0c3eee4892816a87c1f0db0bc0aae09/requirements_test.txt#L7).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss @cdrini @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
