### PR TITLE
Bug fix and French language corrections

### DIFF
--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -670,7 +670,7 @@ msgstr "Ce mois-ci"
 
 #: trending.html:10
 msgid "This Year"
-msgstr ""
+msgstr "Cette année"
 
 #: trending.html:10
 #, fuzzy

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: traduc@traduc.org\n"
-"POT-Creation-Date: 2021-11-23 08:44+0000\n"
+"POT-Creation-Date: 2023-01-06 20:53+0000\n"
 "PO-Revision-Date: 2021-12-11 19:04+0100\n"
 "Last-Translator: Julien Lepiller <julien@lepiller.eu>\n"
 "Language: fr\n"
@@ -19,31 +19,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: account.html:7 account.html:12 account/notifications.html:13
-#: account/privacy.html:13 lib/nav_head.html:15 lib/search_head.html:71
-#: type/user/view.html:27
+#: account.html:7 account.html:15 account/notifications.html:13
+#: account/privacy.html:13 lib/nav_head.html:15 type/user/view.html:27
 msgid "Settings"
 msgstr "Paramètres"
 
-#: account.html:16
-msgid "Change Password"
-msgstr "Changer le mot de passe"
-
-#: account.html:17
-msgid "Update Email Address"
-msgstr "Mettre à jour l'adresse de courriel"
-
-#: account.html:18
-msgid "Your Notifications"
-msgstr "Vos notifications"
-
-#: account.html:19
-msgid "Internet Archive Announcements"
-msgstr "Annonces d'Internet Archive"
-
 #: account.html:20
-msgid "Your Privacy Settings"
-msgstr "Vos paramètres de confidentialité"
+msgid "Settings & Privacy"
+msgstr ""
 
 #: account.html:21 databarDiff.html:12
 msgid "View"
@@ -53,8 +36,10 @@ msgstr "Voir"
 msgid "or"
 msgstr "ou"
 
-#: account.html:21 databarHistory.html:27 databarTemplate.html:13
-#: databarView.html:34 type/edition/view.html:359 type/work/view.html:359
+#: account.html:21 check_ins/check_in_prompt.html:26
+#: check_ins/reading_goal_progress.html:26 databarHistory.html:27
+#: databarTemplate.html:13 databarView.html:34
+#: type/edition/compact_title.html:11
 msgid "Edit"
 msgstr "Modifier"
 
@@ -74,7 +59,34 @@ msgstr "Voir ou modifier vos listes"
 msgid "Import and Export Options"
 msgstr "Options d'import et d'export"
 
+#: account.html:25
+#, fuzzy
+msgid "Manage Privacy Settings"
+msgstr "Gérer vos paramètres de confidentialité"
+
 #: account.html:26
+#, fuzzy
+msgid "Manage Notifications Settings"
+msgstr "Gérer vos paramètres de confidentialité"
+
+#: account.html:27
+msgid "Manage Mailing List Subscriptions"
+msgstr ""
+
+#: account.html:28
+msgid "Change Password"
+msgstr "Changer le mot de passe"
+
+#: account.html:29
+msgid "Update Email Address"
+msgstr "Mettre à jour l'adresse de courriel"
+
+#: account.html:30
+#, fuzzy
+msgid "Deactivate Account"
+msgstr "Supprimer le compte"
+
+#: account.html:32
 msgid "Please contact us if you need help with anything else."
 msgstr ""
 "Contactez-nous si vous avez besoin d'aide à propos de quoi que ce soit "
@@ -84,18 +96,18 @@ msgstr ""
 msgid "Barcode Scanner (Beta)"
 msgstr "Scanner de code-barres (Beta)"
 
-#: barcodescanner.html:14
+#: barcodescanner.html:15
 msgid "Point your camera at a barcode! 📷"
 msgstr "Pointez votre caméra sur un code-barres ! 📷"
 
-#: account/loans.html:69 borrow_admin.html:104
+#: account/loans.html:63 borrow_admin.html:104
 #, python-format
 msgid "1 Current Loan"
 msgid_plural "%(count)d Current Loans"
 msgstr[0] "1 emprunt en cours"
 msgstr[1] "%(count)d emprunts en cours"
 
-#: account/loans.html:71 admin/loans_table.html:41 borrow_admin.html:106
+#: account/loans.html:65 admin/loans_table.html:41 borrow_admin.html:106
 msgid "Loan Expires"
 msgstr "Échéance de l'emprunt"
 
@@ -139,11 +151,9 @@ msgstr "Non modifié"
 msgid "Revision %d"
 msgstr "Révision %d"
 
-#: AuthorList.html:9 SearchResultsWork.html:45 books/check.html:32
-#: books/edit/edition.html:75 books/show.html:16 covers/book_cover.html:41
-#: covers/book_cover_single_edition.html:36 covers/book_cover_work.html:32
-#: diff.html:42 lists/preview.html:20 type/edition/publisher_line.html:15
-#: type/edition/view.html:190 type/work/view.html:190
+#: books/check.html:32 books/edit/edition.html:76 books/show.html:16
+#: covers/book_cover.html:41 covers/book_cover_single_edition.html:36
+#: covers/book_cover_work.html:32 diff.html:42 lists/preview.html:20
 msgid "by"
 msgstr "par"
 
@@ -171,7 +181,7 @@ msgstr "Annuler et revenir."
 msgid "YAML Representation:"
 msgstr "Représentation YAML :"
 
-#: BookPreview.html:11 editpage.html:15
+#: BookPreview.html:11 books/edit/edition.html:669 editpage.html:15
 msgid "Preview"
 msgstr "Aperçu"
 
@@ -213,7 +223,7 @@ msgstr "Comparer"
 msgid "See Diff"
 msgstr "Voir les différences"
 
-#: history.html:48 lib/history.html:78
+#: history.html:48 lib/history.html:76
 #, python-format
 msgid "View revision %s"
 msgstr "Voir la révision %s"
@@ -245,12 +255,17 @@ msgstr ""
 msgid "Library Explorer"
 msgstr "Explorateur de bibliothèque"
 
-#: lib/header_dropdown.html:46 lib/nav_head.html:107 login.html:10
-#: login.html:72
+#: lib/header_dropdown.html:59 lib/nav_head.html:118 login.html:10
+#: login.html:75
 msgid "Log In"
 msgstr "Se connecter"
 
-#: login.html:15
+#: account/create.html:19 login.html:16
+#, fuzzy
+msgid "OR"
+msgstr "ou"
+
+#: login.html:18
 msgid ""
 "Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
 "email and password to access your Open Library account."
@@ -259,12 +274,12 @@ msgstr ""
 "href=\"https://archive.org\">Internet Archive</a> pour accéder à votre "
 "compte Open Library."
 
-#: account/create.html:46 login.html:18
+#: account/create.html:50 login.html:21
 #, python-format
 msgid "You are already logged into Open Library as %(user)s."
 msgstr "Vous êtes déjà enregistré sur Open Library en tant que %(user)s."
 
-#: account/create.html:47 login.html:19
+#: account/create.html:51 login.html:22
 msgid ""
 "If you'd like to create a new, different Open Library account, you'll "
 "need to <a href=\"javascript:;\" "
@@ -276,27 +291,27 @@ msgstr ""
 "onclick=\"document.forms['logout'].submit()\">déconnecter</a> et "
 "recommencer l'enregistrement."
 
-#: login.html:39
+#: login.html:42
 msgid "Email"
 msgstr "Courriel"
 
-#: login.html:41
+#: login.html:44
 msgid "Forgot your Internet Archive email?"
 msgstr "Avez-vous oublié votre courriel pour Internet Archive ?"
 
-#: account/email/forgot-ia.html:33 forms.py:31 login.html:51
+#: account/email/forgot-ia.html:33 forms.py:31 login.html:54
 msgid "Password"
 msgstr "Mot de passe"
 
-#: login.html:61
+#: login.html:64
 msgid "Remember me"
 msgstr "Se souvenir de moi"
 
-#: account/email/forgot.html:48 login.html:76
+#: account/email/forgot.html:48 login.html:79
 msgid "Forgot your Password?"
 msgstr "Avez-vous oublié votre mot de passe ?"
 
-#: login.html:78
+#: login.html:81
 msgid "Not a member of Open Library? <a href=\"/account/create\">Sign up now</a>."
 msgstr ""
 "Pas encore membre d'Open Library ? <a href=\"/account/create"
@@ -387,29 +402,34 @@ msgstr "Entrée MARC non valide."
 msgid "Server status"
 msgstr "Statut du serveur"
 
-#: SubjectTags.html:23 lib/nav_foot.html:28 lib/nav_head.html:29
-#: subjects.html:9 subjects/notfound.html:11 type/author/view.html:161
-#: type/list/view_body.html:276 work_search.html:68
+#: SearchNavigation.html:24 SubjectTags.html:23 lib/nav_foot.html:28
+#: lib/nav_head.html:28 subjects.html:9 subjects/notfound.html:11
+#: type/author/view.html:176 type/list/view_body.html:280 work_search.html:75
 msgid "Subjects"
 msgstr "Thèmes"
 
-#: SubjectTags.html:27 subjects.html:9 type/author/view.html:162
-#: type/list/view_body.html:278 work_search.html:70
+#: SubjectTags.html:27 subjects.html:9 type/author/view.html:177
+#: type/list/view_body.html:282 work_search.html:79
 msgid "Places"
 msgstr "Lieux"
 
 #: SubjectTags.html:25 admin/menu.html:20 subjects.html:9
-#: type/author/view.html:163 type/list/view_body.html:277 work_search.html:69
+#: type/author/view.html:178 type/list/view_body.html:281 work_search.html:78
 msgid "People"
 msgstr "Personnes"
 
-#: SubjectTags.html:29 subjects.html:9 type/list/view_body.html:279
-#: work_search.html:71
+#: SubjectTags.html:29 subjects.html:9 type/list/view_body.html:283
+#: work_search.html:80
 msgid "Times"
 msgstr "Périodes"
 
-#: merge/authors.html:89 publishers/view.html:17 subjects.html:19
-#: type/author/view.html:110
+#: subjects.html:19
+#, fuzzy
+msgid "See all works"
+msgstr "Tout voir"
+
+#: merge/authors.html:93 publishers/view.html:17 subjects.html:19
+#: type/author/view.html:121
 #, python-format
 msgid "1 work"
 msgid_plural "%(count)d works"
@@ -421,12 +441,12 @@ msgstr[1] "%(count)d œuvres"
 msgid "Search for books with subject %(name)s."
 msgstr "Rechercher des livres sur le thème %(name)s."
 
-#: authors/index.html:20 lib/nav_head.html:91 lib/search_head.html:24
-#: lists/home.html:25 publishers/notfound.html:19 publishers/view.html:115
-#: search/advancedsearch.html:44 search/authors.html:48 search/inside.html:17
-#: search/lists.html:17 search/publishers.html:19 search/subjects.html:34
+#: authors/index.html:21 lib/nav_head.html:102 lists/home.html:25
+#: publishers/notfound.html:19 publishers/view.html:115
+#: search/advancedsearch.html:48 search/authors.html:27 search/inside.html:17
+#: search/lists.html:17 search/publishers.html:19 search/subjects.html:28
 #: subjects.html:27 subjects/notfound.html:19 type/local_id/view.html:42
-#: work_search.html:84
+#: work_search.html:91
 msgid "Search"
 msgstr "Rechercher"
 
@@ -482,8 +502,8 @@ msgstr "Aucun résultat."
 msgid "See more books by, and learn about, this author"
 msgstr "Voir plus de livres de cet auteur et en apprendre plus"
 
-#: account/waitlist.html:68 authors/index.html:27 publishers/view.html:83
-#: search/authors.html:66 search/publishers.html:29 search/subjects.html:89
+#: account/loans.html:147 authors/index.html:28 publishers/view.html:83
+#: search/authors.html:57 search/publishers.html:29 search/subjects.html:73
 #: subjects.html:88
 #, python-format
 msgid "1 book"
@@ -503,7 +523,7 @@ msgstr "qui a écrit le plus de livres sur ce thème"
 msgid "Get more information about this publisher"
 msgstr "Obtenir plus d'informations sur cet éditeur"
 
-#: SearchResultsWork.html:75 books/check.html:36 merge/authors.html:82
+#: SearchResultsWork.html:86 books/check.html:36 merge/authors.html:86
 #: publishers/view.html:106 subjects.html:111
 #, python-format
 msgid "1 edition"
@@ -619,15 +639,82 @@ msgstr "Quelle page regardiez vous ?"
 msgid "Send"
 msgstr "Envoyer"
 
-#: EditButtons.html:23 EditButtonsMacros.html:26 account/create.html:86
-#: account/notifications.html:59 account/password/reset.html:24
-#: account/privacy.html:56 admin/imports-add.html:28 books/add.html:84
-#: books/edit/addfield.html:87 books/edit/addfield.html:133
-#: books/edit/addfield.html:177 covers/add.html:78 covers/manage.html:51
-#: databarAuthor.html:66 databarEdit.html:13 lists/widget.html:340
-#: merge/authors.html:97 support.html:71
+#: EditButtons.html:23 EditButtonsMacros.html:26 ReadingLogDropper.html:167
+#: account/create.html:90 account/notifications.html:59
+#: account/password/reset.html:24 account/privacy.html:56
+#: admin/imports-add.html:28 books/add.html:108 books/edit/addfield.html:87
+#: books/edit/addfield.html:133 books/edit/addfield.html:177 covers/add.html:79
+#: covers/manage.html:52 databarAuthor.html:66 databarEdit.html:13
+#: merge/authors.html:109 support.html:71
 msgid "Cancel"
 msgstr "Annuler"
+
+#: trending.html:10
+#, fuzzy
+msgid "Now"
+msgstr "non"
+
+#: admin/graphs.html:47 check_ins/check_in_form.html:71
+#: check_ins/check_in_prompt.html:36 trending.html:10
+msgid "Today"
+msgstr "Aujourd'hui"
+
+#: admin/graphs.html:48 trending.html:10
+msgid "This Week"
+msgstr "Cette semaine"
+
+#: stats/readinglog.html:20 stats/readinglog.html:37 stats/readinglog.html:54
+#: trending.html:10
+msgid "This Month"
+msgstr "Ce mois-ci"
+
+#: trending.html:10
+msgid "This Year"
+msgstr ""
+
+#: trending.html:10
+#, fuzzy
+msgid "All Time"
+msgstr "De tous les temps"
+
+#: home/index.html:27 trending.html:11
+msgid "Trending Books"
+msgstr "Les livres les plus populaires"
+
+#: trending.html:12
+msgid "See what readers from the community are adding to their bookshelves"
+msgstr ""
+
+#: ReadingLogDropper.html:27 ReadingLogDropper.html:66
+#: ReadingLogDropper.html:189 account/mybooks.html:75 account/sidebar.html:26
+#: trending.html:23
+msgid "Want to Read"
+msgstr "Envie de lire"
+
+#: ReadingLogDropper.html:25 ReadingLogDropper.html:74 account/books.html:33
+#: account/mybooks.html:74 account/readinglog_shelf_name.html:8
+#: account/sidebar.html:25 trending.html:23
+msgid "Currently Reading"
+msgstr "En cours de lecture"
+
+#: LoanReadForm.html:9 ReadButton.html:19
+#: book_providers/gutenberg_read_button.html:15
+#: book_providers/openstax_read_button.html:15
+#: book_providers/standard_ebooks_read_button.html:15
+#: books/edit/edition.html:665 books/show.html:34 trending.html:23
+#: type/list/embed.html:69 widget.html:34
+msgid "Read"
+msgstr "Lire"
+
+#: trending.html:24
+#, python-format
+msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
+msgstr ""
+
+#: trending.html:26
+#, python-format
+msgid "Logged %(count)i times %(time_unit)s"
+msgstr ""
 
 #: viewpage.html:13
 msgid "Revert to this revision?"
@@ -642,19 +729,13 @@ msgstr "Revenir à cette version"
 msgid "Read \"%(title)s\""
 msgstr "Lire « %(title)s »"
 
-#: LoanReadForm.html:9 ReadButton.html:19
-#: book_providers/gutenberg_read_button.html:15
-#: book_providers/standard_ebooks_read_button.html:15 books/show.html:34
-#: type/list/embed.html:68 widget.html:34
-msgid "Read"
-msgstr "Lire"
-
 #: widget.html:39
 #, python-format
 msgid "Borrow \"%(title)s\""
 msgstr "Emprunter « %(title)s »"
 
-#: ReadButton.html:15 type/list/embed.html:79 widget.html:39
+#: ReadButton.html:15 books/edit/edition.html:668 type/list/embed.html:80
+#: widget.html:39
 msgid "Borrow"
 msgstr "Emprunter"
 
@@ -663,7 +744,7 @@ msgstr "Emprunter"
 msgid "Join waitlist for &quot;%(title)s&quot;"
 msgstr "Rejoindre la liste d'attente pour « %(title)s »"
 
-#: LoanStatus.html:98 widget.html:45
+#: LoanStatus.html:112 widget.html:45
 msgid "Join Waitlist"
 msgstr "Réserver"
 
@@ -672,7 +753,7 @@ msgstr "Réserver"
 msgid "Learn more about &quot;%(title)s&quot; at OpenLibrary"
 msgstr "En savoir plus sur « %(title)s » à OpenLibrary"
 
-#: LoanStatus.html:117 widget.html:49
+#: widget.html:49
 msgid "Learn More"
 msgstr "En savoir plus"
 
@@ -680,287 +761,247 @@ msgstr "En savoir plus"
 msgid "on "
 msgstr "sur "
 
-#: search/authors.html:37 search/subjects.html:27 work_search.html:58
-#: work_search.html:169
+#: work_search.html:68
+#, fuzzy
+msgid "Search Books"
+msgstr "%s livre"
+
+#: work_search.html:72
+msgid "eBook?"
+msgstr "livre électronique ?"
+
+#: type/edition/view.html:246 type/work/view.html:246 work_search.html:73
+msgid "Language"
+msgstr "Langue"
+
+#: books/add.html:42 books/edit.html:92 books/edit/edition.html:245
+#: lib/nav_head.html:93 merge_queue/merge_queue.html:77
+#: search/advancedsearch.html:24 work_search.html:74 work_search.html:164
+msgid "Author"
+msgstr "Auteur"
+
+#: work_search.html:76
+msgid "First published"
+msgstr "Première publication"
+
+#: search/advancedsearch.html:44 type/edition/view.html:231
+#: type/work/view.html:231 work_search.html:77
+msgid "Publisher"
+msgstr "Éditeur"
+
+#: work_search.html:81
+msgid "Classic eBooks"
+msgstr "Livres électroniques classiques"
+
+#: work_search.html:89
+msgid "Keywords"
+msgstr "Mots-clés"
+
+#: recentchanges/index.html:60 work_search.html:94
+msgid "Everything"
+msgstr "Tout"
+
+#: work_search.html:96
+msgid "Ebooks"
+msgstr "Livres électroniques"
+
+#: work_search.html:98
+msgid "Print Disabled"
+msgstr "Malvoyant"
+
+#: work_search.html:101
+msgid "This is only visible to super librarians."
+msgstr ""
+
+#: work_search.html:107
+msgid "Solr Editions <i>Beta</i>"
+msgstr ""
+
+#: work_search.html:124
+msgid "eBook"
+msgstr "livre électronique"
+
+#: work_search.html:127
+msgid "Classic eBook"
+msgstr "Livre électronique classique"
+
+#: work_search.html:146
+msgid "Explore Classic eBooks"
+msgstr "Parcourir les livres électroniques classiques"
+
+#: work_search.html:146
+msgid "Only Classic eBooks"
+msgstr "Seulement les livres électroniques classiques"
+
+#: work_search.html:150 work_search.html:152 work_search.html:154
+#: work_search.html:156
+#, python-format
+msgid "Explore books about %(subject)s"
+msgstr "Parcourir les livres sur %(subject)s"
+
+#: merge/authors.html:88 work_search.html:158
+msgid "First published in"
+msgstr "Première publication en"
+
+#: work_search.html:160
+msgid "Written in"
+msgstr "Écrit en"
+
+#: work_search.html:162
+msgid "Published by"
+msgstr "Publié par"
+
+#: work_search.html:165
+msgid "Click to remove this facet"
+msgstr "Cliquez pour supprimer ce volet"
+
+#: work_search.html:167
+#, python-format
+msgid "%(title)s - search"
+msgstr "%(title)s - recherche"
+
+#: search/lists.html:29 work_search.html:181
+msgid "No results found."
+msgstr "Aucun résultat trouvé."
+
+#: search/lists.html:30 work_search.html:184
+#, python-format
+msgid "Search for books containing the phrase \"%s\"?"
+msgstr "Rechercher des livres contenant la phrase « %s » ?"
+
+#: work_search.html:188
+#, fuzzy
+msgid "Add a new book to Open Library?"
+msgstr "Ajouter un nouveau livre à Open Library"
+
+#: account/reading_log.html:40 search/authors.html:44 search/subjects.html:35
+#: work_search.html:194
 #, python-format
 msgid "1 hit"
 msgid_plural "%(count)s hits"
 msgstr[0] "1 résultat"
 msgstr[1] "%(count)s résultats"
 
