### PR TITLE
Add author to page title instead of date (#7499)

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -80,7 +80,9 @@ $ ocaid = edition.get('ocaid')
 $ book_title = edition.get('title', '') or (work.title if work else '')
 $ work_title = work.title if work else edition.get('title', '')
 $ book_subtitle = edition.get('subtitle', '')
-$ title_suffix = cond(edition.get('publish_date'), u"({0} edition)".format(edition.get('publish_date')), "(edition)")
+$ authors = work.get_authors() if work else edition.get('authors', {})
+$# Only display the first / primary author
+$ title_suffix = "by " + authors[0].name if authors else ""
 $ title = book_title + " " + title_suffix
 $ title_with_site = _("%(page_title)s | Open Library", page_title=title)
 $ meta_cover_url = item_image((edition or work).get_cover_url("L"), default="https://openlibrary.org/images/icons/avatar_book-sm.png")

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -80,7 +80,7 @@ $ ocaid = edition.get('ocaid')
 $ book_title = edition.get('title', '') or (work.title if work else '')
 $ work_title = work.title if work else edition.get('title', '')
 $ book_subtitle = edition.get('subtitle', '')
-$ authors = work.get_authors() if work else edition.get('authors', {})
+$ authors = work.get_authors() if work else edition.get_authors()
 $# Only display the first / primary author
 $ title_suffix = "by " + authors[0].name if authors else ""
 $ title = book_title + " " + title_suffix


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7499

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR is to update the page title to include the author's name. 

### Technical
This PR does the following:
- get a list of authors
- if the list is present, append the name of the first author to the page title. Else, append an empty string

### Testing
- Run `docker-compose up` to load the website on local
- Look up "Upon A Midnight Clear"
- Verify that the page title is {title of the edition/work} by {author}
- I was only able to test this with "work". When i load the website in my local, it only has one book: Upon A Midnight Clear. So I'm unable to test with "edition" or with book that doesn't have any author (if such book existed)

### Screenshot
Verified that page title is using the form {title} by {primary author} 
![Screen Shot 2023-02-13 at 23 48 45](https://user-images.githubusercontent.com/17926344/218676150-4463dc8e-b2ae-431b-9cd9-23f872798050.png)

### Stakeholders
@seabelis @jimchamp @RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
