### PR TITLE
7864/bugfix/ile ignore link clicks

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -82,8 +82,10 @@ export default class SelectionManager {
      * @param {MouseEvent & { currentTarget: HTMLElement }} clickEvent
      */
     toggleSelected(clickEvent) {
-        // If there is text selection, dont do anything
-        if (window.getSelection()?.toString() !== '') return;
+        // If there is text selection or the click is on a link that isn't a select handle, don't do anything
+        if (window.getSelection()?.toString() !== '' || 
+            ($(clickEvent.target).closest('a').is('a') &&
+            $(clickEvent.target).not('.ile-select-handle').length > 0)) return;
 
         const el = clickEvent.currentTarget;
         const isCurSelected = el.classList.contains('ile-selected');

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -83,7 +83,7 @@ export default class SelectionManager {
      */
     toggleSelected(clickEvent) {
         // If there is text selection or the click is on a link that isn't a select handle, don't do anything
-        if (window.getSelection()?.toString() !== '' || 
+        if (window.getSelection()?.toString() !== '' ||
             ($(clickEvent.target).closest('a').is('a') &&
             $(clickEvent.target).not('.ile-select-handle').length > 0)) return;
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7864 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In lists of works, editions, or authors, clicking on the item's link adds that item to the ILE blue bar, even as the link takes you to the item's page. This wasn't a problem when selections were cleared on each page load, but with the persistent ILE, librarians end up collecting a lot of random items in the blue bar just by navigating around the site normally.

### Testing
As a librarian, try adding works, editions, or authors to the ILE blue bar from a variety of different pages. Clicking in the selection target area should work normally; clicks on links within the target area should just trigger the link, not add to the ILE selection.

### Stakeholders
@mheiman @cdrini 