-#: lib/nav_foot.html:30 lib/nav_head.html:35 search/advancedsearch.html:7
-#: search/advancedsearch.html:10 search/advancedsearch.html:14
-#: work_search.html:62
-msgid "Advanced Search"
-msgstr "Recherche avancée"
-
-#: work_search.html:66
-msgid "eBook?"
-msgstr "livre électronique ?"
-
-#: books/add.html:34 books/edit.html:85 books/edit/edition.html:244
-#: lib/nav_head.html:82 lib/search_foot.html:9 lib/search_head.html:9
-#: search/advancedsearch.html:20 work_search.html:67 work_search.html:147
-msgid "Author"
-msgstr "Auteur"
-
-#: work_search.html:72
-msgid "First published"
-msgstr "Première publication"
-
-#: lib/search_foot.html:14 lib/search_head.html:14
-#: search/advancedsearch.html:40 work_search.html:73
-msgid "Publisher"
-msgstr "Éditeur"
-
-#: lib/search_foot.html:29 work_search.html:74
-msgid "Language"
-msgstr "Langue"
-
-#: work_search.html:75
-msgid "Classic eBooks"
-msgstr "Livres électroniques classiques"
-
-#: work_search.html:82
-msgid "Keywords"
-msgstr "Mots-clés"
-
-#: recentchanges/index.html:60 work_search.html:87
-msgid "Everything"
-msgstr "Tout"
-
-#: work_search.html:89
-msgid "Ebooks"
-msgstr "Livres électroniques"
-
-#: work_search.html:91
-msgid "Print Disabled"
-msgstr "Malvoyant"
-
-#: work_search.html:107
-msgid "eBook"
-msgstr "livre électronique"
-
-#: work_search.html:110
-msgid "Classic eBook"
-msgstr "Livre électronique classique"
-
-#: work_search.html:129
-msgid "Explore Classic eBooks"
-msgstr "Parcourir les livres électroniques classiques"
-
-#: work_search.html:129
-msgid "Only Classic eBooks"
-msgstr "Seulement les livres électroniques classiques"
-
-#: work_search.html:133 work_search.html:135 work_search.html:137
-#: work_search.html:139
-#, python-format
-msgid "Explore books about %(subject)s"
-msgstr "Parcourir les livres sur %(subject)s"
-
-#: merge/authors.html:84 work_search.html:141
-msgid "First published in"
-msgstr "Première publication en"
-
-#: work_search.html:143
-msgid "Written in"
-msgstr "Écrit en"
-
-#: work_search.html:145
-msgid "Published by"
-msgstr "Publié par"
-
-#: work_search.html:148
-msgid "Click to remove this facet"
-msgstr "Cliquez pour supprimer ce volet"
-
-#: work_search.html:150
-#, python-format
-msgid "%(title)s - search"
-msgstr "%(title)s - recherche"
-
-#: search/lists.html:29 work_search.html:164
-msgid "No results found."
-msgstr "Aucun résultat trouvé."
-
-#: search/lists.html:30 work_search.html:165
-#, python-format
-msgid "Search for books containing the phrase \"%s\"?"
-msgstr "Rechercher des livres contenant la phrase « %s » ?"
-
-#: work_search.html:194
+#: work_search.html:225
 msgid "Zoom In"
 msgstr "Zoomer"
 
-#: work_search.html:195
+#: work_search.html:226
 msgid "Focus your results using these"
 msgstr "Affinez les résultats avec ces"
 
-#: work_search.html:195
+#: work_search.html:226
 msgid "filters"
 msgstr "filtres"
 
-#: work_search.html:207
+#: search/facet_section.html:20 work_search.html:238
 msgid "Merge duplicate authors from this search"
 msgstr "Fusionner les auteurs en double de cette recherche"
 
-#: type/work/editions.html:17 work_search.html:207
+#: search/facet_section.html:20 type/work/editions.html:17 work_search.html:238
 msgid "Merge duplicates"
 msgstr "Fusionner les doublons"
 
-#: work_search.html:219
+#: search/facet_section.html:32 work_search.html:250
 msgid "yes"
 msgstr "oui"
 
-#: work_search.html:221
+#: search/facet_section.html:34 work_search.html:252
 msgid "no"
 msgstr "non"
 
-#: work_search.html:222
+#: search/facet_section.html:35 work_search.html:253
 msgid "Filter results for ebook availability"
 msgstr "Filtrer les résultats par disponibilité de livres électroniques"
 
-#: work_search.html:224
+#: search/facet_section.html:37 work_search.html:255
 #, python-format
 msgid "Filter results for %(facet)s"
 msgstr "Filtrer les résultats pour %(facet)s"
 
-#: work_search.html:229
+#: search/facet_section.html:42 work_search.html:260
 msgid "more"
 msgstr "plus"
 
-#: work_search.html:233
+#: search/facet_section.html:46 work_search.html:264
 msgid "less"
 msgstr "moins"
 
-#: account/books.html:24 account/books.html:69 type/user/view.html:50
+#: account/books.html:27 account/sidebar.html:24 type/user/view.html:50
 #: type/user/view.html:55
 msgid "Reading Log"
 msgstr "Journal de lecture"
 
-#: account/books.html:28 account/books.html:83
-msgid "Sponsorships"
-msgstr "Parrainages"
+#: account/books.html:31 lib/nav_head.html:13 lib/nav_head.html:25
+#: lib/nav_head.html:76
+#, fuzzy
+msgid "My Books"
+msgstr "Livres électroniques"
 
-#: account/books.html:30
-msgid "Book Notes"
-msgstr "Notes de livre"
-
-#: EditionNavBar.html:20 account/books.html:32 account/observations.html:33
-msgid "Reviews"
-msgstr "Critiques"
-
-#: account/books.html:34
-msgid "Books You've Checked Out"
-msgstr "Livres que vous avez empruntés"
-
-#: account/books.html:36
-msgid "Books You're Waiting For"
-msgstr "Livres que vous attendez"
-
-#: account/books.html:38
-msgid "Imports and Exports"
-msgstr "Imports et exports"
-
-#: account/books.html:40 lib/nav_head.html:12
-msgid "My Lists"
-msgstr "Mes listes"
-
-#: account/books.html:52 admin/menu.html:22 admin/people/view.html:225
-#: lib/search_head.html:69 type/user/view.html:29
-msgid "Loans"
-msgstr "Emprunts"
-
-#: account/books.html:55 type/list/embed.html:74
-msgid "Checked out"
-msgstr "Emprunté"
-
-#: account/books.html:60
-msgid "Waitlist"
-msgstr "Liste d'attente"
-
-#: account/books.html:64
-msgid "Loan History"
-msgstr "Historique d'emprunt"
-
-#: ReadingLogButton.html:9 account/books.html:70
-#: account/readinglog_shelf_name.html:8 lists/widget.html:128
-msgid "Currently Reading"
-msgstr "En cours de lecture"
-
-#: ReadingLogButton.html:9 account/books.html:71 lists/widget.html:130
-#: lists/widget.html:170 lists/widget.html:285
-msgid "Want to Read"
+#: account/books.html:35 account/readinglog_shelf_name.html:10
+msgid "Want To Read"
 msgstr "Envie de lire"
 
-#: ReadingLogButton.html:9 account/books.html:72
-#: account/readinglog_shelf_name.html:12 lists/widget.html:126
-#: lists/widget.html:190
+#: ReadingLogDropper.html:23 ReadingLogDropper.html:82 account/books.html:37
+#: account/mybooks.html:76 account/readinglog_shelf_name.html:12
+#: account/sidebar.html:27
 msgid "Already Read"
 msgstr "Déjà lu"
 
-#: account/books.html:75
-msgid "My Notes"
-msgstr "Mes notes"
+#: account/books.html:40 account/sidebar.html:38
+msgid "Sponsorships"
+msgstr "Parrainages"
 
-#: account/books.html:76
-msgid "My Reviews"
-msgstr "Mes critiques"
+#: account/books.html:42
+msgid "Book Notes"
+msgstr "Notes de livre"
 
-#: account/books.html:78
-msgid "Reading Stats"
-msgstr "Statistiques de lecture"
+#: EditionNavBar.html:26 account/books.html:44 account/observations.html:33
+msgid "Reviews"
+msgstr "Critiques"
+
+#: account/books.html:46 account/sidebar.html:19 admin/menu.html:22
+#: admin/people/view.html:233 type/user/view.html:29
+msgid "Loans"
+msgstr "Emprunts"
+
+#: account/books.html:48
+msgid "Imports and Exports"
+msgstr "Imports et exports"
+
+#: account/books.html:50
+msgid "My Lists"
+msgstr "Mes listes"
 
 #: account/books.html:79
-msgid "Import & Export Options"
-msgstr "Options d'import et d'export"
-
-#: account/books.html:87
-msgid "Sponsoring"
-msgstr "Parrainage"
-
-#: account/books.html:91 lib/nav_head.html:31 lib/nav_head.html:85
-#: lib/search_head.html:70 lists/home.html:7 lists/home.html:10
-#: lists/widget.html:261 recentchanges/index.html:41 search/lists.html:10
-#: type/list/embed.html:27 type/list/view_body.html:47 type/user/view.html:35
-#: type/user/view.html:66
-msgid "Lists"
-msgstr "Listes"
-
-#: account/books.html:91
-msgid "See All"
-msgstr "Tout voir"
-
-#: account/books.html:117
 msgid "View stats about this shelf"
 msgstr "Voir les statistiques de cette étagère"
 
-#: account/books.html:117 account/readinglog_stats.html:93 admin/index.html:19
+#: account/books.html:79 account/readinglog_stats.html:93 admin/index.html:19
 msgid "Stats"
 msgstr "Statistiques"
 
-#: account/books.html:123
+#: account/books.html:85
 msgid "Your book notes are private and cannot be viewed by other patrons."
 msgstr ""
 "Vos notes de livre sont privées et ne peuvent être vues par d'autres "
 "utilisateurs."
 
-#: account/books.html:125
+#: account/books.html:87
 msgid "Your book reviews will be shared anonymously with other patrons."
 msgstr ""
 "Vos critiques de livre seront partagées anonymement avec les autres "
 "utilisateurs."
 
-#: account/books.html:128
+#: account/books.html:90
 msgid "Your reading log is currently set to public"
 msgstr "Votre journal de lecture est publique"
 
-#: account/books.html:131
+#: account/books.html:93
 msgid "Your reading log is currently set to private"
 msgstr "Votre journal de lecture est privé"
 
-#: account/books.html:133 type/user/view.html:57
+#: account/books.html:95 type/user/view.html:57
 msgid "Manage your privacy settings"
 msgstr "Gérer vos paramètres de confidentialité"
 
@@ -968,30 +1009,30 @@ msgstr "Gérer vos paramètres de confidentialité"
 msgid "Sign Up to Open Library"
 msgstr "S'enregistrer sur Open Library"
 
-#: account/create.html:12 account/create.html:85 lib/header_dropdown.html:47
-#: lib/nav_head.html:108 lib/search_head.html:78
+#: account/create.html:12 account/create.html:89 lib/header_dropdown.html:60
+#: lib/nav_head.html:119
 msgid "Sign Up"
 msgstr "S'enregistrer"
 
-#: account/create.html:14
+#: account/create.html:21
 msgid "Complete the form below to create a new Internet Archive account."
 msgstr ""
 "Remplissez le formulaire suivant pour créer un nouveau compte Internet "
 "Archive."
 
-#: account/create.html:15
+#: account/create.html:22
 msgid "Each field is required"
 msgstr "Tous les champs sont obligatoires"
 
-#: account/create.html:56
+#: account/create.html:60
 msgid "Your URL"
 msgstr "Votre URL"
 
-#: account/create.html:56
+#: account/create.html:60
 msgid "screenname"
 msgstr "nom_dutilisateur"
 
-#: account/create.html:73
+#: account/create.html:77
 msgid ""
 "If you have security settings or privacy blockers installed, please "
 "disable them to see the reCAPTCHA."
@@ -999,11 +1040,11 @@ msgstr ""
 "Si vous avez des paramètres de sécurité ou des outils de confidentialité,"
 " veuillez les désactiver pour voir le reCAPTCHA."
 
-#: account/create.html:77
+#: account/create.html:81
 msgid "Incorrect. Please try again."
 msgstr "Incorrect. Veuillez réessayer."
 
-#: account/create.html:81
+#: account/create.html:85
 msgid ""
 "By signing up, you agree to the Internet Archive's <a "
 "href='//archive.org/about/terms.php' target='_blank'>Terms of "
@@ -1037,36 +1078,188 @@ msgstr "Charger les livres"
 msgid "Export your Reading Log"
 msgstr "Exporter votre journal de lecture"
 
-#: account/import.html:31
+#: account/import.html:28
+msgid "Download a copy of your reading log."
+msgstr ""
+
+#: account/import.html:28
+msgid "What is this?"
+msgstr ""
+
+#: account/import.html:33 account/import.html:44 account/import.html:55
+#: account/import.html:66 account/import.html:77
 msgid "Download (.csv format)"
 msgstr "Télécharger (format .csv)"
 
-#: account/loans.html:61
+#: account/import.html:38
+#, fuzzy
+msgid "Export your book notes"
+msgstr "Mettre à jour ma note de livre"
+
+#: account/import.html:39
+msgid "Download a copy of your book notes."
+msgstr ""
+
+#: account/import.html:39
+#, fuzzy
+msgid "What are book notes?"
+msgstr "Ajouter une note de livre"
+
+#: account/import.html:49
+#, fuzzy
+msgid "Export your reviews"
+msgstr "Exporter votre journal de lecture"
+
+#: account/import.html:50
+msgid "Download a copy of your review tags."
+msgstr ""
+
+#: account/import.html:50
+msgid "What are review tags?"
+msgstr ""
+
+#: account/import.html:60
+msgid "Export your list overview"
+msgstr ""
+
+#: account/import.html:61
+msgid "Download a summary of your lists and their contents."
+msgstr ""
+
+#: account/import.html:61
+msgid "What are lists?"
+msgstr ""
+
+#: account/import.html:71
+#, fuzzy
+msgid "Export your star ratings"
+msgstr "Exporter votre journal de lecture"
+
+#: account/import.html:72
+msgid "Download a copy of your star ratings"
+msgstr ""
+
+#: account/import.html:72
+msgid "What are star ratings?"
+msgstr ""
+
+#: account/loans.html:54
 msgid "You've not checked out any books at this moment."
 msgstr "Vous n'avez emprunté aucun livre pour le moment."
 
-#: account/loans.html:72
+#: account/loans.html:66
 msgid "Loan actions"
 msgstr "Actions d'emprunt"
 
-#: ManageLoansButtons.html:13 account/loans.html:99
+#: ManageLoansButtons.html:13 account/loans.html:93
 #, python-format
 msgid "There is one person waiting for this book."
 msgid_plural "There are %(n)d people waiting for this book."
 msgstr[0] "Il y a une personne qui attend ce livre."
 msgstr[1] "Il y a %(n)d personnes qui attendent ce livre."
 
-#: account/loans.html:105
+#: account/loans.html:99
 msgid "Not yet downloaded."
 msgstr "Pas encore téléchargé."
 
-#: account/loans.html:106
+#: account/loans.html:100
 msgid "Download Now"
 msgstr "Télécharger maintenant"
 
-#: account/loans.html:115
+#: account/loans.html:109
 msgid "Return via<br/>Adobe Digital Editions"
 msgstr "Rendre via<br/>Adobe Digital Editions"
+
+#: account/loans.html:120
+msgid "Books You're Waiting For"
+msgstr "Livres que vous attendez"
+
+#: account/loans.html:127
+msgid "You are not waiting for any books at this moment."
+msgstr "Vous n'attendez aucun livre pour le moment."
+
+#: account/loans.html:130
+msgid "Leave the Waiting List"
+msgstr "Quitter la liste d'attente"
+
+#: account/loans.html:130
+msgid ""
+"Are you sure you want to leave the waiting list "
+"of<br/><strong>TITLE</strong>?"
+msgstr ""
+"Voulez-vous vraiment quitter la liste d'attente de "
+"<br/><strong>TITLE</strong> ?"
+
+#: account/loans.html:149 admin/loans_table.html:43 admin/menu.html:33
+#: merge_queue/merge_queue.html:59
+msgid "Status"
+msgstr "Statut"
+
+#: RecentChangesAdmin.html:23 account/loans.html:150 admin/loans_table.html:47
+msgid "Actions"
+msgstr "Actions"
+
+#: account/loans.html:172
+#, python-format
+msgid "Waiting for 1 day"
+msgid_plural "Waiting for %(count)d days"
+msgstr[0] "En attente depuis 1 jour"
+msgstr[1] "En attente depuis %(count)d jours"
+
+#: account/loans.html:179
+msgid "You are the next person to receive this book."
+msgstr "Vous êtes la prochaine personne à recevoir ce livre."
+
+#: ManageWaitlistButton.html:21 account/loans.html:181
+#, python-format
+msgid "There is one person ahead of you in the waiting list."
+msgid_plural "There are %(count)d people ahead of you in the waiting list."
+msgstr[0] "Il y a une personne devant vous sur la liste d'attente."
+msgstr[1] "Il y a %(count)d personnes devant vous sur la liste d'attente."
+
+#: account/loans.html:190
+msgid "You have less than an hour to borrow it."
+msgstr "Vous avez moins d'une heure pour l'emprunter."
+
+#: account/loans.html:192
+#, python-format
+msgid "You have one more hour to borrow it."
+msgid_plural "You have %(hours)d more hours to borrow it."
+msgstr[0] "Vous avez encore une heure pour l'emprunter."
+msgstr[1] "Vous avez %(hours)d heures supplémentaires pour l'emprunter."
+
+#: account/loans.html:199
+msgid "Borrow Now"
+msgstr "Emprunter maintenant"
+
+#: account/loans.html:204
+msgid "Leave the waiting list?"
+msgstr "Quitter la liste d'attente ?"
+
+#: account/loans.html:218 home/index.html:34
+msgid "Books We Love"
+msgstr "Livres que nous aimons"
+
+#: account/mybooks.html:19 account/sidebar.html:33
+msgid "My Reading Stats"
+msgstr "Mes statistiques de lecture"
+
+#: account/mybooks.html:23 account/sidebar.html:34
+msgid "Import & Export Options"
+msgstr "Options d'import et d'export"
+
+#: account/mybooks.html:35
+#, python-format
+msgid "Set %(year_span)s reading goal"
+msgstr ""
+
+#: account/mybooks.html:69
+msgid "No books are on this shelf"
+msgstr "Aucun livre n'est sur cette étagère"
+
+#: account/mybooks.html:73
+msgid "My Loans"
+msgstr "Mes emprunts"
 
 #: account/not_verified.html:7 account/not_verified.html:18
 #: account/verify/failed.html:10
@@ -1077,7 +1270,7 @@ msgstr "Oups !"
 msgid "Resend the verification email"
 msgstr "Renvoyer le courriel de vérification"
 
-#: SearchResultsWork.html:57 SearchResultsWork.html:63 account/notes.html:25
+#: BookByline.html:10 SearchResultsWork.html:68 account/notes.html:25
 #: account/observations.html:26
 msgid "Unknown author"
 msgstr "Auteur inconnu"
@@ -1094,21 +1287,21 @@ msgstr "Titre manquant"
 msgid "Publish date unknown"
 msgstr "Date de publication inconnue"
 
-#: account/notes.html:48 books/edition-sort.html:58 books/works-show.html:30
+#: account/notes.html:48 books/edition-sort.html:63 books/works-show.html:30
 #: type/work/editions.html:38
 msgid "Publisher unknown"
 msgstr "Éditeur inconnu"
 
-#: account/notes.html:53 type/work/editions.html:47
+#: account/notes.html:53
 #, python-format
 msgid "in %(language)s"
 msgstr "en %(language)s"
 
-#: NotesModal.html:40 account/notes.html:66
+#: NotesModal.html:42 account/notes.html:66
 msgid "Delete Note"
 msgstr "Supprimer la note"
 
-#: NotesModal.html:41 account/notes.html:67
+#: NotesModal.html:43 account/notes.html:67
 msgid "Save Note"
 msgstr "Enregistrer la note"
 
@@ -1149,7 +1342,7 @@ msgid "Yes! Please!"
 msgstr "Oui, avec plaisir !"
 
 #: EditButtons.html:21 EditButtonsMacros.html:24 account/notifications.html:57
-#: account/privacy.html:54 covers/manage.html:50
+#: account/privacy.html:54 covers/manage.html:51
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -1161,7 +1354,7 @@ msgstr "Supprimer"
 msgid "Update Reviews"
 msgstr "Mettre à jour les critiques"
 
-#: account/observations.html:50
+#: account/observations.html:52
 msgid "No observations found."
 msgstr "Aucune critique trouvée."
 
@@ -1177,7 +1370,7 @@ msgstr "Paramètres de confidentialité"
 msgid "Yes"
 msgstr "Oui"
 
-#: account/privacy.html:46 books/edit/edition.html:305
+#: account/privacy.html:46 books/edit/edition.html:306
 msgid "No"
 msgstr "Non"
 
@@ -1229,25 +1422,33 @@ msgstr ""
 msgid "Books %(userdisplayname)s is sponsoring"
 msgstr "Livres parrainés par %(userdisplayname)s"
 
