### PR TITLE
Feature/persist ile selections

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -42,7 +42,7 @@ export class IntegratedLibrarianEnvironment {
     }
 
     /**
-     * Unselects selected search result items adn resets status bar.
+     * Unselects selected search result items and resets status bar.
      */
     reset() {
         for (const elem of $('.ile-selected')) {
@@ -52,6 +52,5 @@ export class IntegratedLibrarianEnvironment {
         this.$selectionActions.empty();
         this.$statusImages.empty();
         this.$actions.empty();
-        this.$toolbar.hide();
     }
 }

--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -14,27 +14,31 @@ export class IntegratedLibrarianEnvironment {
         /** This is the main ILE toolbar. Should be moved to a Vue component. */
         this.$toolbar = $(`
             <div id="ile-toolbar">
-                <div style="flex: 1">
+                <div id="ile-selections">
                     <div id="ile-drag-status">
                         <div class="text"></div>
-                        <div class="images"></div>
+                        <div class="images"><ul></ul></div>
                     </div>
+                    <div id="ile-selection-actions"></div>
                 </div>
                 <div id="ile-drag-actions"></div>
             </div>`.trim());
+        this.$selectionActions = this.$toolbar.find('#ile-selection-actions');
         this.$statusText = this.$toolbar.find('.text');
+        this.$statusImages = this.$toolbar.find('.images ul');
+        this.$actions = this.$toolbar.find('#ile-drag-actions');
     }
 
     init() {
-        this.selectionManager.init();
-
         // Add the ILE toolbar to bottom of screen
-        $(document.body).append(this.$toolbar);
+        $(document.body).append(this.$toolbar.hide());
+        this.selectionManager.init();
     }
 
     /** @param {string} text */
     setStatusText(text) {
         this.$statusText.text(text);
+        this.$toolbar.toggle(text.length > 0);
     }
 
     /**
@@ -44,7 +48,10 @@ export class IntegratedLibrarianEnvironment {
         for (const elem of $('.ile-selected')) {
             elem.classList.remove('ile-selected')
         }
-        this.setStatusText('')
-        $('#ile-drag-actions').empty();
+        this.setStatusText('');
+        this.$selectionActions.empty();
+        this.$statusImages.empty();
+        this.$actions.empty();
+        this.$toolbar.hide();
     }
 }

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -7,6 +7,11 @@ import './SelectionManager.less';
  * The SelectionManager is responsible for making things (e.g. books in search results,
  * or authors on books pages) on Open Library selectable and drag/droppable from one
  * Open Library window to another.
+ *
+ * Selected items are stored in tab-specific storage until manually cleared, in an object
+ * containing arrays of olids keyed by type: {'edition':['OL1M','OL2M'], 'work':[],...}
+ * The work array may contain entries of the form OL3W:OL4M where the second value is the
+ * id of the specific edition surfaced in a search result.
  */
 export default class SelectionManager {
     /**
@@ -16,19 +21,22 @@ export default class SelectionManager {
         this.ile = ile;
         this.curpath = curpath;
         this.inited = false;
+        this.selectedItems = {};
 
         this.toggleSelected = this.toggleSelected.bind(this);
+        this.clearSelectedItems = this.clearSelectedItems.bind(this);
         this.dragStart = this.dragStart.bind(this);
+        this.dragEnd = this.dragEnd.bind(this);
         this.onDrop = this.onDrop.bind(this);
         this.allowDrop = this.allowDrop.bind(this);
 
         // Collator used to naturally order OLIDs before constructing URL
         this.collator = new Intl.Collator('en-US', {numeric: true});
-        this.canMerge = document.querySelector('body').dataset.canMerge ? true : false
     }
 
     init() {
         this.inited = true;
+        this.getSelectedItems();
 
         // Label each selectable element with a class, and bind the click event
         const providers = this.getPossibleProviders();
@@ -37,16 +45,33 @@ export default class SelectionManager {
             .addClass('ile-selectable')
             .on('click', this.toggleSelected);
 
-        // Some providers need a "handle" to allow dragging.
         for (const provider of providers) {
-            if (provider.addHandle) {
-                for (const el of $(provider.selector).toArray()) {
+            for (const el of $(provider.selector).toArray()) {
+                // Some providers need a "handle" to allow dragging.
+                if (provider.addHandle) {
                     const handle = $('<span class="ile-select-handle">&bull;</span>');
                     handle[0].addEventListener('click', ev => ev.preventDefault(), { capture: true });
                     $(el).prepend(handle);
                 }
+                // Restore any stored selections on this page
+                for (const type of provider.type) {
+                    if (this.selectedItems[type].length) {
+                        if (this.selectedItems[type].indexOf(provider.data(el)) !== -1) {
+                            this.setElementSelectionAttributes(el, true);
+                        }
+                    }
+                }
             }
         }
+
+        // Populate the status bar images for stored selections
+        for (const type of SelectionManager.TYPES) {
+            this.selectedItems[type.singular].forEach(item => {
+                this.ile.$statusImages.append(`<li><img title="${item}" src="${type.image(item)}" /></li>`);
+            });
+        }
+
+        this.updateToolbar();
 
         // Add the drag/drop handlers to the main white part of the page
         document.getElementById('test-body-mobile').addEventListener('drop', this.onDrop);
@@ -61,54 +86,112 @@ export default class SelectionManager {
         if (window.getSelection()?.toString() !== '') return;
 
         const el = clickEvent.currentTarget;
-        el.classList.toggle('ile-selected');
-        const selected = el.classList.contains('ile-selected');
-        el.draggable = selected;
+        const selected = !el.classList.contains('ile-selected');
         const provider = this.getProvider(el);
-        // FIXME: this is a bug if we support selecting multiple types
-        const count = $('.ile-selected').length;
-        this.ile.setStatusText(`${count} ${count === 1 ? provider.singular : provider.plural} selected`);
-        $('#ile-drag-actions').empty();
-        const img_src = provider.image(el);
-
-        const actions = SelectionManager.ACTIONS.filter(a => (
-            a.applies_to_type === provider.singular &&
-            (a.multiple_only ? count > 1 : count > 0)
-        ));
-        const items = this.getSelectedItems().sort(this.collator.compare);
-
-        for (const action of actions) {
-            $('#ile-drag-actions').append($(`<a target="_blank" href="${action.href(items)}">${action.name}</a>`));
-        }
+        const olid = provider.data(el);
+        const img_src = this.getType(olid)?.image(olid);
+        this.setElementSelectionAttributes(el, selected);
 
         if (selected) {
-            el.addEventListener('dragstart', this.dragStart);
-            const factor = -sigmoid($('#ile-drag-status .images img').length) + 1 + 0.5;
-            $('#ile-drag-status .images').append(`<img src="${img_src}" style="padding: ${(1 - factor) * 5}px 0; width: ${(factor ** 3) * 100}%"/>`);
+            this.addSelectedItem(olid);
+            this.ile.$statusImages.append(`<li><img title="${olid}" src="${img_src}"/></li>`);
         } else {
-            el.removeEventListener('dragstart', this.dragStart);
+            this.removeSelectedItem(olid);
             const img_el = $('#ile-drag-status .images img').toArray().find(el => el.src === img_src);
             $(img_el).remove();
         }
+        this.updateToolbar();
+    }
+
+    setElementSelectionAttributes(el, selected) {
+        el.classList.toggle('ile-selected', selected);
+        el.draggable = selected;
+        if (selected) {
+            el.addEventListener('dragstart', this.dragStart);
+            el.addEventListener('dragend', this.dragEnd);
+        } else {
+            el.removeEventListener('dragstart', this.dragStart);
+            el.removeEventListener('dragend', this.dragEnd);
+        }
+    }
+
+    updateToolbar() {
+        const statusParts = [];
+        this.ile.$actions.empty();
+        this.ile.$selectionActions.empty();
+        SelectionManager.TYPES.forEach(type => {
+            const count = this.selectedItems[type.singular].length;
+            if (count) statusParts.push(`${count} ${count === 1 ? type.singular : type.plural}`);
+        });
+
+        if (statusParts.length) {
+            this.ile.setStatusText(`${statusParts.join(', ')} selected`);
+            this.ile.$selectionActions.append($('<a>Clear Selections</a>').on('click', this.clearSelectedItems));
+        } else {
+            this.ile.setStatusText('');
+        }
+
+        for (const action of SelectionManager.ACTIONS) {
+            const items = [];
+            action.applies_to_type.forEach(type => items.push(...this.selectedItems[type]));
+            if (action.multiple_only ? items.length > 1 : items.length > 0)
+                this.ile.$actions.append($(`<a target="_blank" href="${action.href(this.getOlidsFromSelectionList(items))}">${action.name}</a>`));
+        }
+    }
+
+    addSelectedItem(item) {
+        this.selectedItems[this.getType(item).singular].push(item);
+        sessionStorage.setItem('ile-items', JSON.stringify(this.selectedItems));
+    }
+
+    removeSelectedItem(item) {
+        const type = this.getType(item);
+        const index = this.selectedItems[type.singular].indexOf(item);
+        if (index > -1) {
+            this.selectedItems[type.singular].splice(index, 1);
+            sessionStorage.setItem('ile-items', JSON.stringify(this.selectedItems));
+        }
+    }
+
+    getSelectedItems() {
+        if (Object.keys(this.selectedItems).length === 0) {
+            if (sessionStorage.getItem('ile-items')) {
+                this.selectedItems = JSON.parse(sessionStorage.getItem('ile-items'));
+            } else {
+                SelectionManager.TYPES.forEach(type => {this.selectedItems[type.singular] = []});
+            }
+        }
+
+        const items = [];
+        for (const type in this.selectedItems) items.push(...this.selectedItems[type]);
+        return items;
+    }
+
+    clearSelectedItems() {
+        for (const type in this.selectedItems) this.selectedItems[type] = [];
+        sessionStorage.setItem('ile-items', JSON.stringify(this.selectedItems));
+        this.ile.reset();
     }
 
     /**
      * @param {DragEvent} ev
      */
     dragStart(ev) {
-        const selected = $('.ile-selected').toArray();
-        if (selected.length > 1) {
+        const items = this.getSelectedItems();
+        const from = this.curpath.match(/OL\d+[AWM]/);
+        if (items.length > 1) {
+            $('#ile-drag-status .images').addClass('drag-image');
             ev.dataTransfer.setDragImage($('#ile-drag-status')[0], 0, 0);
         }
         const data = {
-            from: this.curpath.match(/OL\d+[AWM]/)[0],
-            items: this.getSelectedItems()
+            from: (from ? from[0] : null),
+            items: this.getOlidsFromSelectionList(items)
         };
         ev.dataTransfer.setData('text', JSON.stringify(data));
     }
 
-    getSelectedItems() {
-        return $('.ile-selected').toArray().map(el => this.getProvider(el).data(el));
+    dragEnd() {
+        $('#ile-drag-status .images').removeClass('drag-image');
     }
 
     /**
@@ -133,6 +216,10 @@ export default class SelectionManager {
         document.getElementById('test-body-mobile').classList.add('ile-drag-over');
     }
 
+    getType(olid) {
+        return SelectionManager.TYPES.find(t => t.regex.test(olid));
+    }
+
     getHandler() {
         return SelectionManager.DROP_HANDLERS.find(h => h.path.test(this.curpath));
     }
@@ -147,6 +234,10 @@ export default class SelectionManager {
     getProvider(el) {
         return SelectionManager.SELECTION_PROVIDERS
             .find(p => p.path.test(this.curpath) && el.matches(p.selector));
+    }
+
+    getOlidsFromSelectionList(list) {
+        return list.map(item => item.split(':')[0]);
     }
 }
 
@@ -198,6 +289,33 @@ SelectionManager.DROP_HANDLERS = [
     },
 ];
 
+SelectionManager.TYPES = [
+    {
+        singular: 'work',
+        plural: 'works',
+        regex: /OL\d+W/,
+        image: olid => {
+            const imgOlid = olid.split(':').pop();
+            if (imgOlid.slice(-1) === 'M')
+                return `https://covers.openlibrary.org/b/olid/${imgOlid}-M.jpg?default=https://openlibrary.org/images/icons/avatar_book-lg.png`
+            else
+                return `https://covers.openlibrary.org/w/olid/${imgOlid}-M.jpg?default=https://openlibrary.org/images/icons/avatar_book-lg.png`
+        },
+    },
+    {
+        singular: 'edition',
+        plural: 'editions',
+        regex: /OL\d+M/,
+        image: olid => `https://covers.openlibrary.org/b/olid/${olid}-M.jpg?default=https://openlibrary.org/images/icons/avatar_book-lg.png`,
+    },
+    {
+        singular: 'author',
+        plural: 'authors',
+        regex: /OL\d+A/,
+        image: olid => `https://covers.openlibrary.org/a/olid/${olid}-M.jpg?default=https://openlibrary.org/images/icons/avatar_author-lg.png`,
+    }
+]
+
 /**
  * Selection Providers define what is selectable on a page. E.g. the path regex
  * determines the url to apply the selection provider to.
@@ -209,14 +327,15 @@ SelectionManager.SELECTION_PROVIDERS = [
     {
         path: /(\/authors\/OL\d+A.*|\/search)$/,
         selector: '.searchResultItem',
-        image: el => $(el).find('.bookcover img')[0].src,
-        singular: 'work',
-        plural: 'works',
+        type: ['work','edition'],
         /**
          * @param {HTMLElement} el
          * @return {import('../ol.js').WorkOLID}
          **/
-        data: el => $(el).find('.booktitle a')[0].href.match(/OL\d+W/)[0],
+        data: el => {
+            const parts = $(el).find('.booktitle a')[0].href.match(/OL\d+[WM]/g);
+            return (parts.length > 1 && parts[0] !== parts[1]) ? parts.join(':') : parts[0];
+        },
     },
     /**
      * This selection provider makes editions in the editions table selectable.
@@ -224,9 +343,7 @@ SelectionManager.SELECTION_PROVIDERS = [
     {
         path: /(\/works\/OL\d+W.*|\/books\/OL\d+M.*)/,
         selector: '.book',
-        image: el => $(el).find('.cover img')[0].src,
-        singular: 'edition',
-        plural: 'editions',
+        type: ['edition'],
         /**
          * @param {HTMLElement} el
          * @return {import('../ol.js').EditionOLID}
@@ -240,9 +357,7 @@ SelectionManager.SELECTION_PROVIDERS = [
         path: /(\/works\/OL\d+W.*|\/books\/OL\d+M.*)/,
         selector: 'a[href^="/authors/OL"]',
         addHandle: true,
-        image: el => `https://covers.openlibrary.org/a/olid/${el.href.match(/OL\d+A/)[0]}-M.jpg?default=https://openlibrary.org/images/icons/avatar_author-lg.png`,
-        singular: 'author',
-        plural: 'authors',
+        type: ['author'],
         /**
          * @param {HTMLAnchorElement} el
          * @return {import('../ol.js').AuthorOLID}
@@ -255,9 +370,7 @@ SelectionManager.SELECTION_PROVIDERS = [
     {
         path: /^(\/search\/authors)$/,
         selector: '.searchResultItem',
-        image: el => $(el).find('img.cover')[0].src,
-        singular: 'author',
-        plural: 'authors',
+        type: ['author'],
         data: el => $(el).find('a')[0].href.match(/OL\d+A/)[0],
     },
 ];
@@ -267,27 +380,23 @@ SelectionManager.SELECTION_PROVIDERS = [
  */
 SelectionManager.ACTIONS = [
     {
-        applies_to_type: 'work',
+        applies_to_type: ['work','edition'],
         multiple_only: true,
         name: 'Merge Works...',
         href: olids => `/works/merge?records=${olids.join(',')}`,
     },
+    /* Uncomment this when edition merging is available.
     {
-        // Someday, anyways!
-        applies_to_type: 'edition',
+        applies_to_type: ['edition'],
         multiple_only: true,
         name: 'Merge Editions...',
         href: olids => `/works/merge?records=${olids.join(',')}`,
     },
+    */
     {
-        applies_to_type: 'author',
+        applies_to_type: ['author'],
         multiple_only: true,
         name: 'Merge Authors...',
         href: olids => `/authors/merge?${olids.map(olid => `key=${olid}`).join('&')}`,
     },
 ];
-
-
-function sigmoid(x) {
-    return Math.exp(x) / (Math.exp(x) + 1);
-}

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -133,7 +133,7 @@ export default class SelectionManager {
 
         for (const action of SelectionManager.ACTIONS) {
             const items = [];
-            if (this.selectedItems[action.requires_type].length) {
+            if (action.requires_type.every(type => this.selectedItems[type].length > 0)) {
                 action.applies_to_type.forEach(type => items.push(...this.selectedItems[type]));
                 if (action.multiple_only ? items.length > 1 : items.length > 0)
                     this.ile.$actions.append($(`<a target="_blank" href="${action.href(this.getOlidsFromSelectionList(items))}">${action.name}</a>`));

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -66,8 +66,8 @@ export default class SelectionManager {
 
         // Populate the status bar images for stored selections
         for (const type of SelectionManager.TYPES) {
-            this.selectedItems[type.singular].forEach(item => {
-                this.ile.$statusImages.append(`<li><img title="${item}" src="${type.image(item)}" /></li>`);
+            this.selectedItems[type.singular].forEach(olid => {
+                this.ile.$statusImages.append(`<li><img title="${olid}" src="${type.image(olid)}" /></li>`);
             });
         }
 
@@ -86,19 +86,19 @@ export default class SelectionManager {
         if (window.getSelection()?.toString() !== '') return;
 
         const el = clickEvent.currentTarget;
-        const selected = !el.classList.contains('ile-selected');
+        const isCurSelected = el.classList.contains('ile-selected');
         const provider = this.getProvider(el);
         const olid = provider.data(el);
         const img_src = this.getType(olid)?.image(olid);
-        this.setElementSelectionAttributes(el, selected);
+        this.setElementSelectionAttributes(el, !isCurSelected);
 
-        if (selected) {
-            this.addSelectedItem(olid);
-            this.ile.$statusImages.append(`<li><img title="${olid}" src="${img_src}"/></li>`);
-        } else {
+        if (isCurSelected) {
             this.removeSelectedItem(olid);
             const img_el = $('#ile-drag-status .images img').toArray().find(el => el.src === img_src);
             $(img_el).remove();
+        } else {
+            this.addSelectedItem(olid);
+            this.ile.$statusImages.append(`<li><img title="${olid}" src="${img_src}"/></li>`);
         }
         this.updateToolbar();
     }

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -133,9 +133,11 @@ export default class SelectionManager {
 
         for (const action of SelectionManager.ACTIONS) {
             const items = [];
-            action.applies_to_type.forEach(type => items.push(...this.selectedItems[type]));
-            if (action.multiple_only ? items.length > 1 : items.length > 0)
-                this.ile.$actions.append($(`<a target="_blank" href="${action.href(this.getOlidsFromSelectionList(items))}">${action.name}</a>`));
+            if (this.selectedItems[action.requires_type].length) {
+                action.applies_to_type.forEach(type => items.push(...this.selectedItems[type]));
+                if (action.multiple_only ? items.length > 1 : items.length > 0)
+                    this.ile.$actions.append($(`<a target="_blank" href="${action.href(this.getOlidsFromSelectionList(items))}">${action.name}</a>`));
+            }
         }
     }
 
@@ -381,6 +383,7 @@ SelectionManager.SELECTION_PROVIDERS = [
 SelectionManager.ACTIONS = [
     {
         applies_to_type: ['work','edition'],
+        requires_type: ['work'],
         multiple_only: true,
         name: 'Merge Works...',
         href: olids => `/works/merge?records=${olids.join(',')}`,
@@ -388,6 +391,7 @@ SelectionManager.ACTIONS = [
     /* Uncomment this when edition merging is available.
     {
         applies_to_type: ['edition'],
+        requires_type: ['edition'],
         multiple_only: true,
         name: 'Merge Editions...',
         href: olids => `/works/merge?records=${olids.join(',')}`,
@@ -395,6 +399,7 @@ SelectionManager.ACTIONS = [
     */
     {
         applies_to_type: ['author'],
+        requires_type: ['author'],
         multiple_only: true,
         name: 'Merge Authors...',
         href: olids => `/authors/merge?${olids.map(olid => `key=${olid}`).join('&')}`,

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.less
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.less
@@ -21,16 +21,36 @@
 #ile-toolbar {
   display: flex;
   position: sticky;
-  bottom: 0;
+  bottom: 12px;
+  padding: 7px;
+  margin: 0 15px;
+  border-radius: 5px;
   background: @ile-toolbar-background;
   color: @ile-toolbar-text-color;
   z-index: @ile-toolbar-z-index;
   font-size: .9em;
 }
+#ile-toolbar a {
+  padding: 4px 16px;
+  display: inline-block;
+  color: @ile-toolbar-text-color;
+  text-decoration: none;
+  border-left: 2px dotted @ile-toolbar-text-color;
+  transition: background .2s;
+  cursor: pointer;
+}
+#ile-selection-actions {
+  display: inline-block;
+}
+#ile-selections {
+  flex: 1;
+}
 #ile-drag-status {
   display: inline-block;
 }
-
+#ile-drag-status .drag-image {
+  max-width: 300px;
+}
 #ile-drag-status .text {
   border-radius: 100px;
   background: @ile-toolbar-background;
@@ -39,22 +59,19 @@
 #ile-drag-status .images {
   position: absolute;
   top: calc(100% + 5px);
-  display: flex;
   left: 8px;
 }
+#ile-drag-status ul {
+  display: flex;
+}
 #ile-drag-status .images img {
-  width: 30px;
+  max-width: 100%;
   height: 80px;
   object-fit: cover;
+  object-position: right;
 }
-#ile-drag-status .images img:first-child { width: auto; }
-#ile-drag-actions a {
-  padding: 4px 16px;
-  display: inline-block;
-  color: @ile-toolbar-text-color;
-  text-decoration: none;
-  border-left: 2px dotted @ile-toolbar-text-color;
-  transition: background .2s;
+#ile-drag-status .images li:first-child {
+  flex-shrink: 0;
 }
 #ile-drag-actions a:hover { background: rgba(0,0,0,.15); }
 

--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -8,8 +8,6 @@ $if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ct
   $if ctx.user and ((ctx.user.is_librarian() or ctx.user.is_admin())):
     $bodyclass.append('show-librarian-tools')
     $bodyattrs.append('data-username="%s"' % ctx.user.key.split('/')[-1])
-    $if ctx.user.is_usergroup_member('/usergroup/super-librarians'):
-      $bodyattrs.append('data-can-merge="%s"' % 'true')
 
 <body class="$(' '.join(bodyclass))" $:(' '.join(bodyattrs))>
   <script>

--- a/tests/unit/js/SelectionManager.test.js
+++ b/tests/unit/js/SelectionManager.test.js
@@ -1,36 +1,29 @@
 import SelectionManager from '../../../openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js';
 
-describe('SelectionManager', () => {
-    describe('getSelectedItems', () => {
-        test('empty', () => {
-            document.body.innerHTML = `
-            <ul>
-                <li class="searchResultItem ile-selectable" itemscope="" itemtype="https://schema.org/Book" draggable="true">
-                    <h3 itemprop="name" class="booktitle">
-                        <a itemprop="url" href="/works/OL15000194W?edition=ia%3Awintersongpoem00shak" class="results">The Long Run</a>
-                    </h3>
-                </li>
-            </ul>`;
-            const sm = new SelectionManager();
-            expect(sm.getSelectedItems()).toEqual([]);
-        });
 
-        test('has selected', () => {
-            document.body.innerHTML = `
-            <ul>
-                <li class="searchResultItem ile-selectable ile-selected" itemscope="" itemtype="https://schema.org/Book" draggable="true">
-                    <h3 itemprop="name" class="booktitle">
-                        <a itemprop="url" href="/works/OL15000194W?edition=ia%3Awintersongpoem00shak" class="results">The Long Run</a>
-                    </h3>
-                </li>
-                <li class="searchResultItem ile-selectable" itemscope="" itemtype="https://schema.org/Book" draggable="true">
-                    <h3 itemprop="name" class="booktitle">
-                        <a itemprop="url" href="/works/OL15000194W?edition=ia%3Awintersongpoem00shak" class="results">The Long Run</a>
-                    </h3>
-                </li>
-            </ul>`;
-            const sm = new SelectionManager(null, '/search');
-            expect(sm.getSelectedItems()).toEqual(['OL15000194W']);
+describe('SelectionManager', () => {
+    afterEach(() => {
+        window.sessionStorage.clear();
+    });
+
+    test('getSelectedItems initializes selected item types', () => {
+        const sm = new SelectionManager(null, '/search');
+        sm.getSelectedItems();
+        expect(sm.selectedItems).toEqual({
+            work: [],
+            edition: [],
+            author: [],
+        });
+    });
+
+    test('addSelectedItem', () => {
+        const sm = new SelectionManager(null, '/search');
+        sm.getSelectedItems(); // to initialize types for push to work
+        sm.addSelectedItem('OL1W');
+        expect(sm.selectedItems).toEqual({
+            work: ['OL1W'],
+            edition: [],
+            author: [],
         });
     });
 });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #7486

This PR adds several enhancements to the ILE toolbar:
- Selected items are stored within the tab session, so a selection (and deselection) can be done across multiple search result pages or other browsing.
- The toolbar now provides feedback when different types are selected in the same session
- The Merge Works button is now visible when both works and editions are selected
- The toolbar is now only visible when in use, and its appearance has been made slightly more prominent to reduce the risk of accidental selection carryover.

### Technical
Selected items are stored in tab-specific storage until manually cleared, in an object containing arrays of olids keyed by type: `{'edition':['OL1M','OL2M'], 'work':[],...}` The `work` array may contain entries of the form `OL3W:OL4M` where the second value is the id of the specific edition surfaced in a search result.

### Testing
Try a variety of selections on search, author and work pages. Set up a merge. Drag works and editions between authors and works.

### Screenshot
<img width="1008" alt="Screenshot 2023-02-03 at 3 07 29 PM" src="https://user-images.githubusercontent.com/886889/216710887-39767344-4e5d-40d2-b12d-c4544b3c4698.png">

### Stakeholders
@cdrini @mek @mheiman