### PR TITLE
Add reading goal banner announcement

### DIFF
--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -33,7 +33,8 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       </div>
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
-      $ announcement = None
+      $ copy = _('Let Open Library help you reach your 2023 reading goals')
+      $ announcement = '%s <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>'% copy
       $if announcement:
         <div class="page-banner page-banner-body">
          $:announcement

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -33,8 +33,12 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       </div>
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
-      $ copy = _('Let Open Library help you reach your 2023 reading goals')
-      $ announcement = '%s <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>'% copy
+      $ learn_more_copy = _('Learn More')
+      $ learn_more_btn = '<a href="#" class="btn primary">%s</a>' % learn_more_copy
+      $ set_goal_copy = _('Set your 2023 goal')
+      $ set_goal_btn = '<a href="/account/books" class="btn primary">%s</a>' % set_goal_copy
+      $ cta_copy = _('Announcing Yearly Reading Goals: %(learn_btn)s or %(set_btn)s', learn_btn=learn_more_btn, set_btn=set_goal_btn)
+      $ announcement = cta_copy
       $if announcement:
         <div class="page-banner page-banner-body">
          $:announcement

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -34,7 +34,7 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
       $# Paste next line into announcement variable to show the blue banner
       $# <strong>Title:</strong> Description &nbsp; <a href="#" data-ol-link-track="AnnouncementsBar|BlogWidget" class="btn primary">Learn More</a>
       $ learn_more_copy = _('Learn More')
-      $ learn_more_btn = '<a href="#" class="btn primary">%s</a>' % learn_more_copy
+      $ learn_more_btn = '<a href="https://blog.openlibrary.org/2022/12/31/reach-your-2023-reading-goals-with-open-library" class="btn primary">%s</a>' % learn_more_copy
       $ set_goal_copy = _('Set your 2023 goal')
       $ set_goal_btn = '<a href="/account/books" class="btn primary">%s</a>' % set_goal_copy
       $ cta_copy = _('Announcing Yearly Reading Goals: %(learn_btn)s or %(set_btn)s', learn_btn=learn_more_btn, set_btn=set_goal_btn)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7241

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds banner announcement for yearly reading goals.

TODO:
1. Set `href`of "Learn More" button to the yearly reading goals blog post.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
