### PR TITLE
Internationalize add book ISBN error messages

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -1,5 +1,9 @@
 import {parseIsbn, isFormatValidIsbn10, isChecksumValidIsbn10, isFormatValidIsbn13, isChecksumValidIsbn13} from './edit.js'
 
+let invalidChecksum;
+let invalidIsbn10;
+let invalidIsbn13;
+
 export function initAddBookImport () {
     $('.list-books a').on('click', function() {
         var li = $(this).parents('li').first();
@@ -10,14 +14,16 @@ export function initAddBookImport () {
         $('input#work').val('none-of-these');
         $('form#addbook').trigger('submit');
     });
+
+    const i18nStrings = JSON.parse(document.querySelector('#id-errors').dataset.i18n)
+    invalidChecksum = i18nStrings.invalid_checksum
+    invalidIsbn10 = i18nStrings.invalid_isbn10
+    invalidIsbn13 = i18nStrings.invalid_isbn13
+
     $('#addbook').on('submit', parseAndValidateIsbn);
     $('#id_value').on('input', clearIsbnError);
     $('#id_name').on('change', clearIsbnError);
 }
-
-const isbn_invalid_checksum = 'Invalid ISBN checksum digit';
-const isbn10_wrong_length_or_chars = 'ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531';
-const isbn13_wrong_length_or_chars = 'ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100';
 
 // a flag to make raiseIsbnError perform differently upon subsequent calls
 let addBookWithIsbnErrors = false;
@@ -52,18 +58,18 @@ function parseAndValidateIsbn(event) {
     const isbn = parseIsbn(document.getElementById('id_value').value);
     if (fieldName === 'isbn_10') {
         if (!isFormatValidIsbn10(isbn)) {
-            return raiseIsbnError(event, isbn10_wrong_length_or_chars);
+            return raiseIsbnError(event, invalidIsbn10);
         }
         if (!isChecksumValidIsbn10(isbn)) {
-            return raiseIsbnError(event, isbn_invalid_checksum);
+            return raiseIsbnError(event, invalidChecksum);
         }
     }
     else if (fieldName === 'isbn_13') {
         if (!isFormatValidIsbn13(isbn)) {
-            return raiseIsbnError(event, isbn13_wrong_length_or_chars);
+            return raiseIsbnError(event, invalidIsbn13);
         }
         if (!isChecksumValidIsbn13(isbn)) {
-            return raiseIsbnError(event, isbn_invalid_checksum);
+            return raiseIsbnError(event, invalidChecksum);
         }
     }
     // parsing valid ISBN that passes checks

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -28,7 +28,7 @@ export function initAddBookImport () {
 // a flag to make raiseIsbnError perform differently upon subsequent calls
 let addBookWithIsbnErrors = false;
 
-function raiseIsbnError(event, errorMessage) {
+function displayIsbnError(event, errorMessage) {
     if (!addBookWithIsbnErrors) {
         addBookWithIsbnErrors = true;
         const errorDiv = document.getElementById('id-errors');
@@ -58,18 +58,18 @@ function parseAndValidateIsbn(event) {
     const isbn = parseIsbn(document.getElementById('id_value').value);
     if (fieldName === 'isbn_10') {
         if (!isFormatValidIsbn10(isbn)) {
-            return raiseIsbnError(event, invalidIsbn10);
+            return displayIsbnError(event, invalidIsbn10);
         }
         if (!isChecksumValidIsbn10(isbn)) {
-            return raiseIsbnError(event, invalidChecksum);
+            return displayIsbnError(event, invalidChecksum);
         }
     }
     else if (fieldName === 'isbn_13') {
         if (!isFormatValidIsbn13(isbn)) {
-            return raiseIsbnError(event, invalidIsbn13);
+            return displayIsbnError(event, invalidIsbn13);
         }
         if (!isChecksumValidIsbn13(isbn)) {
-            return raiseIsbnError(event, invalidChecksum);
+            return displayIsbnError(event, invalidChecksum);
         }
     }
     // parsing valid ISBN that passes checks

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -2,6 +2,12 @@ $def with (work=None, author=None, recaptcha=None)
 
 $var title: $_("Add a book")
 
+$ i18n_strings = {
+    $ "invalid_checksum": _("Invalid ISBN checksum digit"),
+    $ "invalid_isbn10": _("ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"),
+    $ "invalid_isbn13": _("ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100")
+    $ }
+
 <div id="contentHead">
     <div class="head">
         <h1>$_("Add a book to Open Library")</h1>
@@ -55,7 +61,7 @@ $var title: $_("Add a book")
         <div class="formElement">
             <div class="label"><label for="id_value">$:_("And optionally, an ID number &#151; like an ISBN &#151; would be helpful...")</label></div>
                 <label for="id_name" class="hidden">$_("ID Type")</label>
-                <div id="id-errors" class="note hidden"></div>
+                <div id="id-errors" class="note hidden" data-i18n="$json_encode(i18n_strings)"></div>
                 <div id="confirm-add" class="note hidden">$_('ISBN may be invalid. Click "Add" again to submit.')</div>
             <div class="input">
                 <select name="id_name" id="id_name">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Localizes recently added ISBN error strings for the "Add Book" page.  Also changes a function's name for clarity.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Navigate to the "Add a Book" page.
2. Select "ISBN10" from the ID dropdown.  Input a 9 digit number and press enter.  Confirm that an invalid ISBN10 message appears.
3. Input a 10 digit ISBN with an incorrect checksum, then press enter.  Confirm that an invalid checksum message appears.
4. Select "ISBN13" from the ID dropdown.  Input a 12 digit number and press enter.  Confirm that an invalid ISBN13 message is displayed.
5. Input a 13 digit ISBN with an incorrect checksum, then press enter.  Confirm that an invalid checksum message appears.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tfmorris 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
