### PR TITLE
Delete records created by blocked patron

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -314,7 +314,9 @@ class people_view:
         keys_to_delete = set()
         while not stop:
             changes = account.get_recentchanges(limit=100, offset=100 * i)
-            added_records: list[list[dict]] = [c.changes for c in changes if c.kind == 'add-book']
+            added_records: list[list[dict]] = [
+                c.changes for c in changes if c.kind == 'add-book'
+            ]
             flattened_records: list[dict] = sum(added_records, [])
             keys_to_delete |= {r['key'] for r in flattened_records}
             changeset_ids = [c.id for c in changes]
@@ -329,7 +331,8 @@ class people_view:
         ]
         web.ctx.site.save_many(delete_payload, 'Delete spam')
         add_flash_message(
-            "info", f"Blocked the account and reverted all {edits} edits. {len(delete_payload)} records deleted."
+            "info",
+            f"Blocked the account and reverted all {edits} edits. {len(delete_payload)} records deleted.",
         )
         raise web.seeother(web.ctx.path)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7204

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Deletes every new record created by a user who's edits are being reverted.  Adds deleted record count to flash message.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
