### PR TITLE
Implement new design for "my lists" section

### DIFF
--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -1,5 +1,12 @@
 $def with (user, mybooks, public=False, owners_page=False, counts=None, lists=None)
 
+$ username = user.key.split('/')[-1]
+
+$if not (lists and counts):
+  $ pa = get_public_patron_account(username)
+$ lists = lists or pa.lists
+$ counts = counts or pa.get_sidebar_counts
+
 $def year_span(year, use_local_year=False):
   $if use_local_year:
     <span class="use-local-year" data-server-year="$year">$year</span>
@@ -34,14 +41,20 @@ $ hidden = 'hidden' if current_goal else ''
     <span id="reading-goal-container">
       $:render_template('check_ins/reading_goal_progress', [current_goal])
     </span>
-</div>
+  </div>
 
 $code:
     def compact_carousel(data, secondary_action=False):
-        key, title, url = data
-        books = mybooks[key].docs
-        count = mybooks[key].total_results
+        key, title, url, lsts = data
+        # In case the carousel is for My Lists, no books are sent, only the lists.
+        if key == "my-lists":
+          books = []
+          count = len(lsts)
+        else:
+          books = mybooks[key].docs
+          count = mybooks[key].total_results
         return render_template("books/custom_carousel", **{
+            "lists": lsts,
             "books": books,
             "title": "%s (%d)" % (title, count),
             "url": url,
@@ -51,23 +64,27 @@ $code:
             "compact_mode": True,
             "test": False,
             "secondary_action": secondary_action
-        }) if books else None
+        }) if (books or lsts) else None
 
 $def empty_carousel(data):
-  $ key, title, url = data
+  $ key, title, url, lsts = data
   <div class="carousel-section-header">
     <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
   </div>
   <p>$_('No books are on this shelf')</p>
 
 $# Data for carousels
-$ loans = ["loans", _('My Loans'), "/account/loans"]
-$ currently_reading = ["currently-reading", _('Currently Reading'), "/account/books/currently-reading"]
-$ want_to_read = ["want-to-read", _('Want to Read'), "/account/books/want-to-read"]
-$ already_read = ["already-read", _('Already Read'), "/account/books/already-read"]
+$ loans = ["loans", _('My Loans'), "/account/loans", []]
+$ currently_reading = ["currently-reading", _('Currently Reading'), "/account/books/currently-reading", []]
+$ want_to_read = ["want-to-read", _('Want to Read'), "/account/books/want-to-read", []]
+$ already_read = ["already-read", _('Already Read'), "/account/books/already-read", []]
+
+$ my_lists_url = "/people/%s/lists" % (username)
+$ my_lists = ["my-lists", _('My Lists'), my_lists_url, lists]
 
 $# Render carousels
 $:(compact_carousel(loans, True) or empty_carousel(loans))
 $:(compact_carousel(currently_reading) or empty_carousel(currently_reading))
 $:(compact_carousel(want_to_read) or empty_carousel(want_to_read))
 $:(compact_carousel(already_read) or empty_carousel(already_read))
+$:(compact_carousel(my_lists) or empty_carousel(my_lists))

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -22,10 +22,10 @@ $def render_carousel_cover(book, lazy):
     $ num_seeds = len(seeds)
     $if num_seeds > 3:
       $ num_seeds = 3
-    
+
     $ lst_url = url + "/" + list_id
     <a class="my-lists-item" href="$url">
-    
+
       $ lst_title = lst['name']
       $if len(lst_title) >= 16:
         $ lst_title = lst_title[0:16] + "..."
@@ -36,7 +36,7 @@ $def render_carousel_cover(book, lazy):
         $else:
           <p class="my-list-num-books">1 Book</p>
       </div>
-    
+
       <div class="my-list-covers">
         $for i in range(num_seeds):
           $ bk = seeds[i-1]
@@ -126,7 +126,7 @@ $if test or (books and len(books) >= min_books) or (lists and len(lists) >= min_
         <div class="carousel-section-header">
           <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
         </div>
-      
+
       $# The decorations are different for the My Lists carousel.
       $if key == "my-lists":
         $ container_decorated = "my-lists-container"

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,4 +1,4 @@
-$def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False, compact_mode=False, secondary_action=False)
+$def with(lists=[], books=[], title="", url="", key="", min_books=1, load_more=None, test=False, compact_mode=False, secondary_action=False)
 
 $ ctx.setdefault("links", [])
 $# Apparently fonts always need crossorigin for some reason
