### PR TITLE
Fix reading log dropdown toggling

### DIFF
--- a/openlibrary/macros/ReadingLogDropper.html
+++ b/openlibrary/macros/ReadingLogDropper.html
@@ -31,7 +31,7 @@ $if ctx.user or not work_key:
             <input type="hidden" name="bookshelf_id" value="$(bookshelf_id_value)"/>
             <input type="hidden" name="default-key" value="$(key)" />
 
-            <button class="book-progress-btn want-to-read $(activated_status)" type="submit">
+            <button class="book-progress-btn want-to-read $(activated_status) dropper__close" type="submit">
               <span class="activated-check$(checkmark_visibility)">✓</span>
               <span class="btn-text">$(message)</span>
             </button>
@@ -61,7 +61,7 @@ $if ctx.user or not work_key:
               $if edition_key:
                 <input type="hidden" name="edition_id" value="$(edition_key)"/>
               <input type="hidden" id="work_id" name="work_id" value="$(work_key)"/>
-              <button class="remove-from-list hidden" type="submit">$_('Remove From Shelf')</button>
+              <button class="remove-from-list dropper__close hidden" type="submit">$_('Remove From Shelf')</button>
             </form>
 
             <form class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
@@ -69,7 +69,7 @@ $if ctx.user or not work_key:
               <input type="hidden" name="bookshelf_id" value="1"/>
               $if edition_key:
                 <input type="hidden" name="edition_id" value="$(edition_key)"/>
-              <button class="nostyle-btn$(classes[0])" type="submit">$_('Want to Read')</button>
+              <button class="nostyle-btn$(classes[0]) dropper__close" type="submit">$_('Want to Read')</button>
             </form>
 
             <form class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
@@ -77,7 +77,7 @@ $if ctx.user or not work_key:
               <input type="hidden" name="bookshelf_id" value="2"/>
               $if edition_key:
                 <input type="hidden" name="edition_id" value="$(edition_key)"/>
-              <button class="nostyle-btn$(classes[1])" type="submit">$_('Currently Reading')</button>
+              <button class="nostyle-btn$(classes[1]) dropper__close" type="submit">$_('Currently Reading')</button>
             </form>
 
             <form class="readingLog" method="POST" action="$(work_key)/bookshelves.json">
@@ -85,7 +85,7 @@ $if ctx.user or not work_key:
               <input type="hidden" name="bookshelf_id" value="3"/>
               $if edition_key:
                 <input type="hidden" name="edition_id" value="$(edition_key)"/>
-              <button class="nostyle-btn$(classes[2])" type="submit">$_('Already Read')</button>
+              <button class="nostyle-btn$(classes[2]) dropper__close" type="submit">$_('Already Read')</button>
             </form>
           </div>
 

--- a/openlibrary/plugins/openlibrary/js/droppers/index.js
+++ b/openlibrary/plugins/openlibrary/js/droppers/index.js
@@ -1,9 +1,17 @@
 import { debounce } from '../nonjquery_utils';
 
 /**
- * Adds expand and collapse functionality to our droppers.
+ * Holds references to each dropper on a page.
+ * @type {Array<HTMLElement>}
  */
