### PR TITLE
Create script for deleting import_item entries

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -141,7 +141,9 @@ class ImportItem(web.storage):
         self.set_status(status='modified', ol_key=ol_key)
 
     @classmethod
-    def delete_items(cls, ia_ids: list[str], batch_id: int | None = None , _test: bool = False):
+    def delete_items(
+        cls, ia_ids: list[str], batch_id: int | None = None, _test: bool = False
+    ):
         oldb = db.get_db()
         data: dict[str, Any] = {
             'ia_ids': ia_ids,
@@ -153,12 +155,7 @@ class ImportItem(web.storage):
             data['batch_id'] = batch_id
             where += ' AND batch_id=$batch_id'
 
-        return oldb.delete(
-            'import_item',
-            where=where,
-            vars=data,
-            _test=_test
-        )
+        return oldb.delete('import_item', where=where, vars=data, _test=_test)
 
 
 class Stats:

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -138,6 +138,20 @@ class ImportItem(web.storage):
     def mark_modified(self, ol_key):
         self.set_status(status='modified', ol_key=ol_key)
 
+    @classmethod
+    def delete_items(cls, ia_ids: list[str], sentinel_id: int = 321, _test: bool = False):
+        oldb = db.get_db()
+        data = {
+            'batch_id': sentinel_id,
+            'ia_ids': ia_ids,
+        }
+        return oldb.delete(
+            'import_item',
+            where=('batch_id > $batch_id AND ia_id IN $ia_ids'),
+            vars=data,
+            _test=_test
+        )
+
 
 class Stats:
     """Import Stats."""

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -139,15 +139,21 @@ class ImportItem(web.storage):
         self.set_status(status='modified', ol_key=ol_key)
 
     @classmethod
-    def delete_items(cls, ia_ids: list[str], sentinel_id: int = 321, _test: bool = False):
+    def delete_items(cls, ia_ids: list[str], batch_id: int | None = None , _test: bool = False):
         oldb = db.get_db()
         data = {
-            'batch_id': sentinel_id,
             'ia_ids': ia_ids,
         }
+
+        where = 'ia_id IN $ia_ids'
+
+        if batch_id:
+            data['batch_id'] = batch_id
+            where += ' AND batch_id=$batch_id'
+
         return oldb.delete(
             'import_item',
-            where=('batch_id > $batch_id AND ia_id IN $ia_ids'),
+            where=where,
             vars=data,
             _test=_test
         )

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -1,6 +1,8 @@
 """Interface to import queue.
 """
 from collections import defaultdict
+from typing import Any
+
 import logging
 import datetime
 import time
@@ -141,7 +143,7 @@ class ImportItem(web.storage):
     @classmethod
     def delete_items(cls, ia_ids: list[str], batch_id: int | None = None , _test: bool = False):
         oldb = db.get_db()
-        data = {
+        data: dict[str, Any] = {
             'ia_ids': ia_ids,
         }
 

--- a/openlibrary/tests/core/test_imports.py
+++ b/openlibrary/tests/core/test_imports.py
@@ -1,0 +1,70 @@
+import web
+
+from openlibrary.core.db import get_db
+from openlibrary.core.imports import ImportItem
+
+class TestImportItem:
+    IMPORT_ITEM_DDL = """
+    CREATE TABLE import_item (
+        id serial primary key,
+        batch_id integer,
+        status text default 'pending',
+        error text,
+        ia_id text,
+        data text,
+        ol_key text,
+        comments text,
+        UNIQUE (batch_id, ia_id)
+    );
+    """
+
+    IMPORT_ITEM_DATA = [
+        {
+            'id': 1,
+            'batch_id': 1,
+            'ia_id': 'unique_id_1',
+        },
+        {
+            'id': 2,
+            'batch_id': 1,
+            'ia_id': 'unique_id_2',
+        },
+        {
+            'id': 3,
+            'batch_id': 2,
+            'ia_id': 'unique_id_1',
+        },
+    ]
+
+    @classmethod
+    def setup_class(cls):
+        web.config.db_parameters = dict(dbn='sqlite', db=':memory:')
+        db = get_db()
+        db.query(cls.IMPORT_ITEM_DDL)
+
+    @classmethod
+    def teardown_class(cls):
+        db = get_db()
+        db.query('delete from import_item;')
+
+    def setup_method(self):
+        self.db = get_db()
+        self.db.multiple_insert('import_item', self.IMPORT_ITEM_DATA)
+
+    def teardown_method(self):
+        self.db.query('delete from import_item;')
+
+    def test_delete(self):
+        assert len(list(self.db.select('import_item'))) == 3
+
+        ImportItem.delete_items(['unique_id_1'])
+        assert len(list(self.db.select('import_item'))) == 1
+
+    def test_delete_with_batch_id(self):
+        assert len(list(self.db.select('import_item'))) == 3
+
+        ImportItem.delete_items(['unique_id_1'], batch_id=1)
+        assert len(list(self.db.select('import_item'))) == 2
+
+        ImportItem.delete_items(['unique_id_1'], batch_id=2)
+        assert len(list(self.db.select('import_item'))) == 1

--- a/openlibrary/tests/core/test_imports.py
+++ b/openlibrary/tests/core/test_imports.py
@@ -3,6 +3,7 @@ import web
 from openlibrary.core.db import get_db
 from openlibrary.core.imports import ImportItem
 
+
 class TestImportItem:
     IMPORT_ITEM_DDL = """
     CREATE TABLE import_item (

--- a/scripts/delete_import_items.py
+++ b/scripts/delete_import_items.py
@@ -1,5 +1,18 @@
 """
 Deletes entries from the import_item table.
+
+Reads ia_ids that should be deleted from an input file.  The input file is expected to be tab-delimited, and each line will have the following format: 
+{N number of ia_ids in this line} {edition_key} {ia_id 1} [...] {ia_id N}
+
+Requires a configuration file in order to run.  You can use the following as a template for the configuration file:
+
+[args]
+in_file=./import-item-cleanup/in.txt
+state_file=./import-item-cleanup/curline.txt
+error_file=./import-item-cleanup/errors.txt
+batch_size=1000
+dry_run=True
+ol_config=/path/to/openlibrary.yml
 """
 import argparse
 import time
@@ -110,8 +123,8 @@ def init_and_start(args):
     print(f'Records deleted: {results["num_deleted"]}')
 
 def build_parser():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('-c', '--config_file', help='Path to configuration file', default='./import-item-cleanup/config.ini')
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('config_file', metavar='config_path', help='Path to configuration file')
     parser.set_defaults(func=init_and_start)
     return parser
 

--- a/scripts/delete_import_items.py
+++ b/scripts/delete_import_items.py
@@ -75,7 +75,7 @@ class DeleteImportItemJob:
                     if not self.dry_run:
                         write_to(self.error_file, line, mode='a+')
                 lines_processed += 1
-                affected_records += int(fields[1])
+                affected_records += int(fields[0])
 
         # Write next line number to state file:
         if not self.dry_run:

--- a/scripts/delete_import_items.py
+++ b/scripts/delete_import_items.py
@@ -50,7 +50,8 @@ class DeleteImportItemJob:
           f.readline()
 
         # Delete a batch of records
-        num_processed = 0
+        lines_processed = 0
+        affected_records = 0
         num_deleted = 0
         for _ in range(self.batch_size):
           line = f.readline()
@@ -70,15 +71,17 @@ class DeleteImportItemJob:
             print(f'Error when deleting: {e}')
             if not self.dry_run:
               write_to(self.error_file, line, mode='a+')
-          num_processed += 1
+          lines_processed += 1
+          affected_records += int(fields[1])
 
       # Write next line number to state file:
       if not self.dry_run:
-        write_to(self.state_file, f'{self.start_line + num_processed}')
+        write_to(self.state_file, f'{self.start_line + lines_processed}')
 
       return {
-        'num_processed': num_processed,
-        'num_deleted': num_deleted
+        'lines_processed': lines_processed,
+        'num_deleted': num_deleted,
+        'affected_records': affected_records,
       }
 
 def write_to(filepath, s, mode='w+'):
@@ -119,7 +122,8 @@ def init_and_start(args):
     # Delete affected files
     results = DeleteImportItemJob(**config_args).run()
 
-    print(f'Lines of input processed: {results["num_processed"]}')
+    print(f'Lines of input processed: {results["lines_processed"]}')
+    print(f'Records read from input file: {results["affected_records"]}')
     print(f'Records deleted: {results["num_deleted"]}')
 
 def build_parser():

--- a/scripts/delete_import_items.py
+++ b/scripts/delete_import_items.py
@@ -1,0 +1,131 @@
+"""
+Deletes entries from the import_item table.
+"""
+import argparse
+import time
+
+from configparser import ConfigParser
+from pathlib import Path
+
+import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
+
+from openlibrary.config import load_config
+from openlibrary.core.imports import ImportItem
+from openlibrary.core.edits import CommunityEditsQueue
+
+class DeleteImportItemJob:
+    def __init__(self, in_file='', state_file='', error_file='', batch_size=1000, dry_run=False):
+        self.in_file = in_file
+        self.state_file = state_file
+        self.error_file = error_file
+
+        self.batch_size = batch_size
+        self.dry_run = dry_run
+
+        self.start_line = 1
+        state_path = Path(state_file)
+        if state_path.exists():
+            with state_path.open('r') as f:
+              line = f.readline()
+              if line:
+                self.start_line = int(line)
+
+    def run(self):
+      with open(self.in_file, 'r') as f:
+        # Seek to start line
+        for _ in range(1, self.start_line):
+          f.readline()
+
+        # Delete a batch of records
+        num_processed = 0
+        num_deleted = 0
+        for _ in range(self.batch_size):
+          line = f.readline()
+          if not line:
+            break
+          fields = line.strip().split('\t')
+          ia_ids = fields[2:]
+          try:
+            result = ImportItem.delete_items(ia_ids, _test=self.dry_run)
+            if self.dry_run:
+              # Result is string "DELETE FROM ..."
+              print(result)
+            else:
+              # Result is number of records deleted
+              num_deleted += result
+          except Exception as e:
+            print(f'Error when deleting: {e}')
+            if not self.dry_run:
+              write_to(self.error_file, line, mode='a+')
+          num_processed += 1
+
+      # Write next line number to state file:
+      if not self.dry_run:
+        write_to(self.state_file, f'{self.start_line + num_processed}')
+
+      return {
+        'num_processed': num_processed,
+        'num_deleted': num_deleted
+      }
+
+def write_to(filepath, s, mode='w+'):
+  print(mode)
+  path = Path(filepath)
+  path.parent.mkdir(exist_ok=True, parents=True)
+
+  with path.open(mode=mode) as f:
+    f.write(s)
+
+def read_args_from_config(config_path):
+    path = Path(config_path)
+    if not path.exists():
+        raise Exception(f'No configuration file found at {config_path}')
+
+    config = ConfigParser()
+    config.read(path)
+    args = config['args']
+
+    return {
+        'in_file': args.get('in_file'),
+        'state_file': args.get('state_file'),
+        'error_file': args.get('error_file'),
+        'batch_size': args.getint('batch_size'),
+        'dry_run': bool(args.get('dry_run')),
+        'ol_config': args.get('ol_config')
+    }
+
+def init_and_start(args):
+    # Read arguments from config file:
+    config_args = read_args_from_config(args.config_file)
+
+    # Set up Open Library
+    load_config(config_args['ol_config'])
+
+    del config_args['ol_config']
+
+    # Delete affected files
+    results = DeleteImportItemJob(**config_args).run()
+
+    print(f'Lines of input processed: {results["num_processed"]}')
+    print(f'Records deleted: {results["num_deleted"]}')
+
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-c', '--config_file', help='Path to configuration file', default='./import-item-cleanup/config.ini')
+    parser.set_defaults(func=init_and_start)
+    return parser
+
+if __name__ == '__main__':
+    start_time = time.time()
+
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except Exception as e:
+        print(f'Error: {e}')
+        print('Stopping script early.')
+
+    end_time = time.time()
+    print(f'\nTime elapsed: {end_time - start_time} seconds\n')
+    print('Program terminated...')

--- a/scripts/import-item-cleanup/config.ini
+++ b/scripts/import-item-cleanup/config.ini
@@ -1,0 +1,7 @@
+[args]
+in_file=./import-item-cleanup/in.txt
+state_file=./import-item-cleanup/curline.txt
+error_file=./import-item-cleanup/errors.txt
+batch_size=1000
+dry_run=True
+ol_config=../config/openlibrary.yml

--- a/scripts/import-item-cleanup/config.ini
+++ b/scripts/import-item-cleanup/config.ini
@@ -1,7 +1,0 @@
-[args]
-in_file=./import-item-cleanup/in.txt
-state_file=./import-item-cleanup/curline.txt
-error_file=./import-item-cleanup/errors.txt
-batch_size=1000
-dry_run=True
-ol_config=../config/openlibrary.yml


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds function for deleting entries from the `import_item` table, and script for deleting such entries in bulk.

### Technical
<!-- What should be noted about the implementation? -->
DB entries that should be deleted will have a `batch_id` > 321, hence the default value in the `delete_items` function.

Script relies on an input file containing the `ia_id`s of entries that should be deleted.  Each line of the tab-separated input file is expected to be in the following format:
`{N number of IA IDs in this line} {edition_key} {IA ID 1} ... {IA ID N}`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Running this with `dry_run=True` will result in each `DELETE` statement being printed out, but with no data actually being deleted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
