### PR TITLE
Fix French plurals in i18n

### DIFF
--- a/openlibrary/i18n/de/messages.po
+++ b/openlibrary/i18n/de/messages.po
@@ -88,9 +88,9 @@ msgstr "Richten Sie die Kamera auf den Barcode! 📷"
 
 #: account/loans.html:69 borrow_admin.html:104
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
-msgstr[0] "1 ausgeliehenes Buch"
+msgstr[0] "%(count)d ausgeliehenes Buch"
 msgstr[1] "%(count)d ausgeliehene Bücher"
 
 #: account/loans.html:71 admin/loans_table.html:41 borrow_admin.html:106
@@ -403,9 +403,9 @@ msgstr "Zeiten"
 #: merge/authors.html:89 publishers/view.html:17 subjects.html:19
 #: type/author/view.html:110
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
-msgstr[0] "1 Werk"
+msgstr[0] "%(count)d Werk"
 msgstr[1] "%(count)d Werke"
 
 #: subjects.html:22
@@ -477,9 +477,9 @@ msgstr "Mehr Bücher von und Informationen über diese*n Autor*in ansehen"
 #: search/authors.html:66 search/publishers.html:29 search/subjects.html:89
 #: subjects.html:88
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
-msgstr[0] "1 Buch"
+msgstr[0] "%(count)d Buch"
 msgstr[1] "%(count)d Bücher"
 
 #: subjects.html:92
@@ -497,9 +497,9 @@ msgstr "Mehr Informationen über diesen Verlag"
 #: SearchResultsWork.html:75 books/check.html:36 merge/authors.html:82
 #: publishers/view.html:106 subjects.html:111
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] "1 Ausgabe"
+msgstr[0] "%(count)s Ausgabe"
 msgstr[1] "%(count)s Ausgaben"
 
 #: support.html:7 support.html:10
@@ -671,9 +671,9 @@ msgstr "auf "
 #: search/authors.html:37 search/subjects.html:27 work_search.html:58
 #: work_search.html:169
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] "1 Treffer"
+msgstr[0] "%(count)s Treffer"
 msgstr[1] "%(count)s Treffer"
 
 #: lib/nav_foot.html:30 lib/nav_head.html:35 search/advancedsearch.html:7
@@ -2816,9 +2816,9 @@ msgstr "durchsuche %(subject)s Bücher"
 
 #: home/categories.html:31
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 Buch"
+msgstr[0] "%(count)s Buch"
 msgstr[1] "%(count)s Bücher"
 
 #: home/index.html:8 home/welcome.html:9
@@ -2991,9 +2991,9 @@ msgstr "%(date)s erstellt"
 
 #: lib/history.html:32
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 Version"
+msgstr[0] "%(count)d Version"
 msgstr[1] "%(count)d Versionen"
 
 #: lib/history.html:44
@@ -3480,9 +3480,9 @@ msgstr "von <a href=\"%(key)s\">%(owner)s</a>"
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
 #: type/list/embed.html:17 type/list/view_body.html:38
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
-msgstr[0] "1 Gegenstand"
+msgstr[0] "%(count)d Gegenstand"
 msgstr[1] "%(count)d Gegenstände"
 
 #: lists/home.html:53 lists/preview.html:26 lists/snippet.html:20
@@ -3717,9 +3717,9 @@ msgstr "Etwas anderes probieren?"
 # | msgid_plural "%s ebooks"
 #: publishers/view.html:19
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
-msgstr[0] "1 eBook"
+msgstr[0] "%(count)s eBook"
 msgstr[1] "%(count)s eBooks"
 
 #: publishers/view.html:33
@@ -3824,9 +3824,9 @@ msgstr "Duplikate"
 
 #: recentchanges/merge-authors/view.html:45
 #, python-format
-msgid "1 record modified."
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
-msgstr[0] "1 Eintrag geändert."
+msgstr[0] "%(count)d Eintrag geändert."
 msgstr[1] "%(count)d Einträge geändert."
 
 # | msgid "Delete Record"
@@ -3875,12 +3875,19 @@ msgstr "Volltextsuche"
 msgid "No hits for: %(query)s"
 msgstr "Keine Treffer für: %(query)s"
 
-#: search/inside.html:37
+#: search/inside.html:29
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Es wurde 1 Ergebnis in %(seconds)s gefunden"
-msgstr[1] "Es wurden %(count)s Ergebnisse in %(seconds)s gefunden"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "Es wurde %(count)s Ergebnis"
+msgstr[1] "Es wurden %(count)s Ergebnisse"
+
+#: search/inside.html:29
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "in %(seconds)s gefunden"
+msgstr[1] "in %(seconds)s gefunden"
 
 # | msgid "Search Results"
 #: search/lists.html:7
@@ -4033,9 +4040,9 @@ msgstr ""
 #: stats/readinglog.html:70 stats/readinglog.html:78 stats/readinglog.html:87
 #: stats/readinglog.html:96
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
-msgstr[0] "Insgesamt 1 mal hinzugefügt"
+msgstr[0] "Insgesamt %(count)d mal hinzugefügt"
 msgstr[1] "Insgesamt %(count)d mal hinzugefügt"
 
 #: stats/readinglog.html:74
@@ -4947,9 +4954,9 @@ msgstr "Buch zurückgeben"
 
 #: SearchResultsWork.html:67
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
-msgstr[0] "1 weitere"
+msgstr[0] "%(n)s weitere"
 msgstr[1] "%(n)s weitere"
 
 #: SearchResultsWork.html:78

--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -99,9 +99,9 @@ msgstr "¡Apunta tu cámara a un código de barras! 📷"
 
 #: account/loans.html:63 borrow_admin.html:104
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
-msgstr[0] "1 préstamo actual"
+msgstr[0] "%(count)d préstamo actual"
 msgstr[1] "%(count)d préstamos actuales"
 
 #: account/loans.html:65 admin/loans_table.html:41 borrow_admin.html:106
@@ -422,9 +422,9 @@ msgstr "Ver todas las obras"
 #: merge/authors.html:93 publishers/view.html:17 subjects.html:19
 #: type/author/view.html:121
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
-msgstr[0] "1 obra"
+msgstr[0] "%(count)d obra"
 msgstr[1] "%(count)d obras"
 
 #: subjects.html:22
@@ -497,9 +497,9 @@ msgstr "Ver más libros de este autor y aprender más sobre él"
 #: search/authors.html:57 search/publishers.html:29 search/subjects.html:73
 #: subjects.html:88
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
-msgstr[0] "1 libro"
+msgstr[0] "%(count)d libro"
 msgstr[1] "%(count)d libros"
 
 #: subjects.html:92
@@ -517,9 +517,9 @@ msgstr "Obtener más información sobre esta editorial"
 #: SearchResultsWork.html:86 books/check.html:36 merge/authors.html:86
 #: publishers/view.html:106 subjects.html:111
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] "1 edición"
+msgstr[0] "%(count)s edición"
 msgstr[1] "%(count)s ediciones"
 
 #: support.html:7 support.html:10
@@ -867,9 +867,9 @@ msgstr "Añadir un nuevo libro a la Biblioteca Abierta"
 #: account/reading_log.html:40 search/authors.html:44 search/subjects.html:35
 #: work_search.html:194
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] "1 coincidencia"
+msgstr[0] "%(count)s coincidencia"
 msgstr[1] "%(count)s coincidencias"
 
 #: work_search.html:225
@@ -3274,9 +3274,9 @@ msgstr "explorar por libros de %(subject)s"
 
 #: home/categories.html:31
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 libro"
+msgstr[0] "%(count)s libro"
 msgstr[1] "%(count)s librs"
 
 #: home/index.html:8 home/welcome.html:9
@@ -3514,9 +3514,9 @@ msgstr "Creado %(date)s"
 
 #: lib/history.html:32
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 revisión"
+msgstr[0] "%(count)d revisión"
 msgstr[1] "%(count)d revisiones"
 
 #: lib/history.html:44
@@ -3937,9 +3937,9 @@ msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
 #: type/list/embed.html:18 type/list/view_body.html:39
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
-msgstr[0] "1 elemento"
+msgstr[0] "%(count)d elemento"
 msgstr[1] "%(count)d elementos"
 
 #: lists/home.html:53 lists/preview.html:26 lists/snippet.html:20
@@ -4256,9 +4256,9 @@ msgstr "¿Intentar algo más?"
 
 #: publishers/view.html:19
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
-msgstr[0] "1 libro electrónico"
+msgstr[0] "%(count)s libro electrónico"
 msgstr[1] "%(count)s libros electrónicos"
 
 #: publishers/view.html:33
