### PR TITLE
fix commiting from Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,9 +19,14 @@ tasks:
     # because: https://github.com/gitpod-io/gitpod/issues/9311
     chmod o+rx /workspace/openlibrary
   # init runs once for each commit to the default branch
-  init: ./scripts/setup_gitpod.sh
+  # init: ./scripts/setup_gitpod.sh
   # command runs each time a user starts their workspace
   command: docker-compose up
+- name: Setup Python
+  # init runs once for each commit to the default branch
+  # init: ./scripts/setup_gitpod.sh
+  # command runs each time a user starts their workspace
+  command: ./scripts/setup_gitpod.sh
 
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,3 @@
-image: gitpod/workspace-python-3.11
-
 ports:
 - port: 8080
 # ignore these ports by default to avoid extra notifications

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,7 @@ tasks:
     # because: https://github.com/gitpod-io/gitpod/issues/9311
     chmod o+rx /workspace/openlibrary
   # init runs once for each commit to the default branch
-  # init: ./scripts/setup_gitpod.sh
+  init: docker-compose up --no-start
   # command runs each time a user starts their workspace
   command: docker-compose up
 - name: dev shell

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,18 +10,18 @@ ports:
 - port: 3000
   onOpen: ignore
 tasks:
-- name: Start App
-  before: |
-    # run chown because https://github.com/gitpod-io/gitpod/issues/4851
-    sudo chown -R gitpod:999 /workspace/openlibrary
-    # Give container (ie group) write access to this volume
-    sudo chmod g+w -R /workspace/openlibrary/
-    # because: https://github.com/gitpod-io/gitpod/issues/9311
-    chmod o+rx /workspace/openlibrary
-  # init runs once for each commit to the default branch
-  # init: ./scripts/setup_gitpod.sh
-  # command runs each time a user starts their workspace
-  command: docker-compose up
+# - name: Start App
+#   before: |
+#     # run chown because https://github.com/gitpod-io/gitpod/issues/4851
+#     sudo chown -R gitpod:999 /workspace/openlibrary
+#     # Give container (ie group) write access to this volume
+#     sudo chmod g+w -R /workspace/openlibrary/
+#     # because: https://github.com/gitpod-io/gitpod/issues/9311
+#     chmod o+rx /workspace/openlibrary
+#   # init runs once for each commit to the default branch
+#   # init: ./scripts/setup_gitpod.sh
+#   # command runs each time a user starts their workspace
+#   command: docker-compose up
 - name: Setup Python
   # init runs once for each commit to the default branch
   # init: ./scripts/setup_gitpod.sh

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,23 +10,22 @@ ports:
 - port: 3000
   onOpen: ignore
 tasks:
-# - name: Start App
-#   before: |
-#     # run chown because https://github.com/gitpod-io/gitpod/issues/4851
-#     sudo chown -R gitpod:999 /workspace/openlibrary
-#     # Give container (ie group) write access to this volume
-#     sudo chmod g+w -R /workspace/openlibrary/
-#     # because: https://github.com/gitpod-io/gitpod/issues/9311
-#     chmod o+rx /workspace/openlibrary
-#   # init runs once for each commit to the default branch
-#   # init: ./scripts/setup_gitpod.sh
-#   # command runs each time a user starts their workspace
-#   command: docker-compose up
-- name: Setup Python
+- name: Start App
+  before: |
+    # run chown because https://github.com/gitpod-io/gitpod/issues/4851
+    sudo chown -R gitpod:999 /workspace/openlibrary
+    # Give container (ie group) write access to this volume
+    sudo chmod g+w -R /workspace/openlibrary/
+    # because: https://github.com/gitpod-io/gitpod/issues/9311
+    chmod o+rx /workspace/openlibrary
   # init runs once for each commit to the default branch
   # init: ./scripts/setup_gitpod.sh
   # command runs each time a user starts their workspace
-  command: ./scripts/setup_gitpod.sh
+  command: docker-compose up
+- name: dev shell
+  # init runs once for each commit to the default branch
+  init: ./scripts/setup_gitpod.sh
+  openMode: split-right
 
 github:
   prebuilds:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image: gitpod/workspace-python-3.11
