### PR TITLE
Fix covers nginx weblogs having wrong hostname

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -84,6 +84,7 @@ services:
     environment:
       - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs
     restart: unless-stopped
+    hostname: "$HOSTNAME"
     depends_on:
       - covers
     volumes:


### PR DESCRIPTION
The webserver logs are displaying the container ID instead of the hostname : https://archive.org/download/ia_webserverlogs_20230215/openlibrary/

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Not testing; trivial change. I assume just an oversight.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
