### PR TITLE
Improve page count and language detection for IA imports

### DIFF
--- a/openlibrary/catalog/add_book/tests/conftest.py
+++ b/openlibrary/catalog/add_book/tests/conftest.py
@@ -8,10 +8,13 @@ def add_languages(mock_site):
         ('spa', 'Spanish'),
         ('fre', 'French'),
         ('yid', 'Yiddish'),
+        ('fri', 'Frisian'),
+        ('fry', 'Frisian'),
     ]
     for code, name in languages:
         mock_site.save(
             {
+                'code': code,
                 'key': '/languages/' + code,
                 'name': name,
                 'type': {'key': '/type/language'},

--- a/openlibrary/plugins/importapi/tests/test_code.py
+++ b/openlibrary/plugins/importapi/tests/test_code.py
@@ -1,0 +1,111 @@
+from .. import code
+from openlibrary.catalog.add_book.tests.conftest import add_languages
+import web
+import pytest
+
+
+def test_get_ia_record(monkeypatch, mock_site, add_languages) -> None:  # noqa F811
+    """
+    Try to test every field that get_ia_record() reads.
+    """
+    monkeypatch.setattr(web, "ctx", web.storage())
+    web.ctx.lang = "eng"
+    web.ctx.site = mock_site
+
+    ia_metadata = {
+        "creator": "Drury, Bob",
+        "date": "2013",
+        "description": [
+            "The story of the great Ogala Sioux chief Red Cloud",
+        ],
+        "identifier": "heartofeverythin0000drur_j2n5",
+        "isbn": [
+            "9781451654684",
+            "1451654685",
+        ],
+        "language": "French",
+        "lccn": "2013003200",
+        "oclc-id": "1226545401",
+        "publisher": "New York : Simon & Schuster",
+        "subject": [
+            "Red Cloud, 1822-1909",
+            "Oglala Indians",
+        ],
+        "title": "The heart of everything that is",
+        "imagecount": "454",
+    }
+
+    expected_result = {
+        "authors": [{"name": "Drury, Bob"}],
+        "description": ["The story of the great Ogala Sioux chief Red Cloud"],
+        "isbn": ["9781451654684", "1451654685"],
+        "languages": ["fre"],
+        "lccn": ["2013003200"],
+        "number_of_pages": 450,
+        "oclc": "1226545401",
+        "publish_date": "2013",
+        "publisher": "New York : Simon & Schuster",
+        "subjects": ["Red Cloud, 1822-1909", "Oglala Indians"],
+        "title": "The heart of everything that is",
+    }
+
+    result = code.ia_importapi.get_ia_record(ia_metadata)
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "tc,exp",
+    [("Frisian", "Multiple language matches"), ("Fake Lang", "No language matches")],
+)
+def test_get_ia_record_logs_warning_when_language_has_multiple_matches(
+    mock_site, monkeypatch, add_languages, caplog, tc, exp  # noqa F811
+) -> None:
+    """
+    When the IA record uses the language name rather than the language code,
+    get_ia_record() should log a warning if there are multiple name matches,
+    and set no language for the edition.
+    """
+    monkeypatch.setattr(web, "ctx", web.storage())
+    web.ctx.lang = "eng"
+    web.ctx.site = mock_site
+
+    ia_metadata = {
+        "creator": "The Author",
+        "date": "2013",
+        "identifier": "ia_frisian001",
+        "language": f"{tc}",
+        "publisher": "The Publisher",
+        "title": "Frisian is Fun",
+    }
+
+    expected_result = {
+        "authors": [{"name": "The Author"}],
+        "publish_date": "2013",
+        "publisher": "The Publisher",
+        "title": "Frisian is Fun",
+    }
+
+    result = code.ia_importapi.get_ia_record(ia_metadata)
+
+    assert result == expected_result
+    assert exp in caplog.text
+
+
+@pytest.mark.parametrize("tc,exp", [(5, 1), (4, 4), (3, 3)])
+def test_get_ia_record_handles_very_short_books(tc, exp) -> None:
+    """
+    Because scans have extra images for the cover, etc, and the page count from
+    the IA metadata is based on `imagecount`, 4 pages are subtracted from
+    number_of_pages. But make sure this doesn't go below 1.
+    """
+    ia_metadata = {
+        "creator": "The Author",
+        "date": "2013",
+        "identifier": "ia_frisian001",
+        "imagecount": f"{tc}",
+        "publisher": "The Publisher",
+        "title": "Frisian is Fun",
+    }
+
+    result = code.ia_importapi.get_ia_record(ia_metadata)
+    assert result.get("number_of_pages") == exp

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -41,6 +41,20 @@ from openlibrary.core.middleware import GZipMiddleware
 from openlibrary.core import cache
 
 
+class LanguageMultipleMatchError(Exception):
+    """Exception raised when more than one possible language match is found."""
+
+    def __init__(self, language_name):
+        self.language_name = language_name
+
+
+class LanguageNoMatchError(Exception):
+    """Exception raised when no matching languages are found."""
+
+    def __init__(self, language_name):
+        self.language_name = language_name
+
+
 class MultiDict(MutableMapping):
     """Ordered Dictionary that can store multiple values.
 
@@ -642,7 +656,7 @@ def strip_accents(s: str) -> str:
 
 
 @functools.cache
-def get_languages():
+def get_languages() -> dict:
     keys = web.ctx.site.things({"type": "/type/language", "limit": 1000})
     return {lang.key: lang for lang in web.ctx.site.get_many(keys)}
 
@@ -689,21 +703,42 @@ def autocomplete_languages(prefix: str) -> Iterator[web.storage]:
             continue
 
 
-def get_abbrev_from_full_lang_name(lang_name: str) -> str:
+def get_abbrev_from_full_lang_name(input_lang_name: str, languages=None) -> str:
     """
-    Take a language name, in English, such as 'English' or 'French' and return 'eng' or 'fre', respectively.
-    If there's no match, this returns an empty string.
+    Take a language name, in English, such as 'English' or 'French' and return
+    'eng' or 'fre', respectively, if there is one match.
+
+    If there are zero matches, raise LanguageNoMatchError.
+    If there are multiple matches, raise a LanguageMultipleMatchError.
     """
-    possible_lang_abbrevs = autocomplete_languages(lang_name)
-    target_lang = next(
-        (
-            lang.code
-            for lang in possible_lang_abbrevs
-            if lang_name.lower() == lang.name.lower()
-        ),
-        "",
-    )
-    return target_lang
+    if languages is None:
+        languages = get_languages().values()
+    target_abbrev = ""
+
+    def normalize(s: str) -> str:
+        return strip_accents(s).lower()
+
+    for language in languages:
+        if normalize(language.name) == normalize(input_lang_name):
+            if target_abbrev:
+                raise LanguageMultipleMatchError(input_lang_name)
+
+            target_abbrev = language.code
+            continue
+
+        for key in language.name_translated.keys():
+            if normalize(language.name_translated[key][0]) == normalize(
+                input_lang_name
+            ):
+                if target_abbrev:
+                    raise LanguageMultipleMatchError(input_lang_name)
+                target_abbrev = language.code
+                break
+
+    if not target_abbrev:
+        raise LanguageNoMatchError(input_lang_name)
+
+    return target_abbrev
 
 
 def get_language(lang_or_key: Thing | str) -> Thing | None:


### PR DESCRIPTION
Improve page count and language detection for IA imports where no MARC record is available.

<!-- What issue does this PR close? -->
Closes no PR.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
Previously, `get_ia_record()` in `openlibrary/plugins/importapi/code.py` wouldn't try to get the page count from IA metadata, nor would it try to get a language from that metadata unless the language was represented as a three character abbreviation.

This PR:
- allows language detection where the IA metadata has, for example `'language': 'English'`;
- gets the page count from the IA record's `imagecount`, which appears to be where the page number comes from on the details page for an IA scanned book.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try importing an IA record that has metadata where `'language'` is an English-word-representation of a language and where there is an `'imagecount'`, along with no MARC data.

Two such examples are:
- [Activity Ideas for the Budget Minded](https://archive.org/details/activityideasfor00debr) (activityideasfor00debr), and
- [What's Great](https://archive.org/details/whatsgreatphonic00harc/page/n15/mode/2up) (whatsgreatphonic00harc).


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
