### PR TITLE
Add additional importable fields to edition

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -800,14 +800,15 @@ def load(rec, account_key=None):
         need_edition_save = True
 
     # Add list fields to edition as needed
-    edition_fields = [
+    edition_list_fields = [
         'local_id',
         'lccn',
         'lc_classifications',
         'oclc_numbers',
         'source_records',
+        'publishers',
     ]
-    for f in edition_fields:
+    for f in edition_list_fields:
         if f not in rec or not rec[f]:
             continue
         # ensure values is a list
@@ -819,6 +820,17 @@ def load(rec, account_key=None):
         else:
             e[f] = to_add = values
         if to_add:
+            need_edition_save = True
+
+    other_edition_fields = [
+        'number_of_pages',
+        'publish_date',
+    ]
+    for f in other_edition_fields:
+        if f not in rec or not rec[f]:
+            continue
+        if f not in e:
+            e[f] = rec[f]
             need_edition_save = True
 
     # Add new identifiers


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7493

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Imports `publishers`, `publish_date`, and `number_of_pages` fields when a matching edition is found.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
