### PR TITLE
Allow work merge if 200+ edition work is present but unselected

### DIFF
--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -186,6 +186,7 @@ export default {
 
             const unmergeable_works = this.records
                 .filter(work => work.type.key === '/type/work' &&
+                this.selected[work.key] &&
                 work.key !== this.master_key &&
                 this.editions[work.key].entries.length < this.editions[work.key].size)
                 .map(r => r.key);


### PR DESCRIPTION
This is a small interaction fix for MergeUI. The code currently checks to see if any works have more than 200 editions and blocks the merge in that case. However, it doesn't check whether the large work is actually selected to be included in the merge, so you can't make your merge go through just by unchecking the offending item.

This PR adds one line of code to check for selected status so that the process behaves as expected.

### Testing
You don't really want to mess around with big merges to test this, but you can if you want to. I've tested it thoroughly in a local instance.

### Stakeholders
@cdrini @mheiman 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
