### PR TITLE
Add 'Remove From Shelf' option to Reading Log dropper

### DIFF
--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -54,6 +54,16 @@ $if ctx.user or not work_key:
 
             $ classes[int(users_work_read_status) - 1] = ' hidden'
 
+            <form id="remove-from-list" class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
+              <input type="hidden" name="action" value="remove"/>
+              <input type="hidden" name="bookshelf_id" value=""/>
+              <input type="hidden" name="default-key" value="$(key)" />
+              $if edition_key:
+                <input type="hidden" name="edition_id" value="$(edition_key)"/>
+              <input type="hidden" id="work_id" name="work_id" value="$(work_key)"/>
+              <button class="remove-from-list hidden" type="submit">$_('Remove From Shelf')</button>
+            </form>
+
             <form class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
               <input type="hidden" name="action" value="add"/>
               <input type="hidden" name="bookshelf_id" value="1"/>
@@ -76,16 +86,6 @@ $if ctx.user or not work_key:
               $if edition_key:
                 <input type="hidden" name="edition_id" value="$(edition_key)"/>
               <button class="nostyle-btn$(classes[2])" type="submit">$_('Already Read')</button>
-            </form>
-
-            <form id="remove-from-list" class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
-              <input type="hidden" name="action" value="remove"/>
-              <input type="hidden" name="bookshelf_id" value=""/>
-              <input type="hidden" name="default-key" value="$(key)" />
-              $if edition_key:
-                <input type="hidden" name="edition_id" value="$(edition_key)"/>
-              <input type="hidden" id="work_id" name="work_id" value="$(work_key)"/>
-              <button class="remove-from-list hidden" type="submit">$_('Remove From Shelf')</button>
             </form>
           </div>
 

--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -77,6 +77,16 @@ $if ctx.user or not work_key:
                 <input type="hidden" name="edition_id" value="$(edition_key)"/>
               <button class="nostyle-btn$(classes[2])" type="submit">$_('Already Read')</button>
             </form>
+
+            <form id="remove-from-list" class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
+              <input type="hidden" name="action" value="remove"/>
+              <input type="hidden" name="bookshelf_id" value=""/>
+              <input type="hidden" name="default-key" value="$(key)" />
+              $if edition_key:
+                <input type="hidden" name="edition_id" value="$(edition_key)"/>
+              <input type="hidden" id="work_id" name="work_id" value="$(work_key)"/>
+              <button class="remove-from-list hidden" type="submit">$_('Remove From Shelf')</button>
+            </form>
           </div>
 
           $if include_lists:

--- a/static/css/components/read-statuses.less
+++ b/static/css/components/read-statuses.less
@@ -21,6 +21,10 @@
     }
   }
 
+  .remove-from-list {
+    color: @red;
+  }
+
   /* stylelint-disable selector-max-specificity */
   form:last-child {
     button.nostyle-btn {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially closes #7433

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

I goofed this up a bit by creating an implementation prior to any sort of UX decision. Lesson learned on that one. After hemming and hawing I decided to submit this as a possible stopgap. I understand that #7433 involves more.

### Technical
<!-- What should be noted about the implementation? -->
This adds a 'Remove From Shelf' item to the Reading Log dropper that, when clicks, behaves as if someone clicked the `primaryButton` in the Reading Log dropper to remove an item from the shelf.

### Testing

#### Some visual inspections
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Add an item to one of the `want-to-read`, `already-ready`, `currently-reading` shelves.
- Activate the dropper, select 'Remove From Shelf', and verify the item is removed from the shelf.
- Verify the same behavior while viewing an edition: http://localhost:8080/books/OL20431791M/Flatland_A_Romance_of_Many_Dimensions
- Verify the same behavior while viewing a work: http://localhost:8080/works/OL118420W/Flatland?
- Verify the same behavior in search results: http://localhost:8080/search?q=flatland&mode=everything

#### Verify request payload:
With a book on the `Want to Read` shelf, try to remove it via clicking the primary button and via `Remove From Shelf` in the dropper:

Via the primary button:
```
Content-Disposition: form-data; name="action": remove
Content-Disposition: form-data; name="bookshelf_id": 1
Content-Disposition: form-data; name="default-key"
Content-Disposition: form-data; name="work_id": /works/OL118420W
```

Via the `Remove From Shelf` dropper
```
Content-Disposition: form-data; name="action": remove
Content-Disposition: form-data; name="bookshelf_id": 1
Content-Disposition: form-data; name="default-key"
Content-Disposition: form-data; name="work_id": /works/OL118420W
```

Add and remove a book repeatedly to different shelves via the dropper and the primary button, to make sure nothing goes out of sync. E.g.
- Search for Flatland
- Click `Want to Read`
- Visit `My Books`
- Click on the `Want to Read` shelf
- Remove Flatland by clicking the primaryButton
- Add it back by clicking the primaryButton
- Switch to `currently-reading` via the dropper
- Remove from `currently-reading` via `Remove From Shelf` in the dropper
```
Content-Disposition: form-data; name="action": remove
Content-Disposition: form-data; name="bookshelf_id": 2
Content-Disposition: form-data; name="default-key"
Content-Disposition: form-data; name="work_id": /works/OL118420W
```
- Verify the dropper menu appears correct with no `Remove From Shelf` item.
- Verify clicking `Currently Reading` adds the item back to `Currently Reading` as one would expect:
```
Content-Disposition: form-data; name="action": add
Content-Disposition: form-data; name="bookshelf_id": 2
Content-Disposition: form-data; name="default-key"
Content-Disposition: form-data; name="work_id": /works/OL118420W
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
A book not yet on a shelf:
![image](https://user-images.githubusercontent.com/26524678/220760424-56765e93-75e9-41e6-ac52-e30690f2caf7.png)

A book added to `want-to-read`:
![image](https://user-images.githubusercontent.com/26524678/220760835-1bf352f1-f6a8-4030-b10d-22e914bd5135.png)

Having removed the book again:
![image](https://user-images.githubusercontent.com/26524678/220760580-c3b101e4-3238-4ea2-b3f1-b43b4b4bb45b.png)

Verifying 'Remove From Shelf` only shows up when the book is not on a shelf:
![image](https://user-images.githubusercontent.com/26524678/220760669-509f6571-585e-458d-807c-8cdbd136cdd1.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
