### PR TITLE
Remove solrbuilder ES rate limits

### DIFF
--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -143,6 +143,9 @@ class DataProvider:
                 r = await client.get(
                     "https://archive.org/advancedsearch.php",
                     timeout=30,  # The default is silly short
+                    headers={
+                        'x-application-id': 'ol-solr',
+                    },
                     params={
                         'q': f"identifier:({' OR '.join(ocaids)})",
                         'rows': len(ocaids),
@@ -150,6 +153,7 @@ class DataProvider:
                         'page': 1,
                         'output': 'json',
                         'save': 'yes',
+                        'service': 'metadata__unlimited',
                     },
                 )
             r.raise_for_status()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7467 . Fix. Remove ES limits since these internally used requests.


### Technical
- We have access to the service unlimited param because we are in the cluster.

### Testing
Full reindex now completes correctly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@ximm 