-#: account/reading_log.html:32 search/sort_options.html:7
+#: account/reading_log.html:34
+#, fuzzy
+msgid "Search your reading log"
+msgstr "Exporter votre journal de lecture"
+
+#: account/reading_log.html:42 search/sort_options.html:8
 msgid "Sorting by"
 msgstr "Trier par"
 
-#: account/reading_log.html:34 account/reading_log.html:38
+#: account/reading_log.html:44 account/reading_log.html:48
 msgid "Date Added (newest)"
 msgstr "Date d'ajout (la plus récente)"
 
-#: account/reading_log.html:36 account/reading_log.html:40
+#: account/reading_log.html:46 account/reading_log.html:50
 msgid "Date Added (oldest)"
 msgstr "Date d'ajout (la plus ancienne)"
 
-#: account/reading_log.html:53
-msgid "No books are on this shelf"
-msgstr "Aucun livre n'est sur cette étagère"
+#: account/reading_log.html:70
+#, fuzzy
+msgid "You haven't added any books to this shelf yet."
+msgstr "Vous n'avez emprunté aucun livre pour le moment."
 
-#: account/readinglog_shelf_name.html:10
-msgid "Want To Read"
-msgstr "Envie de lire"
+#: account/reading_log.html:71
+msgid ""
+"<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
+"href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
+msgstr ""
 
 #: account/readinglog_stats.html:8 account/readinglog_stats.html:95
 #, python-format
@@ -1326,78 +1527,48 @@ msgstr "Œuvres correspondantes"
 msgid "Click on a bar to see matching works"
 msgstr "Cliquez sur une barre pour voir des œuvres correspondantes"
 
+#: account/sidebar.html:20
+msgid "Loan History"
+msgstr "Historique d'emprunt"
+
+#: account/sidebar.html:30
+msgid "My Notes"
+msgstr "Mes notes"
+
+#: account/sidebar.html:31
+msgid "My Reviews"
+msgstr "Mes critiques"
+
+#: account/sidebar.html:42
+msgid "Sponsoring"
+msgstr "Parrainage"
+
+#: EditionNavBar.html:30 SearchNavigation.html:28 account/sidebar.html:45
+#: lib/nav_head.html:31 lib/nav_head.html:96 lists/home.html:7
+#: lists/home.html:10 lists/widget.html:67 recentchanges/index.html:41
+#: type/list/embed.html:28 type/list/view_body.html:48 type/user/view.html:35
+#: type/user/view.html:66
+msgid "Lists"
+msgstr "Listes"
+
+#: account/sidebar.html:45
+msgid "See All"
+msgstr "Tout voir"
+
+#: account/sidebar.html:47
+msgid "Untitled list"
+msgstr ""
+
 #: account/verify.html:7
 msgid "Verification email sent"
 msgstr "Courriel de vérification envoyé"
 
-#: account.py:422 account.py:460 account/password/reset_success.html:10
+#: account.py:419 account.py:457 account/password/reset_success.html:10
 #: account/verify.html:9 account/verify/activated.html:10
 #: account/verify/success.html:10
 #, python-format
 msgid "Hi, %(user)s"
 msgstr "Bonjour, %(user)s"
-
-#: account/waitlist.html:48
-msgid "You are not waiting for any books at this moment."
-msgstr "Vous n'attendez aucun livre pour le moment."
-
-#: account/waitlist.html:51
-msgid "Leave the Waiting List"
-msgstr "Quitter la liste d'attente"
-
-#: account/waitlist.html:51
-msgid ""
-"Are you sure you want to leave the waiting list "
-"of<br/><strong>TITLE</strong>?"
-msgstr ""
-"Voulez-vous vraiment quitter la liste d'attente de "
-"<br/><strong>TITLE</strong> ?"
-
-#: account/waitlist.html:70 admin/loans_table.html:43 admin/menu.html:33
-msgid "Status"
-msgstr "Statut"
-
-#: RecentChangesAdmin.html:23 account/waitlist.html:71
-#: admin/loans_table.html:47
-msgid "Actions"
-msgstr "Actions"
-
-#: account/waitlist.html:93
-#, python-format
-msgid "Waiting for 1 day"
-msgid_plural "Waiting for %(count)d days"
-msgstr[0] "En attente depuis 1 jour"
-msgstr[1] "En attente depuis %(count)d jours"
-
-#: account/waitlist.html:100
-msgid "You are the next person to receive this book."
-msgstr "Vous êtes la prochaine personne à recevoir ce livre."
-
-#: ManageWaitlistButton.html:21 account/waitlist.html:102
-#, python-format
-msgid "There is one person ahead of you in the waiting list."
-msgid_plural "There are %(count)d people ahead of you in the waiting list."
-msgstr[0] "Il y a une personne devant vous sur la liste d'attente."
-msgstr[1] "Il y a %(count)d personnes devant vous sur la liste d'attente."
-
-#: account/waitlist.html:111
-msgid "You have less than an hour to borrow it."
-msgstr "Vous avez moins d'une heure pour l'emprunter."
-
-#: account/waitlist.html:113
-#, python-format
-msgid "You have one more hour to borrow it."
-msgid_plural "You have %(hours)d more hours to borrow it."
-msgstr[0] "Vous avez encore une heure pour l'emprunter."
-msgstr[1] "Vous avez %(hours)d heures supplémentaires pour l'emprunter."
-
-#: account/waitlist.html:120
-msgid "Borrow Now"
-msgstr "Emprunter maintenant"
-
-#: account/waitlist.html:125
-msgid "Leave the waiting list?"
-msgstr "Quitter la liste d'attente ?"
 
 #: account/email/forgot-ia.html:10 account/email/forgot.html:10
 msgid "Forgot Your Internet Archive Email?"
@@ -1449,7 +1620,7 @@ msgid "Send It"
 msgstr "Envoyer"
 
 #: account/password/reset.html:7 account/password/reset.html:10
-#: admin/people/view.html:162
+#: admin/people/view.html:161
 msgid "Reset Password"
 msgstr "Réinitialiser le mot de passe"
 
@@ -1542,16 +1713,9 @@ msgstr "En attente de connexion du débogueur…"
 msgid "Start"
 msgstr "Démarrer"
 
-#: admin/graphs.html:47
-msgid "Today"
-msgstr "Aujourd'hui"
-
-#: admin/graphs.html:48
-msgid "This Week"
-msgstr "Cette semaine"
-
 #: admin/imports-add.html:26 admin/ip/view.html:95 admin/people/edits.html:92
-#: covers/add.html:77
+#: check_ins/check_in_form.html:77 check_ins/reading_goal_form.html:16
+#: covers/add.html:78
 msgid "Submit"
 msgstr "Envoyer"
 
@@ -1560,12 +1724,14 @@ msgid "BookReader"
 msgstr "Lecteur de livre"
 
 #: admin/loans_table.html:18 book_providers/ia_download_options.html:12
+#: book_providers/openstax_download_options.html:13 books/edit/edition.html:677
 msgid "PDF"
 msgstr "PDF"
 
 #: admin/loans_table.html:19 book_providers/gutenberg_download_options.html:17
 #: book_providers/ia_download_options.html:16
-#: book_providers/standard_ebooks_download_options.html:14
+#: book_providers/standard_ebooks_download_options.html:15
+#: books/edit/edition.html:676
 msgid "ePub"
 msgstr "ePub"
 
@@ -1622,7 +1788,7 @@ msgstr "Inspecter la base de données"
 msgid "Inspect memcache"
 msgstr "Inspecter memcache"
 
-#: admin/people/view.html:172 admin/profile.html:7
+#: admin/people/view.html:171 admin/profile.html:7
 msgid "Admin"
 msgstr "Administrateur"
 
@@ -1638,7 +1804,7 @@ msgstr "Écrire une entrée par ligne"
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: admin/waitinglists.html:29
+#: FormatExpiry.html:23 admin/waitinglists.html:29
 msgid "Expires"
 msgstr "Échéance"
 
@@ -1673,13 +1839,13 @@ msgid "Please, leave a short note about what you changed:"
 msgstr "Veuillez laisser une courte description de ce que vous avez modifié :"
 
 #: RecentChanges.html:61 RecentChangesAdmin.html:56 RecentChangesUsers.html:58
-#: admin/people/edits.html:100 recentchanges/render.html:61
+#: admin/people/edits.html:100 recentchanges/render.html:66
 msgid "Older"
 msgstr "Plus ancien"
 
 #: RecentChanges.html:64 RecentChangesAdmin.html:58 RecentChangesAdmin.html:60
 #: RecentChangesUsers.html:61 admin/people/edits.html:103
-#: recentchanges/render.html:64
+#: recentchanges/render.html:69
 msgid "Newer"
 msgstr "Plus récent"
 
@@ -1687,7 +1853,7 @@ msgstr "Plus récent"
 msgid "Find Account"
 msgstr "Trouver le compte"
 
-#: admin/people/index.html:32 admin/people/view.html:152
+#: admin/people/index.html:32 admin/people/view.html:151
 msgid "Email Address:"
 msgstr "Adresse de courriel :"
 
@@ -1695,7 +1861,7 @@ msgstr "Adresse de courriel :"
 msgid "Recent Accounts"
 msgstr "Comptes récents"
 
-#: admin/people/index.html:58 type/author/edit.html:26
+#: admin/people/index.html:58 type/author/edit.html:32
 #: type/language/view.html:27
 msgid "Name"
 msgstr "Nom"
@@ -1708,57 +1874,66 @@ msgstr "courriel"
 msgid "Edits"
 msgstr "Modifications"
 
-#: admin/people/index.html:75 admin/people/view.html:239
+#: admin/people/index.html:75 admin/people/view.html:247
 msgid "Edit History"
 msgstr "Modifier l'historique"
 
-#: admin/people/view.html:148 lists/widget.html:322
+#: ReadingLogDropper.html:149 admin/people/view.html:147
 msgid "Name:"
 msgstr "Nom :"
 
-#: admin/people/view.html:174
+#: admin/people/view.html:173
 msgid "Bot"
 msgstr "Bot"
 
-#: admin/people/view.html:192
+#: admin/people/view.html:191
 msgid "# Edits"
 msgstr "# Modifications"
 
-#: admin/people/view.html:196
+#: admin/people/view.html:195
 msgid "Member Since:"
 msgstr "Membre depuis :"
 
-#: admin/people/view.html:205
+#: admin/people/view.html:204
 msgid "Last Login:"
 msgstr "Dernière connexion :"
 
-#: admin/people/view.html:214
+#: admin/people/view.html:213
 msgid "Tags:"
 msgstr "Étiquettes :"
 
-#: admin/people/view.html:235
+#: admin/people/view.html:221
+#, fuzzy
+msgid "Anonymize Account:"
+msgstr "Un commentaire anonyme :"
+
+#: admin/people/view.html:226
+msgid "Anonymize Account"
+msgstr ""
+
+#: admin/people/view.html:243
 msgid "Waiting Loans"
 msgstr "Emprunts en attente"
 
-#: admin/people/view.html:248
+#: admin/people/view.html:256
 msgid "Debug Info"
 msgstr "Info de débogage"
 
-#: authors/index.html:8 authors/index.html:11 lib/nav_foot.html:27
-#: merge/authors.html:53 publishers/view.html:87
+#: SearchNavigation.html:16 authors/index.html:9 authors/index.html:12
+#: lib/nav_foot.html:27 merge/authors.html:57 publishers/view.html:87
 msgid "Authors"
 msgstr "Auteurs"
 
-#: authors/index.html:17
+#: authors/index.html:18
 msgid "Search for an Author"
 msgstr "Rechercher un auteur"
 
-#: authors/index.html:38 search/authors.html:76
+#: authors/index.html:39 search/authors.html:69
 #, python-format
 msgid "about %(subjects)s"
 msgstr "au sujet de %(subjects)s"
 
-#: authors/index.html:39 search/authors.html:77
+#: authors/index.html:40 search/authors.html:70
 #, python-format
 msgid "including <i>%(topwork)s</i>"
 msgstr "dont <i>%(topwork)s</i>"
@@ -1766,7 +1941,8 @@ msgstr "dont <i>%(topwork)s</i>"
 #: book_providers/gutenberg_download_options.html:11
 #: book_providers/ia_download_options.html:9
 #: book_providers/librivox_download_options.html:9
-#: book_providers/standard_ebooks_download_options.html:11
+#: book_providers/openstax_download_options.html:11
+#: book_providers/standard_ebooks_download_options.html:12
 msgid "Download Options"
 msgstr "Options de téléchargement"
 
@@ -1775,7 +1951,7 @@ msgid "Download an HTML from Project Gutenberg"
 msgstr "Télécharger un fichier HTML de Project Gutenberg"
 
 #: book_providers/gutenberg_download_options.html:15
-#: book_providers/standard_ebooks_download_options.html:13
+#: book_providers/standard_ebooks_download_options.html:14
 msgid "HTML"
 msgstr "HTML"
 
@@ -1824,18 +2000,21 @@ msgstr ""
 
 #: book_providers/gutenberg_read_button.html:22
 #: book_providers/librivox_read_button.html:25
+#: book_providers/openstax_read_button.html:22
 #: book_providers/standard_ebooks_read_button.html:22
 msgid "Learn more"
 msgstr "En savoir plus"
 
-#: BookPreview.html:19 DonateModal.html:15 NotesModal.html:30
-#: ObservationsModal.html:25 book_providers/gutenberg_read_button.html:24
+#: BookPreview.html:20 DonateModal.html:15 NotesModal.html:32
+#: ObservationsModal.html:32 ReadingLogDropper.html:144 ShareModal.html:25
+#: book_providers/gutenberg_read_button.html:24
 #: book_providers/librivox_read_button.html:27
+#: book_providers/openstax_read_button.html:24
 #: book_providers/standard_ebooks_read_button.html:24
 #: covers/author_photo.html:22 covers/book_cover.html:39
 #: covers/book_cover_single_edition.html:34 covers/book_cover_work.html:30
 #: covers/change.html:44 lib/markdown.html:12 lists/lists.html:53
-#: lists/widget.html:317
+#: merge_queue/merge_queue.html:121
 msgid "Close"
 msgstr "Fermer"
 
@@ -1863,7 +2042,7 @@ msgstr "MOBI"
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
 msgstr "Télécharger open DAISY d'Internet Archive (format pour malvoyant)"
 
-#: book_providers/ia_download_options.html:19 type/list/embed.html:84
+#: book_providers/ia_download_options.html:19 type/list/embed.html:85
 msgid "DAISY"
 msgstr "DAISY"
 
@@ -1907,40 +2086,62 @@ msgstr ""
 "approuvé de livres audio dans le domaine publique, narrés par des "
 "volontaires et distribués gratuitement sur internet."
 
-#: book_providers/standard_ebooks_download_options.html:13
+#: book_providers/openstax_download_options.html:13
+msgid "Download PDF from OpenStax"
+msgstr ""
+
+#: book_providers/openstax_download_options.html:14
+msgid "More at OpenStax"
+msgstr ""
+
+#: book_providers/openstax_read_button.html:10
+#, fuzzy
+msgid "Read eBook from OpenStax"
+msgstr "Lire le livre électronique depuis l'Internet Archive"
+
+#: book_providers/openstax_read_button.html:21
+msgid ""
+"This book is available from <a "
+"href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax is a trusted "
+"book provider and a 501(c)(3) nonprofit charitable corporation dedicated "
+"to providing free high-quality, peer-reviewed, openly licensed textbooks "
+"online."
+msgstr ""
+
+#: book_providers/standard_ebooks_download_options.html:14
 msgid "Download an HTML from Standard Ebooks"
 msgstr "Télécharger un fichier HTML de Standard Ebooks"
 
-#: book_providers/standard_ebooks_download_options.html:14
+#: book_providers/standard_ebooks_download_options.html:15
 msgid "Download an ePub from Standard Ebook."
 msgstr "Télécharger un ePub de Standard Ebook."
 
-#: book_providers/standard_ebooks_download_options.html:15
+#: book_providers/standard_ebooks_download_options.html:16
 msgid "Download a Kindle file from Standard Ebooks"
 msgstr "Télécharger un fichier Kindle de Standard Ebooks"
 
-#: book_providers/standard_ebooks_download_options.html:15
+#: book_providers/standard_ebooks_download_options.html:16
 msgid "Kindle (azw3)"
 msgstr "Kindle (azw3)"
 
-#: book_providers/standard_ebooks_download_options.html:16
+#: book_providers/standard_ebooks_download_options.html:17
 msgid "Download a Kobo file from Standard Ebooks"
 msgstr "Télécharger un fichier Kobo de Standard Ebooks"
 
-#: book_providers/standard_ebooks_download_options.html:16
+#: book_providers/standard_ebooks_download_options.html:17
 msgid "Kobo (kepub)"
 msgstr "Kobo (kepub)"
 
-#: book_providers/standard_ebooks_download_options.html:17
+#: book_providers/standard_ebooks_download_options.html:18
 msgid "View the source code for this Standard Ebook at GitHub"
 msgstr "Voir le code source de ce livre Standard Ebooks sur GitHub"
 
 #: Subnavigation.html:13
-#: book_providers/standard_ebooks_download_options.html:17
+#: book_providers/standard_ebooks_download_options.html:18
 msgid "Source Code"
 msgstr "Code source"
 
-#: book_providers/standard_ebooks_download_options.html:18
+#: book_providers/standard_ebooks_download_options.html:19
 msgid "More at Standard Ebooks"
 msgstr "Davantage à Standard Ebooks"
 
@@ -1963,15 +2164,46 @@ msgstr ""
 "dans le domaine publique qui sont mises en forme avec amour, ouvertes, "
 "libres de droits et gratuites."
 
+#: books/RelatedWorksCarousel.html:19
+msgid "You might also like"
+msgstr ""
+
+#: books/RelatedWorksCarousel.html:25
+#, fuzzy
+msgid "More by this author"
+msgid_plural "More by these authors"
+msgstr[0] "Supprimer cet auteur"
+msgstr[1] ""
+
 #: books/add.html:7 books/check.html:10
 msgid "Add a book"
 msgstr "Ajouter un livre"
 
+#: books/add.html:10
+msgid "Invalid ISBN checksum digit"
+msgstr ""
+
 #: books/add.html:11
+#, fuzzy
+msgid ""
+"ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or"
+" 0198534531"
+msgstr "L'identifiant doit contenir exactement 10 caractères de 0 à 9 ou X."
+
+#: books/add.html:12
+#, fuzzy
+msgid ""
+"ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
+"9783161484100"
+msgstr ""
+"L'identifiant doit contenir exactement 13 chiffres de 0 à 9. Par exemple "
+": 978-1-56619-909-4"
+
+#: books/add.html:17
 msgid "Add a book to Open Library"
 msgstr "Ajouter un livre à Open Library"
 
-#: books/add.html:13
+#: books/add.html:19
 msgid ""
 "We require a minimum set of fields to create a new record. These are "
 "those fields."
@@ -1979,14 +2211,26 @@ msgstr ""
 "Nous avons au moins besoin des champs suivants pour créer une nouvelle "
 "entrée."
 
-#: books/add.html:24 books/edit.html:79 books/edit/edition.html:95
-#: lib/nav_head.html:81 lib/search_foot.html:8 lib/search_head.html:8
-#: search/advancedsearch.html:16 type/about/edit.html:19 type/i18n/edit.html:64
-#: type/page/edit.html:20 type/rawtext/edit.html:18 type/template/edit.html:18
+#: books/add.html:31 books/edit.html:86 books/edit/edition.html:96
+#: lib/nav_head.html:92 search/advancedsearch.html:20 type/about/edit.html:19
+#: type/i18n/edit.html:64 type/page/edit.html:20 type/rawtext/edit.html:18
+#: type/template/edit.html:18
 msgid "Title"
 msgstr "Titre"
 
-#: books/add.html:34
+#: books/add.html:31 books/edit.html:86
+msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
+msgstr ""
+"Utilisez le format <b><i>Titre: Sous-titre</i></b> pour ajouter un sous-"
+"titre."
+
+#: books/add.html:31 books/add.html:48 books/add.html:57 books/edit.html:86
+#: books/edit/addfield.html:100 books/edit/addfield.html:145
+#: type/author/edit.html:35
+msgid "Required field"
+msgstr "Champ obligatoire"
+
+#: books/add.html:42
 msgid ""
 "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
 "check to see if we already know the author."
@@ -1994,19 +2238,23 @@ msgstr ""
 "Par exemple, « Agatha Christie » ou « Jean-Paul Sartre ». Nous "
 "vérifierons aussi à la volée si nous connaissons déjà cet auteur."
 
-#: books/add.html:39 books/edit/edition.html:118
+#: books/add.html:48 books/edit/edition.html:119
 msgid "Who is the publisher?"
 msgstr "Quel est l'éditeur ?"
 
-#: books/add.html:46 books/edit/edition.html:138
+#: books/add.html:48 books/edit/edition.html:120
+msgid "For example"
+msgstr "Par exemple"
+
+#: books/add.html:57 books/edit/edition.html:139
 msgid "When was it published?"
 msgstr "Quand a-t-il été publié ?"
 
-#: books/add.html:46
-msgid "The year it was published is plenty."
-msgstr "L'année de publication suffit."
+#: books/add.html:57 books/edit/edition.html:140
+msgid "You should be able to find this in the first few pages of the book."
+msgstr "Vous devriez pouvoir trouver cela dans les premières pages du livre."
 