@@ -12,65 +12,126 @@ $def render_carousel_cover(book, lazy):
   $ url = book.get('key') or book.url
   $ title = book.title
 
-  $ cover_id = book.get('cover_id') or book.get('cover_i') or book.get('covers') and book['covers'][0]
-  $if book.get('cover_url'):
-    $ cover_url = book.get('cover_url')
-  $elif cover_id and cover_id != -1:
-    $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, cover_id)
-  $elif book.get('ia'):
-    $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
-  $elif book.get('cover_edition_key'):
-    $ cover_url = '%s/b/olid/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
-  $else:
-    $ cover_url = False
-
-  $if book.get('authors'):
-    $ author_names = [author.name for author in book.authors]
-  $elif book.get('author_name'):
-    $ author_names = book.get('author_name', [])
-  $else:
-    $ author_names = []
-
-  $if author_names:
-    $ byline = _(' by %(name)s', name=', '.join(author_names))
-  $else:
-    $ byline = ''
-
-  $ modifier = ''
-  $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
-
-  <div class="book carousel__item">
-    <div class="book-cover">
-      <a href="$(url)">
-        $if cover_url:
-          <img class="bookcover" loading="lazy"
-            title="$('%s%s'%(title,byline))"
-            alt="$('%s%s'%(title,byline))"
-          $if lazy:
-            data-lazy="$(cover_url)"
-            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
-          $else:
-            src="$(cover_url)"/>
+  $# In case the carusel is for My Lists, the items are rendered in a different way.
+  $if key == "my-lists":
+    $# Here, 'book' is actually a 'list'.
+    $ lst = book
+    $ title = lst.title
+    $ list_id = lst.key.split('/')[-1]
+    $ seeds = lst.get_seeds(sort=True, resolve_redirects=True)
+    $ num_seeds = len(seeds)
+    $if num_seeds > 3:
+      $ num_seeds = 3
+    
+    $ lst_url = url + "/" + list_id
+    <a class="my-lists-item" href="$url">
+    
+      $ lst_title = lst['name']
+      $if len(lst_title) >= 16:
+        $ lst_title = lst_title[0:16] + "..."
+      <div class="my-list-name-tag">
+        <p class="my-list-title">${lst_title}</p>
+        $if num_seeds > 1:
+          <p class="my-list-num-books">${num_seeds} Books</p>
         $else:
-          <div class="carousel__item__blankcover"  title="$(title)">
-            <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
-            $if author_names:
-              <div class="carousel__item__blankcover--authors">$:macros.TruncateString(', '.join(author_names), 30)</div>
-          </div>
-      </a>
-    </div>
-    <div class="book-cta">
-      $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action)
-    </div>
-  </div>
+          <p class="my-list-num-books">1 Book</p>
+      </div>
+    
+      <div class="my-list-covers">
+        $for i in range(num_seeds):
+          $ bk = seeds[i-1]
+          $ default_image = "https://openlibrary.org/images/icons/avatar_book-sm.png"
+          $ cover = bk.get_cover()
+          $if cover:
+            $ cover_url = item_image(cover.url("M"), default=default_image)
+          $else:
+            $ cover_url = default_image
 
-$if test or (books and len(books) >= min_books):
+          <div class="book-cover my-list-cover">
+            $if cover_url:
+              <img class="bookcover" loading="lazy"
+                title="$('%s'%(title))"
+                alt="$('%s'%(title))"
+              $if lazy:
+                data-lazy="$(cover_url)"
+                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
+              $else:
+                src="$(cover_url)"/>
+            $else:
+              <div class="carousel__item__blankcover"  title="$(title)">
+                <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
+              </div>
+          </div>
+        </div>
+      </a>
+
+    $# If the carosuel is not for My Lists, the items can be rendered as any other.
+  $else:
+    $ cover_id = book.get('cover_id') or book.get('cover_i') or book.get('covers') and book['covers'][0]
+    $if book.get('cover_url'):
+      $ cover_url = book.get('cover_url')
+    $elif cover_id and cover_id != -1:
+      $ cover_url = '%s/b/id/%s-M.jpg'%(cover_host, cover_id)
+    $elif book.get('ia'):
+      $ cover_url = '%s/b/ia/%s-M.jpg?default=%s'%(cover_host, book.get('ia')[0], fallback_cover)
+    $elif book.get('cover_edition_key'):
+      $ cover_url = '%s/b/olid/%s-M.jpg'%(cover_host, book.get('cover_edition_key'))
+    $else:
+      $ cover_url = False
+
+    $if book.get('authors'):
+      $ author_names = [author.name for author in book.authors]
+    $elif book.get('author_name'):
+      $ author_names = book.get('author_name', [])
+    $else:
+      $ author_names = []
+
+    $if author_names:
+      $ byline = _(' by %(name)s', name=', '.join(author_names))
+    $else:
+      $ byline = ''
+
+    $ modifier = ''
+    $ work_key = book.key if book.key.startswith('/work') else book.get('work_key')
+
+    <div class="book carousel__item">
+      <div class="book-cover">
+        <a href="$(url)">
+          $if cover_url:
+            <img class="bookcover" loading="lazy"
+              title="$('%s%s'%(title,byline))"
+              alt="$('%s%s'%(title,byline))"
+            $if lazy:
+              data-lazy="$(cover_url)"
+              src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
+            $else:
+              src="$(cover_url)"/>
+          $else:
+            <div class="carousel__item__blankcover"  title="$(title)">
+              <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
+              $if author_names:
+                <div class="carousel__item__blankcover--authors">$:macros.TruncateString(', '.join(author_names), 30)</div>
+            </div>
+        </a>
+      </div>
+      <div class="book-cta">
+        $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action)
+      </div>
+    </div>
+
+$if test or (books and len(books) >= min_books) or (lists and len(lists) >= min_books):
     <div class="carousel-section">
       $if title and url:
         <div class="carousel-section-header">
           <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
         </div>