@@ -4358,9 +4358,9 @@ msgstr "Duplicados"
 
 #: recentchanges/merge-authors/view.html:49
 #, python-format
-msgid "1 record modified."
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
-msgstr[0] "1 registro modificado."
+msgstr[0] "%(count)d registro modificado."
 msgstr[1] "%(count)d registros modificados."
 
 #: recentchanges/merge-authors/view.html:53
@@ -4413,12 +4413,19 @@ msgstr "Buscar dentro"
 msgid "No hits for: %(query)s"
 msgstr "Sin coincidencias para: %(query)s"
 
-#: search/inside.html:37
+#: search/inside.html:29
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Alrededor de 1 resultado encontrado en %(seconds)s"
-msgstr[1] "Alrededor de %(count)s resultados encontrados en %(seconds)s"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "Alrededor de %(count)s resultado encontrado"
+msgstr[1] "Alrededor de %(count)s resultados encontrados"
+
+#: search/inside.html:29
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "en %(seconds)s"
+msgstr[1] "en %(seconds)s"
 
 #: search/lists.html:7
 msgid "Search results for Lists"
@@ -4563,9 +4570,9 @@ msgstr "Libros más deseados (este mes)"
 #: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
 #: stats/readinglog.html:97
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
-msgstr[0] "Añadido 1 vez"
+msgstr[0] "Añadido %(count)d vez"
 msgstr[1] "Añadido %(count)d veces"
 
 #: stats/readinglog.html:75
@@ -5275,9 +5282,9 @@ msgstr "Falta el título"
 
 #: type/work/editions_datatable.html:13
 #, python-format
-msgid "Showing one featured edition."
+msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
-msgstr[0] "Se muestra una edición destacada."
+msgstr[0] "Se muestra %(count)d edición destacada."
 msgstr[1] "Se muestran %(count)d ediciones destacadas."
 
 #: type/work/editions_datatable.html:14
@@ -5324,9 +5331,9 @@ msgstr "Buscar esta edición a la venta en %(store)s"
 
 #: BookByline.html:20
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
-msgstr[0] "1 otra"
+msgstr[0] "%(n)s otra"
 msgstr[1] "%(n)s otras"
 
 #: BookByline.html:36

--- a/openlibrary/i18n/fr/messages.po
+++ b/openlibrary/i18n/fr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Last-Translator: Julien Lepiller <julien@lepiller.eu>\n"
 "Language: fr\n"
 "Language-Team: fr <traduc@traduc.org>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"Plural-Forms: nplurals=2; plural=(n >= 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -100,11 +100,15 @@ msgstr "Scanner de code-barres (Beta)"
 msgid "Point your camera at a barcode! 📷"
 msgstr "Pointez votre caméra sur un code-barres ! 📷"
 
-#: account/loans.html:63 borrow_admin.html:104
-#, python-format
+#: borrow_admin.html:97
 msgid "1 Current Loan"
+msgstr "1 emprunt en cours"
+
+#: account/loans.html:59
+#, python-format
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
-msgstr[0] "1 emprunt en cours"
+msgstr[0] "%(count)d emprunt en cours"
 msgstr[1] "%(count)d emprunts en cours"
 
 #: account/loans.html:65 admin/loans_table.html:41 borrow_admin.html:106
@@ -428,12 +432,12 @@ msgstr "Périodes"
 msgid "See all works"
 msgstr "Tout voir"
 
-#: merge/authors.html:93 publishers/view.html:17 subjects.html:19
-#: type/author/view.html:121
+#: merge/authors.html:89 publishers/view.html:13 subjects.html:15
+#: type/author/view.html:117
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
-msgstr[0] "1 œuvre"
+msgstr[0] "%(count)d œuvre"
 msgstr[1] "%(count)d œuvres"
 
 #: subjects.html:22
@@ -502,13 +506,13 @@ msgstr "Aucun résultat."
 msgid "See more books by, and learn about, this author"
 msgstr "Voir plus de livres de cet auteur et en apprendre plus"
 
-#: account/loans.html:147 authors/index.html:28 publishers/view.html:83
-#: search/authors.html:57 search/publishers.html:29 search/subjects.html:73
-#: subjects.html:88
+#: account/loans.html:143 authors/index.html:24 publishers/view.html:79
+#: search/authors.html:56 search/publishers.html:29 search/subjects.html:66
+#: subjects.html:84
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
-msgstr[0] "1 livre"
+msgstr[0] "%(count)d livre"
 msgstr[1] "%(count)d livres"
 
 #: subjects.html:92
@@ -523,12 +527,12 @@ msgstr "qui a écrit le plus de livres sur ce thème"
 msgid "Get more information about this publisher"
 msgstr "Obtenir plus d'informations sur cet éditeur"
 
-#: SearchResultsWork.html:86 books/check.html:36 merge/authors.html:86
-#: publishers/view.html:106 subjects.html:111
+#: SearchResultsWork.html:82 books/check.html:32 merge/authors.html:82
+#: publishers/view.html:102 subjects.html:107
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] "1 édition"
+msgstr[0] "%(count)s édition"
 msgstr[1] "%(count)s éditions"
 
 #: support.html:7 support.html:10
@@ -874,12 +878,12 @@ msgstr "Rechercher des livres contenant la phrase « %s » ?"
 msgid "Add a new book to Open Library?"
 msgstr "Ajouter un nouveau livre à Open Library"
 
-#: account/reading_log.html:40 search/authors.html:44 search/subjects.html:35
-#: work_search.html:194
+#: account/reading_log.html:36 search/authors.html:41 search/subjects.html:31
+#: work_search.html:190
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] "1 résultat"
+msgstr[0] "%(count)s résultat"
 msgstr[1] "%(count)s résultats"
 
 #: work_search.html:225
@@ -3293,11 +3297,11 @@ msgstr "Explorer par thèmes"
 msgid "browse %(subject)s books"
 msgstr "explorer des livres au sujet de %(subject)s"
 
-#: home/categories.html:31
+#: home/categories.html:27
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 livre"
+msgstr[0] "%(count)s livre"
 msgstr[1] "%(count)s livres"
 
 #: home/index.html:8 home/welcome.html:9
@@ -3531,11 +3535,11 @@ msgstr "Historique"
 msgid "Created %(date)s"
 msgstr "Créé le %(date)s"
 
-#: lib/history.html:32
+#: lib/history.html:28
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 révision"
+msgstr[0] "%(count)d révision"
 msgstr[1] "%(count)d révisions"
 
 #: lib/history.html:44
@@ -3961,12 +3965,12 @@ msgstr "Listes actives"
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 
-#: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
-#: type/list/embed.html:18 type/list/view_body.html:39
+#: lists/home.html:47 lists/preview.html:19 lists/snippet.html:14
+#: type/list/embed.html:12 type/list/view_body.html:35
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
-msgstr[0] "1 élément"
+msgstr[0] "%(count)d élément"
 msgstr[1] "%(count)d éléments"
 
 #: lists/home.html:53 lists/preview.html:26 lists/snippet.html:20
@@ -4287,11 +4291,11 @@ msgstr "Nous n'avons trouvé aucun livre publié par %(publisher)s."
 msgid "Try something else?"
 msgstr "Essayer autre chose ?"
 
-#: publishers/view.html:19
+#: publishers/view.html:15
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
-msgstr[0] "1 livre électronique"
+msgstr[0] "%(count)s livre électronique"
 msgstr[1] "%(count)s livres électroniques"
 
 #: publishers/view.html:33
@@ -4390,11 +4394,18 @@ msgstr "Principal"
 msgid "Duplicates"
 msgstr "Doublons"
 
-#: recentchanges/merge-authors/view.html:49
+#: recentchanges/merge/comment.html:20
 #, python-format
-msgid "1 record modified."
+msgid "Merged %(count)d duplicate %(type)s record into this primary."
+msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
+msgstr[0] ""
+msgstr[1] ""
+
+#: recentchanges/merge/view.html:51
+#, python-format
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
-msgstr[0] "1 entrée modifiée."
+msgstr[0] "%(count)d entrée modifiée."
 msgstr[1] "%(count)d entrées modifiées."
 
 #: recentchanges/merge-authors/view.html:53
@@ -4448,12 +4459,19 @@ msgstr "Recherche plein texte"
 msgid "No hits for: %(query)s"
 msgstr "Aucun résultat pour : %(query)s"
 
