### PR TITLE
Open yearly goal modal when `goal` in query params

### DIFF
--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -423,6 +423,13 @@ export function initYearlyGoalPrompt(link) {
     link.addEventListener('click', function() {
         yearlyGoalModal.showModal()
     })
+
+    if (link.offsetParent !== null) {  // Goal link is visible on screen
+        if (link.classList.contains('open')) {
+            link.classList.remove('open')
+            link.click()
+        }
+    }
 }
 
 /**

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -749,9 +749,11 @@ class account_my_books(delegate.page):
 
     @require_login
     def GET(self):
+        i = web.input(goal=None)
         user = accounts.get_current_user()
         username = user.key.split('/')[-1]
-        raise web.seeother(f'/people/{username}/books')
+        query_str = f'?goal={i.goal}' if i.goal else ''
+        raise web.seeother(f'/people/{username}/books{query_str}')
 
 
 # This would be by the civi backend which would require the api keys

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -21,11 +21,14 @@ $ year = get_reading_goals_year()
 $ current_goal = get_reading_goals(year=year)
 $ hidden = 'hidden' if current_goal else ''
 
+$# Decorate goal link if "goal" query param exists:
+$ link_class = 'open' if query_param('goal', '') else ''
+
 <div class="yearly-goal-section">
   <div class="chip-group $hidden">
     <span class="chip value-chip category-chip chip--selectable goal-chip">
       $ year_markup = year_span(year)
-      <a id="set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
+      <a id="set-reading-goal-link" class="$link_class" data-ol-link-track="MyBooksLandingPage|SetReadingGoal" href="javascript:;">$:_('Set %(year_span)s reading goal', year_span=year_markup)</a>
     </span>
     $ reading_goal_form = render_template('check_ins/reading_goal_form', year=year)
     $:render_template('native_dialog', 'yearly-goal-modal', reading_goal_form, title="Yearly Reading Goal")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7361

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Opens yearly goal modal on My Books page when `goal` is passed as query parameter.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
