### PR TITLE
7416/feature/safe mode

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -692,10 +692,13 @@ class account_privacy(delegate.page):
 
     @require_login
     def POST(self):
+        #i = web_input(public_readlog="", safe_mode="")
         user = accounts.get_current_user()
-        user.save_preferences(web.input())
+        user.save_preferences(web_input())
+        #web.setcookie('sfw', i.get('safe_mode'), expires=expires)
         add_flash_message(
             'note', _("Notification preferences have been updated successfully.")
+            #'note', _(str(i.get('safe_mode')))
         )
         web.seeother("/account")
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -681,6 +681,7 @@ class account_audit(delegate.page):
         result = audit_accounts(email, password, test=test)
         return delegate.RawText(json.dumps(result), content_type="application/json")
 
+
 class account_privacy(delegate.page):
     path = "/account/privacy"
 

--- a/openlibrary/templates/account.html
+++ b/openlibrary/templates/account.html
@@ -18,7 +18,7 @@ $var title: $_("Settings")
       <p class="sansserif larger"><a href="/account/books">$_("View or Edit your Reading Log")</a></p>
       <p class="sansserif larger"><a href="/account/lists">$_("View or Edit your Lists")</a></p>
       <p class="sansserif larger"><a href="/account/import">$_("Import and Export Options")</a></p>
-      <p class="sansserif larger"><a href="/account/privacy">$_("Manage Privacy Settings")</a></p>
+      <p class="sansserif larger"><a href="/account/privacy">$_("Manage Privacy & Content Moderation Settings")</a></p>
       <p class="sansserif larger"><a href="/account/notifications">$_("Manage Notifications Settings")</a></p>
       <p class="sansserif larger"><a href="//archive.org/account/index.php?settings=1">$_("Manage Mailing List Subscriptions")</a></p>
       <p class="sansserif larger"><a href="https://archive.org/account/index.php?settings=1">$_("Change Password")</a></p>

--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -16,6 +16,7 @@ $def selected(value, value2):
     $if value == value2: checked="checked"
 
 $ public_readlog = d.get('public_readlog', 'no')
+$ safe_mode = d.get('safe_mode', 'no')
 
 <div id="contentBody">
     <form method="post" class="olform" action="" id="privacy">
@@ -40,17 +41,6 @@ $ public_readlog = d.get('public_readlog', 'no')
                 </div>
             </div>
         </div>
-        <div class="formElement bottom">
-            <div class="input">
-                <br/>
-                <button type="submit" class="larger" name="save" title="$_('Save')">$_("Save")</button>
-                &nbsp;
-                <a href="javascript:history.go(-1);" class="smaller attn">$_('Cancel')</a>
-            </div>
-        </div>
-    </form>
-    <form method="post" class="olform" action="" id="safe_mode">
-
         <div class="formElement">
             <h3 class="collapse">Enable Safe Mode? Safe Mode helps you tailor your experience where possible to moderate the content you are shown.</h3>
         </div>
@@ -80,4 +70,5 @@ $ public_readlog = d.get('public_readlog', 'no')
             </div>
         </div>
     </form>
-</div>
+
+

--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -9,7 +9,7 @@ $var title: $_("Your Privacy on Open Library")
       <a href="$homepath()/account">$_("Settings")</a>
       &raquo; Privacy
     </div>
-    <h1>$_("Privacy Settings")</h1>
+    <h1>$_("Privacy & Content Moderation Settings")</h1>
 </div>
 
 $def selected(value, value2):
@@ -35,6 +35,37 @@ $ public_readlog = d.get('public_readlog', 'no')
             <div class="input radio">
                 <div class="sansserif larger">
                     <input type="radio" name="public_readlog" id="r1" value="no" $selected(public_readlog, "no")/>
+                    <label for="u1">$_("No")</label>
+                    <br/><br/>
+                </div>
+            </div>
+        </div>
+        <div class="formElement bottom">
+            <div class="input">
+                <br/>
+                <button type="submit" class="larger" name="save" title="$_('Save')">$_("Save")</button>
+                &nbsp;
+                <a href="javascript:history.go(-1);" class="smaller attn">$_('Cancel')</a>
+            </div>
+        </div>
+    </form>
+    <form method="post" class="olform" action="" id="safe_mode">
+
+        <div class="formElement">
+            <h3 class="collapse">Enable Safe Mode? Safe Mode helps you tailor your experience where possible to moderate the content you are shown.</h3>
+        </div>
+        <br/>
+        <div class="formElement">
+            <div class="input radio">
+                <div class="sansserif larger">
+                    <input type="radio" name="safe_mode" id="r2" value="yes" $selected(safe_mode, "yes")/>
+                    <label for="u0">$_("Yes")</label>
+                    <br/><br/>
+                </div>
+            </div>
+            <div class="input radio">
+                <div class="sansserif larger">
+                    <input type="radio" name="safe_mode" id="r3" value="no" $selected(safe_mode, "no")/>
                     <label for="u1">$_("No")</label>
                     <br/><br/>
                 </div>

--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -70,5 +70,4 @@ $ safe_mode = d.get('safe_mode', 'no')
             </div>
         </div>
     </form>
-
-
+</div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7416 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This is a draft PR that implements a feature---users will be able to opt-in to a new Safe Mode, which will be saved in their account preferences. Books that are marked as NSFW/containing inappropriate content will have their covers blurred if Safe Mode is enabled for the user.

### Technical
<!-- What should be noted about the implementation? -->
Safe Mode options are added to the form for the Manage Privacy Settings account page, now Manage Privacy and Content Moderation Settings. When a user sets their Safe Mode preference, a cookie named `sfw` is set that keeps track of their preference across sessions.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to user settings -> click Manage Privacy and Content Moderation Settings -> enable Safe Mode and save preferences -> open developer tools and you should see the `sfw` cookie with your preferences.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![图片](https://user-images.githubusercontent.com/17033120/231045994-87d692f8-c449-40e9-9916-90d4858f5d22.png)
![图片](https://user-images.githubusercontent.com/17033120/231046205-fc18c578-fcc2-4723-91f2-6bba47c0385d.png)




<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
