### PR TITLE
Fix F401 unused imports from the typing module

### DIFF
--- a/openlibrary/i18n/validators.py
+++ b/openlibrary/i18n/validators.py
@@ -1,6 +1,5 @@
 from itertools import groupby
 import re
-from typing import List
 
 from babel.messages.catalog import TranslationError, Message, Catalog
 from babel.messages.checkers import python_format

--- a/openlibrary/plugins/importapi/import_validator.py
+++ b/openlibrary/plugins/importapi/import_validator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 
 from pydantic import BaseModel, ValidationError, validator

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -9,7 +9,7 @@ import asyncio
 import itertools
 import logging
 import re
-from typing import List, Optional, TypedDict, cast
+from typing import Optional, TypedDict, cast
 from collections.abc import Iterable, Sized
 
 import httpx

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -6,7 +6,7 @@ import re
 from json import JSONDecodeError
 from math import ceil
 from statistics import median
-from typing import Literal, List, Optional, cast, Any, Union
+from typing import Literal, Optional, cast, Any, Union
 from collections.abc import Iterable
 
 import httpx

--- a/openlibrary/utils/solr.py
+++ b/openlibrary/utils/solr.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import List, Optional, TypeVar
+from typing import Optional, TypeVar
 from collections.abc import Callable, Iterable
 
 import requests

--- a/scripts/ipstats.py
+++ b/scripts/ipstats.py
@@ -15,7 +15,7 @@ import web
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 import infogami  # must be after _init_path
 from openlibrary.config import load_config
-from typing import Dict, IO, List
+from typing import IO
 
 
 def run_piped(cmds: list[list[str]], stdin: IO | None = None):

--- a/scripts/partner_batch_imports.py
+++ b/scripts/partner_batch_imports.py
@@ -15,7 +15,7 @@ import datetime
 import logging
 import os
 import re
-from typing import TypedDict, cast
+from typing import cast
 
 import requests
 

--- a/scripts/solr_builder/solr_builder/index_subjects.py
+++ b/scripts/solr_builder/solr_builder/index_subjects.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from asyncio import Future
-from typing import Literal, Set
+from typing import Literal
 
 import httpx
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
The fixer in `pyupgrade` was quite good at converting `List[str]` type hints into `list[str]` but it did not clean up the unused imports.  Fortunately `ruff --select=F403 --fix` can remove the unused imports from `typing`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make certain relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
