### PR TITLE
ol-www: Sitemaps are in /1/var/lib/openlibrary/sitemaps/

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -94,7 +94,7 @@ services:
       - ./docker/public_nginx.conf:/etc/nginx/sites-available/public_nginx.conf:ro
       # Needs access to openlibrary for static files
       - ../olsystem:/olsystem
-      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
+      - /1/var/lib/openlibrary/sitemaps:/sitemaps
       # web log rotation
       - ../olsystem/etc/logrotate.d/nginx:/etc/logrotate.d/nginx
       # Persist the nginx logs


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

# olsystem cron jobs in /etc/cron.d
filename | run on | in Docker container | purpose | last modified
--- | --- | --- | --- | ---
archive-webserver-logs | ol-home0 | covers_nginx | archive-webserver-logs | 2 years
mrtg | | | | 12 years
openlibrary.allnodes | ol-www1, | bare metal | Copy sitemaps | 2 years
openlibrary.ol_home0 | ol-home0 | cron-jobs | Monthly data dumps | 3 months
pg-backups | ol-home | bare metal | Backup postgres | 9 years
