### PR TITLE
Allow super-librarians to edit type yamls

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -811,6 +811,9 @@ class User(Thing):
     def is_librarian(self):
         return self.is_usergroup_member('/usergroup/librarians')
 
+    def is_super_librarian(self):
+        return self.is_usergroup_member('/usergroup/super-librarians')
+
     def in_sponsorship_beta(self):
         return self.is_usergroup_member('/usergroup/sponsors')
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -655,7 +655,7 @@ class _yaml_edit(_yaml):
 
     def is_admin(self):
         u = delegate.context.user
-        return u and u.is_admin()
+        return u and (u.is_admin() or u.is_super_librarian())
 
     def GET(self, key):
         # only allow admin users to edit yaml


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Allows super-librarians to edit `yaml` files.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
