### PR TITLE
Moving to single password field for registration

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -526,4 +526,10 @@ jQuery(function () {
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
 
+    // Password visibility toggle:
+    const passwordVisibilityToggle = document.querySelector('.password-visibility-toggle')
+    if (passwordVisibilityToggle) {
+        import(/* webpackChunkName: "password-visibility-toggle" */ './password-toggle')
+            .then(module => module.initPasswordToggling(passwordVisibilityToggle))
+    }
 });

--- a/openlibrary/plugins/openlibrary/js/password-toggle.js
+++ b/openlibrary/plugins/openlibrary/js/password-toggle.js
@@ -4,15 +4,16 @@
  * @param {HTMLElement} elem Reference to affordance that toggles a password input's visibility
  */
 export function initPasswordToggling(elem) {
+    const i18nStrings = JSON.parse(elem.dataset.i18n)
     const passwordInput = document.querySelector('input[type=password]')
 
     elem.addEventListener('click', () => {
         if (passwordInput.type === 'password') {
             passwordInput.type = 'text'
-            elem.textContent = 'Hide password'
+            elem.textContent = i18nStrings['hide_password']
         } else {
             passwordInput.type = 'password'
-            elem.textContent = 'Show password'
+            elem.textContent = i18nStrings['show_password']
         }
     })
 }

--- a/openlibrary/plugins/openlibrary/js/password-toggle.js
+++ b/openlibrary/plugins/openlibrary/js/password-toggle.js
@@ -1,0 +1,18 @@
+/**
+ * Adds ability to toggle a password field's visibilty.
+ *
+ * @param {HTMLElement} elem Reference to affordance that toggles a password input's visibility
+ */
+export function initPasswordToggling(elem) {
+    const passwordInput = document.querySelector('input[type=password]')
+
+    elem.addEventListener('click', () => {
+        if (passwordInput.type === 'password') {
+            passwordInput.type = 'text'
+            elem.textContent = 'Hide password'
+        } else {
+            passwordInput.type = 'password'
+            elem.textContent = 'Show password'
+        }
+    })
+}

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -102,15 +102,6 @@ class RegisterForm(Form):
             klass='required',
             validators=[vpass],
         ),
-        Password(
-            'password2',
-            description=_('Confirm password'),
-            klass='required',
-            validators=[
-                vpass,
-                EqualToValidator('password', _("Passwords didn't match.")),
-            ],
-        ),
         Checkbox(
             'ia_newsletter',
             description=_(

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -56,7 +56,6 @@ $else:
         $:field(form.username, suffix=str(screenname_url()))
         $:field(form.password)
 
-        <br/>
         <label>
             $:form.ia_newsletter.render() $:form.ia_newsletter.description
         </label>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -30,7 +30,11 @@ $def field(input, suffix=''):
         <div class="input">
             $:input.render()
             $if input.name == 'password':
-                <a href="javascript:;" class="password-visibility-toggle">$_("Show password")</a>
+                $ i18n_strings = {
+                $    "show_password": _('Show password'),
+                $    "hide_password": _('Hide password')
+                $  }
+                <a href="javascript:;" class="password-visibility-toggle" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
             <span class="invalid clearfix" id="$(input.id)Message">$input.note</span>
             <span class="sansserif smaller lighter">$:suffix</span>
         </div>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -28,10 +28,9 @@ $def field(input, suffix=''):
                 <span class="smaller lighter">$input.help</span>
         </div>
         <div class="input">
-            <script src="https://kit.fontawesome.com/a076d05399.js"></script>
             $:input.render()
             $if input.name == 'password':
-            $:suffix
+                <a href="javascript:;" class="password-visibility-toggle">$_("Show password")</a>
             <span class="invalid clearfix" id="$(input.id)Message">$input.note</span>
             <span class="sansserif smaller lighter">$:suffix</span>
         </div>
@@ -74,31 +73,4 @@ $else:
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>
     </form>
-    <style>
-        #password-visibility-toggle {
-            font-size: 14px;
-            margin-left: 5px;
-            cursor: pointer;
-        }
-
-    </style>
-    <script>
-        window.addEventListener("load", function() {
-            var passwordInput = document.getElementById("password");
-            var passwordVisibilityToggle = document.createElement("span");
-            passwordVisibilityToggle.id = "password-visibility-toggle";
-            passwordVisibilityToggle.innerHTML = '<i class="far fa-eye"></i>';
-            passwordVisibilityToggle.addEventListener("click", function(e) {
-                e.preventDefault();
-                if (passwordInput.type === "password") {
-                    passwordInput.type = "text";
-                    passwordVisibilityToggle.innerHTML = '<i class="far fa-eye-slash"></i>';
-                } else {
-                    passwordInput.type = "password";
-                    passwordVisibilityToggle.innerHTML = '<i class="far fa-eye"></i>';
-                }
-            });
-            passwordInput.parentNode.appendChild(passwordVisibilityToggle);
-        });
-    </script>
 </div>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -80,7 +80,7 @@ $else:
             margin-left: 5px;
             cursor: pointer;
         }