-#: books/add.html:54
+#: books/add.html:66
 msgid ""
 "And optionally, an ID number &#151; like an ISBN &#151; would be "
 "helpful..."
@@ -2014,21 +2262,33 @@ msgstr ""
 "Et facultativement, un numéro d'identification &#151; comme un ISBN "
 "&#151; serait utile…"
 
-#: books/add.html:55
+#: books/add.html:67
 msgid "ID Type"
 msgstr "Type d'identifiant"
 
-#: books/add.html:58
+#: books/add.html:69
+msgid "ISBN may be invalid. Click \"Add\" again to submit."
+msgstr ""
+
+#: books/add.html:72
 msgid "Select"
 msgstr "Sélectionner"
 
-#: books/add.html:72
+#: books/add.html:87 books/edit/edition.html:652
+msgid "Book URL"
+msgstr ""
+
+#: books/add.html:87
+msgid "Only fill this out if this is a web book"
+msgstr ""
+
+#: books/add.html:96
 msgid "Since you are not logged in, please satisfy the reCAPTCHA below."
 msgstr ""
 "Comme vous n'êtes pas connecté, veuillez recopier le texte ou les "
 "chiffres suivants."
 
-#: EditButtons.html:17 EditButtonsMacros.html:20 books/add.html:79
+#: EditButtons.html:17 EditButtonsMacros.html:20 books/add.html:103
 msgid ""
 "By saving a change to this wiki, you agree that your contribution is "
 "given freely to the world under <a "
@@ -2042,12 +2302,12 @@ msgstr ""
 "target=\"_blank\" title=\"Ouvrir les termes de la Creative Commons dans "
 "une nouvelle fenêtre\">CC0</a>. Youpi !"
 
-#: books/add.html:82
+#: books/add.html:106
 msgid "Add this book now"
 msgstr "Ajouter ce livre maintenant"
 
-#: books/add.html:82 books/edit/addfield.html:85 books/edit/addfield.html:131
-#: books/edit/addfield.html:175 books/edit/edition.html:226
+#: books/add.html:106 books/edit/addfield.html:85 books/edit/addfield.html:131
+#: books/edit/addfield.html:175 books/edit/edition.html:227
 #: books/edit/edition.html:456 books/edit/edition.html:521
 #: books/edit/excerpts.html:50 covers/change.html:49
 msgid "Add"
@@ -2065,7 +2325,7 @@ msgstr "Supprimer cet auteur"
 msgid "Add another author?"
 msgstr "Ajouter un autre auteur ?"
 
-#: books/check.html:13 lib/nav_foot.html:41 lib/nav_head.html:23
+#: books/check.html:13 lib/nav_foot.html:41 lib/nav_head.html:38
 msgid "Add a Book"
 msgstr "Ajouter un livre"
 
@@ -2095,16 +2355,16 @@ msgstr "Choisir ce livre"
 msgid "First published in %(year)d"
 msgstr "Première publication en %(year)d"
 
-#: books/custom_carousel.html:33
+#: books/custom_carousel.html:41
 #, python-format
 msgid " by %(name)s"
 msgstr " par %(name)s"
 
-#: books/edit.html:28 books/edit.html:31 books/edit.html:34
+#: books/edit.html:30 books/edit.html:33 books/edit.html:36
 msgid "Add a little more?"
 msgstr "En dire un peu plus ?"
 
-#: books/edit.html:29
+#: books/edit.html:31
 msgid ""
 "Thank you for adding that book! Any more information you could provide "
 "would be wonderful!"
@@ -2112,7 +2372,7 @@ msgstr ""
 "Merci d'avoir ajouté ce livre ! Ce serait formidable si vous pouviez "
 "fournir plus d'informations !"
 
-#: books/edit.html:32
+#: books/edit.html:34
 #, python-format
 msgid ""
 "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
@@ -2123,7 +2383,7 @@ msgstr ""
 "%(publisher)s %(year)s</b>. Merci ! Que connaissez-vous de plus sur cette"
 " édition ?"
 
-#: books/edit.html:35
+#: books/edit.html:37
 #, python-format
 msgid ""
 "We already know about the <b>%(year)s %(publisher)s edition</b> of "
@@ -2132,39 +2392,28 @@ msgstr ""
 "Nous connaissons déjà l'<b>édition %(publisher)s %(year)s</b> de "
 "<b>%(work_title)s</b>, mais dites-nous en plus !"
 
-#: books/edit.html:37
+#: books/edit.html:39
 msgid "Editing..."
 msgstr "En cours de modification…"
 
-#: EditButtons.html:25 EditButtonsMacros.html:27 books/edit.html:41
+#: EditButtonsMacros.html:27 books/edit.html:45 type/author/edit.html:17
 #: type/template/edit.html:51
 msgid "Delete Record"
 msgstr "Supprimer l'entrée"
 
-#: books/edit.html:58
+#: books/edit.html:65
 msgid "Work Details"
 msgstr "Détails de l'œuvre"
 
-#: books/edit.html:63
+#: books/edit.html:70
 msgid "Unknown publisher edition"
 msgstr "Édition inconnue"
 
-#: books/edit.html:73
+#: books/edit.html:80
 msgid "This Work"
 msgstr "Cette œuvre"
 
-#: books/edit.html:79
-msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
-msgstr ""
-"Utilisez le format <b><i>Titre: Sous-titre</i></b> pour ajouter un sous-"
-"titre."
-
-#: books/edit.html:79 books/edit/addfield.html:100 books/edit/addfield.html:145
-#: type/author/edit.html:29
-msgid "Required field"
-msgstr "Champ obligatoire"
-
-#: books/edit.html:86
+#: books/edit.html:93
 msgid ""
 "You can search by author name (like <em>j k rowling</em>) or by Open "
 "Library ID (like <a href=\"/authors/OL23919A\" "
@@ -2174,80 +2423,87 @@ msgstr ""
 "rowling</em>) ou par identifiant Open Library (comme <a "
 "href=\"/authors/OL23919A\" target=\"_blank\"><em>OL23919A</em></a>)."
 
-#: books/edit.html:91
+#: books/edit.html:98
 msgid "Author editing requires javascript"
 msgstr "La modification d'auteur nécessite javascript"
 
-#: books/edit.html:104
+#: books/edit.html:111
 msgid "Add Excerpts"
 msgstr "Ajouter des extraits"
 
-#: books/edit.html:110 type/about/edit.html:39 type/author/edit.html:44
+#: books/edit.html:117 type/about/edit.html:39 type/author/edit.html:50
 msgid "Links"
 msgstr "Liens"
 
-#: books/edit/edition.html:65 books/edition-sort.html:37 lists/preview.html:9
-#: lists/snippet.html:9 lists/widget.html:89 type/work/editions.html:27
+#: SearchResultsWork.html:45 SearchResultsWork.html:46
+#: books/edit/edition.html:66 books/edition-sort.html:39
+#: books/edition-sort.html:40 lists/list_overview.html:11 lists/preview.html:9
+#: lists/snippet.html:9 lists/widget.html:83 type/work/editions.html:27
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr "Couverture de : %(title)s"
 
-#: books/edition-sort.html:44
+#: books/edition-sort.html:49
 #, python-format
 msgid "%(title)s: %(subtitle)s"
 msgstr "%(title)s : %(subtitle)s"
 
-#: books/edition-sort.html:56
+#: books/edition-sort.html:61
 #, python-format
 msgid "Publish date unknown, %(publisher)s"
 msgstr "Date de publication inconnue, %(publisher)s"
 
-#: books/edition-sort.html:66
+#: books/edition-sort.html:71 type/work/editions.html:47
 #, python-format
 msgid "in %(languagelist)s"
 msgstr "en %(languagelist)s"
 
-#: books/edition-sort.html:94
+#: books/edition-sort.html:99
 msgid "Libraries near you:"
 msgstr "Bibliothèques près de chez vous :"
 
-#: books/edit/about.html:10
+#: books/edit/about.html:21
+#, fuzzy
+msgid "Select this subject"
+msgstr "Choisir ce livre"
+
+#: books/edit/about.html:28
 msgid "How would you describe this book?"
 msgstr "Comment décririez-vous ce livre ?"
 
-#: books/edit/about.html:11
+#: books/edit/about.html:29
 msgid "There's no wrong answer here."
 msgstr "Il n'y a pas de mauvaise réponse ici."
 
-#: books/edit/about.html:20
+#: books/edit/about.html:38
 msgid "Subject keywords?"
 msgstr "Mots-clés du thème ?"
 
-#: books/edit/about.html:21
+#: books/edit/about.html:39
 msgid "Please separate with commas."
 msgstr "Veuillez les séparer par des virgules."
 
-#: books/edit/about.html:21 books/edit/about.html:35 books/edit/about.html:49
-#: books/edit/about.html:63 books/edit/addfield.html:77
+#: books/edit/about.html:39 books/edit/about.html:50 books/edit/about.html:61
+#: books/edit/about.html:72 books/edit/addfield.html:77
 #: books/edit/addfield.html:104 books/edit/addfield.html:113
-#: books/edit/addfield.html:149 books/edit/edition.html:106
-#: books/edit/edition.html:129 books/edit/edition.html:162
-#: books/edit/edition.html:172 books/edit/edition.html:265
-#: books/edit/edition.html:367 books/edit/edition.html:381
+#: books/edit/addfield.html:149 books/edit/edition.html:107
+#: books/edit/edition.html:130 books/edit/edition.html:163
+#: books/edit/edition.html:173 books/edit/edition.html:266
+#: books/edit/edition.html:368 books/edit/edition.html:382
 #: books/edit/edition.html:582 books/edit/excerpts.html:19
-#: books/edit/web.html:23 type/author/edit.html:107
+#: books/edit/web.html:23 type/author/edit.html:113
 msgid "For example:"
 msgstr "Par exemple :"
 
-#: books/edit/about.html:34
+#: books/edit/about.html:49
 msgid "A person? Or, people?"
 msgstr "Une personne ? Ou un groupe de personnes ?"
 
-#: books/edit/about.html:48
+#: books/edit/about.html:60
 msgid "Note any places mentioned?"
 msgstr "Des lieux particuliers de mentionnés ?"
 
-#: books/edit/about.html:62
+#: books/edit/about.html:71
 msgid "When is it set or about?"
 msgstr "Quand l'histoire se passe-t-elle ou de quelle époque parle le livre ?"
 
@@ -2292,148 +2548,140 @@ msgstr ""
 msgid "Select this language"
 msgstr "Choisir cette langue"
 
-#: books/edit/edition.html:31 books/edit/edition.html:40
+#: books/edit/edition.html:32 books/edit/edition.html:41
 msgid "Remove this language"
 msgstr "Supprimer cette langue"
 
-#: books/edit/edition.html:32
+#: books/edit/edition.html:33
 msgid "Add another language?"
 msgstr "Ajouter une autre langue ?"
 
-#: books/edit/edition.html:51
+#: books/edit/edition.html:52
 msgid "Remove this work"
 msgstr "Supprimer cette œuvre"
 
-#: books/edit/edition.html:59 books/edit/edition.html:400
+#: books/edit/edition.html:60 books/edit/edition.html:401
 msgid "-- Move to a new work"
 msgstr "-- Déplacer vers une nouvelle œuvre"
 
-#: EditionNavBar.html:17 books/edit/edition.html:86
+#: books/edit/edition.html:87
 msgid "This Edition"
 msgstr "Cette édition"
 
-#: books/edit/edition.html:96
+#: books/edit/edition.html:97
 msgid "Enter the title of this specific edition."
 msgstr "Entrez le titre de cette édition spécifique."
 
-#: books/edit/edition.html:105
+#: books/edit/edition.html:106
 msgid "Subtitle"
 msgstr "Sous-titre"
 
-#: books/edit/edition.html:106
+#: books/edit/edition.html:107
 msgid "Usually distinguished by different or smaller type."
 msgstr "Habituellement distingué par une fonte différente ou plus petite."
 
-#: books/edit/edition.html:113
+#: books/edit/edition.html:114
 msgid "Publishing Info"
 msgstr "Informations sur la publication"
 
-#: books/edit/edition.html:119
-msgid "For example"
-msgstr "Par exemple"
-
-#: books/edit/edition.html:128
+#: books/edit/edition.html:129
 msgid "Where was the book published?"
 msgstr "Où le livre a-t-il été publié ?"
 
-#: books/edit/edition.html:129
+#: books/edit/edition.html:130
 msgid "City, Country please."
 msgstr "Ville, pays s'il-vous-plaît."
 
-#: books/edit/edition.html:139
-msgid "You should be able to find this in the first few pages of the book."
-msgstr "Vous devriez pouvoir trouver cela dans les premières pages du livre."
-
-#: books/edit/edition.html:151
+#: books/edit/edition.html:152
 msgid "What is the copyright date?"
 msgstr "Qu'elle est la date des droits d'auteur ?"
 
-#: books/edit/edition.html:152
+#: books/edit/edition.html:153
 msgid "The year following the copyright statement."
 msgstr "L'année qui suit la déclaration des droits d'auteur."
 
-#: books/edit/edition.html:161
+#: books/edit/edition.html:162
 msgid "Edition Name (if applicable):"
 msgstr "Nom de l'édition (si applicable) :"
 
-#: books/edit/edition.html:171
+#: books/edit/edition.html:172
 msgid "Series Name (if applicable)"
 msgstr "Nom de la série (si applicable) :"
 
-#: books/edit/edition.html:172
+#: books/edit/edition.html:173
 msgid "The name of the publisher's series."
 msgstr "Le nom de la série de l'éditeur."
 
-#: books/edit/edition.html:200 type/edition/view.html:441
-#: type/work/view.html:441
+#: books/edit/edition.html:201 type/edition/view.html:417
+#: type/work/view.html:417
 msgid "Contributors"
 msgstr "Contributeurs"
 
-#: books/edit/edition.html:202
+#: books/edit/edition.html:203
 msgid "Please select a role."
 msgstr "Veuillez sélectionner un rôle."
 
-#: books/edit/edition.html:202
+#: books/edit/edition.html:203
 msgid "You need to give this ROLE a name."
 msgstr "Vous devez donner un nom à ROLE."
 
-#: books/edit/edition.html:204
+#: books/edit/edition.html:205
 msgid "List the people involved"
 msgstr "Listez les personnes impliquées"
 
-#: books/edit/edition.html:214
+#: books/edit/edition.html:215
 msgid "Select role"
 msgstr "Choisissez un rôle"
 
-#: books/edit/edition.html:219
+#: books/edit/edition.html:220
 msgid "Add a new role"
 msgstr "Ajouter un nouveau rôle"
 
-#: books/edit/edition.html:239 books/edit/edition.html:255
+#: books/edit/edition.html:240 books/edit/edition.html:256
 msgid "Remove this contributor"
 msgstr "Supprimer ce contributeur"
 
-#: books/edit/edition.html:264
+#: books/edit/edition.html:265
 msgid "By Statement:"
 msgstr "Déclaration des contributeurs :"
 
-#: books/edit/edition.html:275
+#: books/edit/edition.html:276
 msgid "Languages"
 msgstr "Langues"
 
-#: books/edit/edition.html:279
+#: books/edit/edition.html:280
 msgid "What language is this edition written in?"
 msgstr "En quelle langue cette édition est-elle écrite ?"
 
-#: books/edit/edition.html:291
+#: books/edit/edition.html:292
 msgid "Is it a translation of another book?"
 msgstr "Est-ce la traduction d'un autre livre ?"
 
-#: books/edit/edition.html:309
+#: books/edit/edition.html:310
 msgid "Yes, it's a translation"
 msgstr "Oui, c'est une traduction"
 
-#: books/edit/edition.html:314
+#: books/edit/edition.html:315
 msgid "What's the original book?"
 msgstr "Quel est le livre d'origine ?"
 
-#: books/edit/edition.html:323
+#: books/edit/edition.html:324
 msgid "What language was the original written in?"
 msgstr "En quelle langue l'original est-il écrit ?"
 
-#: books/edit/edition.html:341
+#: books/edit/edition.html:342
 msgid "Description of this edition"
 msgstr "Description de cette édition"
 
-#: books/edit/edition.html:342
+#: books/edit/edition.html:343
 msgid "Only if it's different from the work's description"
 msgstr "Seulement si elle est différente de la description de l'œuvre"
 
-#: TableOfContents.html:10 books/edit/edition.html:351
+#: TableOfContents.html:10 books/edit/edition.html:352
 msgid "Table of Contents"
 msgstr "Table des matières"
 
-#: books/edit/edition.html:352
+#: books/edit/edition.html:353
 msgid ""
 "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
 "new lines. Like this:"
@@ -2441,19 +2689,19 @@ msgstr ""
 "Utilisez un « * » pour l'indentation, un « | » pour ajouter une colonne "
 "et un retour à la ligne pour une nouvelle ligne. Comme ceci :"
 
-#: books/edit/edition.html:366
+#: books/edit/edition.html:367
 msgid "Any notes about this specific edition?"
 msgstr "Des remarques sur cette édition spécifique ?"
 
-#: books/edit/edition.html:367
+#: books/edit/edition.html:368
 msgid "Anything about the book that may be of interest."
 msgstr "Tout ce qui pourrait être intéressant à propos de ce livre."
 
-#: books/edit/edition.html:376
+#: books/edit/edition.html:377
 msgid "Is it known by any other titles?"
 msgstr "Est-elle connue par d'autres titres ?"
 
-#: books/edit/edition.html:377
+#: books/edit/edition.html:378
 msgid ""
 "Use this field if the title is different on the cover or spine. If the "
 "edition is a collection or anthology, you may also add the individual "
@@ -2463,15 +2711,15 @@ msgstr ""
 "Si l'édition est une collection ou une anthologie, vous pouvez également "
 "ajouter les titres individuels de chaque œuvre ici."
 
-#: books/edit/edition.html:381
+#: books/edit/edition.html:382
 msgid "is an alternate title for"
 msgstr "est un autre titre de"
 
-#: books/edit/edition.html:391
+#: books/edit/edition.html:392
 msgid "What work is this an edition of?"
 msgstr "De quelle œuvre est-ce une édition ?"
 
-#: books/edit/edition.html:393
+#: books/edit/edition.html:394
 msgid ""
 "Sometimes editions can be associated with the wrong work. You can correct"
 " that here."
@@ -2479,11 +2727,11 @@ msgstr ""
 "Parfois des éditions sont associées à la mauvaise œuvre. Vous pouvez "
 "corriger cela ici."
 
-#: books/edit/edition.html:394
+#: books/edit/edition.html:395
 msgid "You can search by title or by Open Library ID (like"
 msgstr "Vous pouvez chercher par titre ou par identifiant Open Library (comme"
 
-#: books/edit/edition.html:397
+#: books/edit/edition.html:398
 msgid "WARNING: Any edits made to the work from this page will be ignored."
 msgstr ""
 "ATTENTION : Toutes modifications de l'œuvre depuis cette page sera "
@@ -2506,13 +2754,17 @@ msgid "ID must be exactly 10 characters [0-9] or X."
 msgstr "L'identifiant doit contenir exactement 10 caractères de 0 à 9 ou X."
 
 #: books/edit/edition.html:414
+msgid "That ISBN already exists for this edition."
+msgstr ""
+
+#: books/edit/edition.html:414
 msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
 msgstr ""
 "L'identifiant doit contenir exactement 13 chiffres de 0 à 9. Par exemple "
 ": 978-1-56619-909-4"
 
-#: books/edit/edition.html:416 type/author/view.html:173
-#: type/edition/view.html:462 type/work/view.html:462
+#: books/edit/edition.html:416 type/author/view.html:188
+#: type/edition/view.html:438 type/work/view.html:438
 msgid "ID Numbers"
 msgstr "Identifiants"
 
@@ -2536,8 +2788,8 @@ msgstr "Veuillez sélectionner une classification."
 msgid "You need to give a value to CLASS."
 msgstr "Vous devez donner une valeur à CLASS."
 
-#: books/edit/edition.html:494 type/edition/view.html:334
-#: type/edition/view.html:416 type/work/view.html:334 type/work/view.html:416
+#: books/edit/edition.html:494 type/edition/view.html:392
+#: type/work/view.html:392
 msgid "Classifications"
 msgstr "Classifications"
 
@@ -2557,8 +2809,8 @@ msgstr "Ajouter un nouveau type de classification"
 msgid "Remove this classification"
 msgstr "Supprimer cette classification"
 
-#: books/edit/edition.html:552 type/edition/view.html:450
-#: type/work/view.html:450
+#: books/edit/edition.html:552 type/edition/view.html:426
+#: type/work/view.html:426
 msgid "The Physical Object"
 msgstr "L'objet physique"
 
@@ -2590,8 +2842,8 @@ msgstr "Aide"
 msgid "How much does the book weigh?"
 msgstr "Combien pèse ce livre ?"
 
-#: books/edit/edition.html:603 type/edition/view.html:455
-#: type/work/view.html:455
+#: books/edit/edition.html:603 type/edition/view.html:431
+#: type/work/view.html:431
 msgid "Dimensions"
 msgstr "Dimensions"
 
