### PR TITLE
Revert hamburger menu google sign in button

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -436,16 +436,6 @@ jQuery(function () {
             .removeAttr('open');
     });
 
-    // Load and unload third party login iframes when toggling hamburger menu
-    const hamburgerMenu = document.querySelector('.hamburger-component > details')
-    hamburgerMenu.addEventListener('toggle', () => {
-        if (hamburgerMenu.open) {
-            window.LOAD_THIRD_PARTY_LOGINS()
-        } else {
-            window.UNLOAD_THIRD_PARTY_LOGINS()
-        }
-    })
-
     // Prevent default star rating behavior:
     const ratingForms = document.querySelectorAll('.star-rating-form')
     if (ratingForms.length) {

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -1,23 +1,14 @@
-$def with (lazy=False)
+$def with ()
 
 $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
-    $("src" if not lazy else "data-src")="https://archive.org/account/login.thirdparty.php?$(urlencode(params))"
+    src="https://archive.org/account/login.thirdparty.php?$(urlencode(params))"
 
-    style="border:0; width: 100%; min-width: 250px; height: 40px"
+    style="border:0; width: 100%; height: 44px"
 ></iframe>
 
 <script>
-    window.LOAD_THIRD_PARTY_LOGINS = function() {
-        var iframe = document.getElementById('ia-third-party-logins');
-        iframe.src = iframe.getAttribute('data-src')
-    };
-
-    window.UNLOAD_THIRD_PARTY_LOGINS = function() {
-        var iframe = document.getElementById('ia-third-party-logins');
-        iframe.src = '';
-    };
     window.addEventListener(
         'message',
         function(e) {

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -54,7 +54,6 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
               <li class="$(link['loginClass'])">
                 <a class="login-links__secondary" href="/account/login">$_('Log In')</a>
                 <a class="login-links__primary" href="/account/create">$_('Sign Up')</a>
-                $:render_template("account/ia_thirdparty_logins", lazy=True)
               </li>
             $else:
               <li>

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -137,7 +137,7 @@
       margin: 0 8px;
     }
 
-    li a, li button {
+    li a, li button, .login-links {
       padding: 10px 8px;
     }
 
@@ -154,11 +154,9 @@
 
     .login-links {
       display: flex;
-      flex-direction: column;
       border-bottom: none;
       justify-content: space-evenly;
-      gap: 8px;
-      padding: 10px 8px;
+      column-gap: 16px;
       &:hover {
         background-color: transparent;
       }
@@ -171,7 +169,6 @@
       align-items: center;
       border-radius: 6px;
       padding: 6px;
-      min-height: 38px;
       transition: .3s;
     }
 


### PR DESCRIPTION
This reverts commit 753a27b28fecc647d93b7de7a69f674bee53d105.

We've seen a dip in registrations and an increase in errors on infogami. Possibly related to this.

This was deployed on 03/30

![image](https://user-images.githubusercontent.com/6251786/232528808-e41ce5ea-a9ad-437b-b862-a857f2559a80.png)

![image](https://user-images.githubusercontent.com/6251786/232529960-d4dc27b1-4501-4c1c-8db7-9fa0a9c0c336.png)


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Going to patch deploy on prod to see if it reduces the infogami errors.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
