### PR TITLE
Add sort options for authors

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -603,13 +603,14 @@ class author_search(delegate.page):
     def GET(self):
         return render_template('search/authors', self.get_results)
 
-    def get_results(self, q, offset=0, limit=100, fields='*'):
+    def get_results(self, q, offset=0, limit=100, fields='*', sort=''):
         resp = run_solr_query(
             AuthorSearchScheme(),
             {'q': q},
             offset=offset,
             rows=limit,
             fields=fields,
+            sort=sort,
         )
 
         return resp
@@ -620,12 +621,14 @@ class author_search_json(author_search):
     encoding = 'json'
 
     def GET(self):
-        i = web.input(q='', offset=0, limit=100, fields='*')
+        i = web.input(q='', offset=0, limit=100, fields='*', sort='')
         offset = safeint(i.offset, 0)
         limit = safeint(i.limit, 100)
         limit = min(1000, limit)  # limit limit to 1000.
 
-        response = self.get_results(i.q, offset=offset, limit=limit, fields=i.fields)
+        response = self.get_results(
+            i.q, offset=offset, limit=limit, fields=i.fields, sort=i.sort
+        )
         raw_resp = response.raw_resp['response']
         for doc in raw_resp['docs']:
             # SIGH the public API exposes the key like this :(

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -10,6 +10,7 @@ $else:
 $ offset = (page - 1) * results_per_page
 
 $var title: Search Open Library for "$q"
+$ sort = query_param('sort', None)
 
 <div id="contentHead">
     <h1>$_("Search Authors")</h1>
@@ -25,7 +26,7 @@ $var title: Search Open Library for "$q"
 </div>
 
 <div id="contentMeta">
-    $ results = get_results(q, offset=offset, limit=results_per_page)
+    $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
 
     $if q and results.error:
         <strong>
@@ -38,6 +39,8 @@ $var title: Search Open Library for "$q"
     $if q and not results.error:
         $if results.num_found:
             <div class="search-results-stats">$ungettext('1 hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
+              $if results.num_found > 1:
+                $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
               $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
               $if results.num_found >= 2 and user_can_merge:
                 $ keys = '&'.join('key=%s' % doc['key'].split("/")[-1] for doc in results.docs)

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -1,16 +1,23 @@
-$def with (selected_sort, exclude=None, default_sort='relevance')
+$def with (selected_sort, exclude=None, default_sort='relevance', search_scheme='works')
 
 <span class="tools">
     <img src="/images/icons/icon_sort.png" class="" alt="$_('Sorting by')" width="9" height="11" class="sorter" />
     $_('Sorted by'):
-    $code:
-      sort_options = [
-        { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
-        { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
-        { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
-        { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
-        { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
+$code:
+     if search_scheme == 'authors':
+       sort_options = [
+         { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
+         { 'sort': 'work_count desc', 'name': _("Work Count"), 'ga_key': 'WorkCountDesc' },
+         { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
       ]
+     else:
+       sort_options = [
+         { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
+         { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
+         { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
+         { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
+         { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
+       ]
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:
         $continue


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7365

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature/Adds sort options to authors

### Technical
<!-- What should be noted about the implementation? -->
The issue #7365 said there should be two options but the example said 3. I went with 3 options and it does default to relevance when there are authors. I have also noticed that relevance and work count appears to return identical results.   

I expect this might need a revision as the sort options might need to change :)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to author search, search for an author and sort by relevance or work count or random.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://user-images.githubusercontent.com/92345662/216898484-27488950-6857-4d7d-b255-653a462484f5.png)

![image](https://user-images.githubusercontent.com/92345662/216898539-483b8afa-ba1a-4759-9930-dcc2fc3e4edd.png)

![image](https://user-images.githubusercontent.com/92345662/216898581-f3ae8b4f-5d64-4ee7-980a-c352215b062a.png)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
