### PR TITLE
DRAFT: pre-commit: pyupgrade --py311-plus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
+  - repo: https://github.com/MarcoGorelli/auto-walrus
+    rev: v0.2.2
+    hooks:
+      - id: auto-walrus
+
   - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
@@ -51,9 +56,8 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args:  # Solr on Cython is not yet ready for 3.10 type hints
-          - --py39-plus
-          - --keep-runtime-typing
+        args:
+          - --py311-plus
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.10.1

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -25,7 +25,7 @@ class EbookAccess(OrderedEnum):
 class IALiteMetadata(TypedDict):
     boxid: set[str]
     collection: set[str]
-    access_restricted_item: Optional[Literal['true', 'false']]
+    access_restricted_item: Literal['true', 'false'] | None
 
 
 TProviderMetadata = TypeVar('TProviderMetadata')
@@ -57,7 +57,7 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
     def solr_key(self):
         return f"id_{self.identifier_key}"
 
-    def get_identifiers(self, ed_or_solr: Union[Edition, dict]) -> list[str]:
+    def get_identifiers(self, ed_or_solr: Edition | dict) -> list[str]:
         return (
             # If it's an edition
             ed_or_solr.get('identifiers', {}).get(self.identifier_key, [])
@@ -69,19 +69,19 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
     def choose_best_identifier(self, identifiers: list[str]) -> str:
         return identifiers[0]
 
-    def get_best_identifier(self, ed_or_solr: Union[Edition, dict]) -> str:
+    def get_best_identifier(self, ed_or_solr: Edition | dict) -> str:
         identifiers = self.get_identifiers(ed_or_solr)
         assert identifiers
         return self.choose_best_identifier(identifiers)
 
-    def get_best_identifier_slug(self, ed_or_solr: Union[Edition, dict]) -> str:
+    def get_best_identifier_slug(self, ed_or_solr: Edition | dict) -> str:
         """Used in eg /work/OL1W?edition=ia:foobar URLs, for example"""
         return f'{self.short_name}:{self.get_best_identifier(ed_or_solr)}'
 
     def get_template_path(self, typ: Literal['read_button', 'download_options']) -> str:
         return f"book_providers/{self.short_name}_{typ}.html"
 
-    def render_read_button(self, ed_or_solr: Union[Edition, dict]):
+    def render_read_button(self, ed_or_solr: Edition | dict):
         return render_template(
             self.get_template_path('read_button'), self.get_best_identifier(ed_or_solr)
         )
@@ -121,7 +121,7 @@ class InternetArchiveProvider(AbstractBookProvider[IALiteMetadata]):
     def solr_key(self):
         return "ia"
 
-    def get_identifiers(self, ed_or_solr: Union[Edition, dict]) -> list[str]:
+    def get_identifiers(self, ed_or_solr: Edition | dict) -> list[str]:
         # Solr work record augmented with availability
         # Sometimes it's set explicitly to None, for some reason
         availability = ed_or_solr.get('availability', {}) or {}
@@ -229,7 +229,7 @@ PROVIDER_ORDER: list[AbstractBookProvider] = [
 ]
 
 
-def get_cover_url(ed_or_solr: Union[Edition, dict]) -> Optional[str]:
+def get_cover_url(ed_or_solr: Edition | dict) -> str | None:
     """
     Get the cover url most appropriate for this edition or solr work search result
     """
@@ -283,7 +283,7 @@ def is_non_ia_ocaid(ocaid: str) -> bool:
     return any(provider.is_own_ocaid(ocaid) for provider in providers)
 
 
-def get_book_provider_by_name(short_name: str) -> Optional[AbstractBookProvider]:
+def get_book_provider_by_name(short_name: str) -> AbstractBookProvider | None:
     return next((p for p in PROVIDER_ORDER if p.short_name == short_name), None)
 
 
@@ -317,9 +317,7 @@ def get_provider_order(prefer_ia=False) -> list[AbstractBookProvider]:
     return provider_order
 
 
-def get_book_providers(
-    ed_or_solr: Union[Edition, dict]
-) -> Iterator[AbstractBookProvider]:
+def get_book_providers(ed_or_solr: Edition | dict) -> Iterator[AbstractBookProvider]:
 
     # On search results which don't have an edition selected, we want to display
     # IA copies first.
@@ -347,19 +345,17 @@ def get_book_providers(
             yield provider
 
 
-def get_book_provider(
-    ed_or_solr: Union[Edition, dict]
-) -> Optional[AbstractBookProvider]:
+def get_book_provider(ed_or_solr: Edition | dict) -> AbstractBookProvider | None:
     return next(get_book_providers(ed_or_solr), None)
 
 
 def get_best_edition(
     editions: list[Edition],
-) -> tuple[Optional[Edition], Optional[AbstractBookProvider]]:
+) -> tuple[Edition | None, AbstractBookProvider | None]:
     provider_order = get_provider_order(True)
 
     # Map provider name to position/ranking
-    provider_rank_lookup: dict[Optional[AbstractBookProvider], int] = {
+    provider_rank_lookup: dict[AbstractBookProvider | None, int] = {
         provider: i for i, provider in enumerate(provider_order)
     }
 

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -5,7 +5,8 @@ import string
 import time
 import threading
 import functools
-from typing import Callable, Literal
+from typing import Literal
+from collections.abc import Callable
 
 import memcache
 import json

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -190,9 +190,7 @@ class CommunityEditsQueue:
         )
 
     @classmethod
-    def assign_request(
-        cls, rid: int, reviewer: Optional[str]
-    ) -> dict[str, Optional[str]]:
+    def assign_request(cls, rid: int, reviewer: str | None) -> dict[str, str | None]:
         """Changes assignees to the request with the given ID.
 
         This method only modifies requests that are not closed.

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -334,7 +334,7 @@ class Seed:
         * cover
     """
 
-    def __init__(self, list, value: Union[web.storage, str]):
+    def __init__(self, list, value: web.storage | str):
         self._list = list
         self._type = None
 

--- a/openlibrary/core/ratings.py
+++ b/openlibrary/core/ratings.py
@@ -38,7 +38,7 @@ class Ratings(db.CommonExtras):
         }
 
     @classmethod
