### PR TITLE
Replace deprecated bable.numbers.format_number()

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -195,18 +195,15 @@ def cond(pred, true_value, false_value=""):
 
     Hanly to use instead of if-else expression.
     """
-    if pred:
-        return true_value
-    else:
-        return false_value
+    return true_value if pred else false_value
 
 
 def commify(number, lang=None):
     """localized version of web.commify"""
     try:
         lang = lang or web.ctx.get("lang") or "en"
-        return babel.numbers.format_number(int(number), lang)
-    except:
+        return babel.numbers.format_decimal(int(number), lang)
+    except Exception:
         return str(number)
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
[`bable.numbers.format_number()` is deprecated in favor of `bable.numbers.format_decimal()`](https://babel.pocoo.org/en/latest/api/numbers.html#number-formatting).
https://github.com/python-babel/babel/blob/134c792df3b6aa84de3e74e81a875493c95dcc2e/babel/numbers.py#L386-L404

Fix eleven warnings from our pytest runs:
```
openlibrary/plugins/openlibrary/tests/test_home.py: 5 warnings
openlibrary/tests/core/test_helpers.py: 6 warnings
  /opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/babel/numbers.py:352:
   DeprecationWarning: Use babel.numbers.format_decimal() instead.
    warnings.warn('Use babel.numbers.format_decimal() instead.', DeprecationWarning)
```

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
