### PR TITLE
Fix get_software_version() to properly captue the git SHA

### DIFF
--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -194,7 +194,7 @@ def is_number(s):
 
 def get_software_version() -> str:
     cmd = "git rev-parse --short HEAD --".split()
-    return run(cmd, text=True).stdout
+    return run(cmd, capture_output=True, text=True).stdout.strip()
 
 
 # See https://docs.python.org/3/library/enum.html#orderedenum

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -193,6 +193,9 @@ def is_number(s):
 
 
 def get_software_version() -> str:
+    """
+    assert get_software_version()  # Should never return a falsy value
+    """
     cmd = "git rev-parse --short HEAD --".split()
     return run(cmd, capture_output=True, text=True).stdout.strip()
 


### PR DESCRIPTION
Fixes #7070

Running `openlibrary.utils.get_software_version()` was printing the current git SHA to stdout but was not returning it as a str to the caller.  This change adds [`subprocess.run(capture_output=True)`](https://docs.python.org/3/library/subprocess.html#subprocess.run) to successfully capture the git SHA as a str and return it to the caller.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made my best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
