### PR TITLE
Fix work redirects in history causing i18n error

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -19,6 +19,13 @@ $else:
   $ work = page.make_work_from_orphaned_edition()
   $ show_observations = False
 
+$# This can happen when looking at past versions of an edition who's work
+$# has since been merged.
+$if work.type.key == '/type/redirect':
+  $ redir = work
+  $ work = get_document(redir.key)
+  $ work['title'] = '↪ ' + redir.key
+
 $ edition = storage({})
 $if query_param('edition', '').startswith('key:'):
   $ edition = get_type(query_param('edition', '').split(':')[1])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7784

Fix Sentry error https://sentry.archive.org/organizations/ia-ux/issues/35685 ; `work.edition_count` is `Nothing` because `work` is a redirect

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Before: Errors https://openlibrary.org/books/OL23244503M/Riding_freedom?v=6
- After: No error! https://testing.openlibrary.org/books/OL23244503M/Riding_freedom?v=6

### Screenshot
Now displays an icon and the old work key, but links to the new work key: 
![image](https://user-images.githubusercontent.com/6251786/233671339-8cc78e13-40c0-4be0-8cba-1a422b9dcf2f.png)


### Stakeholders
@cclauss 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
