### PR TITLE
Delete check-ins when book removed from all shelves

### DIFF
--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -197,3 +197,15 @@ class BookshelvesEvents(db.CommonExtras):
         where_vars = {'username': username}
 
         return oldb.delete(cls.TABLENAME, where=where_clause, vars=where_vars)
+
+    @classmethod
+    def delete_by_username_and_work(cls, username, work_id):
+        oldb = db.get_db()
+
+        where_clause = 'username=$username AND work_id=$work_id'
+        data = {
+            'username': username,
+            'work_id': work_id,
+        }
+
+        return oldb.delete(cls.TABLENAME, where=where_clause, vars=data)

--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -1,11 +1,11 @@
-$def with (lists, work=None, edition_key=None, key=None, users_work_read_status=None, reading_log_only=False, use_work=False, page_url=None, async_load=False, remove_on_change=False)
+$def with (lists, work=None, edition_key=None, key=None, users_work_read_status=None, reading_log_only=False, use_work=False, page_url=None, async_load=False)
 
 $ user_key = ctx.user and ctx.user.key
 $ username = ctx.user and ctx.user.key.split('/')[-1]
 $ work_key = work and work.key
 
 $if ctx.user or not work_key:
-  <div class="widget-add $:(not work_key and 'old-style-lists') $:(remove_on_change and 'removable')">
+  <div class="widget-add $:(not work_key and 'old-style-lists')">
     <input type="hidden" name="user-key" value="$(user_key)" />
     <div class="dropit Tools">
       $if edition_key and not work_key:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -21,6 +21,7 @@ from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.plugins.worksearch.subjects import get_subject
 from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.core import ia, db, models, lending, helpers as h
+from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.observations import Observations, get_observation_metrics
 from openlibrary.core.models import Booknotes, Work
 from openlibrary.core.sponsorships import qualifies_for_sponsorship
@@ -324,6 +325,7 @@ class work_bookshelves(delegate.page):
             work_bookshelf = Bookshelves.remove(
                 username=username, work_id=work_id, bookshelf_id=current_status
             )
+            BookshelvesEvents.delete_by_username_and_work(username, work_id)
 
         else:
             edition_id = int(i.edition_id.split('/')[2][2:-1]) if i.edition_id else None

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -244,20 +244,18 @@ function addReadingLogButtonClickListener(button) {
         event.preventDefault();
 
         const form = button.parentElement
+        const actionInput = form.querySelector('input[name=action]')
         const dropper = button.closest('.widget-add')
         const primaryButton = dropper.querySelector('.want-to-read')
         const initialText = primaryButton.children[1].innerText
         const dropClick = dropper.querySelector('.dropclick')
-
-        primaryButton.children[1].innerText = 'saving...'
+        const workKey = dropper.querySelector('input[name=work_id').value
+        const workOlid = workKey.split('/').slice(-1).pop()
+        const modal = document.querySelector(`#check-in-dialog-${workOlid}`)
+        // If there is a check-in modal, then a `.check-in-prompt` component may exist:
+        const datePrompt = modal ? document.querySelector(`#prompt-${workOlid}`) : null
 
         const success = function() {
-            const actionInput = form.querySelector('input[name=action]')
-            const workKey = document.querySelector('input[name=work_id').value
-            const workOlid = workKey.split('/').slice(-1).pop()
-            const modal = document.querySelector(`#check-in-dialog-${workOlid}`)
-            // If there is a check-in modal, then a `.check-in-prompt` component may exist:
-            const datePrompt = modal ? document.querySelector(`#prompt-${workOlid}`) : null
             const dateDisplay = document.querySelector(`#check-in-display-${workOlid}`)
 
             if (datePrompt) {
@@ -280,8 +278,7 @@ function addReadingLogButtonClickListener(button) {
                     datePrompt.classList.add('hidden')
                 }
             }
-            if (button.classList.contains('want-to-read')) {
-                // Primary button pressed
+            if (button.classList.contains('want-to-read')) {  // Primary button pressed
                 // Toggle checkmark
                 button.children[0].classList.toggle('hidden')
 
@@ -309,9 +306,8 @@ function addReadingLogButtonClickListener(button) {
                 if ($(dropper).find('.arrow').first().hasClass('up')) {
                     toggleDropper(dropper)
                 }
-            } else {
+            } else {  // Secondary button pressed
                 toggleDropper(dropper)
-                // Secondary button pressed
 
                 // Change primary button's text to new value:
                 primaryButton.children[1].innerText = button.innerText
@@ -341,8 +337,36 @@ function addReadingLogButtonClickListener(button) {
             }
         }
 
-        updateReadingLog(form, success)
+        const checkInDisplay = document.querySelector(`#check-in-display-${workOlid}`)
+        let hasCheckIn = false
+        if (checkInDisplay) {
+            hasCheckIn = checkInDisplay.classList.contains('hidden') ? false : true
+        }
+
+        const hideCheckIn = actionInput.value === 'remove'
+
+        let canUpdateBookshelves = true
+        if (actionInput.value === 'remove' && hasCheckIn) {
+            canUpdateBookshelves = confirmDeletion()
+        }
+        if (canUpdateBookshelves) {
+            primaryButton.children[1].innerText = 'saving...'
+            updateReadingLog(form, success)
+
+            if (hideCheckIn) {
+                checkInDisplay.classList.add('hidden')
+                datePrompt.classList.add('hidden')
+                const checkInIdInput = modal.querySelector('input[name=event_id]')
+                checkInIdInput.value = ''
+                const checkInDeleteButton = modal.querySelector('.check-in__delete-btn')
+                checkInDeleteButton.classList.add('invisible')
+            }
+        }
     })
+}
+
+function confirmDeletion() {
+    return confirm('Removing this book from your shelves will delete your check-ins for this work.  Continue?')
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -245,7 +245,6 @@ function addReadingLogButtonClickListener(button) {
 
         const form = button.parentElement
         const dropper = button.closest('.widget-add')
-        const isRemovable = dropper.classList.contains('removable')
         const primaryButton = dropper.querySelector('.want-to-read')
         const initialText = primaryButton.children[1].innerText
         const dropClick = dropper.querySelector('.dropclick')
@@ -339,10 +338,6 @@ function addReadingLogButtonClickListener(button) {
                     btn.classList.remove('hidden')
                 }
                 button.classList.add('hidden')
-            }
-            // Remove work search list item if this is a reading log page:
-            if (isRemovable) {
-                dropper.closest('.searchResultItem').remove()
             }
         }
 

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -53,7 +53,7 @@ $if shelf_count > 0:
         $ doc_number = 1
         $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
         $for idx, doc in enumerate(docs):
-          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id, remove_on_change=True)
+          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id)
           $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
           $:macros.SearchResultsWork(doc, reading_log=dropper, availability=doc.get('availability'), rating=star_rating)
           $ doc_number = doc_number + 1


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7333 
Closes #7334

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes all check-ins for a work whenever the work is removed from all bookshelves.  Prompts patron to confirm that they'd like to proceed with this destructive action.

Prevents work card from being removed from "My Books" reading log views on shelf change.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
