### PR TITLE
Add --no-cache when fully resetting the development environment

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -188,9 +188,9 @@ Been away for a while? Are you getting strange errors you weren't getting before
 # Stop the site
 docker compose down
 
-# Build the latest oldev image, whilst also pulling the latest olbase image from docker hub
-# (Takes a while; ~20min for me)
-docker compose build --pull
+# Build the latest oldev image, without cache, whilst also pulling the latest olbase image from docker hub.
+# This can take from a few minutes to more than 20 on older hardware.
+docker compose build --pull --no-cache
 
 # Remove any old containers; if you use docker for something special, and have containers you don't want to lose, be careful with this. But you likely don't :)
 docker container prune


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
I propose adding `--no-cache` to the "Fully Resetting Your Environment" section of the Docker `README.md`. I have had to use `--no-cache` a few times, including a few moments ago, and at the cost of perhaps a few minutes of CPU time, it may help people avoid Docker woes.

Anyway, just a proposal. :)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