-      <div class="carousel-container carousel-container-decorated">
+      
+      $# The decorations are different for the My Lists carousel.
+      $if key == "my-lists":
+        $ container_decorated = "my-lists-container"
+      $else:
+        $ container_decorated = "carousel-container-decorated"
+      <div class="carousel-container $container_decorated">
         $ attrs = ''
         $if load_more:
           $ load_more_config = {
@@ -87,8 +148,15 @@ $if test or (books and len(books) >= min_books):
         $ compact = "carousel--compact" if compact_mode else ""
         <div class="carousel $compact carousel-$key carousel--progressively-enhanced"
           data-config="$json_encode(config)">
-          $for index, book in enumerate(books or []):
-              $:render_carousel_cover(book, index > 5)
+          $if key == "my-lists":
+            $for index, lst in enumerate(lists or []):
+              $if index < 4:
+                $:render_carousel_cover(lst, index > 4)
+              $else:
+                $break
+          $else:
+            $for index, book in enumerate(books or []):
+                $:render_carousel_cover(book, index > 5)
         </div>
       </div>
     </div>

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -40,6 +40,8 @@ $def render_carousel_cover(book, lazy):
       <div class="my-list-covers">
         $for i in range(num_seeds):
           $ bk = seeds[i-1]
+        $#for i in range(3):
+          $# bk = seeds[0]
           $ default_image = "https://openlibrary.org/images/icons/avatar_book-sm.png"
           $ cover = bk.get_cover()
           $if cover:
@@ -47,21 +49,20 @@ $def render_carousel_cover(book, lazy):
           $else:
             $ cover_url = default_image
 
-          <div class="book-cover my-list-cover">
-            $if cover_url:
-              <img class="bookcover" loading="lazy"
-                title="$('%s'%(title))"
-                alt="$('%s'%(title))"
-              $if lazy:
-                data-lazy="$(cover_url)"
-                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
-              $else:
-                src="$(cover_url)"/>
+          $if cover_url:
+            <img class="book-cover my-list-cover" loading="lazy"
+              title="$('%s'%(title))"
+              alt="$('%s'%(title))"
+            $if lazy:
+              data-lazy="$(cover_url)"
+              src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
             $else:
-              <div class="carousel__item__blankcover"  title="$(title)">
-                <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
-              </div>
-          </div>
+              src="$(cover_url)"/>
+          $else:
+            <div class="carousel__item__blankcover"  title="$(title)">
+              <div class="carousel__item__blankcover--title">$:macros.TruncateString(title, 70)</div>
+            </div>
+
         </div>
       </a>
 

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -113,6 +113,99 @@
   border-top: 1px solid @book-cover-carousel-border-top;
 }
 
