### PR TITLE
Make author search results sort by relevance

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -610,7 +610,6 @@ class author_search(delegate.page):
             offset=offset,
             rows=limit,
             fields=fields,
-            sort='work_count desc',
         )
 
         return resp

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -52,4 +52,6 @@ class AuthorSearchScheme(SearchScheme):
             ('q.op', 'AND'),
             ('defType', 'edismax'),
             ('qf', 'name alternate_names'),
+            ('pf', 'name^10 alternate_names^10'),
+            ('bf', 'min(work_count,20)'),
         ]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7371 

### Technical
Boost phrase matches when performing an author search. E.g. searching for `e h smith` will now show results that match the full phrase `"e h smith"` over those that match `e OR h OR smith` in any order. To make this work, I had to change the default sort order. Previously results were always sorted by `work_count desc`.

### Testing
Compare: https://testing.openlibrary.org/search/authors?q=h.+a.+j
- correct j k rowling boosted
- correct mark twain at top

Improvements in metrics:

Class | AVERAGE of Prod | AVERAGE of Testing
-- | -- | --
Initials | 25.5 | 5.5
Middle names | 1 | 3
Popular Authors | 1 | 1
Top User Searches | 1 | 1.111111111
Grand Total | 4.5 | 1.857142857

See https://docs.google.com/spreadsheets/d/1BN5I7-OkTPaoTr2Es6jQ4O9ICWFmH0q9CP6kEgolCgg/edit#gid=1127406974

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@tfmorris 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
