### PR TITLE
Add number of work part to edition titles. Fixes #701

### DIFF
--- a/openlibrary/catalog/marc/tests/test_data/bin_expect/equalsign_title.mrc
+++ b/openlibrary/catalog/marc/tests/test_data/bin_expect/equalsign_title.mrc
@@ -3,7 +3,7 @@
     "Thedepartment = Yr adran"
   ],
   "pagination": "14p.",
-  "subtitle": "School budgets",
+  "subtitle": "School budgets : 1990/91",
   "title": "Cyllidebau ysgolion",
   "notes": "Welsh and English text = Testyn Cymraeg a Saesneg.",
   "number_of_pages": 14,


### PR DESCRIPTION

Closes #701

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Bugfix for #701 to add the number of work part (245$n) to edition titles. 

### Technical
- it's trivial

### Testing
- run MARC unit tests

### Stakeholders
@hornc @mekarpeles 

