### PR TITLE
Follow login redirect on logged-out star rating

### DIFF
--- a/openlibrary/plugins/openlibrary/js/handlers/index.js
+++ b/openlibrary/plugins/openlibrary/js/handlers/index.js
@@ -1,10 +1,14 @@
 import { FadingToast } from '../Toast.js';
 
 export function initRatingHandlers(ratingForms) {
-    for (const form of ratingForms) {
-        form.addEventListener('submit', function(e) {
-            handleRatingSubmission(e, form);
-        })
+    const isLoggedIn = !document.querySelector('.auth-component')
+
+    if (isLoggedIn) {
+        for (const form of ratingForms) {
+            form.addEventListener('submit', function(e) {
+                handleRatingSubmission(e, form);
+            })
+        }
     }
 }
 

--- a/openlibrary/plugins/openlibrary/js/handlers/index.js
+++ b/openlibrary/plugins/openlibrary/js/handlers/index.js
@@ -1,14 +1,10 @@
 import { FadingToast } from '../Toast.js';
 
 export function initRatingHandlers(ratingForms) {
-    const isLoggedIn = !document.querySelector('.auth-component')
-
-    if (isLoggedIn) {
-        for (const form of ratingForms) {
-            form.addEventListener('submit', function(e) {
-                handleRatingSubmission(e, form);
-            })
-        }
+    for (const form of ratingForms) {
+        form.addEventListener('submit', function(e) {
+            handleRatingSubmission(e, form);
+        })
     }
 }
 
@@ -35,6 +31,10 @@ function handleRatingSubmission(event, form) {
             body: new URLSearchParams(formData)
         })
             .then((response) => {
+                // POST handler will redirect to login page when not logged in
+                if (response.redirected) {
+                    window.location = response.url
+                }
                 if (!response.ok) {
                     throw new Error('Ratings update failed')
                 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7782

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes bug where logged out patron can interact with star rating components.  Root cause of bug is the `event.preventDefault()` call in the `handleRatingSubmission` function, which cancels the redirect to the login page.

The star rating handler redirects to the login page if the request was made by a logged out patron.  This PR modifies the `fetch()` response handler such that redirect responses are honored.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged out:
1. Go to a page with a star rating component.
2. Attempt to rate a book.
3. Ensure that your are redirected to the login page.

While logged in:
1. Go to a page with a star rating component.
2. Attempt to rate a book.
3. Refresh the page.
4. Ensure that your rating was persisted.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
