### PR TITLE
Renovate: Add a label for the datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
+  "datasourceRules": [
+    {
+      "matchDatasource": "pypi",
+      "labels": [
+        "Dependency Update from PyPI"
+      ]
+    }
+  ],
   "extends": [
     "config:base"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,6 @@
       "matchPackagePatterns": ["^actions/"],
       "automerge": true
     }
-  ]
+  ],
+  "prLabels": "{{#if datasource}}Renovate - {{datasource}}{{/if}}"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   "git-submodules": {
     "enabled": true
   },
+  "labels": [
+    "datasource:renovate"
+  ],
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements[^/]*\\.txt$"]
   },
@@ -19,7 +22,7 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["flake8", "mypy", "pytest", "pytest-asyncio", "safety"],
+      "matchPackageNames": ["mypy", "pytest", "pytest-asyncio", "ruff", "safety"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Adding a [datasource](https://docs.renovatebot.com/modules/datasource) label would make it easier to determine which Renovate PRs are for JavaScript vs. Python, etc.

Q: When https://github.com/renovatebot/renovate creates a pull request, can I configure it to add a label for the datasource?

ChatGPT3: 
Yes, you can configure Renovate to add a label for the datasource when it creates a pull request. To do this, you can use the labels option in your Renovate configuration file.

Here's an example configuration that sets a label called "datasource:renovate" for pull requests created by Renovate:
```json
{
  "labels": [
    "datasource:renovate"
  ]
}
```
You can customize the label name to fit your specific needs, and you can also add multiple labels if you want.

Once you've added this configuration to your Renovate file, any pull requests created by Renovate will automatically have the specified label(s) added to them.

---
### Regenerate response: ♻️

ChatGPT3:
Yes, you can configure Renovate to add a label to pull requests that it creates by using the prLabels configuration option.

To add a label for the datasource, you can use the datasource placeholder in the label string. For example, if you want to add a label called "Dependency Update - NPM" for NPM dependencies, you can use the following configuration:

```json
{
  "datasourceRules": [
    {
      "matchDatasource": "npm",
      "labels": [
        "Dependency Update - NPM"
      ]
    }
  ],
  "prLabels": "{{#if datasource}}Dependency Update - {{datasource}}{{/if}}"
}
```
In this configuration, datasourceRules are used to match the datasource (in this case, "npm"), and prLabels are used to add a label to the pull request using the datasource placeholder.

You can customize the label name and use different labels for different datasources by adding more datasourceRules with different labels.