### PR TITLE
Some miscellaneous Ruff fixes

### DIFF
--- a/openlibrary/admin/numbers.py
+++ b/openlibrary/admin/numbers.py
@@ -93,8 +93,10 @@ def admin_range__human_edits(**kargs):
     total_edits = result[0].count
     q1 = (
         "SELECT count(DISTINCT t.id) AS count FROM transaction t, version v WHERE "
-        "v.transaction_id=t.id AND t.created >= '%s' and t.created < '%s' AND "
-        "t.author_id IN (SELECT thing_id FROM account WHERE bot = 't')" % (start, end)
+        "v.transaction_id=t.id AND t.created >= '{}' and t.created < '{}' AND "
+        "t.author_id IN (SELECT thing_id FROM account WHERE bot = 't')".format(
+            start, end
+        )
     )
     result = db.query(q1)
     bot_edits = result[0].count
@@ -113,8 +115,10 @@ def admin_range__bot_edits(**kargs):
         raise TypeError("%s is a required argument for admin_range__bot_edits" % k)
     q1 = (
         "SELECT count(*) AS count FROM transaction t, version v WHERE "
-        "v.transaction_id=t.id AND t.created >= '%s' and t.created < '%s' AND "
-        "t.author_id IN (SELECT thing_id FROM account WHERE bot = 't')" % (start, end)
+        "v.transaction_id=t.id AND t.created >= '{}' and t.created < '{}' AND "
+        "t.author_id IN (SELECT thing_id FROM account WHERE bot = 't')".format(
+            start, end
+        )
     )
     result = db.query(q1)
     count = result[0].count

--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -383,4 +383,4 @@ def get_solr_keys():
     return [p.solr_key for p in PROVIDER_ORDER]
 
 
-setattr(get_book_provider, 'ia', get_book_provider_by_name('ia'))
+setattr(get_book_provider, 'ia', get_book_provider_by_name('ia'))  # noqa: B010

--- a/openlibrary/catalog/marc/fast_parse.py
+++ b/openlibrary/catalog/marc/fast_parse.py
@@ -1,5 +1,5 @@
-""" Deprecated module,
-    MARC parsing should be done by catalog.marc.parse instead.
+"""Deprecated module,
+MARC parsing should be done by catalog.marc.parse instead.
 """
 
 import re

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -553,14 +553,12 @@ def read_contributions(rec):
     :param (MarcBinary | MarcXml) rec:
     :rtype: dict
     """
-    want = dict(
-        (
-            ('700', 'abcdeq'),
-            ('710', 'ab'),
-            ('711', 'acdn'),
-            ('720', 'a'),
-        )
-    )
+    want = {
+        '700': 'abcdeq',
+        '710': 'ab',
+        '711': 'acdn',
+        '720': 'a',
+    }
     ret = {}
     skip_authors = set()
     for tag in ('100', '110', '111'):

--- a/openlibrary/catalog/marc/tests/test_parse.py
+++ b/openlibrary/catalog/marc/tests/test_parse.py
@@ -116,10 +116,10 @@ class TestParseMARCBinary:
         if not os.path.exists(expect_filename):
             # Missing test expectations file. Create a template from the input, but fail the current test.
             json.dump(edition_marc_bin, open(expect_filename, 'w'), indent=2)
