### PR TITLE
code to audit cover archive uploads

### DIFF
--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -91,7 +91,14 @@ class TarManager:
 idx = id
 
 
-def is_uploaded(item, f):
+def is_uploaded(item: str, f: str):
+    """
+    Looks within an archive.org item and determines whether
+    .tar and .index files exist for the specified filename pattern.  
+    
+    :param item: name of archive.org item to look within
+    :param f: filename pattern to look for
+    """
     command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, capture_output=True)
     output = result.stdout.decode().strip()

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -100,12 +100,12 @@ def is_uploaded(item: str, f: str) -> bool:
     :param f: filename pattern to look for
     """
     command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
-    result = subprocess.run(command, shell=True, capture_output=True)
-    output = result.stdout.decode().strip()
+    result = subprocess.run(command, shell=True, text=True, capture_output=True)
+    output = result.stdout.strip()
     return int(output) == 2
 
 
-def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l')):
+def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l')) -> None:
     """Check which cover batches have been uploaded to archive.org.
 
     Checks the archive.org items pertaining to this `group` of up to

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -91,15 +91,15 @@ class TarManager:
 idx = id
 
 
-def is_uploaded(item: str, f: str) -> bool:
+def is_uploaded(item: str, filename_pattern: str) -> bool:
     """
     Looks within an archive.org item and determines whether
     .tar and .index files exist for the specified filename pattern.
 
     :param item: name of archive.org item to look within
-    :param f: filename pattern to look for
+    :param filename_pattern: filename pattern to look for
     """
-    command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    command = fr'ia list {item} | grep "{filename_pattern}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, text=True, capture_output=True)
     output = result.stdout.strip()
     return int(output) == 2

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -111,7 +111,7 @@ def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l')):
     :param chunk_ids: (min, max) chunk_id range or max_chunk_id; 2 digit, batch of 10k from [00, 99]
 
     """
-    scope = range(*chunk_ids if isinstance(chunk_ids, range) else *(0, chunk_ids))
+    scope = range(*(chunk_ids if isinstance(chunk_ids, tuple) else (0, chunk_ids)))
     for size in sizes:
         prefix = f"{size}_" if size else ''
         item = f"{prefix}covers_{group_id:04}"

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -98,7 +98,7 @@ def is_uploaded(item, f):
     return int(output) == 2
 
 
-def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l'), upload=False):
+def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l')):
     """Check which cover batches have been uploaded to archive.org.
 
     Checks the archive.org items pertaining to this `group` of up to
@@ -107,15 +107,15 @@ def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l'), upload=False)
     e.g. 81) have been successfully uploaded.
 
     {size}_covers_{group}_{chunk}:
-    group_id - 4 digit, batches of 1M, 0000 to 9999M
-    chunk_ids - (min, max) chunk_id range or max_chunk_id; 2 digit, batch of 10k from [00, 99]
+    :param group_id: 4 digit, batches of 1M, 0000 to 9999M
+    :param chunk_ids: (min, max) chunk_id range or max_chunk_id; 2 digit, batch of 10k from [00, 99]
 
     """
-    scope = chunk_ids if isinstance(chunk_ids, range) else range(0, chunk_ids)
+    scope = range(*chunk_ids if isinstance(chunk_ids, range) else *(0, chunk_ids))
     for size in sizes:
         prefix = f"{size}_" if size else ''
-        item = f"{prefix}covers_{primary}"
-        files = [f"{prefix}covers_0008_{'%02i' % i}" for i in scope]
+        item = f"{prefix}covers_{group_id:04}"
+        files = (f"{prefix}covers_{group_id:04}_{i:02}" for i in scope)
         missing_files = []
         sys.stdout.write(f"\n{size or 'full'}: ")
         for f in files:
@@ -131,8 +131,6 @@ def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l'), upload=False)
             print(
                 f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10"
             )
-            if upload:
-                pass
 
 
 def archive(test=True):

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -91,7 +91,7 @@ class TarManager:
 idx = id
 
 
-def is_uploaded(item: str, f: str):
+def is_uploaded(item: str, f: str) -> bool:
     """
     Looks within an archive.org item and determines whether
     .tar and .index files exist for the specified filename pattern.

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -92,7 +92,7 @@ idx = id
 
 
 def is_uploaded(item, f):
