### PR TITLE
Fix nginx restart loop

### DIFF
--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -87,7 +87,8 @@ server {
 }
 
 server {
-    include /etc/nginx/sites-available/public_nginx.conf;
+    listen 80;
+    listen 443 ssl;
     server_name www.openlibrary.org *.openlibrary.org;
 
     rewrite ^(.*)$ http://openlibrary.org$1 permanent;


### PR DESCRIPTION
Remove duplicate listens on ports 80 default, 443

<!-- What issue does this PR close? -->
Closes #7544


### Technical
We tested by modifying our local etc/hosts to map www0's ip to `x-openlibrary.org` and `www.x-openlibrary.org`, and confirmed the rewrites happened. (Also updated the server_name on www0's conf to be `x-openlibrary.org` for testing.)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
