### PR TITLE
sort books by most recently added/updated

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -355,14 +355,14 @@ class Bookshelves(db.CommonExtras):
                 query = (
                     "SELECT work_id, created, edition_id from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
-                    "ORDER BY created DESC "
+                    "ORDER BY updated DESC "
                     "LIMIT $limit OFFSET $offset"
                 )
             else:
                 query = (
                     "SELECT work_id, created, edition_id from bookshelves_books WHERE "
                     "bookshelf_id=$bookshelf_id AND username=$username "
-                    "ORDER BY created ASC "
+                    "ORDER BY updated ASC "
                     "LIMIT $limit OFFSET $offset"
                 )
             if not bookshelf_id:
@@ -531,6 +531,7 @@ class Bookshelves(db.CommonExtras):
                 where=where,
                 bookshelf_id=bookshelf_id,
                 edition_id=edition_id,
+                updated=datetime.utcnow(),
                 vars=data,
             )
 

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -276,7 +276,7 @@ class MyBooksTemplate:
     ):
         def get_shelf(name, page=1):
             return self.readlog.get_works(
-                key=name, page=page, limit=6, sort='created', sort_order='asc'
+                key=name, page=page, limit=6, sort='created', sort_order='desc'
             )
 
         if self.key == 'mybooks':


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7526 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Books carousel is now sorted by most recently added.
Most recently added refers to the "updated" field from the API schema. Reason for doing so is because since the original updated field is same as created field (when book is first added to mybooks bookshelf), it is safe to compare using the "updated field". Therefore, when a user changes a book from "Want to Read" to "Already Read", the book added to the "Already Read" shelf will be at the front of the carousel list.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles Lead
@bicolino34 Created issue
