### PR TITLE
Bust cache if homepage fails to render

### DIFF
--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -628,9 +628,16 @@ def get_cached_homepage():
     if pd:
         key += '.pd'
 
-    return cache.memcache_memoize(
+    mc = cache.memcache_memoize(
         get_homepage, key, timeout=five_minutes, prethread=caching_prethread()
-    )()
+    )
+
+    page = mc()
+
+    if not page:
+        mc(_cache='delete')
+
+    return page
 
 
 # Because of caching, memcache will call `get_homepage` on another thread! So we


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Invalidates cache entry for homepage if homepage fails to render.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
