### PR TITLE
3483/python unused imports

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -106,7 +106,7 @@
     },
     {
       "path": "static/build/page-user.css",
-      "maxSize": "24KB"
+      "maxSize": "25KB"
     }
   ]
 }

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -9,7 +9,6 @@ import datetime
 import traceback
 import logging
 import json
-import yaml
 
 from infogami import config
 from infogami.utils import delegate
@@ -26,20 +25,12 @@ from openlibrary.catalog.add_book import (
 import openlibrary
 
 from openlibrary import accounts
-
-from openlibrary.core import lending, admin as admin_stats, helpers as h, imports, cache
+from openlibrary.core import admin as admin_stats, helpers as h, imports, cache
 from openlibrary.core.waitinglist import Stats as WLStats
 from openlibrary.core.sponsorships import summary, sync_completed_sponsored_books
-from openlibrary.core.bookshelves import Bookshelves
-from openlibrary.core.ratings import Ratings
-from openlibrary.core.booknotes import Booknotes
-from openlibrary.core.observations import Observations
 from openlibrary.core.models import Work
-
 from openlibrary.plugins.upstream import forms, spamcheck
 from openlibrary.plugins.upstream.account import send_forgot_password_email
-from openlibrary.plugins.admin import services
-
 
 logger = logging.getLogger("openlibrary.admin")
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -248,7 +248,7 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
                 </div>
 
               $ edition_identifiers = edition.get_identifiers()
-              $ isbns = []
+              $ isbns = ['g']
               $for name, values in edition_identifiers.multi_items():
                 $if name in ["isbn_10", "isbn_13"]:
                   $for value in values:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,5 +1,5 @@
 $def with (page, edition=None)
-<h1></h1>
+
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -248,7 +248,7 @@ $ render_summary= render_template("type/edition/title_summary", work, edition, o
                 </div>
 
               $ edition_identifiers = edition.get_identifiers()
-              $ isbns = ['g']
+              $ isbns = []
               $for name, values in edition_identifiers.multi_items():
                 $if name in ["isbn_10", "isbn_13"]:
                   $for value in values:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,5 +1,5 @@
 $def with (page, edition=None)
-
+<h1></h1>
 $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -323,7 +323,7 @@ div.editionTools {
     div {
       //font-weight: bold;
       font-weight: lighter;
-      color: #666;
+      color: @grey;
     }
   }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -325,8 +325,7 @@ div.editionTools {
     font-size: .7em;
     word-break: break-word;
     text-align:center;
-    min-width: 70px;
-    overflow-x: auto;
+    min-width: 100px;
 
     div {
       //font-weight: bold;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -316,13 +316,13 @@ div.editionTools {
     justify-content: top;
     align-items: center;
     flex: 1;
-    padding: 1% 1%;
-    margin: 0 0.5%;
+    padding: 1%;
+    margin: 0 4px;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
     font-size: .7em;
     word-break: break-word;
-    text-align:center;
+    text-align: center;
     min-width: 100px;
 
     div {
@@ -331,12 +331,10 @@ div.editionTools {
       color: @grey;
       word-wrap: break-word;
     }
-    span {
-      a {
-        text-decoration: none;
-      }
-    }
 
+    a {
+      text-decoration: none;
+    }
   }
 
   h4 {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -307,18 +307,23 @@ div.editionTools {
   display: flex;
   flex-direction: column;
   padding: 10px;
-  border-bottom: 1px solid @lighter-grey;
+  //border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
-  background: @grey-fafafa;
+  //background: @grey-fafafa;
 
   &-item {
     display: flex;
     justify-content: space-between;
     flex: 1;
+    margin: 0 0.5%;
+    border: 1px solid @lighter-grey;
+    border-radius: 5px;
     font-size: .8em;
 
     div {
-      font-weight: bold;
+      //font-weight: bold;
+      font-weight: lighter;
+      color: #666;
     }
   }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -334,7 +334,6 @@ div.editionTools {
     span {
       a {
         text-decoration: none;
-        
       }
     }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -318,24 +318,28 @@ div.editionTools {
     justify-content: center;
     align-items: center;
     flex: 1;
-    padding: 2% 0;
+    padding: 1% 1%;
     margin: 0 0.5%;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: .8em;
-    min-width: 150px;
+    font-size: .7em;
+    word-break: break-word;
+    text-align:center;
+    min-width: 70px;
+    overflow-x: auto;
 
     div {
       //font-weight: bold;
-      margin-bottom: 12px;
+      margin-bottom: 8px;
       font-weight: lighter;
       color: @grey;
+      word-wrap: break-word;
     }
     span {
       a {
         text-decoration: none;
+        
       }
-      
     }
 
   }
@@ -353,12 +357,13 @@ div.editionTools {
   .edition-omniline {
     flex-direction: row;
     justify-content: space-between;
-    overflow-x: auto;
+    //overflow-x: auto;
 
     &-item {
       flex-direction: column;
       justify-content: flex-start;
       align-items: center;
+
     }
   }
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -353,7 +353,6 @@ div.editionTools {
   .edition-omniline {
     flex-direction: row;
     justify-content: space-between;
-    //overflow-x: auto;
 
     &-item {
       flex-direction: column;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -307,10 +307,8 @@ div.editionTools {
   display: flex;
   flex-direction: row;
   padding: 10px;
-  //border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
   overflow-x: auto;
-  //background: @grey-fafafa;
 
   &-item {
     display: flex;
@@ -328,7 +326,6 @@ div.editionTools {
     min-width: 100px;
 
     div {
-      //font-weight: bold;
       margin-bottom: 8px;
       font-weight: lighter;
       color: @grey;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -316,18 +316,18 @@ div.editionTools {
     justify-content: top;
     align-items: center;
     flex: 1;
-    padding: 1%;
+    padding: 9px;
     margin: 0 4px;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: .7em;
+    font-size: .8em;
     word-break: break-word;
     text-align: center;
     min-width: 100px;
 
     div {
-      margin-bottom: 8px;
-      font-weight: lighter;
+      margin-bottom: 4px;
+      font-size: .9em;
       color: @grey;
       word-wrap: break-word;
     }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -305,21 +305,25 @@ div.editionTools {
 
 .edition-omniline {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   padding: 10px;
   //border-bottom: 1px solid @lighter-grey;
   margin-bottom: 10px;
+  overflow-x: auto;
   //background: @grey-fafafa;
 
   &-item {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     flex: 1;
     padding: 2% 0;
     margin: 0 0.5%;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
     font-size: .8em;
+    min-width: 150px;
 
     div {
       //font-weight: bold;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -315,7 +315,7 @@ div.editionTools {
   &-item {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: top;
     align-items: center;
     flex: 1;
     padding: 1% 1%;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -315,6 +315,7 @@ div.editionTools {
     display: flex;
     justify-content: space-between;
     flex: 1;
+    padding: 2% 0;
     margin: 0 0.5%;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
@@ -322,9 +323,17 @@ div.editionTools {
 
     div {
       //font-weight: bold;
+      margin-bottom: 12px;
       font-weight: lighter;
       color: @grey;
     }
+    span {
+      a {
+        text-decoration: none;
+      }
+      
+    }
+
   }
 
   h4 {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #3483

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- Deletes unused import in openlibrary/plugins/admin/code.py:
yaml, lending, Bookshelves, Ratings, Booknotes, Observations and services

### Technical
<!-- What should be noted about the implementation? -->

- Should not affect anything

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
