### PR TITLE
Add client_id, s3, scope to bulk availability API

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -300,7 +300,9 @@ def get_availability(key: str, ids: list[str]) -> dict:
             "x-application-id": "openlibrary",
         }
         if config_ia_ol_metadata_write_s3:
-            headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(**config_ia_ol_metadata_write_s3)
+            headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(
+                **config_ia_ol_metadata_write_s3
+            )
 
         # Make authenticated request to Bulk Availability API
         response = requests.get(

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -300,9 +300,7 @@ def get_availability(key: str, ids: list[str]) -> dict:
             "x-application-id": "openlibrary",
         }
         if config_ia_ol_metadata_write_s3:
-            access_key = config_ia_ol_metadata_write_s3['s3_key']
-            secret_key = config_ia_ol_metadata_write_s3['s3_secret']
-            headers["authorization"] = f"LOW {access_key}:{secret_key}"
+            headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(**config_ia_ol_metadata_write_s3)
 
         # Make authenticated request to Bulk Availability API
         response = requests.get(

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -293,7 +293,25 @@ def get_availability(key: str, ids: list[str]) -> dict:
 
     url = '{}?{}={}'.format(config_ia_availability_api_v2_url, key, ','.join(ids))
     try:
-        response = requests.get(url, timeout=config_http_request_timeout)
+        client_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR', 'ol-internal')
+        params = {
+            "scope": "printdisabled"
+        }
+        headers = {
+            "x-preferred-client-id": client_ip,
+            "x-application-id": "openlibrary",
+        }
+        if config_ia_ol_metadata_write_s3:
+            access_key = config_ia_ol_metadata_write_s3['s3_key'] 
+            secret_key = config_ia_ol_metadata_write_s3['s3_secret']
+            headers["authorization"] = f"LOW {access_key}:{secret_key}" 
+
+        # Make authenticated request to Bulk Availability API
+        response = requests.get(
+            url, params=params, headers=headers,
+            timeout=config_http_request_timeout
+        )
+        
         items = response.json().get('responses', {})
         for pkey in items:
             ocaid = pkey if key == 'identifier' else items[pkey].get('identifier')

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -294,24 +294,21 @@ def get_availability(key: str, ids: list[str]) -> dict:
     url = '{}?{}={}'.format(config_ia_availability_api_v2_url, key, ','.join(ids))
     try:
         client_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR', 'ol-internal')
-        params = {
-            "scope": "printdisabled"
-        }
+        params = {"scope": "printdisabled"}
         headers = {
             "x-preferred-client-id": client_ip,
             "x-application-id": "openlibrary",
         }
         if config_ia_ol_metadata_write_s3:
-            access_key = config_ia_ol_metadata_write_s3['s3_key'] 
+            access_key = config_ia_ol_metadata_write_s3['s3_key']
             secret_key = config_ia_ol_metadata_write_s3['s3_secret']
-            headers["authorization"] = f"LOW {access_key}:{secret_key}" 
+            headers["authorization"] = f"LOW {access_key}:{secret_key}"
 
         # Make authenticated request to Bulk Availability API
         response = requests.get(
-            url, params=params, headers=headers,
-            timeout=config_http_request_timeout
+            url, params=params, headers=headers, timeout=config_http_request_timeout
         )
-        
+
         items = response.json().get('responses', {})
         for pkey in items:
             ocaid = pkey if key == 'identifier' else items[pkey].get('identifier')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In response to (internal) Bulk Availability API PR https://git.archive.org/ia/petabox/-/merge_requests/3516/diffs

This PR decorates our calls to the Bulk Availability API (petabox) to include headers with s3 authorization, scope, application, and client_ip to help enforce security/permissions and rate limiting. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

The `scope` field may need to be changed? I'm not sure what values are acceptable.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

This PR can be deployed to testing when there's a petabox PR to test against

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@ximm @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
