### PR TITLE
Fixing py3 cover archiver + extending cluster allowlist IDs

### DIFF
--- a/docker/ol-covers-start.sh
+++ b/docker/ol-covers-start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 python --version
+git checkout openlibrary/coverstore/archive.py
 scripts/coverstore-server "$COVERSTORE_CONFIG" \
     --gunicorn $GUNICORN_OPTS \
     --bind :7075

--- a/docker/ol-covers-start.sh
+++ b/docker/ol-covers-start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 python --version
-git checkout openlibrary/coverstore/archive.py
 scripts/coverstore-server "$COVERSTORE_CONFIG" \
     --gunicorn $GUNICORN_OPTS \
     --bind :7075

--- a/openlibrary/coverstore/README.md
+++ b/openlibrary/coverstore/README.md
@@ -52,7 +52,7 @@ The item name itself (e.g. `coverd_0007`) is a combination of the prefix `covers
 
 **Recipe for moving one batch of 10k covers at a time into tars on archive.org.**
 
-1. On ol-covers0 docker container, run archive.py on ~10k items to create a new partial of unarchived covers, starting at stable ID 8M (e.g. `covers_0008_01`)
+1. On ol-covers0 docker container, run archive.py on ~10k items to create a new partial of unarchived covers, starting at stable ID 8M (e.g. `covers_0008_00`)
     ```
     from openlibrary.coverstore import config
     from openlibrary.coverstore.server import load_config
@@ -61,15 +61,15 @@ The item name itself (e.g. `coverd_0007`) is a combination of the prefix `covers
     archive.archive(test=False)
     ```
 2. `ia upload` each partial to the 4 respective items:
-    * `covers_0008` -> `covers_0008_01.index` and `covers_0008_01.tar`
-    * `s_covers_0008` -> `s_covers_0008_01.index` and `s_covers_0008_01.tar`
-    * `m_covers_0008` -> `m_covers_0008_01.index` and `m_covers_0008_01.tar`
-    * `l_covers_0008` -> `l_covers_0008_01.index` and `l_covers_0008_01.tar`
+    * `covers_0008` -> `covers_0008_00.index` and `covers_0008_00.tar`
+    * `s_covers_0008` -> `s_covers_0008_00.index` and `s_covers_0008_00.tar`
+    * `m_covers_0008` -> `m_covers_0008_00.index` and `m_covers_0008_00.tar`
+    * `l_covers_0008` -> `l_covers_0008_00.index` and `l_covers_0008_00.tar`
 3. Update the upper bound value in code.py ~L290 by +10k (on `ol-covers0` container 1 & 2 + restart)
-  * `if (8020000 > int(value) >= 8000000):`  ...
+  * `if (8100000 > int(value) >= 8000000):` (or whatever is the upper bound)  ...
 4. Restart the containers + test to make sure the service is resolving to archive.org for all sizes
-5. Remove only the completed partial (e.g. 01 from each folder on /1/var/lib/openlibrary/coverstore/items/
-  * `rm /1/var/lib/openlibrary/coverstore/items/cover_0008/covers_0008_01.*`
-  * `rm /1/var/lib/openlibrary/coverstore/items/s_cover_0008/s_covers_0008_01.*`
-  * `rm /1/var/lib/openlibrary/coverstore/items/m_cover_0008/m_covers_0008_01.*`
-  * `rm /1/var/lib/openlibrary/coverstore/items/l_cover_0008/l_covers_0008_01.*`
+5. Remove only the completed partial (e.g. 00 from each folder on /1/var/lib/openlibrary/coverstore/items/
+  * `rm /1/var/lib/openlibrary/coverstore/items/cover_0008/covers_0008_00.*`
+  * `rm /1/var/lib/openlibrary/coverstore/items/s_cover_0008/s_covers_0008_00.*`
+  * `rm /1/var/lib/openlibrary/coverstore/items/m_cover_0008/m_covers_0008_00.*`
+  * `rm /1/var/lib/openlibrary/coverstore/items/l_cover_0008/l_covers_0008_00.*`

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -121,8 +121,7 @@ def archive(test=True):
                 ),
             }
 
-            for file_type in files:
-                f = files[file_type]
+            for file_type, f in files.items():
                 files[file_type].path = f.filename and os.path.join(
                     config.data_root, "localdisk", f.filename
                 )

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -267,6 +267,10 @@ class cover:
             if value and self.is_cover_in_cluster(value):
                 url = zipview_url_from_id(int(value), size)
                 raise web.found(url)