-    def total_num_books_rated(cls, since=None, distinct=False) -> Optional[int]:
+    def total_num_books_rated(cls, since=None, distinct=False) -> int | None:
         oldb = db.get_db()
         query = "SELECT count(%s work_id) from ratings" % (
             'DISTINCT' if distinct else ''
@@ -84,7 +84,7 @@ class Ratings(db.CommonExtras):
         return result[0] if result else {}
 
     @classmethod
-    def get_work_ratings_summary(cls, work_id: int) -> Optional[WorkRatingsSummary]:
+    def get_work_ratings_summary(cls, work_id: int) -> WorkRatingsSummary | None:
         oldb = db.get_db()
         # NOTE: Using some old postgres syntax here :/ for modern postgres syntax,
         # see the query in solr_builder.py

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -60,7 +60,7 @@ def make_path_prefix(olid, date=None):
     )
 
 
-def write_image(data: bytes, prefix: str) -> Optional[Image.Image]:
+def write_image(data: bytes, prefix: str) -> Image.Image | None:
     path_prefix = find_image_path(prefix)
     dirname = os.path.dirname(path_prefix)
     if not os.path.exists(dirname):

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -12,7 +12,7 @@ from openlibrary.core import ia
 from infogami.utils.delegate import register_exception
 
 
