### PR TITLE
archive another ~570k covers

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -275,9 +275,9 @@ class cover:
             url = zipview_url_from_id(int(value), size)
             raise web.found(url)
 
-        # covers_0008 partials [_00, _23] are tar'd in archive.org items
+        # covers_0008 partials [_00, _55] are tar'd in archive.org items
         if isinstance(value, int) or value.isnumeric():
-            if 8240000 > int(value) >= 8000000:
+            if 8560000 > int(value) >= 8000000:
                 prefix = f"{size.lower()}_" if size else ""
                 pid = "%010d" % int(value)
                 item_id = f"{prefix}covers_{pid[:4]}"

--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -275,9 +275,9 @@ class cover:
             url = zipview_url_from_id(int(value), size)
             raise web.found(url)
 
-        # covers_0008 partials [_00, _55] are tar'd in archive.org items
+        # covers_0008 partials [_00, _80] are tar'd in archive.org items
         if isinstance(value, int) or value.isnumeric():
-            if 8560000 > int(value) >= 8000000:
+            if 8810000 > int(value) >= 8000000:
                 prefix = f"{size.lower()}_" if size else ""
                 pid = "%010d" % int(value)
                 item_id = f"{prefix}covers_{pid[:4]}"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7362 

Followup to #7260.

QA required to ensure all files on archive.org before deleting.

Example IDs are those between 8240000 and 8810000.

* ✅ https://covers.openlibrary.org/b/id/8500001-L.jpg -- correctly resolves
* ✅ https://covers.openlibrary.org/b/id/8500001-M.jpg -- correctly resolves
* ✅ https://covers.openlibrary.org/b/id/8500001-S.jpg -- correctly resolves
* ✅  https://covers.openlibrary.org/b/id/8500001.jpg -- does **not** seem to resolve!

### Updates

**2023-01-29** All resolved -- wrote a script #7472 to audit uploads to ensure all covers parts successfully uploaded!

Deleted `[s,m,l]_covers_0008` up to `80` from disk.
Patch deployed this PR for images up to id `8810000`

**2023-01-28** Not all uploads succeeded to `covers_0008` (full size). Re-uploading now.
Looks like a catalog red row may have occurred: https://archive.org/catalog.php?history=1&id=covers_0008

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