@@ -2607,19 +2859,54 @@ msgstr "Largeur :"
 msgid "Depth:"
 msgstr "Épaisseur :"
 
-#: books/edit/edition.html:640
+#: books/edit/edition.html:648
+#, fuzzy
+msgid "Web Book Providers"
+msgstr "Couvertures"
+
+#: books/edit/edition.html:653
+#, fuzzy
+msgid "Access Type"
+msgstr "Type de page"
+
+#: books/edit/edition.html:654
+msgid "File Format"
+msgstr ""
+
+#: books/edit/edition.html:655
+msgid "Provider Name"
+msgstr ""
+
+#: ReadButton.html:39 books/edit/edition.html:666
+msgid "Listen"
+msgstr "Écouter"
+
+#: books/edit/edition.html:667
+#, fuzzy
+msgid "Buy"
+msgstr "par"
+
+#: books/edit/edition.html:675
+msgid "Web"
+msgstr ""
+
+#: books/edit/edition.html:685
+msgid "Add a provider"
+msgstr ""
+
+#: books/edit/edition.html:690
 msgid "Admin Only"
 msgstr "Administrateur uniquement"
 
-#: books/edit/edition.html:643
+#: books/edit/edition.html:693
 msgid "Additional Metadata"
 msgstr "Métadonnée supplémentaire"
 
-#: books/edit/edition.html:644
+#: books/edit/edition.html:694
 msgid "This field can accept arbitrary key:value pairs"
 msgstr "Ce champ supporte des pairs de clé:valeur arbitraire"
 
-#: books/edit/edition.html:656
+#: books/edit/edition.html:706
 msgid "First sentence"
 msgstr "Première phrase"
 
@@ -2697,39 +2984,178 @@ msgstr ""
 "soient pertinents pour le livre. Les sites non pertinents pourront être "
 "supprimés. Le spam flagrant sera supprimé sans remord."
 
-#: covers/add.html:11
+#: check_ins/check_in_form.html:10
+#, fuzzy
+msgid "January"
+msgstr "n'importe lequel"
+
+#: check_ins/check_in_form.html:11
+#, fuzzy
+msgid "February"
+msgstr "Open Library"
+
+#: check_ins/check_in_form.html:12
+#, fuzzy
+msgid "March"
+msgstr "Rechercher"
+
+#: check_ins/check_in_form.html:13
+#, fuzzy
+msgid "April"
+msgstr "courriel"
+
+#: check_ins/check_in_form.html:14
+#, fuzzy
+msgid "May"
+msgstr "n'importe lequel"
+
+#: check_ins/check_in_form.html:15
+msgid "June"
+msgstr ""
+
+#: check_ins/check_in_form.html:16
+msgid "July"
+msgstr ""
+
+#: check_ins/check_in_form.html:17
+msgid "August"
+msgstr ""
+
+#: check_ins/check_in_form.html:18
+#, fuzzy
+msgid "September"
+msgstr "Se souvenir de moi"
+
+#: check_ins/check_in_form.html:19
+msgid "October"
+msgstr ""
+
+#: check_ins/check_in_form.html:20
+msgid "November"
+msgstr ""
+
+#: check_ins/check_in_form.html:21
+#, fuzzy
+msgid "December"
+msgstr "Se souvenir de moi"
+
+#: check_ins/check_in_form.html:38
+msgid ""
+"Add an optional check-in date.  Check-in dates are used to track yearly "
+"reading goals."
+msgstr ""
+
+#: check_ins/check_in_form.html:41
+#, fuzzy
+msgid "End Date:"
+msgstr "Envoyer"
+
+#: check_ins/check_in_form.html:43
+msgid "Year:"
+msgstr ""
+
+#: check_ins/check_in_form.html:45
+#, fuzzy
+msgid "Year"
+msgstr "Rechercher"
+
+#: check_ins/check_in_form.html:53
+msgid "Month:"
+msgstr ""
+
+#: check_ins/check_in_form.html:55
+msgid "Month"
+msgstr ""
+
+#: check_ins/check_in_form.html:62
+#, fuzzy
+msgid "Day:"
+msgstr "Aujourd'hui"
+
+#: check_ins/check_in_form.html:64
+#, fuzzy
+msgid "Day"
+msgstr "Aujourd'hui"
+
+#: check_ins/check_in_form.html:76
+#, fuzzy
+msgid "Delete Event"
+msgstr "Supprimer le compte"
+
+#: check_ins/check_in_prompt.html:32
+#, fuzzy
+msgid "When did you finish this book?"
+msgstr "Comment décririez-vous ce livre ?"
+
+#: check_ins/check_in_prompt.html:37
+#, fuzzy
+msgid "Other"
+msgstr "1 autre"
+
+#: check_ins/check_in_prompt.html:42
+msgid "Check-In"
+msgstr ""
+
+#: check_ins/reading_goal_form.html:12
+#, fuzzy
+msgid "How many books would you like to read this year?"
+msgstr "Que souhaiteriez vous faire ?"
+
+#: check_ins/reading_goal_form.html:18
+msgid "Note: Submit \"0\" to delete your goal.  Your check-ins will be preserved."
+msgstr ""
+
+#: check_ins/reading_goal_progress.html:18
+#, python-format
+msgid "%(year)d Reading Goal:"
+msgstr ""
+
+#: check_ins/reading_goal_progress.html:25
+#, python-format
+msgid ""
+"<span class=\"reading-goal-progress__books-"
+"read\">%(books_read)d</span>/<span class=\"reading-goal-"
+"progress__goal\">%(goal)d</span> books"
+msgstr ""
+
+#: check_ins/reading_goal_progress.html:31
+#, python-format
+msgid "Edit %(year)d Reading Goal"
+msgstr ""
+
+#: covers/add.html:12
 msgid "There are two ways to put an author's image on Open Library"
 msgstr "Il y a deux manières de mettre une photo de l'auteur sur Open Library"
 
-#: covers/add.html:13
+#: covers/add.html:14
 msgid "Image Guidelines"
 msgstr "Conseils pour les images"
 
-#: covers/add.html:15
+#: covers/add.html:16
 msgid "There are two ways to put a cover image on Open Library"
 msgstr "Il y a deux manières de mettre une couverture sur Open Library"
 
-#: covers/add.html:17
+#: covers/add.html:18
 msgid "Cover Guidelines"
 msgstr "Conseils pour les couvertures"
 
-#: covers/add.html:22 covers/add.html:26
+#: covers/add.html:23 covers/add.html:27
 msgid "Please provide a valid image."
 msgstr "Merci de fournir une image valide."
 
-#: covers/add.html:24
+#: covers/add.html:25
 msgid "Please provide an image URL."
 msgstr "Merci de fournir une URL d'image."
 
-#: covers/add.html:39
+#: covers/add.html:40
 msgid "<strong>Pick one</strong> from the existing covers,"
 msgstr "<strong>Choisissez l'une</strong> des couvertures existantes,"
 
-#: covers/add.html:60
+#: covers/add.html:61
 msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr "Choisissez un fichier JPG, GIF ou PNG sur votre ordinateur,"
 
-#: covers/add.html:69
+#: covers/add.html:70
 msgid "Or, paste in the image URL if it's on the web."
 msgstr "Ou, collez l'URL de l'image si elle est sur le web."
 
@@ -2788,7 +3214,7 @@ msgstr "Ajouter une couverture"
 msgid "Manage"
 msgstr "Gérer"
 
-#: covers/manage.html:11
+#: covers/manage.html:12
 msgid ""
 "You can drag and drop thumbnails to reorder, or into the trash to delete "
 "them."
@@ -2796,19 +3222,19 @@ msgstr ""
 "Vous pouvez cliquer-déposer les miniatures pour les réordonner ou les "
 "supprimer."
 
-#: covers/saved.html:16
+#: covers/saved.html:17
 msgid "Saved!"
 msgstr "Enregistré !"
 
-#: covers/saved.html:19
+#: covers/saved.html:20
 msgid "Notes:"
 msgstr "Remarques :"
 
-#: covers/saved.html:29
+#: covers/saved.html:30
 msgid "Add another image"
 msgstr "Ajouter une autre image"
 
-#: covers/saved.html:35
+#: covers/saved.html:36
 msgid "Finished"
 msgstr "Terminé"
 
@@ -2838,8 +3264,7 @@ msgstr ""
 "Open Library est un catalogue de bibliothèque ouvert et modifiable, qui "
 "cherche à créer une page web pour chaque livre qui ait jamais été publié."
 
-#: AffiliateLinks.html:70 home/about.html:16 lib/nav_head.html:40
-#: lib/nav_head.html:65
+#: AffiliateLinks.html:70 home/about.html:16
 msgid "More"
 msgstr "Plus"
 
@@ -2880,31 +3305,27 @@ msgstr[1] "%(count)s livres"
 msgid "Welcome to Open Library"
 msgstr "Bienvenue sur Open Library"
 
-#: home/index.html:26
+#: home/index.html:29
 msgid "Classic Books"
 msgstr "Livres classiques"
 
-#: home/index.html:31
-msgid "Books We Love"
-msgstr "Livres que nous aimons"
-
-#: home/index.html:33
+#: home/index.html:36
 msgid "Recently Returned"
 msgstr "Récemment rendu"
 
-#: home/index.html:35
+#: home/index.html:38
 msgid "Romance"
 msgstr "Livres d'amour"
 
-#: home/index.html:37
+#: home/index.html:40
 msgid "Kids"
 msgstr "Enfants"
 
-#: home/index.html:39
+#: home/index.html:42
 msgid "Thrillers"
 msgstr "Romans policiers"
 
-#: home/index.html:41
+#: home/index.html:44
 msgid "Textbooks"
 msgstr "Manuels scolaires"
 
@@ -2924,6 +3345,10 @@ msgstr ""
 msgid "See all visitors to OpenLibrary.org"
 msgstr "Voir tous les visiteurs d'OpenLibrary.org"
 
+#: home/stats.html:16
+msgid "Area graph of recent unique visitors"
+msgstr ""
+
 #: home/stats.html:17
 msgid "Unique Visitors"
 msgstr "Visiteurs uniques"
@@ -2931,6 +3356,10 @@ msgstr "Visiteurs uniques"
 #: home/stats.html:22 home/stats.html:24
 msgid "How many new Open Library members have we welcomed?"
 msgstr "Combien de nouveaux membres d'Open Library avons-nous accueillis ?"
+
+#: home/stats.html:23
+msgid "Area graph of new members"
+msgstr ""
 
 #: home/stats.html:24
 msgid "New Members"
@@ -2940,6 +3369,10 @@ msgstr "Nouveaux membres"
 msgid "People are constantly updating the catalog"
 msgstr "Les gens mettent constamment à jour le catalogue"
 
+#: home/stats.html:29
+msgid "Area graph of recent catalog edits"
+msgstr ""
+
 #: home/stats.html:30
 msgid "Catalog Edits"
 msgstr "Modifications du catalogue"
@@ -2948,6 +3381,10 @@ msgstr "Modifications du catalogue"
 msgid "Members can create Lists"
 msgstr "Les membres peuvent créer des listes"
 
+#: home/stats.html:36
+msgid "Area graph of lists created recently"
+msgstr ""
+
 #: home/stats.html:37
 msgid "Lists Created"
 msgstr "Listes créées"
@@ -2955,6 +3392,10 @@ msgstr "Listes créées"
 #: home/stats.html:42 home/stats.html:44
 msgid "We're a library, so we lend books, too"
 msgstr "Nous sommes une bibliothèque, donc nous prêtons aussi des livres"
+
+#: home/stats.html:43
+msgid "Area graph of ebooks borrowed recently"
+msgstr ""
 
 #: home/stats.html:44
 msgid "eBooks Borrowed"
@@ -2985,18 +3426,27 @@ msgid "Digital shelves organized like a physical library"
 msgstr "Étagères numériques organisées comme dans une bibliothèque"
 
 #: home/welcome.html:68
+#, fuzzy
+msgid "Try Fulltext Search"
+msgstr "Recherche en plein texte"
+
+#: home/welcome.html:69
+msgid "Find matching results within the text of millions of books"
+msgstr ""
+
+#: home/welcome.html:82
 msgid "Be an Open Librarian"
 msgstr "Être bibliothécaire"
 
-#: home/welcome.html:69
+#: home/welcome.html:83
 msgid "Dozens of ways you can help improve the library"
 msgstr "Des douzaines de manière d'améliorer la bibliothèque"
 
-#: home/welcome.html:82
+#: home/welcome.html:96
 msgid "Send us feedback"
 msgstr "Envoyer nous vos impressions"
 
-#: home/welcome.html:83
+#: home/welcome.html:97
 msgid "Your feedback will help us improve these cards"
 msgstr "Votre retour nous aidera à améliorer ces encarts"
 
@@ -3006,6 +3456,46 @@ msgid "%s book"
 msgid_plural "%s books"
 msgstr[0] "%s livre"
 msgstr[1] "%s livres"
+
+#: languages/language_list.html:8
+msgid "Czech"
+msgstr "tchèque"
+
+#: languages/language_list.html:9
+msgid "German"
+msgstr "allemand"
+
+#: languages/language_list.html:10
+msgid "English"
+msgstr "anglais"
+
+#: languages/language_list.html:11
+msgid "Spanish"
+msgstr "espagnol"
+
+#: languages/language_list.html:12
+msgid "French"
+msgstr "français"
+
+#: languages/language_list.html:13
+msgid "Croatian"
+msgstr "croate"
+
+#: languages/language_list.html:14
+msgid "Portuguese"
+msgstr "portugais"
+
+#: languages/language_list.html:15
+msgid "Telugu"
+msgstr "télougou"
+
+#: languages/language_list.html:16
+msgid "Ukrainian"
+msgstr ""
+
+#: languages/language_list.html:17
+msgid "Chinese"
+msgstr "chinois"
 
 #: languages/notfound.html:7
 #, python-format
@@ -3025,11 +3515,11 @@ msgstr "Ce document a été modifié pour la dernière fois par"
 msgid "This doc was last edited anonymously"
 msgstr "Ce document a été modifié pour la dernière fois de manière anonyme"
 
-#: lib/header_dropdown.html:26
+#: lib/header_dropdown.html:38
 msgid "Menu"
 msgstr "Menu"
 
-#: lib/header_dropdown.html:58
+#: lib/header_dropdown.html:74
 msgid "New!"
 msgstr "Nouveau !"
 
@@ -3066,16 +3556,16 @@ msgstr "Citation Wikipédia"
 msgid "Copy and paste this code into your Wikipedia page."
 msgstr "Copiez et collez ce code dans votre page Wikipédia."
 
-#: lib/history.html:83 lib/history.html:85
+#: lib/history.html:81 lib/history.html:83
 msgid "an anonymous user"
 msgstr "un utilisateur anonyme"
 
-#: lib/history.html:87
+#: lib/history.html:85
 #, python-format
 msgid "Created by %(user)s"
 msgstr "Créé par %(user)s"
 
-#: lib/history.html:89
+#: lib/history.html:87
 #, python-format
 msgid "Edited by %(user)s"
 msgstr "Modifié par %(user)s"
@@ -3158,7 +3648,7 @@ msgstr "Accueil"
 msgid "Explore Books"
 msgstr "Parcourir les livres"
 
-#: lib/nav_foot.html:26
+#: SearchNavigation.html:12 lib/nav_foot.html:26
 msgid "Books"
 msgstr "Livres"
 
@@ -3178,6 +3668,12 @@ msgstr "Parcourir les collections"
 msgid "Collections"
 msgstr "Collections"
 
+#: SearchNavigation.html:32 lib/nav_foot.html:30 lib/nav_head.html:35
+#: search/advancedsearch.html:7 search/advancedsearch.html:14
+#: search/advancedsearch.html:18
+msgid "Advanced Search"
+msgstr "Recherche avancée"
+
 #: lib/nav_foot.html:31
 msgid "Navigate to top of this page"
 msgstr "Aller en haut de cette page"
@@ -3194,7 +3690,7 @@ msgstr "Développer"
 msgid "Explore Open Library Developer Center"
 msgstr "Parcourir le centre des développeurs d'Open Library"
 
-#: lib/nav_foot.html:37 lib/nav_head.html:25
+#: lib/nav_foot.html:37 lib/nav_head.html:43
 msgid "Developer Center"
 msgstr "Centre des développeurs"
 
@@ -3250,35 +3746,11 @@ msgstr "Proposition de modifications"
 msgid "Change Website Language"
 msgstr "Changer la langue du site"
 
-#: lib/nav_foot.html:59
-msgid "Czech"
-msgstr "tchèque"
-
-#: lib/nav_foot.html:60 lib/search_foot.html:33
-msgid "German"
-msgstr "allemand"
-
-#: lib/nav_foot.html:61 lib/search_foot.html:32
-msgid "English"
-msgstr "anglais"
-
-#: lib/nav_foot.html:62 lib/search_foot.html:35
-msgid "Spanish"
-msgstr "espagnol"
-
-#: lib/nav_foot.html:63 lib/search_foot.html:34
-msgid "French"
-msgstr "français"
-
-#: lib/nav_foot.html:64
-msgid "Croatian"
-msgstr "croate"
+#: lib/nav_foot.html:63 lib/nav_head.html:63 type/list/embed.html:23
+msgid "Open Library logo"
+msgstr "Logo d'Open Library"
 
 #: lib/nav_foot.html:65
-msgid "Telugu"
-msgstr "télougou"
-
-#: lib/nav_foot.html:73
 msgid ""
 "Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
 "Archive</a>, a 501(c)(3) non-profit, building a digital library of "
@@ -3297,7 +3769,7 @@ msgstr ""
 "href=\"//archive.org/\">archive.org</a> et <a href=\"//archive-it.org"
 "\">archive-it.org</a>"
 
-#: lib/nav_foot.html:78
+#: lib/nav_foot.html:70
 #, python-format
 msgid ""
 "version <a "
@@ -3306,33 +3778,26 @@ msgstr ""
 "version <a "
 "href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 
-#: lib/nav_head.html:10
-msgid "My Profile"
-msgstr "Mon profil"
-
-#: lib/nav_head.html:11
-msgid "My Loans"
-msgstr "Mes emprunts"
-
 #: lib/nav_head.html:13
-msgid "My Reading Log"
-msgstr "Mon journal de lecture"
+msgid "Loans, Reading Log, Lists, Stats"
+msgstr ""
 
 #: lib/nav_head.html:14
-msgid "My Reading Stats"
-msgstr "Mes statistiques de lecture"
+msgid "My Profile"
+msgstr "Mon profil"
 
 #: lib/nav_head.html:16
 msgid "Log out"
 msgstr "Déconnexion"
 
-#: lib/nav_head.html:24
-msgid "Recent Community Edits"
-msgstr "Modifications récentes de la communauté"
+#: lib/nav_head.html:19
+msgid "Pending Merge Requests"
+msgstr ""
 
-#: lib/nav_head.html:26
-msgid "Help & Support"
-msgstr "Aide & Support"
+#: lib/nav_head.html:29
+#, fuzzy
+msgid "Trending"
+msgstr "Les livres les plus populaires"
 
 #: lib/nav_head.html:33
 msgid "K-12 Student Library"
@@ -3343,41 +3808,53 @@ msgid "Random Book"
 msgstr "Livre au hasard"
 
 #: lib/nav_head.html:39
+msgid "Recent Community Edits"
+msgstr "Modifications récentes de la communauté"
+
+#: lib/nav_head.html:42
+msgid "Help & Support"
+msgstr "Aide & Support"
+
+#: lib/nav_head.html:44
+msgid "Librarians Portal"
+msgstr ""
+
+#: lib/nav_head.html:48
 msgid "My Open Library"
 msgstr "Mon Open Library"
 
-#: lib/nav_head.html:40 lib/nav_head.html:59
+#: lib/nav_head.html:49 lib/nav_head.html:70
 msgid "Browse"
 msgstr "Explorer"
 
-#: lib/nav_head.html:48
+#: lib/nav_head.html:50
+#, fuzzy
+msgid "Contribute"
+msgstr "Contributeurs"
+
+#: lib/nav_head.html:51
+msgid "Resources"
+msgstr ""
+
+#: lib/nav_head.html:59
 msgid "The Internet Archive's Open Library: One page for every book"
 msgstr "La bibliothèque libre d'Internet Archive : Une page pour chaque livre"
 
-#: lib/nav_head.html:52 type/list/embed.html:22
-msgid "Open Library logo"
-msgstr "Logo d'Open Library"
-
-#: lib/nav_head.html:80
+#: lib/nav_head.html:91
 msgid "All"
 msgstr "Tout"
 
-#: lib/nav_head.html:83
+#: lib/nav_head.html:94
 msgid "Text"
 msgstr "Texte"
 
-#: lib/nav_head.html:84 lib/search_foot.html:11 lib/search_head.html:11
-#: search/advancedsearch.html:28
+#: lib/nav_head.html:95 search/advancedsearch.html:32
 msgid "Subject"
 msgstr "Thème"
 
-#: lib/nav_head.html:86 lib/search_foot.html:63 lib/search_head.html:29
+#: lib/nav_head.html:97
 msgid "Advanced"
 msgstr "Avancé"
-
-#: NotesModal.html:29 lib/nav_head.html:124
-msgid "My Book Notes"
-msgstr "Mes notes de livre"
 
 #: lib/not_logged.html:7
 msgid ""