-#: search/inside.html:37
+#: search/inside.html:29
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Environ 1 résultat trouvé en %(seconds)s secondes"
-msgstr[1] "Environ %(count)s résultats trouvés en %(seconds)s secondes"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "Environ %(count)s résultat trouvé"
+msgstr[1] "Environ %(count)s résultats trouvés"
+
+#: search/inside.html:29
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "en %(seconds)s seconde"
+msgstr[1] "en %(seconds)s secondes"
 
 #: search/lists.html:7
 msgid "Search results for Lists"
@@ -4596,12 +4614,12 @@ msgstr "# total d'évaluateurs uniques (de tous les temps)"
 msgid "Most Wanted Books (This Month)"
 msgstr "Lives les plus recherchés (Ce mois-ci)"
 
-#: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
-#: stats/readinglog.html:97
+#: stats/readinglog.html:67 stats/readinglog.html:75 stats/readinglog.html:84
+#: stats/readinglog.html:93
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
-msgstr[0] "Ajouté 1 fois"
+msgstr[0] "Ajouté %(count)d fois"
 msgstr[1] "Ajouté %(count)d fois"
 
 #: stats/readinglog.html:75
@@ -5312,9 +5330,9 @@ msgstr "Ajouter une autre"
 msgid "Title missing"
 msgstr "Titre manquant"
 
-#: type/work/editions_datatable.html:13
+#: type/work/editions_datatable.html:9
 #, python-format
-msgid "Showing one featured edition."
+msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
 msgstr[0] ""
 msgstr[1] ""
@@ -5361,11 +5379,11 @@ msgstr "Bookshop.org"
 msgid "Look for this edition for sale at %(store)s"
 msgstr "Rechercher cette édition en vente sur %(store)s"
 
-#: BookByline.html:20
+#: BookByline.html:11
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
-msgstr[0] "1 autre"
+msgstr[0] "%(n)s autre"
 msgstr[1] "%(n)s autres"
 
 #: BookByline.html:36

--- a/openlibrary/i18n/hr/messages.po
+++ b/openlibrary/i18n/hr/messages.po
@@ -100,9 +100,9 @@ msgstr "Usmjeri kameru na barkod! 📷"
 
 #: account/loans.html:63 borrow_admin.html:104
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
-msgstr[0] "1 trenutačna posudba"
+msgstr[0] "%(count)d trenutačna posudba"
 msgstr[1] "%(count)d trenutačne posudbe"
 msgstr[2] "%(count)d trenutačnih posudbi"
 
@@ -423,9 +423,9 @@ msgstr "Pogledaj sva djela"
 #: merge/authors.html:93 publishers/view.html:17 subjects.html:19
 #: type/author/view.html:121
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
-msgstr[0] "1 djelo"
+msgstr[0] "%(count)d djelo"
 msgstr[1] "%(count)d djela"
 msgstr[2] "%(count)d djela"
 
@@ -498,9 +498,9 @@ msgstr "Pogledaj još knjiga ovog autora i saznaj više o njemu"
 #: search/authors.html:57 search/publishers.html:29 search/subjects.html:73
 #: subjects.html:88
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
-msgstr[0] "1 knjiga"
+msgstr[0] "%(count)d knjiga"
 msgstr[1] "%(count)d knjige"
 msgstr[2] "%(count)d knjiga"
 
@@ -519,9 +519,9 @@ msgstr "Saznaj više o ovom izdavaču"
 #: SearchResultsWork.html:86 books/check.html:36 merge/authors.html:86
 #: publishers/view.html:106 subjects.html:111
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] "1 izdanje"
+msgstr[0] "%(count)s izdanje"
 msgstr[1] "%(count)s izdanja"
 msgstr[2] "%(count)s izdanja"
 
@@ -865,9 +865,9 @@ msgstr "Dodati novu knjigu u Open Library?"
 #: account/reading_log.html:40 search/authors.html:44 search/subjects.html:35
 #: work_search.html:194
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] "1 rezultat"
+msgstr[0] "%(count)s rezultat"
 msgstr[1] "%(count)s rezultata"
 msgstr[2] "%(count)s rezultata"
 
@@ -3239,9 +3239,9 @@ msgstr "pregledaj knjige u području %(subject)s"
 
 #: home/categories.html:31
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 knjiga"
+msgstr[0] "%(count)s knjiga"
 msgstr[1] "%(count)s knjige"
 msgstr[2] "%(count)s knjiga"
 
@@ -3479,9 +3479,9 @@ msgstr "Stvoreno %(date)s"
 
 #: lib/history.html:32
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 revizija"
+msgstr[0] "%(count)d revizija"
 msgstr[1] "%(count)d revizije"
 msgstr[2] "%(count)d revizija"
 
@@ -3904,9 +3904,9 @@ msgstr "Vlasnik: <a href=\"%(key)s\">%(owner)s</a>"
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
 #: type/list/embed.html:18 type/list/view_body.html:39
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
-msgstr[0] "1 element"
+msgstr[0] "%(count)d element"
 msgstr[1] "%(count)d elementa"
 msgstr[2] "%(count)d elemenata"
 
@@ -4324,9 +4324,9 @@ msgstr "Duplikati"
 
 #: recentchanges/merge-authors/view.html:49
 #, python-format
-msgid "1 record modified."
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
-msgstr[0] "1 zapis promijenjen."
+msgstr[0] "%(count)d zapis promijenjen."
 msgstr[1] "%(count)d zapisa promijenjena."
 msgstr[2] "%(count)d zapisa promijenjeno."
 
@@ -4380,13 +4380,21 @@ msgstr "Traži unutar"
 msgid "No hits for: %(query)s"
 msgstr "Nema rezultata za: %(query)s"
 
+#: search/inside.html:29
+#, python-format
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "Pronađen je otprilike %(count)s rezultat u roku"
+msgstr[1] "Pronađena su otprilike %(count)s rezultata u roku"
+msgstr[2] "Pronađeno je otprilike %(count)s rezultata u roku"
+
 #: search/inside.html:37
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Pronađen je otprilike 1 rezultat u roku od %(seconds)s"
-msgstr[1] "Pronađena su otprilike %(count)s rezultata u roku od %(seconds)s"
-msgstr[2] "Pronađeno je otprilike %(count)s rezultata u roku od %(seconds)s"
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "od %(seconds)s"
+msgstr[1] "od %(seconds)s"
+msgstr[2] "od %(seconds)s"
 
 #: search/lists.html:7
 msgid "Search results for Lists"
@@ -4531,9 +4539,9 @@ msgstr "Najtraženije knjige (ovaj mjesec)"
 #: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
 #: stats/readinglog.html:97
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
-msgstr[0] "Dodano 1 puta"
+msgstr[0] "Dodano %(count)d puta"
 msgstr[1] "Dodano %(count)d puta"
 msgstr[2] "Dodano %(count)d puta"
 
@@ -5236,9 +5244,9 @@ msgstr "Naslov nedostaje"
 
 #: type/work/editions_datatable.html:13
 #, python-format
-msgid "Showing one featured edition."
+msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
-msgstr[0] "Prikazuje se jedno preporučeno izdanje."
+msgstr[0] "Prikazuje se %(count)d preporučeno izdanje."
 msgstr[1] "Prikazuju se %(count)d preporučena izdanja."
 msgstr[2] "Prikazuje se %(count)d preporučenih izdanja."
 
@@ -5286,9 +5294,9 @@ msgstr "Traži ovo izdanje na rasprodaji na %(store)s"
 
 #: BookByline.html:20
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
-msgstr[0] "još 1"
+msgstr[0] "još %(n)s"
 msgstr[1] "još %(n)s"
 msgstr[2] "još %(n)s"
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -94,9 +94,9 @@ msgstr ""
 msgid "Point your camera at a barcode! 📷"
 msgstr ""
 
-#: account/loans.html:63 borrow_admin.html:104
+#: account/loans.html:59
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
 msgstr[0] ""
 msgstr[1] ""
@@ -405,10 +405,10 @@ msgstr ""
 msgid "See all works"
 msgstr ""
 
-#: merge/authors.html:93 publishers/view.html:17 subjects.html:19
-#: type/author/view.html:121
+#: merge/authors.html:89 publishers/view.html:13 subjects.html:15
+#: type/author/view.html:117
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
 msgstr[0] ""
 msgstr[1] ""
@@ -475,11 +475,11 @@ msgstr ""
 msgid "See more books by, and learn about, this author"
 msgstr ""
 