-            assert (
-                False
-            ), 'Expectations file {} not found: template generated in {}. Please review and commit this file.'.format(
-                expect_filename, '/bin_expect'
+            raise AssertionError(
+                'Expectations file {} not found: template generated in {}. Please review and commit this file.'.format(
+                    expect_filename, '/bin_expect'
+                )
             )
         j = json.load(open(expect_filename))
         assert j, 'Unable to open test data: %s' % expect_filename

--- a/openlibrary/catalog/merge/names.py
+++ b/openlibrary/catalog/merge/names.py
@@ -241,7 +241,7 @@ def amazon_spaced_name(amazon, marc):
     if normalize(amazon_surname) != normalize(marc_surname):
         return False
     marc_first_parts = split_parts(m.group(2))
-    amazon_first_parts = [x for x in amazon_initals]
+    amazon_first_parts = list(amazon_initals)
     if compare_parts(marc_first_parts, amazon_first_parts):
         return True
     if match_seq(amazon_first_parts, marc_first_parts):

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -27,7 +27,6 @@ def get_status_for_view(status_code: int) -> str:
 
 
 class CommunityEditsQueue:
-
     """Schema
     id: Primary identifier
     submitter: username of person that made the request

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -76,7 +76,7 @@ class Batch(web.storage):
             i.e. of a format id_type:value which cannot be a valid IA id.
         """
         if not items:
-            return None
+            return
 
         logger.info("batch %s: adding %d items", self.name, len(items))
 
@@ -95,7 +95,7 @@ class Batch(web.storage):
                         pass
             logger.info("batch %s: added %d items", self.name, len(items))
 
-        return None
+        return
 
     def get_items(self, status="pending"):
         result = db.where("import_item", batch_id=self.id, status=status)

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -170,7 +170,7 @@ class Thing(client.Thing):
         key. If this method returns a string, it is sanitized and added to key
         after adding a "/".
         """
-        return None
+        return
 
     def _get_lists(self, limit=50, offset=0, sort=True):
         # cache the default case

--- a/openlibrary/mocks/mock_infobase.py
+++ b/openlibrary/mocks/mock_infobase.py
@@ -351,7 +351,7 @@ class MockStore(dict):
         return [doc['_key'] for doc in self._query(**kw)]
 
     def values(self, **kw):
-        return [doc for doc in self._query(**kw)]
+        return list(self._query(**kw))
 
     def items(self, **kw):
         return [(doc["_key"], doc) for doc in self._query(**kw)]

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -1,4 +1,4 @@
-""" 'Read' api implementation.  This is modeled after the HathiTrust
+"""'Read' api implementation.  This is modeled after the HathiTrust
 Bibliographic API, but also includes information about loans and other
 editions of the same work that might be available.
 """

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1046,7 +1046,7 @@ def is_bot():
     if not web.ctx.env.get('HTTP_USER_AGENT'):
         return True
     user_agent = web.ctx.env['HTTP_USER_AGENT'].lower()
-    return any([bot in user_agent for bot in user_agent_bots])
+    return any(bot in user_agent for bot in user_agent_bots)
 
 
 def setup_template_globals():

--- a/openlibrary/plugins/openlibrary/infobase_hook.py
+++ b/openlibrary/plugins/openlibrary/infobase_hook.py
@@ -1,6 +1,6 @@
 """Infobase hook for openlibrary.
 
-    * Log all modified book pages as required for the search engine.
+* Log all modified book pages as required for the search engine.
 """
 
 from infogami.infobase import config

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -399,7 +399,7 @@ class account_login(delegate.page):
             "/account/login",
             "/account/create",
         ]
-        if i.redirect == "" or any([path in i.redirect for path in blacklist]):
+        if i.redirect == "" or any(path in i.redirect for path in blacklist):
             i.redirect = "/account/books"
         raise web.seeother(i.redirect)
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -244,7 +244,7 @@ class borrow_status(delegate.page):
             'id': key,
             'loan_available': loan_available,
             'available_formats': available_formats,
-            'lending_subjects': [lending_subject for lending_subject in subjects],
+            'lending_subjects': list(subjects),
         }
 
         output_text = json.dumps(output)
@@ -728,7 +728,7 @@ def is_users_turn_to_borrow(user, edition):
 
 
 def is_admin():
