### PR TITLE
Handle read date in the Goodreads importer

### DIFF
--- a/openlibrary/plugins/openlibrary/js/goodreads_import.js
+++ b/openlibrary/plugins/openlibrary/js/goodreads_import.js
@@ -15,7 +15,7 @@ export function initGoodreadsImport() {
                 $(this).removeAttr('checked');
             }
         });
-        var l = $('.add-book[checked*="checked"]').length;
+        const l = $('.add-book[checked*="checked"]').length;
         $('.import-submit').attr('value', `Import ${l} Books`);
     });
 
@@ -26,7 +26,7 @@ export function initGoodreadsImport() {
         else {
             $(this).removeAttr('checked');
         }
-        var l = $('.add-book[checked*="checked"]').length;
+        const l = $('.add-book[checked*="checked"]').length;
         $('.import-submit').attr('value', `Import ${l} Books`);
     });
 
@@ -54,10 +54,6 @@ export function initGoodreadsImport() {
         $('input.add-book').each(function () {
             var input = $(this),
                 checked = input.prop('checked');
-            if (!checked) {
-                return true;
-            }
-
             var value = JSON.parse(input.val().replace(/'/g, '"'));
             var shelf = value['Exclusive Shelf'];
             var shelf_id = 0;
@@ -66,12 +62,17 @@ export function initGoodreadsImport() {
             };
             var fail = function (reason) {
                 if (!has_failure()) {
-                    var element = $(`[isbn=${value['ISBN']}]`);
+                    const element = $(`[isbn=${value['ISBN']}]`);
                     element.append(`<td class="error-imported">Error</td><td class="error-imported">${reason}</td>'`)
                     element.removeClass('selected');
                     element.addClass('import-failure');
                 }
             };
+
+            if (!checked) {
+                return true;
+            }
+
             if (shelves[shelf]) {
                 shelf_id = shelves[shelf];
             }
@@ -115,7 +116,7 @@ export function initGoodreadsImport() {
                     }
                 }).then(function () {
                     if (value['Date Read'] !== '') {
-                        let date_read = value['Date Read'].split('/'); // Format: "YYYY/MM/DD"
+                        const date_read = value['Date Read'].split('/'); // Format: "YYYY/MM/DD"
                         return $.ajax({
                             url: `${obj['works'][0].key}/check-ins`,
                             type: 'POST',

--- a/openlibrary/plugins/openlibrary/js/goodreads_import.js
+++ b/openlibrary/plugins/openlibrary/js/goodreads_import.js
@@ -31,8 +31,8 @@ export function initGoodreadsImport() {
     });
 
     function func1(value) {
-        var l = $('.add-book[checked*="checked"]').length;
-        var elem = document.getElementById('myBar');
+        const l = $('.add-book[checked*="checked"]').length;
+        const elem = document.getElementById('myBar');
         elem.style.width = `${value * (100 / l)}%`;
         elem.innerHTML = `${value} Books`;
         if (value * (100 / l) >= 100) {
@@ -57,11 +57,11 @@ export function initGoodreadsImport() {
             var value = JSON.parse(input.val().replace(/'/g, '"'));
             var shelf = value['Exclusive Shelf'];
             var shelf_id = 0;
-            var has_failure = function () {
+            const hasFailure = function () {
                 return $(`[isbn=${value['ISBN']}]`).hasClass('import-failure');
             };
-            var fail = function (reason) {
-                if (!has_failure()) {
+            const fail = function (reason) {
+                if (!hasFailure()) {
                     const element = $(`[isbn=${value['ISBN']}]`);
                     element.append(`<td class="error-imported">Error</td><td class="error-imported">${reason}</td>'`)
                     element.removeClass('selected');
@@ -70,7 +70,7 @@ export function initGoodreadsImport() {
             };
 
             if (!checked) {
-                return true;
+                return false;
             }
 
             if (shelves[shelf]) {
@@ -79,7 +79,7 @@ export function initGoodreadsImport() {
             if (shelf_id === 0) {
                 fail('Book in different Shelf');
                 func1(++count);
-                return true;
+                return false;
             }
 
             prevPromise = prevPromise.then(function () { // prevPromise changes in each iteration
@@ -139,7 +139,7 @@ export function initGoodreadsImport() {
                         });
                     }
                 });
-                if (!has_failure()) {
+                if (!hasFailure()) {
                     $(`[isbn=${value['ISBN']}]`).append('<td class="success-imported">Imported</td>')
                     $(`[isbn=${value['ISBN']}]`).removeClass('selected');
                 }

--- a/openlibrary/plugins/openlibrary/js/goodreads_import.js
+++ b/openlibrary/plugins/openlibrary/js/goodreads_import.js
@@ -2,41 +2,37 @@ import Promise from 'promise-polyfill';
 
 export function initGoodreadsImport() {
 
-    var l, elem, count, prevPromise;
+    var count, prevPromise;
 
     $(document).on('click', 'th.toggle-all input', function () {
         var checked = $(this).prop('checked');
-        if (!checked) {
-            $(this).prop('checked', false);
-            $('input.add-book').each(function () {
-                $(this).prop('checked', false);
-            });
-        }
-        else {
-            $(this).prop('checked', true)
-            $('input.add-book').each(function () {
-                $(this).prop('checked', true);
-            });
-        }
-        l = $('.add-book[checked*="checked"]').length;
+        $('input.add-book').each(function () {
+            $(this).prop('checked', checked);
+            if (checked) {
+                $(this).attr('checked', 'checked');
+            }
+            else {
+                $(this).removeAttr('checked');
+            }
+        });
+        var l = $('.add-book[checked*="checked"]').length;
         $('.import-submit').attr('value', `Import ${l} Books`);
     });
 
     $(document).on('click', 'input.add-book', function () {
-        var checked = $(this).prop('checked');
-        if (!checked) {
-            $(this).prop('checked', false);
+        if ($(this).prop('checked')) {
+            $(this).attr('checked', 'checked');
         }
         else {
-            $(this).prop('checked', true);
+            $(this).removeAttr('checked');
         }
-        l = $('.add-book[checked*="checked"]').length;
+        var l = $('.add-book[checked*="checked"]').length;
         $('.import-submit').attr('value', `Import ${l} Books`);
     });
 
     function func1(value) {
-        l = $('.add-book[checked*="checked"]').length;
-        elem = document.getElementById('myBar');
+        var l = $('.add-book[checked*="checked"]').length;
+        var elem = document.getElementById('myBar');
         elem.style.width = `${value * (100 / l)}%`;
         elem.innerHTML = `${value} Books`;
         if (value * (100 / l) >= 100) {
@@ -52,76 +48,107 @@ export function initGoodreadsImport() {
         $('input.import-submit').addClass('hidden');
         $('th.import-status').removeClass('hidden');
         $('th.status-reason').removeClass('hidden');
+        const shelves = { read: 3, 'currently-reading': 2, 'to-read': 1 };
         count = 0;
         prevPromise = Promise.resolve();
         $('input.add-book').each(function () {
             var input = $(this),
                 checked = input.prop('checked');
+            if (!checked) {
+                return true;
+            }
+
             var value = JSON.parse(input.val().replace(/'/g, '"'));
             var shelf = value['Exclusive Shelf'];
-            const shelves = {read: 3, 'currently-reading': 2,  'to-read': 1};
             var shelf_id = 0;
-            if (shelves[shelf]){
+            var has_failure = function () {
+                return $(`[isbn=${value['ISBN']}]`).hasClass('import-failure');
+            };
+            var fail = function (reason) {
+                if (!has_failure()) {
+                    var element = $(`[isbn=${value['ISBN']}]`);
+                    element.append(`<td class="error-imported">Error</td><td class="error-imported">${reason}</td>'`)
+                    element.removeClass('selected');
+                    element.addClass('import-failure');
+                }
+            };
+            if (shelves[shelf]) {
                 shelf_id = shelves[shelf];
             }
-            if (checked && shelf_id !== 0) {
-                prevPromise = prevPromise.then(function () { // prevPromise changes in each iteration
-                    $(`[isbn=${value['ISBN']}]`).addClass('selected');
-                    return getWork(value['ISBN']); // return a new Promise
-                }).then(function (data) {
-                    var obj = JSON.parse(data);
-                    $.ajax({
-                        url: `${obj['works'][0].key}/bookshelves.json`,
-                        type: 'POST',
-                        data: {
-                            dont_remove: true,
-                            edition_id: obj['key'],
-                            bookshelf_id: shelf_id
-                        },
-                        datatype: 'json',
-                        success: function () {
-                            if (value['My Rating'] !== '0') {
-                                $.ajax({
-                                    url: `${obj['works'][0].key}/ratings.json`,
-                                    type: 'POST',
-                                    data: {
-                                        rating: parseInt(value['My Rating']),
-                                        edition_id: obj['key'],
-                                        bookshelf_id: shelf_id
-                                    },
-                                    datatype: 'json',
-                                    success: function () {
-                                        $(`[isbn=${value['ISBN']}]`).append('<td class="success-imported">Imported</td>')
-                                        $(`[isbn=${value['ISBN']}]`).removeClass('selected');
-                                    },
-                                    fail: function () {
-                                        $(`[isbn=${value['ISBN']}]`).append('<td class="error-imported">Error</td><td class="error-imported">Failed to add Rating</td>')
-                                        $(`[isbn=${value['ISBN']}]`).removeClass('selected');
-                                    }
-                                });
-                            }
-                            else {
-                                $(`[isbn=${value['ISBN']}]`).append('<td class="success-imported">Imported</td>')
-                                $(`[isbn=${value['ISBN']}]`).removeClass('selected');
-                            }
-                        },
-                        fail: function () {
-                            $(`[isbn=${value['ISBN']}]`).append('<td class="error-imported">Error</td><td class="error-imported">Failed to add book to reading log</td>')
-                            $(`[isbn=${value['ISBN']}]`).removeClass('selected');
-                        }
-                    });
-                    func1(++count);
-                }).catch(function () {
-                    $(`[isbn=${value['ISBN']}]`).append('<td class="error-imported">Error</td><td class="error-imported">Book not in collection</td>')
-                    $(`[isbn=${value['ISBN']}]`).removeClass('selected');
-                    func1(++count);
-                });
-            }
-            else if (checked && shelf_id === 0) {
-                $(`[isbn=${value['ISBN']}]`).append('<td class="error-imported">Error</td><td class="error-imported">Book in different Shelf</td>');
+            if (shelf_id === 0) {
+                fail('Book in different Shelf');
                 func1(++count);
+                return true;
             }
+
+            prevPromise = prevPromise.then(function () { // prevPromise changes in each iteration
+                $(`[isbn=${value['ISBN']}]`).addClass('selected');
+                return getWork(value['ISBN']); // return a new Promise
+            }).then(function (data) {
+                var obj = JSON.parse(data);
+                $.ajax({
+                    url: `${obj['works'][0].key}/bookshelves.json`,
+                    type: 'POST',
+                    data: {
+                        dont_remove: true,
+                        edition_id: obj['key'],
+                        bookshelf_id: shelf_id
+                    },
+                    dataType: 'json'
+                }).fail(function () {
+                    fail('Failed to add book to reading log');
+                }).done(function () {
+                    if (value['My Rating'] !== '0') {
+                        return $.ajax({
+                            url: `${obj['works'][0].key}/ratings.json`,
+                            type: 'POST',
+                            data: {
+                                rating: parseInt(value['My Rating']),
+                                edition_id: obj['key'],
+                                bookshelf_id: shelf_id
+                            },
+                            dataType: 'json',
+                            fail: function () {
+                                fail('Failed to add rating');
+                            }
+                        });
+                    }
+                }).then(function () {
+                    if (value['Date Read'] !== '') {
+                        let date_read = value['Date Read'].split('/'); // Format: "YYYY/MM/DD"
+                        return $.ajax({
+                            url: `${obj['works'][0].key}/check-ins`,
+                            type: 'POST',
+                            data: JSON.stringify({
+                                edition_key: obj['key'],
+                                event_type: 3,  // BookshelfEvent.FINISH
+                                year: parseInt(date_read[0]),
+                                month: parseInt(date_read[1]),
+                                day: parseInt(date_read[2])
+                            }),
+                            dataType: 'json',
+                            contentType: 'application/json',
+                            beforeSend: function(xhr) {
+                                xhr.setRequestHeader('Content-Type', 'application/json');
+                                xhr.setRequestHeader('Accept', 'application/json');
+                            },
+                            fail: function () {
+                                fail('Failed to set the read date');
+                            }
+                        });
+                    }
+                });
+                if (!has_failure()) {
+                    $(`[isbn=${value['ISBN']}]`).append('<td class="success-imported">Imported</td>')
+                    $(`[isbn=${value['ISBN']}]`).removeClass('selected');
+                }
+                func1(++count);
+            }).catch(function () {
+                fail('Book not in collection');
+                func1(++count);
+            });
         });
+
         $('td.books-wo-isbn').each(function () {
             $(this).removeClass('hidden');
         });

--- a/openlibrary/templates/account/import.html
+++ b/openlibrary/templates/account/import.html
@@ -88,7 +88,7 @@ $def with (books=None, books_wo_isbns=None)
     </div>
 
     <input type="submit" class="import-submit cta-btn cta-btn--unavailable" value="Import $len(books) Books">
-    $ keys = ['ISBN', 'Title', 'My Rating', 'Exclusive Shelf']
+    $ keys = ['ISBN', 'Title', 'My Rating', 'Exclusive Shelf', 'Date Read']
     <div class="div-class">
       <table class="import-table">
         <thead>
@@ -110,8 +110,8 @@ $def with (books=None, books_wo_isbns=None)
           $for isbn in books:
             <tr class="table-row" isbn="$isbn">
               <td>
-              $ dict = {'ISBN':'', 'Title':'', 'My Rating':'', 'Exclusive Shelf':''}
-              $ k = ['ISBN', 'My Rating', 'Exclusive Shelf']
+              $ dict = {'ISBN':'', 'Title':'', 'My Rating':'', 'Exclusive Shelf':'', 'Date Read':''}
+              $ k = ['ISBN', 'My Rating', 'Exclusive Shelf', 'Date Read']
               $for key in k:
                   $ dict[key] = books[isbn].get(key)
               <input class="add-book" value="$(dict)" type="checkbox" checked="checked">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7399

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Fix for missing read dates when importing Goodreads data.
- Fix the "Import N Books" title that wasn't updated when (un)checking checkboxes.
- Fix the progress bar not taking into account unchecked books in percent computation.

### Technical
<!-- What should be noted about the implementation? -->

Nothing.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Open the browser at the `/account/import` page, select your Goodreads export, then click on import.
From there, play with checkboxes to see that the number of books-to-import is updated in real-time.
finally, run the import, and check any read book page to see the check-in date properly set.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

The video of the title being updated:

https://user-images.githubusercontent.com/2033598/216003419-0e79b782-144b-4675-901b-956b52b4af99.mp4

The screenshot with calls to update the read date (it includes several books to cover all use case like unchecked book, and book not in the library):
![Screenshot from 2023-02-01 10-18-07](https://user-images.githubusercontent.com/2033598/216002697-1171c674-e264-4a39-8822-106b060555fb.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
