### PR TITLE
i18n.GetText(): If kwargs['count'] is Nothing then set it to zero

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -13,6 +13,8 @@ from babel.messages.pofile import read_po, write_po
 from babel.messages.mofile import write_mo
 from babel.messages.extract import extract_from_file, extract_from_dir, extract_python
 
+from infogami.infobase.client import Nothing
+
 from .validators import validate
 
 root = os.path.dirname(__file__)
@@ -314,6 +316,8 @@ class GetText:
         if args:
             value = value % args
         elif kwargs:
+            if isinstance(kwargs.get('count'), Nothing):
+                kwargs['count'] = 0
             value = value % kwargs
 
         return value


### PR DESCRIPTION
The most common Sentry error on our web nodes with 39k instances in the past 30 days is:
* https://sentry.archive.org/organizations/ia-ux/issues/35685

`i18n.GetText()`, is trying to format `kwargs['count']` as a real number which raises `TypeError` when it is set to [`Nothing`](https://github.com/internetarchive/infogami/blob/master/infogami/infobase/client.py#L696)
`TypeError: %d format: a real number is required, not Nothing`

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
