### PR TITLE
Combine if statements: ruff --select=SIM114,SIM116

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.260
+    rev: v0.0.261
     hooks:
       - id: ruff
 
@@ -49,7 +49,7 @@ repos:
           - tomli
 
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.14.0
+    rev: v0.15.0
     hooks:
     - id: cython-lint
 

--- a/openlibrary/catalog/merge/merge.py
+++ b/openlibrary/catalog/merge/merge.py
@@ -223,9 +223,9 @@ def compare_publisher(amazon, marc):
             norm_marc = normalize(marc_pub)
             if norm_amazon == norm_marc:
                 return ('publisher', 'match', 100)
-            elif substr_match(norm_amazon, norm_marc):
-                return ('publisher', 'occur within the other', 100)
-            elif substr_match(norm_amazon.replace(' ', ''), norm_marc.replace(' ', '')):
+            elif substr_match(norm_amazon, norm_marc) or substr_match(
+                norm_amazon.replace(' ', ''), norm_marc.replace(' ', '')
+            ):
                 return ('publisher', 'occur within the other', 100)
             elif short_part_publisher_match(norm_amazon, norm_marc):
                 return ('publisher', 'match', 100)

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -299,9 +299,9 @@ def compare_publisher(e1, e2):
                 e2_norm = normalize(e2_pub)
                 if e1_norm == e2_norm:
                     return ('publisher', 'match', 100)
-                elif substr_match(e1_norm, e2_norm):
-                    return ('publisher', 'occur within the other', 100)
-                elif substr_match(e1_norm.replace(' ', ''), e2_norm.replace(' ', '')):
+                elif substr_match(e1_norm, e2_norm) or substr_match(
+                    e1_norm.replace(' ', ''), e2_norm.replace(' ', '')
+                ):
                     return ('publisher', 'occur within the other', 100)
                 elif short_part_publisher_match(e1_norm, e2_norm):
                     return ('publisher', 'match', 100)

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -374,21 +374,13 @@ class Seed:
                 return None
 
     @cached_property
-    def type(self):
+    def type(self) -> str:
         if self._type:
             return self._type
-        type = self.document.type.key
-
-        if type == "/type/edition":
-            return "edition"
-        elif type == "/type/work":
-            return "work"
-        elif type == "/type/author":
-            return "author"
-        elif type == "/type/redirect":
-            return "redirect"
-        else:
-            return "unknown"
+        key = self.document.type.key
+        if key in ("/type/author", "/type/edition", "/type/redirect", "/type/work"):
+            return key.split("/")[-1]
+        return "unknown"
 
     @property
     def title(self):

--- a/openlibrary/core/processors/invalidation.py
+++ b/openlibrary/core/processors/invalidation.py
@@ -88,9 +88,7 @@ class InvalidationProcessor:
 
         cookie_time = self.get_cookie_time()
 
-        if cookie_time and cookie_time > self.last_poll_time:
-            self.reload()
-        elif self.is_timeout():
+        if self.is_timeout() or cookie_time and cookie_time > self.last_poll_time:
             self.reload()
 
         # last update in recent timeout seconds?

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -583,12 +583,9 @@ def is_loaned_out(resource_id):
 
 
 def is_loaned_out_from_status(status):
-    if not status:
+    if not status or status['returned'] == 'T':
+        # Current loan has been returned
         return False
-    else:
-        if status['returned'] == 'T':
-            # Current loan has been returned
-            return False
 
     # Has status and not returned
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ ignore = [
   "PIE804",
   "PLC1901",
   "RSE102",
+  "SIM102",
+  "SIM105",
+  "SIM108",
+  "SIM115",
+  "SIM300",
   "SLF001",
   "UP007",
   "UP031",
@@ -69,6 +74,7 @@ select = [
   "PLR091",  # Pylint Refactor just for max-args, max-branches, etc.
   "PYI",     # flake8-pyi
   "RSE",     # flake8-raise
+  "SIM",     # flake8-simplify
   "SLF",     # flake8-self
   "T10",     # flake8-debugger
   "UP",      # pyupgrade
@@ -100,7 +106,6 @@ select = [
   # "RET",   # flake8-return
   # "RUF",   # Ruff-specific rules
   # "S",     # flake8-bandit
-  # "SIM",   # flake8-simplify
   # "T20",   # flake8-print
   # "TCH",   # flake8-type-checking
   # "TID",   # flake8-tidy-imports

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -307,9 +307,7 @@ def copy_list(src, dest, list_key, comment):
         return d['entries']  # [x['url'] for x in d['entries']]
 
     def add_seed(seed):
-        if seed['type'] == 'edition':
-            keys.add(seed['url'])
-        elif seed['type'] == 'work':
+        if seed['type'] in ('edition', 'work'):
             keys.add(seed['url'])
         elif seed['type'] == 'subject':
             doc = jsonget(seed['url'] + '.json')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Adds [ruff rules SIM](https://beta.ruff.rs/docs/rules/#flake8-simplify-sim) from [flake8-simplify](https://pypi.org/project/flake8_simplify/) to our testing with fixes for six instances:
% `ruff --select=SIM114,SIM116 .`
```
openlibrary/catalog/merge/merge.py:226:18: SIM114 Combine `if` branches using logical `or` operator
openlibrary/catalog/merge/merge_marc.py:302:22: SIM114 Combine `if` branches using logical `or` operator
openlibrary/core/processors/invalidation.py:91:9: SIM114 Combine `if` branches using logical `or` operator
openlibrary/plugins/upstream/borrow.py:586:5: SIM114 Combine `if` branches using logical `or` operator
scripts/copydocs.py:310:9: SIM114 Combine `if` branches using logical `or` operator

openlibrary/core/lists/model.py:382:9: SIM116 Use a dictionary instead of consecutive `if` statements

Found 6 errors.
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
