### PR TITLE
Use more IA data when (re)importing via /api/imports/ia (and overwrite v1 promise items)

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -206,19 +206,11 @@ def build_query(rec):
                     east = east_in_by_statement(rec, author)
                     book['authors'].append(import_author(author, eastern=east))
             continue
-        if k == 'languages':
+        if k in ('languages', 'translated_from'):
             for language in v:
                 if web.ctx.site.get('/languages/' + language) is None:
                     raise InvalidLanguage(language)
-            book['languages'] = [{'key': '/languages/' + language} for language in v]
-            continue
-        if k == 'translated_from':
-            for language in v:
-                if web.ctx.site.get('/languages/' + language) is None:
-                    raise InvalidLanguage(language)
-            book['translated_from'] = [
-                {'key': '/languages/' + language} for language in v
-            ]
+            book[k] = [{'key': '/languages/' + language} for language in v]
             continue
         if k in type_map:
             t = '/type/' + type_map[k]

--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -212,6 +212,14 @@ def build_query(rec):
                     raise InvalidLanguage(language)
             book['languages'] = [{'key': '/languages/' + language} for language in v]
             continue
+        if k == 'translated_from':
+            for language in v:
+                if web.ctx.site.get('/languages/' + language) is None:
+                    raise InvalidLanguage(language)
+            book['translated_from'] = [
+                {'key': '/languages/' + language} for language in v
+            ]
+            continue
         if k in type_map:
             t = '/type/' + type_map[k]
             if isinstance(v, list):

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -117,10 +117,10 @@ def edition_from_item_metadata(itemid, metadata):
 def get_cover_url(item_id):
     """Gets the URL of the archive.org item's title (or cover) page."""
     base_url = f'{IA_BASE_URL}/download/{item_id}/page/'
-    title_response = requests.head(base_url + 'title.jpg', allow_redirects=True)
-    if title_response.status_code == 404:
-        return base_url + 'cover.jpg'
-    return base_url + 'title.jpg'
+    cover_response = requests.head(base_url + 'cover.jpg', allow_redirects=True)
+    if cover_response.status_code == 404:
+        return base_url + 'title.jpg'
+    return base_url + 'cover.jpg'
 
 
 def get_item_manifest(item_id, item_server, item_path):

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -117,10 +117,10 @@ def edition_from_item_metadata(itemid, metadata):
 def get_cover_url(item_id):
     """Gets the URL of the archive.org item's title (or cover) page."""
     base_url = f'{IA_BASE_URL}/download/{item_id}/page/'
-    cover_response = requests.head(base_url + 'cover.jpg', allow_redirects=True)
-    if cover_response.status_code == 404:
-        return base_url + 'title.jpg'
-    return base_url + 'cover.jpg'
+    title_response = requests.head(base_url + 'title.jpg', allow_redirects=True)
+    if title_response.status_code == 404:
+        return base_url + 'cover.jpg'
+    return base_url + 'title.jpg'
 
 
 def get_item_manifest(item_id, item_server, item_path):

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -234,7 +234,6 @@ class ia_importapi(importapi):
                 raise_non_book_marc(marc_record)
             try:
                 edition_data = read_edition(marc_record)
