### PR TITLE
move covers_0008 parts _10 to _23 -> ia

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -276,9 +276,9 @@ class cover:
             url = zipview_url_from_id(int(value), size)
             raise web.found(url)
 
-        # These 100k covers are tar'd in archive.org item covers_0008
+        # covers_0008 partials [_00, _23] are tar'd in archive.org items
         if isinstance(value, int) or value.isnumeric():
-            if 8100000 >= int(value) >= 8000000:
+            if 8240000 > int(value) >= 8000000:
                 prefix = f"{size.lower()}_" if size else ""
                 pid = "%010d" % int(value)
                 item_id = f"{prefix}covers_{pid[:4]}"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Archives covers between 8100000 and 8230000 in archive.org items `covers_0008`, `l_covers_0008`, `m_covers_0008`, and `s_covers_0008` so the tars can be removed off disk. Bumps the coverstore ranges from including part `_10` to `_23`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