-#: account/loans.html:147 authors/index.html:28 publishers/view.html:83
-#: search/authors.html:57 search/publishers.html:29 search/subjects.html:73
-#: subjects.html:88
+#: account/loans.html:143 authors/index.html:24 publishers/view.html:79
+#: search/authors.html:56 search/publishers.html:29 search/subjects.html:66
+#: subjects.html:84
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
@@ -496,10 +496,10 @@ msgstr ""
 msgid "Get more information about this publisher"
 msgstr ""
 
-#: SearchResultsWork.html:86 books/check.html:36 merge/authors.html:86
-#: publishers/view.html:106 subjects.html:111
+#: SearchResultsWork.html:82 books/check.html:32 merge/authors.html:82
+#: publishers/view.html:102 subjects.html:107
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
 msgstr[0] ""
 msgstr[1] ""
@@ -829,10 +829,10 @@ msgstr ""
 msgid "Add a new book to Open Library?"
 msgstr ""
 
-#: account/reading_log.html:40 search/authors.html:44 search/subjects.html:35
-#: work_search.html:194
+#: account/reading_log.html:36 search/authors.html:41 search/subjects.html:31
+#: work_search.html:190
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
 msgstr[0] ""
 msgstr[1] ""
@@ -3099,9 +3099,9 @@ msgstr ""
 msgid "browse %(subject)s books"
 msgstr ""
 
-#: home/categories.html:31
+#: home/categories.html:27
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
 msgstr[0] ""
 msgstr[1] ""
@@ -3335,9 +3335,9 @@ msgstr ""
 msgid "Created %(date)s"
 msgstr ""
 
-#: lib/history.html:32
+#: lib/history.html:28
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
 msgstr[0] ""
 msgstr[1] ""
@@ -3731,10 +3731,10 @@ msgstr ""
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr ""
 
-#: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
-#: type/list/embed.html:18 type/list/view_body.html:39
+#: lists/home.html:47 lists/preview.html:19 lists/snippet.html:14
+#: type/list/embed.html:12 type/list/view_body.html:35
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
@@ -4042,9 +4042,9 @@ msgstr ""
 msgid "Try something else?"
 msgstr ""
 
-#: publishers/view.html:19
+#: publishers/view.html:15
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
 msgstr[0] ""
 msgstr[1] ""
@@ -4138,9 +4138,16 @@ msgstr ""
 msgid "Duplicates"
 msgstr ""
 
-#: recentchanges/merge-authors/view.html:49
+#: recentchanges/merge/comment.html:20
 #, python-format
-msgid "1 record modified."
+msgid "Merged %(count)d duplicate %(type)s record into this primary."
+msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
+msgstr[0] ""
+msgstr[1] ""
+
+#: recentchanges/merge/view.html:51
+#, python-format
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
 msgstr[0] ""
 msgstr[1] ""
@@ -4195,10 +4202,17 @@ msgstr ""
 msgid "No hits for: %(query)s"
 msgstr ""
 
-#: search/inside.html:37
+#: search/inside.html:29
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] ""
+msgstr[1] ""
+
+#: search/inside.html:29
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4335,10 +4349,10 @@ msgstr ""
 msgid "Most Wanted Books (This Month)"
 msgstr ""
 
-#: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
-#: stats/readinglog.html:97
+#: stats/readinglog.html:67 stats/readinglog.html:75 stats/readinglog.html:84
+#: stats/readinglog.html:93
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
 msgstr[0] ""
 msgstr[1] ""
@@ -5008,9 +5022,9 @@ msgstr ""
 msgid "Title missing"
 msgstr ""
 
-#: type/work/editions_datatable.html:13
+#: type/work/editions_datatable.html:9
 #, python-format
-msgid "Showing one featured edition."
+msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
 msgstr[0] ""
 msgstr[1] ""
@@ -5057,9 +5071,9 @@ msgstr ""
 msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
-#: BookByline.html:20
+#: BookByline.html:11
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
 msgstr[0] ""
 msgstr[1] ""

--- a/openlibrary/i18n/pt/messages.po
+++ b/openlibrary/i18n/pt/messages.po
@@ -86,9 +86,9 @@ msgstr "Aponte sua camera a um código de barras! 📷"
 
 #: account/loans.html:69 borrow_admin.html:104
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
-msgstr[0] "1 empréstimo atual"
+msgstr[0] "%(count)d empréstimo atual"
 msgstr[1] "%(count)d empréstimos atuais"
 
 #: account/loans.html:71 admin/loans_table.html:41 borrow_admin.html:106
@@ -403,9 +403,9 @@ msgstr "Tempos"
 #: merge/authors.html:89 publishers/view.html:17 subjects.html:19
 #: type/author/view.html:110
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
-msgstr[0] "1 obra"
+msgstr[0] "%(count)d obra"
 msgstr[1] "%(count)d obras"
 
 #: subjects.html:22
@@ -478,9 +478,9 @@ msgstr "Ver mais livros desse autor e aprender mais sobre ele"
 #: search/authors.html:66 search/publishers.html:29 search/subjects.html:89
 #: subjects.html:88
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
-msgstr[0] "1 livro"
+msgstr[0] "%(count)d livro"
 msgstr[1] "%(count)d livros"
 
 #: subjects.html:92
@@ -498,9 +498,9 @@ msgstr "Obter mais informação sobre esta editora"
 #: SearchResultsWork.html:75 books/check.html:36 merge/authors.html:82
 #: publishers/view.html:106 subjects.html:111
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] "1 edição"
+msgstr[0] "%(count)s edição"
 msgstr[1] "%(count)s edições"
 
 #: support.html:7 support.html:10
@@ -673,9 +673,9 @@ msgstr "em "
 #: search/authors.html:37 search/subjects.html:27 work_search.html:58
 #: work_search.html:169
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] "1 correspondente"
+msgstr[0] "%(count)s correspondente"
 msgstr[1] "%(count)s correspondentes"
 
 #: lib/nav_foot.html:30 lib/nav_head.html:35 search/advancedsearch.html:7
@@ -2858,9 +2858,9 @@ msgstr "explorar por livros de %(subject)s"
 
 #: home/categories.html:31
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 livro"
+msgstr[0] "%(count)s livro"
 msgstr[1] "%(count)s livros"
 
 #: home/index.html:8 home/welcome.html:9
@@ -3032,9 +3032,9 @@ msgstr "Criado %(date)s"
 
 #: lib/history.html:32
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 revisão"
+msgstr[0] "%(count)d revisão"
 msgstr[1] "%(count)d revisões"
 
 #: lib/history.html:44
@@ -3528,9 +3528,9 @@ msgstr "de <a href=\"%(key)s\">%(owner)s</a>"
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
 #: type/list/embed.html:17 type/list/view_body.html:38
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
-msgstr[0] "1 elemento"
+msgstr[0] "%(count)d elemento"
 msgstr[1] "%(count)d elementos"
 
 #: lists/home.html:53 lists/preview.html:26 lists/snippet.html:20
@@ -3759,9 +3759,9 @@ msgstr "Tentar outra coisa?"
 
 #: publishers/view.html:19
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
-msgstr[0] "1 eBook"
+msgstr[0] "%(count)s eBook"
 msgstr[1] "%(count)s eBooks"
 
 #: publishers/view.html:33
@@ -3861,9 +3861,9 @@ msgstr "Duplicados"
 
 #: recentchanges/merge-authors/view.html:45
 #, python-format
-msgid "1 record modified."
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
-msgstr[0] "1 registro modificado."
+msgstr[0] "%(count)d registro modificado."
 msgstr[1] "%(count)d registros modificados."
 
 #: recentchanges/merge-authors/view.html:49
@@ -3908,12 +3908,19 @@ msgstr "Buscar dentro"
 msgid "No hits for: %(query)s"
 msgstr "Sem resultados para: %(query)s"
 
-#: search/inside.html:37
+#: search/inside.html:29
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Por volta de 1 resultado encontrado em %(seconds)s"
-msgstr[1] "Por volta de %(count)s resultados encontrados em %(seconds)s"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "Por volta de %(count)s resultado encontrado"
+msgstr[1] "Por volta de %(count)s resultados encontrados"
+
+#: search/inside.html:29
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "em %(seconds)s"
+msgstr[1] "em %(seconds)s"
 
 #: search/lists.html:7
 msgid "Search results for Lists"
@@ -4054,9 +4061,9 @@ msgstr "Libros mais desejados (de todo tempo)"
 #: stats/readinglog.html:70 stats/readinglog.html:78 stats/readinglog.html:87
 #: stats/readinglog.html:96
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
-msgstr[0] "Adicionado 1 vez"
+msgstr[0] "Adicionado %(count)d vez"
 msgstr[1] "Adicionado %(count)d vezes"
 
 #: stats/readinglog.html:74