-                edition_data["has_marc_record"] = True
             except MarcException as e:
                 logger.error(
                     'failed to read from MARC record %s: %s', identifier, str(e)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -234,6 +234,7 @@ class ia_importapi(importapi):
                 raise_non_book_marc(marc_record)
             try:
                 edition_data = read_edition(marc_record)
+                edition_data["has_marc_record"] = True
             except MarcException as e:
                 logger.error(
                     'failed to read from MARC record %s: %s', identifier, str(e)

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -205,6 +205,8 @@ class ia_importapi(importapi):
         :param bool force_import: force import of this record
         :returns: the data of the imported book or raises  BookImportError
         """
+        from_marc_record = False
+
         # Case 1 - Is this a valid Archive.org item?
         metadata = ia.get_metadata(identifier)
         if not metadata:
@@ -230,6 +232,8 @@ class ia_importapi(importapi):
         if require_marc and not marc_record:
             raise BookImportError('no-marc-record')
         if marc_record:
+            from_marc_record = True
+
             if not force_import:
                 raise_non_book_marc(marc_record)
             try:
@@ -247,7 +251,7 @@ class ia_importapi(importapi):
 
         # Add IA specific fields: ocaid, source_records, and cover
         edition_data = cls.populate_edition_data(edition_data, identifier)
-        return cls.load_book(edition_data)
+        return cls.load_book(edition_data, from_marc_record)
 
     def POST(self):
         web.header('Content-Type', 'application/json')
@@ -410,7 +414,7 @@ class ia_importapi(importapi):
         return d
 
     @staticmethod
-    def load_book(edition_data: dict) -> str:
+    def load_book(edition_data: dict, from_marc_record: bool = False) -> str:
         """
         Takes a well constructed full Edition record and sends it to add_book
         to check whether it is already in the system, and to add it, and a Work
@@ -418,7 +422,7 @@ class ia_importapi(importapi):
 
         :param dict edition_data: Edition record
         """
-        result = add_book.load(edition_data)
+        result = add_book.load(rec=edition_data, from_marc_record=from_marc_record)
         return json.dumps(result)
 
     @staticmethod


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes: #7521 (I hope)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix:
- `ia.get_cover_url()` now defaults to the cover image rather than the title image.
- revision 1 promise items will have their record overwritten with MARC data if that data is available.
- the `translated_from` field format is now the same as `languages` so that `save_many()` doesn't error.

### Technical
<!-- What should be noted about the implementation? -->
This copies (almost) _all_ fields, rather than specified fields. Introducing a new field that shouldn't end up in an edition would break import, as would a field that broke the schema `save_many()` expects.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try re-importing, via `/api/imports/ia`, a revision 1 promise item that has MARC data available on IA.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

#### The current state of affairs

[OL43522513M](https://openlibrary.org/books/OL43522513M/Les_noirs_et_les_rouges_%28Folio_policier%29_%28French_Edition%29?v=1) as a revision 1 promise item.
![image](https://user-images.githubusercontent.com/26524678/216149370-6fdc6ff9-3452-48ac-b42f-e8cf151cb975.png)

JSON
```json
{
  "type":{
    "key":"/type/edition"
  },
  "isbn_10":[
    "2072702216"
  ],
  "isbn_13":[
    "9782072702211"
  ],
  "local_id":[
    "urn:bwbsku:KO-626-968"
  ],
  "publish_date":"????",
  "source_records":[
    "promise:bwb_daily_pallets_2020-12-14"
  ],
  "title":"Les noirs et les rouges (Folio policier) (French Edition)",
  "works":[
    {
      "key":"/works/OL31822851W"
    }
  ],
  "key":"/books/OL43522513M",
  "latest_revision":1,
  "revision":1,
  "created":{
    "type":"/type/datetime",
    "value":"2022-12-09T07:59:12.188920"
  },
  "last_modified":{
    "type":"/type/datetime",
    "value":"2022-12-09T07:59:12.188920"
  }
}
```

How it looks currently, after re-import (i.e. without this PR)
![image](https://user-images.githubusercontent.com/26524678/216151241-5182a009-8e29-41ab-b610-607fbf67a5b0.png)

JSON as it is currently, after re-import (i.e. without this PR)
```json
{
  "type": {
    "key": "/type/edition"
  },
  "isbn_10": [
    "2072702216"
  ],
  "isbn_13": [
    "9782072702211"
  ],
  "local_id": [
    "urn:bwbsku:KO-626-968"
  ],
  "publish_date": "????",
  "source_records": [
    "promise:bwb_daily_pallets_2020-12-14",
    "ia:lesnoirsetlesrou0000garl"
  ],
  "title": "Les noirs et les rouges (Folio policier) (French Edition)",
  "works": [
    {
      "key": "/works/OL31822851W"
    }
  ],
  "key": "/books/OL43522513M",
  "covers": [
    13154713
  ],
  "ocaid": "lesnoirsetlesrou0000garl",
  "oclc_numbers": [
    "981947280"
  ],
  "latest_revision": 2,
  "revision": 2,
  "created": {
    "type": "/type/datetime",
    "value": "2022-12-09T07:59:12.188920"
  },
  "last_modified": {
    "type": "/type/datetime",
    "value": "2023-01-25T22:55:15.585878"
  }
}
```

#### How things are after re-import with this PR

JSON reply from `/api/imports/ia:

```json
{
    "edition": {
        "key": "/books/OL10M",
        "status": "modified"
    },
    "success": true,
    "work": {
        "key": "/works/OL2W",
        "status": "matched"
    }
}
```

Visual diff (with a bonus blue line artifact that only appears in the screenshot)
![image](https://user-images.githubusercontent.com/26524678/216149872-0a020c4a-af12-410b-8c4d-65951d14c722.png)

Edition page:
![image](https://user-images.githubusercontent.com/26524678/216150029-be007853-2b12-4f11-8df4-0a3ee0c114ea.png)

Updated JSON
```json
{
  "type": {
    "key": "/type/edition"
  },
  "isbn_10": [
    "2072702216"
  ],
  "isbn_13": [
    "9782072702211"
  ],
  "local_id": [
    "urn:bwbsku:KO-626-968"
  ],
  "publish_date": "2017",
  "source_records": [
    "promise:bwb_daily_pallets_2020-12-14",
    "ia:lesnoirsetlesrou0000garl"
  ],
  "title": "Les noirs et les rouges",
  "works": [
    {
      "key": "/works/OL2W"
    }
  ],
  "key": "/books/OL10M",
  "publish_country": "fr",
  "languages": [
    {
      "key": "/languages/fre"
    }
  ],
  "authors": [
    {
      "key": "/authors/OL10A"
    }
  ],
  "oclc_numbers": [
    "981947280"
  ],
  "dewey_decimal_class": [
    "853.92"
  ],
  "work_titles": [
    "Legge dell'odio"
  ],
  "series": [
    "Folio, Policier : roman noir -- 820"
  ],
  "description": {
    "type": "/type/text",
    "value": "Stefano Guerra, étudiant d'extrême droite, naît à la politique en 1968. Alors qu'il participe aux affrontements à Rome, il commet l'irréparable : il tue par accident un jeune homme qu'il voulait seulement menacer. Ce crime marque le début d'une longue dérive, du militantisme à la clandestinité, de la politique à la violence, dans un monde où hommes d'État, criminels et agents des services secrets se mêlent. Au bout du compte, qui est Stefano Guerra? Un tueur psychopathe, un terroriste? Un Pinocchio moderne, un exalté? Ou un dangereux idéaliste, engagé dans une cavale qui pourrait bien se révéler sans issue?"
  },
  "links": [
    {
      "url": "http://catalogue.bnf.fr/ark:/12148/cb45224769s",
      "title": "Notice et cote du catalogue de la Bibliothèque nationale de France"
    }
  ],
  "translated_from": [
    {
      "key": "/languages/ita"
    }
  ],
  "contributions": [
    "Raynaud, Vincent, 1971- ..."
  ],
  "by_statement": "Alberto Garlini ; traduit de l'italien par Vincent Raynaud",
  "publishers": [
    "Gallimard"
  ],
  "publish_places": [
    "[Paris]"
  ],
  "pagination": "1 v. (920 p.)",
  "ocaid": "lesnoirsetlesrou0000garl",
  "covers": [
    5
  ],
  "latest_revision": 3,
  "revision": 3,
  "created": {
    "type": "/type/datetime",
    "value": "2023-02-01T19:47:12.045269"
  },
  "last_modified": {
    "type": "/type/datetime",
    "value": "2023-02-01T19:56:23.194126"
  }
}
```

JSON reply after trying to reimport the same thing again:
```json
{
    "edition": {
        "key": "/books/OL10M",
        "status": "matched"
    },
    "success": true,
    "work": {
        "key": "/works/OL2W",
        "status": "matched"
    }
}
```

There is no change to the history either.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
