### PR TITLE
Make MergeUI work reference network errors non-blocking

### DIFF
--- a/openlibrary/components/MergeUI/MergeRowReferencesField.vue
+++ b/openlibrary/components/MergeUI/MergeRowReferencesField.vue
@@ -1,22 +1,22 @@
 <template>
     <div v-if="record.type.key === '/type/work' && (!merged || (merged && record != merged.record))">
-        <div class="list-counts" v-if="lists">
-            <a v-if="lists[record.key].error" :href="`${record.key}/-/lists`" title="Network error: failed to load">⚠️&#xFE0E; lists</a>
+        <div class="list-counts">
+            <span v-if="!lists">⏳ lists</span>
+            <a v-else-if="lists[record.key].error" :href="`${record.key}/-/lists`" title="Network error: failed to load">⚠️&#xFE0E; lists</a>
             <a v-else :href="`${record.key}/-/lists`">{{lists[record.key].size}} list{{lists[record.key].size == 1 ? '' : 's'}}</a>
         </div>
-        <div v-else>⏳ lists</div>
-        <div class="bookshelf-counts" v-if="bookshelves">
+        <div class="bookshelf-counts">
             RL:
-            <span v-if="bookshelves[record.key].error" title="Network error: failed to load">⚠️&#xFE0E;</span>
+            <span v-if="!bookshelves">⏳ / ⏳ / ⏳</span>
+            <span v-else-if="bookshelves[record.key].error" title="Network error: failed to load">⚠️&#xFE0E;</span>
             <span v-else><span v-for="(value, name, index) in bookshelves[record.key].counts" :key="index" :title="name">{{value}}</span></span>
         </div>
-        <div v-else>RL: ⏳ / ⏳ / ⏳</div>
-        <div class="ratings-counts" v-if="ratings">
+        <div class="ratings-counts">
             Ratings:
-            <span v-if="ratings[record.key].error" title="Network error: failed to load">⚠️&#xFE0E;</span>
+            <span v-if="!ratings">⏳</span>
+            <span v-else-if="ratings[record.key].error" title="Network error: failed to load">⚠️&#xFE0E;</span>
             <span v-else>{{ratings[record.key].summary.count}}</span>
         </div>
-        <div v-else>Ratings: ⏳</div>
     </div>
     <div class="list-counts" v-else-if="merged && record == merged.record">{{merged.list_count}} list{{merged.list_count == 1 ? '' : 's'}}</div>
 </template>

--- a/openlibrary/components/MergeUI/MergeRowReferencesField.vue
+++ b/openlibrary/components/MergeUI/MergeRowReferencesField.vue
@@ -1,21 +1,22 @@
 <template>
     <div v-if="record.type.key === '/type/work' && (!merged || (merged && record != merged.record))">
         <div class="list-counts" v-if="lists">
-        <a :href="`${record.key}/-/lists`">{{lists[record.key].size}} list{{lists[record.key].size == 1 ? '' : 's'}}</a>
+            <a v-if="lists[record.key].error" :href="`${record.key}/-/lists`" title="Network error: failed to load">⚠️&#xFE0E; lists</a>
+            <a v-else :href="`${record.key}/-/lists`">{{lists[record.key].size}} list{{lists[record.key].size == 1 ? '' : 's'}}</a>
         </div>
-        <div v-else>⏳</div>
+        <div v-else>⏳ lists</div>
         <div class="bookshelf-counts" v-if="bookshelves">
-        RL: <span v-for="(value, name, index) in bookshelves[record.key]" :key="index" :title="name">
-            {{value}}
-        </span>
+            RL:
+            <span v-if="bookshelves[record.key].error" title="Network error: failed to load">⚠️&#xFE0E;</span>
+            <span v-else><span v-for="(value, name, index) in bookshelves[record.key].counts" :key="index" :title="name">{{value}}</span></span>
         </div>
         <div v-else>RL: ⏳ / ⏳ / ⏳</div>
-
-        <div>
-        Ratings:
-            <span v-if="ratings">{{ratings[record.key].summary.count}}</span>
-            <span v-else>⏳</span>
+        <div class="ratings-counts" v-if="ratings">
+            Ratings:
+            <span v-if="ratings[record.key].error" title="Network error: failed to load">⚠️&#xFE0E;</span>
+            <span v-else>{{ratings[record.key].summary.count}}</span>
         </div>
