### PR TITLE
Book page star ratings analytics + small refactor

### DIFF
--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -18,7 +18,7 @@ $ form_id = "ratingsForm%s" % id
       <input type="hidden" value="$page" name="page"/>
     <input type="hidden" value="$redir_url" name="redir_url"/>
   <div class="review" id="starRatingSection">
-    <div class="stars">
+    <div class="stars" data-ol-link-track="StarRating|BookRated">
       $ NUM_STARS = 5
       $for star in range(1, NUM_STARS + 1)
         <input type="submit" value="$star" name="rating"

--- a/openlibrary/macros/StarRatingsStats.html
+++ b/openlibrary/macros/StarRatingsStats.html
@@ -5,7 +5,7 @@ $ stats_by_bookshelf = work and work.get_num_users_by_bookshelf() or {}
 $ avg = rating_stats.get('avg_rating')
 
 <ul class="readers-stats" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-  <li class="avg-ratings" onclick="location.href='#starRatingSection';">
+  <li class="avg-ratings" onclick="location.href='#starRatingSection';" data-ol-link-track="StarRating|StatsComponentClick">
     $if avg:
       $ stats_decimal = (float(avg))-(int(avg))
       $:('<span class="readers-stats__star">★</span>' * int(avg))

--- a/static/css/components/rating-form.less
+++ b/static/css/components/rating-form.less
@@ -14,10 +14,6 @@
   cursor: pointer;
   margin: 0 auto;
 }
-// allows smooth scrolling after clicking on anchor link
-html {
-  scroll-behavior: smooth;
-}
 .review {
   display: flex;
   scroll-margin-top: 100px;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -5,6 +5,11 @@
 @compact-title-height: 35px;
 @test-body-mobile-width: 1060px;
 
+// allows smooth scrolling after clicking on book page jump links
+html {
+  scroll-behavior: smooth;
+}
+
 /* stylelint-disable no-descending-specificity */
 .workDetails {
   padding: 20px 0;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds analytics to the star rating and star rating stats components.  Also, moves `scroll-behavior` rule (added in #7125) to `work.less`.

### Technical
<!-- What should be noted about the implementation? -->
No distinction is made between star rating clicks on the book page and star rating clicks in search items.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
