### PR TITLE
Add rating, reading log to sort options

### DIFF
--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -133,6 +133,9 @@
                   <label>
                     <input type="radio" v-model="sortState.order" value="rating">Top Rated
                   </label>
+                  <label>
+                    <input type="radio" v-model="sortState.order" value="readinglog">Reading Log
+                  </label>
                   <label title="I.e. Classification order. Note some books maybe missing when sorting by shelf order–we're working on it.">
                     <input type="radio" v-model="sortState.order" :value="`${settingsState.selectedClassification.field}_sort asc`" >Shelf Order
                   </label>

--- a/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
+++ b/openlibrary/components/LibraryExplorer/components/LibraryToolbar.vue
@@ -130,6 +130,9 @@
                   <label>
                     <input type="radio" v-model="sortState.order" value="old">Oldest
                   </label>
+                  <label>
+                    <input type="radio" v-model="sortState.order" value="rating">Top Rated
+                  </label>
                   <label title="I.e. Classification order. Note some books maybe missing when sorting by shelf order–we're working on it.">
                     <input type="radio" v-model="sortState.order" :value="`${settingsState.selectedClassification.field}_sort asc`" >Shelf Order
                   </label>

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -73,6 +73,10 @@ class WorkSearchScheme(SearchScheme):
         "author_facet",
         "first_publish_year",
         "ratings_count",
+        "readinglog_count",
+        "want_to_read_count",
+        "currently_reading_count",
+        "already_read_count",
         # Subjects
         "subject_key",
         "person_key",
@@ -118,6 +122,10 @@ class WorkSearchScheme(SearchScheme):
         'rating': 'ratings_sortable desc',
         'rating asc': 'ratings_sortable asc',
         'rating desc': 'ratings_sortable desc',
+        'readinglog': 'readinglog_count desc',
+        'want_to_read': 'want_to_read_count desc',
+        'currently_reading': 'currently_reading_count desc',
+        'already_read': 'already_read_count desc',
         'title': 'title_sort asc',
         'scans': 'ia_count desc',
         # Classifications

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -72,6 +72,7 @@ class WorkSearchScheme(SearchScheme):
         "publisher_facet",
         "author_facet",
         "first_publish_year",
+        "ratings_count",
         # Subjects
         "subject_key",
         "person_key",
@@ -114,6 +115,9 @@ class WorkSearchScheme(SearchScheme):
         'editions': 'edition_count desc',
         'old': 'def(first_publish_year, 9999) asc',
         'new': 'first_publish_year desc',
+        'rating': 'ratings_sortable desc',
+        'rating asc': 'ratings_sortable asc',
+        'rating desc': 'ratings_sortable desc',
         'title': 'title_sort asc',
         'scans': 'ia_count desc',
         # Classifications

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -64,6 +64,7 @@ class subjects(delegate.page):
             key,
             details=True,
             filters={'public_scan_b': 'false', 'lending_edition_s': '*'},
+            sort=web.input(sort='readinglog').sort,
         )
 
         delegate.context.setdefault('cssfile', 'subject')

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -17,6 +17,18 @@ $code:
          { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
          { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
          { 'sort': 'rating', 'name': _("Top Rated"), 'ga_key': 'Rating' },
+         {
+            'sort': 'readinglog',
+            'name': _("Reading Log"),
+            'ga_key': 'ReadingLog',
+            'selected': selected_sort in ('readinglog', 'want_to_read', 'currently_reading', 'already_read'),
+            'sub_sorts': [
+              { 'sort': 'readinglog', 'name': _("Any"), 'ga_key': 'ReadingLogAny' },
+              { 'sort': 'want_to_read', 'name': _("Want to Read"), 'ga_key': 'ReadingLogWantToRead' },
+              { 'sort': 'currently_reading', 'name': _("Currently Reading"), 'ga_key': 'ReadingLogCurrentlyReading' },
+              { 'sort': 'already_read', 'name': _("Already Read"), 'ga_key': 'ReadingLogAlreadyRead' },
+            ]
+          },
          { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
        ]
     $for sort_option in sort_options:
@@ -29,8 +41,20 @@ $code:
           <a href="$changequery(sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
              data-ol-link-track="SearchSort|$sort_option['ga_key']"
           >$sort_option['name']</a>
+      $if sort_option.get('sub_sorts') and is_selected:
+        <select
+          data-ol-link-track="SearchSort|$sort_option['ga_key']SubSort"
+          onchange="window.location.href = this.value"
+        >
+          $for sub_sort in sort_option['sub_sorts']:
+            $ is_selected = sub_sort['sort'] == selected_sort
+            <option
+              value="$changequery(sort=cond(sub_sort['sort'] == default_sort, None, sub_sort['sort']))"
+              $cond(is_selected, 'selected')
+            >$sub_sort['name']</option>
+        </select>
       $if not loop.last:
-          |
+        |
     $if selected_sort and selected_sort.startswith('random'):
       (<a href="$changequery(sort='random_%s' % today().timestamp())"
          data-ol-link-track="SearchSort|RandomShuffle"

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -16,6 +16,7 @@ $code:
          { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
          { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
          { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
+         { 'sort': 'rating', 'name': _("Top Rated"), 'ga_key': 'Rating' },
          { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
        ]
     $for sort_option in sort_options:


### PR DESCRIPTION
Adds rating and reading log options to search results pages and library explorer.

Also changes the default subject search order to be reading log count.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
The UI on the search page is definitely non ideal and getting long ; longer term we should flatten this and put it in a drop menu of some sort. But don't have the time for that now.

![image](https://github.com/internetarchive/openlibrary/assets/6251786/d707173d-d27b-4ca5-8134-7e1f00bc84af)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/93101668-bff8-4222-a359-7334d7cf4812)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/b3b7ac63-338a-4235-a2b3-bc7c417e471c)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/b4562991-bb2d-4f95-987a-177948ce7d1e)


### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
