### PR TITLE
Configure nginx to only serve OL on correct server_name

### DIFF
--- a/docker/covers_nginx.conf
+++ b/docker/covers_nginx.conf
@@ -1,5 +1,8 @@
+include /etc/nginx/sites-available/public_nginx.conf;
+
 server {
-      include /etc/nginx/sites-available/public_nginx.conf;
+      listen 80;
+      listen 443;
       server_name  covers.openlibrary.org;
 
       root /openlibrary;

--- a/docker/public_nginx.conf
+++ b/docker/public_nginx.conf
@@ -3,10 +3,11 @@
 # Sets up HTTP2 listening on 443 with ssl_protocols and ssl_ciphers.
 # Should be used for all public facing Nginx instances.
 
-#server {
+server {
     listen 80 default;
     listen [::]:443 ssl http2 ipv6only=on;
     listen 443 ssl http2;
+    server_name localhost;
 
     ssl_certificate /run/secrets/ssl_certificate;
     ssl_certificate_key /run/secrets/ssl_certificate_key;
@@ -16,4 +17,4 @@
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
     ssl_prefer_server_ciphers on;
-#}
+}

--- a/docker/web_nginx.conf
+++ b/docker/web_nginx.conf
@@ -16,8 +16,11 @@ upstream webnodes {
     server web_haproxy:7072;
 }
 
+include /etc/nginx/sites-available/public_nginx.conf;
+
 server {
-    include /etc/nginx/sites-available/public_nginx.conf;
+    listen 80;
+    listen 443;
     server_name  openlibrary.org;
 
     # Set the referrer policy so browsers send referrers to our own servers


### PR DESCRIPTION
Have other server names 404

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested on ol-www0 with etc hosts, and worked

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles @cclauss @samuel-archive 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