@@ -3398,64 +3875,6 @@ msgstr ""
 #: Pager.html:27 lib/pagination.html:22
 msgid "Previous"
 msgstr "Précédent"
-
-#: lib/search_foot.html:12 lib/search_head.html:12
-#: search/advancedsearch.html:32
-msgid "Place"
-msgstr "Lieu"
-
-#: lib/search_foot.html:13 lib/search_head.html:13
-#: search/advancedsearch.html:36
-msgid "Person"
-msgstr "Personne"
-
-#: lib/search_foot.html:31
-msgid "any"
-msgstr "n'importe lequel"
-
-#: lib/search_foot.html:36
-msgid "Russian"
-msgstr "russe"
-
-#: lib/search_foot.html:37
-msgid "Italian"
-msgstr "italien"
-
-#: lib/search_foot.html:38
-msgid "Chinese"
-msgstr "chinois"
-
-#: lib/search_foot.html:39
-msgid "Arabic"
-msgstr "arabe"
-
-#: lib/search_foot.html:40
-msgid "Japanese"
-msgstr "japonais"
-
-#: lib/search_foot.html:41
-msgid "Portuguese"
-msgstr "portugais"
-
-#: lib/search_foot.html:42
-msgid "Polish"
-msgstr "polonais"
-
-#: lib/search_foot.html:68 lib/search_head.html:34
-msgid "Only eBooks"
-msgstr "Seulement les livres électroniques"
-
-#: lib/search_foot.html:70 lib/search_head.html:36
-msgid "Search eBook text"
-msgstr "Rechercher dans les livres électroniques"
-
-#: lib/search_head.html:68
-msgid "Your Profile"
-msgstr "Votre profil"
-
-#: lib/search_head.html:76
-msgid "Log in"
-msgstr "Se connecter"
 
 #: lists/header.html:11 lists/header.html:24 lists/header.html:38
 #: lists/header.html:47 lists/header.html:56
@@ -3545,7 +3964,7 @@ msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
-#: type/list/embed.html:17 type/list/view_body.html:38
+#: type/list/embed.html:18 type/list/view_body.html:39
 #, python-format
 msgid "1 item"
 msgid_plural "%(count)d items"
@@ -3561,13 +3980,25 @@ msgstr "Dernière modification le %(date)s"
 msgid "No description."
 msgstr "Pas de description."
 
-#: lists/home.html:65 lists/lists.html:124 type/user/view.html:81
+#: lists/home.html:65 lists/lists.html:130 type/user/view.html:81
 msgid "Recent Activity"
 msgstr "Activité récente"
 
 #: lists/home.html:66 type/user/view.html:67
 msgid "See all"
 msgstr "Tout voir"
+
+#: lists/list_overview.html:15 lists/widget.html:84
+msgid "See this list"
+msgstr "Voir cette liste"
+
+#: lists/list_overview.html:25 lists/widget.html:85
+msgid "Remove from your list?"
+msgstr "Supprimer de votre liste ?"
+
+#: lists/list_overview.html:28 lists/widget.html:87
+msgid "You"
+msgstr "Vous"
 
 #: lists/lists.html:10
 #, python-format
@@ -3578,13 +4009,13 @@ msgstr "%(owner)s / Listes"
 msgid "Delete this list"
 msgstr "Supprimer cette liste"
 
-#: lists/lists.html:38 type/list/view_body.html:110
-#: type/list/view_body.html:140
+#: lists/lists.html:38 type/list/view_body.html:111
+#: type/list/view_body.html:141
 msgid "Yes, I'm sure"
 msgstr "Oui, je suis sûr"
 
-#: lists/lists.html:49 type/list/view_body.html:127
-#: type/list/view_body.html:149
+#: lists/lists.html:49 type/list/view_body.html:128
+#: type/list/view_body.html:150
 msgid "No, cancel"
 msgstr "Non, annuler"
 
@@ -3606,83 +4037,41 @@ msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list
 msgstr "Voulez-vous vraiment supprimer <strong>%(title)s</strong> de cette liste ?"
 
 #: lists/lists.html:121
-msgid "No lists yet!"
-msgstr "Pas encore de listes !"
+msgid "This reader hasn't created any lists yet."
+msgstr ""
+
+#: lists/lists.html:123
+msgid "You haven't created any lists yet."
+msgstr ""
+
+#: lists/lists.html:126
+msgid "Learn how to create your first list."
+msgstr ""
 
 #: lists/preview.html:17
 msgid "by <a href=\"$owner.key\">You</a>"
 msgstr "par <a href=\"$owner.key\">Vous</a>"
 
-#: lists/widget.html:48
-#, python-format
-msgid "Are you sure you want to remove <strong>%(title)s</strong> from your list?"
-msgstr "Voulez-vous vraiment supprimer <strong>%(title)s</strong> de votre liste ?"
-
-#: lists/widget.html:93
-msgid "See this list"
-msgstr "Voir cette liste"
-
-#: lists/widget.html:95
-msgid "Remove from your list?"
-msgstr "Supprimer de votre liste ?"
-
-#: lists/widget.html:98
-msgid "You"
-msgstr "Vous"
-
-#: lists/widget.html:196
-msgid "My Reading Lists:"
-msgstr "Mes listes de lecture :"
-
-#: lists/widget.html:206
-msgid "Use this Work"
-msgstr "Utiliser cette œuvre"
-
-#: databarAuthor.html:27 databarAuthor.html:34 lists/widget.html:209
-#: lists/widget.html:226 lists/widget.html:316
-msgid "Create a new list"
-msgstr "Créer une nouvelle liste"
-
-#: lists/widget.html:219
-msgid "Add to List"
-msgstr "Ajouter à la liste"
-
-#: lists/widget.html:251
+#: lists/widget.html:57
 msgid "watch for edits or export all records"
 msgstr "surveiller les modifications ou exporter toutes les entrées"
 
-#: lists/widget.html:258
+#: lists/widget.html:64
 #, python-format
 msgid "%(count)d List"
 msgid_plural "%(count)d Lists"
 msgstr[0] "%(count)d liste"
 msgstr[1] "%(count)d listes"
 
-#: lists/widget.html:298
-msgid "Update my book note"
-msgstr "Mettre à jour ma note de livre"
+#: databarAuthor.html:86 lists/widget.html:86
+msgid "from"
+msgstr "de"
 
-#: lists/widget.html:300
-msgid "Add a book note"
-msgstr "Ajouter une note de livre"
-
-#: ReadingLogButton.html:15 lists/widget.html:310
+#: lists/widget.html:113
 msgid "Remove"
 msgstr "Supprimer"
 
-#: lists/widget.html:330
-msgid "Description:"
-msgstr "Description :"
-
-#: lists/widget.html:338
-msgid "Create new list"
-msgstr "Créer une nouvelle liste"
-
-#: lists/widget.html:674
-msgid "saving..."
-msgstr "enregistrement…"
-
-#: merge/authors.html:7 merge/authors.html:11 merge/authors.html:95
+#: merge/authors.html:7 merge/authors.html:11 merge/authors.html:102
 msgid "Merge Authors"
 msgstr "Fusionner les auteurs"
 
@@ -3718,29 +4107,158 @@ msgstr "Pas d'entrée principale"
 msgid "You must select a primary record to point the duplicates toward."
 msgstr "Vous devez sélectionner une entrée principale comme cible des doublons."
 
-#: merge/authors.html:42
+#: merge/authors.html:43
 msgid "Please Be Careful..."
 msgstr "S'il vous plaît, soyez prudent…"
 
-#: merge/authors.html:43
+#: merge/authors.html:44
 msgid "<b>Are you sure</b> you want to merge these records?"
 msgstr "<b>Êtes-vous sûr</b> de vouloir fusionner ces entrées ?"
 
-#: merge/authors.html:51
+#: merge/authors.html:55
 msgid "Primary"
 msgstr "Principal"
 
-#: merge/authors.html:52
+#: merge/authors.html:56 merge_queue/merge_queue.html:125
 msgid "Merge"
 msgstr "Fusionner"
 
-#: merge/authors.html:82
+#: merge/authors.html:86
 msgid "Open in a new window"
 msgstr "Ouvrir dans une nouvelle fenêtre"
 
-#: merge/authors.html:89
+#: merge/authors.html:93
 msgid "Visit this author's page in a new window"
 msgstr "Visiter la page de cet auteur dans une nouvelle fenêtre"
+
+#: merge/authors.html:99
+#, fuzzy
+msgid "Comment:"
+msgstr "Commentaire"
+
+#: merge/authors.html:99
+#, fuzzy
+msgid "Comment..."
+msgstr "Commentaire"
+
+#: merge/authors.html:104
+msgid "Request Merge"
+msgstr ""
+
+#: merge/authors.html:107
+#, fuzzy
+msgid "Reject Merge"
+msgstr "Choisissez un rôle"
+
+#: merge/works.html:9
+#, fuzzy
+msgid "Merge Works"
+msgstr "Fusionner des auteurs"
+
+#: merge_queue/comment.html:21
+msgid "Just now"
+msgstr ""
+
+#: merge_queue/merge_queue.html:18
+#, python-format
+msgid "Showing %(username)s's requests only."
+msgstr ""
+
+#: merge_queue/merge_queue.html:19
+msgid "Show all requests"
+msgstr ""
+
+#: merge_queue/merge_queue.html:22
+msgid "Showing all requests."
+msgstr ""
+
+#: merge_queue/merge_queue.html:23
+msgid "Show my requests"
+msgstr ""
+
+#: merge_queue/merge_queue.html:27
+#, fuzzy
+msgid "Community Edit Requests"
+msgstr "Critiques de la communauté"
+
+#: merge_queue/merge_queue.html:33
+#, python-format
+msgid "Showing requests reviewed by %(reviewer)s only."
+msgstr ""
+
+#: merge_queue/merge_queue.html:33
+msgid "Remove reviewer filter"
+msgstr ""
+
+#: merge_queue/merge_queue.html:35
+msgid "Show requests that I've reviewed"
+msgstr ""
+
+#: merge_queue/merge_queue.html:47
+#, fuzzy
+msgid "Open"
+msgstr "personne"
+
+#: merge_queue/merge_queue.html:50
+#, fuzzy
+msgid "Closed"
+msgstr "Fermer"
+
+#: merge_queue/merge_queue.html:58
+#, fuzzy
+msgid "Submitter"
+msgstr "Envoyer"
+
+#: RecentChangesAdmin.html:22 merge_queue/merge_queue.html:60
+#: merge_queue/merge_queue.html:85
+msgid "Comments"
+msgstr "Commentaires"
+
+#: merge_queue/merge_queue.html:61
+#, fuzzy
+msgid "Reviewer"
+msgstr "Aperçu"
+
+#: merge_queue/merge_queue.html:62
+#, fuzzy
+msgid "Resolve"
+msgstr "Supprimer"
+
+#: merge_queue/merge_queue.html:68
+#, fuzzy
+msgid "No entries here!"
+msgstr "Détails ici"
+
+#: merge_queue/merge_queue.html:77
+#, fuzzy
+msgid "Work"
+msgstr "œuvre"
+
+#: merge_queue/merge_queue.html:84
+#, python-format
+msgid ""
+"<strong>%(type)s</strong> merge request for <span class=\"book-"
+"title\">%(title)s</span>"
+msgstr ""
+
+#: merge_queue/merge_queue.html:90
+msgid "Showing most recent comment only."
+msgstr ""
+
+#: merge_queue/merge_queue.html:91
+#, fuzzy
+msgid "View all"
+msgstr "voir"
+
+#: merge_queue/merge_queue.html:101
+#, fuzzy
+msgid "No comments yet."
+msgstr "Pas encore de liens."
+
+#: merge_queue/merge_queue.html:106
+#, fuzzy
+msgid "Add a comment..."
+msgstr "Modifié sans commentaire."
 
 #: observations/review_component.html:16
 msgid "Community Reviews"
@@ -3754,7 +4272,7 @@ msgstr "Aucune critique de la communauté n'a été enregistrée pour cette œuv
 msgid "+ Add your community review"
 msgstr "+ Ajouter votre critique communautaire"
 
-#: observations/review_component.html:44
+#: observations/review_component.html:46
 msgid "+ Log in to add your community review"
 msgstr "+ Se connecter pour ajouter votre critique communautaire"
 
@@ -3870,42 +4388,51 @@ msgstr "Détails ici"
 msgid "Master"
 msgstr "Principal"
 
-#: recentchanges/merge-authors/view.html:36 type/author/view.html:67
+#: recentchanges/merge-authors/view.html:40 type/author/view.html:78
 msgid "Duplicates"
 msgstr "Doublons"
 
-#: recentchanges/merge-authors/view.html:45
+#: recentchanges/merge-authors/view.html:49
 #, python-format
 msgid "1 record modified."
 msgid_plural "%(count)d records modified."
 msgstr[0] "1 entrée modifiée."
 msgstr[1] "%(count)d entrées modifiées."
 
-#: recentchanges/merge-authors/view.html:49
+#: recentchanges/merge-authors/view.html:53
 msgid "Updated Records"
 msgstr "Entrées mise à jour"
 
-#: search/advancedsearch.html:24
+#: search/advancedsearch.html:28
 msgid "ISBN"
 msgstr "ISBN"
 
-#: search/advancedsearch.html:46
+#: search/advancedsearch.html:36
+msgid "Place"
+msgstr "Lieu"
+
+#: search/advancedsearch.html:40
+msgid "Person"
+msgstr "Personne"
+
+#: search/advancedsearch.html:50
 msgid "Full Text Search"
 msgstr "Recherche en plein texte"
 
-#: search/authors.html:28
+#: search/authors.html:19
+#, fuzzy
+msgid "Search Authors"
+msgstr "Fusionner des auteurs"
+
+#: search/authors.html:48
 msgid "Is the same author listed twice?"
 msgstr "Le même auteur est-il répertorié deux fois ?"
 
-#: search/authors.html:29
+#: search/authors.html:48
 msgid "Merge authors"
 msgstr "Fusionner des auteurs"
 
-#: search/authors.html:32
-msgid "Author Search"
-msgstr "Recherche d'auteur"
-
-#: search/authors.html:39
+#: search/authors.html:51
 msgid "No hits"
 msgstr "Aucun résultat"
 
@@ -3914,7 +4441,7 @@ msgstr "Aucun résultat"
 msgid "Search Open Library for %s"
 msgstr "Rechercher %s sur Open Library"
 
-#: BookSearchInside.html:9 search/inside.html:10
+#: BookSearchInside.html:9 SearchNavigation.html:20 search/inside.html:10
 msgid "Search Inside"
 msgstr "Recherche plein texte"
 
@@ -3934,63 +4461,74 @@ msgstr[1] "Environ %(count)s résultats trouvés en %(seconds)s secondes"
 msgid "Search results for Lists"
 msgstr "Résultats de recherche des listes"
 
+#: search/lists.html:10
+#, fuzzy
+msgid "Search Lists"
+msgstr "Résultats de recherche des listes"
+
 #: search/publishers.html:9
 msgid "Publishers Search"
 msgstr "Recherche d'éditeur"
 
-#: search/sort_options.html:10
+#: search/sort_options.html:9
+#, fuzzy
+msgid "Sorted by"
+msgstr "Trier par"
+
+#: search/sort_options.html:12
 msgid "Relevance"
 msgstr "Pertinence"
 
-#: search/sort_options.html:11
+#: search/sort_options.html:13
 msgid "Most Editions"
 msgstr "Le plus d'éditions"
 
-#: search/sort_options.html:12
+#: search/sort_options.html:14
 msgid "First Published"
 msgstr "Les plus anciennes"
 
-#: search/sort_options.html:13
+#: search/sort_options.html:15
 msgid "Most Recent"
 msgstr "Les plus récentes"
 
-#: search/sort_options.html:14
+#: search/sort_options.html:16
 msgid "Random"
 msgstr "Au hasard"
 
-#: search/sort_options.html:31
+#: search/sort_options.html:33
 msgid "Shuffle"
 msgstr "Mélanger"
 
 #: search/subjects.html:19
-msgid "Subject Search"
-msgstr "Recherche par thème"
+#, fuzzy
+msgid "Search Subjects"
+msgstr "Parcourir les thèmes"
 
-#: search/subjects.html:74
+#: search/subjects.html:57
 msgid "time"
 msgstr "période"
 
-#: search/subjects.html:76
+#: search/subjects.html:59
 msgid "subject"
 msgstr "thème"
 
-#: search/subjects.html:78
+#: search/subjects.html:61
 msgid "place"
 msgstr "lieu"
 
-#: search/subjects.html:80
+#: search/subjects.html:63
 msgid "org"
 msgstr "organisation"
 
-#: search/subjects.html:82
+#: search/subjects.html:65
 msgid "event"
 msgstr "événement"
 
-#: search/subjects.html:84
+#: search/subjects.html:67
 msgid "person"
 msgstr "personne"
 
-#: search/subjects.html:86
+#: search/subjects.html:69
 msgid "work"
 msgstr "œuvre"
 
@@ -3998,7 +4536,7 @@ msgstr "œuvre"
 msgid "View all recent changes"
 msgstr "Voir tous les changements récents"
 
-#: site/body.html:18
+#: site/body.html:24
 msgid "It looks like you're offline."
 msgstr "Il semble que vous soyez hors ligne."
 
@@ -4032,10 +4570,6 @@ msgstr "Le nombre total de livres enregistrés en utilisant le journal de lectur
 msgid "All time"
 msgstr "De tous les temps"
 
-#: stats/readinglog.html:20 stats/readinglog.html:37 stats/readinglog.html:54
-msgid "This Month"
-msgstr "Ce mois-ci"
-
 #: stats/readinglog.html:28
 msgid "# Unique Users Logging Books"
 msgstr "# Utilisateurs uniques ayant enregistré des livres"
@@ -4060,35 +4594,35 @@ msgstr "Le nombre total de livres qui ont été notés"
 msgid "Total # Unique Raters (all time)"
 msgstr "# total d'évaluateurs uniques (de tous les temps)"
 
-#: stats/readinglog.html:66
-msgid "Most Wanted Books (All Time)"
-msgstr "Lives les plus recherchés (De tous les temps)"
+#: stats/readinglog.html:67
+msgid "Most Wanted Books (This Month)"
+msgstr "Lives les plus recherchés (Ce mois-ci)"
 
-#: stats/readinglog.html:70 stats/readinglog.html:78 stats/readinglog.html:87
-#: stats/readinglog.html:96
+#: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
+#: stats/readinglog.html:97
 #, python-format
 msgid "Added 1 time"
 msgid_plural "Added %(count)d times"
 msgstr[0] "Ajouté 1 fois"
 msgstr[1] "Ajouté %(count)d fois"
 
-#: stats/readinglog.html:74
-msgid "Most Wanted Books (This Month)"
-msgstr "Lives les plus recherchés (Ce mois-ci)"
+#: stats/readinglog.html:75
+msgid "Most Wanted Books (All Time)"
+msgstr "Lives les plus recherchés (De tous les temps)"
 
-#: stats/readinglog.html:82
+#: stats/readinglog.html:83
 msgid "Most Logged Books"
 msgstr "Lives les plus enregistrés"
 
-#: stats/readinglog.html:83
+#: stats/readinglog.html:84
 msgid "Most Read Books (All Time)"
 msgstr "Livres les plus lus (De tous les temps)"
 
-#: stats/readinglog.html:91
+#: stats/readinglog.html:92
 msgid "Most Rated Books"
 msgstr "Livres les plus notés"
 
-#: stats/readinglog.html:92
+#: stats/readinglog.html:93
 msgid "Most Rated Books (All Time)"
 msgstr "Livres les plus notés (De tous les temps)"
 
@@ -4131,11 +4665,11 @@ msgstr "Liste de diffusion"
 msgid "This appears below the links list."
 msgstr "Ceci apparaît sous la liste de liens."
 
-#: type/author/edit.html:13
+#: type/author/edit.html:19
 msgid "Edit Author"
 msgstr "Modifier l'auteur"
 
-#: type/author/edit.html:28
+#: type/author/edit.html:34
 msgid ""
 "Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
 "<strong>Tolstoy, Leo</strong>."
@@ -4143,15 +4677,15 @@ msgstr ""
 "Utilisez l'ordre naturel. Par exemple : <strong>Léon Tolstoï</strong> et "
 "non <strong>Tolstoï, Léon</strong>."
 
-#: type/author/edit.html:43
+#: type/author/edit.html:49
 msgid "About"
 msgstr "À propos"
 
-#: type/author/edit.html:53
+#: type/author/edit.html:59
 msgid "A short bio?"
 msgstr "Une courte biographie ?"
 
-#: type/author/edit.html:54
+#: type/author/edit.html:60
 msgid ""
 "If you \"borrow\" information from somewhere, please make sure to cite "
 "the source."
@@ -4159,15 +4693,15 @@ msgstr ""
 "Si vous « empruntez » des informations ailleurs, assurez-vous d'en citer "
 "la source."
 
-#: type/author/edit.html:65
+#: type/author/edit.html:71
 msgid "Date of birth"
 msgstr "Date de naissance"
 
-#: type/author/edit.html:74
+#: type/author/edit.html:80
 msgid "Date of death"
 msgstr "Date de décès"
 
