### PR TITLE
Prep reading goals for release

### DIFF
--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -167,7 +167,7 @@ $if ctx.user or not work_key:
             </form>
         </div>
     </div>
-  $if work_key and ctx.user.is_usergroup_member('/usergroup/beta-testers'):
+  $if work_key:
     $ last_read_date = get_latest_read_date(work_key)
     $ date = last_read_date['event_date'] if last_read_date else None
     $ event_id = last_read_date['id'] if last_read_date else None

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -50,7 +50,7 @@ export function initCheckInForms(elems) {
         const currentYear = new Date().getFullYear();
         const hiddenYear = yearSelect.querySelector('.show-if-local-year')
 
-        // The year selector has a hidden option for next year.  This option is 
+        // The year selector has a hidden option for next year.  This option is
         // shown on 1 January if the client's local year is different from
         // the server's local year.
         if (Number(hiddenYear.value) === currentYear) {

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -50,6 +50,9 @@ export function initCheckInForms(elems) {
         const currentYear = new Date().getFullYear();
         const hiddenYear = yearSelect.querySelector('.show-if-local-year')
 
+        // The year selector has a hidden option for next year.  This option is 
+        // shown on 1 January if the client's local year is different from
+        // the server's local year.
         if (Number(hiddenYear.value) === currentYear) {
             hiddenYear.classList.remove('hidden')
         }
@@ -417,10 +420,6 @@ function deleteEvent(rootElem, workOlid, eventId) {
 export function initYearlyGoalPrompt(link) {
     const yearlyGoalModal = document.querySelector('#yearly-goal-modal')
 
-    // Set form's year to local year to avoid issues on 1 January
-    const currentYear = new Date().getFullYear();
-    yearlyGoalModal.querySelector('input[name=year]').value = currentYear
-
     link.addEventListener('click', function() {
         yearlyGoalModal.showModal()
     })
@@ -536,7 +535,8 @@ function addGoalSubmissionListener(submitButton) {
                         updateProgressComponent(progressComponent, Number(formData.get('goal')))
                     }
                 } else {
-                    fetchProgressAndUpdateView(yearlyGoalSection)
+                    const goalYear = formData.get('year')
+                    fetchProgressAndUpdateView(yearlyGoalSection, goalYear)
                 }
             })
     })