+        elif key == 'test':
+            cover_id = 8000001
+
+            pass
         elif key == 'ia':
             url = self.get_ia_cover_url(value, size)
             if url:
@@ -276,15 +280,25 @@ class cover:
         elif key != 'id':
             value = self.query(category, key, value)
 
-        if value and safeint(value) in config.blocked_covers:
+        if not value or (value and safeint(value) in config.blocked_covers):
             raise web.notfound()
 
         # redirect to archive.org cluster for large size and original images whenever possible
-        if value and (size == "L" or size == "") and self.is_cover_in_cluster(value):
+        if (size == "L" or size == "") and self.is_cover_in_cluster(value):
             url = zipview_url_from_id(int(value), size)
             raise web.found(url)
+        # These items have been tar archived in items, starting with covers_0008
+        if 8010000 > int(value) >= 8000000:
+            prefix = f"{size.lower()}_" if size else ""
+            pid = "%010d" % int(value)
+            item_id = f"{prefix}covers_{pid[:4]}"
+            item_tar = f"{prefix}covers_{pid[:4]}_{pid[4:6]}.tar"
+            item_file = f"{pid}{'-' + size.upper() if size else ''}"
+            path = f"{item_id}/{item_tar}/{item_file}.jpg"
+            protocol = web.ctx.protocol
+            raise web.found(f"{protocol}://archive.org/download/{path}")
 
-        d = value and self.get_details(value, size.lower())
+        d = self.get_details(value, size.lower())
         if not d:
             return notfound()
 

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -269,8 +269,6 @@ class cover:
                 raise web.found(url)
         elif key == 'test':
             cover_id = 8000001
-
-            pass
         elif key == 'ia':
             url = self.get_ia_cover_url(value, size)
             if url:
@@ -284,19 +282,21 @@ class cover:
             raise web.notfound()
 
         # redirect to archive.org cluster for large size and original images whenever possible
-        if (size == "L" or size == "") and self.is_cover_in_cluster(value):
+        if size in ("L", "") and self.is_cover_in_cluster(value):
             url = zipview_url_from_id(int(value), size)
             raise web.found(url)
-        # These items have been tar archived in items, starting with covers_0008
-        if 8010000 > int(value) >= 8000000:
-            prefix = f"{size.lower()}_" if size else ""
-            pid = "%010d" % int(value)
-            item_id = f"{prefix}covers_{pid[:4]}"
-            item_tar = f"{prefix}covers_{pid[:4]}_{pid[4:6]}.tar"
-            item_file = f"{pid}{'-' + size.upper() if size else ''}"
-            path = f"{item_id}/{item_tar}/{item_file}.jpg"
-            protocol = web.ctx.protocol
-            raise web.found(f"{protocol}://archive.org/download/{path}")
+
+        # These 100k covers are tar'd in archive.org item covers_0008
+        if isinstance(value, int) or value.isnumeric():
+            if 8100000 >= int(value) >= 8000000:
+                prefix = f"{size.lower()}_" if size else ""
+                pid = "%010d" % int(value)
+                item_id = f"{prefix}covers_{pid[:4]}"
+                item_tar = f"{prefix}covers_{pid[:4]}_{pid[4:6]}.tar"
+                item_file = f"{pid}{'-' + size.upper() if size else ''}"
+                path = f"{item_id}/{item_tar}/{item_file}.jpg"
+                protocol = web.ctx.protocol
+                raise web.found(f"{protocol}://archive.org/download/{path}")
 
         d = self.get_details(value, size.lower())
         if not d:

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -259,16 +259,6 @@ class cover:
         if key == 'isbn':
             value = value.replace("-", "").strip()  # strip hyphens from ISBN
             value = self.query(category, key, value)
-
-            # Redirect isbn requests to archive.org.
-            # This will heavily reduce the load on coverstore server.
-            # The max_coveritem_index config parameter specifies the latest
-            # olcovers items uploaded to archive.org.
-            if value and self.is_cover_in_cluster(value):
-                url = zipview_url_from_id(int(value), size)
-                raise web.found(url)
-        elif key == 'test':
-            cover_id = 8000001
         elif key == 'ia':
             url = self.get_ia_cover_url(value, size)
             if url:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Code fixes for #7197 

See: [README edits](https://github.com/internetarchive/openlibrary/pull/7230/files?short_path=a584955#diff-a5849555f8f6b6f9948f815963e945e4b66981c66eb57a1cf83941c133d5f696)

So far we've successfully archived `covers_0008_00` for all sizes and cleared up ~5GB.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
