### PR TITLE
Fix cursor styling for better ux in nearby libraries pannel

### DIFF
--- a/static/css/components/read-panel.less
+++ b/static/css/components/read-panel.less
@@ -89,6 +89,7 @@
 .buy-options-table {
   .more {
     margin-left: 0;
+    cursor: pointer;
 
     &::marker {
       content: "";


### PR DESCRIPTION
### Fix
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The ".more" class in the "li" tag on the "works" path for each book had a default cursor, which could lead the user to think there were no more links to be seen in that panel. As a result, more people would ignore clicking that button. You can see that button, for example, on the "works page" in the "Check nearby libraries" section for this [Harry Potter](https://openlibrary.org/works/OL82536W/Harry_Potter_and_the_Prisoner_of_Azkaban) book  (Screenshots below).

### Technical
<!-- What should be noted about the implementation? -->
The "li" tag with ".more" class lacked of ```cursor: pointer;``` property. Some other similar tags in the same view, with similar styling, have the said property.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Tests were run to verify everything worked after changing the .less file as said in the guide with:

```sh
docker-compose exec web make test
```

Since it was just a css fix, there wasn't any issue.
### Screenshots
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
#### Example of "li" tag with cursor pointer within this view [Harry Potter Book](https://openlibrary.org/works/OL82536W/Harry_Potter_and_the_Prisoner_of_Azkaban)
<br>

![image](https://user-images.githubusercontent.com/87588133/218548252-bc5ac3c5-becc-4f12-8688-032150c17550.png)


#### What was fixed:

![image](https://user-images.githubusercontent.com/87588133/218547960-0f8ee94c-b0f3-48b9-94c9-fae5e013f1e3.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->

No bugs.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
