### PR TITLE
Password Confirmation deleted

### DIFF
--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -99,12 +99,6 @@ class RegisterForm(Form):
             'password',
             description=_('Choose a password'),
             klass='required',
-            validators=[vpass],
-        ),
-        Password(
-            'password2',
-            description=_('Confirm password'),
-            klass='required',
             validators=[
                 vpass,
                 EqualToValidator('password', _("Passwords didn't match.")),

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -48,7 +48,6 @@ $else:
         $:field(form.email)
         $:field(form.username, suffix=str(screenname_url()))
         $:field(form.password)
-        $:field(form.password2)
 
         <br/>
         <label>


### PR DESCRIPTION
Closes: #7645 

Removed password confirmation object in the account creation form







<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
