### PR TITLE
Redirect correctly on work edit

### DIFF
--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -3,6 +3,7 @@ $def with (page, edition=None)
 $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
     $if edition and page.type.key in ["/type/work"]:
         $ edit_url = edition.url(suffix="/edit")
+        $ edit_url += '?work_key=%s' % page.key
     $else:
         $ edit_url = page.url(suffix="/edit")
 $else:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -901,7 +901,12 @@ class book_edit(delegate.page):
             else:
                 add_flash_message("info", utils.get_message("flash_book_updated"))
 
-            raise safe_seeother(i.work_key or edition.url())
+            if i.work_key and i.work_key.startswith('/works/'):
+                url = i.work_key
+            else:
+                url = edition.url()
+
+            raise safe_seeother(url)
         except ClientException as e:
             add_flash_message('error', e.args[-1] or e.json)
             return self.GET(key)

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -838,7 +838,7 @@ class book_edit(delegate.page):
     path = r"(/books/OL\d+M)/edit"
 
     def GET(self, key):
-        i = web.input(v=None, work_key=None)
+        i = web.input(v=None)
         v = i.v and safeint(i.v, None)
 
         if not web.ctx.site.can_write(key):

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -838,7 +838,7 @@ class book_edit(delegate.page):
     path = r"(/books/OL\d+M)/edit"
 
     def GET(self, key):
-        i = web.input(v=None)
+        i = web.input(v=None, work_key=None)
         v = i.v and safeint(i.v, None)
 
         if not web.ctx.site.can_write(key):
@@ -861,7 +861,7 @@ class book_edit(delegate.page):
         return render_template('books/edit', work, edition, recaptcha=get_recaptcha())
 
     def POST(self, key):
-        i = web.input(v=None, _method="GET")
+        i = web.input(v=None, work_key=None, _method="GET")
 
         if spamcheck.is_spam(allow_privileged_edits=True):
             return render_template(
@@ -901,7 +901,7 @@ class book_edit(delegate.page):
             else:
                 add_flash_message("info", utils.get_message("flash_book_updated"))
 
-            raise safe_seeother(edition.url())
+            raise safe_seeother(i.work_key or edition.url())
         except ClientException as e:
             add_flash_message('error', e.args[-1] or e.json)
             return self.GET(key)

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -47,7 +47,9 @@ $:macros.HiddenSaveButton("addWork")
 </div>
 
 <div id="contentBody">
-    <form method="post" id="addWork" class="olform books validate" name="edit" action="">
+    $ work_key = query_param('work_key', None)
+    $ action = '?work_key=%s' % work_key if work_key else ''
+    <form method="post" id="addWork" class="olform books validate" name="edit" action="$action">
 
         <input type="hidden" name="work--key" value="$work.key">
         $ authors = work.authors and [a.author for a in work.authors]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4993

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents redirect to edition page after editing a work page.

### Technical
<!-- What should be noted about the implementation? -->
Whenever the edit button for a work page is rendered, the associated edition's edit URL is used in place of the work edit URL.  If the URL is not updated, the edition tab would not be present in the edit view.

This PR passes a `work_key` query parameter whenever the edit URL changes from a work to an edition.  `work_key` is passed to the POST handler by way of the edit form's `action` attribute.  If the `work_key` is passed to the handler, and it starts with `/works/`, patrons are redirected back to the work page.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Navigate to an edition page and click the "Edit" button.  When the edit form loads, click the "Save" button without making any edits.  Ensure that you are redirected back to the edition page.  This is BAU, and no obvious regressions have occurred.
2. Navigate to a work page and click the "Edit" button.
3. When the edit form loads, check the page's URL in your browser.  Ensure that the URL is like `{edition_key}/edit?work_key={work_key}`
4. Click the "Save" button without editing any fields.  Ensure that you are redirected to the work page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