-#: type/author/edit.html:83
+#: type/author/edit.html:89
 msgid ""
 "We're not storing structured dates (yet) so a date like \"21 May 2000\" "
 "is recommended."
@@ -4175,11 +4709,11 @@ msgstr ""
 "Nous ne stockons pas (encore) de dates structurées donc une date au "
 "format « 21 May 2000 » est conseillé."
 
-#: type/author/edit.html:92
+#: type/author/edit.html:98
 msgid "Date"
 msgstr "Date"
 
-#: type/author/edit.html:99
+#: type/author/edit.html:105
 msgid ""
 "This is a deprecated field. You can help improve this record by removing "
 "this date and populating the \"Date of birth\" and \"Date of death\" "
@@ -4189,15 +4723,19 @@ msgstr ""
 "cette date et en renseignant les champs « date de naissance » et « date "
 "de décès ». Merci !"
 
-#: type/author/edit.html:106
+#: type/author/edit.html:112
 msgid "Does this author go by any other names?"
 msgstr "Cet auteur est-il connu sous d'autres noms ?"
 
-#: type/author/edit.html:123
+#: type/author/edit.html:119
+msgid "Author Identifiers Purpose"
+msgstr ""
+
+#: type/author/edit.html:129
 msgid "Websites"
 msgstr "Sites Web"
 
-#: type/author/edit.html:124
+#: type/author/edit.html:130
 msgid "Deprecated"
 msgstr "Obsolète"
 
@@ -4205,7 +4743,7 @@ msgstr "Obsolète"
 msgid "name missing"
 msgstr "nom manquant"
 
-#: type/author/view.html:19 type/edition/view.html:60 type/work/view.html:60
+#: type/author/view.html:19 type/edition/view.html:89 type/work/view.html:89
 #, python-format
 msgid "%(page_title)s | Open Library"
 msgstr "%(page_title)s | Open Library"
@@ -4215,23 +4753,23 @@ msgstr "%(page_title)s | Open Library"
 msgid "Author of %(book_titles)s"
 msgstr "Auteur de %(book_titles)s"
 
-#: type/author/view.html:65
+#: type/author/view.html:76
 msgid "Merging Authors..."
 msgstr "Fusion d'auteurs en cours…"
 
-#: type/author/view.html:66
+#: type/author/view.html:77
 msgid "In progress..."
 msgstr "En cours…"
 
-#: type/author/view.html:78
+#: type/author/view.html:89
 msgid "Refresh the page?"
 msgstr "Actualiser la page ?"
 
-#: type/author/view.html:79
+#: type/author/view.html:90
 msgid "Success!"
 msgstr "Succès !"
 
-#: type/author/view.html:80
+#: type/author/view.html:91
 msgid ""
 "OK. The merge is in motion. <i>It will take <u>a few minutes to "
 "finish</u> the update.</i>"
@@ -4239,29 +4777,29 @@ msgstr ""
 "OK. La fusion est en cours. <i>Il faudra <u>quelques minutes pour "
 "terminer</u> la mise à jour.</i>"
 
-#: type/author/view.html:84
+#: type/author/view.html:95
 msgid "Argh!"
 msgstr "Ooph !"
 
-#: type/author/view.html:85
+#: type/author/view.html:96
 msgid "That merge didn't work. It's our fault, and we've made a note of it."
 msgstr ""
 "Cette fusion n'a pas fonctionné. C'est notre faute, et nous en avons pris"
 " note."
 
-#: type/author/view.html:97
+#: type/author/view.html:108
 msgid "Website"
 msgstr "Site Web"
 
-#: type/author/view.html:103
+#: type/author/view.html:114
 msgid "Location"
 msgstr "Emplacement"
 
-#: type/author/view.html:111
+#: type/author/view.html:122
 msgid "Add another?"
 msgstr "Ajouter une autre ?"
 
-#: type/author/view.html:119
+#: type/author/view.html:130
 #, python-format
 msgid ""
 "Showing all works by author. Would you like to see <a "
@@ -4270,7 +4808,7 @@ msgstr ""
 "Affichage de toutes les œuvres de l'auteur. Souhaitez-vous voir <a "
 "href=\"%(url)s\">uniquement des livres électroniques</a> ?"
 
-#: type/author/view.html:121
+#: type/author/view.html:132
 #, python-format
 msgid ""
 "Showing ebooks only. Would you like to see <a "
@@ -4279,27 +4817,27 @@ msgstr ""
 "Affichage des livres électroniques uniquement. Aimeriez-vous voir <a "
 "href=\"%(url)s\">tout</a> de cet auteur ?"
 
-#: type/author/view.html:164
+#: type/author/view.html:179
 msgid "Time"
 msgstr "Période"
 
-#: type/author/view.html:175
+#: type/author/view.html:190
 msgid "OLID"
 msgstr "OLID"
 
-#: type/author/view.html:186
+#: type/author/view.html:201
 msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
 msgstr "Liens <span class=\"gray small sansserif\">(en dehors d'Open Library)"
 
-#: type/author/view.html:196
+#: type/author/view.html:211
 msgid "No links yet."
 msgstr "Pas encore de liens."
 
-#: type/author/view.html:196
+#: type/author/view.html:211
 msgid "Add one"
 msgstr "En ajouter un"
 
-#: type/author/view.html:203
+#: type/author/view.html:218
 msgid "Alternative names"
 msgstr "Autres noms"
 
@@ -4343,48 +4881,63 @@ msgstr "Synchroniser l'identifiant Archive.org"
 msgid "View Book on Archive.org"
 msgstr "Voir ce livre sur Archive.org"
 
-#: type/edition/admin_bar.html:28
+#: SearchResultsWork.html:107 type/edition/admin_bar.html:28
 msgid "Orphaned Edition"
 msgstr "Édition orpheline"
 
-#: type/edition/publisher_line.html:11
-msgid "This edition was published"
-msgstr "Cette édition a été publiée"
+#: databarHistory.html:26 databarView.html:33
+#: type/edition/compact_title.html:10
+msgid "Edit this template"
+msgstr "Modifier ce modèle"
 
-#: SearchResultsWork.html:78 type/edition/publisher_line.html:13
-#: type/edition/publisher_line.html:26
-msgid "in"
-msgstr "en"
+#: type/edition/modal_links.html:25
+#, fuzzy
+msgid "Review"
+msgstr "Aperçu"
 
-#: type/edition/publisher_line.html:19
+#: type/edition/modal_links.html:28
+#, fuzzy
+msgid "Notes"
+msgstr "a commenté :"
+
+#: type/edition/modal_links.html:32
+msgid "Share"
+msgstr ""
+
+#: type/edition/title_summary.html:8
+msgid "An edition of"
+msgstr "Une édition de"
+
+#: type/edition/title_summary.html:10
+#, python-format
+msgid "First published in %s"
+msgstr "Première publication en %s"
+
+#: type/edition/view.html:226 type/work/view.html:226
+#, fuzzy
+msgid "Publish Date"
+msgstr "Date de publication inconnue"
+
+#: type/edition/view.html:236 type/work/view.html:236
 #, python-format
 msgid "Show other books from %(publisher)s"
 msgstr "Montrer les autres livres de %(publisher)s"
 
-#: type/edition/publisher_line.html:23
+#: type/edition/view.html:240 type/work/view.html:240
 #, python-format
 msgid "Search for other books from %(publisher)s"
 msgstr "Rechercher d'autres livres de %(publisher)s"
 
-#: type/edition/publisher_line.html:29
-#, python-format
-msgid "Search for subjects about %(place)s"
-msgstr "Rechercher à propos de %(place)s"
-
-#: type/edition/view.html:181 type/work/view.html:181
-msgid "An edition of"
-msgstr "Une édition de"
-
-#: type/edition/view.html:207 type/work/view.html:207
-#, python-format
-msgid "Written in %(language)s"
-msgstr "Écrit en %(language)s"
-
-#: type/edition/view.html:212 type/work/view.html:212
-msgid "pages"
+#: type/edition/view.html:251 type/work/view.html:251
+#, fuzzy
+msgid "Pages"
 msgstr "pages"
 
-#: type/edition/view.html:230 type/work/view.html:230
+#: databarWork.html:101 type/edition/view.html:297 type/work/view.html:297
+msgid "Buy this book"
+msgstr "Acheter ce livre"
+
+#: type/edition/view.html:329 type/work/view.html:329
 #, python-format
 msgid ""
 "This edition doesn't have a description yet. Can you <b><a "
@@ -4393,131 +4946,120 @@ msgstr ""
 "Cette édition n'a pas encore de description. Pouvez-vous <b><a "
 "href='%(url)s'>en ajouter une</a></b> ?"
 
-#: type/edition/view.html:268 type/work/view.html:268
-#, python-format
-msgid "First published in %s"
-msgstr "Première publication en %s"
+#: type/edition/view.html:352 type/work/view.html:352
+#, fuzzy
+msgid "Book Details"
+msgstr "Détails de l'œuvre"
 
-#: type/edition/view.html:279 type/edition/view.html:280
-#: type/edition/view.html:377 type/work/view.html:279 type/work/view.html:280
-#: type/work/view.html:377
+#: type/edition/view.html:356 type/work/view.html:356
+#, fuzzy
+msgid "Published in"
+msgstr "Première publication en"
+
+#: type/edition/view.html:364 type/edition/view.html:454
+#: type/edition/view.html:455 type/work/view.html:364 type/work/view.html:454
+#: type/work/view.html:455
 msgid "First Sentence"
 msgstr "Première phrase"
 
-#: type/edition/view.html:283 type/work/view.html:283
+#: type/edition/view.html:374 type/work/view.html:374
+msgid "Edition Notes"
+msgstr "Notes de l'édition"
+
+#: type/edition/view.html:379 type/work/view.html:379
+msgid "Series"
+msgstr "Séries"
+
+#: type/edition/view.html:380 type/work/view.html:380
+msgid "Volume"
+msgstr "Volume"
+
+#: type/edition/view.html:381 type/work/view.html:381
+msgid "Genre"
+msgstr "Genre"
+
+#: type/edition/view.html:382 type/work/view.html:382
+msgid "Other Titles"
+msgstr "Autres titres"
+
+#: type/edition/view.html:383 type/work/view.html:383
+msgid "Copyright Date"
+msgstr "Date des droits d'auteur"
+
+#: type/edition/view.html:384 type/work/view.html:384
+msgid "Translation Of"
+msgstr "Traduction de"
+
+#: type/edition/view.html:385 type/work/view.html:385
+msgid "Translated From"
+msgstr "Traduit de"
+
+#: type/edition/view.html:404 type/work/view.html:404
+msgid "External Links"
+msgstr "Liens externes"
+
+#: type/edition/view.html:428 type/work/view.html:428
+msgid "Format"
+msgstr "Format"
+
+#: type/edition/view.html:429 type/work/view.html:429
+msgid "Pagination"
+msgstr "Pagination"
+
+#: type/edition/view.html:430 type/work/view.html:430
+msgid "Number of pages"
+msgstr "Nombre de pages"
+
+#: type/edition/view.html:432 type/work/view.html:432
+msgid "Weight"
+msgstr "Poids"
+
+#: type/edition/view.html:458 type/work/view.html:458
 msgid "Work Description"
 msgstr "Description de l'œuvre"
 
-#: type/edition/view.html:289 type/work/view.html:289
+#: type/edition/view.html:467 type/work/view.html:467
 msgid "Original languages"
 msgstr "Langues d'origine"
 
-#: type/edition/view.html:294 type/work/view.html:294
+#: type/edition/view.html:472 type/work/view.html:472
 msgid "Excerpts"
 msgstr "Extraits"
 
-#: type/edition/view.html:304 type/work/view.html:304
+#: type/edition/view.html:482 type/work/view.html:482
 #, python-format
 msgid "Page %(page)s"
 msgstr "Page %(page)s"
 
-#: type/edition/view.html:311 type/work/view.html:311
+#: type/edition/view.html:489 type/work/view.html:489
 #, python-format
 msgid "added by %(authorlink)s."
 msgstr "ajouté par %(authorlink)s."
 
-#: type/edition/view.html:313 type/work/view.html:313
+#: type/edition/view.html:491 type/work/view.html:491
 msgid "added anonymously."
 msgstr "ajouté anonymement."
 
-#: type/edition/view.html:321 type/work/view.html:321
+#: type/edition/view.html:499 type/work/view.html:499
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
 msgstr "Liens <span class=\"gray small sansserif\">en dehors d'Open Library</span>"
 
-#: type/edition/view.html:325 type/work/view.html:325
+#: type/edition/view.html:503 type/work/view.html:503
 msgid "Wikipedia"
 msgstr "Wikipédia"
 
-#: type/edition/view.html:337 type/work/view.html:337
-msgid "Library of Congress"
-msgstr "Bibliothèque du Congrès"
-
-#: type/edition/view.html:340 type/work/view.html:340
-msgid "Dewey"
-msgstr "Dewey"
-
-#: databarHistory.html:26 databarView.html:33 type/edition/view.html:358
-#: type/work/view.html:358
-msgid "Edit this template"
-msgstr "Modifier ce modèle"
-
-#: type/edition/view.html:362 type/work/view.html:362
-msgid "No editions available"
-msgstr "Aucune édition disponible"
-
-#: type/edition/view.html:383 type/work/view.html:383
-msgid "Edition Description"
-msgstr "Description de l'édition"
-
-#: type/edition/view.html:398 type/work/view.html:398
-msgid "Edition Notes"
-msgstr "Notes de l'édition"
-
-#: type/edition/view.html:403 type/work/view.html:403
-msgid "Series"
-msgstr "Séries"
-
-#: type/edition/view.html:404 type/work/view.html:404
-msgid "Volume"
-msgstr "Volume"
-
-#: type/edition/view.html:405 type/work/view.html:405
-msgid "Genre"
-msgstr "Genre"
-
-#: type/edition/view.html:406 type/work/view.html:406
-msgid "Other Titles"
-msgstr "Autres titres"
-
-#: type/edition/view.html:407 type/work/view.html:407
-msgid "Copyright Date"
-msgstr "Date des droits d'auteur"
-
-#: type/edition/view.html:408 type/work/view.html:408
-msgid "Translation Of"
-msgstr "Traduction de"
-
-#: type/edition/view.html:409 type/work/view.html:409
-msgid "Translated From"
-msgstr "Traduit de"
-
-#: type/edition/view.html:428 type/work/view.html:428
-msgid "External Links"
-msgstr "Liens externes"
-
-#: type/edition/view.html:452 type/work/view.html:452
-msgid "Format"
-msgstr "Format"
-
-#: type/edition/view.html:453 type/work/view.html:453
-msgid "Pagination"
-msgstr "Pagination"
-
-#: type/edition/view.html:454 type/work/view.html:454
-msgid "Number of pages"
-msgstr "Nombre de pages"
-
-#: type/edition/view.html:456 type/work/view.html:456
-msgid "Weight"
-msgstr "Poids"
-
-#: type/edition/view.html:488 type/work/view.html:488
+#: type/edition/view.html:519 type/work/view.html:519
 msgid "Lists containing this Book"
 msgstr "Listes contenant ce livre"
 
 #: type/language/view.html:22
 msgid "Code"
 msgstr "Code"
+
+#: type/language/view.html:31
+#, python-format
+msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
+msgstr ""
 
 #: type/list/edit.html:14
 msgid "Edit List"
@@ -4531,15 +5073,15 @@ msgstr "Étiquette"
 msgid "Description"
 msgstr "Description"
 
-#: type/list/embed.html:22
+#: type/list/embed.html:23
 msgid "Visit Open Library"
 msgstr "Visiter Open Library"
 
-#: type/list/embed.html:41 type/list/view_body.html:198
+#: type/list/embed.html:42 type/list/view_body.html:199
 msgid "Unknown authors"
 msgstr "Auteurs inconnus"
 
-#: type/list/embed.html:66
+#: type/list/embed.html:67
 msgid ""
 "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
 "formats from main book page"
@@ -4547,19 +5089,23 @@ msgstr ""
 "Ouvrir dans le lecteur de livres en ligne. Téléchargements disponibles "
 "aux formats ePub, DAISY, PDF, TXT à partir de la page principale du livre"
 
-#: type/list/embed.html:72
+#: type/list/embed.html:73
 msgid "This book is checked out"
 msgstr "Ce livre est déjà emprunté"
 
-#: type/list/embed.html:77
+#: type/list/embed.html:75
+msgid "Checked out"
+msgstr "Emprunté"
+
+#: type/list/embed.html:78
 msgid "Borrow book"
 msgstr "Emprunter le livre"
 
-#: type/list/embed.html:82
+#: type/list/embed.html:83
 msgid "Protected DAISY"
 msgstr "DAISY protégé"
 
-#: type/list/embed.html:99
+#: BookByline.html:34 type/list/embed.html:100
 #, python-format
 msgid "by %(name)s"
 msgstr "par %(name)s"
@@ -4609,37 +5155,37 @@ msgstr ""
 msgid "%(name)s | Lists | Open Library"
 msgstr "%(name)s | Listes | Open Library"
 
-#: type/list/view_body.html:18
+#: type/list/view_body.html:17
 #, python-format
 msgid "%(title)s: %(description)s"
 msgstr "%(title)s : %(description)s"
 
-#: type/list/view_body.html:27
+#: type/list/view_body.html:26
 msgid "View the list on Open Library."
 msgstr "Voir la liste sur Open Library."
 
-#: type/list/view_body.html:164
+#: type/list/view_body.html:165
 msgid "Remove this item?"
 msgstr "Supprimer cet élément ?"
 
-#: type/list/view_body.html:178
+#: type/list/view_body.html:179
 #, python-format
 msgid "Last updated <span>%(date)s</span>"
 msgstr "Dernière mise à jour le <span>%(date)s</span>"
 
-#: type/list/view_body.html:189
+#: type/list/view_body.html:190
 msgid "Remove seed"
 msgstr "Supprimer l'élément"
 
-#: type/list/view_body.html:189
+#: type/list/view_body.html:190
 msgid "Are you sure you want to remove this item from the list?"
 msgstr "Voulez-vous vraiment supprimer cet élément de la liste ?"
 
-#: type/list/view_body.html:190
+#: type/list/view_body.html:191
 msgid "Remove Seed"
 msgstr "Supprimer l'élément"
 
-#: type/list/view_body.html:191
+#: type/list/view_body.html:192
 msgid ""
 "You are about to remove the last item in the list. That will delete the "
 "whole list. Are you sure you want to continue?"
@@ -4647,11 +5193,11 @@ msgstr ""
 "Vous êtes sur le point de supprimer le dernier élément de la liste. Cela "
 "supprimera toute la liste. Êtes-vous sûr de vouloir continuer ?"
 
-#: type/list/view_body.html:257
+#: type/list/view_body.html:261
 msgid "List Metadata"
 msgstr "Métadonnées de la liste"
 
-#: type/list/view_body.html:258
+#: type/list/view_body.html:262
 msgid "Derived from seed metadata"
 msgstr "Dérivées des métadonnées des éléments"
 
@@ -4750,12 +5296,12 @@ msgstr "Ce lecteur a choisi de garder son journal de lecture privé."
 msgid "No edits. Yet."
 msgstr "Pas encore de modifications."
 
-#: SearchResultsWork.html:72 type/work/editions.html:11
+#: SearchResultsWork.html:83 type/work/editions.html:11
 #, python-format
 msgid "First published in %(year)s"
 msgstr "Première publication en %(year)s"
 
-#: type/work/editions.html:14 type/work/editions_datatable.html:37
+#: type/work/editions.html:14 type/work/editions_datatable.html:47
 #, python-format
 msgid "Add another edition of %(work)s"
 msgstr "Ajouter une autre édition de %(work)s"
@@ -4769,14 +5315,30 @@ msgid "Title missing"
 msgstr "Titre manquant"
 
 #: type/work/editions_datatable.html:13
+#, python-format
+msgid "Showing one featured edition."
+msgid_plural "Showing %(count)d featured editions."
+msgstr[0] ""
+msgstr[1] ""
+
+#: type/work/editions_datatable.html:14
+#, fuzzy, python-format
+msgid "View all %(count)d editions?"
+msgstr "Voir %(count)d édition"
+
+#: type/work/editions_datatable.html:20
 msgid "Edition"
 msgstr "Édition"
 
-#: type/work/editions_datatable.html:14
+#: type/work/editions_datatable.html:21
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: type/work/editions_datatable.html:37
+#: type/work/editions_datatable.html:42
+msgid "No editions available"
+msgstr "Aucune édition disponible"
+
+#: type/work/editions_datatable.html:47
 msgid "Add another edition?"
 msgstr "Ajouter une autre édition ?"
 
@@ -4801,19 +5363,22 @@ msgstr "Bookshop.org"
 msgid "Look for this edition for sale at %(store)s"
 msgstr "Rechercher cette édition en vente sur %(store)s"
 
-#: AuthorList.html:9
-msgid "Go to this author's page"
-msgstr "Aller à la page de cet auteur"
+#: BookByline.html:20
+#, python-format
+msgid "1 other"
+msgid_plural "%(n)s others"
+msgstr[0] "1 autre"
+msgstr[1] "%(n)s autres"
 
-#: AuthorList.html:11
+#: BookByline.html:36
 msgid "by an <em>unknown author</em>"
 msgstr "par un <em>auteur inconnu</em>"
 
