### PR TITLE
Fix "view profile" link on `/admin/people/{person}` page

### DIFF
--- a/openlibrary/templates/admin/people/view.html
+++ b/openlibrary/templates/admin/people/view.html
@@ -141,7 +141,7 @@ $ has_profile = person.get_user() is not None
     <tbody>
     <tr>
         <td>$_("Name:")</td>
-        <td>$person.displayname - <a href="$homepath()$person.username" style="color: #900; text-decoration: none;">view profile</a></td>
+        <td>$person.displayname - <a href="/people/$person.username" style="color: #900; text-decoration: none;">view profile</a></td>
     </tr>
     <tr>
         <td>$_("Email Address:")</td>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Noticed that the "View profile" links in `/admin/people/{person}` pages do not actually link to the person's page. This PR corrects the issue.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as an admin:
1. Navigate to a patron's `/admin/people` page.
2. Ensure that the red "View profile" link references the persons public profile page (rather than the current page).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
