### PR TITLE
Fix broken `stats/readinglog` page

### DIFF
--- a/openlibrary/templates/stats/readinglog.html
+++ b/openlibrary/templates/stats/readinglog.html
@@ -44,15 +44,15 @@ $def with (stats)
       <tbody>
         <tr>
           <th>$_('All time')</th>
-          <td>$stats['total_books_starred']['total']['count']</td>
+          <td>$stats['total_books_starred']['total']</td>
         </tr>
         <tr>
           <th>$_('This Month')</th>
-          <td>$stats['total_books_starred']['month']['count']</td>
+          <td>$stats['total_books_starred']['month']</td>
         </tr>
         <tr>
           <th>$_('Total # Unique Raters (all time)')</th>
-          <td>$stats['total_books_starred']['unique']['count']</td>
+          <td>$stats['total_star_raters']['total']</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
While prepping for #7218, I noticed that the `stats/readinglog` page was not rendering due to incorrect keys being accessed on the `stats` object.  This PR uses the correct values in the reading log stats template.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This branch has been deployed to testing.  You can test by comparing the following pages:
https://testing.openlibrary.org/stats/readinglog
https://openlibrary.org/stats/readinglog

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
