### PR TITLE
Python linting: Ignore ruff rule PLC1901

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.254
+    rev: v0.0.256
     hooks:
       - id: ruff
 
@@ -40,19 +40,19 @@ repos:
       - id: black  # See pyproject.toml for args
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
       - id: codespell  # See pyproject.toml for args
         additional_dependencies:
           - tomli
 
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.12.5
+    rev: v0.13.0
     hooks:
     - id: cython-lint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.0.1'
+    rev: 'v1.1.1'
     hooks:
       - id: mypy  # See pyproject.toml for args
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ ignore = [
     "F401",
     "F841",
     "I",
+    "PLC1901",  # `s == ''` can be simplified to `not s` as an empty string is falsey
 ]
 line-length = 200
 select = [
@@ -55,7 +56,7 @@ select = [
     "PLC",
     "W",
 ]
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.mccabe]
 max-complexity = 41


### PR DESCRIPTION
`s == ''` can be simplified to `not s` as an empty string is falsey

* https://github.com/internetarchive/openlibrary/pull/7652#issuecomment-1469339549

% `ruff rule PLC1901`
# compare-to-empty-string (PLC1901)

Derived from the **Pylint** linter.

Message formats:
* `{}` can be simplified to `{}` as an empty string is falsey