@@ -4958,9 +4965,9 @@ msgstr "Devolver livro"
 
 #: SearchResultsWork.html:67
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
-msgstr[0] "1 outra"
+msgstr[0] "%(n)s outra"
 msgstr[1] "%(n)s outras"
 
 #: SearchResultsWork.html:78

--- a/openlibrary/i18n/uk/messages.po
+++ b/openlibrary/i18n/uk/messages.po
@@ -100,7 +100,7 @@ msgstr "Наведіть камеру на штрихкод! 📷"
 
 #: account/loans.html:63 borrow_admin.html:104
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
 msgstr[0] "%(count)d активна позика"
 msgstr[1] "%(count)d активні позики"
@@ -425,7 +425,7 @@ msgstr "Побачити всі роботи"
 #: merge/authors.html:93 publishers/view.html:17 subjects.html:19
 #: type/author/view.html:121
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
 msgstr[0] "%(count)d робота"
 msgstr[1] "%(count)d роботи"
@@ -500,7 +500,7 @@ msgstr "Побачити більше книг від цього автора і
 #: search/authors.html:57 search/publishers.html:29 search/subjects.html:73
 #: subjects.html:88
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
 msgstr[0] "%(count)d книга"
 msgstr[1] "%(count)d книги"
@@ -521,7 +521,7 @@ msgstr "Отримати більше інформації про цього в�
 #: SearchResultsWork.html:86 books/check.html:36 merge/authors.html:86
 #: publishers/view.html:106 subjects.html:111
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
 msgstr[0] "%(count)s видання"
 msgstr[1] "%(count)s видання"
@@ -868,7 +868,7 @@ msgstr "Додати нову книгу до Open Library?"
 #: account/reading_log.html:40 search/authors.html:44 search/subjects.html:35
 #: work_search.html:194
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
 msgstr[0] "%(count)s співпадіння"
 msgstr[1] "%(count)s співпадіння"
@@ -3245,7 +3245,7 @@ msgstr "Шукати книги з темою %(subject)s"
 
 #: home/categories.html:31
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
 msgstr[0] "%(count)s книга"
 msgstr[1] "%(count)s книги"
@@ -3485,7 +3485,7 @@ msgstr "Створено %(date)s"
 
 #: lib/history.html:32
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
 msgstr[0] "%(count)d редагування"
 msgstr[1] "%(count)d редагування"
@@ -3909,7 +3909,7 @@ msgstr "від <a href=\"%(key)s\">%(owner)s</a>"
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
 #: type/list/embed.html:18 type/list/view_body.html:39
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] "%(count)d елемент"
 msgstr[1] "%(count)d елементи"
@@ -4225,7 +4225,7 @@ msgstr "Спробувати щось інше?"
 
 #: publishers/view.html:19
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
 msgstr[0] "%(count)s електронна книга"
 msgstr[1] "%(count)s електронні книги"
@@ -4329,7 +4329,7 @@ msgstr "Дублікати"
 
 #: recentchanges/merge-authors/view.html:49
 #, python-format
-msgid "1 record modified."
+msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
 msgstr[0] "%(count)d запис змінено."
 msgstr[1] "%(count)d записи змінено."
@@ -4385,13 +4385,21 @@ msgstr "Шукати всередині"
 msgid "No hits for: %(query)s"
 msgstr "Немає результатів для: %(query)s"
 
-#: search/inside.html:37
+#: search/inside.html:29
 #, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
-msgstr[0] "Близько %(count)s результату знайдено за %(seconds)s"
-msgstr[1] "Близько %(count)s результатів знайдено за %(seconds)s"
-msgstr[2] "Близько %(count)s результатів знайдено за %(seconds)s"
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] "Близько %(count)s результату знайдено"
+msgstr[1] "Близько %(count)s результатів знайдено"
+msgstr[2] "Близько %(count)s результатів знайдено"
+
+#: search/inside.html:29
+#, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
+msgstr[0] "за %(seconds)s"
+msgstr[1] "за %(seconds)s"
+msgstr[2] "за %(seconds)s"
 
 #: search/lists.html:7
 msgid "Search results for Lists"
@@ -4534,7 +4542,7 @@ msgstr "Найбажаніші книги (цього місяця)"
 #: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
 #: stats/readinglog.html:97
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
 msgstr[0] ""
 msgstr[1] ""
@@ -5230,7 +5238,7 @@ msgstr "Потрібна назва"
 
 #: type/work/editions_datatable.html:13
 #, python-format
-msgid "Showing one featured edition."
+msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
 msgstr[0] "Показуємо %(count)d вибране видання."
 msgstr[1] "Показуємо %(count)d вибрані видання."
@@ -5280,7 +5288,7 @@ msgstr ""
 
 #: BookByline.html:20
 #, python-format
-msgid "1 other"
+msgid "%(n)s other"
 msgid_plural "%(n)s others"
 msgstr[0] ""
 msgstr[1] ""

--- a/openlibrary/i18n/zh/messages.po
+++ b/openlibrary/i18n/zh/messages.po
@@ -90,7 +90,7 @@ msgstr "请将您的相机对准条形码！ 📷"
 
 #: account/borrow.html:82 borrow_admin.html:104
 #, python-format
-msgid "1 Current Loan"
+msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
 msgstr[0] "目前的贷款"
 msgstr[1] "%(count)d 目前贷款"
@@ -405,9 +405,9 @@ msgstr "时间"
 #: merge/authors.html:89 publishers/view.html:17 subjects.html:19
 #: type/author/view.html:110
 #, python-format
-msgid "1 work"
+msgid "%(count)d work"
 msgid_plural "%(count)d works"
-msgstr[0] "1份作品"
+msgstr[0] "%(count)d 份作品"
 msgstr[1] "%(count)d 份作品"
 
 #: subjects.html:22
@@ -480,9 +480,9 @@ msgstr "查看更多该作者的书籍，以及了解该作者"
 #: search/authors.html:66 search/publishers.html:29 search/subjects.html:89
 #: subjects.html:88
 #, python-format
-msgid "1 book"
+msgid "%(count)d book"
 msgid_plural "%(count)d books"
-msgstr[0] "1本书"
+msgstr[0] "%(count)d 本书"
 msgstr[1] "%(count)d 本书"
 
 #: subjects.html:92
@@ -500,9 +500,9 @@ msgstr "获取更多关于该出版商的信息"
 #: SearchResultsWork.html:55 books/check.html:36 merge/authors.html:82
 #: publishers/view.html:106 subjects.html:111
 #, python-format
-msgid "1 edition"
+msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
-msgstr[0] "1个版本"
+msgstr[0] "%(count)s 个版本"
 msgstr[1] "%(count)s 个版本"
 
 #: support.html:7 support.html:10
@@ -671,9 +671,9 @@ msgstr "在"
 #: search/authors.html:37 search/subjects.html:27 work_search.html:58
 #: work_search.html:169
 #, python-format
-msgid "1 hit"
+msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
-msgstr[0] "1 次点击"
+msgstr[0] "%(count)s 次点击"
 msgstr[1] "%(count)s 次点击"
 
 #: lib/nav_foot.html:30 lib/nav_head.html:36 search/advancedsearch.html:7
@@ -2723,9 +2723,9 @@ msgstr "浏览有关%(subject)s的书籍"
 
 #: home/categories.html:30
 #, python-format
-msgid "1 Book"
+msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
-msgstr[0] "1 本书"
+msgstr[0] "%(count)s 本书"
 msgstr[1] "%(count)s 本书"
 
 #: home/index.html:8 home/welcome.html:9
@@ -2898,9 +2898,9 @@ msgstr "于 %(date)s 创建"
 
 #: lib/history.html:32
 #, python-format
-msgid "1 revision"
+msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
-msgstr[0] "1 次修订"
+msgstr[0] "%(count)d 次修订"
 msgstr[1] "%(count)d 次修订"
 
 #: lib/history.html:44
@@ -3394,9 +3394,9 @@ msgstr "来自<a href=\"%(key)s\">%(owner)s</a>"
 #: lists/home.html:51 lists/preview.html:23 lists/snippet.html:18
 #: type/list/embed.html:17 type/list/view.html:40
 #, python-format
-msgid "1 item"
+msgid "%(count)d item"
 msgid_plural "%(count)d items"
-msgstr[0] "1 个项目"
+msgstr[0] "%(count)d 个项目"
 msgstr[1] "%(count)d 个项目"
 
 #: lists/home.html:53 lists/preview.html:26 lists/snippet.html:20