-    """ "Returns True if the current user is in admin usergroup."""
+    """Returns True if the current user is in admin usergroup."""
     user = accounts.get_current_user()
     return user and user.key in [
         m.key for m in web.ctx.site.get('/usergroup/admin').members

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -669,7 +669,7 @@ class Work(models.Work):
                     not filter_unicode
                     or (subject.replace(' ', '').isalnum() and is_ascii(subject))
                 )
-                and all([char not in subject for char in blacklist_chars])
+                and all(char not in subject for char in blacklist_chars)
             ):
                 ok_subjects.append(subject)
         return ok_subjects

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -333,7 +333,6 @@ def get_mybooks_template(username, key, list):
 
 
 class ReadingLog:
-
     """Manages the user's account page books (reading log, waitlists, loans)"""
 
     # Constants

--- a/openlibrary/plugins/upstream/tests/test_forms.py
+++ b/openlibrary/plugins/upstream/tests/test_forms.py
@@ -6,7 +6,7 @@ class TestRegister:
     def test_validate(self, monkeypatch):
         monkeypatch.setattr(forms, 'find_account', lambda **kw: None)
         monkeypatch.setattr(forms, 'find_ia_account', lambda **kw: None)
-        monkeypatch.setattr(spamcheck, "get_spam_domains", lambda: [])
+        monkeypatch.setattr(spamcheck, "get_spam_domains", list)
 
         f = forms.Register()
         d = {

--- a/openlibrary/solr/find_modified_works.py
+++ b/openlibrary/solr/find_modified_works.py
@@ -94,7 +94,7 @@ def poll_for_changes(start_time_file, max_chunk_size, delay):
         url = date.strftime(BASE_URL + "%Y/%m/%d.json")
         logging.debug("-- Fetching changes from %s", url)
         changes = list(requests.get(url).json())
-        unseen_changes = list(x for x in changes if x['id'] not in seen)
+        unseen_changes = [x for x in changes if x['id'] not in seen]
         logging.debug("%d changes fetched", len(changes))
         logging.debug(" of which %d are unseen", len(unseen_changes))
 

--- a/openlibrary/solr/solrwriter.py
+++ b/openlibrary/solr/solrwriter.py
@@ -55,7 +55,6 @@ class SolrWriter:
         self.pending_updates.append(document)
         if len(self.pending_updates) >= 100:
             self.flush()
-        return
 
     def flush(self):
         if self.pending_updates:

--- a/scripts/import_standard_ebooks.py
+++ b/scripts/import_standard_ebooks.py
@@ -4,7 +4,7 @@ import requests
 import time
 from typing import Any, Optional
 
-import os.path as path
+from os import path
 
 import feedparser
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

[`ruff --fix`](https://beta.ruff.rs/docs/rules) enables us to clean up our code.  Not all rules should be fixed up but my sense is that these ones are OK.  I picked some rules that only have less than a handful of instances in our codebase.

ruff --select=B010,B011,C400,C406,C416,D208,D210,D211,PIE802,PIE807,PLR0402,PLR1711,RET501,UP031 --statistics .
```
1	B010   	[*] Do not call `setattr` with a constant attribute value. It is not any safer than normal property access.
1	B011   	[*] Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
1	C400   	[*] Unnecessary generator (rewrite as a `list` comprehension)
1	C406   	[*] Unnecessary `tuple` literal (rewrite as a `dict` literal)
3	C416   	[*] Unnecessary `list` comprehension (rewrite using `list()`)
2	D208   	[*] Docstring is over-indented
3	D210   	[*] No whitespaces allowed surrounding docstring text
2	D211   	[*] No blank lines allowed before class docstring
3	PIE802 	[*] Unnecessary list comprehension.
1	PIE807 	[*] Prefer `list` over useless lambda
1	PLR0402	[*] Use `from os import path` in lieu of alias
1	PLR1711	[*] Useless `return` statement at the end of a function
3	RET501 	[*] Do not explicitly `return None` in function if it is the only possible return value
2	UP031  	[*] Use format specifiers instead of percent format
```
### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
