### PR TITLE
If edition title already exists, make the edition title field required.

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -90,7 +90,8 @@ $jsdef render_work_autocomplete_item(item):
                 <span class="tip">$_("Enter the title of this specific edition.")</span>
             </div>
             <div class="input">
-                <input type="text" name="edition--title" id="edition-title" value="$book.title"/>
+                $ required = cond(book.title, 'required', '')
+                <input type="text" name="edition--title" id="edition-title" value="$book.title" $required />
                 <input type="hidden" name="edition--title_prefix" value=""/>
             </div>
         </div>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -90,8 +90,14 @@ $jsdef render_work_autocomplete_item(item):
                 <span class="tip">$_("Enter the title of this specific edition.")</span>
             </div>
             <div class="input">
-                $ required = cond(book.title, 'required', '')
-                <input type="text" name="edition--title" id="edition-title" value="$book.title" $required />
+                <input
+                    type="text"
+                    name="edition--title"
+                    id="edition-title"
+                    value="$book.title"
+                    $# Prevent erasure of edition title
+                    $cond(book.title, 'required', '')
+                />
                 <input type="hidden" name="edition--title_prefix" value=""/>
             </div>
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7265 

If the edition already has a title don't allow the field to be blanked. Uses HTML5 client side validation, namely the required attribute, to prevent the edition title from being removed entirely but still allows it to be edited.

### Technical
Uses HTML validation as suggested by Mek on #7265.

### Testing

- Testing with an edition that has an empty edition title, test that the form can be submitted without setting an edition title.
- Testing with an edition that already has an edition title,  check that the form can still be edited and the form submitted if the edition title unchanged.
- Testing with an edition that already has an edition title, ensure that the edit form cannot be submitted if the edition title has been removed completely.

### Screenshot

![Screenshot from 2022-12-29 20-04-26](https://user-images.githubusercontent.com/722096/210006169-d4bf422f-cf2f-49aa-99f3-f8cfb174e469.png)

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