+        <div v-else>Ratings: ⏳</div>
     </div>
     <div class="list-counts" v-else-if="merged && record == merged.record">{{merged.list_count}} list{{merged.list_count == 1 ? '' : 's'}}</div>
 </template>

--- a/openlibrary/components/MergeUI/MergeRowReferencesField.vue
+++ b/openlibrary/components/MergeUI/MergeRowReferencesField.vue
@@ -18,7 +18,7 @@
             <span v-else>{{ratings[record.key].summary.count}}</span>
         </div>
     </div>
-    <div class="list-counts" v-else-if="merged && record == merged.record">{{merged.list_count}} list{{merged.list_count == 1 ? '' : 's'}}</div>
+    <div class="list-counts" v-else-if="merged && record == merged.record && merged.list_count != null">{{merged.list_count}} list{{merged.list_count == 1 ? '' : 's'}}</div>
 </template>
 
 <script>

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -146,7 +146,7 @@ export default {
             );
             const responses = promises.map(p => p.value || p);
             return _.fromPairs(
-                this.records.map((work, i) => [work.key, responses[i].counts])
+                this.records.map((work, i) => [work.key, responses[i]])
             );
         },
 

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -163,7 +163,7 @@ export default {
         },
 
         async merge() {
-            if (!this.master_key || !this.records || !this.editions || !this.lists || !this.bookshelves)
+            if (!this.master_key || !this.records || !this.editions)
                 return undefined;
 
             const master = this.records.find(r => r.key === this.master_key);

--- a/openlibrary/components/MergeUI/MergeTable.vue
+++ b/openlibrary/components/MergeUI/MergeTable.vue
@@ -181,7 +181,7 @@ export default {
 
             const extras = {
                 edition_count: _.sum(records.map(r => this.editions[r.key].size)),
-                list_count: _.sum(records.map(r => this.lists[r.key].size))
+                list_count: (this.lists) ? _.sum(records.map(r => this.lists[r.key].size)) : null
             };
 
             const unmergeable_works = this.records

--- a/openlibrary/components/MergeUI/utils.js
+++ b/openlibrary/components/MergeUI/utils.js
@@ -136,21 +136,21 @@ export function get_editions(work_key) {
 export function get_lists(key, limit=10) {
     return fetch(`${key}/lists.json?${new URLSearchParams({ limit })}`).then(r => {
         if (r.ok) return r.json();
-        if (confirm(`Network error; failed to load list data for ${key}. Click OK to reload.`)) location.reload();
+        return {error: true};
     });
 }
 
 export function get_bookshelves(key) {
     return fetch(`${key}/bookshelves.json`).then(r => {
         if (r.ok) return r.json();
-        if (confirm(`Network error; failed to load reading log data for ${key}. Click OK to reload.`)) location.reload();
+        return {error: true};
     });
 }
 
 export function get_ratings(key) {
     return fetch(`${key}/ratings.json`).then(r => {
         if (r.ok) return r.json();
-        if (confirm(`Network error; failed to load ratings for ${key}. Click OK to reload.`)) location.reload();
+        return {error: true};
     });
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addresses #7608

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR modifies the MergeUI workflow so that network errors when retrieving counts for lists, reading logs, and ratings don't block the entire merge process. Failures instead display a warning symbol to indicate that something has gone wrong, and the Super Librarian can make the decision whether to attempt a reload or continue with the merge.

Failures to load edition data continue to be blocking, as not having this data could create a bad merge.

### Technical
Rather than throwing a JS alert on network errors, the relevant functions in utils.js now pass back an error value, which is handled by the Vue component.

### Testing
Setup an arbitrary merge — the more works, the more likely you'll have failures. Unfortunately, the performance issue seems to be happening mostly in production, so this may be hard to test elsewhere.

### Screenshot

<img width="522" alt="Screenshot 2023-03-10 at 3 37 17 PM" src="https://user-images.githubusercontent.com/886889/224433762-66dd534f-e4f1-480b-8361-d150d523ea1c.png">

### Stakeholders
@cdrini @mheiman @seabelis 
