### PR TITLE
Update check-in prompt

### DIFF
--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -88,6 +88,11 @@ export function initCheckInPrompts(elems) {
         customDateLink.addEventListener('click', function() {
             modal.showModal()
         })
+
+        const yearLink = elem.querySelector('.prompt-current-year')
+        yearLink.addEventListener('click', function() {
+            onYearClick(modal)
+        })
     }
 }
 
@@ -126,23 +131,29 @@ function onTodayClick(modal, doSubmit=false) {
     }
 }
 
+function onYearClick(modal) {
+    const year = new Date().getFullYear()
+    setDate(modal, year)
+    submitEvent(modal.querySelector('.check-in'))
+}
+
 /**
  * Sets the date selectors of the given form to the given year, month, and day.
  *
  * @param {HTMLElement} parentElement The root element of the check-in component
  * @param {Number} year Four digit year
- * @param {Number} month One-indexed month
- * @param {Number} day The day
+ * @param {Number|null} month One-indexed month
+ * @param {Number|null} day The day
  */
-export function setDate(parentElement, year, month, day) {
+export function setDate(parentElement, year, month=null, day=null) {
     const yearSelect = parentElement.querySelector('select[name=year]')
     const monthSelect = parentElement.querySelector('select[name=month]')
     const daySelect = parentElement.querySelector('select[name=day]')
     const submitButton = parentElement.querySelector('.check-in__submit-btn')
 
     yearSelect.value = year
-    monthSelect.value = month
-    daySelect.value = day
+    monthSelect.value = month ? month : ''
+    daySelect.value = day ? day : ''
 
     let daysInMonth = DAYS_IN_MONTH[month - 1]
     if (month === 2 && isLeapYear(year)) {
@@ -152,7 +163,7 @@ export function setDate(parentElement, year, month, day) {
     toggleDayVisibility(daySelect, daysInMonth)
 
     monthSelect.disabled = false
-    daySelect.disabled = false
+    daySelect.disabled = day ? false : true
     submitButton.disabled = false
 }
 

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -47,6 +47,12 @@ export function initCheckInForms(elems) {
         })
 
         const yearSelect = elem.querySelector('select[name=year]')
+        const currentYear = new Date().getFullYear();
+        const hiddenYear = yearSelect.querySelector('.show-if-local-year')
+
+        if (Number(hiddenYear.value) === currentYear) {
+            hiddenYear.classList.remove('hidden')
+        }
         yearSelect.addEventListener('change', function(event) {
             onYearChange(elem, event.target.value)
         })
@@ -390,7 +396,9 @@ function deleteEvent(rootElem, workOlid, eventId) {
 }
 
 /**
- * Adds listener to open reading goal modal, and updates year to
+ * Adds listener to open reading goal modal.
+ *
+ * Updates yearly goal form's current year to the patron's
  * local year.
  *
  * @param {HTMLElement} link Prompt for adding a reading goal
@@ -398,7 +406,9 @@ function deleteEvent(rootElem, workOlid, eventId) {
 export function initYearlyGoalPrompt(link) {
     const yearlyGoalModal = document.querySelector('#yearly-goal-modal')
 
-    setLocalYear(yearlyGoalModal.querySelector('form'))
+    // Set form's year to local year to avoid issues on 1 January
+    const currentYear = new Date().getFullYear();
+    yearlyGoalModal.querySelector('input[name=year]').value = currentYear
 
     link.addEventListener('click', function() {
         yearlyGoalModal.showModal()
@@ -408,18 +418,22 @@ export function initYearlyGoalPrompt(link) {
 /**
  * Updates year to the client's local year.
  *
- * Used to prevent issues on New Year's day.  Sets
- * the year input in the reading log form, and updates
- * the year in the "set goal" CTA link.
+ * Used to display the correct local year on 1 January.
  *
- * @param {HTMLFormElement} form Reading goal form
+ * Elements passed to this function are expected to have a
+ * `data-server-year` attribute, which is set to the server's
+ * local year.
+ *
+ * @param {HTMLCollection<HTMLElement>} elems ELements which display only the current year
  */
-function setLocalYear(form) {
-    const currentYearSpan = document.querySelector('#reading-goal-current-year')
-    const currentYear = new Date().getFullYear();
-    currentYearSpan.textContent = currentYear
-
-    form.querySelector('input[name=year]').value = currentYear
+export function displayLocalYear(elems) {
+    const localYear = new Date().getFullYear()
+    for (const elem of elems) {
+        const serverYear = Number(elem.dataset.serverYear)
+        if (localYear !== serverYear) {
+            elem.textContent = localYear
+        }
+    }
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -389,7 +389,8 @@ jQuery(function () {
     const checkInForms = document.querySelectorAll('.check-in')
     const checkInPrompts = document.querySelectorAll('.check-in-prompt')
     const checkInEditLinks = document.querySelectorAll('.prompt-edit-date')
-    if (setGoalLink || goalEditLinks.length || goalSubmitButtons.length || checkInForms.length || checkInPrompts.length || checkInEditLinks.length) {
+    const yearElements = document.querySelectorAll('.use-local-year')
+    if (setGoalLink || goalEditLinks.length || goalSubmitButtons.length || checkInForms.length || checkInPrompts.length || checkInEditLinks.length || yearElements.length) {
         import(/* webpackChunkName: "check-ins" */ './check-ins')
             .then((module) => {
                 if (setGoalLink) {
@@ -409,6 +410,9 @@ jQuery(function () {
                 }
                 if (checkInEditLinks.length) {
                     module.initCheckInEdits(checkInEditLinks)
+                }
+                if (yearElements.length) {
+                    module.displayLocalYear(yearElements)
                 }
             })
     }

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,6 +1,7 @@
 $def with (user, mybooks, public=False, owners_page=False, counts=None, lists=None)
 
-$ username = user.key.split('/')[-1]
+$def year_span(year):
+  <span class="use-local-year" data-server-year="$year">$year</span>
 
 <div class="chip-group">
   <span class="chip value-chip category-chip chip--selectable">
@@ -20,8 +21,9 @@ $if user.is_beta_tester():
   <div class="yearly-goal-section">
     <div class="chip-group $hidden">
       <span class="chip value-chip category-chip chip--selectable goal-chip">
-        <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"
-          href="javascript:;">$:_('Set <span id="reading-goal-current-year">2023</span> reading goal')</a>
+        $ year = current_year()
+        $ year_markup = year_span(year)
+        <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
       </span>
       $ reading_goal_form = render_template('check_ins/reading_goal_form')
       $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title="Yearly Reading Goal")

--- a/openlibrary/templates/check_ins/check_in_form.html
+++ b/openlibrary/templates/check_ins/check_in_form.html
@@ -39,6 +39,7 @@ $if last_read_date:
         <label>$_('Year:')</label>
         <select class="check-in__select" name="year">
           <option value="">$_('Year')</option>
+          <option class="hidden show-if-local-year" value="$(year + 1)">$(year + 1)</option>
           $for i in range(120):
             $ is_selected = year - i == year_read
             <option value="$(year - i)" $cond(is_selected, 'selected', '')>$(year - i)</option>

--- a/openlibrary/templates/check_ins/check_in_prompt.html
+++ b/openlibrary/templates/check_ins/check_in_prompt.html
@@ -19,10 +19,7 @@ $ prompt_id = 'prompt-%s' % work_olid
   <span class="date-display">
     <span class="read-label">Read: </span>
     <span class="check-in-date">$last_read_date</span>
-  </span>
-
-  <span class="prompt-options">
-    <a class="prompt-edit-date" href="javascript:;" data-work-olid="$(work_olid)" data-ol-link-track="CheckInPrompt|EditDate">$_("Edit Date")</a>
+    <a class="prompt-edit-date" href="javascript:;" data-work-olid="$(work_olid)" data-ol-link-track="CheckInPrompt|EditDate">$_("Edit")</a>
   </span>
 </div>
 

--- a/openlibrary/templates/check_ins/check_in_prompt.html
+++ b/openlibrary/templates/check_ins/check_in_prompt.html
@@ -30,8 +30,10 @@ $ display_prompt = read_status == 3
 <div id="$(prompt_id)" class="check-in-prompt $cond((display_prompt and not last_read_date), '', 'hidden')" data-work-olid="$(work_olid)">
   <span class="prompt-copy">$_("When did you finish this book?")</span>
   <span class="prompt-options">
+    $ year = current_year()
+    <a class="prompt-current-year use-local-year" href="javascript:;" data-ol-link-track="CheckInPrompt|SetDateCurrentYear" data-server-year="$year">$year</a>
     <a class="prompt-today" href="javascript:;" data-ol-link-track="CheckInPrompt|SetDateToday">$_("Today")</a>
-    <a class="prompt-custom" href="javascript:;" data-ol-link-track="CheckInPrompt|SetDateCustom">$_("Custom Date")</a>
+    <a class="prompt-custom" href="javascript:;" data-ol-link-track="CheckInPrompt|SetDateCustom">$_("Other")</a>
   </span>
 </div>
 

--- a/static/css/components/check-in.less
+++ b/static/css/components/check-in.less
@@ -117,12 +117,6 @@
       font-weight: 700;
     }
   }
-
-  .prompt-options {
-    display: inline-block;
-    width: 100%;
-    text-align: center;
-  }
 }
 
 .check-in-prompt {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7335

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR does the following:
1. Allows patron's to submit a check-in with the current year as the date in a single click.
2. Places check-in edit button on the same line as the read date.
3. Updates the year to the patron's local year, if necessary.

This branch is forked from #7343.  This branch will be ready for review once #7343 is merged and this branch is rebased.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2022-12-29 14-22-08](https://user-images.githubusercontent.com/28732543/210017385-1ef983f7-d9a2-41a3-ab50-4c17413d3e27.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
