### PR TITLE
7008/feature/restyle omnibar

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -248,7 +248,7 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
                 </div>
 
               $ edition_identifiers = edition.get_identifiers()
-              $ isbns = []
+              $ isbns = ['g']
               $for name, values in edition_identifiers.multi_items():
                 $if name in ["isbn_10", "isbn_13"]:
                   $for value in values:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,5 +1,5 @@
 $def with (page, edition=None)
-<h1></h1>
+
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,5 +1,5 @@
 $def with (page, edition=None)
-
+<h1></h1>
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -323,7 +323,7 @@ div.editionTools {
     div {
       //font-weight: bold;
       font-weight: lighter;
-      color: #666;
+      color: @grey;
     }
   }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -325,8 +325,7 @@ div.editionTools {
     font-size: .7em;
     word-break: break-word;
     text-align:center;
-    min-width: 70px;
-    overflow-x: auto;
+    min-width: 100px;
 
     div {
       //font-weight: bold;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -307,18 +307,23 @@ div.editionTools {
   display: flex;
   flex-direction: column;
   padding: 10px;
-  border-bottom: 1px solid @lighter-grey;
+  //border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
-  background: @grey-fafafa;
+  //background: @grey-fafafa;
 
   &-item {
     display: flex;
     justify-content: space-between;
     flex: 1;
+    margin: 0 0.5%;
+    border: 1px solid @lighter-grey;
+    border-radius: 5px;
     font-size: .8em;
 
     div {
-      font-weight: bold;
+      //font-weight: bold;
+      font-weight: lighter;
+      color: #666;
     }
   }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -318,24 +318,28 @@ div.editionTools {
     justify-content: center;
     align-items: center;
     flex: 1;
-    padding: 2% 0;
+    padding: 1% 1%;
     margin: 0 0.5%;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: .8em;
-    min-width: 150px;
+    font-size: .7em;
+    word-break: break-word;
+    text-align:center;
+    min-width: 70px;
+    overflow-x: auto;
 
     div {
       //font-weight: bold;
-      margin-bottom: 12px;
+      margin-bottom: 8px;
       font-weight: lighter;
       color: @grey;
+      word-wrap: break-word;
     }
     span {
       a {
         text-decoration: none;
+        
       }
-      
     }
 
   }
@@ -353,12 +357,13 @@ div.editionTools {
   .edition-omniline {
     flex-direction: row;
     justify-content: space-between;
-    overflow-x: auto;
+    //overflow-x: auto;
 
     &-item {
       flex-direction: column;
       justify-content: flex-start;
       align-items: center;
+
     }
   }
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -305,21 +305,25 @@ div.editionTools {
 
 .edition-omniline {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   padding: 10px;
   //border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
+  overflow-x: auto;
   //background: @grey-fafafa;
 
   &-item {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     flex: 1;
     padding: 2% 0;
     margin: 0 0.5%;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
     font-size: .8em;
+    min-width: 150px;
 
     div {
       //font-weight: bold;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -315,7 +315,7 @@ div.editionTools {
   &-item {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: top;
     align-items: center;
     flex: 1;
     padding: 1% 1%;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -315,6 +315,7 @@ div.editionTools {
     display: flex;
     justify-content: space-between;
     flex: 1;
+    padding: 2% 0;
     margin: 0 0.5%;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
@@ -322,9 +323,17 @@ div.editionTools {
 
     div {
       //font-weight: bold;
+      margin-bottom: 12px;
       font-weight: lighter;
       color: @grey;
     }
+    span {
+      a {
+        text-decoration: none;
+      }
+      
+    }
+
   }
 
   h4 {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -337,7 +337,7 @@ div.editionTools {
     span {
       a {
         text-decoration: none;
-        
+
       }
     }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7008

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restyles the omni bar items to boxe layout.

### Technical
<!-- What should be noted about the implementation? -->
- Changed CSS only in Work.less file

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
A visual test

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/83380248/208195121-dc202d1b-9eea-42fc-a82b-f3c318238dc9.png)
![image](https://user-images.githubusercontent.com/83380248/208195228-981fb3d8-0378-490a-8b23-70e73e711f06.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