-export function initDroppers() {
+const droppers = []
+
+/**
+ * Adds expand and collapse functionality to our droppers.
+ *
+ * @param {HTMLCollection<HTMLElement>} dropperElements
+ */
+export function initDroppers(dropperElements) {
     /**
      * close an open dropdown in a given container
      * @param {jQuery.Object} $container
@@ -13,26 +21,26 @@ export function initDroppers() {
         $container.find('.arrow').removeClass('up');
     }
 
-    // Events are registered on document as HTML is subject to change due to JS inside
-    // openlibrary/templates/lists/widget.html
-    $(document).on('click', '.dropclick', debounce(function(){
-        $(this).next('.dropdown').slideToggle(25);
-        $(this).parent().next('.dropdown').slideToggle(25);
-        $(this).parent().find('.arrow').toggleClass('up');
-    }, 300, false));
+    for (const dropper of dropperElements) {
+        droppers.push(dropper)
 
-    $(document).on('click', 'a.add-to-list', debounce(function(){
-        $(this).closest('.dropdown').slideToggle(25);
-        $(this).closest('.arrow').toggleClass('up');
-    }, 300, false));
+        $(dropper).on('click', '.dropclick', debounce(function() {
+            $(this).next('.dropdown').slideToggle(25);
+            $(this).parent().next('.dropdown').slideToggle(25);
+            $(this).parent().find('.arrow').toggleClass('up');
+        }, 300, false))
 
-    // Close any open dropdown list if the user clicks outside...
-    $(document).on('click', function() {
-        closeDropdown($('.widget-add'));
-    });
+        $(dropper).on('click', '.dropper__close', debounce(function() {
+            closeDropdown($(dropper))
+        }, 300, false))
+    }
 
-    // ... but don't let that happen if user is clicking inside dropdown
-    $(document).on('click', '.widget-add', function(e) {
-        e.stopPropagation();
+    // Close any open dropdown list if the user clicks outside of component:
+    $(document).on('click', function(event) {
+        for (const dropper of droppers) {
+            if (!dropper.contains(event.target)) {
+                closeDropdown($(dropper))
+            }
+        }
     });
 }

--- a/openlibrary/plugins/openlibrary/js/droppers/index.js
+++ b/openlibrary/plugins/openlibrary/js/droppers/index.js
@@ -1,0 +1,38 @@
+import { debounce } from '../nonjquery_utils';
+
+/**
+ * Adds expand and collapse functionality to our droppers.
+ */
+export function initDroppers() {
+    /**
+     * close an open dropdown in a given container
+     * @param {jQuery.Object} $container
+     */
+    function closeDropdown($container) {
+        $container.find('.dropdown').slideUp(25);
+        $container.find('.arrow').removeClass('up');
+    }
+
+    // Events are registered on document as HTML is subject to change due to JS inside
+    // openlibrary/templates/lists/widget.html
+    $(document).on('click', '.dropclick', debounce(function(){
+        $(this).next('.dropdown').slideToggle(25);
+        $(this).parent().next('.dropdown').slideToggle(25);
+        $(this).parent().find('.arrow').toggleClass('up');
+    }, 300, false));
+
+    $(document).on('click', 'a.add-to-list', debounce(function(){
+        $(this).closest('.dropdown').slideToggle(25);
+        $(this).closest('.arrow').toggleClass('up');
+    }, 300, false));
+
+    // Close any open dropdown list if the user clicks outside...
+    $(document).on('click', function() {
+        closeDropdown($('.widget-add'));
+    });
+
+    // ... but don't let that happen if user is clicking inside dropdown
+    $(document).on('click', '.widget-add', function(e) {
+        e.stopPropagation();
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -354,18 +354,24 @@ jQuery(function () {
         $('#cboxSlideshow').attr({'aria-label': 'Slideshow button', 'aria-hidden': 'true'});
     }
 
+    const dropper = document.querySelector('.dropit')
+    if (dropper) {
+        import(/* webpackChunkName: "droppers" */ './droppers')
+            .then((module) => module.initDroppers())
+    }
+
     // "Want to Read" buttons:
-    const droppers = document.getElementsByClassName('widget-add');
+    const readingLogDroppers = document.getElementsByClassName('widget-add');
 
     // Async lists components:
     const wtrLoadingIndicator = document.querySelector('.list-loading-indicator')
     const overviewLoadingIndicator = document.querySelector('.list-overview-loading-indicator')
 
-    if (droppers.length || wtrLoadingIndicator || overviewLoadingIndicator) {
+    if (readingLogDroppers.length || wtrLoadingIndicator || overviewLoadingIndicator) {
         import(/* webpackChunkName: "lists" */ './lists')
             .then((module) => {
-                if (droppers.length) {
-                    module.initDroppers(droppers);
+                if (readingLogDroppers.length) {
+                    module.initReadingLogDroppers(readingLogDroppers);
                     // Removable list items:
                     // TODO: Is this the correct place to initalize these?
                     const actionableListItems = document.querySelectorAll('.actionable-item')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -354,10 +354,10 @@ jQuery(function () {
         $('#cboxSlideshow').attr({'aria-label': 'Slideshow button', 'aria-hidden': 'true'});
     }
 
-    const dropper = document.querySelector('.dropit')
-    if (dropper) {
+    const droppers = document.querySelectorAll('.dropit')
+    if (droppers.length) {
         import(/* webpackChunkName: "droppers" */ './droppers')
-            .then((module) => module.initDroppers())
+            .then((module) => module.initDroppers(droppers))
     }
 
     // "Want to Read" buttons:

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -354,7 +354,7 @@ jQuery(function () {
         $('#cboxSlideshow').attr({'aria-label': 'Slideshow button', 'aria-hidden': 'true'});
     }
 
-    const droppers = document.querySelectorAll('.dropit')
+    const droppers = document.querySelectorAll('.dropper')
     if (droppers.length) {
         import(/* webpackChunkName: "droppers" */ './droppers')
             .then((module) => module.initDroppers(droppers))

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -253,9 +253,8 @@ export function syncReadingLogDropdownRemoveWithPrimaryButton(dropper) {
  * @param {HTMLButtonElement} button Adds click listener to the given reading log button.
  * @param {HTMLAElement} An anchor element item that expands the dropper.
  * @param {string} A text string with the initial text value of primaryButton
- * @param {HTMLDivElement} A div containing the dropper widget
  */
-function togglePrimaryButton(primaryButton, dropClick, initialText, dropper) {
+function togglePrimaryButton(primaryButton, dropClick, initialText) {
     const actionInput = primaryButton.parentElement.querySelector('input[name=action]')
     // Toggle checkmark
     primaryButton.children[0].classList.toggle('hidden')

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -129,24 +129,11 @@ function addListClickListener(elem, parentDropper) {
                     actionableItems[listKey] = [li]
                 }
             }
-
-            // close dropper
-            toggleDropper(parentDropper)
         }
 
         addToList(listKey, seed, successCallback)
 
     })
-}
-
-/**
- * Toggles given dropper's expanded state.
- *
- * @param {HTMLDivElement} dropper A reading log button reference.
- */
-function toggleDropper(dropper) {
-    $(dropper).find('.dropdown').first().slideToggle(25);
-    $(dropper).find('.arrow').first().toggleClass('up');
 }
 
 /**
@@ -288,11 +275,6 @@ function togglePrimaryButton(primaryButton, dropClick, initialText, dropper) {
     actionInput.value = (actionInput.value === 'add') ? 'remove' : 'add'
 
     primaryButton.children[1].innerText = initialText
-
-    // Close dropper if expanded:
-    if ($(dropper).find('.arrow').first().hasClass('up')) {
-        toggleDropper(dropper)
-    }
 }
 
 /**
@@ -345,13 +327,10 @@ function addReadingLogButtonClickListener(button) {
                 togglePrimaryButton(primaryButton, dropClick, initialText, dropper)
                 syncReadingLogDropdownRemoveWithPrimaryButton(dropper)
             } else if (button.classList.contains('remove-from-list')) { // Clicking 'remove from list' (i.e. toggling a boofshelf) from the dropper.
-                toggleDropper(dropper)
                 togglePrimaryButton(primaryButton, dropClick, initialText, dropper)
                 syncReadingLogDropdownRemoveWithPrimaryButton(dropper)
 
             } else {  // Secondary button pressed -- all other drop down items.
-                toggleDropper(dropper)
-
                 // Change primary button's text to new value:
                 primaryButton.children[1].innerText = button.innerText
 

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -38,7 +38,7 @@ const ReadingLog = {
  *
  * @param {HTMLCollection} droppers Collection of reading log droppers.
  */
-export function initDroppers(droppers) {
+export function initReadingLogDroppers(droppers) {
     for (const dropper of droppers) {
         const anchors = dropper.querySelectorAll('.add-to-list');
         initAddToListAnchors(anchors, dropper)

--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -474,7 +474,7 @@ function addRemoveClickListener(elem) {
  * @returns {HTMLParagraphElement} The newly created add-to-list link.
  */
 function updateDropperList(listKey, listTitle, coverUrl) {
-    const itemMarkUp = `<a href="${listKey}" class="add-to-list" data-list-cover-url="${coverUrl}" data-list-key="${listKey}">${listTitle}</a>`
+    const itemMarkUp = `<a href="${listKey}" class="add-to-list dropper__close" data-list-cover-url="${coverUrl}" data-list-key="${listKey}">${listTitle}</a>`
 
     const p = document.createElement('p')
     p.classList.add('list')

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -23,43 +23,9 @@ export default function init() {
         new SearchPage($('.siteSearch.olform'), new SearchModeSelector($('.search-mode')));
     }
 
-    initReadingListFeature();
     initBorrowAndReadLinks();
     initPreviewButton();
     initWebsiteTranslationOptions();
-}
-
-export function initReadingListFeature() {
-    /**
-     * close an open dropdown in a given container
-     * @param {jQuery.Object} $container
-     */
-    function closeDropdown($container) {
-        $container.find('.dropdown').slideUp(25);
-        $container.find('.arrow').removeClass('up');
-    }
-    // Events are registered on document as HTML is subject to change due to JS inside
-    // openlibrary/templates/lists/widget.html
-    $(document).on('click', '.dropclick', debounce(function(){
-        $(this).next('.dropdown').slideToggle(25);
-        $(this).parent().next('.dropdown').slideToggle(25);
-        $(this).parent().find('.arrow').toggleClass('up');
-    }, 300, false));
-
-    $(document).on('click', 'a.add-to-list', debounce(function(){
-        $(this).closest('.dropdown').slideToggle(25);
-        $(this).closest('.arrow').toggleClass('up');
-    }, 300, false));
-
-    // Close any open dropdown list if the user clicks outside...
-    $(document).on('click', function() {
-        closeDropdown($('.widget-add'));
-    });
-
-    // ... but don't let that happen if user is clicking inside dropdown
-    $(document).on('click', '.widget-add', function(e) {
-        e.stopPropagation();
-    });
 }
 
 export function initBorrowAndReadLinks() {

--- a/openlibrary/plugins/openlibrary/js/ol.js
+++ b/openlibrary/plugins/openlibrary/js/ol.js
@@ -1,4 +1,3 @@
-import { debounce } from './nonjquery_utils.js';
 import * as Browser from './Browser';
 import { SearchBar } from './SearchBar';
 import { SearchPage } from './SearchPage';

--- a/openlibrary/templates/lists/dropper_lists.html
+++ b/openlibrary/templates/lists/dropper_lists.html
@@ -3,5 +3,5 @@ $def with (lists)
 $for list in lists:
   $if not list['active']:
     <p class="list">
-      <a href="$list.key" class="add-to-list" data-list-cover-url="$list.cover_url" data-list-key="$list.key">$list.name</a>
+      <a href="$list.key" class="add-to-list dropper__close" data-list-cover-url="$list.cover_url" data-list-key="$list.key">$list.name</a>
     </p>

--- a/tests/unit/js/droppers.test.js
+++ b/tests/unit/js/droppers.test.js
@@ -1,6 +1,6 @@
 import jquery from 'jquery';
 import sinon from 'sinon';
-import { initReadingListFeature } from '../../../openlibrary/plugins/openlibrary/js/ol';
+import { initDroppers } from '../../../openlibrary/plugins/openlibrary/js/droppers';
 import { bookDropdownSample } from './html-test-data'
 import * as nonjquery_utils from '../../../openlibrary/plugins/openlibrary/js/nonjquery_utils.js';
 let sandbox;
@@ -11,12 +11,12 @@ beforeEach(() => {
     sandbox.stub(global, '$').callsFake(jquery);
 });
 
-describe('initReadingList', () => {
+describe('initDroppers', () => {
     test.only('dropdown changes arrow direction on click', () => {
         // Stub debounce to avoid have to manipulate time (!)
         const stub = sinon.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
 
-        initReadingListFeature();
+        initDroppers();
         $(document.body).html(bookDropdownSample);
         const $dropclick = $('.dropclick');
         const $arrow = $dropclick.find('.arrow');

--- a/tests/unit/js/droppers.test.js
+++ b/tests/unit/js/droppers.test.js
@@ -16,10 +16,10 @@ describe('initDroppers', () => {
         // Stub debounce to avoid have to manipulate time (!)
         const stub = sinon.stub(nonjquery_utils, 'debounce').callsFake(fn => fn);
 
-        initDroppers();
         $(document.body).html(bookDropdownSample);
         const $dropclick = $('.dropclick');
         const $arrow = $dropclick.find('.arrow');
+        initDroppers(document.querySelectorAll('.dropper'));
 
         for (let i = 0; i < 2; i++) {
             $dropclick.trigger('click');

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -69,9 +69,11 @@ export const editionIdentifiersSample = `<fieldset id="identifiers" data-config=
 
 /** Part/Simplification of the .widget-add element */
 export const bookDropdownSample = `
-    <a href="javascript:;" class="dropclick dropclick-unactivated">
-        <div class="arrow arrow-unactivated"></div>
-    </a>
+    <div class="dropper">
+        <a href="javascript:;" class="dropclick dropclick-unactivated">
+            <div class="arrow arrow-unactivated"></div>
+        </a>
+    </div>
 `;
 
 export const listCreationForm = `


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6530

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removed redundant `toggleDropper()` function.  This was interfering with other code in `ol.js` that toggled the droppers.  Droppers should now behave as they did before the list widget refactor.

### Technical
<!-- What should be noted about the implementation? -->
`ol.js` seems to be a catch-all file that contains JS that was previously inlined.  I moved all dropper-related code from `ol.js` to a new `/droppers/index.js` file.

Since the `ol.test.js` only contained a test for the dropper, I have renamed the file `droppers.test.js`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@DebbieSan 
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
