### PR TITLE
Add scripts/get_web_error.py to review user-reported errors

### DIFF
--- a/scripts/get_web_error.py
+++ b/scripts/get_web_error.py
@@ -7,8 +7,8 @@ To see the contents of an Open Library user-reported like 2023-02-03/01155653562
 1. Copy this script into your user directory on any Open Library host.
 2. Type the command above substituting in the error code you are looking for.
 
-This script will ssh into ol-web1 and ol-web2 and if that file is found in the
-openlibrary_web_1 container, it will print its contents to stdout.
+This script will ssh into hosts ol-web1 and ol-web2 and if that file is found in the
+docker_container openlibrary_web_1, it will print its contents to stdout.
 
 Type `yes` if ssh prompts you to add the hosts to your known_hosts file.
 
@@ -17,27 +17,31 @@ If lynx is not yet installed, please type `sudo apt-get install lynx` to install
 
 import subprocess
 import sys
-from datetime import date
+from collections.abc import Iterable
 
 usage = f"""Usage: {sys.argv[0]} [filename] | lynx --stdin
 filename is like 2023-02-03/000008077313.html"""
 
 
-def get_web_error(filename: str = "2023-02-03/000008077313.html") -> str:
+def get_web_error(
+    filename: str,
+    hosts: Iterable[str] = ("ol-web1.us.archive.org", "ol-web2.us.archive.org"),
+    docker_container: str = "openlibrary_web_1",
+) -> str:
     """
-    ssh into ol-web1 and ol-web2 and if filename is found in the
-    openlibrary_web_1 Docker container then return its contents.
+    ssh into hosts ol-web1 and ol-web2 and if filename is found in the
+    docker_container openlibrary_web_1 then return its contents.
     """
     file_path = f"/var/log/openlibrary/ol-errors/{filename}"
-    for host in ("ol-web1.us.archive.org", "ol-web2.us.archive.org"):
-        command = f"ssh -A -t {host} 'docker exec -i openlibrary_web_1 cat {file_path}'"
+    for host in hosts:
+        cmd = f"ssh -A -t {host} 'docker exec -i {docker_container} cat {file_path}'"
         try:
-            if output := subprocess.check_output(command, shell=True, text=True):
+            if output := subprocess.check_output(cmd, shell=True, text=True):
                 return output
         except subprocess.CalledProcessError as e:
             print(f"Error: {e!r}")
             raise (e)
-    return f"Error: {file_path} was not found on either ol-web1 or ol-web2"
+    return f"Error: {file_path} was not found on {' or '.join(hosts)}."
 
 
 if __name__ == "__main__":

--- a/scripts/get_web_error.py
+++ b/scripts/get_web_error.py
@@ -17,7 +17,6 @@ If lynx is not yet installed, please type `sudo apt-get install lynx` to install
 
 import subprocess
 import sys
-from collections.abc import Iterable
 
 usage = f"""Usage: {sys.argv[0]} [filename] | lynx --stdin
 filename is like 2023-02-03/000008077313.html"""

--- a/scripts/get_web_error.py
+++ b/scripts/get_web_error.py
@@ -25,7 +25,7 @@ filename is like 2023-02-03/000008077313.html"""
 
 def get_web_error(
     filename: str,
-    hosts = ("ol-web1.us.archive.org", "ol-web2.us.archive.org"),
+    hosts=("ol-web1.us.archive.org", "ol-web2.us.archive.org"),
     docker_container: str = "openlibrary_web_1",
 ) -> str:
     """

--- a/scripts/get_web_error.py
+++ b/scripts/get_web_error.py
@@ -25,7 +25,7 @@ filename is like 2023-02-03/000008077313.html"""
 
 def get_web_error(
     filename: str,
-    hosts: Iterable[str] = ("ol-web1.us.archive.org", "ol-web2.us.archive.org"),
+    hosts = ("ol-web1.us.archive.org", "ol-web2.us.archive.org"),
     docker_container: str = "openlibrary_web_1",
 ) -> str:
     """

--- a/scripts/get_web_error.py
+++ b/scripts/get_web_error.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+"""
+% `python3 get_web_error.py 2023-02-03/011556535629.html | lynx --stdin`
+
+To see the contents of an Open Library user-reported like 2023-02-03/011556535629.html:
+1. Copy this script into your user directory on any Open Library host.
+2. Type the command above substituting in the error code you are looking for.
+
+This script will ssh into ol-web1 and ol-web2 and if that file is found in the
+openlibrary_web_1 container, it will print its contents to stdout.
+
+Type `yes` if ssh prompts you to add the hosts to your known_hosts file.
+
+If lynx is not yet installed, please type `sudo apt-get install lynx` to install it.
+"""
+
+import subprocess
+import sys
+from datetime import date
+
+usage = f"""Usage: {sys.argv[0]} [filename] | lynx --stdin
+filename is like 2023-02-03/000008077313.html"""
+
+
+def get_web_error(filename: str = "2023-02-03/000008077313.html") -> str:
+    """
+    ssh into ol-web1 and ol-web2 and if filename is found in the
+    openlibrary_web_1 Docker container then return its contents.
+    """
+    file_path = f"/var/log/openlibrary/ol-errors/{filename}"
+    for host in ("ol-web1.us.archive.org", "ol-web2.us.archive.org"):
+        command = f"ssh -A -t {host} 'docker exec -i openlibrary_web_1 cat {file_path}'"
+        try:
+            if output := subprocess.check_output(command, shell=True, text=True):
+                return output
+        except subprocess.CalledProcessError as e:
+            print(f"Error: {e!r}")
+            raise (e)
+    return f"Error: {file_path} was not found on either ol-web1 or ol-web2"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        print(get_web_error(sys.argv[1]))
+    else:
+        print(usage)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

> Sorry. There seems to be a problem with what you were just looking at.
We’ve noted the error 2023-02-02/133571627493 and will look into it as soon as possible. Head for [home](https://openlibrary.org/)?

### ssh into `ol-web1` and `ol-web2` and if `filename` is found in the `openlibrary_web_1` Docker container then return its contents.

% `python3 get_web_error.py 2023-02-03/011556535629.html | lynx --stdin`

To see the contents of an Open Library user-reported like `2023-02-03/011556535629.html`:
1. Copy this script into your user directory on any Open Library host.
2. Type the command above substituting in the error code you are looking for.

This script will ssh into `ol-web1` and `ol-web2` and if that file is found in the
`openlibrary_web_1 container`, it will print its contents to stdout.

Type `yes` if ssh prompts you to add the hosts to your known_hosts file.

If lynx is not yet installed, please type `sudo apt-get install lynx` to install it.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
