### PR TITLE
Correctly handle author data in edition diff display

### DIFF
--- a/openlibrary/templates/diff.html
+++ b/openlibrary/templates/diff.html
@@ -113,7 +113,7 @@ $def diff_display(name, value):
                     return thingdiff("/type/text", "table_of_contents", a.get_toc_text(), b.get_toc_text())
                 elif p == "title_prefix":
                     return thingdiff("/type/string", "title_prefix", a[p].strip(), b[p].strip())
-                elif p == "authors":
+                elif p == "authors" and a.type.key == "/type/work":
                     label = "authors"
                     t = "/type/author"
                     ap = [val.author for val in a.authors]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7355

This fixes the problem of the diff display not showing author changes for editions.

### Technical
Editions store authors differently than works, so the special case in the diff routine for work authors fails when handling an edition. However, the default behavior works just fine for editions, so limiting the special case to works solves the problem.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
BEFORE:
<img width="1078" alt="Screenshot 2023-01-03 at 7 47 32 PM" src="https://user-images.githubusercontent.com/886889/210469689-ba59f77e-2934-40eb-988e-a49d03dad06e.png">

AFTER:
<img width="1070" alt="Screenshot 2023-01-03 at 7 47 46 PM" src="https://user-images.githubusercontent.com/886889/210469704-9204e061-e55e-4830-aea3-7192ecbe253d.png">



### Stakeholders
@mheiman @tfmorris @cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
