### PR TITLE
remove non-existent form field 'distributors'

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -712,7 +712,6 @@ class SaveBookHelper:
         """Process input data for edition."""
         edition.publishers = edition.get('publishers', '').split(';')
         edition.publish_places = edition.get('publish_places', '').split(';')
-        edition.distributors = edition.get('distributors', '').split(';')
 
         edition = trim_doc(edition)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ lxml==4.9.1
 Pillow==9.4.0
 psycopg2==2.9.3
 pydantic==1.9.0
-pymarc==4.2.0
+pymarc==4.2.2
 python-dateutil==2.8.2
 python-memcached==1.59
 PyYAML==6.0


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

This is taking values from the edition edit web form -- there is no `distributors` value on that form to read this data from.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
