### PR TITLE
change reading log dropper color

### DIFF
--- a/static/css/components/dropper.less
+++ b/static/css/components/dropper.less
@@ -35,7 +35,7 @@
       background-size: 45px;
     }
     div.arrow-unactivated {
-      background-image: url(/images/icons/icon_dropit2.png);
+      background-image: url(/images/icons/icon_dropit.png);
       background-repeat: no-repeat;
       background-position: 0 0;
       background-size: 45px;
@@ -226,7 +226,6 @@ div#listsWork {
     z-index: @z-index-level-7;
     &.on {
       background-color: @lightest-grey;
-      border: 1px solid @mid-grey;
       border-radius: 4px;
     }
     h3 {
@@ -285,10 +284,9 @@ div#listsWork {
       border-right: 1px solid @lighter-grey;
     }
     &.unactivated {
-      color: @white;
-      background: @green;
-      border: 2px solid @green;
-      border-right: 1px solid @green-two;
+      color: @primary-blue;
+      background: @white;
+      border: 1.5px solid @primary-blue;
     }
     span.activated-check {
       color: @green;
@@ -320,7 +318,8 @@ div#listsWork {
 }
 
 .dropclick-unactivated {
-  background-color: @green;
+  background-color: @white;
+  border: 1.5px solid @primary-blue;
 }
 
 .user-book-options {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7005 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changed the style of the Reading log dropper as requested

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="173" alt="Want to Read" src="https://user-images.githubusercontent.com/90945854/221371013-a639849d-7071-4784-be3f-f1ed4ee2f70e.png">
<img width="179" alt="Pasted Graphic 26" src="https://user-images.githubusercontent.com/90945854/221371016-db3fdd06-8330-4bbd-8829-815cd0e7aeaf.png">
<img width="172" alt="Want to Read" src="https://user-images.githubusercontent.com/90945854/221371021-7670301f-7636-449b-85d4-82b5b8965f9a.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp Created issue