+
 ports:
 - port: 8080
 # ignore these ports by default to avoid extra notifications

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 # Learn more about this config here: https://pre-commit.com/
 default_language_version:
-  python: python3.8
+  python: python3.11
 
 ci:
   submodules: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 # Learn more about this config here: https://pre-commit.com/
 default_language_version:
-  python: python3.11
+  python: python3.8
 
 ci:
   submodules: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,49 +23,49 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
-  # - repo: https://github.com/MarcoGorelli/auto-walrus
-  #   rev: v0.2.2
-  #   hooks:
-  #     - id: auto-walrus
+  - repo: https://github.com/MarcoGorelli/auto-walrus
+    rev: v0.2.2
+    hooks:
+      - id: auto-walrus
 
-  # - repo: https://github.com/psf/black
-  #   rev: 22.12.0
-  #   hooks:
-  #     - id: black  # See pyproject.toml for args
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black  # See pyproject.toml for args
 
-  # - repo: https://github.com/codespell-project/codespell
-  #   rev: v2.2.2
-  #   hooks:
-  #     - id: codespell  # See pyproject.toml for args
-  #       additional_dependencies:
-  #         - tomli
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell  # See pyproject.toml for args
+        additional_dependencies:
+          - tomli
 
-  # - repo: https://github.com/MarcoGorelli/cython-lint
-  #   rev: v0.10.1
-  #   hooks:
-  #   - id: cython-lint
+  - repo: https://github.com/MarcoGorelli/cython-lint
+    rev: v0.10.1
+    hooks:
+    - id: cython-lint
 
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: 'v0.991'
-  #   hooks:
-  #     - id: mypy  # See pyproject.toml for args
-  #       additional_dependencies:
-  #         - types-all
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.991'
+    hooks:
+      - id: mypy  # See pyproject.toml for args
+        additional_dependencies:
+          - types-all
 
-  # - repo: https://github.com/asottile/pyupgrade
-  #   rev: v3.3.1
-  #   hooks:
-  #     - id: pyupgrade
-  #       args:  # Solr on Cython is not yet ready for 3.10 type hints
-  #         - --py39-plus
-  #         - --keep-runtime-typing
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args:  # Solr on Cython is not yet ready for 3.10 type hints
+          - --py39-plus
+          - --keep-runtime-typing
 
-  # - repo: https://github.com/abravalheri/validate-pyproject
-  #   rev: v0.11
-  #   hooks:
-  #     - id: validate-pyproject
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.11
+    hooks:
+      - id: validate-pyproject
 
-  # - repo: https://github.com/pycqa/flake8
-  #   rev: 6.0.0
-  #   hooks:
-  #     - id: flake8  # See the file .flake8 for args
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8  # See the file .flake8 for args

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,49 +23,49 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
-  - repo: https://github.com/MarcoGorelli/auto-walrus
-    rev: v0.2.2
-    hooks:
-      - id: auto-walrus
+  # - repo: https://github.com/MarcoGorelli/auto-walrus
+  #   rev: v0.2.2
+  #   hooks:
+  #     - id: auto-walrus
 
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black  # See pyproject.toml for args
+  # - repo: https://github.com/psf/black
+  #   rev: 22.12.0
+  #   hooks:
+  #     - id: black  # See pyproject.toml for args
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
-    hooks:
-      - id: codespell  # See pyproject.toml for args
-        additional_dependencies:
-          - tomli
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: v2.2.2
+  #   hooks:
+  #     - id: codespell  # See pyproject.toml for args
+  #       additional_dependencies:
+  #         - tomli
 
