### PR TITLE
Update book notes UI CTA button styles

### DIFF
--- a/openlibrary/macros/NotesModal.html
+++ b/openlibrary/macros/NotesModal.html
@@ -35,8 +35,8 @@ $ context = {
         <input type="hidden" name="work_id" value="$work_key.split('/')[-1]" />
         <input type="hidden" name="edition_id" value="$edition.key.split('/')[-1]" />
         <div class="note-form-buttons">
-          <button class="delete-note-button cta-btn cta-btn--shell $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
-          <button class="update-note-button">$_("Save Note")</button>
+          <button class="delete-note-button cta-btn cta-btn--delete $('' if display_delete_button else 'hidden')" type="button">$_("Delete Note")</button>
+          <button class="update-note-button cta-btn cta-btn--shell">$_("Save Note")</button>
         </div>
       </form>
     </div>

--- a/openlibrary/templates/account/notes.html
+++ b/openlibrary/templates/account/notes.html
@@ -59,8 +59,8 @@ $def with (notes, user, num_found, page=1, results_per_page=25)
                     <textarea class="notes-textarea" id="$textarea_id" rows="10">$i['notes'][k]</textarea>
                     <input type="hidden" name="workId" value="$work_id" />
                     <div class="note-page-buttons" id="$button_div_id">
-                      <button class="delete-note-button cta-btn cta-btn--shell" type="button">$_("Delete Note")</button>
-                      <button class="update-note-link-button">$_("Save Note")</button>
+                      <button class="delete-note-button cta-btn cta-btn--delete" type="button">$_("Delete Note")</button>
+                      <button class="update-note-link-button cta-btn cta-btn--shell">$_("Save Note")</button>
                     </div>
                   </div>
                 </li>

--- a/static/css/components/metadata-form.less
+++ b/static/css/components/metadata-form.less
@@ -31,11 +31,6 @@
     width: unset;
   }
 
-  .delete-note-button {
-    border-color: @red;
-    color: @red;
-  }
-
   .update-note-button {
     margin-left: auto;
     margin-top: 5px;

--- a/static/css/components/notes-view.less
+++ b/static/css/components/notes-view.less
@@ -73,11 +73,6 @@
     width: unset;
   }
 
-  .delete-note-button {
-    border-color: @red;
-    color: @red;
-  }
-
   .update-note-link-button {
     margin-left: auto;
     margin-top: 5px;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates classes of CTA buttons found in book notes components.  The delete buttons are now solid red with white letters, and the save buttons use the blue "shell" styling.  These changes make the notes component buttons consistent with the buttons on the new check-in form.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Navigate to a book page, and open the note modal and confirm that the submit button is styled properly.
2. Submit a note for the book. The notes modal should close (this is BAU).
3. Open the notes modal again.  Verify that the delete button is properly styled.
4. Navigate to the "My Notes" section of the My Books page.
5. Verify that the delete and save buttons are properly styled.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-12-13 17-39-41](https://user-images.githubusercontent.com/28732543/207485372-76613ad2-2eaf-4154-b348-28d6c4365502.png)
_Book page notes modal_

![Screenshot from 2022-12-13 17-40-05](https://user-images.githubusercontent.com/28732543/207485403-9270a63a-4d54-4815-a8bf-462bdc04e1eb.png)
_"My Notes" page notes component_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
