### PR TITLE
Add unit tests for syncReadingLogDropdownRemoveWithPrimaryButton

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -241,7 +241,7 @@ export function clearCreateListForm() {
  * This sets up the 'Remove From Shelf' button to behave as if it were the
  * primaryButton in terms of removal from a shelf.
  */
-function syncReadingLogDropdownRemoveWithPrimaryButton(dropper) {
+export function syncReadingLogDropdownRemoveWithPrimaryButton(dropper) {
     const primaryForm = dropper.querySelector('.readingLog')
     const shelfToRemoveFrom = primaryForm.querySelector('[name=bookshelf_id]').value
     const removalForm = dropper.querySelector('#remove-from-list')

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -209,3 +209,16 @@ export const checkInForm = `
   </form>
 </div>
 `
+
+export const readingLogDropperForm = `
+<div id="dropper">
+    <form class="readingLog">
+        <input type="hidden" name="bookshelf_id" value="1">
+        <input type="hidden" name="action" value="">
+    </form>
+    <form id="remove-from-list">
+        <input type="hidden" name="bookshelf_id">
+        <button class="hidden">Remove From Shelf</button>
+    </form>
+</div>
+`

--- a/tests/unit/js/lists.test.js
+++ b/tests/unit/js/lists.test.js
@@ -1,5 +1,5 @@
-import { clearCreateListForm } from '../../../openlibrary/plugins/openlibrary/js/lists/index.js';
-import { listCreationForm } from './html-test-data';
+import { clearCreateListForm, syncReadingLogDropdownRemoveWithPrimaryButton } from '../../../openlibrary/plugins/openlibrary/js/lists/index.js';
+import { listCreationForm, readingLogDropperForm } from './html-test-data';
 
 describe('clearCreateListForm', () => {
     document.body.innerHTML = listCreationForm
@@ -14,3 +14,63 @@ describe('clearCreateListForm', () => {
         expect(listDesc.value.length).toBe(0)
     })
 })
+
+describe('syncReadingLogDropdownRemoveWithPrimaryButton', () => {
+    test('displays remove-from-shelf button only if book is on a shelf', () => {
+        // Setup
+        document.body.innerHTML = readingLogDropperForm
+        const dropper = document.querySelector('#dropper');
+
+        // Add "remove" to the action to simulate a book on the shelf
+        document.querySelector('[name=action]').value = 'remove'
+
+        // Test
+        syncReadingLogDropdownRemoveWithPrimaryButton(dropper);
+
+        // Verify
+        const removalButton = dropper.querySelector('#remove-from-list button');
+        expect(removalButton.classList.contains('hidden')).toBe(false);
+
+        // Teardown
+        document.body.innerHTML = '';
+    });
+
+    test('hides remove-from-shelf button if book is not on a shelf', () => {
+        // Setup
+        document.body.innerHTML = readingLogDropperForm
+        const dropper = document.querySelector('#dropper');
+
+        // Add "add" to the action to simulate a book off the shelf
+        document.querySelector('[name=action]').value = 'add'
+
+        // Test
+        syncReadingLogDropdownRemoveWithPrimaryButton(dropper);
+
+        // Verify
+        const removalButton = dropper.querySelector('#remove-from-list button');
+        expect(removalButton.classList.contains('hidden')).toBe(true);
+
+        // Teardown
+        document.body.innerHTML = '';
+    });
+
+    test('syncs bookshelf_id in remove-from-list form with primaryButton', () => {
+        // Setup
+        document.body.innerHTML = readingLogDropperForm
+        const dropper = document.querySelector('#dropper');
+
+        // Sync the shelf for removal.
+        document.querySelector('[name=bookshelf_id]').value = '2'
+
+        // Test
+        syncReadingLogDropdownRemoveWithPrimaryButton(dropper);
+
+        // Verify
+        const removalForm = dropper.querySelector('#remove-from-list')
+        const bookshelfIdInput = removalForm.querySelector('[name=bookshelf_id]');
+        expect(bookshelfIdInput.value).toBe('2');
+
+        // Teardown
+        document.body.innerHTML = '';
+    });
+});


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes no issue

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
Adds unit tests for syncReadingLogDropdownRemoveWithPrimaryButton. This also helps get the JS unit testing threshold back over 16%. :)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`docker-compose run --rm web npm run test`
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
