### PR TITLE
Stop promise items from creating editions with publish_date=????

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -137,6 +137,9 @@ class importapi:
                 edition.pop('publishers')
             if edition.get('authors') == [{"name": "????"}]:
                 edition.pop('authors')
+            if edition.get('publish_date') == "????":
+                edition.pop('publish_date')
+
         except DataError as e:
             return self.error(str(e), 'Failed to parse import data')
         except ValidationError as e:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes no issue

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

Currently it seems possible for promise items to create an edition with `publish_date="????"`. Promise items sometimes have dummy data of `????` filled in for `authors`, `publishers` and `publish_date`.

(I say 'seems' because I had trouble reproducing import of promise items and am basing the continued existence of this issue on reading the code and the best simulation I could do.)

This dummy data is then removed from `authors` and `publishers`, but not `publish_date`.

### Technical
<!-- What should be noted about the implementation? -->
`map_book_to_olbook()` in [scripts/promise_batch_imports.py](https://github.com/internetarchive/openlibrary/blob/c0de1e96e438e3e7351d43bb4b152c5b8cade67f/scripts/promise_batch_imports.py#L-56-L60), adds dummy data to `authors`, `publishers`, and `publish_date` thus:
```python
'authors': [{"name": book['ProductJSON'].get('Author') or '????'}],
'publishers': [book['ProductJSON'].get('Publisher') or '????'],
'source_records': [f"promise:{promise_id}"],
# format_date adds hyphens between YYYY-MM-DD
'publish_date': publish_date and format_date(publish_date) or '????',
``` 

This dummy data is then removed in [importapi/code.py](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/importapi/code.py#L136-L139), but only for `publishers` and `authors`:
```python
# Validation requires valid publishers and authors.
# If data unavailable, provide throw-away data which validates
# We use ["????"] as an override pattern
if edition.get('publishers') == ["????"]:
    edition.pop('publishers')
if edition.get('authors') == [{"name": "????"}]:
    edition.pop('authors')
```

This PR should stop that by adding an equivalent for `publish_date`:
```python
if edition.get('publish_date') == "????":
    edition.pop('publish_date')
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Import a book via the import API with a `publish_date` of `????`, and see that a `publish_date` of `????` should no longer pass through to `load()`.

POSTing to `/api/import` with `publish_date="????"`:
```
http POST http://localhost:8080/api/import title="Les noirs et les rouges" source_records\[\]="ia:lesnoirsetlesrou0000garl" authors\[\]\[name\]="Alberto Garlini" publishers\[\]="Gallimard" publish_date=\?\?\?\? isbn_13=9782072702211 Cookie:$OL_COOKIE
```

Before
openlibrary-web-1 | `rec` as passed to load():
```json
{
  "title":"Les noirs et les rouges",
  "source_records":[
    "ia:lesnoirsetlesrou0000garl"
  ],
  "authors":[
    {
      "name":"Alberto Garlini"
    }
  ],
  "publishers":[
    "Gallimard"
  ],
  "publish_date":"????",
  "isbn_13":"9782072702211"
}
```

After:

openlibrary-web-1 | `rec` as passed to load():
```json
{
  "title":"Les noirs et les rouges",
  "source_records":[
    "ia:lesnoirsetlesrou0000garl"
  ],
  "authors":[
    {
      "name":"Alberto Garlini"
    }
  ],
  "publishers":[
    "Gallimard"
  ],
  "isbn_13":"9782072702211"
}
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