-        
+
     </style>
     <script>
         window.addEventListener("load", function() {

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -28,11 +28,15 @@ $def field(input, suffix=''):
                 <span class="smaller lighter">$input.help</span>
         </div>
         <div class="input">
+            <script src="https://kit.fontawesome.com/a076d05399.js"></script>
             $:input.render()
+            $if input.name == 'password':
+            $:suffix
             <span class="invalid clearfix" id="$(input.id)Message">$input.note</span>
             <span class="sansserif smaller lighter">$:suffix</span>
         </div>
     </div>
+
 
 $if ctx.user:
     $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
@@ -48,7 +52,6 @@ $else:
         $:field(form.email)
         $:field(form.username, suffix=str(screenname_url()))
         $:field(form.password)
-        $:field(form.password2)
 
         <br/>
         <label>
@@ -71,5 +74,31 @@ $else:
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>
     </form>
-
+    <style>
+        #password-visibility-toggle {
+            font-size: 14px;
+            margin-left: 5px;
+            cursor: pointer;
+        }
+        
+    </style>
+    <script>
+        window.addEventListener("load", function() {
+            var passwordInput = document.getElementById("password");
+            var passwordVisibilityToggle = document.createElement("span");
+            passwordVisibilityToggle.id = "password-visibility-toggle";
+            passwordVisibilityToggle.innerHTML = '<i class="far fa-eye"></i>';
+            passwordVisibilityToggle.addEventListener("click", function(e) {
+                e.preventDefault();
+                if (passwordInput.type === "password") {
+                    passwordInput.type = "text";
+                    passwordVisibilityToggle.innerHTML = '<i class="far fa-eye-slash"></i>';
+                } else {
+                    passwordInput.type = "password";
+                    passwordVisibilityToggle.innerHTML = '<i class="far fa-eye"></i>';
+                }
+            });
+            passwordInput.parentNode.appendChild(passwordVisibilityToggle);
+        });
+    </script>
 </div>

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -85,7 +85,8 @@
   }
 
   input[type=number],
-  input[type=text] {
+  input[type=text],
+  input[type=password] {
     margin: 0 10px 5px 0;
   }
 


### PR DESCRIPTION
Closes #7645

An button to show and hide password

### Technical
<!-- What should be noted about the implementation? -->
Changes in html and a python file. Also used fontawesome eye icon
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
docker compose up , then  redirect to sign in page.
### Screenshot
Before
![Screenshot_2023-03-25-06-48-05_1920x1080](https://user-images.githubusercontent.com/69034460/227719579-86f5000d-faad-4737-bf4d-036aae772480.png)
After
![Screenshot_2023-03-25-06-43-27_1920x1080](https://user-images.githubusercontent.com/69034460/227719627-6fd47b0b-62aa-4c65-992c-1fa4beaef65d.png)

### Stakeholders
@beccat123 

