### PR TITLE
Removed quote doubling code from subject editing

### DIFF
--- a/openlibrary/templates/books/edit/about.html
+++ b/openlibrary/templates/books/edit/about.html
@@ -6,7 +6,6 @@ $jsdef render_subject_field(name, data):
         $code:
             subjects = []
             for s in data:
-                s = s.replace('"', '""')
                 subjects.append('"' + s + '"' if ',' in s else s)
             subject_str = ', '.join(subjects)
             rows = len(subject_str) // 95 + 1


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7374

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Stops the editing interface from doubling quotation marks embedded within subject tags.

### Technical
<!-- What should be noted about the implementation? -->
The quote doubling function was in place for the previous version of the subject editing code, and was no longer needed, so I removed it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create a tag with internal quotes, e.g. Winnie "The" Pooh. Save the change, then edit again. The quotes should remain as originally entered.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mheiman @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
