### PR TITLE
Adds pre-check logic to affiliate-server amz imports

### DIFF
--- a/scripts/affiliate-server
+++ b/scripts/affiliate-server
@@ -55,6 +55,14 @@ urls = (
 
 API_MAX_ITEMS_PER_CALL = 10
 API_MAX_WAIT_SECONDS = 0.9
+AZ_OL_MAP = {
+    'cover': 'covers',
+    'title': 'title',
+    'authors': 'authors',
+    'publishers': 'publishers',
+    'publish_date': 'publish_date',
+    'number_of_pages': 'pagination',
+}
 
 batch_name = ""
 batch: Batch = None
@@ -103,12 +111,38 @@ def process_amazon_batch(isbn_10s: list[str]) -> None:
         logger.debug("DB parameters missing from affiliate-server infobase")
         return
 
-    # XXX temporarily disable until covers + substantive changes added
-    #if books := [clean_amazon_metadata_for_load(product) for product in products]:
-    #    get_current_amazon_batch().add_items(
-    #        [{'ia_id': b['source_records'][0], 'data': b} for b in books]
-    #    )
-
+    if books := [clean_amazon_metadata_for_load(product) for product in products]:
+        pending_books = []
+            isbns = [isbn for isbns in [ 
+                b.get('isbn_10', []) + b.get('isbn_13', [])
+                for b in books
+            ] for isbn in isbns]
+        unique_edition_ids = set(web.ctx.site.things({
+            'type': '/type/edition',
+            'isbn_': [str(x) for x in isbns]
+        }))
+        editions = web.ctx.site.get_many(list(unique_edition_ids))
+        # For each amz book, check that we need its data 
+        for book in books:
+            if ed := next(
+                ed for ed in editions if
+                set(book.get('isbn_13')).intersection(set(ed.isbn_13)) or
+                set(book.get('isbn_10')).intersection(set(ed.isbn_10))
+            ):
+                book_needed = False
+                # if ed missing important book data, queue it
+                for (k, v) in AZ_OL_MAP.items():
+                    if book.get(k) and not ed.get(v):
+                        print(f"{ed} needs {k}: {book.get(k)}")
+                        book_needed = True
+                if book_needed:
+                    pending_books.append(book)
+            else: # if no such edition in OL, queue it for import
+                pending_books.append(book)
+        if pending_books:
+            get_current_amazon_batch().add_items(
+                [{'ia_id': b['source_records'][0], 'data': b} for b in pending_books]
+            )
 
 def seconds_remaining(start_time: int) -> int:
     return max(API_MAX_WAIT_SECONDS - (time.time() - start_time), 0)

--- a/scripts/affiliate-server
+++ b/scripts/affiliate-server
@@ -61,7 +61,7 @@ AZ_OL_MAP = {
     'authors': 'authors',
     'publishers': 'publishers',
     'publish_date': 'publish_date',
-    'number_of_pages': 'pagination',
+    'number_of_pages': 'number_of_pages',
 }
 
 batch_name = ""

--- a/scripts/affiliate-server
+++ b/scripts/affiliate-server
@@ -113,7 +113,7 @@ def process_amazon_batch(isbn_10s: list[str]) -> None:
 
     if books := [clean_amazon_metadata_for_load(product) for product in products]:
         pending_books = []
-            isbns = [isbn for isbns in [ 
+            isbns = [isbn for isbns in [
                 b.get('isbn_10', []) + b.get('isbn_13', [])
                 for b in books
             ] for isbn in isbns]
@@ -122,7 +122,7 @@ def process_amazon_batch(isbn_10s: list[str]) -> None:
             'isbn_': [str(x) for x in isbns]
         }))
         editions = web.ctx.site.get_many(list(unique_edition_ids))
-        # For each amz book, check that we need its data 
+        # For each amz book, check that we need its data
         for book in books:
             if ed := next(
                 ed for ed in editions if


### PR DESCRIPTION
Only attempt to queue amz records with new data or for editions we don't yet have OL records for import

<!-- What issue does this PR close? -->
Closes #7245  which is required for #7184 
Depends on #7316 which closes #7244 


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

This code likely needs to be cleaned up, moved to a function, and possible done in different thread if there are concerns about blocking time.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

See https://github.com/internetarchive/openlibrary/issues/7184#issuecomment-1362439106 which has very thorough test instructions.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
