### PR TITLE
Prevent `read-only` patrons from uploading images

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -37,7 +37,7 @@ class add_cover(delegate.page):
             raise web.notfound("")
 
         user = accounts.get_current_user()
-        if user.is_read_only():
+        if user and user.is_read_only():
             raise web.forbidden(message="Patron not permitted to upload images")
 
         i = web.input(file={}, url="")

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -36,6 +36,10 @@ class add_cover(delegate.page):
         if not book:
             raise web.notfound("")
 
+        user = accounts.get_current_user()
+        if user.is_read_only():
+            raise web.forbidden(message="Patron not permitted to upload images")
+
         i = web.input(file={}, url="")
 
         # remove references to field storage objects


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7835

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents image uploads from patron's in the `read-only` usergroup.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in as a member of the `read-only`usergroup:
1. Navigate to any book page.
2. Open the manage cover modal and submit a URL or image.
3. Ensure that the image isn't uploaded.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-04-27 13-49-16](https://user-images.githubusercontent.com/28732543/234988774-04d21584-3e15-4801-8edc-449607407961.png)
_Error message displayed after attempted `read-only` edit._

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
