### PR TITLE
ol-www0: Add cron job pull-sitemaps-from-ol-home0

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -172,7 +172,7 @@ services:
     user: root
     command: docker/ol-nginx-start.sh
     environment:
-      - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs
+      - CRONTAB_FILES="/etc/cron.d/archive-webserver-logs /etc/cron.d/pull-sitemaps-from-ol-home0"
     volumes:
       # nginx configurations
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
@@ -186,7 +186,7 @@ services:
       # Persist the nginx logs
       - /1/var/log/nginx:/var/log/nginx
       # sitemap generation (we also need olsystem/etc/cron.d + openlibrary/scripts)
-      - /1/var/lib/openlibrary/sitemaps/sitemaps:/sitemaps
+      - /1/var/lib/openlibrary/sitemaps:/sitemaps
       # Archive nginx logs regularly
       - ../olsystem/etc/cron.d/archive-webserver-logs:/etc/cron.d/archive-webserver-logs
       - archive-webserver-logs-data:/archive-webserver-logs-data

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -44,7 +44,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends nginx curl \
     # nginx-plus
     apt-transport-https lsb-release ca-certificates wget \
     # log rotation service for ol-nginx
-    logrotate
+    logrotate \
+    # rsync service for pulling monthly sitemaps from ol-home0 to ol-www0
+    rsync
 RUN wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
 RUN echo "deb http://openresty.org/package/debian $(lsb_release -sc) openresty" \
     | tee /etc/apt/sources.list.d/openresty.list

--- a/docker/ol-nginx-start.sh
+++ b/docker/ol-nginx-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -n "$CRONTAB_FILES" ] ; then
-  crontab $CRONTAB_FILES
+  cat $CRONTAB_FILES | crontab -
   service cron start
 fi
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7580

Add a second cron job to the `openlibrary_web_nginx` Docker container which runs on the host `ol-www0`.  This job runs at 8 pm on the first day of every month and pulls the newly created `sitemaps` from the host `ol-home0`.
* [x] The pull operation is performed by `rsync` which must be added to the `openlibrary_web_nginx` Docker container.
* [x] The modification to `docker/ol-nginx-start.sh` concatenates multiple files into one before feeding them to crontab.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
On `ol-www0`...
rsync --version
docker exec -it openlibrary_web_nginx_1 bash # --> docker container

rsync --version
cd /sitemaps
ls
rm -r previous_sitemaps
rm rsync.log
apt-get update && apt-get install rsync  # https://internetarchive.slack.com/archives/GM13CHXBP/p1681428713708969
vi /olsystem/etc/cron.d/pull-sitemaps-from-ol-home0
> copy the line and modify the new line to start with `X * * * *` where X is an upcoming minute.

CRONTAB_FILES="/etc/cron.d/archive-webserver-logs /etc/cron.d/pull-sitemaps-from-ol-home0"
cat $CRONTAB_FILES | crontab -
crontab -l
> Ensure that all $CRONTAB_FILES content is present

service cron start
> Wait until X

ls
> Look for `previous_sitemaps` and `rsync.log` and scan the log to ensure no errors.
> Revert all changes made to `/etc/cron.d/pull-sitemaps-from-ol-home0`

cat $CRONTAB_FILES | crontab -
crontab -l
> Ensure that all $CRONTAB_FILES content is present

service cron start


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

# olsystem cron jobs in /etc/cron.d
filename | run on | in Docker container | purpose | last modified
--- | --- | --- | --- | ---
archive-webserver-logs | ol-covers0 | covers_nginx | archive-webserver-logs | 2 years
archive-webserver-logs | ol-www0 | web_nginx | archive-webserver-logs | 2 years
~mrtg~ | | | | 12 years
~openlibrary.allnodes~ | ol-www1, | bare metal | Copy sitemaps | 2 years
openlibrary.ol_home0 | ol-home0 | cron-jobs | Monthly data dumps | 3 months
pg-backups | ol-home | bare metal | Backup postgres | 9 years
pull-sitemaps-from-ol-home0 | ol-www0 | web_nginx | pull sitemaps monthly | now
