### PR TITLE
Updated the URL scheme for LearnAwesome.org

### DIFF
--- a/openlibrary/plugins/openlibrary/pages/config_edition.page
+++ b/openlibrary/plugins/openlibrary/pages/config_edition.page
@@ -530,7 +530,7 @@
             "label": "LC Control Number"
         },
         {
-            "url": "https://learnawesome.org/items/@@@",
+            "url": "https://learnawesome.org/#/item/@@@",
             "website": "https://learnawesome.org",
             "name": "learnawesome",
             "label": "LearnAwesome.org"


### PR DESCRIPTION
LearnAwesome.org went through a rewrite recently. The URL scheme for identifiers has changed. This change fixes it.

Here's an example URL to a book on LA: https://learnawesome.org/#/item/34d8cd4d8294
Here's the corresponding book in OpenLibrary that has such an identifier present. This PR will fix the link: https://openlibrary.org/works/OL2745855W/Exit_voice_and_loyalty?edition=key%3A/books/OL3319564M

@cdrini had reviewed and merged the initial introduction of these identifiers: https://github.com/internetarchive/openlibrary/issues/3382

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
