### PR TITLE
Add Invisible reCaptcha on Registration Page

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -151,6 +151,10 @@ plugin_recaptcha:
     public_key: ''
     private_key: ''
 
+plugin_invisible_recaptcha:
+  public_key: ''
+  private_key: ''
+
 plugin_inside:
     search_endpoint: https://be-api.us.archive.org/fts/v1/search
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -253,9 +253,10 @@ class account_create(delegate.page):
 
     def get_recap(self):
         if self.is_plugin_enabled('recaptcha'):
-            public_key = config.plugin_recaptcha.public_key
-            private_key = config.plugin_recaptcha.private_key
-            return recaptcha.Recaptcha(public_key, private_key)
+        public_key = config.plugin_invisible_recaptcha.public_key  # Updated to use the new config entry
+        private_key = config.plugin_invisible_recaptcha.private_key  # Updated to use the new config entry
+        return recaptcha.Recaptcha(public_key, private_key)
+
 
     def is_plugin_enabled(self, name):
         return (

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -253,10 +253,9 @@ class account_create(delegate.page):
 
     def get_recap(self):
         if self.is_plugin_enabled('recaptcha'):
-        public_key = config.plugin_invisible_recaptcha.public_key  # Updated to use the new config entry
-        private_key = config.plugin_invisible_recaptcha.private_key  # Updated to use the new config entry
-        return recaptcha.Recaptcha(public_key, private_key)
-
+            public_key = config.plugin_invisible_recaptcha.public_key
+            private_key = config.plugin_invisible_recaptcha.private_key
+            return recaptcha.Recaptcha(public_key, private_key)
 
     def is_plugin_enabled(self, name):
         return (

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -3,6 +3,7 @@ $def with (form)
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:
 
 $var title: $_("Sign Up to Open Library")
+<script src="https://www.google.com/recaptcha/api.js"></script>
 
 <div id="contentHead">
     <h1>$_("Sign Up")</h1>
@@ -56,22 +57,17 @@ $else:
         </label>
 
         <hr/>
-
-        $if form.has_recaptcha:
-            <div class="formElement">
-                <div class="label smaller lighter">$_("If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA.")</div>
-                <div class="g-recaptcha" data-sitekey="$form['recaptcha'].public_key"></div>
-                <div class="input">
-                    $if form['recaptcha'].error:
-                        <span class="invalid clearfix">$_('Incorrect. Please try again.')</span>
-                </div>
-            </div>
-
+        <div class="label smaller lighter">$_("If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA.")</div>
+    <br/>
         <small>$:_("By signing up, you agree to the Internet Archive's <a href='//archive.org/about/terms.php' target='_blank'>Terms of Service</a>.")</small>
-
         <div class="formElement bottom">
+            <script>
+                function onSubmit(token) {
+                  document.getElementById("demo-form").submit();
+                }
+              </script>
             <br/>
-            <button type="submit" name="signup" id="signup" class="larger">$_("Sign Up")</button>
+            <button type="submit" name="signup" id="signup" class="g-recaptcha" data-sitekey="6LfRaxMlAAAAAHJk5I3MCt1WgfxH5b6gDg0Lzb7W" data-callback='onSubmit' data-action='submit'>$_("Sign Up")</button>
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>
     </form>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -56,8 +56,6 @@ $else:
         </label>
 
         <hr/>
-        <div class="label smaller lighter">$_("If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA.")</div>
-    <br/>
         <small>$:_("By signing up, you agree to the Internet Archive's <a href='//archive.org/about/terms.php' target='_blank'>Terms of Service</a>.")</small>
         <div class="formElement bottom">
             <script>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -3,7 +3,6 @@ $def with (form)
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:
 
 $var title: $_("Sign Up to Open Library")
-<script src="https://www.google.com/recaptcha/api.js"></script>
 
 <div id="contentHead">
     <h1>$_("Sign Up")</h1>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -67,7 +67,7 @@ $else:
                 }
               </script>
             <br/>
-            <button type="submit" name="signup" id="signup" class="g-recaptcha" data-sitekey="6LfRaxMlAAAAAHJk5I3MCt1WgfxH5b6gDg0Lzb7W" data-callback='onSubmit' data-action='submit'>$_("Sign Up")</button>
+            <button type="submit" name="signup" id="signup" class="g-recaptcha" data-sitekey="reCAPTCHA_site_key" data-callback='onSubmit' data-action='submit'>$_("Sign Up")</button>
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>
     </form>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -64,7 +64,8 @@ $else:
                 }
               </script>
             <br/>
-            <button type="submit" name="signup" id="signup" class="g-recaptcha" data-sitekey="reCAPTCHA_site_key" data-callback='onSubmit' data-action='submit'>$_("Sign Up")</button>
+            $ sitekey = form['recaptcha'].public_key if form.has_recaptcha else ''
+            <button type="submit" name="signup" id="signup" class="g-recaptcha larger" data-sitekey="$sitekey">$_("Sign Up")</button>
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>
     </form>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -58,14 +58,10 @@ $else:
         <hr/>
         <small>$:_("By signing up, you agree to the Internet Archive's <a href='//archive.org/about/terms.php' target='_blank'>Terms of Service</a>.")</small>
         <div class="formElement bottom">
-            <script>
-                function onSubmit(token) {
-                  document.getElementById("demo-form").submit();
-                }
-              </script>
+
             <br/>
             $ sitekey = form['recaptcha'].public_key if form.has_recaptcha else ''
-            <button type="submit" name="signup" id="signup" class="g-recaptcha larger" data-sitekey="$sitekey">$_("Sign Up")</button>
+             <button type="submit" name="signup" id="signup" class="g-recaptcha" data-sitekey="reCAPTCHA_site_key" data-callback='onSubmit' data-action='submit'>$_("Sign Up")</button>
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>
     </form>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7674
Closes #7695 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds a Invisible Google reCaptcha on registration page of Open Library.

### Screenshot
![Screenshot_20230319_140409](https://user-images.githubusercontent.com/77228428/226163316-1be46ec7-6871-47f6-9f57-3517a4d7a3eb.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