-#: BookPreview.html:18
+#: BookPreview.html:19
 msgid "Preview Book"
 msgstr "Aperçu du livre"
 
-#: BookPreview.html:28
+#: BookPreview.html:29
 msgid "See more about this book on Archive.org"
 msgstr "En voir plus sur ce livre sur Archive.org"
 
@@ -4821,87 +5386,89 @@ msgstr "En voir plus sur ce livre sur Archive.org"
 msgid "(Optional, but very useful!)"
 msgstr "(Facultatif, mais très utile !)"
 
-#: EditButtons.html:27
-msgid ""
-"<em>Please Note:</em> Only Admins can delete things. <a href=\"/contact\""
-" class=\"blue\">Let us know</a> if there's a problem."
-msgstr ""
-"<em>Remarque :</em> Seuls les administrateurs peuvent supprimer des "
-"éléments. <a href=\"/contact\" class=\"blue\">Faites-nous savoir</a> s'il"
-" y a un problème."
-
 #: EditButtonsMacros.html:27
 msgid "Delete this record"
 msgstr "Supprimer cette entrée"
 
-#: EditionNavBar.html:10
+#: EditionNavBar.html:11
+msgid "Overview"
+msgstr "Aperçu"
+
+#: EditionNavBar.html:15
 #, python-format
 msgid "View %(count)s Edition"
 msgid_plural "View %(count)s Editions"
 msgstr[0] "Voir %(count)s édition"
 msgstr[1] "Voir %(count)s éditions"
 
-#: EditionNavBar.html:14
-msgid "Overview"
-msgstr "Aperçu"
+#: EditionNavBar.html:19
+#, fuzzy
+msgid "Details"
+msgstr "courriel"
 
-#: LoanStatus.html:44
+#: EditionNavBar.html:24
+#, python-format
+msgid "%(reviews)s Review"
+msgid_plural "%(reviews)s Reviews"
+msgstr[0] ""
+msgstr[1] ""
+
+#: EditionNavBar.html:33
+#, fuzzy
+msgid "Related Books"
+msgstr "Manuels scolaires"
+
+#: LoanStatus.html:56
 msgid "Return eBook"
 msgstr "Rendre le livre"
 
-#: LoanStatus.html:51
+#: LoanStatus.html:62
 msgid "Really return this book?"
 msgstr "Vraiment rendre ce livre ?"
 
-#: LoanStatus.html:79
+#: LoanStatus.html:97
 msgid "You are <strong>next</strong> on the waiting list"
 msgstr "Vous êtes le <strong>suivant</strong> sur la liste d'attente"
 
-#: LoanStatus.html:81
+#: LoanStatus.html:99
 #, python-format
 msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
 msgstr "Vous êtes <strong>#%(spot)d</strong> de %(wlsize)d sur la liste d'attente."
 
-#: LoanStatus.html:86
+#: LoanStatus.html:104
 msgid "Leave waiting list"
 msgstr "Quitter la liste d'attente"
 
-#: LoanStatus.html:92
-#, python-format
-msgid "Readers waiting for this title: %(count)s"
+#: LoanStatus.html:118
+#, fuzzy, python-format
+msgid "Readers in line: %(count)s"
 msgstr "Lecteurs en attente de ce livre : %(count)s"
 
-#: LoanStatus.html:94
+#: LoanStatus.html:120
 msgid "You'll be next in line."
 msgstr "Vous serez le prochain dans la file."
 
-#: LoanStatus.html:103
+#: LoanStatus.html:125
 msgid "This book is currently checked out, please check back later."
 msgstr "Ce livre est déjà emprunté, veuillez réessayer plus tard."
 
-#: LoanStatus.html:104
+#: LoanStatus.html:126
 msgid "Checked Out"
 msgstr "Emprunté"
 
-#: LoanStatus.html:113
-msgid "Donate Book"
-msgstr "Faire un don de livre"
-
-#: LoanStatus.html:116
-msgid "We don't have this book yet. Can you donate it to the Lending Library?"
-msgstr ""
-"Nous n'avons pas encore ce livre. Pouvez-vous en faire don à notre "
-"bibliothéque ?"
-
-#: LoanStatus.html:120 LoanStatus.html:125
+#: NotInLibrary.html:9
 msgid "Not in Library"
 msgstr "Indisponible"
 
-#: NotesModal.html:33
+#: NotesModal.html:31
+msgid "My Book Notes"
+msgstr "Mes notes de livre"
+
+#: NotesModal.html:35
 msgid "My private notes about this edition:"
 msgstr "Mes notes privées sur cette édition :"
 
-#: ObservationsModal.html:24
+#: ObservationsModal.html:31
 msgid "My Book Review"
 msgstr "Mes critiques de livre"
 
@@ -4929,10 +5496,6 @@ msgstr "Emprunter le livre électronique sur Internet Archive"
 msgid "Read ebook from Internet Archive"
 msgstr "Lire le livre électronique depuis l'Internet Archive"
 
-#: ReadButton.html:39
-msgid "Listen"
-msgstr "Écouter"
-
 #: ReadMore.html:7
 msgid "Read more"
 msgstr "Lire plus"
@@ -4941,6 +5504,31 @@ msgstr "Lire plus"
 msgid "Read less"
 msgstr "Lire moins"
 
+#: ReadingLogDropper.html:88
+msgid "My Reading Lists:"
+msgstr "Mes listes de lecture :"
+
+#: ReadingLogDropper.html:103
+msgid "Use this Work"
+msgstr "Utiliser cette œuvre"
+
+#: ReadingLogDropper.html:106 ReadingLogDropper.html:127
+#: ReadingLogDropper.html:143 databarAuthor.html:27 databarAuthor.html:34
+msgid "Create a new list"
+msgstr "Créer une nouvelle liste"
+
+#: ReadingLogDropper.html:117 ReadingLogDropper.html:133
+msgid "Add to List"
+msgstr "Ajouter à la liste"
+
+#: ReadingLogDropper.html:157
+msgid "Description:"
+msgstr "Description :"
+
+#: ReadingLogDropper.html:165
+msgid "Create new list"
+msgstr "Créer une nouvelle liste"
+
 #: RecentChanges.html:54
 msgid "View MARC"
 msgstr "Voir MARC"
@@ -4948,10 +5536,6 @@ msgstr "Voir MARC"
 #: RecentChangesAdmin.html:21
 msgid "Path"
 msgstr "Chemin"
-
-#: RecentChangesAdmin.html:22
-msgid "Comments"
-msgstr "Commentaires"
 
 #: RecentChangesAdmin.html:41
 msgid "view"
@@ -4969,51 +5553,52 @@ msgstr "différences"
 msgid "Return book"
 msgstr "Rendre le livre"
 
-#: SearchResultsWork.html:67
+#: SearchResultsWork.html:89
 #, python-format
-msgid "1 other"
-msgid_plural "%(n)s others"
-msgstr[0] "1 autre"
-msgstr[1] "%(n)s autres"
+msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">1 language</a>"
+msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
+msgstr[0] ""
+msgstr[1] ""
 
-#: SearchResultsWork.html:78
-msgid "languages"
-msgstr "langues"
-
-#: SearchResultsWork.html:81
+#: SearchResultsWork.html:92
 #, python-format
 msgid "%s previewable"
 msgstr "%s prévisualisable"
 
-#: SocialShare.html:16
-msgid "Share this book"
-msgstr "Partager ce livre"
+#: SearchResultsWork.html:102
+msgid "This is only visible to librarians."
+msgstr ""
 
-#: SocialShare.html:31
+#: SearchResultsWork.html:104
+#, fuzzy
+msgid "Work Title"
+msgstr "Statistiques de l'œuvre"
+
+#: ShareModal.html:44
 msgid "Embed this book in your website"
 msgstr "Intégrer ce livre dans votre site Web"
 
-#: SocialShare.html:35
+#: ShareModal.html:48
 msgid "Embed"
 msgstr "Intégrer"
 
-#: StarRatings.html:51
+#: StarRatings.html:52
 msgid "Clear my rating"
 msgstr "Supprimer mon évaluation"
 
-#: StarRatingsStats.html:21
+#: StarRatingsStats.html:22
 msgid "Ratings"
 msgstr "Évaluations"
 
-#: StarRatingsStats.html:23
+#: StarRatingsStats.html:24
 msgid "Want to read"
 msgstr "Envie de lire"
 
-#: StarRatingsStats.html:24
+#: StarRatingsStats.html:25
 msgid "Currently reading"
 msgstr "En cours de lecture"
 
-#: StarRatingsStats.html:25
+#: StarRatingsStats.html:26
 msgid "Have read"
 msgstr "A lu"
 
@@ -5108,18 +5693,6 @@ msgstr "Consulter les bibliothèques à proximité"
 msgid "Check WorldCat for an edition near you"
 msgstr "Consulter WorldCat pour une édition près de chez vous"
 
-#: daisy.html:10
-msgid "Encrypted daisy download for authorized print-disabled patrons"
-msgstr "Téléchargement daisy chiffré pour utilisateurs malvoyants habilités"
-
-#: daisy.html:12
-msgid "Encrypted daisy lock"
-msgstr "Verrou daisy chiffré"
-
-#: daisy.html:14
-msgid "Download for print-disabled"
-msgstr "Télécharger pour les malvoyants"
-
 #: databarAuthor.html:20
 msgid "Add to list"
 msgstr "Ajouter à la liste"
@@ -5132,10 +5705,6 @@ msgstr "×"
 msgid "Add new list"
 msgstr "Ajouter une nouvelle liste"
 
-#: databarAuthor.html:86
-msgid "from"
-msgstr "de"
-
 #: databarHistory.html:16 databarView.html:22
 #, python-format
 msgid "Last edited by %(author_link)s"
@@ -5145,24 +5714,20 @@ msgstr "Dernière modification par %(author_link)s"
 msgid "Last edited anonymously"
 msgstr "Dernière modification anonyme"
 
-#: databarWork.html:86
-msgid "Buy this book"
-msgstr "Acheter ce livre"
-
-#: databarWork.html:105
+#: databarWork.html:115
 #, python-format
 msgid "This book was generously donated by %(donor)s"
 msgstr "Ce livre a été généreusement donné par %(donor)s"
 
-#: databarWork.html:107
+#: databarWork.html:117
 msgid "This book was generously donated anonymously"
 msgstr "Ce livre a été généreusement donné anonymement"
 
-#: databarWork.html:112
+#: databarWork.html:122
 msgid "Learn more about Book Sponsorship"
 msgstr "En savoir plus sur le parrainage de livres"
 
-#: account.py:423 account.py:461
+#: account.py:420 account.py:458
 #, python-format
 msgid ""
 "We've sent the verification email to %(email)s. You'll need to read that "
@@ -5172,31 +5737,31 @@ msgstr ""
 "l'ouvrir et cliquer sur le lien de vérification pour valider votre "
 "courriel."
 
-#: account.py:489
+#: account.py:486
 msgid "Username must be between 3-20 characters"
 msgstr "Le nom d'utilisateur doit contenir entre 3 et 20 caractères"
 
-#: account.py:491
+#: account.py:488
 msgid "Username may only contain numbers and letters"
 msgstr "Le nom d'utilisateur doit seulement contenir des chiffres et des lettres"
 
-#: account.py:494
+#: account.py:491
 msgid "Username unavailable"
 msgstr "Nom d'utilisateur indisponible"
 
-#: account.py:499 forms.py:60
+#: account.py:496 forms.py:60
 msgid "Must be a valid email address"
 msgstr "Doit être une adresse de courriel valide"
 
-#: account.py:503 forms.py:41
+#: account.py:500 forms.py:41
 msgid "Email already registered"
 msgstr "Courriel déjà enregistré"
 
-#: account.py:530
+#: account.py:526
 msgid "Email address is already used."
 msgstr "L'adresse de courriel est déjà utilisée."
 
-#: account.py:531
+#: account.py:527
 msgid ""
 "Your email address couldn't be updated. The specified email address is "
 "already used."
@@ -5204,21 +5769,21 @@ msgstr ""
 "Votre adresse de courriel n'a pas pu être mise à jour. L'adresse de "
 "courriel spécifiée est déjà utilisée."
 
-#: account.py:537
+#: account.py:533
 msgid "Email verification successful."
 msgstr "Vérification du courriel réussie."
 
-#: account.py:538
+#: account.py:534
 msgid ""
 "Your email address has been successfully verified and updated in your "
 "account."
 msgstr "Votre adresse de courriel a été vérifiée et mise à jour dans votre compte."
 
-#: account.py:544
+#: account.py:540
 msgid "Email address couldn't be verified."
 msgstr "L'adresse de courriel n'a pas pu être vérifiée."
 
-#: account.py:545
+#: account.py:541
 msgid ""
 "Your email address couldn't be verified. The verification link seems "
 "invalid."
@@ -5226,11 +5791,11 @@ msgstr ""
 "Votre adresse de courriel n'a pas pu être vérifiée. Le lien de "
 "vérification semble incorrect."
 
-#: account.py:649 account.py:659
+#: account.py:645 account.py:655
 msgid "Password reset failed."
 msgstr "La mise à jour du mot de passe a échoué."
 
-#: account.py:706 account.py:725
+#: account.py:702 account.py:721
 msgid "Notification preferences have been updated successfully."
 msgstr "Les préférences de notifications ont été mises à jour."
 
@@ -5262,31 +5827,31 @@ msgstr "Doit contenir entre 3 et 20 lettres et chiffres"
 msgid "Must be between 3 and 20 characters"
 msgstr "Doit contenir entre 3 et 20 caractères"
 
-#: forms.py:78 forms.py:154
+#: forms.py:78 forms.py:156
 msgid "Your email address"
 msgstr "Votre adresse de courriel"
 
 #: forms.py:90
-msgid "Choose a screen name"
-msgstr "Choisissez un nom d'utilisateur"
+msgid "Choose a screen name. Screen names are public and cannot be changed later."
+msgstr ""
 
-#: forms.py:92
+#: forms.py:94
 msgid "Letters and numbers only please, and at least 3 characters."
 msgstr "Uniquement des lettres et des chiffres, et au moins 3 caractères."
 
-#: forms.py:98 forms.py:160
+#: forms.py:100 forms.py:162
 msgid "Choose a password"
 msgstr "Choisissez un mot de passe"
 
-#: forms.py:104
+#: forms.py:106
 msgid "Confirm password"
 msgstr "Confirmez le mot de passe"
 
-#: forms.py:108
+#: forms.py:110
 msgid "Passwords didn't match."
 msgstr "Les mots de passe ne correspondent pas."
 
-#: forms.py:113
+#: forms.py:115
 msgid ""
 "I want to receive news, announcements, and resources from the <a "
 "href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
@@ -5296,6 +5861,139 @@ msgstr ""
 "href=\"https://archive.org/\">Internet Archive</a>, l'association à but "
 "non lucratif qui gère Open Library."
 
-#: forms.py:149
+#: forms.py:151
 msgid "Invalid password"
 msgstr "Mot de passe incorrect"
+
+#~ msgid "Your Notifications"
+#~ msgstr "Vos notifications"
+
+#~ msgid "Internet Archive Announcements"
+#~ msgstr "Annonces d'Internet Archive"
+
+#~ msgid "Your Privacy Settings"
+#~ msgstr "Vos paramètres de confidentialité"
+
+#~ msgid "Books You've Checked Out"
+#~ msgstr "Livres que vous avez empruntés"
+
+#~ msgid "Waitlist"
+#~ msgstr "Liste d'attente"
+
+#~ msgid "Reading Stats"
+#~ msgstr "Statistiques de lecture"
+
+#~ msgid "The year it was published is plenty."
+#~ msgstr "L'année de publication suffit."
+
+#~ msgid "My Reading Log"
+#~ msgstr "Mon journal de lecture"
+
+#~ msgid "Russian"
+#~ msgstr "russe"
+
+#~ msgid "Italian"
+#~ msgstr "italien"
+
+#~ msgid "Arabic"
+#~ msgstr "arabe"
+
+#~ msgid "Japanese"
+#~ msgstr "japonais"
+
+#~ msgid "Polish"
+#~ msgstr "polonais"
+
+#~ msgid "Only eBooks"
+#~ msgstr "Seulement les livres électroniques"
+
+#~ msgid "Search eBook text"
+#~ msgstr "Rechercher dans les livres électroniques"
+
+#~ msgid "Your Profile"
+#~ msgstr "Votre profil"
+
+#~ msgid "Log in"
+#~ msgstr "Se connecter"
+
+#~ msgid "No lists yet!"
+#~ msgstr "Pas encore de listes !"
+
+#~ msgid ""
+#~ "Are you sure you want to remove"
+#~ " <strong>%(title)s</strong> from your list?"
+#~ msgstr ""
+#~ "Voulez-vous vraiment supprimer "
+#~ "<strong>%(title)s</strong> de votre liste ?"
+
+#~ msgid "saving..."
+#~ msgstr "enregistrement…"
+
+#~ msgid "Author Search"
+#~ msgstr "Recherche d'auteur"
+
+#~ msgid "Subject Search"
+#~ msgstr "Recherche par thème"
+
+#~ msgid "This edition was published"
+#~ msgstr "Cette édition a été publiée"
+
+#~ msgid "in"
+#~ msgstr "en"
+
+#~ msgid "Search for subjects about %(place)s"
+#~ msgstr "Rechercher à propos de %(place)s"
+
+#~ msgid "Written in %(language)s"
+#~ msgstr "Écrit en %(language)s"
+
+#~ msgid "Library of Congress"
+#~ msgstr "Bibliothèque du Congrès"
+
+#~ msgid "Dewey"
+#~ msgstr "Dewey"
+
+#~ msgid "Edition Description"
+#~ msgstr "Description de l'édition"
+
+#~ msgid "Go to this author's page"
+#~ msgstr "Aller à la page de cet auteur"
+
+#~ msgid ""
+#~ "<em>Please Note:</em> Only Admins can "
+#~ "delete things. <a href=\"/contact\" "
+#~ "class=\"blue\">Let us know</a> if there's "
+#~ "a problem."
+#~ msgstr ""
+#~ "<em>Remarque :</em> Seuls les administrateurs"
+#~ " peuvent supprimer des éléments. <a "
+#~ "href=\"/contact\" class=\"blue\">Faites-nous "
+#~ "savoir</a> s'il y a un problème."
+
+#~ msgid "Donate Book"
+#~ msgstr "Faire un don de livre"
+
+#~ msgid "We don't have this book yet. Can you donate it to the Lending Library?"
+#~ msgstr ""
+#~ "Nous n'avons pas encore ce livre. "
+#~ "Pouvez-vous en faire don à notre "
+#~ "bibliothéque ?"
+
+#~ msgid "languages"
+#~ msgstr "langues"
+
+#~ msgid "Share this book"
+#~ msgstr "Partager ce livre"
+
+#~ msgid "Encrypted daisy download for authorized print-disabled patrons"
+#~ msgstr "Téléchargement daisy chiffré pour utilisateurs malvoyants habilités"
+
+#~ msgid "Encrypted daisy lock"
+#~ msgstr "Verrou daisy chiffré"
+
+#~ msgid "Download for print-disabled"
+#~ msgstr "Télécharger pour les malvoyants"
+
+#~ msgid "Choose a screen name"
+#~ msgstr "Choisissez un nom d'utilisateur"
+

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -936,7 +936,7 @@ msgstr "Journal de lecture"
 #: lib/nav_head.html:76
 #, fuzzy
 msgid "My Books"
-msgstr "Livres électroniques"
+msgstr "Mes livres"
 
 #: account/books.html:35 account/readinglog_shelf_name.html:10
 msgid "Want To Read"

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -934,7 +934,6 @@ msgstr "Journal de lecture"
 
 #: account/books.html:31 lib/nav_head.html:13 lib/nav_head.html:25
 #: lib/nav_head.html:76
-#, fuzzy
 msgid "My Books"
 msgstr "Mes livres"
 

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -683,7 +683,7 @@ msgstr "Les livres les plus populaires"
 
 #: trending.html:12
 msgid "See what readers from the community are adding to their bookshelves"
-msgstr ""
+msgstr "Voir ce que les lecteurs de cette communauté ajoutent à leur bibliothèque"
 
 #: ReadingLogDropper.html:27 ReadingLogDropper.html:66
 #: ReadingLogDropper.html:189 account/mybooks.html:75 account/sidebar.html:26


### PR DESCRIPTION

 **What issue does this PR close?**

There is not any PR associated with this issue.

I have translated the "Trending Books" portion of the French home page. The intention of this translation is to ensure the home page is read more naturally by French speakers.

In addition, upon updating the file, I ran into an issue as it seems another portion of the file had been changed but not updated.

```
openlibrary/i18n/fr/messages.po:5326: 'Voir %(count)s édition'
    incompatible format for placeholder 'count': 's' and 'd' are not compatible
    Failed custom string format validation

Validation failed...
Please correct the errors before proceeding.
Validation failed.
2 errors found...
```




This was fixed by switching "s" to "d" on the French translated portion. Once updated all tests passed.

 **What does this PR achieve?**

Translates the " Trending Books" portion of the French home page.

**Testing**

To check this has been rectified on the main page, the "Trending Books" section should read " Les livres les plus populaires".




<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
