### PR TITLE
7862/feature/add js and css linting to pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,15 @@ repos:
     rev: v0.12.2
     hooks:
       - id: validate-pyproject
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.40.0
+    hooks:
+      - id: eslint
+        types: [file]
+        types_or: [javascript, vue]
+        additional_dependencies:
+          - eslint@6.8.0
+          - eslint-plugin-no-jquery@2.6.0
+          - eslint-plugin-vue@7.15.0
+          - babel-eslint@10.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,12 @@ repos:
           - eslint-plugin-no-jquery@2.6.0
           - eslint-plugin-vue@7.15.0
           - babel-eslint@10.1.0
+
+  - repo: https://github.com/awebdeveloper/pre-commit-stylelint
+    rev: 0.0.2
+    hooks:
+    - id: stylelint
+      files: \.(css|less)$
+      additional_dependencies:
+        - stylelint@13.13.1
+        - stylelint-declaration-use-variable@1.7.3


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7862 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
This adds `pre-commit` hooks for `eslint` and `styelint`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Change some CSS/LESS and JS files in ways that break the linting configurations in `.eslintrc.json` and `.stylelintrc.json`, such as using the wrong number of spaces.
2. Stage the commits.
3. Then run `pre-commit run` and verify that the errors are caught.

```
❯ pre-commit run
check toml...........................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.....................................(no files to check)Skipped
mixed line ending........................................................Passed
fix requirements.txt.................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
auto-walrus..........................................(no files to check)Skipped
ruff.................................................(no files to check)Skipped
black................................................(no files to check)Skipped
codespell................................................................Passed
cython-lint..........................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
Validate pyproject.toml..............................(no files to check)Skipped
eslint...................................................................Failed
- hook id: eslint
- exit code: 1


/home/scott/code/openlibrary/openlibrary/plugins/openlibrary/js/index.js
  243:1  error  Expected indentation of 12 spaces but found 10  indent

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.


stylelint................................................................Failed
- hook id: stylelint
- exit code: 2

static/css/layout/v2.less
 15:2  ✖  Expected indentation of 2 spaces   indentation
 16:2  ✖  Expected indentation of 2 spaces   indentation
 17:2  ✖  Expected indentation of 2 spaces   indentation
```


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
