### PR TITLE
use new smaller gitpod button

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 ![Python Build](https://github.com/internetarchive/openlibrary/actions/workflows/python_tests.yml/badge.svg)
 ![JS Build](https://github.com/internetarchive/openlibrary/actions/workflows/javascript_tests.yml/badge.svg)
 [![Join the chat at https://gitter.im/theopenlibrary/Lobby](https://badges.gitter.im/theopenlibrary/Lobby.svg)](https://gitter.im/theopenlibrary/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
+[![Open in Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
 
 [Open Library](https://openlibrary.org) is an open, editable library catalog, building towards a web page for every book ever published.
 
@@ -45,7 +45,7 @@ or [video tutorial](https://archive.org/embed/openlibrary-developer-docs/openlib
 ***Alternatively***, if you do not want to set up Open Library on your local computer, try Gitpod!
 This lets you work on Open Library entirely in your browser without having to install anything on your personal computer.
 Warning: This integration is still experimental.
-[![Open In Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
+[![Open In Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/internetarchive/openlibrary/)
 
 ### Developer's Guide
 


### PR DESCRIPTION
This is just following the docs [here](https://www.gitpod.io/docs/introduction/getting-started#contribute-with-gitpod-badge) to use the new smaller (uniform) button for the readme :)


# Before
<img width="919" alt="image" src="https://user-images.githubusercontent.com/921217/216469646-1b1c6291-7282-48bc-9562-2b086d74b59c.png">


# After

<img width="922" alt="image" src="https://user-images.githubusercontent.com/921217/216469599-d203888c-7901-4282-9080-0f53a5b984ca.png">

# Stakeholders
@cclauss 