### PR TITLE
updating antialias to lanczos

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -545,7 +545,7 @@ def render_list_preview_image(lst_key):
             basewidth = 162
             wpercent = basewidth / float(img.size[0])
             hsize = int(float(img.size[1]) * float(wpercent))
-            img = img.resize((basewidth, hsize), Image.ANTIALIAS)
+            img = img.resize((basewidth, hsize), Image.LANCZOS)
             image.append(img)
     max_height = 0
     for img in image:
@@ -576,7 +576,7 @@ def render_list_preview_image(lst_key):
     else:
         background.paste(image[0], (431, 174 + max_height - image[0].size[1]))
 
-    logo = logo.resize((120, 74), Image.ANTIALIAS)
+    logo = logo.resize((120, 74), Image.LANCZOS)
     background.paste(logo, (880, 14), logo)
 
     draw = ImageDraw.Draw(background)

--- a/openlibrary/coverstore/coverlib.py
+++ b/openlibrary/coverstore/coverlib.py
@@ -102,7 +102,7 @@ def resize_image(image, size):
         y = size[1]
     size = x, y
 
-    return image.resize(size, Image.ANTIALIAS)
+    return image.resize(size, Image.LANCZOS)
 
 
 def find_image_path(filename):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7678 
 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Modifies instances to remove deprecated ANTIALIAS.
 
### Technical
<!-- What should be noted about the implementation? -->
 
### Testing

The images generated are identical.
 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
 
![Old-M](https://user-images.githubusercontent.com/92345662/226709481-71d48c7b-e74a-4c56-90ce-68de309611c9.jpg)
![new-M](https://user-images.githubusercontent.com/92345662/226709540-6bfab375-29b4-4927-ad65-073afb303c18.jpg)

### Stakeholders
 
<!-- @ tag stakeholders of this bug -->
@cclauss 
 
<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->