@@ -3628,9 +3628,9 @@ msgstr "试试别的？"
 
 #: publishers/view.html:19
 #, python-format
-msgid "1 ebook"
+msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
-msgstr[0] "1 本电子书"
+msgstr[0] "%(count)s 本电子书"
 msgstr[1] "%(count)s 本电子书"
 
 #: publishers/view.html:33
@@ -3771,12 +3771,19 @@ msgstr "在内部搜索"
 msgid "No hits for: %(query)s"
 msgstr "未找到符合条件: %(query)s"
 
-#: search/inside.html:37
-#, python-format
-msgid "About 1 result found in %(seconds)s"
-msgid_plural "About %(count)s results found in %(seconds)s"
+#: search/inside.html:29
+#, fuzzy, python-format
+msgid "About %(count)s result found"
+msgid_plural "About %(count)s results found"
+msgstr[0] ""
+msgstr[1] ""
+
+#: search/inside.html:29
+#, fuzzy, python-format
+msgid "in %(seconds)s second"
+msgid_plural "in %(seconds)s seconds"
 msgstr[0] "在%(seconds)s秒内找到约1个结果"
-msgstr[1] "在%(seconds)s秒内找到约%(count)s个结果"
+msgstr[1] "在%(seconds)s秒内找到约个结果"
 
 #: search/lists.html:7
 msgid "Search results for Lists"
@@ -3914,9 +3921,9 @@ msgstr "人们最想要的书(全部时间)"
 #: stats/readinglog.html:70 stats/readinglog.html:78 stats/readinglog.html:87
 #: stats/readinglog.html:96
 #, python-format
-msgid "Added 1 time"
+msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
-msgstr[0] "已添加1次"
+msgstr[0] "已添加%(count)d次"
 msgstr[1] "已添加%(count)d次"
 
 #: stats/readinglog.html:74

--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -8,7 +8,7 @@ $def render_author_link(name, url):
     <span $:attrs>$rendered_name</span>
 
 $def render_overflow_link(remaining_authors, overflow_url):
-  <small><em><a href="$overflow_url" $:attrs>$ungettext('1 other', '%(n)s others', remaining_authors, n=remaining_authors)</a></em></small>
+  <small><em><a href="$overflow_url" $:attrs>$ungettext('%(n)s other', '%(n)s others', remaining_authors, n=remaining_authors)</a></em></small>
 
 $code:
   if limit is None:

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -79,10 +79,10 @@ $code:
             $_('First published in %(year)s', year=doc.first_publish_year)
           </span>
         $if doc.get('edition_count'):
-          <a href="$work_edition_url#editions-list">$ungettext('1 edition', '%(count)d editions', doc.edition_count, count=doc.edition_count)</a>
+          <a href="$work_edition_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
           $if doc.get('languages'):
             <span class="languages">
-              $:ungettext('in <a class="hoverlink" title="%(langs)s">1 language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
+              $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))
             </span>
           $if doc.get('ia'):
             &mdash; $_('%s previewable', len(doc.get('ia')))

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -86,7 +86,7 @@ $else:
                     $ wlsize = book.get_waitinglist_size()
                     $if wlsize:
                         <div class="smallest lightgreen sansserif waitrank">
-                            $ungettext("There is %(count)d person waiting for this book.", "There are %(n)d people waiting for this book.", wlsize, n=wlsize)
+                            $ungettext("There is %(count)d person waiting for this book.", "There are %(count)d people waiting for this book.", wlsize, count=wlsize)
                         </div>
                 </td>
                 <td class="expires">

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -56,7 +56,7 @@ $else:
         <thead>
             <tr>
                 <th class="titles" colspan="2">
-                $ungettext("1 Current Loan", "%(count)d Current Loans", len(loans), count=len(loans))
+                $ungettext("%(count)d Current Loan", "%(count)d Current Loans", len(loans), count=len(loans))
                 </th>
                 <th class="expires">$_("Loan Expires")</th>
                 <th class="actions">$_("Loan actions")</th>
@@ -86,7 +86,7 @@ $else:
                     $ wlsize = book.get_waitinglist_size()
                     $if wlsize:
                         <div class="smallest lightgreen sansserif waitrank">
-                            $ungettext("There is one person waiting for this book.", "There are %(n)d people waiting for this book.", wlsize, n=wlsize)
+                            $ungettext("There is %(count)d person waiting for this book.", "There are %(n)d people waiting for this book.", wlsize, n=wlsize)
                         </div>
                 </td>
                 <td class="expires">
@@ -140,7 +140,7 @@ $else:
               <thead>
                   <tr>
                       <th class="titles" colspan="2">
-                      $ungettext("1 book", "%(count)d books", len(waitinglist), count=len(waitinglist))
+                      $ungettext("%(count)d book", "%(count)d books", len(waitinglist), count=len(waitinglist))
                       </th>
                       <th class="status">$_("Status")</th>
                       <th class="actions">$_("Actions")</th>

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -33,7 +33,7 @@ $if shelf_count > 0:
 
   <div class="mybooks-list">
     $if q:
-      <span class="search-results-stats">$ungettext('1 hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
+      <span class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
     $else:
       <span class="mybooks-tools"><img src="/images/icons/icon_sort.png" alt="$_('Sorting by')" style="margin-right:10px;" width="9" height="11">
         $if sort_order == 'desc':

--- a/openlibrary/templates/authors/index.html
+++ b/openlibrary/templates/authors/index.html
@@ -21,7 +21,7 @@ $var title: $_('Authors')
         $for doc in results.docs:
             $ name = doc['name']
             $ work_count = doc['work_count']
-            $ work_count_str = ungettext("1 book", "%(count)d books", work_count, count=work_count)
+            $ work_count_str = ungettext("%(count)d book", "%(count)d books", work_count, count=work_count)
             $ date = ''
             $if 'birth_date' in doc or 'death_date' in doc:
                 $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')

--- a/openlibrary/templates/books/check.html
+++ b/openlibrary/templates/books/check.html
@@ -29,7 +29,7 @@ $var title: $_("Add a book")
                             $for a in work.authors:
                                 $a.name$cond(not loop.last, ',')
                         </span>
-                        <span class="resultPublisher">$ungettext('1 edition', '%(count)s editions', work.edition_count, count=commify(work.edition_count))
+                        <span class="resultPublisher">$ungettext('%(count)s edition', '%(count)s editions', work.edition_count, count=commify(work.edition_count))
                         $if work.first_publish_year:
                             <span class="smallest">&bull;</span> $_('First published in %(year)d', year=work.first_publish_year)
                         </span>

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -24,7 +24,7 @@ $if subjects:
               <p class="category-title">$presentable_subject_name</p>
               $if 'work_count' in subject:
                 $ count = commify(subject['work_count'])
-                <p class="category-count">$ungettext('1 Book', '%(count)s Books', subject['work_count'], count=count)</p>
+                <p class="category-count">$ungettext('%(count)s Book', '%(count)s Books', subject['work_count'], count=count)</p>
             </a>
           </div>
       </div>

--- a/openlibrary/templates/lib/history.html
+++ b/openlibrary/templates/lib/history.html
@@ -25,7 +25,7 @@ $ show_wikipedia_citation_link = page.wp_citation_fields
             $ url = changequery(m='history')
 
         $ latest = versions[0]
-        <li class="link inline"><a rel="nofollow" href="$url">$ungettext('1 revision', '%(count)d revisions', latest.revision, count=latest.revision)</a></li>
+        <li class="link inline"><a rel="nofollow" href="$url">$ungettext('%(count)d revision', '%(count)d revisions', latest.revision, count=latest.revision)</a></li>
         </ul>
         $if page.key.startswith("/works") or page.key.startswith("/books") or page.key.startswith("/authors"):
             $if cur_v:

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -44,7 +44,7 @@ $var title: $_('Lists')
                     $:_('from <a href="%(key)s">%(owner)s</a>', key=owner.key, owner=owner.displayname)
                 </div>
                 <div class="meta">
-                    $ msg = ungettext("1 item", "%(count)d items", len(list.seeds))
+                    $ msg = ungettext("%(count)d item", "%(count)d items", len(list.seeds))
                     $sprintf(msg, count=len(list.seeds))
                     | $_('Last modified %(date)s', date=datestr(list.last_modified))
                 </div>

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -16,7 +16,7 @@ $def with (list)
                 <span class="list-owner small grey"> $_('by') <a href="$owner.key">$owner.displayname</a></span>
 
             <div class="editions smaller">
-                $ungettext("1 item", "%(count)d items", len(list.seeds), count=len(list.seeds))
+                $ungettext("%(count)d item", "%(count)d items", len(list.seeds), count=len(list.seeds))
 
                 <span class="lightgreen">
                   $_('Last modified %(date)s', date=datestr(list.last_modified))

--- a/openlibrary/templates/lists/snippet.html
+++ b/openlibrary/templates/lists/snippet.html
@@ -11,7 +11,7 @@ $def with (list)
             <a href="$list.key" class="results"><b>$list.name</b></a>
         </h3>
         <span class="editions">
-            $ungettext('1 item','%(count)d items', len(list.seeds), count=len(list.seeds))
+            $ungettext('%(count)d item','%(count)d items', len(list.seeds), count=len(list.seeds))
             $if list.last_update:
                 | $_('Last modified %(date)s', date=datestr(list.last_modified))
         </span>

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -79,14 +79,14 @@ $if can_merge:
                     </label>
                     <ul>
                     $for doc in top.docs:
-                        <li><a href="$doc['key']'" target="new" title="$_('Open in a new window')">$doc['title']</a> <span class="smaller">$ungettext('1 edition', '%(count)d editions', doc['edition_count'], count=doc['edition_count']),
+                        <li><a href="$doc['key']'" target="new" title="$_('Open in a new window')">$doc['title']</a> <span class="smaller">$ungettext('%(count)s edition', '%(count)s editions', doc['edition_count'], count=doc['edition_count']),
                         $if doc.get('first_publish_year'):
                             <span title="$_('First published in')">$doc['first_publish_year']</span>
                         </span></li>
                     </ul>
                 </div>
                 <div class="data count">
-                    <a href="/authors/$k" target="new" title="$_('Visit this author\'s page in a new window')">$ungettext("1 work", "%(count)d works", top.num_found, count=top.num_found)</a>
+                    <a href="/authors/$k" target="new" title="$_('Visit this author\'s page in a new window')">$ungettext("%(count)d work", "%(count)d works", top.num_found, count=top.num_found)</a>
                 </div>
             </div>
     </div>

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -10,9 +10,9 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
     <h1>
         $page.name
         <span class="count" id="coversCount">
-            <em>Publisher</em> - <strong><span>$ungettext("1 work", "%(count)d works", page.work_count, count=page.work_count)</span></strong>
+            <em>Publisher</em> - <strong><span>$ungettext("%(count)d work", "%(count)d works", page.work_count, count=page.work_count)</span></strong>
             $if page.ebook_count > 0:
-                / <span class="ebookcount"><span id="ebooks">$ungettext("1 ebook", "%(count)s ebooks", page.ebook_count, count=commify(page.ebook_count))</span></span>
+                / <span class="ebookcount"><span id="ebooks">$ungettext("%(count)s ebook", "%(count)s ebooks", page.ebook_count, count=commify(page.ebook_count))</span></span>
             $else:
                 / 0 ebooks
             <span class="clickdata"></span>
@@ -76,7 +76,7 @@ $jsdef renderAuthors(authors):
         <span class="tag">
             <a href="$a.key" title="$_('See more books by, and learn about, this author')">$a.name</a>,
         </span>
-        <span class="count">$ungettext("1 book", "%(count)d books", a.count, count=a.count)</span>
+        <span class="count">$ungettext("%(count)d book", "%(count)d books", a.count, count=a.count)</span>
         <br/>
 <div id="resultsAuthors" class="widget-box">
     <div class="head">
@@ -99,7 +99,7 @@ $jsdef renderPublishers(publishers):
             $else:
                 <a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')&amp;publisher_facet=$p.name.replace('"', '\\"').replace('&','%26')" title="$_('Get more information about this publisher')">$p.name</a>,
         </span>
-        <span class="count">$ungettext("1 edition", "%(count)s editions", p.count, count=commify(p.count))</span>
+        <span class="count">$ungettext("%(count)s edition", "%(count)s editions", p.count, count=commify(p.count))</span>
          <br/>
 
 <div class="section clearfix"></div>

--- a/openlibrary/templates/recentchanges/merge/comment.html
+++ b/openlibrary/templates/recentchanges/merge/comment.html
@@ -17,7 +17,7 @@ $else:
 
     $if context == primary:
         $# comment in the primary record
-        $ungettext('Merged 1 duplicate %(type)s record into this primary.', 'Merged %(count)d duplicate %(type)s records into this primary.', len(duplicates), count=len(duplicates), type=type)
+        $ungettext('Merged %(count)d duplicate %(type)s record into this primary.', 'Merged %(count)d duplicate %(type)s records into this primary.', len(duplicates), count=len(duplicates), type=type)
         $:details
     $elif context in duplicates:
         $# comment in the duplicate record

--- a/openlibrary/templates/recentchanges/merge/view.html
+++ b/openlibrary/templates/recentchanges/merge/view.html
@@ -48,7 +48,7 @@ $ label = primary.name if type == "author" else primary.title
         </div>
 
         <p class="smallest gray sansserif">
-            $ungettext("1 record modified.", "%(count)d records modified.", len(change.changes), count=len(change.changes))
+            $ungettext("%(count)d record modified.", "%(count)d records modified.", len(change.changes), count=len(change.changes))
         </p>
     </div>
 

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -38,7 +38,7 @@ $ sort = query_param('sort', None)
 
     $if q and not results.error:
         $if results.num_found:
-            <div class="search-results-stats">$ungettext('1 hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
+            <div class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', results.num_found, count=commify(results.num_found))
               $if results.num_found > 1:
                 $:render_template("search/sort_options.html", selected_sort=sort, search_scheme="authors")
               $ user_can_merge = ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin())
@@ -53,7 +53,7 @@ $ sort = query_param('sort', None)
         $for doc in results.docs:
             $ n = doc['name']
             $ num = doc['work_count']
-            $ wc = ungettext("1 book", "%(count)d books", num, count=num)
+            $ wc = ungettext("%(count)d book", "%(count)d books", num, count=num)
             $ date = ''
             $if 'birth_date' in doc or 'death_date' in doc:
                 $ date = doc.get('birth_date', '') + ' - ' + doc.get('death_date', '')

--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -26,7 +26,7 @@ $var title: $_('Search Open Library for %s', q)
             <p class="sansserif red collapse">$:_('No hits for: %(query)s', query=escaped_query())</p>
 
         $else:
-            <p class="search-results-stats">$ungettext('About 1 result found in %(seconds)s', 'About %(count)s results found in %(seconds)s', num_found, count=commify(num_found), seconds="%.2f" % search_time)</p>
+            <p class="search-results-stats">$ungettext('About %(count)s result found', 'About %(count)s results found', num_found, count=commify(num_found)) $ungettext('in %(seconds)s second', 'in %(seconds)s seconds', search_time, seconds="%.2f" % search_time)</p>
 
         $:macros.FulltextResults(q, results, page=page)
 </div>

--- a/openlibrary/templates/search/publishers.html
+++ b/openlibrary/templates/search/publishers.html
@@ -22,7 +22,7 @@ $def with (q, result)
                 <a href="$p.key">$p.name</a>
 
                 <span class="count">
-                    <b>$ungettext("1 book", "%(count)d books", p.count, count=p.count)</b>
+                    <b>$ungettext("%(count)d book", "%(count)d books", p.count, count=p.count)</b>
                 </span>
             </li>
     </ul>

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -28,7 +28,7 @@ $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
 $if q:
     $ response = get_results(q, offset=offset, limit=results_per_page)
     $if not response.error:
-        <p class="search-results-stats">$ungettext('1 hit', '%(count)s hits', response.num_found, count=commify(response.num_found))</p>
+        <p class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', response.num_found, count=commify(response.num_found))</p>
 
 $if q and response.error:
     <strong>
@@ -63,7 +63,7 @@ $if q and not response.error:
                     <span class="black">$_("work")</span>
                 $else:
                     $doc['subject_type']
-            <span class="count">&nbsp;&nbsp;<b>$ungettext('1 book', '%(count)d books', doc['work_count'], count=doc['work_count'])</b>, $:render_type(doc['subject_type'])</span>
+            <span class="count">&nbsp;&nbsp;<b>$ungettext('%(count)d book', '%(count)d books', doc['work_count'], count=doc['work_count'])</b>, $:render_type(doc['subject_type'])</span>
         </li>
     </ul>
     $:macros.Pager(page, response.num_found, results_per_page)

--- a/openlibrary/templates/stats/readinglog.html
+++ b/openlibrary/templates/stats/readinglog.html
@@ -64,7 +64,7 @@ $def with (stats)
     <div class="mybooks-list">
      <ul class="list-books">
         $for book in stats['leaderboard']['most_wanted_month']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
       </ul>
     </div>
 
@@ -72,7 +72,7 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books">
         $for book in stats['leaderboard']['most_wanted_all']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
       </ul>
     </div>
 
@@ -81,7 +81,7 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books">
         $for book in stats['leaderboard']['most_read']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
       </ul>
     </div>
 
@@ -90,7 +90,7 @@ $def with (stats)
     <div class="mybooks-list">
       <ul class="list-books">
         $for book in stats['leaderboard']['most_rated_all']:
-            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added 1 time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
+            $:macros.SearchResultsWork(book['work'], decorations=ungettext("Added %(count)d time", "Added %(count)d times", book['cnt'], count=book['cnt']), availability=book.get('availability'))
       </ul>
     </div>
   </div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -12,7 +12,7 @@ $ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), 
     </h1>
     <span class="heading">
         <span class="count" id="coversCount">
