### PR TITLE
Add analytics for patron imports and exports

### DIFF
--- a/openlibrary/templates/account/import.html
+++ b/openlibrary/templates/account/import.html
@@ -15,7 +15,7 @@ $def with (books=None, books_wo_isbns=None)
           </div>
           <div>
             <input class="cta-btn cta-btn--available cta-btn--small"
-                type="submit" value="$_('Load Books')">
+                type="submit" value="$_('Load Books')" data-ol-link-track="PatronImports|Goodreads">
           </div>
         </form>
       </div>
@@ -26,7 +26,7 @@ $def with (books=None, books_wo_isbns=None)
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="reading_log">
           <div>
-            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')" data-ol-link-track="PatronExports|ReadingLog">
           </div>
         </form>
       </div>
@@ -37,7 +37,7 @@ $def with (books=None, books_wo_isbns=None)
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="book_notes">
           <div>
-            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')" data-ol-link-track="PatronExports|BookNotes">
           </div>
         </form>
       </div>
@@ -48,7 +48,7 @@ $def with (books=None, books_wo_isbns=None)
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="reviews">
           <div>
-            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')" data-ol-link-track="PatronExports|ReviewTags">
           </div>
         </form>
       </div>
@@ -59,7 +59,7 @@ $def with (books=None, books_wo_isbns=None)
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="lists">
           <div>
-            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')" data-ol-link-track="PatronExports|ListsSummary">
           </div>
         </form>
       </div>
@@ -70,7 +70,7 @@ $def with (books=None, books_wo_isbns=None)
             enctype="multipart/form-data" class="olform olform--decoration">
           <input type="hidden" name="type" value="ratings">
           <div>
-            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')">
+            <input type="submit" class="cta-btn cta-btn--available cta-btn--small" value="$_('Download (.csv format)')" data-ol-link-track="PatronExports|StarRatings">
           </div>
         </form>
       </div>

--- a/openlibrary/templates/type/list/exports.html
+++ b/openlibrary/templates/type/list/exports.html
@@ -1,13 +1,13 @@
 $def with (list)
 
 $def json_link():
-    <a rel="nofollow" href="$list.url('/export?format=json')">JSON</a>
+    <a rel="nofollow" href="$list.url('/export?format=json')" data-ol-link-track="PatronExports|ListJSON">JSON</a>
 
 $def html_link():
-    <a rel="nofollow" href="$list.url('/export?format=html')">HTML</a>
+    <a rel="nofollow" href="$list.url('/export?format=html')" data-ol-link-track="PatronExports|ListHTML">HTML</a>
 
 $def bibtex_link():
-    <a rel="nofollow" href="$list.url('/export?format=bibtex')">BibTex</a>
+    <a rel="nofollow" href="$list.url('/export?format=bibtex')" data-ol-link-track="PatronExports|BibTex">BibTex</a>
 
 <div id="listTools">
     $if list.seed_count <= 10000:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds Google Analytics tracking for the following actions:
- Goodreads imports
- Reading log exports
- Star Rating exports
- Lists summary exports
- Book notes exports
- Review tag exports
- JSON list export
- HTML list export
- BibTex list export

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
