### PR TITLE
Fix z-index book cover animation issue in Safari

### DIFF
--- a/static/css/components/illustration.less
+++ b/static/css/components/illustration.less
@@ -8,6 +8,7 @@
   text-align: center;
   margin-bottom: 10px;
   position: relative;
+  z-index: @z-index-level-1;
   img {
     width: 180px;
     border-radius: 5px;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -24,6 +24,8 @@ html {
   padding-right: 1.5em;
   .cover-animation {
     transition: transform .8s, opacity .8s;
+    position: relative;
+    z-index: @z-index-level-negative;
   }
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);


### PR DESCRIPTION
Closes #4924

This PR fixes a z-index issue that occurs on the book detail page and (seems to be) specific to Safari.

### Technical
This fix sets the `z-index` for the parent, and then sets the child to a negative `z-index` (relative to its parent context). This keeps the cover from jumping above anything while its animation effect is being painted and allows it to still be clickable.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. To test, please make sure the browser you test in is a narrow enough viewport size to make the "Browse" menu overlap the book image.
2. Navigate to a book detail page.
3. Click the "Browse" menu.
4. With the "Browse" menu still open/expanded, hover your cursor over the book cover image.
5. Interacting via hover with the book cover image should trigger an animation, but the image should stay beneath the menu.

I was able to replicate this issue and the fix in desktop **Safari v.14.1.2**.

I couldn't replicate this issue outside of desktop Safari; I tried to replicate it in the latest Chrome & Firefox (desktop), Android Firefox, and Xcode iOS Simulator (iPhone 12 Pro Max/iOS 14.4).

### Screenshot
Previously, if a user hovered on the cover illustration for a book while the "Browse" menu was open, the book image would appear on top of the menu:
<img width="725" alt="Screen Shot 2023-03-17 at 1 33 49 PM" src="https://user-images.githubusercontent.com/13765801/226062915-ffe34538-8f12-4991-a3bc-93508ec5a78e.png">

After this fix, the book image now stays underneath the menu when it is open:
<img width="725" alt="Screen Shot 2023-03-17 at 2 42 11 PM" src="https://user-images.githubusercontent.com/13765801/226062965-6a40a26d-d744-448e-9f0a-074964ff8618.png">

### Stakeholders
@cdrini 
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
