### PR TITLE
ruff fixes: Call pytest decorators as functions

### DIFF
--- a/openlibrary/catalog/add_book/tests/conftest.py
+++ b/openlibrary/catalog/add_book/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def add_languages(mock_site):
     languages = [
         ('eng', 'English'),

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -27,7 +27,7 @@ def open_test_data(filename):
     return open(fullpath, mode='rb')
 
 
-@pytest.fixture
+@pytest.fixture()
 def ia_writeback(monkeypatch):
     """Prevent ia writeback from making live requests."""
     monkeypatch.setattr(add_book, 'update_ia_metadata_for_ol_edition', lambda olid: {})

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -7,7 +7,7 @@ from openlibrary.catalog.add_book.load_book import (
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def new_import(monkeypatch):
     monkeypatch.setattr(load_book, 'find_entity', lambda a: None)
 

--- a/openlibrary/conftest.py
+++ b/openlibrary/conftest.py
@@ -43,7 +43,7 @@ def no_sleep(monkeypatch):
     monkeypatch.setattr("time.sleep", mock_sleep)
 
 
-@pytest.fixture
+@pytest.fixture()
 def monkeytime(monkeypatch):
     cur_time = 1
 
@@ -58,12 +58,12 @@ def monkeytime(monkeypatch):
     monkeypatch.setattr("time.sleep", sleep)
 
 
-@pytest.fixture
+@pytest.fixture()
 def wildcard():
     return Wildcard()
 
 
-@pytest.fixture
+@pytest.fixture()
 def render_template(request):
     """Utility to test templates."""
     template.load_templates("openlibrary")

--- a/openlibrary/coverstore/tests/test_coverstore.py
+++ b/openlibrary/coverstore/tests/test_coverstore.py
@@ -13,7 +13,7 @@ image_formats = [
 ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_dir(tmpdir):
     tmpdir.mkdir('localdisk')
     tmpdir.mkdir('items')

--- a/openlibrary/coverstore/tests/test_webapp.py
+++ b/openlibrary/coverstore/tests/test_webapp.py
@@ -25,7 +25,7 @@ def setup_db():
     db.insert('category', name='b')
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_dir(tmpdir):
     tmpdir.mkdir('localdisk')
     tmpdir.mkdir('items')

--- a/openlibrary/mocks/mock_ia.py
+++ b/openlibrary/mocks/mock_ia.py
@@ -4,7 +4,7 @@ import pytest
 from openlibrary.core import ia
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_ia(request, monkeypatch):
     """pytest funcarg to mock openlibrary.core.ia module.
 

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -357,7 +357,7 @@ class MockStore(dict):
         return [(doc["_key"], doc) for doc in self._query(**kw)]
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_site(request):
     """mock_site funcarg.
 

--- a/openlibrary/mocks/mock_memcache.py
+++ b/openlibrary/mocks/mock_memcache.py
@@ -32,7 +32,7 @@ class Client:
             pass
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_memcache(request, monkeypatch):
     """This patches all the existing memcache connections to use mock memcache instance."""
     m = monkeypatch

--- a/openlibrary/mocks/mock_ol.py
+++ b/openlibrary/mocks/mock_ol.py
@@ -13,7 +13,7 @@ from openlibrary.mocks.mock_infobase import mock_site, MockConnection
 from openlibrary.plugins import ol_infobase
 
 
-@pytest.fixture
+@pytest.fixture()
 def ol(request):
     """ol funcarg for pytest tests.
 
@@ -50,7 +50,7 @@ class OLBrowser(AppBrowser):
 class OL:
     """Mock OL object for all tests."""
 
-    @pytest.fixture
+    @pytest.fixture()
     def __init__(self, request, monkeypatch):
         self.request = request
 

--- a/openlibrary/plugins/admin/tests/conftest.py
+++ b/openlibrary/plugins/admin/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def serviceconfig(request):
     import os
     import yaml

--- a/openlibrary/plugins/books/tests/test_dynlinks.py
+++ b/openlibrary/plugins/books/tests/test_dynlinks.py
@@ -17,7 +17,7 @@ from openlibrary.mocks import mock_infobase
 from openlibrary.plugins.books import dynlinks
 
 
-@pytest.fixture
+@pytest.fixture()
 def data0(request):
     return {
         "/books/OL0M": {"key": "/books/OL0M", "title": "book-0"},
@@ -34,7 +34,7 @@ def data0(request):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def data1(request):
     return {
         "/books/OL1M": {
@@ -51,7 +51,7 @@ def data1(request):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def data9(request):
     return {
         "/authors/OL9A": {"key": "/authors/OL9A", "name": "Mark Twain"},

--- a/openlibrary/plugins/upstream/tests/test_account.py
+++ b/openlibrary/plugins/upstream/tests/test_account.py
@@ -162,7 +162,7 @@ class TestGoodReadsImport:
         assert books_wo_isbns == self.expected_books_wo_isbns
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail()
 class TestAccount:
     def signup(self, b, displayname, username, password, email):
         b.open("/account/create")

--- a/openlibrary/tests/core/conftest.py
+++ b/openlibrary/tests/core/conftest.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_crontabfile(request):
     "Creates a dummy crontab file that can be used for to try things"
     cronfile = os.tmpnam()
@@ -15,7 +15,7 @@ def dummy_crontabfile(request):
     return cronfile
 
 
-@pytest.fixture
+@pytest.fixture()
 def crontabfile(request):
     """Creates a file with an actual command that we can use to test
     running of cron lines"""
@@ -30,7 +30,7 @@ def crontabfile(request):
     return cronfile
 
 
-@pytest.fixture
+@pytest.fixture()
 def counter(request):
     """Returns a decorator that will create a 'counted' version of the
     functions. The number of times it's been called is kept in the
@@ -47,7 +47,7 @@ def counter(request):
     return counter
 
 
-@pytest.fixture
+@pytest.fixture()
 def sequence(request):
     """Returns a function that can be called for sequence numbers
     similar to web.ctx.site.sequence.get_next"""

--- a/openlibrary/tests/solr/test_data_provider.py
+++ b/openlibrary/tests/solr/test_data_provider.py
@@ -7,7 +7,7 @@ from openlibrary.solr.data_provider import BetterDataProvider
 
 
 class TestBetterDataProvider:
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_get_document(self):
         mock_site = MagicMock()
         dp = BetterDataProvider(
@@ -30,7 +30,7 @@ class TestBetterDataProvider:
         await dp.get_document('/works/OL1W')
         assert mock_site.get_many.call_count == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_clear_cache(self):
         mock_site = MagicMock()
         dp = BetterDataProvider(

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -117,7 +117,7 @@ class Test_build_data:
     def setup_class(cls):
         update_work.data_provider = FakeDataProvider()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_simple_work(self):
         work = {"key": "/works/OL1M", "type": {"key": "/type/work"}, "title": "Foo"}
 
@@ -127,7 +127,7 @@ class Test_build_data:
         assert d["has_fulltext"] is False
         assert d["edition_count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_edition_count_when_editions_on_work(self):
         work = make_work()
 
@@ -142,7 +142,7 @@ class Test_build_data:
         d = await build_data(work)
         assert d['edition_count'] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_edition_count_when_editions_in_data_provider(self):
         work = make_work()
         d = await build_data(work)
@@ -160,7 +160,7 @@ class Test_build_data:
         d = await build_data(work)
         assert d['edition_count'] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_edition_key(self):
         work = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -175,7 +175,7 @@ class Test_build_data:
         d = await build_data(work)
         assert d['edition_key'] == ["OL1M", "OL2M", "OL3M"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_publish_year(self):
         test_dates = [
             "2000",
@@ -196,7 +196,7 @@ class Test_build_data:
         assert sorted(d['publish_year']) == ["2000", "2001", "2002", "2003", "2004"]
         assert d["first_publish_year"] == 2000
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_isbns(self):
         work = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -211,7 +211,7 @@ class Test_build_data:
         d = await build_data(work)
         assert sorted(d['isbn']) == ['123456789X', '9781234567897']
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_other_identifiers(self):
         work = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -225,7 +225,7 @@ class Test_build_data:
         assert sorted(d['oclc']) == ['123', '234']
         assert sorted(d['lccn']) == ['lccn-1', 'lccn-2', 'lccn-3']
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_identifiers(self):
         work = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -238,7 +238,7 @@ class Test_build_data:
         d = await build_data(work)
         assert sorted(d['id_librarything']) == ['lt-1', 'lt-2']
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_ia_boxid(self):
         w = make_work()
         update_work.data_provider = FakeDataProvider([w, make_edition(w)])
@@ -253,7 +253,7 @@ class Test_build_data:
         assert 'ia_box_id' in d
         assert d['ia_box_id'] == ['foo']
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_with_one_lending_edition(self):
         w = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -270,7 +270,7 @@ class Test_build_data:
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_with_two_lending_editions(self):
         w = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -296,7 +296,7 @@ class Test_build_data:
         assert d['edition_count'] == 2
         assert d['ebook_count_i'] == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_with_one_inlibrary_edition(self):
         w = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -313,7 +313,7 @@ class Test_build_data:
         assert d['edition_count'] == 1
         assert d['ebook_count_i'] == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_with_one_printdisabled_edition(self):
         w = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -343,7 +343,7 @@ class Test_build_data:
         assert f([only_title, no_title]) == {'foo'}
         assert f([with_subtitle, only_title]) == {'foo 2: bar', 'foo'}
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_with_multiple_editions(self):
         w = make_work()
         update_work.data_provider = FakeDataProvider(
@@ -371,7 +371,7 @@ class Test_build_data:
         assert d['edition_count'] == 4
         assert d['ebook_count_i'] == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_subjects(self):
         w = make_work(subjects=["a", "b c"])
         d = await build_data(w)
@@ -397,7 +397,7 @@ class Test_build_data:
             assert d[k + '_facet'] == ['a', "b c"]
             assert d[k + '_key'] == ['a', "b_c"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_author_info(self):
         w = make_work(
             authors=[
@@ -445,7 +445,7 @@ class Test_build_data:
         ),
     }
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @pytest.mark.parametrize(
         "doc_lccs,solr_lccs,sort_lcc_index", LCC_TESTS.values(), ids=LCC_TESTS.keys()
     )
@@ -487,7 +487,7 @@ class Test_build_data:
         'Skips 092s': (['092', '123.5'], ['123.5'], 0),
     }
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     @pytest.mark.parametrize(
         "doc_ddcs,solr_ddcs,sort_ddc_index", DDC_TESTS.values(), ids=DDC_TESTS.keys()
     )
@@ -522,7 +522,7 @@ class Test_update_items:
     def setup_class(cls):
         update_work.data_provider = FakeDataProvider()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_delete_author(self):
         update_work.data_provider = FakeDataProvider(
             [make_author(key='/authors/OL23A', type={'key': '/type/delete'})]
@@ -530,7 +530,7 @@ class Test_update_items:
         requests = await update_work.update_author('/authors/OL23A')
         assert requests[0].to_json_command() == '"delete": ["/authors/OL23A"]'
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_redirect_author(self):
         update_work.data_provider = FakeDataProvider(
             [make_author(key='/authors/OL24A', type={'key': '/type/redirect'})]
@@ -538,7 +538,7 @@ class Test_update_items:
         requests = await update_work.update_author('/authors/OL24A')
         assert requests[0].to_json_command() == '"delete": ["/authors/OL24A"]'
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_update_author(self, monkeypatch):
         update_work.data_provider = FakeDataProvider(
             [make_author(key='/authors/OL25A', name='Somebody')]
@@ -576,7 +576,7 @@ class TestUpdateWork:
     def setup_class(cls):
         update_work.data_provider = FakeDataProvider()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_delete_work(self):
         requests = await update_work.update_work(
             {'key': '/works/OL23W', 'type': {'key': '/type/delete'}}
@@ -584,7 +584,7 @@ class TestUpdateWork:
         assert len(requests) == 1
         assert requests[0].to_json_command() == '"delete": ["/works/OL23W"]'
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_delete_editions(self):
         requests = await update_work.update_work(
             {'key': '/works/OL23M', 'type': {'key': '/type/delete'}}
@@ -592,7 +592,7 @@ class TestUpdateWork:
         assert len(requests) == 1
         assert requests[0].to_json_command() == '"delete": ["/works/OL23M"]'
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_redirects(self):
         requests = await update_work.update_work(
             {'key': '/works/OL23W', 'type': {'key': '/type/redirect'}}
@@ -600,7 +600,7 @@ class TestUpdateWork:
         assert len(requests) == 1
         assert requests[0].to_json_command() == '"delete": ["/works/OL23W"]'
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_no_title(self):
         requests = await update_work.update_work(
             {'key': '/books/OL1M', 'type': {'key': '/type/edition'}}
@@ -613,7 +613,7 @@ class TestUpdateWork:
         assert len(requests) == 1
         assert requests[0].doc['title'] == "__None__"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio()
     async def test_work_no_title(self):
         work = {'key': '/works/OL23W', 'type': {'key': '/type/work'}}
         ed = make_edition(work)

--- a/tests/integration/test_affiliate_links.py
+++ b/tests/integration/test_affiliate_links.py
@@ -6,7 +6,7 @@ class TestAffiliateLinks:
     # host = 'https://openlibrary.org'
     host = 'http://localhost:8080'
 
-    @pytest.fixture
+    @pytest.fixture()
     def browser(self):
         browser = Browser('chrome')
         yield browser

--- a/tests/integration/test_landing.py
+++ b/tests/integration/test_landing.py
@@ -12,7 +12,7 @@ class TestLanding:
         browser_instance.fill('password', 'openlibrary')
         browser_instance.find_by_value('Log In').first.click()
 
-    @pytest.fixture
+    @pytest.fixture()
     def browser(self):
         browser = Browser('chrome')
         yield browser

--- a/tests/integration/test_microdata.py
+++ b/tests/integration/test_microdata.py
@@ -5,7 +5,7 @@ from splinter import Browser
 class TestMicrodata:
     host = 'http://localhost:8080'
 
-    @pytest.fixture
+    @pytest.fixture()
     def browser(self):
         browser = Browser('chrome')
         yield browser

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -6,7 +6,7 @@ class TestSearch:
     # host = 'https://openlibrary.org'
     host = 'http://localhost:8080'
 
-    @pytest.fixture
+    @pytest.fixture()
     def browser(self):
         browser = Browser('chrome')
         yield browser

--- a/tests/integration/test_sharing.py
+++ b/tests/integration/test_sharing.py
@@ -13,7 +13,7 @@ class TestSharing:
         browser_instance.fill('password', 'openlibrary')
         browser_instance.find_by_value('Log In').first.click()
 
-    @pytest.fixture
+    @pytest.fixture()
     def browser(self):
         browser = Browser('chrome')
         yield browser


### PR DESCRIPTION
<!-- What issue does this PR close? -->
[`ruff check --select=PT --ignore=PT006,PT009 --fix .`](https://beta.ruff.rs)

https://pypi.org/project/flake8-pytest-style

`git grep pytest-fixture-no-parentheses ` # --> no hits.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