-def split_key(bib_key: str) -> tuple[Optional[str], Optional[str]]:
+def split_key(bib_key: str) -> tuple[str | None, str | None]:
     """
     >>> split_key('1234567890')
     ('isbn_', '1234567890')

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -4,7 +4,7 @@ import infogami
 from infogami.utils import delegate
 from openlibrary.utils.sentry import Sentry, SentryProcessor
 
-sentry: Optional[Sentry] = None
+sentry: Sentry | None = None
 
 
 def setup():

--- a/openlibrary/plugins/openlibrary/stats.py
+++ b/openlibrary/plugins/openlibrary/stats.py
@@ -167,8 +167,8 @@ def _get_top_level_path_for_metric(full_path: str) -> str:
 
 class GraphiteRequestStats:
     def __init__(self):
-        self.start: Optional[float] = None
-        self.end: Optional[float] = None
+        self.start: float | None = None
+        self.end: float | None = None
         self.state = None  # oneof 'started', 'completed'
         self.method = 'unknown'
         self.path_page_name = 'unknown'

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import json
 import logging
 import re
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from collections.abc import Iterable, Mapping
 
 import web

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -14,7 +14,7 @@ from openlibrary.core.bookshelves_events import BookshelfEvent, BookshelvesEvent
 from openlibrary.utils.decorators import authorized_for
 
 
-def make_date_string(year: int, month: Optional[int], day: Optional[int]) -> str:
+def make_date_string(year: int, month: int | None, day: int | None) -> str:
     """Creates a date string in the expected format, given the year, month, and day.
 
     Event dates can take one of three forms:
@@ -30,7 +30,7 @@ def make_date_string(year: int, month: Optional[int], day: Optional[int]) -> str
     return result
 
 
-def is_valid_date(year: int, month: Optional[int], day: Optional[int]) -> bool:
+def is_valid_date(year: int, month: int | None, day: int | None) -> bool:
     """Validates dates.
 
     Dates are considered valid if there is:

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -105,8 +105,8 @@ def process_facet_counts(
 
 
 def execute_solr_query(
-    solr_path: str, params: Union[dict, list[tuple[str, Any]]]
-) -> Optional[Response]:
+    solr_path: str, params: dict | list[tuple[str, Any]]
+) -> Response | None:
     url = solr_path
     if params:
         url += '&' if '?' in url else '?'
@@ -130,16 +130,16 @@ public(has_solr_editions_enabled)
 
 def run_solr_query(
     scheme: SearchScheme,
-    param: Optional[dict] = None,
+    param: dict | None = None,
     rows=100,
     page=1,
     sort: str | None = None,
     spellcheck_count=None,
     offset=None,
-    fields: Union[str, list[str]] | None = None,
-    facet: Union[bool, Iterable[str]] = True,
+    fields: str | list[str] | None = None,
+    facet: bool | Iterable[str] = True,
     allowed_filter_params: set[str] = None,
-    extra_params: Optional[list[tuple[str, Any]]] = None,
+    extra_params: list[tuple[str, Any]] | None = None,
 ):
     """
     :param param: dict of query parameters
@@ -243,7 +243,7 @@ class SearchResponse:
 
     @staticmethod
     def from_solr_result(
-        solr_result: Optional[dict],
+        solr_result: dict | None,
         sort: str,
         solr_select: str,
     ) -> 'SearchResponse':
@@ -277,7 +277,7 @@ class SearchResponse:
 
 def do_search(
     param: dict,
-    sort: Optional[str],
+    sort: str | None,
     page=1,
     rows=100,
     spellcheck_count=None,

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Callable, Optional, Union
+from typing import Optional, Union
+from collections.abc import Callable
 
 import luqum.tree
 from luqum.exceptions import ParseError
@@ -22,11 +23,11 @@ class SearchScheme:
     # Mapping of user-only fields to solr fields
     field_name_map: dict[str, str]
     # Mapping of user sort to solr sort
-    sorts: dict[str, Union[str, Callable[[], str]]]
+    sorts: dict[str, str | Callable[[], str]]
     # Default
     default_fetched_fields: set[str]
     # Fields that should be rewritten
-    facet_rewrites: dict[tuple[str, str], Union[str, Callable[[], str]]]
+    facet_rewrites: dict[tuple[str, str], str | Callable[[], str]]
 
     def is_search_field(self, field: str):
         return field in self.all_fields or field in self.field_name_map
@@ -100,7 +101,7 @@ class SearchScheme:
     ) -> luqum.tree.Item:
         return q_tree
 
-    def build_q_from_params(self, params: dict) -> Optional[str]:
+    def build_q_from_params(self, params: dict) -> str | None:
         return None
 
     def q_to_solr_params(

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
-from typing import Callable, Union
+from typing import Union
+from collections.abc import Callable
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 
@@ -39,7 +40,7 @@ class AuthorSearchScheme(SearchScheme):
         'top_subjects',
         'work_count',
     }
