### PR TITLE
adds sort, submitter, reviewer dropdown menus to merge queue

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -91,6 +91,18 @@ class CommunityEditsQueue:
         return oldb.query(query, vars=kwargs)[0]['count']
 
     @classmethod
+    def get_submitters(cls):
+        oldb = db.get_db()
+        query = f'SELECT DISTINCT submitter FROM {cls.TABLENAME}'
+        return list(oldb.query(query))
+
+    @classmethod
+    def get_reviewers(cls):
+        oldb = db.get_db()
+        query = f'SELECT DISTINCT reviewer FROM {cls.TABLENAME}'
+        return list(oldb.query(query))
+
+    @classmethod
     def where_clause(cls, mode, **kwargs):
         wheres = []
 

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -476,8 +476,10 @@ jQuery(function () {
     const mergeRequestCommentButtons = document.querySelectorAll('.mr-comment-btn')
     const showCommentsLinks = document.querySelectorAll('.comment-expand')
     const unassignElements = document.querySelectorAll('.mr-unassign')
+    const mergeRequestFilters = document.querySelectorAll('.mr-dropdown-menu')
 
-    if (mergeRequestCloseLinks.length || mergeRequestCommentButtons.length || showCommentsLinks.length || mergeRequestResolveLinks.length || unassignElements.length) {
+    if (mergeRequestCloseLinks.length || mergeRequestCommentButtons.length || showCommentsLinks.length || mergeRequestResolveLinks.length ||
+        unassignElements.length || mergeRequestFilters.length) {
         import(/* webpackChunkName: "merge-request-table" */'./merge-request-table')
             .then(module => {
                 if (mergeRequestCloseLinks.length) {
@@ -494,6 +496,9 @@ jQuery(function () {
                 }
                 if (unassignElements.length) {
                     module.initUnassignment(unassignElements)
+                }
+                if (mergeRequestFilters.length) {
+                    module.initFilters()
                 }
             })
     }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -476,7 +476,7 @@ jQuery(function () {
     const mergeRequestCommentButtons = document.querySelectorAll('.mr-comment-btn')
     const showCommentsLinks = document.querySelectorAll('.comment-expand')
     const unassignElements = document.querySelectorAll('.mr-unassign')
-    const mergeRequestFilters = document.querySelectorAll('.mr-dropdown-menu')
+    const mergeRequestFilters = document.querySelectorAll('.mr-dropdown')
 
     if (mergeRequestCloseLinks.length || mergeRequestCommentButtons.length || showCommentsLinks.length || mergeRequestResolveLinks.length ||
         unassignElements.length || mergeRequestFilters.length) {

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -277,3 +277,95 @@ function toggleMergeLink(mergeLink) {
         mergeLink.classList.toggle('hidden')
     }
 }
+
+/**
+ * Toggle a dropdown menu while closing other dropdown menus.
+ *
+ * @param {Event} event
+ * @param {string} menuButtonId
+ */
+function toggleAMenuWhileClosingOthers(event, menuButtonId) {
+    // prevent closing of menu on bubbling unless click menuButton itself
+    if (event.target.id === menuButtonId) {
+        // close other open menus, then toggle selected menu
+        closeOtherMenus(menuButtonId)
+        event.target.firstElementChild.classList.toggle('hidden')
+    }
+}
+
+/**
+ * Close dropdown menus whose menu button doesn't match a given id.
+ *
+ * @param {string} menuButtonId
+ */
+function closeOtherMenus(menuButtonId) {
+    const dropMenus = document.querySelectorAll('.mr-dropdown')
+    dropMenus.forEach((menuButton) => {
+        if (menuButton.id !== menuButtonId) {
+            menuButton.firstElementChild.classList.add('hidden')
+        }
+    })
+}
+
+/**
+ * Filters of dropdown menu items using case-insensitive string matching.
+ *
+ * @param {Event} event
+ */
+function filterMenuItems(event) {
+    const input = document.getElementById(event.target.id)
+    const filter = input.value.toUpperCase()
+    const menu = input.closest('.mr-dropdown-menu')
+    const items = menu.getElementsByClassName('dropdown-item')
+    // skip first item in menu
+    for (let i=1; i < items.length; i++) {
+        const text = items[i].textContent
+        if (text.toUpperCase().indexOf(filter) > -1) {
+            items[i].style.display = ''
+        }
+        else {
+            items[i].style.display = 'none'
+        }
+    }
+}
+
+/**
+ * Close all dropdown menus when click anywhere on screen that's not part of
+ * the dropdown menu; otherwise, keep dropdown menu open.
+ *
+ * @param {Event} event
+ */
+function closeMenusIfClickOutside(event, dropMenuButtons, dropMenus) {
+    const menusClicked = Array.from(dropMenuButtons).filter((menuButton) => {
+        return menuButton.contains(event.target)
+    })
+    // want to preserve clicking in a menu, i.e. when filtering for users
+    if (!menusClicked.length) {
+        dropMenus.forEach((menu) => menu.classList.add('hidden'))
+    }
+}
+
+/**
+ * Initialize events for merge queue filter dropdown menu functionality.
+ *
+ */
+export function initFilters() {
+    const dropMenuButtons = document.querySelectorAll('.mr-dropdown')
+    const dropMenus = document.querySelectorAll('.mr-dropdown-menu')
+    dropMenuButtons.forEach((menu) => {
+        menu.addEventListener('click', (event) => {
+            toggleAMenuWhileClosingOthers(event, menu.id)
+        })
+    })
+    const closeButtons = document.querySelectorAll('.dropdown-close')
+    closeButtons.forEach((button) => {
+        button.addEventListener('click', (event) => {
+            event.target.closest('.mr-dropdown-menu').classList.toggle('hidden')
+        })
+    })
+    const inputs = document.querySelectorAll('.filter')
+    inputs.forEach((input) => {
+        input.addEventListener('keyup', (event) => filterMenuItems(event))
+    })
+    document.addEventListener('click', (event) => closeMenusIfClickOutside(event, dropMenuButtons, dropMenus))
+}

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -1,6 +1,10 @@
 import { FadingToast } from '../Toast';
 import { commentOnRequest, declineRequest, claimRequest, unassignRequest } from './MergeRequestService';
 
+// "cache" results in file-level variables to prevent re-querying of DOM
+var dropMenuButtons
+var dropMenus
+
 /**
  * Adds functionality for closing librarian requests.
  *
@@ -299,8 +303,7 @@ function toggleAMenuWhileClosingOthers(event, menuButtonId) {
  * @param {string} menuButtonId
  */
 function closeOtherMenus(menuButtonId) {
-    const dropMenus = document.querySelectorAll('.mr-dropdown')
-    dropMenus.forEach((menuButton) => {
+    dropMenuButtons.forEach((menuButton) => {
         if (menuButton.id !== menuButtonId) {
             menuButton.firstElementChild.classList.add('hidden')
         }
@@ -335,7 +338,7 @@ function filterMenuItems(event) {
  *
  * @param {Event} event
  */
-function closeMenusIfClickOutside(event, dropMenuButtons, dropMenus) {
+function closeMenusIfClickOutside(event) {
     const menusClicked = Array.from(dropMenuButtons).filter((menuButton) => {
         return menuButton.contains(event.target)
     })
@@ -350,11 +353,11 @@ function closeMenusIfClickOutside(event, dropMenuButtons, dropMenus) {
  *
  */
 export function initFilters() {
-    const dropMenuButtons = document.querySelectorAll('.mr-dropdown')
-    const dropMenus = document.querySelectorAll('.mr-dropdown-menu')
-    dropMenuButtons.forEach((menu) => {
-        menu.addEventListener('click', (event) => {
-            toggleAMenuWhileClosingOthers(event, menu.id)
+    dropMenuButtons = document.querySelectorAll('.mr-dropdown')
+    dropMenus = document.querySelectorAll('.mr-dropdown-menu')
+    dropMenuButtons.forEach((menuButton) => {
+        menuButton.addEventListener('click', (event) => {
+            toggleAMenuWhileClosingOthers(event, menuButton.id)
         })
     })
     const closeButtons = document.querySelectorAll('.dropdown-close')
@@ -367,5 +370,5 @@ export function initFilters() {
     inputs.forEach((input) => {
         input.addEventListener('keyup', (event) => filterMenuItems(event))
     })
-    document.addEventListener('click', (event) => closeMenusIfClickOutside(event, dropMenuButtons, dropMenus))
+    document.addEventListener('click', (event) => closeMenusIfClickOutside(event))
 }

--- a/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/merge-request-table/index.js
@@ -1,9 +1,8 @@
 import { FadingToast } from '../Toast';
 import { commentOnRequest, declineRequest, claimRequest, unassignRequest } from './MergeRequestService';
 
-// "cache" results in file-level variables to prevent re-querying of DOM
-var dropMenuButtons
-var dropMenus
+let dropMenuButtons
+let dropMenus
 
 /**
  * Adds functionality for closing librarian requests.
@@ -324,10 +323,10 @@ function filterMenuItems(event) {
     for (let i=1; i < items.length; i++) {
         const text = items[i].textContent
         if (text.toUpperCase().indexOf(filter) > -1) {
-            items[i].style.display = ''
+            items[i].classList.remove('hidden')
         }
         else {
-            items[i].style.display = 'none'
+            items[i].classList.add('hidden')
         }
     }
 }

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -50,7 +50,10 @@ class community_edits_queue(delegate.page):
             "closed": CommunityEditsQueue.get_counts_by_mode(
                 mode='closed', submitter=i.submitter, reviewer=i.reviewer
             ),
+            "submitters": CommunityEditsQueue.get_submitters(),
+            "reviewers": CommunityEditsQueue.get_reviewers(),
         }
+
         return render_template(
             'merge_queue/merge_queue',
             total_found,

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -9,6 +9,7 @@ $ can_merge = ctx.user and (ctx.user.is_usergroup_member('/usergroup/super-libra
 $ reviewer = query_param('reviewer', None)
 $ submitter = query_param('submitter', None)
 $ mode = query_param('mode', 'open')
+$ order = query_param('order', 'desc')
 
 $if submitter:
   $ desc = _("Showing %(username)s's requests only.", username=submitter)
@@ -32,20 +33,74 @@ $else:
       </span>
     <span>$desc <a href="$href">$link_text</a></span>
   </div>
-
+  
 $ page = int(input(page=1).page)
 <div class="pager">
   $:macros.Pager(page, total[mode], results_per_page=25)
 </div>
 
-  <ul class="nav-bar">
-    <li class="$(mode=='open' and 'selected' or '')">
-      <a href="$changequery(mode='open', page=None)">$_('Open') ($total['open'])</a>
-    </li>
-    <li class="$(mode=='closed' and 'selected' or '')">
-      <a href="$changequery(mode='closed', page=None)">$_('Closed') ($total['closed'])</a>
-    </li>
-  </ul>
+  <div class="table-header">
+    <a class="$(mode=='open' and 'selected' or '') mode-open" href="$changequery(mode='open', page=None)">$total['open'] $_('Open')</a>
+    <a class="$(mode=='closed' and 'selected' or '') mode-closed" href="$changequery(mode='closed', page=None)">$total['closed'] $_('Closed')</a>
+    <div class="flex-auto"></div>
+    <div class="mr-dropdown" id="submitter-menu-button">Submitter ▾
+      <div class="mr-dropdown-menu hidden">
+        <header class="dropdown-header">
+            <span>Submitter</span>
+            <button class="dropdown-close">&times;</button>
+        </header>
+        <input type="text" class="filter" placeholder="Filter submitters" id="submitter-filter">
+        <a href="$changequery(submitter=username, page=None)" class="dropdown-item">
+          <span class="$('' if submitter==username else 'visibility-hidden') item-checked">✓</span>
+          <span><b>Submitted by me</b></span>
+        </a>
+      $for s in total['submitters']:
+        $ submitter_name = s.get('submitter', 'default submitter')
+        $ submitter_href = changequery(submitter=submitter_name, page=None)
+        <a href="$submitter_href" class="dropdown-item">
+          <span class="$('' if submitter==submitter_name else 'visibility-hidden') item-checked">✓</span>
+          <span>$submitter_name</span>
+        </a>
+      </div>
+    </div>
+    <div class="mr-dropdown" id="reviewer-menu-button">Reviewer ▾
+      <div class="mr-dropdown-menu hidden">
+        <header class="dropdown-header">
+          <span>Reviewer</span>
+          <button class="dropdown-close">&times;</button>
+        </header>
+        <input type="text" class="filter" placeholder="Filter reviewers" id="reviewer-filter">
+        <a href="$changequery(reviewer='None', page=None)" class="dropdown-item">
+          <span class="$('' if reviewer=='None' else 'visibility-hidden') item-checked">✓</span>
+          <span><b>Assigned to nobody</b></span>
+        </a>
+      $for r in total['reviewers']:
+        $ reviewer_name = r.get('reviewer', 'default reviewer')
+        $ reviewer_href = changequery(reviewer=reviewer_name, page=None)
+        $if reviewer_name and reviewer_name != username:
+          <a href="$reviewer_href" class="dropdown-item">
+            <span class="$('' if reviewer==reviewer_name else 'visibility-hidden') item-checked">✓</span>
+            <span>$reviewer_name</span>
+          </a>
+      </div>
+    </div>
+    <div class="mr-dropdown" id="sort-menu-button">Sort ▾
+      <div class="mr-dropdown-menu sort hidden">
+        <header class="dropdown-header">
+          <span>Sort</span>
+          <button class="dropdown-close">&times;</button>
+        </header>
+        <a href="$changequery(order='desc', page=None)" class="dropdown-item">
+          <span class="$('' if order=='desc' else 'visibility-hidden') item-checked">✓</span>
+          <span>Newest</span>
+        </a>
+        <a href="$changequery(order='asc', page=None)" class="dropdown-item">
+          <span class="$('' if order=='asc' else 'visibility-hidden') item-checked">✓</span>
+          <span>Oldest</span>
+        </a>
+      </div>
+    </div>
+  </div>
 
   <div class="table-wrapper">
       <table class="mr-table">

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -52,14 +52,14 @@ $ page = int(input(page=1).page)
         <input type="text" class="filter" placeholder="$_('Filter submitters')" id="submitter-filter">
         $ submitted_by_me_href = changequery(submitter=username, page=None) if submitter != username else changequery(submitter=None,page=None)
         <a href="$submitted_by_me_href" class="dropdown-item">
-          <span class="$('' if submitter==username else 'visibility-hidden') item-checked">✓</span>
+          <span class="$('' if submitter==username else 'invisible') item-checked">✓</span>
           <span><b>$_('Submitted by me')</b></span>
         </a>
       $for s in total['submitters']:
         $ submitter_name = s.get('submitter', 'default submitter')
         $ submitter_href = changequery(submitter=submitter_name, page=None) if submitter != submitter_name else changequery(submitter=None, page=None)
         <a href="$submitter_href" class="dropdown-item">
-          <span class="$('' if submitter==submitter_name else 'visibility-hidden') item-checked">✓</span>
+          <span class="$('' if submitter==submitter_name else 'invisible') item-checked">✓</span>
           <span>$submitter_name</span>
         </a>
       </div>
@@ -73,7 +73,7 @@ $ page = int(input(page=1).page)
         <input type="text" class="filter" placeholder="$_('Filter reviewers')" id="reviewer-filter">
         $ no_reviewer_href = changequery(reviewer='None', page=None) if reviewer==None else changequery(reviewer=None,page=None)
         <a href="$no_reviewer_href" class="dropdown-item">
-          <span class="$('' if reviewer=='None' else 'visibility-hidden') item-checked">✓</span>
+          <span class="$('' if reviewer=='None' else 'invisible') item-checked">✓</span>
           <span><b>$_('Assigned to nobody')
           </b></span>
         </a>
@@ -82,7 +82,7 @@ $ page = int(input(page=1).page)
         $ reviewer_href = changequery(reviewer=reviewer_name, page=None) if reviewer != reviewer_name else changequery(reviewer=None, page=None)
         $if reviewer_name and reviewer_name != username:
           <a href="$reviewer_href" class="dropdown-item">
-            <span class="$('' if reviewer==reviewer_name else 'visibility-hidden') item-checked">✓</span>
+            <span class="$('' if reviewer==reviewer_name else 'invisible') item-checked">✓</span>
             <span>$reviewer_name</span>
           </a>
       </div>
@@ -95,13 +95,13 @@ $ page = int(input(page=1).page)
         </header>
         $ desc_href = changequery(order='desc', page=None) if order!='desc' else changequery(order=None, page=None)
         <a href="$desc_href" class="dropdown-item">
-          <span class="$('' if order=='desc' else 'visibility-hidden') item-checked">✓</span>
+          <span class="$('' if order=='desc' else 'invisible') item-checked">✓</span>
           <span>$_('Newest')
           </span>
         </a>
         $ asc_href = changequery(order='asc', page=None) if order!='asc' else changequery(order=None, page=None)
         <a href="$asc_href" class="dropdown-item">
-          <span class="$('' if order=='asc' else 'visibility-hidden') item-checked">✓</span>
+          <span class="$('' if order=='asc' else 'invisible') item-checked">✓</span>
           <span>$_('Oldest')</span>
         </a>
       </div>

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -43,40 +43,43 @@ $ page = int(input(page=1).page)
     <a class="$(mode=='open' and 'selected' or '') mode-open" href="$changequery(mode='open', page=None)">$total['open'] $_('Open')</a>
     <a class="$(mode=='closed' and 'selected' or '') mode-closed" href="$changequery(mode='closed', page=None)">$total['closed'] $_('Closed')</a>
     <div class="flex-auto"></div>
-    <div class="mr-dropdown" id="submitter-menu-button">Submitter ▾
+    <div class="mr-dropdown" id="submitter-menu-button">$_('Submitter ▾')
       <div class="mr-dropdown-menu hidden">
         <header class="dropdown-header">
-            <span>Submitter</span>
+            <span>$_('Submitter')</span>
             <button class="dropdown-close">&times;</button>
         </header>
-        <input type="text" class="filter" placeholder="Filter submitters" id="submitter-filter">
-        <a href="$changequery(submitter=username, page=None)" class="dropdown-item">
+        <input type="text" class="filter" placeholder="$_('Filter submitters')" id="submitter-filter">
+        $ submitted_by_me_href = changequery(submitter=username, page=None) if submitter != username else changequery(submitter=None,page=None)
+        <a href="$submitted_by_me_href" class="dropdown-item">
           <span class="$('' if submitter==username else 'visibility-hidden') item-checked">✓</span>
-          <span><b>Submitted by me</b></span>
+          <span><b>$_('Submitted by me')</b></span>
         </a>
       $for s in total['submitters']:
         $ submitter_name = s.get('submitter', 'default submitter')
-        $ submitter_href = changequery(submitter=submitter_name, page=None)
+        $ submitter_href = changequery(submitter=submitter_name, page=None) if submitter != submitter_name else changequery(submitter=None, page=None)
         <a href="$submitter_href" class="dropdown-item">
           <span class="$('' if submitter==submitter_name else 'visibility-hidden') item-checked">✓</span>
           <span>$submitter_name</span>
         </a>
       </div>
     </div>
-    <div class="mr-dropdown" id="reviewer-menu-button">Reviewer ▾
+    <div class="mr-dropdown" id="reviewer-menu-button">$_('Reviewer ▾')
       <div class="mr-dropdown-menu hidden">
         <header class="dropdown-header">
-          <span>Reviewer</span>
+          <span>$_('Reviewer')</span>
           <button class="dropdown-close">&times;</button>
         </header>
-        <input type="text" class="filter" placeholder="Filter reviewers" id="reviewer-filter">
-        <a href="$changequery(reviewer='None', page=None)" class="dropdown-item">
+        <input type="text" class="filter" placeholder="$_('Filter reviewers')" id="reviewer-filter">
+        $ no_reviewer_href = changequery(reviewer='None', page=None) if reviewer==None else changequery(reviewer=None,page=None)
+        <a href="$no_reviewer_href" class="dropdown-item">
           <span class="$('' if reviewer=='None' else 'visibility-hidden') item-checked">✓</span>
-          <span><b>Assigned to nobody</b></span>
+          <span><b>$_('Assigned to nobody')
+          </b></span>
         </a>
       $for r in total['reviewers']:
         $ reviewer_name = r.get('reviewer', 'default reviewer')
-        $ reviewer_href = changequery(reviewer=reviewer_name, page=None)
+        $ reviewer_href = changequery(reviewer=reviewer_name, page=None) if reviewer != reviewer_name else changequery(reviewer=None, page=None)
         $if reviewer_name and reviewer_name != username:
           <a href="$reviewer_href" class="dropdown-item">
             <span class="$('' if reviewer==reviewer_name else 'visibility-hidden') item-checked">✓</span>
@@ -84,19 +87,22 @@ $ page = int(input(page=1).page)
           </a>
       </div>
     </div>
-    <div class="mr-dropdown" id="sort-menu-button">Sort ▾
+    <div class="mr-dropdown" id="sort-menu-button">$_('Sort ▾')
       <div class="mr-dropdown-menu sort hidden">
         <header class="dropdown-header">
-          <span>Sort</span>
+          <span>$_('Sort')</span>
           <button class="dropdown-close">&times;</button>
         </header>
-        <a href="$changequery(order='desc', page=None)" class="dropdown-item">
+        $ desc_href = changequery(order='desc', page=None) if order!='desc' else changequery(order=None, page=None)
+        <a href="$desc_href" class="dropdown-item">
           <span class="$('' if order=='desc' else 'visibility-hidden') item-checked">✓</span>
-          <span>Newest</span>
+          <span>$_('Newest')
+          </span>
         </a>
-        <a href="$changequery(order='asc', page=None)" class="dropdown-item">
+        $ asc_href = changequery(order='asc', page=None) if order!='asc' else changequery(order=None, page=None)
+        <a href="$asc_href" class="dropdown-item">
           <span class="$('' if order=='asc' else 'visibility-hidden') item-checked">✓</span>
-          <span>Oldest</span>
+          <span>$_('Oldest')</span>
         </a>
       </div>
     </div>

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -33,7 +33,7 @@ $else:
       </span>
     <span>$desc <a href="$href">$link_text</a></span>
   </div>
-  
+
 $ page = int(input(page=1).page)
 <div class="pager">
   $:macros.Pager(page, total[mode], results_per_page=25)

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "coverageThreshold": {
       "global": {
         "branches": 14,
-        "functions": 13,
+        "functions": 12,
         "lines": 15,
         "statements": 15
       }

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -235,6 +235,3 @@
   color: @check-green;
 }
 
-.visibility-hidden {
-  visibility: hidden;
-}

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -234,4 +234,3 @@
 .item-checked {
   color: @check-green;
 }
-

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -116,3 +116,125 @@
   color: @red;
   cursor: pointer;
 }
+
+.selected {
+  font-weight: bold;
+}
+
+.table-header {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  height: 42px;
+  background-color: @grey-f4f4f4;
+  font-size: 13px;
+  box-sizing: border-box;
+  padding-left: 3rem;
+  padding-right: 2.5rem;
+
+  a {
+    text-decoration: none;
+  }
+
+  .flex-auto {
+    flex: auto;
+  }
+
+  .mode-closed {
+    color: @red-three;
+  }
+
+  .mode-open {
+    color: @check-green;
+  }
+}
+
+.mr-dropdown {
+  color: @dark-grey;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.mr-dropdown-menu {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  z-index: @z-index-level-1;
+  height: 275px;
+  width: 296px;
+  background: @white;
+  border: 1px solid @light-grey;
+  box-shadow: 0 4px 4px @light-mid-grey, 0 4px 4px @light-mid-grey;
+  border-radius: 5px;
+  color: @black;
+  font-size: 13px;
+  cursor: default;
+  overflow: scroll;
+
+  .dropdown-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 8px 10px 15px;
+    height: 34px;
+    border-width: 1px 0;
+    border-style: solid;
+    border-color: @light-grey;
+    cursor: default;
+
+    span {
+      font-weight: bold;
+    }
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 13px;
+      height: 17px;
+      font-size: 28px;
+      font-family: @lucida_sans_serif-1;
+      cursor: pointer;
+      background-color: transparent;
+      border: 0;
+    }
+  }
+
+  input {
+    margin: 7px;
+    height: 31px;
+    padding: 8px;
+  }
+
+  a {
+    text-decoration: none;
+    color: @black;
+  }
+
+  .dropdown-item {
+    gap: 1em;
+    display: flex;
+    padding: 7.5px;
+    border-width: 1px 0;
+    border-style: solid;
+    border-color: @light-grey;
+    height: 34px;
+    cursor: pointer;
+  }
+
+  .dropdown-item:hover {
+    background-color: @light-grey;
+  }
+}
+
+.mr-dropdown-menu.sort {
+  height: 104px;
+}
+
+.item-checked {
+  color: @check-green;
+}
+
+.visibility-hidden {
+  visibility: hidden;
+}

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -124,13 +124,13 @@
 .table-header {
   display: flex;
   align-items: center;
-  gap: 2rem;
+  gap: 24px;
   height: 42px;
   background-color: @grey-f4f4f4;
   font-size: 13px;
   box-sizing: border-box;
-  padding-left: 3rem;
-  padding-right: 2.5rem;
+  padding-left: 41px;
+  padding-right: 27px;
 
   a {
     text-decoration: none;
@@ -212,7 +212,7 @@
   }
 
   .dropdown-item {
-    gap: 1em;
+    gap: 11px;
     display: flex;
     padding: 7.5px;
     border-width: 1px 0;

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -99,6 +99,7 @@
 @white: hsl(0, 0%, 100%);
 @gray-a19b9e: hsl(330, 3%, 62%);
 @gray-d1cfd0: hsl(330, 2%, 82%);
+@grey-f4f4f4: hsl(0, 0%, 96%);
 
 // outliers
 @admin-row-background: hsl(58, 66%, 81%);

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -36,6 +36,7 @@
 @olive: hsl(81, 39%, 35%);
 @light-olive-2: hsl(78, 34%, 63%);
 @lime-green: hsl(75, 100%, 85%);
+@check-green: hsl(126,100%,36%);
 
 // orange
 @orange: hsl(32, 100%, 61%);
@@ -49,6 +50,7 @@
 @red: hsl(8, 78%, 49%);
 @dark-red: hsl(8, 70%, 44%);
 @red-two:hsl(4, 90%, 58%);
+@red-three: hsl(0, 100%, 50%);
 
 // pinks
 @mid-baby-pink: hsl(0, 100%, 88%);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially closes #6816. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. 

Adds dropdown menus to sort and filter merge queue records, specifically:
"""
Adding sort label / link which swaps the sort order from desc to asc
    remember sort across requests / pages
    defaults to desc
Merge Queue: Add UI dropdown to filter by submitter
    remembers submitter across requests / pages
    be able to filter submitters by string
Merge Queue: Add UI dropdown to filter by reviewer
    remembers reviewer across requests / pages
    be able to filter reviewers by string
"""
per Figma

![Screenshot from 2023-05-16 22-04-06](https://github.com/internetarchive/openlibrary/assets/52016758/3a213381-88a2-4bab-a421-1063b77865c0)

### Technical
<!-- What should be noted about the implementation? -->
This addresses #6816 by creating two new fields (a list of submitters and a list of reviewer) that are passed from the model to the controller. Changes to the sorting/filtering of the merge requests are handled by parameters in the GET request. Currently, the query filtering of merge records will chain the various filters (AND statement) but this can be amended. 

Other things to note:
-don't know if filters should be able to be undone, i.e. unchecked from the menu; right now, this is not implemented but I can change that
-the naming in the Figma design is a bit confusing. the top of the dropdown menus are labeled 'submitter' and 'reviewer' but the reviewer dropdown menu contains an item called 'submitted by me' (shouldn't this be in the submitter dropdown?) and the other dropdown is called 'assignee' even though it probably refers to submitters.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Populated merge queue table with sample data and clicked around to see if sorting and filtering of merge records worked. Also clicked around to make sure the menus opened and closed in what seemed like a common sense manner.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-05-16 22-04-57](https://github.com/internetarchive/openlibrary/assets/52016758/66c4e0fa-fa74-423e-85aa-f9ac49b2604c)
![Screenshot from 2023-05-16 22-11-28](https://github.com/internetarchive/openlibrary/assets/52016758/607dcfd2-f41e-43f8-a952-52fe72f90893)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @jimchamp @Eds-Dbug 

I wanted to bring attention to the fact that there may be some overlap in the tasks I have been working on and those that @Eds-Dbug might also be involved in. A few months ago, I was assigned these tasks, so if it would be helpful to anyone, here are the code changes I have made.

Note: I lowered the jest coverage threshold for lines in order to make javascript_tests pass. I can write tests if this PR moves forward. 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
