### PR TITLE
add clarification regarding what first sentence means in edit page

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -697,7 +697,7 @@ $if ctx.user:
         <div class="formElement">
             <div class="label">
                 <label for="edition-first_sentence">$_("First sentence")</label>
-                <span class="tip"></span>
+                <span class="tip">$_('The opening line that starts the lead paragraph (in the original language)')</span>
             </div>
             <div class="input">
                 <textarea name="edition--first_sentence" id="edition-first_sentence" rows="3" cols="50">$book.first_sentence</textarea>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -697,7 +697,7 @@ $if ctx.user:
         <div class="formElement">
             <div class="label">
                 <label for="edition-first_sentence">$_("First sentence")</label>
-                <span class="tip">$_('The opening line that starts the lead paragraph (in the original language)')</span>
+                <span class="tip">$_('The opening line that starts the lead paragraph')</span>
             </div>
             <div class="input">
                 <textarea name="edition--first_sentence" id="edition-first_sentence" rows="3" cols="50">$book.first_sentence</textarea>

--- a/openlibrary/templates/books/edit/excerpts.html
+++ b/openlibrary/templates/books/edit/excerpts.html
@@ -16,7 +16,7 @@ $def with (work)
             </div>
             <div class="input">
                 <input type="text" name="pages" id="excerpts-pages" value="" tabindex="0" onblur="\$('#repeat-exc').addClass('darkgreen');" style="width:60px!important;"/>
-                <span class="tip fixthis"><input type="checkbox" name="first--sentence" id="first--sentence" tabindex="0"/> $_('This is the first sentence.')</span>
+                <span class="tip fixthis"><input type="checkbox" name="first--sentence" id="first--sentence" tabindex="0"/> $_('This is the page number containing the first sentence of the excerpt.')</span>
             </div>
 
         </div>

--- a/openlibrary/templates/books/edit/excerpts.html
+++ b/openlibrary/templates/books/edit/excerpts.html
@@ -16,7 +16,7 @@ $def with (work)
             </div>
             <div class="input">
                 <input type="text" name="pages" id="excerpts-pages" value="" tabindex="0" onblur="\$('#repeat-exc').addClass('darkgreen');" style="width:60px!important;"/>
-                <span class="tip fixthis"><input type="checkbox" name="first--sentence" id="first--sentence" tabindex="0"/> $_('This is the page number containing the first sentence of the excerpt.')</span>
+                <span class="tip fixthis"><input type="checkbox" name="first--sentence" id="first--sentence" tabindex="0"/> $_('This excerpt is the first sentence of the book.')</span>
             </div>
 
         </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5640 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added documentation regarding what "first sentence" means in edit page. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="951" alt="Pasted Graphic 35" src="https://user-images.githubusercontent.com/90945854/223187156-1df61b1b-88a2-449f-a61c-a2e0bb08ef70.png">
<img width="828" alt="Add Excerpts" src="https://user-images.githubusercontent.com/90945854/223187171-427733d9-0180-4731-85ce-858633a30151.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB created issue and lead
@seabelis vetted the copy for the clarification

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
