### PR TITLE
load(): validate publish_date, no independent publishers, no amz/bwb without ISBN

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -45,7 +45,7 @@ from openlibrary.catalog.utils import (
     needs_isbn_and_lacks_one,
     publication_year_too_old,
     published_in_future_year,
-    EARLIEST_PUBLISH_YEAR,
+    EARLIEST_PUBLISH_YEAR_FOR_BOOKSELLERS,
 )
 from openlibrary.core import lending
 from openlibrary.plugins.upstream.utils import strip_accents
@@ -98,7 +98,7 @@ class PublicationYearTooOld(Exception):
         self.year = year
 
     def __str__(self):
-        return f"publication year is too old (i.e. earlier than {EARLIEST_PUBLISH_YEAR}): {self.year}"
+        return f"publication year is too old (i.e. earlier than {EARLIEST_PUBLISH_YEAR_FOR_BOOKSELLERS}): {self.year}"
 
 
 class PublishedInFutureYear(Exception):
@@ -782,7 +782,7 @@ def validate_record(rec: dict) -> None:
     If all the validations pass, implicitly return None.
     """
     if publication_year := get_publication_year(rec.get('publish_date')):
-        if publication_year_too_old(publication_year):
+        if publication_year_too_old(rec):
             raise PublicationYearTooOld(publication_year)
         elif published_in_future_year(publication_year):
             raise PublishedInFutureYear(publication_year)

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -30,7 +30,6 @@ import web
 from collections import defaultdict
 from copy import copy
 from time import sleep
-from web import storage
 
 import requests
 
@@ -40,11 +39,13 @@ from openlibrary import accounts
 from openlibrary.catalog.utils import (
     get_publication_year,
     is_independently_published,
+    get_missing_fields,
     is_promise_item,
     mk_norm,
     needs_isbn_and_lacks_one,
     publication_year_too_old,
     published_in_future_year,
+    EARLIEST_PUBLISH_YEAR,
 )
 from openlibrary.core import lending
 from openlibrary.plugins.upstream.utils import strip_accents
@@ -89,7 +90,7 @@ class RequiredField(Exception):
         self.f = f
 
     def __str__(self):
-        return "missing required field: %s" % self.f
+        return "missing required field(s): %s" % ", ".join(self.f)
 
 
 class PublicationYearTooOld(Exception):
@@ -97,7 +98,7 @@ class PublicationYearTooOld(Exception):
         self.year = year
 
     def __str__(self):
-        return f"publication year is too old (i.e. earlier than 1500): {self.year}"
+        return f"publication year is too old (i.e. earlier than {EARLIEST_PUBLISH_YEAR}): {self.year}"
 
 
 class PublishedInFutureYear(Exception):
@@ -773,36 +774,23 @@ def validate_publication_year(publication_year: int, override: bool = False) -> 
         raise PublishedInFutureYear(publication_year)
 
 
-def validate_record(rec: dict, override_validation: bool = False) -> None:
+def validate_record(rec: dict) -> None:
     """
     Check the record for various issues.
     Each check raises and error or returns None.
 
     If all the validations pass, implicitly return None.
     """
-    required_fields = [
-        'title',
-        'source_records',
-    ]  # ['authors', 'publishers', 'publish_date']
-    for field in required_fields:
-        if not rec.get(field):
-            raise RequiredField(field)
-
-    if (
-        publication_year := get_publication_year(rec.get('publish_date'))
-    ) and not override_validation:
+    if publication_year := get_publication_year(rec.get('publish_date')):
         if publication_year_too_old(publication_year):
             raise PublicationYearTooOld(publication_year)
         elif published_in_future_year(publication_year):
             raise PublishedInFutureYear(publication_year)
 
-    if (
-        is_independently_published(rec.get('publishers', []))
-        and not override_validation
-    ):
+    if is_independently_published(rec.get('publishers', [])):
         raise IndependentlyPublished
 
-    if needs_isbn_and_lacks_one(rec) and not override_validation:
+    if needs_isbn_and_lacks_one(rec):
         raise SourceNeedsISBN
 
 

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -4,8 +4,6 @@ import pytest
 from copy import deepcopy
 from infogami.infobase.client import Nothing
 
-from web import storage
-
 from infogami.infobase.core import Text
 
 from openlibrary.catalog import add_book
@@ -1195,83 +1193,47 @@ def test_add_identifiers_to_edition(mock_site) -> None:
 
 
 @pytest.mark.parametrize(
-    'name,rec,web_input,error,expected',
+    'name,rec,error,expected',
     [
         (
-            "Without override, books that are too old can't be imported",
+            "Books that are too old can't be imported",
             {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '1499'},
-            False,
             PublicationYearTooOld,
             None,
         ),
         (
-            "Can override PublicationYearTooOld error",
-            {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '1499'},
-            True,
+            "But 1500 CE+ can be imported",
+            {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '1500'},
             None,
             None,
         ),
         (
-            "Trying to import a book from a future year raises an error",
+            "But trying to import a book from a future year raises an error",
             {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '3000'},
-            False,
             PublishedInFutureYear,
             None,
         ),
         (
-            "Without override, independently published books can't be imported",
+            "Independently published books can't be imported",
             {
                 'title': 'a book',
                 'source_records': ['ia:ocaid'],
                 'publishers': ['Independently Published'],
             },
-            False,
             IndependentlyPublished,
             None,
         ),
         (
-            "Can override IndependentlyPublished error",
-            {
-                'title': 'a book',
-                'source_records': ['ia:ocaid'],
-                'publishers': ['Independently Published'],
-            },
-            True,
-            None,
-            None,
-        ),
-        (
-            "Without an override, can't import sources that require an ISBN",
+            "Can't import sources that require an ISBN",
             {'title': 'a book', 'source_records': ['amazon:amazon_id'], 'isbn_10': []},
-            False,
             SourceNeedsISBN,
-            None,
-        ),
-        (
-            "Can override SourceNeedsISBN error",
-            {'title': 'a book', 'source_records': ['bwb:bwb_id'], 'isbn_10': []},
-            True,
-            None,
-            None,
-        ),
-        (
-            "Can handle default case of None for web_input",
-            {
-                'title': 'a book',
-                'source_records': ['ia:1234'],
-                'isbn_10': ['1234567890'],
-            },
-            None,
-            None,
             None,
         ),
     ],
 )
-def test_validate_record(name, rec, web_input, error, expected) -> None:
-    _ = name  # Name is just used to make the tests easier to understand.
-
+def test_validate_record(name, rec, error, expected) -> None:
     if error:
         with pytest.raises(error):
-            validate_record(rec, web_input)
+            validate_record(rec)
     else:
-        assert validate_record(rec, web_input) is expected  # type: ignore [func-returns-value]
+        assert validate_record(rec) == expected, f"Assertion failed for test: {name}"  # type: ignore [func-returns-value]

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1196,14 +1196,24 @@ def test_add_identifiers_to_edition(mock_site) -> None:
     'name,rec,error,expected',
     [
         (
-            "Books that are too old can't be imported",
-            {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '1499'},
+            "Books prior to 1400 can't be imported if from a bookseller requiring additional validation",
+            {
+                'title': 'a book',
+                'source_records': ['amazon:123'],
+                'publish_date': '1399',
+                'isbn_10': ['1234567890'],
+            },
             PublicationYearTooOld,
             None,
         ),
         (
-            "But 1500 CE+ can be imported",
-            {'title': 'a book', 'source_records': ['ia:ocaid'], 'publish_date': '1500'},
+            "But 1400 CE+ can be imported",
+            {
+                'title': 'a book',
+                'source_records': ['amazon:123'],
+                'publish_date': '1400',
+                'isbn_10': ['1234567890'],
+            },
             None,
             None,
         ),
@@ -1236,4 +1246,4 @@ def test_validate_record(name, rec, error, expected) -> None:
         with pytest.raises(error):
             validate_record(rec)
     else:
-        assert validate_record(rec) == expected, f"Assertion failed for test: {name}"  # type: ignore [func-returns-value]
+        assert validate_record(rec) == expected, f"Test failed: {name}"  # type: ignore [func-returns-value]

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from re import compile, Match
+from re import Match
 import web
 from unicodedata import normalize
 from openlibrary.catalog.merge.merge_marc import build_titles
@@ -339,8 +339,9 @@ def get_publication_year(publish_date: str | int | None) -> int | None:
     if publish_date is None:
         return None
 
-    pattern = compile(r"\b\d{4}(?!\d)\b")
-    match = pattern.search(str(publish_date))
+    from openlibrary.catalog.utils import re_year
+
+    match = re_year.search(str(publish_date))
 
     return int(match.group(0)) if match else None
 

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -1,11 +1,13 @@
 import datetime
 import re
 from re import compile, Match
-from typing import cast, Mapping
 import web
 from unicodedata import normalize
 from openlibrary.catalog.merge.merge_marc import build_titles
 import openlibrary.catalog.merge.normalize as merge
+
+
+EARLIEST_PUBLISH_YEAR = 1500
 
 
 def cmp(x, y):
@@ -357,7 +359,7 @@ def publication_year_too_old(publish_year: int) -> bool:
     """
     Returns True if publish_year is < 1,500 CE, and False otherwise.
     """
-    return publish_year < 1500
+    return publish_year < EARLIEST_PUBLISH_YEAR
 
 
 def is_independently_published(publishers: list[str]) -> bool:
@@ -404,3 +406,12 @@ def is_promise_item(rec: dict) -> bool:
         record.startswith("promise:".lower())
         for record in rec.get('source_records', "")
     )
+
+
+def get_missing_fields(rec: dict) -> list[str]:
+    """Return missing fields, if any."""
+    required_fields = [
+        'title',
+        'source_records',
+    ]
+    return [field for field in required_fields if rec.get(field, None) is None]

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -356,7 +356,7 @@ def published_in_future_year(publish_year: int) -> bool:
     return publish_year > datetime.datetime.now().year
 
 
-def publication_year_too_old(rec: dict) -> bool:
+def publication_too_old_and_not_exempt(rec: dict) -> bool:
     """
     Returns True for books that are 'too old' per
     EARLIEST_PUBLISH_YEAR_FOR_BOOKSELLERS, but that only applies to

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -325,8 +325,8 @@ def expand_record(rec: dict) -> dict[str, str | list[str]]:
 
 def get_publication_year(publish_date: str | int | None) -> int | None:
     """
-    Try to get the publication year from a book in YYYY format by looking for four
-    consecutive digits not followed by another digit.
+    Return the publication year from a book in YYYY format by looking for four
+    consecutive digits not followed by another digit. If no match, return None.
 
     >>> get_publication_year('1999-01')
     1999
@@ -344,7 +344,7 @@ def get_publication_year(publish_date: str | int | None) -> int | None:
 
 def published_in_future_year(publish_year: int) -> bool:
     """
