### PR TITLE
remove metadata queries for books that has availability fetched from IA

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -56,7 +56,7 @@ def fulltext_search(q, page=1, limit=100, js=False, facets=False):
             if ed.ocaid in ocaids:
                 idx = ocaids.index(ed.ocaid)
                 ia_results['hits']['hits'][idx]['edition'] = (
-                    format_book_data(ed) if js else ed
+                    format_book_data(ed, False) if js else ed
                 )
                 ia_results['hits']['hits'][idx]['availability'] = availability[ed.ocaid]
     return ia_results

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -691,7 +691,7 @@ def get_ia_carousel_books(query=None, subject=None, sorts=None, limit=None):
         sorts=sorts,
         query=query,
     )
-    formatted_books = [format_book_data(book) for book in books if book != 'error']
+    formatted_books = [format_book_data(book, False) for book in books if book != 'error']
     return formatted_books
 
 
@@ -824,7 +824,7 @@ def format_work_data(work):
     return d
 
 
-def format_book_data(book):
+def format_book_data(book, fetch_availability=True):
     d = web.storage()
     d.key = book.get('key')
     d.url = book.url()
@@ -846,13 +846,14 @@ def format_book_data(book):
     elif d.ocaid:
         d.cover_url = 'https://archive.org/services/img/%s' % d.ocaid
 
-    if d.ocaid:
-        collections = ia.get_metadata(d.ocaid).get('collection', [])
+    if fetch_availability:
+        if d.ocaid:
+            collections = ia.get_metadata(d.ocaid).get('collection', [])
 
-        if 'lendinglibrary' in collections or 'inlibrary' in collections:
-            d.borrow_url = book.url("/borrow")
-        else:
-            d.read_url = book.url("/borrow")
+            if 'lendinglibrary' in collections or 'inlibrary' in collections:
+                d.borrow_url = book.url("/borrow")
+            else:
+                d.read_url = book.url("/borrow")
     return d
 
 

--- a/openlibrary/plugins/openlibrary/home.py
+++ b/openlibrary/plugins/openlibrary/home.py
@@ -691,7 +691,9 @@ def get_ia_carousel_books(query=None, subject=None, sorts=None, limit=None):
         sorts=sorts,
         query=query,
     )
-    formatted_books = [format_book_data(book, False) for book in books if book != 'error']
+    formatted_books = [
+        format_book_data(book, False) for book in books if book != 'error'
+    ]
     return formatted_books
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7713

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Previously, `fulltext_search` calls `format_book_data` with an ocaid which is causing `core.ia.metadata` lookups. However, these calls are unnecessary as the availability has already been fetched in bulk from IA using `get_availability_of_ocaids(ocaids)`

Looking through the other calls of `format_book_data`, it seems like `custom_ia_carousel` is indirectly calling `format_book_data` with `core.ia.metadata` lookups even though the availability is already fetched from IA via `lending.get_available`. Removing metadata queries on `custom_ia_carousel` should improve the loading of the home page!

### Technical
<!-- What should be noted about the implementation? -->
Modified format_book_data so it can take an extra parameter defaulting to True which lets callers override the if statement for whether we fetch collections / ia.get_metadata.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Unable to test `fulltext_search` on local environment. It is showing hits but the books are not showing even though I have already fetched the book via `./scripts/copydocs.py`. I suspect it's because editions cannot be fetched on local? @mekarpeles do advise.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
