### PR TITLE
Fix edition_key not working in search

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -357,6 +357,22 @@ class WorkSearchScheme(SearchScheme):
                                 node.name = new_name
                             else:
                                 node.name = f'+{new_name}'
+                            if new_name == 'key':
+                                # need to convert eg 'edition_key:OL123M' to
+                                # 'key:(/books/OL123M)'. Or
+                                # key:(/books/OL123M OR /books/OL456M)
+                                for n, n_parents in luqum_traverse(node.expr):
+                                    if isinstance(
+                                        n, (luqum.tree.Word, luqum.tree.Phrase)
+                                    ):
+                                        val = (
+                                            n.value
+                                            if isinstance(n, luqum.tree.Word)
+                                            else n.value[1:-1]
+                                        )
+                                        if val.startswith('/books/'):
+                                            val = val[7:]
+                                        n.value = f'"/books/{val}"'
                         elif callable(new_name):
                             # Replace this node with a new one
                             # First process the expr


### PR DESCRIPTION
Fix. Searches with field `edition_key` weren't working, because `edition_key` shouldn't include the `/books/` prefix, but `key` should.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
This now works!
- Before: https://openlibrary.org/search?q=edition_key%3AOL10676534M&mode=everything
- After: https://testing.openlibrary.org/search?q=edition_key%3AOL10676534M&mode=everything

Also added a unit test to prevent regression.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
