### PR TITLE
Stop clobbering edition_id when changing shelves

### DIFF
--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -53,7 +53,7 @@ $if shelf_count > 0:
         $ doc_number = 1
         $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
         $for idx, doc in enumerate(docs):
-          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=(bookshelf_id == 3 and doc.logged_edition), users_work_read_status=bookshelf_id, remove_on_change=True)
+          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id, remove_on_change=True)
           $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
           $:macros.SearchResultsWork(doc, reading_log=dropper, availability=doc.get('availability'), rating=star_rating)
           $ doc_number = doc_number + 1


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7246

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In My Reading Log views, the edition ID was being changed to `False` for "Want to Read" and "Currently Reading" shelves.  This PR corrects this issue by removing the bookshelf ID check that occurs when setting the `edition_key` parameter for the reading log droppers.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a beta-tester:
1. Add a book to your "Already Read" shelf.
2. Navigate to your My Reading Log "Already Read" shelf.  You should see a prompt for a check-in date on the newly added item.
3. Move the book to another shelf, then navigate to that shelf.
4. Move the book back to the "Already Read" shelf.  If the check-in prompt is present, then the `edition_id` is not being deleted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