-    command = f'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, capture_output=True)
     output = result.stdout.decode().strip()
     return int(output) == 2

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -90,24 +90,25 @@ class TarManager:
 
 idx = id
 
+
 def is_uploaded(item, f):
-    command = f'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, capture_output=True)
     output = result.stdout.decode().strip()
     return int(output) == 2
 
 
 def audit(major, minor, upload=False, sizes=('', 's', 'm', 'l')):
-    """Checks the archive.org items pertaining to this `major` set (up to                                                                                       
-    1 million images and size specified, 4-digit e.g. 0008) and each                                                                                            
-    specified size, to verify that all `minor` chunks (up to the                                                                                                
-    specified max) and their indices + tars (of 10k images, 2-digit                                                                                             
-    e.g. 81) have been successfully uploaded.                                                                                                                   
-                                                                                                                                                                
-    {size}_covers_{major}_{minor}:                                                                                                                              
-    major - 4  digit, batches of 1M, 0000 to 9999M                                                                                                              
-    minor - 2 digit, batches of 10k from _00 to _99                                                                                                             
-                                                                                                                                                                
+    """Checks the archive.org items pertaining to this `major` set (up to
+    1 million images and size specified, 4-digit e.g. 0008) and each
+    specified size, to verify that all `minor` chunks (up to the
+    specified max) and their indices + tars (of 10k images, 2-digit
+    e.g. 81) have been successfully uploaded.
+
+    {size}_covers_{major}_{minor}:
+    major - 4  digit, batches of 1M, 0000 to 9999M
+    minor - 2 digit, batches of 10k from _00 to _99
+
     """
     scope = minor if isinstance(minor, range) else range(0, minor)
     for size in sizes:
@@ -126,9 +127,12 @@ def audit(major, minor, upload=False, sizes=('', 's', 'm', 'l')):
         sys.stdout.write("\n")
         sys.stdout.flush()
         if missing_files:
-            print(f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10")
+            print(
+                f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10"
+            )
             if upload:
                 pass
+
 
 def archive(test=True):
     """Move files from local disk to tar files and update the paths in the db."""

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -90,30 +90,30 @@ class TarManager:
 
 idx = id
 
-
 def is_uploaded(item, f):
-    command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    command = f'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, capture_output=True)
     output = result.stdout.decode().strip()
     return int(output) == 2
 
 
-def audit(major, minor, upload=False, sizes=('', 's', 'm', 'l')):
-    """Checks the archive.org items pertaining to this `major` set (up to
-    1 million images and size specified, 4-digit e.g. 0008) and each
-    specified size, to verify that all `minor` chunks (up to the
-    specified max) and their indices + tars (of 10k images, 2-digit
+def audit(group_id, chunk_ids=(0,100), sizes=('', 's', 'm', 'l'), upload=False):
+    """Check which cover batches have been uploaded to archive.org.
+    
+    Checks the archive.org items pertaining to this `group` of up to
+    1 million images (4-digit e.g. 0008) for each specified size and verify
+    that all the chunks (within specified range) and their .indices + .tars (of 10k images, 2-digit
     e.g. 81) have been successfully uploaded.
-
-    {size}_covers_{major}_{minor}:
-    major - 4  digit, batches of 1M, 0000 to 9999M
-    minor - 2 digit, batches of 10k from _00 to _99
-
+                                                                                                             
+    {size}_covers_{group}_{chunk}:                                                                                           
+    group_id - 4 digit, batches of 1M, 0000 to 9999M                                                                                                              
+    chunk_ids - (min, max) chunk_id range or max_chunk_id; 2 digit, batch of 10k from [00, 99]                                                                                                             
+                                                                                                                                                                
     """
-    scope = minor if isinstance(minor, range) else range(0, minor)
+    scope = chunk_ids if isinstance(chunk_ids, range) else range(0, chunk_ids)
     for size in sizes:
         prefix = f"{size}_" if size else ''
-        item = f"{prefix}covers_{major}"
+        item = f"{prefix}covers_{primary}"
         files = [f"{prefix}covers_0008_{'%02i' % i}" for i in scope]
         missing_files = []
         sys.stdout.write(f"\n{size or 'full'}: ")
@@ -127,12 +127,9 @@ def audit(major, minor, upload=False, sizes=('', 's', 'm', 'l')):
         sys.stdout.write("\n")
         sys.stdout.flush()
         if missing_files:
-            print(
-                f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10"
-            )
+            print(f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10")
             if upload:
                 pass
-
 
 def archive(test=True):
     """Move files from local disk to tar files and update the paths in the db."""

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -94,8 +94,8 @@ idx = id
 def is_uploaded(item: str, f: str):
     """
     Looks within an archive.org item and determines whether
-    .tar and .index files exist for the specified filename pattern.  
-    
+    .tar and .index files exist for the specified filename pattern.
+
     :param item: name of archive.org item to look within
     :param f: filename pattern to look for
     """

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -92,7 +92,7 @@ idx = id
 
 
 def is_uploaded(item, f):
-    command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    command = f'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, capture_output=True)
     output = result.stdout.decode().strip()
     return int(output) == 2

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -90,25 +90,26 @@ class TarManager:
 
 idx = id
 
+
 def is_uploaded(item, f):
-    command = f'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    command = fr'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
     result = subprocess.run(command, shell=True, capture_output=True)
     output = result.stdout.decode().strip()
     return int(output) == 2
 
 
-def audit(group_id, chunk_ids=(0,100), sizes=('', 's', 'm', 'l'), upload=False):
+def audit(group_id, chunk_ids=(0, 100), sizes=('', 's', 'm', 'l'), upload=False):
     """Check which cover batches have been uploaded to archive.org.
-    
+
     Checks the archive.org items pertaining to this `group` of up to
     1 million images (4-digit e.g. 0008) for each specified size and verify
     that all the chunks (within specified range) and their .indices + .tars (of 10k images, 2-digit
     e.g. 81) have been successfully uploaded.
-                                                                                                             
-    {size}_covers_{group}_{chunk}:                                                                                           
-    group_id - 4 digit, batches of 1M, 0000 to 9999M                                                                                                              
-    chunk_ids - (min, max) chunk_id range or max_chunk_id; 2 digit, batch of 10k from [00, 99]                                                                                                             
-                                                                                                                                                                
+
+    {size}_covers_{group}_{chunk}:
+    group_id - 4 digit, batches of 1M, 0000 to 9999M
+    chunk_ids - (min, max) chunk_id range or max_chunk_id; 2 digit, batch of 10k from [00, 99]
+
     """
     scope = chunk_ids if isinstance(chunk_ids, range) else range(0, chunk_ids)
     for size in sizes:
@@ -127,9 +128,12 @@ def audit(group_id, chunk_ids=(0,100), sizes=('', 's', 'm', 'l'), upload=False):
         sys.stdout.write("\n")
         sys.stdout.flush()
         if missing_files:
-            print(f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10")
+            print(
+                f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10"
+            )
             if upload:
                 pass
+
 
 def archive(test=True):
     """Move files from local disk to tar files and update the paths in the db."""

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -3,6 +3,8 @@
 import tarfile
 import web
 import os
+import sys
+import subprocess
 import time
 
 from openlibrary.coverstore import config, db
@@ -88,6 +90,45 @@ class TarManager:
 
 idx = id
 
+def is_uploaded(item, f):
+    command = f'ia list {item} | grep "{f}\.[tar|index]" | wc -l'
+    result = subprocess.run(command, shell=True, capture_output=True)
+    output = result.stdout.decode().strip()
+    return int(output) == 2
+
+
+def audit(major, minor, upload=False, sizes=('', 's', 'm', 'l')):
+    """Checks the archive.org items pertaining to this `major` set (up to                                                                                       
+    1 million images and size specified, 4-digit e.g. 0008) and each                                                                                            
+    specified size, to verify that all `minor` chunks (up to the                                                                                                
+    specified max) and their indices + tars (of 10k images, 2-digit                                                                                             
+    e.g. 81) have been successfully uploaded.                                                                                                                   
+                                                                                                                                                                
+    {size}_covers_{major}_{minor}:                                                                                                                              
+    major - 4  digit, batches of 1M, 0000 to 9999M                                                                                                              
+    minor - 2 digit, batches of 10k from _00 to _99                                                                                                             
+                                                                                                                                                                
+    """
+    scope = minor if isinstance(minor, range) else range(0, minor)
+    for size in sizes:
+        prefix = f"{size}_" if size else ''
+        item = f"{prefix}covers_{major}"
+        files = [f"{prefix}covers_0008_{'%02i' % i}" for i in scope]
+        missing_files = []
+        sys.stdout.write(f"\n{size or 'full'}: ")
+        for f in files:
+            if is_uploaded(item, f):
+                sys.stdout.write(".")
+            else:
+                sys.stdout.write("X")
+                missing_files.append(f)
+            sys.stdout.flush()
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+        if missing_files:
+            print(f"ia upload {item} {' '.join([f'{item}/{mf}*' for mf in missing_files])} --retries 10")
+            if upload:
+                pass
 
 def archive(test=True):
     """Move files from local disk to tar files and update the paths in the db."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ lxml==4.9.1
 Pillow==9.4.0
 psycopg2==2.9.3
 pydantic==1.9.0
-pymarc==4.2.0
+pymarc==4.2.2
 python-dateutil==2.8.2
 python-memcached==1.59
 PyYAML==6.0


### PR DESCRIPTION
Run with

```
from openlibrary.coverstore import archive;archive.audit("0008", (20, 81), sizes=("l", "m", "s", ''))
```

Enables one to check which cover batches have been uploaded to archive.org, for which size.

e.g.

```
>>> from openlibrary.coverstore import archive;archive.audit("0008", (20, 81), sizes=("l", "m", "s", ''))

l: ...............................X...X.........................
ia upload l_covers_0008 l_covers_0008/l_covers_0008_51* l_covers_0008/l_covers_0008_55* --retries 10

m: ....................................XXXXXXXXXXXXXXXXXXXXXXXXX
ia upload m_covers_0008 m_covers_0008/m_covers_0008_56* m_covers_0008/m_covers_0008_57* m_covers_0008/m_covers_0008_58* m_covers_0008/m_covers_0008_59* m_covers_0008/m_covers_0008_60* m_covers_0008/m_covers_0008_61* m_covers_0008/m_covers_0008_62* m_covers_0008/m_covers_0008_63* m_covers_0008/m_covers_0008_64* m_covers_0008/m_covers_0008_65* m_covers_0008/m_covers_0008_66* m_covers_0008/m_covers_0008_67* m_covers_0008/m_covers_0008_68* m_covers_0008/m_covers_0008_69* m_covers_0008/m_covers_0008_70* m_covers_0008/m_covers_0008_71* m_covers_0008/m_covers_0008_72* m_covers_0008/m_covers_0008_73* m_covers_0008/m_covers_0008_74* m_covers_0008/m_covers_0008_75* m_covers_0008/m_covers_0008_76* m_covers_0008/m_covers_0008_77* m_covers_0008/m_covers_0008_78* m_covers_0008/m_covers_0008_79* m_covers_0008/m_covers_0008_80* --retries 10

s: .............................................................

full: .............................................................
```


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
