### PR TITLE
Add --no-audit to npm install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ A branch name consists of the: issue number, whether it is a feature/hotfix/refa
 With respect to client side patches, before submitting your patch you'll want to check it adheres to code styling rules and tests. We use `npm` to test our client side code.
 
 ```
-npm install
+npm install --no-audit
 npm test
 ```
 

--- a/conf/twa/README.md
+++ b/conf/twa/README.md
@@ -16,7 +16,7 @@ external dependencies.
 ### Installing Bubblewrap
 
 ```shell
-npm i -g @bubblewrap/cli
+npm i --no-audit -g @bubblewrap/cli
 ```
 
 ### Initializing an Android Project

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -13,4 +13,4 @@ RUN ln -s /home/openlibrary/.local/bin/pytest /usr/local/bin/pytest
 USER openlibrary
 
 COPY --chown=openlibrary:openlibrary package*.json ./
-RUN npm install
+RUN npm install --no-audit

--- a/docker/README.md
+++ b/docker/README.md
@@ -155,7 +155,7 @@ For changes to the frontend (JS, CSS, and HTML/[Templetor](http://webpy.org/docs
 
 Other changes:
 - **Editing pip packages?** Rebuild the `home` service: `docker compose build home`
-- **Editing npm packages?** Run `docker compose run --rm home npm install` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)
+- **Editing npm packages?** Run `docker compose run --rm home npm install --no-audit` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)
 - **Editing core dependencies?** You will most likely need to do a full rebuild. This shouldn't happen too frequently. If you are making this sort of change, you will know exactly what you are doing ;) See [Developing the Dockerfile](#developing-the-dockerfile).
 
 ## Useful Runtime Commands
@@ -175,7 +175,7 @@ docker compose run --rm home make test
 
 # Install Node.js modules (if you get an error running tests)
 # Important: npm jobs need to be run inside the Docker environment.
-docker compose run --rm home npm install
+docker compose run --rm home npm install --no-audit
 # build JS/CSS assets:
 docker compose run --rm home npm run build-assets
 ```

--- a/scripts/solr_restarter/Dockerfile
+++ b/scripts/solr_restarter/Dockerfile
@@ -4,7 +4,7 @@ FROM docker:latest
 RUN apk add --update nodejs npm
 
 # Install deps globally for this tiny image; don't create a node_modules folder
-RUN npm install -g node-fetch@2
+RUN npm install --no-audit -g node-fetch@2
 ENV NODE_PATH="/usr/local/lib/node_modules:$NODE_PATH"
 
 COPY . /app

--- a/tests/screenshots/README.md
+++ b/tests/screenshots/README.md
@@ -10,7 +10,7 @@ $ port install node (MacPorts)
  or
 $ brew install node (Homebrew)
 
-$ npm install
+$ npm install --no-audit
 ````
 
 ## Running tests


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7671 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This disables the automatic NPM audit by adding `--no-audit` to:
- every reference to `npm install`, and
- every reference to `npm i`

```
❯ rg "npm i"
tests/screenshots/README.md
13:$ npm install --no-audit

CONTRIBUTING.md
112:npm install --no-audit

docker/Dockerfile.oldev
16:RUN npm install --no-audit

docker/README.md
158:- **Editing npm packages?** Run `docker compose run --rm home npm install --no-audit` (see [#2032](https://github.com/internetarchive/openlibrary/issues/2032) for why)
178:docker compose run --rm home npm install --no-audit

conf/twa/README.md
19:npm i --no-audit -g @bubblewrap/cli

scripts/solr_restarter/Dockerfile
7:RUN npm install --no-audit -g node-fetch@2
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- `docker compose build --no-cache` to ensure the build works without relying on cache.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini, @imlakshay08

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