@@ -571,9 +571,10 @@ function updateProgressComponent(elem, goal) {
  * link for setting reading goal.
  *
  * @param {HTMLElement} yearlyGoalElem Container for progress component and reading goal link.
+ * @param {string} goalYear Year that the goal is set for.
  */
-function fetchProgressAndUpdateView(yearlyGoalElem) {
-    fetch('/reading-goal/partials')
+function fetchProgressAndUpdateView(yearlyGoalElem, goalYear) {
+    fetch(`/reading-goal/partials?year=${goalYear}`)
         .then((response) => {
             if (!response.ok) {
                 throw new Error('Failed to fetch progress element')

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -69,7 +69,6 @@ class patron_check_ins(delegate.page):
     path = r'/works/OL(\d+)W/check-ins'
     encoding = 'json'
 
-    @authorized_for('/usergroup/beta-testers')
     def POST(self, work_id):
         """Validates data, constructs date string, and persists check-in event.
 
@@ -152,7 +151,6 @@ class patron_check_ins(delegate.page):
 class patron_check_in(delegate.page):
     path = r'/check-ins/(\d+)'
 
-    @authorized_for('/usergroup/beta-testers')
     def DELETE(self, check_in_id):
         user = get_current_user()
         if not user:
@@ -175,7 +173,6 @@ class yearly_reading_goal_json(delegate.page):
     path = '/reading-goal'
     encoding = 'json'
 
-    @authorized_for('/usergroup/beta-testers')
     def GET(self):
         i = web.input(year=None)
 
@@ -199,7 +196,6 @@ class yearly_reading_goal_json(delegate.page):
 
         return delegate.RawText(json.dumps({'status': 'ok', 'goal': results}))
 
-    @authorized_for('/usergroup/beta-testers')
     def POST(self):
         i = web.input(goal=0, year=None, is_update=None)
 

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,7 +1,10 @@
 $def with (user, mybooks, public=False, owners_page=False, counts=None, lists=None)
 
-$def year_span(year):
-  <span class="use-local-year" data-server-year="$year">$year</span>
+$def year_span(year, use_local_year=False):
+  $if use_local_year:
+    <span class="use-local-year" data-server-year="$year">$year</span>
+  $else:
+    <span>$year</span>
 
 <div class="chip-group">
   <span class="chip value-chip category-chip chip--selectable">
@@ -14,17 +17,17 @@ $def year_span(year):
   </span>
 </div>
 
-$ current_goal = get_reading_goals()
+$ year = 2023
+$ current_goal = get_reading_goals(year=year)
 $ hidden = 'hidden' if current_goal else ''
 
 <div class="yearly-goal-section">
   <div class="chip-group $hidden">
     <span class="chip value-chip category-chip chip--selectable goal-chip">
-      $ year = current_year()
       $ year_markup = year_span(year)
       <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
     </span>
-    $ reading_goal_form = render_template('check_ins/reading_goal_form')
+    $ reading_goal_form = render_template('check_ins/reading_goal_form', year=year)
     $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title="Yearly Reading Goal")
   </div>
   $if current_goal:

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -17,7 +17,7 @@ $def year_span(year, use_local_year=False):
   </span>
 </div>
 
-$ year = 2023
+$ year = get_reading_goals_year()
 $ current_goal = get_reading_goals(year=year)
 $ hidden = 'hidden' if current_goal else ''
 

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -14,25 +14,24 @@ $def year_span(year):
   </span>
 </div>
 
-$if user.is_beta_tester():
-  $ current_goal = get_reading_goals()
-  $ hidden = 'hidden' if current_goal else ''
+$ current_goal = get_reading_goals()
+$ hidden = 'hidden' if current_goal else ''
 
-  <div class="yearly-goal-section">
-    <div class="chip-group $hidden">
-      <span class="chip value-chip category-chip chip--selectable goal-chip">
-        $ year = current_year()
-        $ year_markup = year_span(year)
-        <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
-      </span>
-      $ reading_goal_form = render_template('check_ins/reading_goal_form')
-      $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title="Yearly Reading Goal")
-    </div>
-    $if current_goal:
-      <span id="reading-goal-container">
-        $:render_template('check_ins/reading_goal_progress', [current_goal])
-      </span>
+<div class="yearly-goal-section">
+  <div class="chip-group $hidden">
+    <span class="chip value-chip category-chip chip--selectable goal-chip">
+      $ year = current_year()
+      $ year_markup = year_span(year)
+      <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
+    </span>
+    $ reading_goal_form = render_template('check_ins/reading_goal_form')
+    $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title="Yearly Reading Goal")
   </div>
+  $if current_goal:
+    <span id="reading-goal-container">
+      $:render_template('check_ins/reading_goal_progress', [current_goal])
+    </span>
+</div>
 
 $code:
     def compact_carousel(data):

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -111,6 +111,13 @@ def current_year():
     return datetime.datetime.now().year
 
 
+@public
+def get_reading_goals_year():
+    now  = datetime.datetime.now()
+    year = now.year
+    return year if now.month < 12 else year + 1
+
+
 @contextmanager
 def elapsed_time(name="elapsed_time"):
     """

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -113,7 +113,7 @@ def current_year():
 
 @public
 def get_reading_goals_year():
-    now  = datetime.datetime.now()
+    now = datetime.datetime.now()
     year = now.year
     return year if now.month < 12 else year + 1
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes beta-tester restrictions for check-ins and yearly reading goals.
Prompts patrons to set their 2023 reading goals (as opposed to setting a goal for the current year, 2022).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
