### PR TITLE
Fix amz imports + stats

### DIFF
--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -201,7 +201,10 @@ def process_amazon_batch(isbn_10s: list[str]) -> None:
 
     if books := [clean_amazon_metadata_for_load(product) for product in products]:
         if pending_books := get_pending_books(books):
-            stats.increment("ol.affiliate.amazon.total_items_batched_for_import", n=len(pending_books))
+            stats.increment(
+                "ol.affiliate.amazon.total_items_batched_for_import",
+                n=len(pending_books),
+            )
             get_current_amazon_batch().add_items(
                 [{'ia_id': b['source_records'][0], 'data': b} for b in pending_books]
             )
@@ -299,7 +302,7 @@ class Submit:
             web.amazon_queue.qsize(),
             rate=0.2,
         )
-        return json.dumps({"status": "submitted", "queue":  web.amazon_queue.qsize()})
+        return json.dumps({"status": "submitted", "queue": web.amazon_queue.qsize()})
 
 
 def load_config(configfile):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Aspires to close #7340, #7184

- [x] add stats/graphite tracking to affiliate_server
- [x] add working pre-check code
- [x] re-enable amz imports

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

## ✅ Enabling Imports 

Once upon a time, Amazon imports from affiliate_server were not working because `db_parameters` was required and this field was in `infogami.yml` which was not available to `affiliate_server.py`. This was recently changed. See: https://github.com/internetarchive/openlibrary/pull/7109/files#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R237

But in doing this, we forgot to update the config load methods to load `infogami.yml` and so the variable was not available. We fix that in this PR.

## ✅  Substantive Imports Only

EDIT 2: Since @jimchamp merged #7495, the catalog should now support the fields we're submitting! 🎉 

EDIT 1: web.ctx.site has been fixed, however, the `pre_check` algorithm now does not seem to be working correctly in that it is allowing entries into the importer which are not substantive changes.

When testing imports, we were getting hundreds of thousands of records queued and batched for import which were not proposing substantive changes (basically the same records queued over and over). So we implemented logic to `pre_check` and filter for records which have changed:

https://github.com/internetarchive/openlibrary/pull/7340/files

Unfortunately, it seems that the `web.ctx.site` logic the `pre_check` requires (which is available in Open Library application) is not available in the context of the `affiliate_server.py` app. **This still needs to be fixed in this PR**

## ✅  Stats

Before this PR, stats was failing because the `stats_server` config variable was never loading. In https://github.com/internetarchive/openlibrary/blob/master/openlibrary/core/stats.py#L22-L36 we can see that the core/stats.py file assumes it will get loaded after the config variable is set, but because stats was being loaded at the top of affiliate_server.py (before configs were loaded) the global stats server was failing to get set. This PR addresses part of that problem but manual testing is required to see if the config variable is getting set and whether there is a valid stats client being created (stats logging it's still not working in this PR).

EDIT: This was an issue with threading which has been resolved by passing in the stats object to the thread and also overwriting the stats client at the appropriate places in the code.

See: http://graphite.us.archive.org/ `stats.ol.affiliate`

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@cdrini


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