-    facet_rewrites: dict[tuple[str, str], Union[str, Callable[[], str]]] = {}
+    facet_rewrites: dict[tuple[str, str], str | Callable[[], str]] = {}
 
     def q_to_solr_params(
         self,

--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
-from typing import Callable, Union
+from typing import Union
+from collections.abc import Callable
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 
@@ -32,7 +33,7 @@ class SubjectSearchScheme(SearchScheme):
         'subject_type',
         'work_count',
     }
-    facet_rewrites: dict[tuple[str, str], Union[str, Callable[[], str]]] = {}
+    facet_rewrites: dict[tuple[str, str], str | Callable[[], str]] = {}
 
     def q_to_solr_params(
         self,

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import logging
 import re
 import sys
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 import luqum.tree
 import web
@@ -310,7 +311,7 @@ class WorkSearchScheme(SearchScheme):
 
             def convert_work_field_to_edition_field(
                 field: str,
-            ) -> Optional[str | Callable[[str], str]]:
+            ) -> str | Callable[[str], str] | None:
                 """
                 Convert a SearchField name (eg 'title') to the correct fieldname
                 for use in an edition query.

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -119,7 +119,7 @@ class DataProvider:
     """
 
     def __init__(self) -> None:
-        self.ia_cache: dict[str, Optional[dict]] = dict()
+        self.ia_cache: dict[str, dict | None] = dict()
 
     @staticmethod
     async def _get_lite_metadata(ocaids: list[str], _recur_depth=0, _max_recur_depth=3):

--- a/openlibrary/solr/process_stats.py
+++ b/openlibrary/solr/process_stats.py
@@ -47,8 +47,7 @@ def get_metadata(ia_id):
 def _get_metadata(ia_id):
     if not ia_id:
         return {}
