### PR TITLE
Use a regular assert instead of unittest-style

### DIFF
--- a/openlibrary/catalog/marc/tests/test_marc.py
+++ b/openlibrary/catalog/marc/tests/test_marc.py
@@ -77,7 +77,7 @@ class TestMarcParse(unittest.TestCase):
                 isbn_type = 'isbn_13'
             else:
                 isbn_type = 'isbn_10'
-            self.assertEqual(expect, output[isbn_type][0])
+            assert expect == output[isbn_type][0]
 
     def test_read_pagination(self):
         data = [
@@ -87,8 +87,8 @@ class TestMarcParse(unittest.TestCase):
         for value, expect in data:
             rec = MockRecord('300', [('a', value)])
             output = read_pagination(rec)
-            self.assertEqual(output['number_of_pages'], expect)
-            self.assertEqual(output['pagination'], value)
+            assert output['number_of_pages'] == expect
+            assert output['pagination'] == value
 
     def test_subjects_for_work(self):
         data = [
@@ -185,7 +185,7 @@ class TestMarcParse(unittest.TestCase):
 
         for value, expect in data:
             output = read_title(MockRecord('245', value))
-            self.assertEqual(expect, output)
+            assert expect == output
 
     def test_by_statement(self):
         data = [
@@ -203,4 +203,4 @@ class TestMarcParse(unittest.TestCase):
         ]
         for value, expect in data:
             output = read_title(MockRecord('245', value))
-            self.assertEqual(expect, output)
+            assert expect == output

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -41,10 +41,9 @@ class OLSession:
         self.driver.find_element_by_id('password').send_keys(password)
         self.driver.find_element_by_name('submit').click()
         if test:
-            test.assertTrue(
-                self.ia_is_logged_in(),
-                f"IA Login failed w/ username: {email} and password: {password}",
-            )
+            assert (
+                self.ia_is_logged_in()
+            ), f"IA Login failed w/ username: {email} and password: {password}"
 
     def ia_is_logged_in(self, domain="https://archive.org"):
         time.sleep(2)
@@ -58,7 +57,7 @@ class OLSession:
     def ia_logout(self, test=None, domain="https://archive.org"):
         self.driver.get('%s/account/logout.php' % domain)
         if test:
-            test.assertTrue(not self.ia_is_logged_in(), "Failed to logout of IA")
+            assert not self.ia_is_logged_in(), "Failed to logout of IA"
 
     def login(self, email, password, test=None, **kwargs):
         self.driver.get(self.url('/account/login'))
@@ -66,10 +65,9 @@ class OLSession:
         self.driver.find_element_by_id("password").send_keys(password)
         self.driver.find_element_by_name('login').click()
         if test:
-            test.assertTrue(
-                self.is_logged_in(),
-                f"OL Login failed w/ username: {email} and password: {password}",
-            )
+            assert (
+                self.is_logged_in()
+            ), f"OL Login failed w/ username: {email} and password: {password}"
 
     def is_logged_in(self):
         time.sleep(2)
@@ -87,7 +85,7 @@ class OLSession:
         ).click()
         self.driver.get(self.url('/account/login'))
         if test:
-            test.assertTrue(not self.is_logged_in(), "Failed to logout of OL")
+            assert not self.is_logged_in(), "Failed to logout of OL"
 
     def connect(self, email, password):
         self.wait_for_clickable('linkAccounts')

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -57,19 +57,19 @@ class Xauth_Test(unittest.TestCase):
         olsession.login('', '')
         _error = errorLookup['invalid_email']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_missing_email(self):
         olsession.login('', 'password')
         _error = errorLookup['invalid_email']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_unregistered_email(self):
         olsession.login('mek+invalid_email@archive.org', 'password')
         _error = errorLookup['account_not_found']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     # ======================================================
     # Test successfully linked account
@@ -78,11 +78,11 @@ class Xauth_Test(unittest.TestCase):
     def test_linked(self):
         olsession.unlink(LINKED['email'])
         olsession.login(**LINKED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
-        self.assertTrue(not olsession.is_logged_in())
+        assert not olsession.is_logged_in()
         olsession.login(**LINKED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
 
         # finalize by unlinking for future tests
@@ -96,31 +96,31 @@ class Xauth_Test(unittest.TestCase):
         olsession.login(IA_VERIFIED['email'], 'password')
         _error = errorLookup['account_bad_password']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_incorrect_password(self):
         olsession.login(IA_VERIFIED['email'], 'password')
         _error = errorLookup['account_bad_password']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_blocked(self):
         olsession.login(**IA_BLOCKED)
         _error = errorLookup['account_locked']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_blocked_incorrect_password(self):
         olsession.login(IA_BLOCKED['email'], '')
         _error = errorLookup['account_bad_password']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_unverified(self):
         olsession.login(**IA_UNVERIFIED)
         _error = errorLookup['account_not_verified']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     # ======================================================
     # All combinations of connect attempts after initial
@@ -134,13 +134,13 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_blocked']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_verified_connect_ol_linked(self):
         # Link LINKED accounts
         olsession.unlink(LINKED['email'])
         olsession.login(**LINKED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
 
         olsession.unlink(OL_VERIFIED['email'])
@@ -149,7 +149,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_already_linked']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
         # finalize by unlinking for future tests
         olsession.unlink(LINKED['email'])
@@ -162,7 +162,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_not_verified']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_verified_connect_ia_unverified(self):
         olsession.unlink(OL_VERIFIED['email'])
@@ -171,13 +171,13 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_not_found']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_verified_CASE(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED_MIXED)
         olsession.connect(**OL_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
         olsession.unlink(OL_VERIFIED['email'])
 
@@ -188,21 +188,21 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_not_found']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ia_verified_connect_ol_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**IA_VERIFIED)
         olsession.connect(**OL_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
-        self.assertTrue(not olsession.is_logged_in())
+        assert not olsession.is_logged_in()
         olsession.login(**IA_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
-        self.assertTrue(not olsession.is_logged_in())
+        assert not olsession.is_logged_in()
         olsession.login(**OL_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
 
         # finalize by unlinking for future tests
@@ -215,13 +215,13 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_blocked']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ol_verified_connect_ol_linked(self):
         # Link LINKED accounts
         olsession.unlink(LINKED['email'])
         olsession.login(**LINKED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
 
         olsession.unlink(OL_VERIFIED['email'])
@@ -230,7 +230,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_already_linked']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
         # finalize by unlinking for future tests
         olsession.unlink(LINKED['email'])
@@ -243,7 +243,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_not_found']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ol_verified_connect_ia_unverified(self):
         olsession.unlink(OL_VERIFIED['email'])
@@ -252,7 +252,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_not_verified']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ol_verified_connect_ol_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
@@ -261,21 +261,21 @@ class Xauth_Test(unittest.TestCase):
         olsession.wait_for_visible('connectError')
         _error = errorLookup['account_not_found']
         error = olsession.driver.find_element_by_id('connectError').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     def test_ol_verified_connect_ia_verified(self):
         olsession.unlink(OL_VERIFIED['email'])
         olsession.login(**OL_VERIFIED)
         olsession.connect(**IA_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
-        self.assertTrue(not olsession.is_logged_in())
+        assert not olsession.is_logged_in()
         olsession.login(**OL_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
-        self.assertTrue(not olsession.is_logged_in())
+        assert not olsession.is_logged_in()
         olsession.login(**IA_VERIFIED)
-        self.assertTrue(olsession.is_logged_in())
+        assert olsession.is_logged_in()
         olsession.logout()
 
         # finalize by unlinking for future tests
@@ -292,7 +292,7 @@ class Xauth_Test(unittest.TestCase):
         olsession.create('')
         _error = errorLookup['max_retries_exceeded']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'
 
     # ======================================================
     # All combinations of Create & Link attempts after initial
@@ -305,4 +305,4 @@ class Xauth_Test(unittest.TestCase):
         olsession.create('')
         _error = errorLookup['max_retries_exceeded']
         error = olsession.driver.find_element_by_class_name('note').text
-        self.assertTrue(error == _error, f'{error} != {_error}')
+        assert error == _error, f'{error} != {_error}'

--- a/tests/integration/test_loans.py
+++ b/tests/integration/test_loans.py
@@ -75,9 +75,7 @@ class Borrow_Test(unittest.TestCase):
             conditions = ia_cta_btn and ia_cta_btn.text == ia_ctas[check_cta]['copy']
 
             if make_assert:
-                self.assertTrue(
-                    conditions, 'Unable to find %s button on page.' % check_cta
-                )
+                assert conditions, 'Unable to find %s button on page.' % check_cta
             if not conditions:
                 return False
 
@@ -101,10 +99,9 @@ class Borrow_Test(unittest.TestCase):
                 return False
 
             if make_assert:
-                self.assertTrue(
-                    ol_cta_btn,
-                    f"{check_cta} button not found on OL edition page: {olid}",
-                )
+                assert (
+                    ol_cta_btn
+                ), f'{check_cta} button not found on OL edition page: {olid}'
             elif not ol_cta_btn:
                 return False
             if click:
@@ -125,10 +122,9 @@ class Borrow_Test(unittest.TestCase):
             olid, check_cta="read", make_assert=True, click=False
         )
         userid = cta.get_attribute('data-userid')
-        self.assertTrue(
-            cta.get_attribute('data-userid') == itemname,
-            f'data-userid should be {itemname}, was {userid}',
-        )
+        assert (
+            cta.get_attribute('data-userid') == itemname
+        ), f'data-userid should be {itemname}, was {userid}'
 
     def test_ia_borrow_ol_read_ol_return(self):
         olsession.ia_login(test=self, **LIVE_USER1)
@@ -195,7 +191,7 @@ class Borrow_Test(unittest.TestCase):
         link = olsession.driver.find_element_by_xpath(
             '//a[@href="/books/%s"]' % OL_EDITION
         )
-        self.assertTrue(link, "Book not found in waiting list on loans page")
+        assert link, 'Book not found in waiting list on loans page'
 
         olsession.logout(test=self)
         olsession.login(test=self, **LIVE_USER1)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

% `ruff --select=PT009 --fix .`
```
Found 49 errors (49 fixed, 0 remaining).
```
Pytest assertion introspection enables it to show the `expected` and `actual` side-by-side when tests fail.
* https://docs.pytest.org/en/7.2.x/how-to/assert.html
* https://docs.pytest.org/en/7.2.x/how-to/assert.html#assert-details

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
