### PR TITLE
fix cannot add edition identifiers with names containing illegal Java…

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -190,7 +190,7 @@ export function validateIdentifiers(data) {
     if (data.name === '' || data.name === '---') {
         return error('#id-errors', 'select-id', dataConfig['Please select an identifier.'])
     }
-    const label = $('#select-id').find(`option[value='${data.name}']`).html();
+    const label = $('#select-id').find("option[value='" + data.name + "']").html();
     if (data.value === '') {
         return error('#id-errors', 'id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
     }
@@ -208,7 +208,7 @@ export function validateIdentifiers(data) {
         return error('#id-errors', 'id-value', dataConfig['That ISBN already exists for this edition.'].replace(/ISBN/, label));
     }
     // Remove spaces and hyphens before checking ISBN 13.
-    if (data. name === 'isbn_13') {
+    if (data.name === 'isbn_13') {
         data.value = parseIsbn(data.value);
     }
     if (data.name === 'isbn_13' && isFormatValidIsbn13(data.value) === false) {
@@ -248,7 +248,7 @@ export function initClassificationValidation() {
                 return error('#classification-errors', '#select-classification', dataConfig['Please select a classification.']);
             }
             if (data.value === '') {
-                const label = $('#select-classification').find(`option[value='${data.name}']`).html();
+                const label = $('#select-classification').find("option[value='" + data.name + "']").html();
                 return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
             }
             $('#classification-errors').hide();

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -451,7 +451,7 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
                     </tr>
                     <tbody id="identifiers-display">
                         <tr id="identifiers-template" style="display: none;" class="repeat-item">
-                            <td align="right"><strong>{{\$("#select-id").find("option[value=" + name + "]").html()}}</strong></td>
+                            <td align="right"><strong>{{\$("#select-id").find("option[value='" + name + "']").html()}}</strong></td>
                             <td>{{value}}
                                 <input type="hidden" name="{{prefix}}identifiers--{{index}}--name" value="{{name}}"/>
                                 <input type="hidden" name="{{prefix}}identifiers--{{index}}--value" value="{{value}}" class="{{name}}"/>
@@ -516,7 +516,7 @@ $ config = ({'Please select an identifier.': _('Please select an identifier.'), 
                     </tr>
                     <tbody id="classifications-display">
                         <tr id="classifications-template" style="display: none;" class="repeat-item">
-                            <td align="right"><strong>{{\$("#select-classification").find("option[value=" + name + "]").html()}}</strong></td>
+                            <td align="right"><strong>{{\$("#select-classification").find("option[value='" + name + "']").html()}}</strong></td>
                             <td>{{value}}
                                 <input type="hidden" name="{{prefix}}classifications--{{index}}--name" value="{{name}}"/>
                                 <input type="hidden" name="{{prefix}}classifications--{{index}}--value" value="{{value}}"/>

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -20,7 +20,7 @@ export const editionIdentifiersSample = `<fieldset id="identifiers" data-config=
     </tr>
     </tbody><tbody id="identifiers-display">
         <tr id="identifiers-template" style="display: none;" class="repeat-item">
-            <td align="right"><strong>{{$("#select-id").find("option[value=" + name + "]").html()}}</strong></td>
+            <td align="right"><strong>{{$("#select-id").find("option[value='" + name + "']").html()}}</strong></td>
             <td>{{value}}
                 <input type="hidden" name="{{prefix}}identifiers--{{index}}--name" value="{{name}}">
                 <input type="hidden" name="{{prefix}}identifiers--{{index}}--value" value="{{value}}" class="{{name}}">


### PR DESCRIPTION
…script id characters

<!-- What issue does this PR close? -->
Closes #7032 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Now able to add identifiers and classifications for names containing illegal javascript characters such as brackets, dots, commas etc. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="380" alt="image" src="https://user-images.githubusercontent.com/90945854/221594106-ae8ece1f-c31b-46f8-8667-31efca6bf612.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tfmorris opened issue
@cdrini closed similar issue in #6300 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
