### PR TITLE
change search request query to include escape character if theres illegal characters

### DIFF
--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -117,7 +117,7 @@ export class SearchBar {
         if (this.facet.read() === 'title') {
             this.$input.val(SearchBar.marshalBookSearchQuery(q));
         }
-        this.$input.val(SearchUtils.checkIllegalChars(q));
+        this.$input.val(SearchUtils.escapeIllegalChars(q));
         this.$form.attr('action', SearchBar.composeSearchUrl(this.facetEndpoint, this.$input.val()));
         SearchUtils.addModeInputsToForm(this.$form, SearchUtils.mode.read());
     }
@@ -211,7 +211,7 @@ export class SearchBar {
      */
     static composeSearchUrl(facetEndpoint, q, json=false, limit=null, fields=null) {
         let url = facetEndpoint;
-        q = SearchUtils.checkIllegalChars(q)
+        q = SearchUtils.escapeIllegalChars(q)
         if (json) {
             url += `.json?q=${q}&_spellcheck_count=0`;
         } else {

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -230,7 +230,7 @@ export class SearchBar {
      * @return {String}
      */
     static marshalBookSearchQuery(q) {
-        if (q && q.indexOf(':') === -1 && q.indexOf('"') === -1 && q.indexOf("'") === -1) {
+        if (q && q.indexOf(':') === -1 && q.indexOf('"') === -1 && q.indexOf('\'') === -1) {
             q = `title: "${q}"`;
         }
         return q;

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -210,6 +210,9 @@ export class SearchBar {
      */
     static composeSearchUrl(facetEndpoint, q, json=false, limit=null, fields=null) {
         let url = facetEndpoint;
+        if (["'", '"', ":"].some(illegalChar => q.indexOf(illegalChar) >= 0)) {
+            q = `"${q}"`;
+        }
         if (json) {
             url += `.json?q=${q}&_spellcheck_count=0`;
         } else {
@@ -228,7 +231,7 @@ export class SearchBar {
      * @return {String}
      */
     static marshalBookSearchQuery(q) {
-        if (q && q.indexOf(':') === -1 && q.indexOf('"') === -1) {
+        if (q && q.indexOf(':') === -1 && q.indexOf('"') === -1 && q.indexOf("'") === -1) {
             q = `title: "${q}"`;
         }
         return q;

--- a/openlibrary/plugins/openlibrary/js/SearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/SearchBar.js
@@ -113,10 +113,11 @@ export class SearchBar {
     }
 
     submitForm() {
+        const q = this.$input.val();
         if (this.facet.read() === 'title') {
-            const q = this.$input.val();
             this.$input.val(SearchBar.marshalBookSearchQuery(q));
         }
+        this.$input.val(SearchUtils.checkIllegalChars(q));
         this.$form.attr('action', SearchBar.composeSearchUrl(this.facetEndpoint, this.$input.val()));
         SearchUtils.addModeInputsToForm(this.$form, SearchUtils.mode.read());
     }
@@ -210,9 +211,7 @@ export class SearchBar {
      */
     static composeSearchUrl(facetEndpoint, q, json=false, limit=null, fields=null) {
         let url = facetEndpoint;
-        if (["'", '"', ":"].some(illegalChar => q.indexOf(illegalChar) >= 0)) {
-            q = `"${q}"`;
-        }
+        q = SearchUtils.checkIllegalChars(q)
         if (json) {
             url += `.json?q=${q}&_spellcheck_count=0`;
         } else {

--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -34,9 +34,10 @@ export function addModeInputsToForm($form, searchMode) {
  * If the input text contains illegal characters, enclose the input text with double quotes
  * @param {str} q the input text
  */
-export function checkIllegalChars(q) {
-    if (['\'', '"', ':'].some(illegalChar => q.indexOf(illegalChar) >= 0) && !(/^".*"$/.test(q))) {
-        return `"${q}"`;
+export function escapeIllegalChars(q) {
+    if (['\'', '"', ':'].some(illegalChar => q.indexOf(illegalChar) >= 0)) {
+        // escape the illegal characters that are not already escaped
+        q = q.replace(/([^\\](\\\\)*)(['":])/g, '$1\\$3');
     }
     return q
 }

--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -35,7 +35,7 @@ export function addModeInputsToForm($form, searchMode) {
  * @param {str} q the input text
  */
 export function checkIllegalChars(q) {
-    if ([`'`, `"`, ":"].some(illegalChar => q.indexOf(illegalChar) >= 0) && !(/^".*"$/.test(q))) {
+    if (['\'', '"', ':'].some(illegalChar => q.indexOf(illegalChar) >= 0) && !(/^".*"$/.test(q))) {
         return `"${q}"`;
     }
     return q

--- a/openlibrary/plugins/openlibrary/js/SearchUtils.js
+++ b/openlibrary/plugins/openlibrary/js/SearchUtils.js
@@ -30,6 +30,16 @@ export function addModeInputsToForm($form, searchMode) {
     }
 }
 
+/**
+ * If the input text contains illegal characters, enclose the input text with double quotes
+ * @param {str} q the input text
+ */
+export function checkIllegalChars(q) {
+    if ([`'`, `"`, ":"].some(illegalChar => q.indexOf(illegalChar) >= 0) && !(/^".*"$/.test(q))) {
+        return `"${q}"`;
+    }
+    return q
+}
 
 /**
  * @typedef {Object} PersistentValue.Options

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -95,7 +95,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
             </select>
           </label>
         </div>
-        <form class="search-bar-input" action="/search" method="get">
+        <form class="search-bar-input" action="/search">
           <input type="text" name="q" placeholder="$_('Search')" aria-label="Search" autocomplete="off">
           <input name="mode" type="checkbox" aria-hidden="true" aria-label="Search checkbox" checked="checked" value="" id="ftokenstop" class="hidden instantsearch-mode">
           <input type="submit" value="" class="search-bar-submit" aria-label="Search submit">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7618 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Upon clicking submit, change request query and input text field to include escape characters in front of the illegal characters

**Previous:** 
https://openlibrary.org/search?q=Cornell+%2777%3A+The+Music%2C+the+Myth+and+the+Magnificence+of+the+Grateful+Dead+Show+at+Barton+Hall&mode=everything

**Now:** 
https://openlibrary.org/search?q=Cornell+%5C%2777%5C%3A+The+Music%2C+the+Myth+and+the+Magnificence+of+the+Grateful+Dead+Show+at+Barton+Hall&mode=everything


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before search submit:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/90945854/225441259-02991d97-6736-4354-8613-4e11a75f0271.png">

After search submit:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/90945854/225702699-1295568a-5e26-4c62-abde-dbcb199242d6.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tfmorris created issue
@cdrini lead

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
