### PR TITLE
run watch commands when starting Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,9 +11,9 @@ ports:
   onOpen: ignore
 tasks:
 - name: watch-js
-  init: docker-compose run --rm home npm run-script watch
+  init: gp sync-await docker-up && docker-compose run --rm home npm run-script watch
 - name: watch-css
-  init: docker-compose run --rm home npm run-script watch-css
+  init: gp sync-await docker-up && docker-compose run --rm home npm run-script watch-css
 - name: Start App
   before: |
     # run chown because https://github.com/gitpod-io/gitpod/issues/4851
@@ -23,7 +23,7 @@ tasks:
     # because: https://github.com/gitpod-io/gitpod/issues/9311
     chmod o+rx /workspace/openlibrary
   # init runs once for each commit to the default branch
-  init: docker-compose up --no-start
+  init: docker-compose up --no-start && gp sync-done docker-up
   # command runs each time a user starts their workspace
   command: docker-compose up
 - name: dev shell

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,8 +11,10 @@ ports:
   onOpen: ignore
 tasks:
 - name: watch-js
+  # This task watches for changes to JS files and automatically builds
   init: gp sync-await docker-up && docker-compose run --rm home npm run-script watch
 - name: watch-css
+  # This task watches for changes to CSS files and automatically builds
   init: gp sync-await docker-up && docker-compose run --rm home npm run-script watch-css
 - name: Start App
   before: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,12 +10,9 @@ ports:
 - port: 3000
   onOpen: ignore
 tasks:
-- name: watch-js
-  # This task watches for changes to JS files and automatically builds
-  init: gp sync-await docker-up && docker-compose run --rm home npm run-script watch
-- name: watch-css
-  # This task watches for changes to CSS files and automatically builds
-  init: gp sync-await docker-up && docker-compose run --rm home npm run-script watch-css
+- name: watch
+  # This task watches for changes to JS/CSS files and automatically builds
+  init: gp sync-await docker-up && docker-compose run --rm home npx concurrently npm:watch npm:watch-css
 - name: Start App
   before: |
     # run chown because https://github.com/gitpod-io/gitpod/issues/4851

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,10 @@ ports:
 - port: 3000
   onOpen: ignore
 tasks:
+- name: watch-js
+  init: docker-compose run --rm home npm run-script watch
+- name: watch-css
+  init: docker-compose run --rm home npm run-script watch-css
 - name: Start App
   before: |
     # run chown because https://github.com/gitpod-io/gitpod/issues/4851


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7497

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Automatically runs the watch commands when starting in Gitpod.

Feel free to edit this PR as needed before merging 👍 

PS: After this I'll work on #6939 :)

### Technical
<!-- What should be noted about the implementation? -->
I didn't use concurrently because I didn't see examples of how to do that and I wasn't clear how to do that.

If someone would like to propose a nicer way to do this I'm open to it. But I figured this is a good point to start talking from.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Open this PR in gitpod and try making changes to css/js.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://user-images.githubusercontent.com/921217/222598532-c8037bb3-6277-48df-9dbc-fc6fcc99c116.mp4



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
