### PR TITLE
Prune older Docker images during deployments

### DIFF
--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -23,7 +23,7 @@ echo "Starting production deployment at $(date)"
 parallel --quote ssh {1} "echo -e '\n\n{}'; cd {2} && sudo git pull origin master" ::: $SERVERS ::: /opt/olsystem /opt/openlibrary
 
 # Get all Docker images and sort them by creation date
-images=($(docker image ls --format '{{.ID}} {{.CreatedAt}}' | sort -k 2 -r | awk '{print $1}'))
+images=($(docker image ls --format '{{.ID}} {{.CreatedAt}} {{.Repository}}' | grep 'openlibrary/olbase' | sort -k 2 -r | awk '{print $1}'))
 
 # Keep the first three images and remove the rest to save disk space
 for image in "${images[@]:3}"

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -22,11 +22,20 @@ echo "Starting production deployment at $(date)"
 # `sudo git pull origin master` the core Open Library repos:
 parallel --quote ssh {1} "echo -e '\n\n{}'; cd {2} && sudo git pull origin master" ::: $SERVERS ::: /opt/olsystem /opt/openlibrary
 
+# Get all Docker images and sort them by creation date
+images=($(docker image ls --format '{{.ID}} {{.CreatedAt}}' | sort -k 2 -r | awk '{print $1}'))
+
+# Keep the first three images and remove the rest to save disk space
+for image in "${images[@]:3}"
+do
+    docker rmi $image
+done
+
 # Rebuild & upload docker image for olbase
 cd /opt/openlibrary
 sudo make git
 set -e
-docker build -t openlibrary/olbase:latest -f docker/Dockerfile.olbase .
+docker build -t openlibrary/olbase:latest -t "openlibrary/olbase:deploy-$(date '+%Y-%m-%d')" -f docker/Dockerfile.olbase .
 docker login
 docker push openlibrary/olbase:latest
 set +e


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes: #4806
Closes: internetarchive/olsystem#74

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

* #4806

Our `openlibrary/olbase` Docker images on `ol-home0` are > 2GB each so let's automate the removal of older `openlibrary/olbase` images before creating a new one.  Avoid deleting any non-`openlibrary/olbase` images.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
ol-home0% `docker image ls`
```
REPOSITORY           TAG           IMAGE ID       CREATED         SIZE
openlibrary/olbase   3e9f6f8       a35ff4dd787f   2 weeks ago     2.08GB
openlibrary/olbase   latest        a35ff4dd787f   2 weeks ago     2.08GB
openlibrary/olbase   <none>        fc631b6a6748   2 weeks ago     2.08GB
openlibrary/olbase   solr-next     940e72eb6d45   5 weeks ago     2.03GB
openlibrary/olbase   c69c9f4       85cc7bab78a7   8 weeks ago     2.03GB
<none>               <none>        059e9513dfb1   2 months ago    2.02GB
openlibrary/olbase   9a2c50c       914d59154d1d   2 months ago    2.02GB
python               3.11.1-slim   aec03f3a1dc1   2 months ago    128MB
openlibrary/olbase   cb9decd       f7f607303c87   5 months ago    2.09GB
ubuntu               xenial        b6f507652425   18 months ago   135MB
```
ol-home0% `./cleanup_docker_images.sh`
```
940e72eb6d45
85cc7bab78a7
059e9513dfb1
914d59154d1d
aec03f3a1dc1
f7f607303c87
b6f507652425
```
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
