### PR TITLE
Only display link to import batch for promise item

### DIFF
--- a/openlibrary/templates/history/comment.html
+++ b/openlibrary/templates/history/comment.html
@@ -12,9 +12,12 @@ $if record_id:
     $ record = get_source_record(record_id)
     $if v.revision == 1:
        $ record_type = ''
-       $if record.source_name not in ('amazon.com', 'Better World Books'):
+       $if record.source_name not in ('amazon.com', 'Better World Books', 'Promise Item'):
             $ record_type = 'item' if record.source_name == 'Internet Archive' else 'MARC'
-       $:_('Imported from %(source)s  <a href="%(url)s">%(type)s record</a>.', source=link(record.source_url, record.source_name), url=record.url, type=record_type)
+       $if record.source_name == 'Promise Item':
+            $:_('Imported from %(source)s', source=link(record.source_url, record.source_name))
+       $else:
+            $:_('Imported from %(source)s  <a href="%(url)s">%(type)s record</a>.', source=link(record.source_url, record.source_name), url=record.url, type=record_type)
     $else:
         $:_('Found a <a href="%(url)s">matching record</a> from %(source)s.', url=record.url, source=link(record.source_url, record.source_name))
 $elif 'history_v2' in ctx.features:

--- a/openlibrary/templates/history/sources.html
+++ b/openlibrary/templates/history/sources.html
@@ -33,6 +33,9 @@ $code:
         if item.startswith("ia:"):
             source_name = "Internet Archive"
             source_url = "//archive.org/details/" + item[3:]
+        elif item.startswith("promise:"):
+            source_name = "Promise Item"
+            source_url = "https://archive.org/details/" + item[8:]
         elif item.startswith("amazon:"):
             source_name = "amazon.com"
             source_url = "https://www.amazon.com/?tag=" + affiliate_id('amazon')


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #7755 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The broken import province footer for the promise item has been fixed, now the footer shows only one link ("https://archive.org/details/{import_batch_name}")


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Search for specific books imported as promise items via OL number (e.g. OL45991226M).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![62d7bc784c314996022ad3d6c0b5c90](https://user-images.githubusercontent.com/60837226/233185676-5670cbe4-3106-4855-9c00-48ad75a15571.png)
![4b9699033612082ae79fb3c3b1c175f](https://user-images.githubusercontent.com/60837226/233185691-5a86d050-ede4-4622-90f0-9ba5a57ae243.png)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
