### PR TITLE
Fix for diff.html not correctly handling redirected author data

### DIFF
--- a/openlibrary/templates/diff.html
+++ b/openlibrary/templates/diff.html
@@ -116,8 +116,8 @@ $def diff_display(name, value):
                 elif p == "authors":
                     label = "authors"
                     t = "/type/author"
-                    ap = a.get_authors()
-                    bp = b.get_authors()
+                    ap = [a.author for a in a.authors]
+                    bp = [b.author for b in b.authors]
                 else:
                     ap = a[p]
                     bp = b[p]

--- a/openlibrary/templates/diff.html
+++ b/openlibrary/templates/diff.html
@@ -116,8 +116,8 @@ $def diff_display(name, value):
                 elif p == "authors":
                     label = "authors"
                     t = "/type/author"
-                    ap = [a.author for a in a.authors]
-                    bp = [b.author for b in b.authors]
+                    ap = [val.author for val in a.authors]
+                    bp = [val.author for val in b.authors]
                 else:
                     ap = a[p]
                     bp = b[p]


### PR DESCRIPTION
I discovered this bug in the diff display while working on merge undo.

If two revisions of a work have different `authors` values, but one of the authors redirects to the other, the diff display will say there is no difference:

<img width="768" alt="Screenshot 2022-12-13 at 8 08 03 PM" src="https://user-images.githubusercontent.com/886889/207488063-c09e6516-4071-4307-b3e9-488322ec3179.png">

This fix causes the pre-redirect values to be compared and displayed:

<img width="769" alt="Screenshot 2022-12-13 at 8 07 26 PM" src="https://user-images.githubusercontent.com/886889/207488187-b12f5d1b-a026-4e81-8c15-13140f0edfbb.png">

### Technical
diff.html was calling `get_authors()` on the work object to retrieve the values for comparison, but `get_authors()` resolves redirects before passing the values back. I replaced the call with a direct retrieval of the object values.

Browsing back through the history of the code in question, it's not clear that this case has ever worked correctly.

### Testing
This problem crops up most when work authors have been reassigned during an author merge. Here's an example:

Look at https://testing.openlibrary.org/works/OL31497827W.json?v=1 and https://testing.openlibrary.org/works/OL31497827W.json?v=2 and note that the authors are different. 

However, the display at https://testing.openlibrary.org/works/OL31497827W?b=2&a=1&_compare=Compare&m=diff doesn't show the difference unless this patch is applied.

### Stakeholders
@mheiman @cdrini
