### PR TITLE
More directions for Docker README; DRY up slightly

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,11 +2,11 @@
 
 ## Prerequisites & Troubleshooting
 
-The openlibrary repository must be cloned with `ssh` and *not* `https`. See the [Git Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) for more, including how to fix this if you use `git clone https://...`
+The openlibrary repository _must_ be cloned with `ssh` and *not* `https` so that git submodules can be fetched correctly. See the [Git Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) for more, including how to fix this if you use `git clone https://...`
 
 Windows users should see [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
 
-Before attempting to build openlibrary using the Docker instructions below, please read through these opening notes about setting up Docker. If you encounter an error, the following section may serve as a troubleshooting guide.
+Before attempting to build openlibrary using the Docker instructions below, please read through these opening notes about setting up Docker. If you encounter any errors, the following section may serve as a troubleshooting guide.
 
 ### Install Docker Engine or Docker Desktop
 Linux users (including those using a VM), can install Docker Engine or Docker Desktop. Docker has an [FAQ about the difference](https://docs.docker.com/desktop/faqs/linuxfaqs/) between the two. Windows and macOS users should use Docker Desktop as of early 2023.
@@ -16,16 +16,16 @@ Linux users (including those using a VM), can install Docker Engine or Docker De
 
 ### A note on `docker-compose` and `docker compose`
 
-As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose, it will install `docker-ce` and `docker-compose-plugin` (Linux only), both of which obviate the need to install `docker-compose` separately.
+As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose v2, it will install `docker-ce` and `docker-compose-plugin` (Linux only), both of which obviate the need to install `docker-compose` v1 separately.
 
 Further, Compose V1 will [no longer be supported by the end of June 2023](https://docs.docker.com/compose/compose-v2/) and will be removed from Docker Desktop. These directions are written for Compose V2, hence the use of `docker compose` rather than `docker-compose`. `docker compose` is [meant to be a drop-in replacement](https://docs.docker.com/compose/compose-v2/#differences-between-compose-v1-and-compose-v2) for `docker-compose`.
 
 If for some reason one cannot use a current version of Docker that includes the Docker Compose plugin, it can [be installed separately](https://docs.docker.com/compose/install/)
 
-Finally, as of this writing (early 2023), the `docker-compose` that comes with relatively recent Linux distributions (e.g. Ubuntu 22.04) still works if one already has it installed.
+Finally, as of this writing (early 2023), the `docker-compose` that comes with relatively recent Linux distributions (e.g. Ubuntu 22.04) still works if it is already installed.
 
 #### Test that Docker works
-Before continuing, ensure you can successfully run the hello-world container.
+Before continuing, ensure you can successfully run Docker's hello-world container.
 
 ```
 docker run hello-world
@@ -33,7 +33,7 @@ docker run hello-world
 
 The output should include a `Hello from Docker!` message that will confirm everything is working with Docker and you can continue.
 
-If Docker is unable to pull the `hello-world:latest` image from Docker Hub, try disabling your VPN if you are using one.
+If Docker is unable to pull the `hello-world:latest` image from Docker Hub, try disabling your VPN if one is installed.
 
 Linux users, note the lack of `sudo` before `docker run hello-world`. See the [Linux post-installation instructions](https://docs.docker.com/engine/install/linux-postinstall/) if you see the following error:
 ```
@@ -66,7 +66,7 @@ All commands are from the project root directory, where `docker-compose.yml` is 
 ```
 docker compose build
 ```
-This can take from a few minutes to up to 15+ on older hardware. If for some reason the build fails, it's worth running again, as sometimes downloads time out.
+This can take from a few minutes to more than 15 on older hardware. If for some reason the build fails, it's worth running again, as sometimes downloads time out.
 
 #### Start the app
 ```sh
@@ -94,7 +94,7 @@ These errors may appear in different containers or with different file names, bu
 
 The likely cause here is that text files were given CRLF line endings during cloning+checkout. See [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
 
-Note: after fixing this error, be on the look out for another error that will appear almost immediately after running `docker compose up` that mentions something about the `role` of `openlibrary` not existing. Read on for addressing that.
+Note: after fixing this error, be on the lookout for another error that will appear almost immediately after running `docker compose up` that mentions something about the `role` of `openlibrary` not existing. Read on for how to address that.
 
 #### An error similar to: FATAL: role "openlibrary" does not exist
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,9 @@
 
 The openlibrary repository must be cloned with `ssh` and *not* `https`. See the [Git Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) for more, including how to fix this if you use `git clone https://...`
 
-Before attempting to build openlibrary using the Docker instructions below, please read through these opening notes about setting up Docker. If you encounter an error, this section may serve as a troubleshooting guide:
+Windows users should see [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
+
+Before attempting to build openlibrary using the Docker instructions below, please read through these opening notes about setting up Docker. If you encounter an error, the following section may serve as a troubleshooting guide.
 
 ### Install Docker Engine or Docker Desktop
 Linux users (including those using a VM), can install Docker Engine or Docker Desktop. Docker has an [FAQ about the difference](https://docs.docker.com/desktop/faqs/linuxfaqs/) between the two. Windows and macOS users should use Docker Desktop as of early 2023.
@@ -14,13 +16,13 @@ Linux users (including those using a VM), can install Docker Engine or Docker De
 
 ### A note on `docker-compose` and `docker compose`
 
-As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose, it will install `docker-ce` and `docker-compose-plugin`, both of which obviate the need to install `docker-compose` separately.
+As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose, it will install `docker-ce` and `docker-compose-plugin` (Linux only), both of which obviate the need to install `docker-compose` separately.
 
 Further, Compose V1 will [no longer be supported by the end of June 2023](https://docs.docker.com/compose/compose-v2/) and will be removed from Docker Desktop. These directions are written for Compose V2, hence the use of `docker compose` rather than `docker-compose`. `docker compose` is [meant to be a drop-in replacement](https://docs.docker.com/compose/compose-v2/#differences-between-compose-v1-and-compose-v2) for `docker-compose`.
 
-If for some reason one cannot use a current version of Docker that includes Docker Compose, the plugin can [be installed separately](https://docs.docker.com/compose/install/)
+If for some reason one cannot use a current version of Docker that includes the Docker Compose plugin, it can [be installed separately](https://docs.docker.com/compose/install/)
 
-Finally, as of this writing (early 2023), the `docker-compose` command still works.
+Finally, as of this writing (early 2023), the `docker-compose` that comes with relatively recent Linux distributions (e.g. Ubuntu 22.04) still works if one already has it installed.
 
 #### Test that Docker works
 Before continuing, ensure you can successfully run the hello-world container.
@@ -41,26 +43,15 @@ See 'docker run --help'.
 
 ### Cloning the Open Library repository
 
-If you have not yet forked and cloned the openlibrary repository, please see the "Preliminary Steps" and the "Forking and Cloning the Open Library Repository" sections of the [Git Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet) on the [wiki](https://github.com/internetarchive/openlibrary/wiki).
+If you have not yet forked and cloned the openlibrary repository, please see [Forking and Cloning the Open Library Repository](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#forking-and-cloning-the-open-library-repository).
 
-Note: make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. See the [Git Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fork-the-open-library-repository) if you cloned with `https`.
+Make sure you `git clone` openlibrary using `ssh` instead of `https` as git submodules (e.g. `infogami` and `acs`) may not fetch correctly otherwise. See [Modifying a repository wrongly cloned with https](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#modifying-a-repository-wrongly-cloned-with-https-or-one-that-is-missing-the-infogami-module) if you cloned with `https`.
 
 ## Setup Commands
 
 ### For Windows Users Only
 
-**Note:** If you get permission issues while executing these commands please run git bash shell as an Administrator.
-
-```bash
-# Configure Git to convert CRLF to LF line endings on commit
-git config --global core.autocrlf input
-
-# Enable Symlinks
-git config core.symlinks true
-
-# Reset the repo (removes any changes you've made to files!)
-git reset --hard HEAD
-```
+Windows users should see [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm). Skipping those steps will likely prevent the containers from coming up.
 
 ### For Users of Macs Containing an M1 Chip
 
@@ -93,11 +84,39 @@ infobase_1      | 172.19.0.5:41790 - - [16/Feb/2023 16:54:20] "HTTP/1.1 GET /ope
 
 At this point, visit http://localhost:8080 and you should see the Open Library banner image with "development version" emblazoned upon it to signify that it's running from your local development server. From here you can [log in locally](http://localhost:8080/account/login).
 
-That's it for the Docker set up. You can read on for more about Docker, including how to gracefully shut down the Docker development environment. Or you can look at the "Contributing" or "Learning the Code" sections of the [Getting Started](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) guide for more on git, how to find a good first issue to work on, how to develop for the front end, etc.
+That's it for the Docker set up. You can read on for more about Docker, including addressing possible errors, how to gracefully shut down the Docker development environment. Or you can look at the "Contributing" or "Learning the Code" sections of the [Getting Started](https://github.com/internetarchive/openlibrary/blob/master/CONTRIBUTING.md) guide for more on git, how to find a good first issue to work on, how to develop for the front end, etc.
+
+### Possible errors
+
+#### `openlibrary-web-1 | exec docker/ol-web-start.sh: no such file or directory` OR `/usr/bin/env: 'python\r': No such file or directory`
+
+These errors may appear in different containers or with different file names, but look for file-not-found type errors where `\r` is in the filename, or there's `exec`, a path that seems to exist, and a `no such file or directory` error.
+
+The likely cause here is that text files were given CRLF line endings during cloning+checkout. See [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
+
+#### `OSError: [Errno 12] Cannot allocate memory: '/openlibrary/openlibrary/core'`
+
+`OSError: [Errno 12] Cannot allocate memory:` could occur in conjunction with `/openlibrary/openlibrary/core` or any number of files. Simply try increasing free RAM or increasing swap/page file/virtual memory for your operating system.
+
+
+#### "No module named 'infogami'"
+
+The following should populate the target of the `infogami` symbolic link (i.e. `vendor/infogami/`):
+```
+cd local-openlibrary-dev-directory
+git submodule init; git submodule sync; git submodule update
+```
+
+Windows users may need to see [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
+
+#### "no configuration file provided: not found" when running `docker compose <command>`
+
+Ensure you're running `docker compose` commands from within the `local-openlibrary-dev-directory`.
 
 ## Teardown commands
 
 ```sh
+cd local-openlibrary-dev-directory
 # stop the app (if started in detached mode)
 docker compose down
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,7 @@ Linux users (including those using a VM), can install Docker Engine or Docker De
 
 ### A note on `docker-compose` and `docker compose`
 
-As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose v2, it will install `docker-ce` and `docker-compose-plugin` (Linux only), both of which obviate the need to install `docker-compose` v1 separately.
+As of early 2023, following the installation instructions on Docker's website will install either Docker Desktop, which includes Docker Compose v2, or `docker-ce` and `docker-compose-plugin` (Linux only), both of which obviate the need to install `docker-compose` v1 separately.
 
 Further, Compose V1 will [no longer be supported by the end of June 2023](https://docs.docker.com/compose/compose-v2/) and will be removed from Docker Desktop. These directions are written for Compose V2, hence the use of `docker compose` rather than `docker-compose`. `docker compose` is [meant to be a drop-in replacement](https://docs.docker.com/compose/compose-v2/#differences-between-compose-v1-and-compose-v2) for `docker-compose`.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,13 +88,23 @@ That's it for the Docker set up. You can read on for more about Docker, includin
 
 ### Possible errors
 
-#### `openlibrary-web-1 | exec docker/ol-web-start.sh: no such file or directory` OR `/usr/bin/env: 'python\r': No such file or directory`
+#### "openlibrary-web-1 | exec docker/ol-web-start.sh: no such file or directory" OR "/usr/bin/env: 'python\r': No such file or directory"
 
-These errors may appear in different containers or with different file names, but look for file-not-found type errors where `\r` is in the filename, or there's `exec`, a path that seems to exist, and a `no such file or directory` error.
+These errors may appear in different containers or with different file names, but look for file-not-found type errors where `\r` is in the filename, or there's `exec`, a path that seems to exist, and a `no such file or directory` error, e.g. `openlibrary-web-1 | exec docker/ol-web-start.sh: no such file or directory`
 
 The likely cause here is that text files were given CRLF line endings during cloning+checkout. See [Fix line endings, symlinks, and git submodules](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet#fix-line-endings-symlinks-and-git-submodules-only-for-windows-users-not-using-a-linux-vm).
 
-#### `OSError: [Errno 12] Cannot allocate memory: '/openlibrary/openlibrary/core'`
+Note: after fixing this error, be on the look out for another error that will appear almost immediately after running `docker compose up` that mentions something about the `role` of `openlibrary` not existing. Read on for addressing that.
+
+#### An error similar to: FATAL: role "openlibrary" does not exist
+
+Look for errors that appear very soon after running `docker compose up` that come from the `openlibrary-db-1` container when it first starts mentioning something about the `role` of `openlibrary` not existing.
+
+In this case, try the steps in [Fully Resetting Your Environment](#fully-resetting-your-environment)
+
+Note: please update this README with the exact wording of the error if you run into it.
+
+#### "OSError: [Errno 12] Cannot allocate memory: '/openlibrary/openlibrary/core'"
 
 `OSError: [Errno 12] Cannot allocate memory:` could occur in conjunction with `/openlibrary/openlibrary/core` or any number of files. Simply try increasing free RAM or increasing swap/page file/virtual memory for your operating system.
 
@@ -189,7 +199,7 @@ docker container prune
 docker volume rm openlibrary_ol-build openlibrary_ol-nodemodules openlibrary_ol-vendor
 
 # Bring it back up again
-docker compose up -d
+docker compose up  # or docker compose up -d
 ```
 
 ## Developing the Dockerfile


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes no issue.

I have noticed Docker and `git` sometimes cause an obstacle to contributions. To help new volunteers I have tried to clarify some elements where I have personally seen people getting confused, and where information about the same topic is found in different places.

I based the directions on Compose V2 as that is where it appears most first-time Docker users will be shepherded. If this was the correct call, I can update the wiki to be consistent with that by changing references from `docker-compose` to `docker compose`.

As part of this PR, see these two diffs for:
- [Frontend Guide](https://github.com/internetarchive/openlibrary/wiki/Frontend-Guide/_compare/edcda40ce92b0845bcc60a458fb0d3c1b583e41d...b48726b18b008dd8e8c5df63c62eb446cb74c4d8)
- [How we use Git: Cheat Sheet](https://github.com/internetarchive/openlibrary/wiki/Git-Cheat-Sheet/_compare/fe80b5c46431dcfefe5e378fca5da30d61d49ac3...cf13388ebf734ad9f092afa2839226d5f545c33e)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss, @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
