### PR TITLE
pre-commit: Add auto-walrus to enforce Python assignment expressions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
+  - repo: https://github.com/MarcoGorelli/auto-walrus
+    rev: v0.2.2
+    hooks:
+      - id: auto-walrus
+
   - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:

--- a/openlibrary/solr/process_stats.py
+++ b/openlibrary/solr/process_stats.py
@@ -47,8 +47,7 @@ def get_metadata(ia_id):
 def _get_metadata(ia_id):
     if not ia_id:
         return {}
-    db = get_ia_db()
-    if db:
+    if db := get_ia_db():
         result = db.query(
             "SELECT collection, sponsor, contributor FROM metadata WHERE identifier=$ia_id",
             vars=locals(),

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -459,8 +459,7 @@ class SolrProcessor:
         :return: Year edition was published
         :rtype: str or None
         """
-        pub_date = e.get('publish_date', None)
-        if pub_date:
+        if pub_date := e.get('publish_date', None):
             m = re_year.search(pub_date)
             if m:
                 return m.group(1)
@@ -555,8 +554,7 @@ class SolrProcessor:
             add_list('publish_year', pub_years)
             add('first_publish_year', min(int(y) for y in pub_years))
 
-        number_of_pages_median = pick_number_of_pages_median(editions)
-        if number_of_pages_median:
+        if number_of_pages_median := pick_number_of_pages_median(editions):
             add('number_of_pages_median', number_of_pages_median)
 
         add_list(
@@ -1372,8 +1370,7 @@ def solr_select_work(edition_key):
             'fl': 'key',
         },
     ).json()
-    docs = reply['response'].get('docs', [])
-    if docs:
+    if docs := reply['response'].get('docs', []):
         return docs[0]['key']  # /works/ prefix is in solr
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
pre-commit: Add the [auto-walrus](https://pypi.org/project/auto-walrus) tool which was used to create #7213 

Can these two solr-related files be modified in this way or will Cython object?  See #7213

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
