### PR TITLE
Rework bwb urls to avoid redirects

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -10,7 +10,7 @@ $code:
     'analytics_key': 'BetterWorldBooks',
     'name': _('Better World Books'),
     'link': 'https://www.betterworldbooks.com/%s' % (
-      ('-id-%s.aspx' % isbn) if isbn else ('search/results?q=' + page.title.replace(' ','%20'))
+      ('product/detail/-%s' % isbn) if isbn else ('search/results?q=' + page.title.replace(' ','%20'))
     ),
     'price_note': _(' - includes shipping')
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Matt Hogberg @ BWB reports: 
> While working on a project I noticed links on http://openlibrary.org point to `betterworldbooks.com/-id-{ISBN13}.aspx`. These work but get a 301 redirect over to `https://betterworldbooks.com/product/detail/-9780747582380`. Feel free to change the format to `betterworldbooks.com/product/detail/{ISBN13}` as this will prevent the redirect.

## After change

On https://testing.openlibrary.org/works/OL17860744W/A_Court_of_Mist_and_Fury
<img width="412" alt="Screenshot 2023-02-03 at 1 12 12 PM" src="https://user-images.githubusercontent.com/978325/216712050-ec57ab2d-dac7-404f-a3e8-58948fcc00d0.png">
<img width="522" alt="Screenshot 2023-02-03 at 1 12 31 PM" src="https://user-images.githubusercontent.com/978325/216712055-32f45f52-aaf0-44ec-8cb2-01199f9fe173.png">



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