+// Container for My Lists carousel.
+.my-lists-container {
+  background: none;
+  overflow-x: scroll;
+}
+
+.carousel-my-lists > div > div {
+  display: flex;
+}
+
+// This affects every My Lists item card.
+.my-lists-item {
+  background: @book-cover-carousel-background;
+  border: 1px solid @my-lists-item-border;
+  border-radius: 4px;
+  box-shadow: 2.5px 2.5px 4px lightgray;
+  width: 100px;
+  height: 120px;
+  position: relative;
+  padding-top: 20px;
+  padding-bottom: 40px;
+  margin-right: 15px;
+  margin-bottom: 5px;
+  flex-shrink: 0;
+}
+
+// This is for the container with the list title and the amount of books.
+.my-list-name-tag {
+    border: 1px solid @my-lists-item-border;
+    border-radius: 2px 2px 4px 4px;
+    box-shadow: 2.5px 2.5px 4px lightgray;
+    background: @modal-background-color;
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 35%;
+    padding-top: 3px;
+    padding-left: 4px;
+    z-index: 4;
+}
+
+.my-list-title {
+  margin: auto;
+  padding: 0;
+  color: black;
+  font-weight: bold;
+}
+
+.my-list-num-books {
+  margin: auto;
+  padding: 0;
+  color: gray;
+  font-size: 0.7em;
+}
+
+// This is the container for the book covers inside the card item.
+.my-list-covers {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80%;
+  margin: 0 auto;
+  position: relative;
+}
+
+// This is a container for an individual book cover image.
+.my-list-cover {
+  width: 33%;
+  height: 100%;
+  margin-left: -5px; // This gives the covers an offset so that they can be behind each other overlapping.
+  box-shadow: 2.5px 2.5px 4px lightgray;
+}
+
+// The following make it so each cover is one slightly behind the other.
+.my-list-covers .my-list-cover:nth-child(1) {
+  z-index: 3;
+  margin-left: 5px;
+}
+
+.my-list-covers .my-list-cover:nth-child(2) {
+  z-index: 2;
+}
+
+.my-list-covers .my-list-cover:nth-child(3) {
+  z-index: 1;
+}
+
+// Resizing the book cover image.
+.my-list-cover img {
+  width: 100%;
+  height: auto;
+}
+
 // TODO: Document where this is used. This is unlikely to need to be so specific.
 .carousel-section {
   .SRPCover {
@@ -193,5 +286,7 @@
     content: "←" !important;
   }
 }
+
+
 
 @import (less) "category-item.less";

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -139,6 +139,7 @@
 }
 
 .my-list {
+  @name-tag-layer: 4;
   &-name-tag {
     border: 1px solid @my-lists-item-border;
     border-radius: 2px 2px 4px 4px;
@@ -150,7 +151,7 @@
     height: 35%;
     padding-top: 3px;
     padding-left: 4px;
-    z-index: 4;
+    z-index: @name-tag-layer;
   }
 
   &-title {
@@ -163,7 +164,7 @@
     margin: auto;
     padding: 0;
     color: @grey-555;
-    font-size: 0.7em;
+    font-size: .7em;
   }
 
   &-cover {
@@ -178,20 +179,23 @@
     width: 80%;
     margin: 0 auto;
     position: relative;
-
-    .my-list-cover:nth-child(1) {
-      z-index: 3;
-      margin-left: 5px;
-    }
-
-    .my-list-cover:nth-child(2) {
-      z-index: 2;
-    }
-
-    .my-list-cover:nth-child(3) {
-      z-index: 1;
-    }
   }
+}
+
+@top-cover: 3;
+@mid-cover: 2;
+@bottom-cover: 1;
+.cover-0 {
+  z-index: @top-cover;
+  margin-left: 5px;
+}
+
+.cover-1 {
+  z-index: @mid-cover;
+}
+
+.cover-2 {
+  z-index: @bottom-cover;
 }
 
 // TODO: Document where this is used. This is unlikely to need to be so specific.
@@ -274,7 +278,4 @@
     content: "←" !important;
   }
 }
-
-
-
 @import (less) "category-item.less";

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -168,7 +168,7 @@
 
   &-cover {
     width: 33%;
-    margin-left: -5px; 
+    margin-left: -5px;
     box-shadow: 2.5px 2.5px 4px @nagios-grey;
   }
 

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -113,37 +113,36 @@
   border-top: 1px solid @book-cover-carousel-border-top;
 }
 
