### PR TITLE
Misc. `checkins.py` fixes

### DIFF
--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -125,10 +125,6 @@ class BookshelvesEvents(db.CommonExtras):
 
         return list(oldb.query(query, vars=data))
 
-    @classmethod
-    def exists(cls, pid) -> bool:
-        return len(cls.select_by_id(pid)) > 0
-
     # Update methods:
     @classmethod
     def update_event(cls, pid, edition_id=None, event_date=None, data=None):

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -81,7 +81,7 @@ class patron_check_ins(delegate.page):
         data = json.loads(web.data())
 
         if not self.validate_data(data):
-            raise web.badrequest('Invalid date submitted')
+            raise web.badrequest(message='Invalid date submitted')
 
         user = get_current_user()
         username = user['key'].split('/')[-1]
@@ -102,7 +102,7 @@ class patron_check_ins(delegate.page):
         if event_id:
             # update existing event
             if not BookshelvesEvents.exists(event_id):
-                raise web.notfound('Check-in event unavailable for edit')
+                raise web.notfound(message='Check-in event unavailable for edit')
             BookshelvesEvents.update_event(
                 event_id, event_date=date_str, edition_id=edition_id
             )
@@ -194,13 +194,13 @@ class yearly_reading_goal_json(delegate.page):
         if i.is_update:
             if goal < 0:
                 raise web.badrequest(
-                    'Reading goal update must be 0 or a positive integer'
+                    message='Reading goal update must be 0 or a positive integer'
                 )
         elif not goal or goal < 1:
-            raise web.badrequest('Reading goal must be a positive integer')
+            raise web.badrequest(message='Reading goal must be a positive integer')
 
         if i.is_update and not i.year:
-            raise web.badrequest('Year required to update reading goals')
+            raise web.badrequest(message='Year required to update reading goals')
 
         user = get_current_user()
         username = user['key'].split('/')[-1]

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -101,8 +101,14 @@ class patron_check_ins(delegate.page):
 
         if event_id:
             # update existing event
-            if not BookshelvesEvents.exists(event_id):
-                raise web.notfound(message='Check-in event unavailable for edit')
+            events = BookshelvesEvents.select_by_id(event_id)
+            if not events:
+                raise web.notfound(message='Event does not exist')
+
+            event = events[0]
+            if username != event['username']:
+                raise web.forbidden()
+
             BookshelvesEvents.update_event(
                 event_id, event_date=date_str, edition_id=edition_id
             )

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -52,6 +52,9 @@ def is_valid_date(year: int, month: Optional[int], day: Optional[int]) -> bool:
 @public
 def get_latest_read_date(work_olid: str) -> dict | None:
     user = get_current_user()
+    if not user:
+        return None
+
     username = user['key'].split('/')[-1]
 
     work_id = extract_numeric_id_from_olid(work_olid)
@@ -84,6 +87,9 @@ class patron_check_ins(delegate.page):
             raise web.badrequest(message='Invalid date submitted')
 
         user = get_current_user()
+        if not user:
+            raise web.unauthorized(message='Requires login')
+
         username = user['key'].split('/')[-1]
 
         edition_key = data.get('edition_key', None)
@@ -174,8 +180,10 @@ class yearly_reading_goal_json(delegate.page):
         i = web.input(year=None)
 
         user = get_current_user()
-        username = user['key'].split('/')[-1]
+        if not user:
+            raise web.unauthorized(message='Requires login')
 
+        username = user['key'].split('/')[-1]
         if i.year:
             results = [
                 {'year': i.year, 'goal': record.target, 'progress': record.current}
@@ -209,8 +217,10 @@ class yearly_reading_goal_json(delegate.page):
             raise web.badrequest(message='Year required to update reading goals')
 
         user = get_current_user()
-        username = user['key'].split('/')[-1]
+        if not user:
+            raise web.unauthorized(message='Requires login')
 
+        username = user['key'].split('/')[-1]
         current_year = i.year or datetime.now().year
 
         if i.is_update:
@@ -229,8 +239,10 @@ class yearly_reading_goal_json(delegate.page):
 @public
 def get_reading_goals(year=None):
     user = get_current_user()
-    username = user['key'].split('/')[-1]
+    if not user:
+        return None
 
+    username = user['key'].split('/')[-1]
     if not year:
         year = datetime.now().year
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -142,9 +142,19 @@ class patron_check_in(delegate.page):
 
     @authorized_for('/usergroup/beta-testers')
     def DELETE(self, check_in_id):
-        # TODO: Check for authorization after removing authorized_for decorator
-        if not BookshelvesEvents.exists(check_in_id):
-            raise web.notfound('Event does not exist')
+        user = get_current_user()
+        if not user:
+            raise web.unauthorized(message="Requires login")
+
+        events = BookshelvesEvents.select_by_id(check_in_id)
+        if not events:
+            raise web.notfound(message='Event does not exist')
+
+        event = events[0]
+        username = user['key'].split('/')[-1]
+        if username != event['username']:
+            raise web.forbidden()
+
         BookshelvesEvents.delete_by_id(check_in_id)
         return web.ok()
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds missing `message` keyword when HTTP errors are raised.
Corrects a type hint.
Most importantly, prevents unauthorized users from deleting check-ins.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
