### PR TITLE
Clearing reading goals

### DIFF
--- a/openlibrary/core/yearly_reading_goals.py
+++ b/openlibrary/core/yearly_reading_goals.py
@@ -100,3 +100,15 @@ class YearlyReadingGoals:
         data = {'username': username}
 
         return oldb.delete(cls.TABLENAME, where=where, vars=data)
+
+    @classmethod
+    def delete_by_username_and_year(cls, username, year):
+        oldb = db.get_db()
+
+        data = {
+            'username': username,
+            'year': year,
+        }
+        where = 'username=$username AND year=$year'
+
+        return oldb.delete(cls.TABLENAME, where=where, vars=data)

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -496,12 +496,22 @@ function addGoalSubmissionListener(submitButton) {
                     modal.close()
                 }
 
-                if (formData.get('is_update')) {
-                    const progressComponent = modal.closest('.reading-goal-progress')
-                    updateProgressComponent(progressComponent, Number(formData.get('goal')))
+                const yearlyGoalSection = modal.closest('.yearly-goal-section')
+                if (formData.get('is_update')) {  // Progress component exists on page
+                    const goalInput = form.querySelector('input[name=goal]')
+                    const isDeleted = Number(goalInput.value) === 0
+
+                    if (isDeleted) {
+                        const chipGroup = yearlyGoalSection.querySelector('.chip-group')
+                        const goalContainer = yearlyGoalSection.querySelector('#reading-goal-container')
+                        goalContainer.remove()
+                        chipGroup.classList.remove('hidden')
+                    } else {
+                        const progressComponent = modal.closest('.reading-goal-progress')
+                        updateProgressComponent(progressComponent, Number(formData.get('goal')))
+                    }
                 } else {
-                    const chipGroup = modal.closest('.chip-group')
-                    updateChipGroup(chipGroup)
+                    fetchProgressAndUpdateView(yearlyGoalSection)
                 }
             })
     })
@@ -530,12 +540,14 @@ function updateProgressComponent(elem, goal) {
 }
 
 /**
- * Replaces "Set reading goal" chip on My Books page with reading goal
- * progress component.
+ * Fetches and displays progress component.
  *
- * @param {HTMLElement} chipGroup Parent container of "set goal" CTA link
+ * Adds listeners to the progress component, and hides
+ * link for setting reading goal.
+ *
+ * @param {HTMLElement} yearlyGoalElem Container for progress component and reading goal link.
  */
-function updateChipGroup(chipGroup) {
+function fetchProgressAndUpdateView(yearlyGoalElem) {
     fetch('/reading-goal/partials')
         .then((response) => {
             if (!response.ok) {
@@ -545,9 +557,12 @@ function updateChipGroup(chipGroup) {
         })
         .then(function(html) {
             const progress = document.createElement('SPAN')
+            progress.id = 'reading-goal-container'
             progress.innerHTML = html
-            chipGroup.parentElement.insertBefore(progress, chipGroup)
-            chipGroup.remove()
+            yearlyGoalElem.appendChild(progress)
+
+            // Hide the "Set 20XX reading goal" link:
+            yearlyGoalElem.children[0].classList.add('hidden')
 
             const progressEditLink = progress.querySelector('.edit-reading-goal-link')
             const updateModal = progress.querySelector('dialog')

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -473,6 +473,11 @@ function addGoalSubmissionListener(submitButton) {
         event.preventDefault()
 
         const form = submitButton.closest('form')
+
+        if (!form.checkValidity()) {
+            form.reportValidity()
+            throw new Error('Form invalid')
+        }
         const formData = new FormData(form)
 
         fetch(form.action, {

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -180,7 +180,10 @@ class yearly_reading_goal_json(delegate.page):
 
         goal = int(i.goal)
 
-        if not goal or goal < 0:
+        if i.is_update:
+            if goal < 0:
+                raise web.badrequest('Reading goal update must be 0 or a positive integer')
+        elif not goal or goal < 1:
             raise web.badrequest('Reading goal must be a positive integer')
 
         if i.is_update and not i.year:
@@ -192,7 +195,12 @@ class yearly_reading_goal_json(delegate.page):
         current_year = i.year or datetime.now().year
 
         if i.is_update:
-            YearlyReadingGoals.update_target(username, i.year, goal)
+            if goal == 0:
+                # Delete goal if "0" was submitted:
+                YearlyReadingGoals.delete_by_username_and_year(username, i.year)
+            else:
+                # Update goal normally:
+                YearlyReadingGoals.update_target(username, i.year, goal)
         else:
             YearlyReadingGoals.create(username, current_year, goal)
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -182,7 +182,9 @@ class yearly_reading_goal_json(delegate.page):
 
         if i.is_update:
             if goal < 0:
-                raise web.badrequest('Reading goal update must be 0 or a positive integer')
+                raise web.badrequest(
+                    'Reading goal update must be 0 or a positive integer'
+                )
         elif not goal or goal < 1:
             raise web.badrequest('Reading goal must be a positive integer')
 

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -15,8 +15,10 @@ $ username = user.key.split('/')[-1]
 
 $if user.is_beta_tester():
   $ current_goal = get_reading_goals()
-  $if not current_goal:
-    <div class="chip-group">
+  $ hidden = 'hidden' if current_goal else ''
+
+  <div class="yearly-goal-section">
+    <div class="chip-group $hidden">
       <span class="chip value-chip category-chip chip--selectable goal-chip">
         <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"
           href="javascript:;">$:_('Set <span id="reading-goal-current-year">2023</span> reading goal')</a>
@@ -24,8 +26,11 @@ $if user.is_beta_tester():
       $ reading_goal_form = render_template('check_ins/reading_goal_form')
       $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title="Yearly Reading Goal")
     </div>
-  $else:
-    $:render_template('check_ins/reading_goal_progress', [current_goal])
+    $if current_goal:
+      <span id="reading-goal-container">
+        $:render_template('check_ins/reading_goal_progress', [current_goal])
+      </span>
+  </div>
 
 $code:
     def compact_carousel(data):

--- a/openlibrary/templates/check_ins/reading_goal_form.html
+++ b/openlibrary/templates/check_ins/reading_goal_form.html
@@ -7,6 +7,9 @@ $def with (goal=None, year=None, update=False)
     <input type="hidden" name="is_update" value="true">
   <span>$_("How many books would you like to read this year?")</span>
   $ goal_value = goal if goal else ''
-  <input type="number" name="goal" min="1" step="1" value="$goal_value" required>
+  $ min_value = 0 if goal else 1
+  <input type="number" name="goal" min="$min_value" step="1" value="$goal_value" required>
   <button class="cta-btn cta-btn--shell reading-goal-submit-button" type="submit" data-ol-link-track="YearlyReadingGoals|SubmitGoal">$_("Submit")</button>
+  $if goal:
+    <div>$_('Note: Submit "0" to delete your goal.  Your check-ins will be preserved.')</div>
 </form>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7329

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Provides patrons with a way to delete their reading goals.  Submitting "0" as a goal update will delete the patron's current reading goal and update the "My Books" view.

Add instructive note to form if reading goal is set.  The note's copy and styling may need adjustment.

### Technical
<!-- What should be noted about the implementation? -->
Restores client-side validation that was disabled with the `event.preventDefault()` call on form submission.
Chip group containing the "Set reading goal" link is now hidden (rather than removed completely).
Removes progress component on goal deletion.
`mybooks.html` adjusted to make updates to make client-side updates to the view easier.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-12-28 16-19-42](https://user-images.githubusercontent.com/28732543/209888565-5052fc1e-e546-4bf5-9e5d-aa06e08a9a5f.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
