### PR TITLE
ruff: Add bugbear and prevent future blind exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,14 @@ exclude = [
   "vendor/*",
 ]
 ignore = [
+  "B007",
+  "B009",
+  "B015",
+  "B023",
+  "B904",
+  "B905",
   "C408",
   "E402",
-  "E722",
   "E741",
   "F401",
   "F841",
@@ -46,6 +51,11 @@ ignore = [
   "PIE790",
   "PIE804",
   "PLC1901",
+  "PLR2004",
+  "PLR5501",
+  "PLW0602",
+  "PLW0603",
+  "PLW2901",
   "RSE102",
   "SIM102",
   "SIM105",
@@ -60,6 +70,8 @@ ignore = [
 ]
 line-length = 162
 select = [
+  "B",       # flake8-bugbear
+  "BLE",     # flake8-blind-except
   "C4",      # flake8-comprehensions
   "C90",     # McCabe cyclomatic complexity
   "E",       # pycodestyle
@@ -69,9 +81,7 @@ select = [
   "ICN",     # flake8-import-conventions
   "INT",     # flake8-gettext
   "PIE",     # flake8-pie
-  "PLC",     # Pylint conventions
-  "PLE",     # Pylint errors
-  "PLR091",  # Pylint Refactor just for max-args, max-branches, etc.
+  "PL",      # Pylint
   "PYI",     # flake8-pyi
   "RSE",     # flake8-raise
   "SIM",     # flake8-simplify
@@ -83,8 +93,6 @@ select = [
   # "A",     # flake8-builtins
   # "ANN",   # flake8-annotations
   # "ARG",   # flake8-unused-arguments
-  # "B",     # flake8-bugbear
-  # "BLE",   # flake8-blind-except
   # "COM",   # flake8-commas
   # "D",     # pydocstyle
   # "DJ",    # flake8-django
@@ -123,4 +131,43 @@ max-returns = 14
 max-statements = 106
 
 [tool.ruff.per-file-ignores]
+"openlibrary/admin/stats.py" = ["BLE001"]
+"openlibrary/catalog/get_ia.py" = ["BLE001", "E722"]
+"openlibrary/catalog/marc/marc_binary.py" = ["BLE001"]
+"openlibrary/catalog/utils/edit.py" = ["E722"]
+"openlibrary/catalog/utils/query.py" = ["E722"]
+"openlibrary/core/booknotes.py" = ["E722"]
+"openlibrary/core/bookshelves.py" = ["BLE001"]
+"openlibrary/core/helpers.py" = ["BLE001"]
+"openlibrary/core/processors/invalidation.py" = ["BLE001"]
+"openlibrary/core/ratings.py" = ["E722"]
+"openlibrary/core/sponsorships.py" = ["E722"]
+"openlibrary/core/stats.py" = ["BLE001"]
+"openlibrary/coverstore/code.py" = ["E722"]
+"openlibrary/i18n/__init__.py" = ["BLE001"]
+"openlibrary/plugins/admin/code.py" = ["E722"]
+"openlibrary/plugins/admin/mem.py" = ["E722"]
+"openlibrary/plugins/admin/memory.py" = ["E722"]
+"openlibrary/plugins/admin/services.py" = ["BLE001"]
+"openlibrary/plugins/books/dynlinks.py" = ["E722"]
+"openlibrary/plugins/books/readlinks.py" = ["E722"]
+"openlibrary/plugins/importapi/code.py" = ["BLE001"]
+"openlibrary/plugins/ol_infobase.py" = ["BLE001"]
+"openlibrary/plugins/openlibrary/code.py" = ["BLE001", "E722"]
+"openlibrary/plugins/openlibrary/connection.py" = ["E722"]
+"openlibrary/plugins/openlibrary/stats.py" = ["BLE001"]
+"openlibrary/plugins/upstream/account.py" = ["BLE001"]
+"openlibrary/plugins/upstream/borrow.py" = ["BLE001", "E722"]
+"openlibrary/plugins/upstream/models.py" = ["BLE001"]
+"openlibrary/plugins/upstream/utils.py" = ["BLE001"]
+"openlibrary/solr/update_work.py" = ["E722"]
+"openlibrary/utils/retry.py" = ["BLE001"]
+"scripts/copydocs.py" = ["BLE001"]
+"scripts/delete_import_items.py" = ["BLE001"]
+"scripts/import_book_covers.py" = ["BLE001"]
+"scripts/lc_marc_update.py" = ["E722"]
+"scripts/manage-imports.py" = ["BLE001"]
+"scripts/sitemaps/sitemap.py" = ["BLE001"]
+"tests/integration/__init__.py" = ["E722"]
+"tests/integration/test_loans.py" = ["E722"]
 "tests/*" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ ignore = [
   "PIE790",
   "PIE804",
   "PLC1901",
-  "PLR2004",
   "PLR5501",
   "PLW0602",
   "PLW0603",
@@ -125,6 +124,7 @@ target-version = "py311"
 max-complexity = 41
 
 [tool.ruff.pylint]
+allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 15
 max-branches = 42
 max-returns = 14


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Lint for most [flake8-bugbear](https://pypi.org/project/flake8-bugbear) and [pylint](https://pylint.readthedocs.io) issues

Also, add per-file-ignores to prevent the addition of new bare exceptions to most Python files.
> A bare `except:` clause will catch SystemExit and KeyboardInterrupt exceptions, making it harder to interrupt a program with Control-C, and can disguise other problems.
* https://peps.python.org/pep-0008/#programming-recommendations
* https://pypi.org/project/flake8-blind-except

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
