### PR TITLE
Affiliate server: Make amazon lookup thread a daemon

### DIFF
--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -237,10 +237,12 @@ def amazon_lookup(site, stats_client) -> None:
                     )
                 except queue.Empty:
                     pass
+            logger.info(f"Before amazon_lookup(): {len(isbn_10s)} items")
             if isbn_10s:
                 time.sleep(seconds_remaining(start_time))
                 stats_client.put("ol.affiliate.amazon.process_batch", len(isbn_10s))
                 process_amazon_batch(list(isbn_10s))
+            logger.info(f"After amazon_lookup(): {len(isbn_10s)} items")
     except Exception:
         logger.exception("amazon_lookup()")
         stats_client.incr("ol.affiliate.amazon.lookup_thread_died")
@@ -371,9 +373,9 @@ def start_server():
         thread_is_alive = bool(
             web.amazon_lookup_thread and web.amazon_lookup_thread.is_alive()
         )
-        logger.info(f"web.amazon_lookup_thread.is_alive() is {thread_is_alive}")
+        logger.critical(f"web.amazon_lookup_thread.is_alive() is {thread_is_alive}")
     else:
-        logger.info("Not starting amazon_lookup_thread in pytest")
+        logger.critical("Not starting amazon_lookup_thread in pytest")
 
     sys.argv = [sys.argv[0]] + list(args)
     app.run()

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -368,6 +368,12 @@ def start_server():
 
     if "pytest" not in sys.modules:
         web.amazon_lookup_thread = make_amazon_lookup_thread(web.ctx.site, stats.client)
+        thread_is_alive = bool(
+            web.amazon_lookup_thread and web.amazon_lookup_thread.is_alive()
+        )
+        logger.info(f"web.amazon_lookup_thread.is_alive() is {thread_is_alive}")
+    else:
+        logger.info("Not starting amazon_lookup_thread in pytest")
 
     sys.argv = [sys.argv[0]] + list(args)
     app.run()

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -261,8 +261,9 @@ class Status:
     def GET(self) -> str:
         return json.dumps(
             {
-                "thread_is_alive": web.amazon_lookup_thread
-                and web.amazon_lookup_thread.is_alive(),
+                "thread_is_alive": bool(
+                    web.amazon_lookup_thread and web.amazon_lookup_thread.is_alive()
+                ),
                 "queue_size": web.amazon_queue.qsize(),
                 "queue": list(web.amazon_queue.queue),
             }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7569

Makes this thread automatically restart.
Adds logging which will appear in Sentry with `amazon_lookup()` for error isolation.
Adds stated logging for:
    1. How many ISBN-10s are batched for processing
    2. How many times does the `amazon_lookup()` thread dies?

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What do you think should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

* https://github.com/internetarchive/openlibrary/wiki/Deployment-Guide#recovering-from-restart-loops
* https://github.com/internetarchive/openlibrary/wiki/Recipes
* HOSTNAME="$HOSTNAME" docker-compose up -d --no-deps affiliate-server

Terminal 1
```
ssh -A ol-home0
docker ps  # Make sure affiliate_server is running
docker logs --tail 20 --follow openlibrary-affiliate-server-1
# Get a sense of how logs look under current conditions.
```

Terminal 0
```
ssh -A ol-home0
docker ps  # Make sure affiliate_server is running
cd /opt/openlibrary
git branch
git status

docker exec -it openlibrary-affiliate-server-1 bash  # Go inside Docker image
vi scripts/affiliate_server.py # make desired changes
exit
COMPOSE_FILE="docker-compose.yml:docker-compose.production.yml" HOSTNAME=$HOST \
    docker-compose restart affiliate-server \
    && docker logs --tail 20 --follow openlibrary_affiliate-server_1
# Test changes
# Go back inside the Docker image

# To revert: Go back inside Docker image
vi scripts/affiliate_server.py  # to be just like the master branch (URL below)
restart 
```
* https://raw.githubusercontent.com/internetarchive/openlibrary/master/scripts/affiliate_server.py

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
