### PR TITLE
ensure books have bwbsku/barcode

### DIFF
--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -39,7 +39,7 @@ def map_book_to_olbook(book, promise_id):
     title = book['ProductJSON'].get('Title')
     isbn = book.get('ISBN') or ' '
     olbook = {
-        'local_id': [f"urn:bwbsku:{book['BookSKUB']}"],
+        'local_id': [f"urn:bwbsku:{book['BookSKUB'] or book['BookSKU'] or book['BookBarcode']}"],
         'identifiers': {
             **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
             **(
@@ -62,27 +62,28 @@ def map_book_to_olbook(book, promise_id):
     return olbook
 
 
-def batch_import(promise_id):
+def batch_import(promise_id, batch_size=1000):
     url = "https://archive.org/download/"
     date = promise_id.split("_")[-1]
     books = requests.get(f"{url}{promise_id}/DailyPallets__{date}.json").json()
     batch = Batch.find(promise_id) or Batch.new(promise_id)
     olbooks = [map_book_to_olbook(book, promise_id) for book in books]
     batch_items = [{'ia_id': b['local_id'][0], 'data': b} for b in olbooks]
-    batch.add_items(batch_items)
+    for i in range(0, len(batch_items), batch_size):
+        batch.add_items(batch_items[i:i+batch_size])
 
-
-def get_promise_items(start_date=None, end_date="9999-01-01"):
-    url = get_promise_items_url(start_date=start_date, end_date=end_date)
+def get_promise_items(**kwargs):
+    url = get_promise_items_url(**kwargs)
     r = requests.get(url)
     return [d['identifier'] for d in r.json()['response']['docs']]
 
 
-def get_promise_items_url(start_date=None, end_date="9999-01-01"):
+def get_promise_items_url(start_date='1996-01-01', end_date="9999-01-01", exact_date=None):
     base = "https://archive.org/advancedsearch.php"
-    q = "collection%3Abookdonationsfrombetterworldbooks+identifier%3Abwb_daily_pallets_*"
-    if start_date:
-        q += f"+publicdate%3A[{start_date} TO {end_date}]"
+    selector = exact_date or '*'
+    q = f"collection:bookdonationsfrombetterworldbooks+identifier:bwb_daily_pallets_{selector}"
+    if not exact_date:
+        q += f'+publicdate:[{start_date or "1996-01-01"} TO {end_date}]'
     sorts = "sort%5B%5D=addeddate+desc&sort%5B%5D=&sort%5B%5D="
     fields = "fl%5B%5D=identifier"
     rows = 5000
@@ -90,12 +91,32 @@ def get_promise_items_url(start_date=None, end_date="9999-01-01"):
     return url
 
 
-def main(ol_config: str, start_date: str):
+def parse_date(date: str = ''):
+    params = {}
+    if ':' in date:
+        if date.endswith(':'):
+            params['exact_date'] = date[1:-1]
+        elif date.startswith(":"):
+            params['end_date'] = date[1:]
+        else:
+            params['start_date'], params['end_date'] = date.split(':')
+    elif date:
+        params['start_date'] = date
+    return params
+
+
+def main(ol_config: str, date: str):
+    """
+    start_date
+    :end_date
+    start_date:end_date
+    :exact_date:
+    """    
     load_config(ol_config)
-    promise_ids = get_promise_items(start_date=start_date)
+    params = parse_date(date)
+    promise_ids = get_promise_items(**params)
     for i, promise_id in enumerate(promise_ids):
         batch_import(promise_id)
-
 
 if __name__ == '__main__':
     FnToCLI(main).run()

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -39,7 +39,9 @@ def map_book_to_olbook(book, promise_id):
     title = book['ProductJSON'].get('Title')
     isbn = book.get('ISBN') or ' '
     olbook = {
-        'local_id': [f"urn:bwbsku:{book['BookSKUB'] or book['BookSKU'] or book['BookBarcode']}"],
+        'local_id': [
+            f"urn:bwbsku:{book['BookSKUB'] or book['BookSKU'] or book['BookBarcode']}"
+        ],
         'identifiers': {
             **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
             **(
@@ -70,7 +72,8 @@ def batch_import(promise_id, batch_size=1000):
     olbooks = [map_book_to_olbook(book, promise_id) for book in books]
     batch_items = [{'ia_id': b['local_id'][0], 'data': b} for b in olbooks]
     for i in range(0, len(batch_items), batch_size):
-        batch.add_items(batch_items[i:i+batch_size])
+        batch.add_items(batch_items[i : i + batch_size])
+
 
 def get_promise_items(**kwargs):
     url = get_promise_items_url(**kwargs)
@@ -78,7 +81,9 @@ def get_promise_items(**kwargs):
     return [d['identifier'] for d in r.json()['response']['docs']]
 
 
-def get_promise_items_url(start_date='1996-01-01', end_date="9999-01-01", exact_date=None):
+def get_promise_items_url(
+    start_date='1996-01-01', end_date="9999-01-01", exact_date=None
+):
     base = "https://archive.org/advancedsearch.php"
     selector = exact_date or '*'
     q = f"collection:bookdonationsfrombetterworldbooks+identifier:bwb_daily_pallets_{selector}"
@@ -111,12 +116,13 @@ def main(ol_config: str, date: str):
     :end_date
     start_date:end_date
     :exact_date:
-    """    
+    """
     load_config(ol_config)
     params = parse_date(date)
     promise_ids = get_promise_items(**params)
     for i, promise_id in enumerate(promise_ids):
         batch_import(promise_id)
+
 
 if __name__ == '__main__':
     FnToCLI(main).run()


### PR DESCRIPTION
The Promise Item importer was queuing far fewer imports than we need because in some cases the field BookSKUB was an empty string. Every time this happened, the result was that the item we were adding to the batch also had an empty `ia_id` (since BookSKUB is part of the record's primary ID) and therefore it was skipped.

This change ensures that (likely) tens of thousands of records which didn't have a `BookSKUB` value will now receive one by virtue of falling back to `BookSKU` (sans the `B`) and `BookBarcode` values. By `or`-ing them, we have a much higher chance one of them will be there. `BookBarcode` seems to almost always be present but since i'm not positive whether Barcode will always be the SKU, we favor the SKU + SKUB fields first.

This code also adds more flexible processing logic specifying start dates, end dates, and exact item names as limits for kicking off imports.

The default case for date is that it runs exactly like before (treated as a start_date) so our existing cron should work without change.

EDIT: Arguably we should make the default case be to require no date (use '1996-01-01' as default) and allow `--date` to be passed optionally, which **would** require a change to the cron as per:
https://github.com/internetarchive/olsystem/blob/master/etc/cron.d/openlibrary.ol_home0#L38

### Test Case

https://ia801502.us.archive.org/31/items/bwb_daily_pallets_2022-09-13/DailyPallets__2022-09-13.json

Perviously only imported 4,357 items when there are 7,425 in the list.

This record previously failed (no `BookSKUB` in the json above) but now exists in the db:
```
select * from import_item where batch_id=371 and ia_id='urn:bwbsku:O6-ASA-673';
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