-// Container for My Lists carousel.
-.my-lists-container {
-  background: none;
-  overflow-x: scroll;
+.my-lists {
+  &-container {
+    background: none;
+    overflow-x: scroll;
+  }
+
+  &-item {
+    background: @book-cover-carousel-background;
+    border: 1px solid @my-lists-item-border;
+    border-radius: 4px;
+    box-shadow: 2px 2px 5px @nagios-grey;
+    width: 100px;
+    height: 120px;
+    position: relative;
+    padding-top: 20px;
+    padding-bottom: 40px;
+    margin-right: 15px;
+    margin-bottom: 5px;
+  }
 }
 
 .carousel-my-lists > div > div {
   display: flex;
 }
 
-// This affects every My Lists item card.
-.my-lists-item {
-  background: @book-cover-carousel-background;
-  border: 1px solid @my-lists-item-border;
-  border-radius: 4px;
-  box-shadow: 2.5px 2.5px 4px lightgray;
-  width: 100px;
-  height: 120px;
-  position: relative;
-  padding-top: 20px;
-  padding-bottom: 40px;
-  margin-right: 15px;
-  margin-bottom: 5px;
-  flex-shrink: 0;
-}
-
-// This is for the container with the list title and the amount of books.
-.my-list-name-tag {
+.my-list {
+  &-name-tag {
     border: 1px solid @my-lists-item-border;
     border-radius: 2px 2px 4px 4px;
-    box-shadow: 2.5px 2.5px 4px lightgray;
+    box-shadow: 2px 2px 5px @nagios-grey;
     background: @modal-background-color;
     position: absolute;
     bottom: 0;
@@ -152,58 +151,47 @@
     padding-top: 3px;
     padding-left: 4px;
     z-index: 4;
-}
+  }
 
-.my-list-title {
-  margin: auto;
-  padding: 0;
-  color: black;
-  font-weight: bold;
-}
+  &-title {
+    margin: auto;
+    color: @black;
+    font-weight: bold;
+  }
 
-.my-list-num-books {
-  margin: auto;
-  padding: 0;
-  color: gray;
-  font-size: 0.7em;
-}
+  &-num-books {
+    margin: auto;
+    padding: 0;
+    color: @grey-555;
+    font-size: 0.7em;
+  }
 
-// This is the container for the book covers inside the card item.
-.my-list-covers {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 80%;
-  margin: 0 auto;
-  position: relative;
-}
+  &-cover {
+    width: 33%;
+    margin-left: -5px; 
+    box-shadow: 2.5px 2.5px 4px @nagios-grey;
+  }
 
-// This is a container for an individual book cover image.
-.my-list-cover {
-  width: 33%;
-  height: 100%;
-  margin-left: -5px; // This gives the covers an offset so that they can be behind each other overlapping.
-  box-shadow: 2.5px 2.5px 4px lightgray;
-}
+  &-covers {
+    display: flex;
+    justify-content: center;
+    width: 80%;
+    margin: 0 auto;
+    position: relative;
 
-// The following make it so each cover is one slightly behind the other.
-.my-list-covers .my-list-cover:nth-child(1) {
-  z-index: 3;
-  margin-left: 5px;
-}
+    .my-list-cover:nth-child(1) {
+      z-index: 3;
+      margin-left: 5px;
+    }
 
-.my-list-covers .my-list-cover:nth-child(2) {
-  z-index: 2;
-}
+    .my-list-cover:nth-child(2) {
+      z-index: 2;
+    }
 
-.my-list-covers .my-list-cover:nth-child(3) {
-  z-index: 1;
-}
-
-// Resizing the book cover image.
-.my-list-cover img {
-  width: 100%;
-  height: auto;
+    .my-list-cover:nth-child(3) {
+      z-index: 1;
+    }
+  }
 }
 
 // TODO: Document where this is used. This is unlikely to need to be so specific.

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -113,6 +113,7 @@
 @book-cover-carousel-border-top: hsl(51, 32%, 88%);
 @book-cover-carousel-border-bottom: hsl(50, 32%, 85%);
 @book-cover-carousel-cards: hsl(47, 54%, 98%);
+@my-lists-item-border: hsl(50, 24%, 65%);
 
 // book cover
 @book-cover-shadow-color: hsl(48, 35%, 64%);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7704 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a new feature. The My Books page would now have a new carousel at the bottom showing the 4 more recent custom lists of a user. Each item in the carousel shows the three most recently added books.

### Technical
<!-- What should be noted about the implementation? -->
The custom_carousel template was altered to consider the possibility of this new design for a carousel. Since this is not a carousel for books, a new case was added to the render_carousel function inside the template. Regarding the styles, new containers and classes were created to implement the desired design. This led to added styles in carousel.less.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
When testing, the file "static/build/page-subject.css" initially exceeded the maximum size allowed. After fixing the Less code, it got reduced to just the allowed size. It passed the test after that.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1437" alt="Screen Shot 2023-03-27 at 21 04 34" src="https://user-images.githubusercontent.com/108767897/228125337-a3a9cce5-3aae-4f4e-84e0-620e51adcf6f.png">

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