-    Look to see if a book is published in a future year as compared to the
+    Return True if a book is published in a future year as compared to the
     current year.
 
     Some import sources have publication dates in a future year, and the
@@ -362,7 +362,7 @@ def publication_year_too_old(publish_year: int) -> bool:
 
 def is_independently_published(publishers: list[str]) -> bool:
     """
-    Return True if publishers contains (casefolded) "independently published".
+    Return True if the book is independently published.
     """
     return any(
         publisher.casefold() == "independently published" for publisher in publishers
@@ -371,8 +371,7 @@ def is_independently_published(publishers: list[str]) -> bool:
 
 def needs_isbn_and_lacks_one(rec: dict) -> bool:
     """
-    Check a record to see if the source indicates that an ISBN is
-    required.
+    Return True if the book is identified as requiring an ISBN.
 
     If an ISBN is NOT required, return False. If an ISBN is required:
         - return False if an ISBN is present (because the rec needs an ISBN and
@@ -397,3 +396,11 @@ def needs_isbn_and_lacks_one(rec: dict) -> bool:
         return any(rec.get('isbn_10', []) or rec.get('isbn_13', []))
 
     return needs_isbn(rec) and not has_isbn(rec)
+
+
+def is_promise_item(rec: dict) -> bool:
+    """Returns True if the record is a promise item."""
+    return any(
+        record.startswith("promise:".lower())
+        for record in rec.get('source_records', "")
+    )

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -129,6 +129,7 @@ class importapi:
             raise web.HTTPError('403 Forbidden')
 
         data = web.data()
+        i = web.input()
 
         try:
             edition, format = parse_data(data)
@@ -151,7 +152,9 @@ class importapi:
             return self.error('unknown-error', 'Failed to parse import data')
 
         try:
-            reply = add_book.load(edition)
+            reply = add_book.load(
+                edition, override_validation=i.get('override-validation', False)
+            )
             # TODO: If any records have been created, return a 201, otherwise 200
             return json.dumps(reply)
         except add_book.RequiredField as e:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -129,7 +129,6 @@ class importapi:
             raise web.HTTPError('403 Forbidden')
 
         data = web.data()
-        i = web.input()
 
         try:
             edition, format = parse_data(data)
@@ -152,9 +151,7 @@ class importapi:
             return self.error('unknown-error', 'Failed to parse import data')
 
         try:
-            reply = add_book.load(
-                edition, override_validation=i.get('override-validation', False)
-            )
+            reply = add_book.load(edition)
             # TODO: If any records have been created, return a 201, otherwise 200
             return json.dumps(reply)
         except add_book.RequiredField as e:

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -336,15 +336,46 @@ def test_published_in_future_year(years_from_today, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    'year,expected',
+    'name,rec,expected',
     [
-        (1499, True),
-        (1500, False),
-        (1501, False),
+        (
+            "1399 is too old for an Amazon source",
+            {'source_records': ['amazon:123'], 'publish_date': '1399'},
+            True,
+        ),
+        (
+            "1400 is acceptable for an Amazon source",
+            {'source_records': ['amazon:123'], 'publish_date': '1400'},
+            False,
+        ),
+        (
+            "1401 is acceptable for an Amazon source",
+            {'source_records': ['amazon:123'], 'publish_date': '1401'},
+            False,
+        ),
+        (
+            "1399 is acceptable for an IA source",
+            {'source_records': ['ia:123'], 'publish_date': '1399'},
+            False,
+        ),
+        (
+            "1400 is acceptable for an IA source",
+            {'source_records': ['ia:123'], 'publish_date': '1400'},
+            False,
+        ),
+        (
+            "1401 is acceptable for an IA source",
+            {'source_records': ['ia:123'], 'publish_date': '1401'},
+            False,
+        ),
     ],
 )
-def test_publication_year_too_old(year, expected) -> None:
-    assert publication_year_too_old(year) == expected
+def test_publication_year_too_old(name, rec, expected) -> None:
+    """
+    See publication_year_too_old for an explanation of which sources require
+    which publication years.
+    """
+    assert publication_year_too_old(rec) == expected, f"Test failed: {name}"
 
 
 @pytest.mark.parametrize(
@@ -410,4 +441,4 @@ def test_is_promise_item(rec, expected) -> None:
 def test_get_missing_field(name, rec, expected) -> None:
     assert sorted(get_missing_fields(rec=rec)) == sorted(
         expected
-    ), f"Assertion failed for test: {name}"
+    ), f"Test failed: {name}"

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -4,6 +4,7 @@ from openlibrary.catalog.utils import (
     author_dates_match,
     expand_record,
     flip_name,
+    get_missing_fields,
     get_publication_year,
     is_independently_published,
     is_promise_item,
@@ -384,3 +385,29 @@ def test_needs_isbn_and_lacks_one(rec, expected) -> None:
 )
 def test_is_promise_item(rec, expected) -> None:
     assert is_promise_item(rec) == expected
+
+
+@pytest.mark.parametrize(
+    'name,rec,expected',
+    [
+        (
+            "Returns an empty list if no fields are missing",
+            {'title': 'A Great Book', 'source_records': ['ia:123']},
+            [],
+        ),
+        (
+            "Catches a missing required field",
+            {'source_records': ['ia:123']},
+            ['title'],
+        ),
+        (
+            "Catches multiple missing required fields",
+            {'publish_date': '1999'},
+            ['source_records', 'title'],
+        ),
+    ],
+)
+def test_get_missing_field(name, rec, expected) -> None:
+    assert sorted(get_missing_fields(rec=rec)) == sorted(
+        expected
+    ), f"Assertion failed for test: {name}"

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -6,6 +6,7 @@ from openlibrary.catalog.utils import (
     flip_name,
     get_publication_year,
     is_independently_published,
+    is_promise_item,
     needs_isbn_and_lacks_one,
     pick_first_date,
     pick_best_name,
@@ -370,3 +371,16 @@ def test_independently_published(publishers, expected) -> None:
 )
 def test_needs_isbn_and_lacks_one(rec, expected) -> None:
     assert needs_isbn_and_lacks_one(rec) == expected
+
+
+@pytest.mark.parametrize(
+    'rec,expected',
+    [
+        ({'source_records': ['promise:123', 'ia:456']}, True),
+        ({'source_records': ['ia:456']}, False),
+        ({'source_records': []}, False),
+        ({}, False),
+    ],
+)
+def test_is_promise_item(rec, expected) -> None:
+    assert is_promise_item(rec) == expected

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -8,16 +8,16 @@ from openlibrary.catalog.utils import (
     get_publication_year,
     is_independently_published,
     is_promise_item,
-    needs_isbn_and_lacks_one,
-    pick_first_date,
-    pick_best_name,
-    pick_best_author,
     match_with_bad_chars,
     mk_norm,
-    publication_year_too_old,
+    needs_isbn_and_lacks_one,
+    pick_best_author,
+    pick_best_name,
+    pick_first_date,
+    publication_too_old_and_not_exempt,
     published_in_future_year,
-    strip_count,
     remove_trailing_dot,
+    strip_count,
 )
 
 
@@ -293,7 +293,7 @@ def test_expand_record_isbn():
 
 
 @pytest.mark.parametrize(
-    'year,expected',
+    'year, expected',
     [
         ('1999-01', 1999),
         ('1999', 1999),
@@ -316,7 +316,7 @@ def test_publication_year(year, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    'years_from_today,expected',
+    'years_from_today, expected',
     [
         (1, True),
         (0, False),
@@ -336,7 +336,7 @@ def test_published_in_future_year(years_from_today, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    'name,rec,expected',
+    'name, rec, expected',
     [
         (
             "1399 is too old for an Amazon source",
@@ -370,16 +370,16 @@ def test_published_in_future_year(years_from_today, expected) -> None:
         ),
     ],
 )
-def test_publication_year_too_old(name, rec, expected) -> None:
+def test_publication_too_old_and_not_exempt(name, rec, expected) -> None:
     """
-    See publication_year_too_old for an explanation of which sources require
+    See publication_too_old_and_not_exempt() for an explanation of which sources require
     which publication years.
     """
-    assert publication_year_too_old(rec) == expected, f"Test failed: {name}"
+    assert publication_too_old_and_not_exempt(rec) == expected, f"Test failed: {name}"
 
 
 @pytest.mark.parametrize(
-    'publishers,expected',
+    'publishers, expected',
     [
         (['INDEPENDENTLY PUBLISHED'], True),
         (['Another Publisher', 'independently published'], True),
@@ -391,7 +391,7 @@ def test_independently_published(publishers, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    'rec,expected',
+    'rec, expected',
     [
         ({'source_records': ['bwb:123'], 'isbn_10': ['1234567890']}, False),
         ({'source_records': ['amazon:123'], 'isbn_13': ['1234567890123']}, False),
@@ -406,7 +406,7 @@ def test_needs_isbn_and_lacks_one(rec, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    'rec,expected',
+    'rec, expected',
     [
         ({'source_records': ['promise:123', 'ia:456']}, True),
         ({'source_records': ['ia:456']}, False),
@@ -419,7 +419,7 @@ def test_is_promise_item(rec, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    'name,rec,expected',
+    'name, rec, expected',
     [
         (
             "Returns an empty list if no fields are missing",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
There's no issue associated with this, but it addresses some of the issues @seabelis raised in #open-librarians-g.

UNLESS the item is a promise item, for imports that go through load(), this PR:
- Stop imports prior to ~~1500 CE~~ 1400 CE from Amazon and BWB;
- Stop imports of AMZ/BWB source_records if the record has no ISBN.
- Stop import of books published in future years; and
- Stop imports of Independently Published books.

If an import is a promise item, based on the source record, these validations are *not* applied.

Additionally, these validations do *not* apply to books added via `/books/add`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature.

### Technical
<!-- What should be noted about the implementation? -->
The `load()` validation has been largely consolidated in its own function, `validate_record()`, in part because they're related, in part because `load()` has quite a lot going on already.

#### Required fields
`normalize_import_record(rec)` checks `rec` for missing fields and raises an error. I did not include that check in `validate_record(rec)` because `validate_record(rec)` does *not* apply to promise items, but the required fields *do* apply to promise items.

I find this a bit confusing and I think it gestures towards the idea that we are starting to have enough rules such that we are getting near the place were our rules are a bit like, "A & B but not C, unless D, in which case, A & C", and that is a bit hard to follow with this flow.

That said, I am not sure if this PR is the place to address that, and instead I think it should help inform discussions about improving the import flow.

However, if it is desirable to partially address this now, perhaps validation could be of the form:
```python
    if not is_promise_item(rec):
        validate_non_promise_item(rec)
    validate_record_universal(rec)    
    normalize_import_record(rec)

```
Then the required fields validation could be moved from `normalize_import_record` to `validate_record_universal`. Whether this is a good road to go too far down I don't know, because the next logical extension is `validate_promise_item`. I am not sure how many more specialized validation functions there might be with this approach.

#### Callers handle error raising
I opted to go with having the validation functions return `bool`s and the like, and having the caller always raise any necessary errors. My rationale was the functions exist merely to perform checks, and it's the caller that decides what to do. That said, I know there are arguments both ways, and I'm happy to move the `raise` statements within the relevant validation functions if that approach is preferred.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`publish_date` has a future year.
```
❯ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["ia:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Gallimard"],
        "isbn_13": ["9782072702211"],
        "publish_date": "3001-01",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import

{"success": false, "error_code": "unhandled-exception", "error": "PublishedInFutureYear(3001)"}
```

`publish_date` prior to 1400 CE with a non-Amazon/BWB source:
```
curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["ia:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Gallimard"],
        "isbn_13": ["9782072702211"],
        "publish_date": "January 1, 1399",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import

{"success": true, "edition": {"key": "/books/OL43522513M", "status": "matched"}, "work": {"key": "/works/OL31822851W", "status": "matched"}}
```

`publish_date` prior to 1400 CE WITH an Amazon/BWB source:
```
curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["amazon:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Gallimard"],
        "isbn_13": ["9782072702211"],
        "publish_date": "January 1, 1399",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import

{"success": false, "error_code": "unhandled-exception", "error": "PublicationYearTooOld(1399)"}
```

Amazon import without an ISBN (BWB behavior is the same):
```
❯ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["amazon:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Gallimard"],
        "isbn_13": [],
        "publish_date": "January 1, 1500",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import

{"success": false, "error_code": "unhandled-exception", "error": "SourceNeedsISBN()"}
```

But other import sources can import without an ISBN:
```
❯ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["ia:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Gallimard"],
        "isbn_13": [],
        "publish_date": "January 1, 2001",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import
{"success": true, "edition": {"key": "/books/OL43522513M", "status": "matched"}, "work": {"key": "/works/OL31822851W", "status": "matched"}}
```

Amazon import with ISBN:
```
❯ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["amazon:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Gallimard"],
        "isbn_13": ["9782072702211"],
        "publish_date": "January 1, 1500",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import

{"success": true, "edition": {"key": "/books/OL43522513M", "status": "modified"}, "work": {"key": "/works/OL31822851W", "status": "matched"}}
```

Independently Published:
```
❯ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["amazon:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Independently Published"],
        "isbn_13": ["9782072702211"],
        "publish_date": "January 1, 1500",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import

{"success": false, "error_code": "unhandled-exception", "error": "IndependentlyPublished()"}
```

Promise items can bypass these checks (independently published in year 1001 without an ISBN). E.g.:
```
❮ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "title": "Les noirs et les rouges",
        "source_records": ["promise:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Independently Published"],
        "isbn_13": [],
        "publish_date": "January 1, 1001",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import
{"success": true, "edition": {"key": "/books/OL13M", "status": "matched"}, "work": {"key": "/works/OL4W", "status": "matched"}}
```

But promise items still need titles, as before:
```
❮ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Cookie: $OL_COOKIE" \
     -d '{
        "source_records": ["promise:lesnoirsetlesrou0000garl"],
        "authors": [{"name": "Alberto Garlini"}],
        "publishers": ["Independently Published"],
        "isbn_13": [],
        "publish_date": "January 1, 1001",
        "number_of_pages": 5
     }' \
     http://localhost:8080/api/import
{"success": false, "error_code": "invalid-value", "error": "1 validation error for Book: title:   field required (type=value_error.missing)"}
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
