### PR TITLE
Make has_fulltext user pd-status aware

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -190,7 +190,7 @@ def run_solr_query(
         if param.get(field) == value:
             if field in facet_params:
                 facet_params.remove(field)
-            params.append(('fq', rewrite))
+            params.append(('fq', rewrite() if callable(rewrite) else rewrite))
 
     for field in facet_params:
         if field == 'author_facet':

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -26,7 +26,7 @@ class SearchScheme:
     # Default
     default_fetched_fields: set[str]
     # Fields that should be rewritten
-    facet_rewrites: dict[tuple[str, str], str]
+    facet_rewrites: dict[tuple[str, str], Union[str, Callable[[], str]]]
 
     def is_search_field(self, field: str):
         return field in self.all_fields or field in self.field_name_map

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+from typing import Callable, Union
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 
@@ -38,7 +39,7 @@ class AuthorSearchScheme(SearchScheme):
         'top_subjects',
         'work_count',
     }
-    facet_rewrites: dict[tuple[str, str], str] = {}
+    facet_rewrites: dict[tuple[str, str], Union[str, Callable[[], str]]] = {}
 
     def q_to_solr_params(
         self,

--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import logging
+from typing import Callable, Union
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 
@@ -31,7 +32,7 @@ class SubjectSearchScheme(SearchScheme):
         'subject_type',
         'work_count',
     }
-    facet_rewrites: dict[tuple[str, str], str] = {}
+    facet_rewrites: dict[tuple[str, str], Union[str, Callable[[], str]]] = {}
 
     def q_to_solr_params(
         self,

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -159,8 +159,14 @@ class WorkSearchScheme(SearchScheme):
         ('public_scan', 'false'): '-ebook_access:public',
         ('print_disabled', 'true'): 'ebook_access:printdisabled',
         ('print_disabled', 'false'): '-ebook_access:printdisabled',
-        ('has_fulltext', 'true'): 'ebook_access:[printdisabled TO *]',
-        ('has_fulltext', 'false'): 'ebook_access:[* TO printdisabled}',
+        (
+            'has_fulltext',
+            'true',
+        ): lambda: f'ebook_access:[{get_fulltext_min()} TO *]',
+        (
+            'has_fulltext',
+            'false',
+        ): lambda: f'ebook_access:[* TO {get_fulltext_min()}}}',
     }
 
     def is_search_field(self, field: str):
@@ -552,3 +558,8 @@ def has_solr_editions_enabled():
         return cookie_value == 'true'
 
     return True
+
+
+def get_fulltext_min():
+    is_printdisabled = web.cookies().get('pd', False)
+    return 'printdisabled' if is_printdisabled else 'borrowable'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7270 . Closes #7284

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- In incognito, https://testing.openlibrary.org/search?q=slovnyk&has_fulltext=true&mode=ebooks&sort=random shows 6 books. Logged in as admin, it shows 37

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
