### PR TITLE
Update Quick Tour video link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Welcome!
 This welcome section is intended for new contributors.
 
-1. **Quick Tour:** [Quick Public Tour of Open Library (10min)](https://archive.org/embed/openlibrary-tour-2020)
+1. **Quick Tour:** [Quick Public Tour of Open Library (10min)](https://archive.org/embed/openlibrary-tour-2020/openlibrary.ogv)
 2. **Orientation:** [Volunteer Orientation Video (1.5h)](https://archive.org/details/openlibrary-orientation-2020?start=80)
     * [Code of conduct](https://github.com/internetarchive/openlibrary/blob/master/CODE_OF_CONDUCT.md)
 3. **Getting Started:**


### PR DESCRIPTION
<!-- What issue does this PR close? -->
[No Ticket #] Discovered this extremely minor issue while running through the steps in `CONTRIBUTING.md`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR makes the link in the outline of the "Getting Started" Markdown document match the link in the body.
Prior to this fix, the "Quick Tour" text linked to a ~2 hour long video.

### Technical
N/A

### Testing
1. Go to the URL specified in the original Markdown link: [https://archive.org/embed/openlibrary-tour-2020](https://archive.org/embed/openlibrary-tour-2020)
2. Verify that it links to an incorrect file ("2021-10-26-OpenLibrary-Community-Celebration")
3. Verify that the updated link matches the URL in the "Quick Tour" section of the body (https://archive.org/embed/openlibrary-tour-2020/openlibrary.ogv)

### Screenshot
N/A

### Stakeholders
Tagging @mekarpeles as the most recent contributor to this file (please let me know if I should tag someone else -- this is my first PR against this project).


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
