### PR TITLE
Fix promise item import cron (path)

### DIFF
--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import requests
 import logging
 
+import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 from infogami import config  # noqa: F401
 from openlibrary.config import load_config
 from openlibrary.core.imports import Batch


### PR DESCRIPTION
@judec reported that promise item crons may not be working. Investigation revealed the cron PYTHONPATH was not being set correctly. We add a line that is used by other crons to load the paths correctly.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
