### PR TITLE
Make author pages used edition-aware data

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -483,13 +483,17 @@ def works_by_author(
                 "time_facet",
             ]
         ),
+        fields=WorkSearchScheme.default_fetched_fields | {'editions'},
         extra_params=[
             ('fq', f'author_key:{akey}'),
             ('facet.limit', 25),
         ],
     )
 
-    result.docs = add_availability([get_doc(doc) for doc in result.docs])
+    result.docs = [get_doc(doc) for doc in result.docs]
+    add_availability(
+        [(work.get('editions') or [None])[0] or work for work in result.docs]
+    )
     return result
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7268

Author pages now prefer editions in the user's language.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- eg https://testing.openlibrary.org/authors/OL2162284A/Stephen_King?lang=fr
- eg https://testing.openlibrary.org/authors/OL23919A/J._K._Rowling?lang=fr

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
