### PR TITLE
Remove deprecated logging.warn()

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -222,7 +222,7 @@ class ListMixin:
 
         # Solr has a maxBooleanClauses constraint there too many seeds, the
         if len(self.seeds) > 500:
-            logger.warn(
+            logger.warning(
                 "More than 500 seeds. skipping solr query for finding subjects."
             )
             return []

--- a/openlibrary/core/statsdb.py
+++ b/openlibrary/core/statsdb.py
@@ -33,7 +33,7 @@ def add_entry(key, data, timestamp=None):
     db = get_db()
     result = db.query("SELECT * FROM stats WHERE key=$key", vars=locals())
     if result:
-        logger.warn(
+        logger.warning(
             "Failed to add stats entry with key %r. An entry is already present."
         )
     else:
@@ -61,7 +61,7 @@ def update_entry(key, data, timestamp=None):
     if result:
         db.update("stats", json=jsontext, updated=t, where="key=$key", vars=locals())
     else:
-        logger.warn(
+        logger.warning(
             "stats entry with key %r doesn't exist to update. adding new entry...", key
         )
         db.insert("stats", type='loan', key=key, created=t, updated=t, json=jsontext)

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -800,7 +800,7 @@ class SaveBookHelper:
             and self.edition.get('ocaid')
             and self.edition.get('ocaid') != ocaid
         ):
-            logger.warn(
+            logger.warning(
                 "Attempt to change ocaid of %s from %r to %r.",
                 self.edition.key,
                 self.edition.get('ocaid'),

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -387,7 +387,7 @@ class BetterDataProvider(LegacyDataProvider):
         if key not in self.cache:
             await self.preload_documents([key])
         if key not in self.cache:
-            logger.warn("NOT FOUND %s", key)
+            logger.warning("NOT FOUND %s", key)
         return self.cache.get(key) or {"key": key, "type": {"key": "/type/delete"}}
 
     async def preload_documents(self, keys):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1428,7 +1428,7 @@ async def update_keys(
         edition = await data_provider.get_document(k)
 
         if edition and edition['type']['key'] == '/type/redirect':
-            logger.warn("Found redirect to %s", edition['location'])
+            logger.warning("Found redirect to %s", edition['location'])
             edition = await data_provider.get_document(edition['location'])
 
         # When the given key is not found or redirects to another edition/work,
@@ -1437,7 +1437,7 @@ async def update_keys(
             deletes.append(k)
 
         if not edition:
-            logger.warn("No edition found for key %r. Ignoring...", k)
+            logger.warning("No edition found for key %r. Ignoring...", k)
             continue
         elif edition['type']['key'] != '/type/edition':
             logger.info(
@@ -1458,7 +1458,7 @@ async def update_keys(
                 # Also remove if there is any work with that key in solr.
                 wkeys.add(k)
             else:
-                logger.warn(
+                logger.warning(
                     "Found a document of type %r. Ignoring...", edition['type']['key']
                 )
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ select = [
     "C9",
     "E",
     "F",
+    "G010",
+    "PLC",
     "W",
 ]
 target-version = "py310"


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
https://docs.python.org/3/library/logging.html#logging.Logger.warning
> There is an obsolete method `warn()` which is functionally identical to `warning()`. As `warn()` is deprecated, please do not use it - use `warning()` instead.

This PR was created with:
% [`ruff --select=G010 --fix .`](https://beta.ruff.rs/docs/rules/#flake8-logging-format-g)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
