### PR TITLE
fix onboarding carousel breakpoint

### DIFF
--- a/openlibrary/templates/home/welcome.html
+++ b/openlibrary/templates/home/welcome.html
@@ -9,7 +9,7 @@ $def with (test=False)
     <div
       class="carousel carousel--progressively-enhanced"
       id="welcome_carousel"
-      data-config="$json_encode(['#welcome_carousel', 3, 3, 2, 1, 1])"
+      data-config="$json_encode(['#welcome_carousel', 3, 2, 2, 1, 1])"
     >
       <div class="carousel__item tutorial__item">
         <a


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5987 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix onboarding carousel inconsistent breakpoint that happens from screensize 1024px-1059px

**Previous**
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/90945854/224532158-92b69f21-cf4a-485f-b5d1-482fb1e7f4c3.png">


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**Current**
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/90945854/224532188-c4dda929-0ad1-4d44-bf8c-5ecaee0dec36.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tuminzee created issue
@jimchamp lead

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