-  - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.10.1
-    hooks:
-    - id: cython-lint
+  # - repo: https://github.com/MarcoGorelli/cython-lint
+  #   rev: v0.10.1
+  #   hooks:
+  #   - id: cython-lint
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.991'
-    hooks:
-      - id: mypy  # See pyproject.toml for args
-        additional_dependencies:
-          - types-all
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: 'v0.991'
+  #   hooks:
+  #     - id: mypy  # See pyproject.toml for args
+  #       additional_dependencies:
+  #         - types-all
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args:  # Solr on Cython is not yet ready for 3.10 type hints
-          - --py39-plus
-          - --keep-runtime-typing
+  # - repo: https://github.com/asottile/pyupgrade
+  #   rev: v3.3.1
+  #   hooks:
+  #     - id: pyupgrade
+  #       args:  # Solr on Cython is not yet ready for 3.10 type hints
+  #         - --py39-plus
+  #         - --keep-runtime-typing
 
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.11
-    hooks:
-      - id: validate-pyproject
+  # - repo: https://github.com/abravalheri/validate-pyproject
+  #   rev: v0.11
+  #   hooks:
+  #     - id: validate-pyproject
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8  # See the file .flake8 for args
+  # - repo: https://github.com/pycqa/flake8
+  #   rev: 6.0.0
+  #   hooks:
+  #     - id: flake8  # See the file .flake8 for args

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -5,7 +5,8 @@
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
 # A downside is that progress messages from docker and pre-commit may be mixed together.
 {
-    pyenv install
+    pyenv install 3.11 # should match .pre-commit-config.yaml
+    pyenv global 3.11
     pip install pre-commit
     # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
     env PIP_USER=false pre-commit install

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -5,8 +5,8 @@
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
 # A downside is that progress messages from docker and pre-commit may be mixed together.
 # {
-# pyenv install 3.8 # should match .pre-commit-config.yaml
-pyenv global 3.8
+pyenv install 3.11 # should match .pre-commit-config.yaml
+pyenv global 3.11
 sudo python3 -m pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
 # env PIP_USER=false pre-commit install

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -1,20 +1,9 @@
 #!/bin/bash
-# This script does the setup needed for gitpod
+# This script does the setup needed for Gitpod
 
 # Setup pre-commit hooks
-# This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
-# A downside is that progress messages from docker and pre-commit may be mixed together.
-# {
 pyenv install 3.11 --skip-existing # should match .pre-commit-config.yaml
 pyenv global 3.11
 sudo python3 -m pip install pre-commit
-# PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
-# env PIP_USER=false pre-commit install
-# env PIP_USER=false pre-commit run
 pre-commit install --install-hooks
 git commit
-# } &
-
-# # Builds the docker images so when user opens env this step is cached.
-# # We do this last because it occasionally fails on gitpod
-# docker-compose up --no-start

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -4,6 +4,6 @@
 # Setup pre-commit hooks
 pyenv install 3.11 --skip-existing # should match .pre-commit-config.yaml
 pyenv global 3.11
-sudo python3 -m pip install pre-commit
+python3 -m pip install pre-commit
 pre-commit install --install-hooks
 git commit

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -4,15 +4,15 @@
 # Setup pre-commit hooks
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
 # A downside is that progress messages from docker and pre-commit may be mixed together.
-{
-    pyenv install 3.11 # should match .pre-commit-config.yaml
-    pyenv global 3.11
-    pip install pre-commit
-    # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
-    env PIP_USER=false pre-commit install
-    env PIP_USER=false pre-commit run
-} &
+# {
+pyenv install 3.11 # should match .pre-commit-config.yaml
+pyenv global 3.11
+pip install pre-commit
+# PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
+env PIP_USER=false pre-commit install
+env PIP_USER=false pre-commit run
+# } &
 
-# Builds the docker images so when user opens env this step is cached.
-# We do this last because it occasionally fails on gitpod
-docker-compose up --no-start
+# # Builds the docker images so when user opens env this step is cached.
+# # We do this last because it occasionally fails on gitpod
+# docker-compose up --no-start

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -5,7 +5,7 @@
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
 # A downside is that progress messages from docker and pre-commit may be mixed together.
 # {
-pyenv install 3.11 # should match .pre-commit-config.yaml
+pyenv install 3.11 --skip-existing # should match .pre-commit-config.yaml
 pyenv global 3.11
 sudo python3 -m pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -5,7 +5,7 @@
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
 # A downside is that progress messages from docker and pre-commit may be mixed together.
 # {
-pyenv install 3.8 # should match .pre-commit-config.yaml
+# pyenv install 3.8 # should match .pre-commit-config.yaml
 pyenv global 3.8
 pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -7,7 +7,7 @@
 # {
 # pyenv install 3.8 # should match .pre-commit-config.yaml
 pyenv global 3.8
-pip install pre-commit
+sudo python3 -m pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
 # env PIP_USER=false pre-commit install
 # env PIP_USER=false pre-commit run

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -2,7 +2,7 @@
 # This script does the setup needed for Gitpod
 
 # Setup pre-commit hooks
-pyenv install 3.11 --skip-existing # should match .pre-commit-config.yaml
+pyenv install 3.11 --skip-existing # must match python version in .pre-commit-config.yaml
 pyenv global 3.11
 python3 -m pip install pre-commit
 pre-commit install --install-hooks

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -6,4 +6,3 @@ pyenv install 3.11 --skip-existing # must match python version in .pre-commit-co
 pyenv global 3.11
 sudo python3 -m pip install pre-commit
 pre-commit install --install-hooks
-git commit

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -4,6 +4,6 @@
 # Setup pre-commit hooks
 pyenv install 3.11 --skip-existing # must match python version in .pre-commit-config.yaml
 pyenv global 3.11
-python3 -m pip install pre-commit
+sudo python3 -m pip install pre-commit
 pre-commit install --install-hooks
 git commit

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -9,8 +9,9 @@ pyenv install 3.11 # should match .pre-commit-config.yaml
 pyenv global 3.11
 pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
-env PIP_USER=false pre-commit install
-env PIP_USER=false pre-commit run
+# env PIP_USER=false pre-commit install
+# env PIP_USER=false pre-commit run
+pre-commit install --install-hooks
 # } &
 
 # # Builds the docker images so when user opens env this step is cached.

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -5,13 +5,14 @@
 # This is in {} so the pyenv and pre-commit steps can run in the background while docker starts
 # A downside is that progress messages from docker and pre-commit may be mixed together.
 # {
-pyenv install 3.11 # should match .pre-commit-config.yaml
-pyenv global 3.11
+pyenv install 3.8 # should match .pre-commit-config.yaml
+pyenv global 3.8
 pip install pre-commit
 # PIP_USER false because https://github.com/gitpod-io/gitpod/issues/4886#issuecomment-963665656
 # env PIP_USER=false pre-commit install
 # env PIP_USER=false pre-commit run
 pre-commit install --install-hooks
+git commit
 # } &
 
 # # Builds the docker images so when user opens env this step is cached.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6918

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes committing via Gitpod.



### Technical
<!-- What should be noted about the implementation? -->

### pyenv version


Before: `pyenv install`

After:
```
pyenv install 3.11 --skip-existing
pyenv global 3.11
```


We were running the install command without specifying the version. I assume at one point we had a `.python-version` file it was reading but we removed it. Setting this here now is a bit clearer. 

It is a small bit of work to keep this file in sync with pre-commit yaml but simpler than trying to parse it.
I didn't look now, but some months ago when I looked there was no straightforward way to sync a precommit config file and the `.python-version` file without bash scripts editing files. 
If someone knows otherwise please let me know.

This is the recommended way to set a python version in Gitpod https://www.gitpod.io/docs/introduction/languages/python#python-versions

### installing pre-commit
Before: `pip install pre-commit`

After: `sudo python3 -m pip install pre-commit`

Why? I'm not totally sure, I don't understand Python environments that well. But if we don't have it we'll get the error: `No module named pre_commit`

The way I found the solution to this was by copying the install method from Gitpod itself:
https://github.com/gitpod-io/gitpod/blob/f98e5a2aa1fcae3bdb5e146dc628ad73631d8b5c/dev/image/Dockerfile#L207

### Cosmetic changes

There is now a new task called `dev shell` that opens split to the right side.

Why?
1. The whole reason this was a confusing error to debug was because it was running in the background in the same shell as the docker up command. That made it much more confusing.
2. It makes the shell script to setup Gitpod much simpler.
3. If someone is going to be making changes they'll almost certainly open the terminal anyway.


PS: Sorry I don't know why the python tests are failing in CI and can't see the logs.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Open this PR in gitpod here: https://gitpod.io/?editor=code#https://github.com/internetarchive/openlibrary/pull/7468

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->


https://user-images.githubusercontent.com/921217/215235580-5224cac8-9d8e-47cc-b1a6-77f0b05dd320.mp4




### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini  @cclauss 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