-    db = get_ia_db()
-    if db:
+    if db := get_ia_db():
         result = db.query(
             "SELECT collection, sponsor, contributor FROM metadata WHERE identifier=$ia_id",
             vars=locals(),

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -1,4 +1,5 @@
-from typing import Callable, Literal, Optional
+from typing import Literal, Optional
+from collections.abc import Callable
 from luqum.parser import parser
 from luqum.tree import Item, SearchField, BaseOperation, Group, Word, Unary
 import re
@@ -165,7 +166,7 @@ def luqum_parser(query: str) -> Item:
     """
     tree = parser.parse(query)
 
-    def find_next_word(item: Item) -> Optional[tuple[Word, Optional[BaseOperation]]]:
+    def find_next_word(item: Item) -> tuple[Word, BaseOperation | None] | None:
         if isinstance(item, Word):
             return item, None
         elif isinstance(item, BaseOperation) and isinstance(item.children[0], Word):

--- a/openlibrary/solr/solr_types.py
+++ b/openlibrary/solr/solr_types.py
@@ -6,70 +6,70 @@ from typing import Literal, TypedDict, Optional
 class SolrDocument(TypedDict):
     key: str
     type: Literal['work', 'author', 'subject']
-    redirects: Optional[list[str]]
-    has_fulltext: Optional[bool]
-    title: Optional[str]
-    title_suggest: Optional[str]
-    title_sort: Optional[str]
-    subtitle: Optional[str]
-    alternative_title: Optional[list[str]]
-    alternative_subtitle: Optional[list[str]]
-    edition_count: Optional[int]
-    edition_key: Optional[list[str]]
-    cover_edition_key: Optional[str]
-    by_statement: Optional[list[str]]
-    publish_date: Optional[list[str]]
-    publish_year: Optional[list[int]]
-    first_publish_year: Optional[int]
-    first_edition: Optional[str]
-    first_publisher: Optional[str]
-    language: Optional[list[str]]
-    number_of_pages_median: Optional[int]
-    lccn: Optional[list[str]]
-    ia: Optional[list[str]]
-    ia_box_id: Optional[list[str]]
-    ia_loaded_id: Optional[list[str]]
-    ia_count: Optional[int]
-    ia_collection: Optional[list[str]]
-    oclc: Optional[list[str]]
-    isbn: Optional[list[str]]
-    ebook_access: Optional[Literal['no_ebook', 'unclassified', 'printdisabled', 'borrowable', 'public']]
-    lcc: Optional[list[str]]
-    lcc_sort: Optional[str]
-    ddc: Optional[list[str]]
-    ddc_sort: Optional[str]
-    contributor: Optional[list[str]]
-    publish_place: Optional[list[str]]
-    publisher: Optional[list[str]]
-    publisher_facet: Optional[list[str]]
-    first_sentence: Optional[list[str]]
-    author_key: Optional[list[str]]
-    author_name: Optional[list[str]]
-    author_alternative_name: Optional[list[str]]
-    author_facet: Optional[list[str]]
-    subject: Optional[list[str]]
-    subject_facet: Optional[list[str]]
-    subject_key: Optional[list[str]]
-    place: Optional[list[str]]
-    place_facet: Optional[list[str]]
-    place_key: Optional[list[str]]
-    person: Optional[list[str]]
-    person_facet: Optional[list[str]]
-    person_key: Optional[list[str]]
-    time: Optional[list[str]]
-    time_facet: Optional[list[str]]
-    time_key: Optional[list[str]]
-    text: Optional[list[str]]
-    seed: Optional[list[str]]
-    name: Optional[str]
-    name_str: Optional[str]
-    alternate_names: Optional[list[str]]
-    birth_date: Optional[str]
-    death_date: Optional[str]
-    date: Optional[str]
-    work_count: Optional[int]
-    top_work: Optional[str]
-    top_subjects: Optional[list[str]]
-    subject_type: Optional[str]
+    redirects: list[str] | None
+    has_fulltext: bool | None
+    title: str | None
+    title_suggest: str | None
+    title_sort: str | None
+    subtitle: str | None
+    alternative_title: list[str] | None
+    alternative_subtitle: list[str] | None
+    edition_count: int | None
+    edition_key: list[str] | None
+    cover_edition_key: str | None
+    by_statement: list[str] | None
+    publish_date: list[str] | None
+    publish_year: list[int] | None
+    first_publish_year: int | None
+    first_edition: str | None
+    first_publisher: str | None
+    language: list[str] | None
+    number_of_pages_median: int | None
+    lccn: list[str] | None
+    ia: list[str] | None
+    ia_box_id: list[str] | None
+    ia_loaded_id: list[str] | None
+    ia_count: int | None
+    ia_collection: list[str] | None
+    oclc: list[str] | None
+    isbn: list[str] | None
+    ebook_access: Literal['no_ebook', 'unclassified', 'printdisabled', 'borrowable', 'public'] | None
+    lcc: list[str] | None
+    lcc_sort: str | None
+    ddc: list[str] | None
+    ddc_sort: str | None
+    contributor: list[str] | None
+    publish_place: list[str] | None
+    publisher: list[str] | None
+    publisher_facet: list[str] | None
+    first_sentence: list[str] | None
+    author_key: list[str] | None
+    author_name: list[str] | None
+    author_alternative_name: list[str] | None
+    author_facet: list[str] | None
+    subject: list[str] | None
+    subject_facet: list[str] | None
+    subject_key: list[str] | None
+    place: list[str] | None
+    place_facet: list[str] | None
+    place_key: list[str] | None
+    person: list[str] | None
+    person_facet: list[str] | None
+    person_key: list[str] | None
+    time: list[str] | None
+    time_facet: list[str] | None
+    time_key: list[str] | None
+    text: list[str] | None
+    seed: list[str] | None
+    name: str | None
+    name_str: str | None
+    alternate_names: list[str] | None
+    birth_date: str | None
+    death_date: str | None
+    date: str | None
+    work_count: int | None
+    top_work: str | None
+    top_subjects: list[str] | None
+    subject_type: str | None
 
 # fmt: on

--- a/openlibrary/solr/update_edition.py
+++ b/openlibrary/solr/update_edition.py
@@ -37,11 +37,11 @@ class EditionSolrBuilder:
         return self.edition['key']
 
     @property
-    def title(self) -> Optional[str]:
+    def title(self) -> str | None:
         return self.get('title')
 
     @property
-    def subtitle(self) -> Optional[str]:
+    def subtitle(self) -> str | None:
         return self.get('subtitle')
 
     @property
@@ -60,7 +60,7 @@ class EditionSolrBuilder:
         return result
 
     @property
-    def cover_i(self) -> Optional[int]:
+    def cover_i(self) -> int | None:
         return next(
             (cover_id for cover_id in self.get('covers', []) if cover_id != -1), None
         )
@@ -83,7 +83,7 @@ class EditionSolrBuilder:
         )
 
     @property
-    def number_of_pages(self) -> Optional[int]:
+    def number_of_pages(self) -> int | None:
         if self.get('number_of_pages') and type(self.get('number_of_pages')) == int:
             return cast(int, self.get('number_of_pages'))
         else:
@@ -106,11 +106,11 @@ class EditionSolrBuilder:
         return uniq(isbn for isbn in isbns if isbn)
 
     @property
-    def publish_date(self) -> Optional[str]:
+    def publish_date(self) -> str | None:
         return self.get('publish_date')
 
     @property
-    def publish_year(self) -> Optional[int]:
+    def publish_year(self) -> int | None:
         if self.publish_date:
             m = re_year.search(self.publish_date)
             return int(m.group(1)) if m else None
@@ -118,7 +118,7 @@ class EditionSolrBuilder:
             return None
 
     @property
-    def ia(self) -> Optional[str]:
+    def ia(self) -> str | None:
         ocaid = self.get('ocaid')
         return ocaid.strip() if ocaid else None
 

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -52,7 +52,7 @@ re_year = re.compile(r'\b(\d{4})\b')
 data_provider = cast(DataProvider, None)
 
 solr_base_url = None
-solr_next: Optional[bool] = None
+solr_next: bool | None = None
 
 
 def get_solr_base_url():
@@ -191,7 +191,7 @@ def pick_cover_edition(editions, work_cover_id):
     )
 
 
-def pick_number_of_pages_median(editions: list[dict]) -> Optional[int]:
+def pick_number_of_pages_median(editions: list[dict]) -> int | None:
     number_of_pages = [
         cast(int, e.get('number_of_pages'))
         for e in editions
@@ -459,8 +459,7 @@ class SolrProcessor:
         :return: Year edition was published
         :rtype: str or None
         """
-        pub_date = e.get('publish_date', None)
-        if pub_date:
+        if pub_date := e.get('publish_date', None):
             m = re_year.search(pub_date)
             if m:
                 return m.group(1)
@@ -555,8 +554,7 @@ class SolrProcessor:
             add_list('publish_year', pub_years)
             add('first_publish_year', min(int(y) for y in pub_years))
 
-        number_of_pages_median = pick_number_of_pages_median(editions)
-        if number_of_pages_median:
+        if number_of_pages_median := pick_number_of_pages_median(editions):
             add('number_of_pages_median', number_of_pages_median)
 
         add_list(
@@ -1244,7 +1242,7 @@ async def update_work(work: dict) -> list[SolrUpdateRequest]:
 
 async def update_author(
     akey, a=None, handle_redirects=True
-) -> Optional[list[SolrUpdateRequest]]:
+) -> list[SolrUpdateRequest] | None:
     """
     Get the Solr requests necessary to insert/update/delete an Author in Solr.
     :param akey: The author key, e.g. /authors/OL23A
@@ -1372,8 +1370,7 @@ def solr_select_work(edition_key):
             'fl': 'key',
         },
     ).json()
-    docs = reply['response'].get('docs', [])
-    if docs:
+    if docs := reply['response'].get('docs', []):
         return docs[0]['key']  # /works/ prefix is in solr
 
 
@@ -1553,7 +1550,7 @@ def load_configs(
     c_host: str,
     c_config: str,
     c_data_provider: (
-        Union[DataProvider, Literal['default', 'legacy', 'external']]
+        DataProvider | Literal['default', 'legacy', 'external']
     ) = 'default',
 ) -> DataProvider:
     host = web.lstrips(c_host, "http://").strip("/")

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -92,7 +92,7 @@ def take_best(
 
 def multisort_best(
     items: list[T], specs: list[tuple[Literal["min", "max"], Callable[[T], float]]]
-) -> Optional[T]:
+) -> T | None:
     """
     Takes the best item, taking into account the multisorts
 

--- a/openlibrary/utils/retry.py
+++ b/openlibrary/utils/retry.py
@@ -11,7 +11,7 @@ class MaxRetriesExceeded(Exception):
 
 class RetryStrategy:
     retry_count = 0
-    last_exception: Optional[Exception] = None
+    last_exception: Exception | None = None
 
     def __init__(self, exceptions: list[type[Exception]], max_retries=3, delay=1):
         self.exceptions = exceptions

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -39,7 +39,7 @@ class Solr:
         key: str,
         fields: list[str] | None = None,
         doc_wrapper: Callable[[dict], T] = web.storage,
-    ) -> Optional[T]:
+    ) -> T | None:
         """Get a specific item from solr"""
         logger.info(f"solr /get: {key}, {fields}")
         resp = self.session.get(

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -364,10 +364,10 @@ def main(
 
     # Mypy doesn't handle union-ing types across if statements -_-
     # https://github.com/python/mypy/issues/6233
-    src_ol: Union[Disk, OpenLibrary] = (
+    src_ol: Disk | OpenLibrary = (
         OpenLibrary(src) if src.startswith("http://") else Disk(src)
     )
-    dest_ol: Union[Disk, OpenLibrary] = (
+    dest_ol: Disk | OpenLibrary = (
         OpenLibrary(dest) if dest.startswith("http://") else Disk(dest)
     )
 

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -68,7 +68,7 @@ def create_batch(records: list[dict[str, str]]) -> None:
     batch.add_items([{'ia_id': r['source_records'][0], 'data': r} for r in records])
 
 
-def get_last_updated_time() -> Optional[str]:
+def get_last_updated_time() -> str | None:
     """Gets date of last import job.
 
     Last updated dates are read from a local file.  If no
@@ -85,7 +85,7 @@ def get_last_updated_time() -> Optional[str]:
     return None
 
 
-def find_last_updated() -> Optional[str]:
+def find_last_updated() -> str | None:
     """Fetches and returns Standard Ebooks most recent update date.
 
     Returns None if the last modified date is not included in the
@@ -95,7 +95,7 @@ def find_last_updated() -> Optional[str]:
     return r.headers['last-modified'] if r.ok else None
 
 
-def convert_date_string(date_string: Optional[str]) -> time.struct_time:
+def convert_date_string(date_string: str | None) -> time.struct_time:
     """Converts HTTP-date format string into a struct_time object.
 
     The date_string will be formatted similarly to this:

--- a/scripts/solr_builder/solr_builder/fn_to_cli.py
+++ b/scripts/solr_builder/solr_builder/fn_to_cli.py
@@ -49,7 +49,7 @@ class FnToCLI:
             description=docs.split(':param', 1)[0],
             formatter_class=ArgumentDefaultsHelpFormatter,
         )
-        self.args: typing.Optional[Namespace] = None
+        self.args: Namespace | None = None
         for arg in arg_names:
             optional = arg in defaults
             cli_name = arg.replace('_', '-')

--- a/scripts/solr_updater.py
+++ b/scripts/solr_updater.py
@@ -108,7 +108,7 @@ class InfobaseLog:
             self.offset = d['offset']
 
 
-def find_keys(d: Union[dict, list]) -> Iterator[str]:
+def find_keys(d: dict | list) -> Iterator[str]:
     """
     Find any keys in the given dict or list.
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to  #5922

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

1. pre-commit: Use modern type hints and syntax via the command `pyupgrade --py311-plus`.
2. pre-commit: Add the `auto-walrus` tool which was featured in #7213 

@cdrini Are Solr on Cython and [fn_to_cli.py](https://github.com/internetarchive/openlibrary/blob/master/scripts/solr_builder/solr_builder/fn_to_cli.py) now ready for the more concise 3.11 type hints?

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
