### PR TITLE
Delete sitemaps before generating them, not after

### DIFF
--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -204,9 +204,10 @@ if [[ ! -d $TMPDIR/sitemaps ]]
 then
     log "generating sitemaps"
     mkdir -p $TMPDIR/sitemaps
+    rm -fr $TMPDIR/sitemaps/*
     cd $TMPDIR/sitemaps
     time python $SCRIPTS/sitemaps/sitemap.py $TMPDIR/dumps/$dump/$dump.txt.gz > sitemaps.log
-    rm -fr $TMPDIR/sitemaps
+    # rm -fr $TMPDIR/sitemaps
     ls -lh
 else
     log "Skipping sitemaps"

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -205,8 +205,9 @@ then
     log "generating sitemaps"
     mkdir -p $TMPDIR/sitemaps
     cd $TMPDIR/sitemaps
+    rm -fr $TMPDIR/sitemaps/*
     time python $SCRIPTS/sitemaps/sitemap.py $TMPDIR/dumps/$dump/$dump.txt.gz > sitemaps.log
-    rm -fr $TMPDIR/sitemaps
+    # rm -fr $TMPDIR/sitemaps
     ls -lh
 else
     log "Skipping sitemaps"

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -205,9 +205,8 @@ then
     log "generating sitemaps"
     mkdir -p $TMPDIR/sitemaps
     cd $TMPDIR/sitemaps
-    rm -fr $TMPDIR/sitemaps/*
     time python $SCRIPTS/sitemaps/sitemap.py $TMPDIR/dumps/$dump/$dump.txt.gz > sitemaps.log
-    # rm -fr $TMPDIR/sitemaps
+    rm -fr $TMPDIR/sitemaps
     ls -lh
 else
     log "Skipping sitemaps"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related to:
* #7581
* #7580

# The dumps will run tonight at midnight.  Let's land this before.

While we are trying to debug the issues above, it would be better for us to preserve the sitemaps.  We can manually delete the sitemaps after we have studied them and in any case this script will erase them before generating them.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