-            <strong><span><a href="/search?$page.subject_type=$page.name.replace('&','%26')" title="$_('See all works')">$ungettext("1 work", "%(count)d works", page.work_count, count=page.work_count)</a></span></strong>
+            <strong><span><a href="/search?$page.subject_type=$page.name.replace('&','%26')" title="$_('See all works')">$ungettext("%(count)d work", "%(count)d works", page.work_count, count=page.work_count)</a></span></strong>
         </span>
     </span>
     <a href="#search" class="shift">$_('Search for books with subject %(name)s.', name=page.name)</a>
@@ -81,7 +81,7 @@ $jsdef renderAuthors(authors):
         <span class="tag">
             <a href="$a.key" title="$_('See more books by, and learn about, this author')">$a.name</a>,
         </span>
-        <span class="count">$ungettext("1 book", "%(count)d books", a.count, count=a.count)</span>
+        <span class="count">$ungettext("%(count)d book", "%(count)d books", a.count, count=a.count)</span>
         <br/>
 <div id="resultsAuthors" class="widget-box">
   <div class="head">
@@ -104,7 +104,7 @@ $jsdef renderPublishers(publishers):
             $else:
                 <a href="/search?${page.subject_type}_facet=$page.name.replace('&','%26')&amp;publisher_facet=$p.name.replace('"', '\\"').replace('&','%26')" title="$_('Get more information about this publisher')">$p.name</a>,
         </span>
-        <span class="count">$ungettext("1 edition", "%(count)s editions", p.count, count=commify(p.count))</span>
+        <span class="count">$ungettext("%(count)s edition", "%(count)s editions", p.count, count=commify(p.count))</span>
         <br/>
 
 $if "lists" in ctx.features:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -114,7 +114,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
         <div class="clearfix"></div>
         <div id="works" class="section">
                 <h2 class="collapse">
-                    $ungettext("1 work", "%(count)d works", books.num_found, count=books.num_found)
+                    $ungettext("%(count)d work", "%(count)d works", books.num_found, count=books.num_found)
                     <span class="count smaller"><a href="/books/add?author=$page.key">$_('Add another?')</a></span>
                 </h2>
                 <p id="books">

--- a/openlibrary/templates/type/list/embed.html
+++ b/openlibrary/templates/type/list/embed.html
@@ -9,7 +9,7 @@ $ page = safeint(query_param('page'), 1) - 1
 $ page_size = 10
 
 $def render_seed_count(seed_count):
-    $ungettext("1 item", "%(count)d items", seed_count, count=seed_count)
+    $ungettext("%(count)d item", "%(count)d items", seed_count, count=seed_count)
 
 <div id="contentHead" style="margin-bottom:0;">
     <div class="superNav">

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -32,7 +32,7 @@ $add_metatag(property="og:image", content=request.canonical_url + "/preview.png"
 $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
 $jsdef render_seed_count(seed_count):
-    $ungettext("1 item", "%(count)d items", seed_count, count=seed_count)
+    $ungettext("%(count)d item", "%(count)d items", seed_count, count=seed_count)
 
 $if not is_owner:
     <div id="contentHead" style="margin-bottom:0;">

--- a/openlibrary/templates/type/work/editions_datatable.html
+++ b/openlibrary/templates/type/work/editions_datatable.html
@@ -6,7 +6,7 @@ $ edition_list_start = time()
 $if editions_limit or (len(editions) < work.edition_count):
   <p class="small sansserif featured-count">
 
-    $ungettext('Showing one featured edition.', 'Showing %(count)d featured editions.', len(editions), count=len(editions))
+    $ungettext('Showing %(count)d featured edition.', 'Showing %(count)d featured editions.', len(editions), count=len(editions))
     <a href="?mode=all">$_("View all %(count)d editions?", count=work.edition_count)</a>
   </p>
 $if editions and len(editions):

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -187,7 +187,7 @@ $ )
 
     $elif param and not error and len(docs):
         <div class="search-results-stats">
-          $ungettext('1 hit', '%(count)s hits', num_found, count=commify(num_found))
+          $ungettext('%(count)s hit', '%(count)s hits', num_found, count=commify(num_found))
 
           $if num_found > 1:
             $:render_template("search/sort_options.html", sort)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7579 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
This takes care of the issue elaborated on in #7579 by editing each (relevant) file in [this GitHub search](https://github.com/search?q=repo%3Ainternetarchive%2Fopenlibrary+%2Fungettext%5C%28%5B%27%22%5D1%2F&type=code&p=1).

However, there are two items to which I'd like to draw attention.

#### Changing Plural-Forms to account for floats < 2

`"Plural-Forms: nplurals=2; plural=(n > 1)\n"` is changed to `"Plural-Forms: nplurals=2; plural=(n >= 2)\n"` so that floats less than `2`, e.g. `1.59`, are rendered as singular, based on my understanding that if a number is greater than one but less than two, the noun associated with that number is grammatically singular.

Note, this does nothing to address the fact that in French `1.59` should be `1,59`.

#### Cases with two variables, where one might be plural and the other singular

There was [one case](https://github.com/internetarchive/openlibrary/blob/e2817ae119da6427567f9006d5501bbeb76fbb86/openlibrary/templates/search/inside.html#L29) where an i18n string had two variables, one for the number of results, and another for the number of seconds. Because it was possible for one variable to be singular, and the other to be plural, I made the following rather ugly change:

This: `<p class="search-results-stats">$ungettext('About 1 result found in %(seconds)s', 'About %(count)s results found in %(seconds)s', num_found, count=commify(num_found), seconds="%.2f" % search_time)</p>`

Became this: `<p class="search-results-stats">$ungettext('About %(count)s result found', 'About %(count)s results found', num_found, count=commify(num_found)) $ungettext('in %(seconds)s second', 'in %(seconds)s seconds', search_time, seconds="%.2f" % search_time)</p>
`

I would love a better way to handle this, but I could not come up with one. It does not seem gettext supports this case natively.

#### Other notes
- I made each language its own commit to make it easier, I hope, to revert this in part if I made mistakes.
- I had trouble with Chinese and the template mentioned above where there were two variables, `seconds` and `count`. I updated `zh/messages.po` to reflect the updated format, but marked the translation for `seconds` and `count` as `fuzzy`.
- I only made changes to languages currently linked in `openlibrary/templates/languages/language_list.html`.
  - For Czech and Telugu there was nothing to update so I changed nothing for them. (As an aside, Czech does not currently validate).
  - French, German, Spanish, Croatian, Portuguese, Ukrainian, and Chinese were updated and all validate.
- I changed `%(count)d edition` to `%(count)s edition` in a few places because the various templates used both `%(count)d` and `%(count)s for the translation of `edition`, and because `%s` can display both strings and digits, I figured I'd unify them around `%s` so translators didn't have to have both `%(count)s edition` and `%(count)d edition`. This change applies to:
  - `SearchResultsWork.html`
  - `merge/authors.html`
- I updated the example for singular/plural in the [Internationalization (i18n) - For programmers](https://github.com/internetarchive/openlibrary/wiki/Frontend-Guide#internationalization-i18n---for-programmers) section of the Frontend Guide on the wiki. I also added a "don't" to the Dos and Don'ts.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The modified `messages.po` all validate, and the unit tests pass. This won't catch any mistakes I made in typing strings; I tried very hard to double check everything.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini, @cclauss, @tfmorris  

~~I am still working on this as I need to update `messages.po` for the other languages, and update the wiki articles to help people avoid hard coding in `1 <whatever>` for singular nouns.~~

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
