### PR TITLE
pre-commit: Add Python linting tool ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,12 @@ repos:
     hooks:
       - id: auto-walrus
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.244
+    hooks:
+      - id: ruff
+
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
@@ -46,7 +52,7 @@ repos:
     - id: cython-lint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.991'
+    rev: 'v1.0.0'
     hooks:
       - id: mypy  # See pyproject.toml for args
         additional_dependencies:
@@ -61,7 +67,7 @@ repos:
           - --keep-runtime-typing
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.6.0"
+    rev: "0.7.0"
     hooks:
       - id: pyproject-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,29 @@ ignore_errors = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+
+[tool.ruff]
+exclude = [
+    "./.*",
+    "vendor/*",
+    "node_modules/*",
+]
+ignore = [
+    "E402",
+    "E722",
+    "E741",
+    "F401",
+    "F841",
+    "I",
+]
+line-length = 200
+select = [
+    "C9",
+    "E",
+    "F",
+    "W",
+]
+target-version = "py310"
+
+[tool.ruff.mccabe]
+max-complexity = 41


### PR DESCRIPTION
Add https://beta.ruff.rs to our pre-commit as a replacement for `black`, `flake8`, `isort`, `pyupgrade`, etc. but written in Rust instead of Python. It can lint the CPython codebase from scratch in 0.29 seconds.

Adopting Ruff should greatly accelerate our pre-commits and our pre-commit.ci jobs. We will run the new and old tools in parallel for a sprint or two to verify the coverage before we completely drop the old tools.