### PR TITLE
Change source record format for promise item imports

### DIFF
--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -38,9 +38,10 @@ def map_book_to_olbook(book, promise_id):
     publish_date = book['ProductJSON'].get('PublicationDate')
     title = book['ProductJSON'].get('Title')
     isbn = book.get('ISBN') or ' '
+    sku = book['BookSKUB'] or book['BookSKU'] or book['BookBarcode']
     olbook = {
         'local_id': [
-            f"urn:bwbsku:{book['BookSKUB'] or book['BookSKU'] or book['BookBarcode']}"
+            f"urn:bwbsku:{sku}"
         ],
         'identifiers': {
             **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
@@ -55,7 +56,7 @@ def map_book_to_olbook(book, promise_id):
         **({'title': title} if title else {}),
         'authors': [{"name": book['ProductJSON'].get('Author') or '????'}],
         'publishers': [book['ProductJSON'].get('Publisher') or '????'],
-        'source_records': [f"promise:{promise_id}"],
+        'source_records': [f"promise:{promise_id}:{sku}"],
         # format_date adds hyphens between YYYY-MM-DD
         'publish_date': publish_date and format_date(publish_date) or '????',
     }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes the `source_record` format of promise item import records from `promise:{item_id}` to `promise:{item_id}:{sku}`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
