### PR TITLE
[api] add ability to sort search results based on key

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -123,6 +123,10 @@ class WorkSearchScheme(SearchScheme):
         'ddc_sort': 'ddc_sort asc',
         'ddc_sort asc': 'ddc_sort asc',
         'ddc_sort desc': 'ddc_sort desc',
+        # Key
+        'key': 'key asc',
+        'key asc': 'key asc',
+        'key desc': 'key desc',
         # Random
         'random': 'random_1 asc',
         'random asc': 'random_1 asc',


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR makes it so you can sort by key. 
Right now an API call like https://openlibrary.org/search.json?q=craigslist&fields=title,key&sort=old works and sorts by title. After this PR is merged https://openlibrary.org/search.json?q=craigslist&fields=title,key&sort=key will work and will sort by key.


Why do I want this?
I would like to sort by key because I want to be notified when new books are added to OL for a certain query. I want to use [followthatpage.com](http://followthatpage.com/) to check once per week for changes in the json response. If items move around in search (as they do occasionally) then I'll get false positives (as follow that page is just doing  a plaintext diff). But if they're sorted by key then I'll just be notified by a new change.

### Technical
<!-- What should be noted about the implementation? -->
It's pretty simple, following Drini's helpful guidance. I'm not sure if there should be tests or anythign else checked.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run locally and try the following URLS:
/search.json?q=mark&fields=key&sort=key
/search.json?q=mark&fields=key&sort=key asc
/search.json?q=mark&fields=key&sort=key desc


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/213806314-600a4700-06a0-470f-a874-f4f490dd22a0.mp4



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 



PS: After this is merged it would be nice to update the docs here: https://openlibrary.org/dev/docs/api/search