### PR TITLE
make expiry relative and fix databar styling

### DIFF
--- a/openlibrary/macros/FormatExpiry.html
+++ b/openlibrary/macros/FormatExpiry.html
@@ -1,24 +1,10 @@
 $def with(expiry)
 
 $if expiry:
-    $if render_once('expire-dates-js'):
-        <script type="text/javascript">
-        <!--
-        // window.q.push(function(){
-        //     \$(".localize-time").each(function() {
-        //         var expiry_utc = \$(this).attr("datetime");
-        //         var options = {hour: '2-digit', minute:'2-digit', month:'2-digit', day:'2-digit', year:'numeric'};
-        //         \$(this).html((new Date(expiry_utc)).toLocaleString([], options));
-        //     });
-        // });
-        //-->
-        </script>
-
     $ expiry_datetime = datetime_from_isoformat(expiry)
     <div class="local-date-time">
       $_('Expires')
-      <time class="localize-time"
-	    datetime="$datetimestr_utc(expiry_datetime)"
+      <time datetime="$datetimestr_utc(expiry_datetime)"
             title="$datetimestr_utc(expiry_datetime)">
 	    $datestr(expiry_datetime)
       </time>

--- a/openlibrary/macros/FormatExpiry.html
+++ b/openlibrary/macros/FormatExpiry.html
@@ -18,7 +18,8 @@ $if expiry:
     <div class="local-date-time">
       $_('Expires')
       <time class="localize-time"
-	    datetime="$datestr(expiry_datetime)">
+	    datetime="$datetimestr_utc(expiry_datetime)"
+            title="$datetimestr_utc(expiry_datetime)">
 	    $datestr(expiry_datetime)
       </time>
     </div>

--- a/openlibrary/macros/FormatExpiry.html
+++ b/openlibrary/macros/FormatExpiry.html
@@ -4,21 +4,21 @@ $if expiry:
     $if render_once('expire-dates-js'):
         <script type="text/javascript">
         <!--
-        window.q.push(function(){
-            \$(".localize-time").each(function() {
-                var expiry_utc = \$(this).attr("data-expiry-utc");
-                var options = {hour: '2-digit', minute:'2-digit', month:'2-digit', day:'2-digit', year:'numeric'};
-                \$(this).html((new Date(expiry_utc)).toLocaleString([], options));
-            });
-        });
+        // window.q.push(function(){
+        //     \$(".localize-time").each(function() {
+        //         var expiry_utc = \$(this).attr("datetime");
+        //         var options = {hour: '2-digit', minute:'2-digit', month:'2-digit', day:'2-digit', year:'numeric'};
+        //         \$(this).html((new Date(expiry_utc)).toLocaleString([], options));
+        //     });
+        // });
         //-->
         </script>
 
     $ expiry_datetime = datetime_from_isoformat(expiry)
     <div class="local-date-time">
       $_('Expires')
-      <span class="localize-time"
-	    data-expiry-utc="$datetimestr_utc(expiry_datetime)">
-	$datetimestr_utc(expiry_datetime)
-      </span>
+      <time class="localize-time"
+	    datetime="$datestr(expiry_datetime)">
+	    $datestr(expiry_datetime)
+      </time>
     </div>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -46,9 +46,10 @@ $if user_loan:
   $if secondary_action:
     $ return_url = doc.url().rsplit('/', 1)[0] + '/do_return/borrow'
     <form action="$return_url" method="post"
-          class="waitinglist-form return-book">
+          class="waitinglist-form return-book" style="margin-bottom: 10px;">
       <input type="hidden" name="action" value="return" />
-      <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--shell" id="return_ebook"/>
+      <input type="submit" value="$_('Return eBook')" class="cta-btn cta-btn--shell" id="return_ebook" style="margin-bottom: 0px;" />
+      $:macros.FormatExpiry(user_loan['expiry'])
     </form>
     $if render_once('LoanStatus:return-book-js'):
       <script type="text/javascript">
@@ -60,7 +61,6 @@ $if user_loan:
           });
         });
       </script>
-  $:macros.FormatExpiry(user_loan['expiry'])
 
 $elif book_provider and book_provider.short_name != 'ia':
   $# Partner Trusted Book Provider Read Buttons

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -158,7 +158,7 @@ class borrow(delegate.page):
             stats.increment('ol.loans.return')
             edition.update_loan_status()
             user.update_loan_status()
-            raise web.seeother('/account/loans')
+            raise web.seeother(web.ctx.path)
         elif action == 'join-waitinglist':
             lending.s3_loan_api(edition.ocaid, s3_keys, action='join_waitlist')
             stats.increment('ol.loans.joinWaitlist')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7640 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

- [x] Investigate making the date relative. (under FormatExpiry.html) **datestr seems to be working for me, the conversion of utc to Singapore time is accurate, @cdrini perhaps you can check again if the conversion is correct for you using datestr**
- [x] Fix spacing on work page between the "Return eBook" button and the expiry; looks funky. (Under LoanStatus.html)
- [x] After returning book, don't go to /loans page. Reload current page

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="256" alt="image" src="https://user-images.githubusercontent.com/90945854/225250851-3a8b83be-e99a-4775-a1a9-79474738d224.png">
<img width="246" alt="image" src="https://user-images.githubusercontent.com/90945854/225251097-784ce86d-ce1f-4b4f-8996-4e81c1660beb.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
