### PR TITLE
Display reading goal banner only on new My Books page

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -58,12 +58,13 @@ $var title: $header_title
 
   <div class="mybooks-details">
     $ component_times['Details header'] = time()
-    $ year = get_reading_goals_year()
-    $ current_goal = get_reading_goals(year=year)
-    $if not current_goal:
+    $if key == 'mybooks':
+      $ year = get_reading_goals_year()
+      $ current_goal = get_reading_goals(year=year)
+      $if not current_goal:
         <div class="page-banner page-banner-body page-banner-mybooks">
           Announcing Yearly Reading Goals: <a href="https://blog.openlibrary.org/2022/12/31/reach-your-2023-reading-goals-with-open-library" class="btn primary">Learn More</a> or <a class="btn primary set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year)s reading goal', year=year)</a>
-	</div>
+        </div>
     <header>
       <div>
         <div class="small sansserif grey account-settings-menu">

--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -57,14 +57,16 @@ $var title: $header_title
   $:render_template("account/sidebar", user, key=key, public=public, owners_page=owners_page, counts=shelf_counts, lists=lists, component_times=component_times)
 
   <div class="mybooks-details">
-    $ component_times['Details header'] = time()
     $if key == 'mybooks':
+      $ component_times['Yearly Goal Banner'] = time()
       $ year = get_reading_goals_year()
       $ current_goal = get_reading_goals(year=year)
       $if not current_goal:
         <div class="page-banner page-banner-body page-banner-mybooks">
           Announcing Yearly Reading Goals: <a href="https://blog.openlibrary.org/2022/12/31/reach-your-2023-reading-goals-with-open-library" class="btn primary">Learn More</a> or <a class="btn primary set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set %(year)s reading goal', year=year)</a>
         </div>
+      $ component_times['Yearly Goal Banner'] = time() - component_times['Yearly Goal Banner']
+    $ component_times['Details header'] = time()
     <header>
       <div>
         <div class="small sansserif grey account-settings-menu">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Checks that `key == 'mybooks'` before rendering yearly reading goals banner on My Books pages.  Failing to do so causes the banner to render on all My Books pages.

Also adds profiling for banner render times.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
