### PR TITLE
Fix malformed reading log exports

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -888,9 +888,7 @@ class export_books(delegate.page):
         bookshelf_map = {1: 'Want to Read', 2: 'Currently Reading', 3: 'Already Read'}
 
         def get_subjects(work: Work, subject_type: str) -> str:
-            return " | ".join(
-                s.title.replace(",", ";") for s in work.get_subject_links(subject_type)
-            )
+            return " | ".join(s.title for s in work.get_subject_links(subject_type))
 
         def escape_record_string(raw_string: str) -> str:
             """
@@ -925,10 +923,10 @@ class export_books(delegate.page):
                 "ratings_average": ratings_average,
                 "ratings_count": ratings_count,
                 "has_ebook": work.has_ebook(),
-                "subjects": get_subjects(work=work, subject_type="subject"),
-                "subject_people": get_subjects(work=work, subject_type="person"),
-                "subject_places": get_subjects(work=work, subject_type="place"),
-                "subject_times": get_subjects(work=work, subject_type="time"),
+                "subjects": escape_record_string(get_subjects(work=work, subject_type="subject")),
+                "subject_people": escape_record_string(get_subjects(work=work, subject_type="person")),
+                "subject_places": escape_record_string(get_subjects(work=work, subject_type="place")),
+                "subject_times": escape_record_string(get_subjects(work=work, subject_type="time")),
             }
 
         books = Bookshelves.iterate_users_logged_books(username)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -923,10 +923,18 @@ class export_books(delegate.page):
                 "ratings_average": ratings_average,
                 "ratings_count": ratings_count,
                 "has_ebook": work.has_ebook(),
-                "subjects": escape_csv_field(get_subjects(work=work, subject_type="subject")),
-                "subject_people": escape_csv_field(get_subjects(work=work, subject_type="person")),
-                "subject_places": escape_csv_field(get_subjects(work=work, subject_type="place")),
-                "subject_times": escape_csv_field(get_subjects(work=work, subject_type="time")),
+                "subjects": escape_csv_field(
+                    get_subjects(work=work, subject_type="subject")
+                ),
+                "subject_people": escape_csv_field(
+                    get_subjects(work=work, subject_type="person")
+                ),
+                "subject_places": escape_csv_field(
+                    get_subjects(work=work, subject_type="place")
+                ),
+                "subject_times": escape_csv_field(
+                    get_subjects(work=work, subject_type="time")
+                ),
             }
 
         books = Bookshelves.iterate_users_logged_books(username)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -890,9 +890,9 @@ class export_books(delegate.page):
         def get_subjects(work: Work, subject_type: str) -> str:
             return " | ".join(s.title for s in work.get_subject_links(subject_type))
 
-        def escape_record_string(raw_string: str) -> str:
+        def escape_csv_field(raw_string: str) -> str:
             """
-            Formats given CVS record string such that it conforms to definition outlined
+            Formats given CVS field string such that it conforms to definition outlined
             in RFC #4180.
             """
             escaped_string = raw_string.replace('"', '""')
@@ -913,8 +913,8 @@ class export_books(delegate.page):
             ratings_average, ratings_count = ratings.values()
             return {
                 "work_id": work_key.split("/")[-1],
-                "title": escape_record_string(work.title),
-                "authors": escape_record_string(" | ".join(work.get_author_names())),
+                "title": escape_csv_field(work.title),
+                "authors": escape_csv_field(" | ".join(work.get_author_names())),
                 "first_publish_year": work.first_publish_year,
                 "edition_id": edition_id,
                 "edition_count": work.edition_count,
@@ -923,10 +923,10 @@ class export_books(delegate.page):
                 "ratings_average": ratings_average,
                 "ratings_count": ratings_count,
                 "has_ebook": work.has_ebook(),
-                "subjects": escape_record_string(get_subjects(work=work, subject_type="subject")),
-                "subject_people": escape_record_string(get_subjects(work=work, subject_type="person")),
-                "subject_places": escape_record_string(get_subjects(work=work, subject_type="place")),
-                "subject_times": escape_record_string(get_subjects(work=work, subject_type="time")),
+                "subjects": escape_csv_field(get_subjects(work=work, subject_type="subject")),
+                "subject_people": escape_csv_field(get_subjects(work=work, subject_type="person")),
+                "subject_places": escape_csv_field(get_subjects(work=work, subject_type="place")),
+                "subject_times": escape_csv_field(get_subjects(work=work, subject_type="time")),
             }
 
         books = Bookshelves.iterate_users_logged_books(username)

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -894,6 +894,9 @@ class export_books(delegate.page):
             """
             Formats given CVS field string such that it conforms to definition outlined
             in RFC #4180.
+            
+            Note: We should probably use
+            https://docs.python.org/3/library/csv.html
             """
             escaped_string = raw_string.replace('"', '""')
             return f'"{escaped_string}"'

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -892,6 +892,14 @@ class export_books(delegate.page):
                 s.title.replace(",", ";") for s in work.get_subject_links(subject_type)
             )
 
+        def escape_record_string(raw_string: str) -> str:
+            """
+            Formats given CVS record string such that it conforms to definition outlined
+            in RFC #4180.
+            """
+            escaped_string = raw_string.replace('"', '""')
+            return f'"{escaped_string}"'
+
         def format_reading_log(book: dict) -> dict:
             """
             Adding, deleting, renaming, or reordering the fields of the dict returned
@@ -907,8 +915,8 @@ class export_books(delegate.page):
             ratings_average, ratings_count = ratings.values()
             return {
                 "work_id": work_key.split("/")[-1],
-                "title": work.title,
-                "authors": " | ".join(work.get_author_names()),
+                "title": escape_record_string(work.title),
+                "authors": escape_record_string(" | ".join(work.get_author_names())),
                 "first_publish_year": work.first_publish_year,
                 "edition_id": edition_id,
                 "edition_count": work.edition_count,

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -894,7 +894,7 @@ class export_books(delegate.page):
             """
             Formats given CVS field string such that it conforms to definition outlined
             in RFC #4180.
-            
+
             Note: We should probably use
             https://docs.python.org/3/library/csv.html
             """


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7421

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Corrects malformed reading log `.csv` issue by escaping `title` and `authors` fields.  Additionally, escapes subject field strings, eliminating the need to replace commas with semicolons in these fields.

The new `escape_csv_field` could be combined with the `csv_string` function to greatly simplify our existing and future `.csv` row formatters.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Follow replication steps outlined in #7421. Verify that the results are as expected.
Additionally, ensure that there are no unexpected semicolons in the subject fields of the exported records.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
