### PR TITLE
Work-level check-ins

### DIFF
--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -167,8 +167,8 @@ $if ctx.user or not work_key:
             </form>
         </div>
     </div>
-  $if work_key and edition_key and ctx.user.is_usergroup_member('/usergroup/beta-testers'):
-    $ last_read_date = get_latest_read_date(work_key, edition_key)
+  $if work_key and ctx.user.is_usergroup_member('/usergroup/beta-testers'):
+    $ last_read_date = get_latest_read_date(work_key)
     $ date = last_read_date['event_date'] if last_read_date else None
     $ event_id = last_read_date['id'] if last_read_date else None
     $:render_template('check_ins/check_in_prompt', work_key, users_work_read_status, edition_key=edition_key, last_read_date=date, event_id=event_id)

--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -1,4 +1,4 @@
-$def with (lists, work=None, edition_key=None, key=None, users_work_read_status=None, reading_log_only=False, use_work=False, page_url=None, async_load=False)
+$def with (lists, work=None, edition_key=None, key=None, users_work_read_status=None, include_lists=True, use_work=False, page_url=None, async_load=False)
 
 $ user_key = ctx.user and ctx.user.key
 $ username = ctx.user and ctx.user.key.split('/')[-1]
@@ -79,7 +79,7 @@ $if ctx.user or not work_key:
             </form>
           </div>
 
-          $if not reading_log_only:
+          $if include_lists:
             <div class="reading-lists">
               <p class="reading-list-title">$_('My Reading Lists:')</p>
               <div class="my-lists">
@@ -132,7 +132,7 @@ $if ctx.user or not work_key:
       </div>
     </div>
   </div>
-  $if not reading_log_only and render_once('lists/widget.addList'):
+  $if include_lists and render_once('lists/widget.addList'):
     <div class="hidden">
         <div class="floaterAdd" id="addList">
             <div class="floaterHead">

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -103,7 +103,9 @@ class patron_check_ins(delegate.page):
             # update existing event
             if not BookshelvesEvents.exists(event_id):
                 raise web.notfound('Check-in event unavailable for edit')
-            BookshelvesEvents.update_event(event_id, event_date=date_str, edition_id=edition_id)
+            BookshelvesEvents.update_event(
+                event_id, event_date=date_str, edition_id=edition_id
+            )
         else:
             # create new event
             result = BookshelvesEvents.create_event(

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -50,15 +50,14 @@ def is_valid_date(year: int, month: Optional[int], day: Optional[int]) -> bool:
 
 
 @public
-def get_latest_read_date(work_olid: str, edition_olid: str | None) -> str | None:
+def get_latest_read_date(work_olid: str) -> dict | None:
     user = get_current_user()
     username = user['key'].split('/')[-1]
 
     work_id = extract_numeric_id_from_olid(work_olid)
-    edition_id = extract_numeric_id_from_olid(edition_olid) if edition_olid else None
 
     result = BookshelvesEvents.get_latest_event_date(
-        username, work_id, edition_id, BookshelfEvent.FINISH
+        username, work_id, BookshelfEvent.FINISH
     )
     return result
 
@@ -104,7 +103,7 @@ class patron_check_ins(delegate.page):
             # update existing event
             if not BookshelvesEvents.exists(event_id):
                 raise web.notfound('Check-in event unavailable for edit')
-            BookshelvesEvents.update_event_date(event_id, date_str)
+            BookshelvesEvents.update_event(event_id, event_date=date_str, edition_id=edition_id)
         else:
             # create new event
             result = BookshelvesEvents.create_event(

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -53,7 +53,7 @@ $if shelf_count > 0:
         $ doc_number = 1
         $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
         $for idx, doc in enumerate(docs):
-          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], reading_log_only=True, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id)
+          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], include_lists=False, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id)
           $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
           $:macros.SearchResultsWork(doc, reading_log=dropper, availability=doc.get('availability'), rating=star_rating)
           $ doc_number = doc_number + 1

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -204,7 +204,7 @@ $ )
 
             $for work in works:
                 $ read_status = work.get('readinglog', None)
-                $ dropper = macros.ReadingLogDropper([], work=work, reading_log_only=True, page_url="/search", users_work_read_status=read_status)
+                $ dropper = macros.ReadingLogDropper([], work=work, include_lists=False, page_url="/search", users_work_read_status=read_status)
                 $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras)
           </ul>
           $:macros.Pager(page, num_found, rows)

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -470,17 +470,17 @@ class TestCheckIns:
 
     def test_get_latest_event_date(self):
         assert (
-            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 4, 3)[
+            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 3)[
                 'event_date'
             ]
             == "2019-10"
         )
         assert (
-            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 4, 3)['id']
+            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 3)['id']
             == 6
         )
         assert (
-            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 4, 1) is None
+            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 1) is None
         )
 
 

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -476,12 +476,9 @@ class TestCheckIns:
             == "2019-10"
         )
         assert (
-            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 3)['id']
-            == 6
+            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 3)['id'] == 6
         )
-        assert (
-            BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 1) is None
-        )
+        assert BookshelvesEvents.get_latest_event_date('@eliot_rosewater', 3, 1) is None
 
 
 class TestYearlyReadingGoals:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7330

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
To avoid issues stemming from our reading log being a work-level feature, check-ins have been changed to be work-level.  When available, edition IDs are persisted with the check-in entry in order to make transitioning to edition-level check-ins easier.

### Technical
<!-- What should be noted about the implementation? -->
Null edition IDs occur when a patron checks in from a search result item.

`edition_id` is still a required field in the `bookshelves_events` table.  If no edition ID is included with the check-in, `edition_id` is set to `-1`.  `edition_id`s of such entries will need to be updated to some best-fit edition ID once check-ins become edition-level.

`edition_id` is now also updated when a check-in date is updated, with one caveat: a valid `edition_id` will not be updated to `-1`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
