### PR TITLE
Don't sync the reading log dropper when .readingLog isn't present

### DIFF
--- a/openlibrary/plugins/openlibrary/js/lists/index.js
+++ b/openlibrary/plugins/openlibrary/js/lists/index.js
@@ -59,7 +59,10 @@ export function initDroppers(droppers) {
             addReadingLogButtonClickListener(button)
         }
 
-        syncReadingLogDropdownRemoveWithPrimaryButton(dropper)
+        const readingLogForm = dropper.querySelector('.readingLog')
+        if (readingLogForm) {
+            syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm)
+        }
     }
 }
 
@@ -240,18 +243,25 @@ export function clearCreateListForm() {
  *
  * This sets up the 'Remove From Shelf' button to behave as if it were the
  * primaryButton in terms of removal from a shelf.
+ * @param {HTMLDivElement} A div containing the dropper widget
+ * @param {HTMLFormElement} The form with the .readingLog selector.
  */
-export function syncReadingLogDropdownRemoveWithPrimaryButton(dropper) {
-    const primaryForm = dropper.querySelector('.readingLog')
-    const shelfToRemoveFrom = primaryForm.querySelector('[name=bookshelf_id]').value
+export function syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm) {
+    if (!readingLogForm) {
+        return;
+    }
+    const shelfToRemoveFrom = readingLogForm.querySelector('[name=bookshelf_id]').value
     const removalForm = dropper.querySelector('#remove-from-list')
+    if (!removalForm) {
+        return;
+    }
     const removalButton = removalForm.querySelector('button')
 
     // Get the remval bookshelf_id from primaryButton.
     removalForm.querySelector('[name=bookshelf_id]').value = shelfToRemoveFrom
 
     // The remove-from-shelf button displays only if a book is already on a bookshelf.
-    if (primaryForm.querySelector('[name=action]').value === 'remove') {
+    if (readingLogForm.querySelector('[name=action]').value === 'remove') {
         removalButton.classList.remove('hidden')
     } else {
         removalButton.classList.add('hidden')
@@ -309,6 +319,7 @@ function addReadingLogButtonClickListener(button) {
         const form = button.parentElement
         const actionInput = form.querySelector('input[name=action]')
         const dropper = button.closest('.widget-add')
+        const readingLogForm = dropper.querySelector('.readingLog')
         const primaryButton = dropper.querySelector('.want-to-read')
         const initialText = primaryButton.children[1].innerText
         const dropClick = dropper.querySelector('.dropclick')
@@ -343,11 +354,11 @@ function addReadingLogButtonClickListener(button) {
             }
             if (button.classList.contains('want-to-read')) {  // Primary button pressed
                 togglePrimaryButton(primaryButton, dropClick, initialText, dropper)
-                syncReadingLogDropdownRemoveWithPrimaryButton(dropper)
+                syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm)
             } else if (button.classList.contains('remove-from-list')) { // Clicking 'remove from list' (i.e. toggling a boofshelf) from the dropper.
                 toggleDropper(dropper)
                 togglePrimaryButton(primaryButton, dropClick, initialText, dropper)
-                syncReadingLogDropdownRemoveWithPrimaryButton(dropper)
+                syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm)
 
             } else {  // Secondary button pressed -- all other drop down items.
                 toggleDropper(dropper)
@@ -378,7 +389,7 @@ function addReadingLogButtonClickListener(button) {
                 }
                 button.classList.add('hidden')
 
-                syncReadingLogDropdownRemoveWithPrimaryButton(dropper)
+                syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm)
             }
         }
 

--- a/tests/unit/js/lists.test.js
+++ b/tests/unit/js/lists.test.js
@@ -20,12 +20,13 @@ describe('syncReadingLogDropdownRemoveWithPrimaryButton', () => {
         // Setup
         document.body.innerHTML = readingLogDropperForm
         const dropper = document.querySelector('#dropper');
+        const readingLogForm = document.querySelector('.readingLog')
 
         // Add "remove" to the action to simulate a book on the shelf
         document.querySelector('[name=action]').value = 'remove'
 
         // Test
-        syncReadingLogDropdownRemoveWithPrimaryButton(dropper);
+        syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm);
 
         // Verify
         const removalButton = dropper.querySelector('#remove-from-list button');
@@ -39,12 +40,13 @@ describe('syncReadingLogDropdownRemoveWithPrimaryButton', () => {
         // Setup
         document.body.innerHTML = readingLogDropperForm
         const dropper = document.querySelector('#dropper');
+        const readingLogForm = document.querySelector('.readingLog')
 
         // Add "add" to the action to simulate a book off the shelf
         document.querySelector('[name=action]').value = 'add'
 
         // Test
-        syncReadingLogDropdownRemoveWithPrimaryButton(dropper);
+        syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm);
 
         // Verify
         const removalButton = dropper.querySelector('#remove-from-list button');
@@ -58,12 +60,13 @@ describe('syncReadingLogDropdownRemoveWithPrimaryButton', () => {
         // Setup
         document.body.innerHTML = readingLogDropperForm
         const dropper = document.querySelector('#dropper');
+        const readingLogForm = document.querySelector('.readingLog')
 
         // Sync the shelf for removal.
         document.querySelector('[name=bookshelf_id]').value = '2'
 
         // Test
-        syncReadingLogDropdownRemoveWithPrimaryButton(dropper);
+        syncReadingLogDropdownRemoveWithPrimaryButton(dropper, readingLogForm);
 
         // Verify
         const removalForm = dropper.querySelector('#remove-from-list')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7855

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This bug was occurring because `syncReadingLogDropdownRemoveWithPrimaryButton()` was unconditionally called by `initDroppers()`, and `syncReadingLogDropdownRemoveWithPrimaryButton()` anticipated that `dropper.querySelector('.readingLog')` would not be null. When it was null, things broke.


This PR:
1. makes `syncReadingLogDropdownRemoveWithPrimaryButton()` exit immediately if `dropper.querySelector('.readingLog')` is null, and
2. stops `syncReadingLogDropdownRemoveWithPrimaryButton()` from being called by `initDroppers()` when the dropper isn't for a reading log.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit an author profile page, e.g. http://localhost:8080/authors/OL20585A/Edwin_Abbott_Abbott.
2. Add the author to a list
3. Reload the page, as the bug was only present then, as it related to `initDroppers()`.
4. Click the `[x]` next to the list to which the author was added.
5. Verify that the author is removed from the list.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini, @jimchamp  

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
