### PR TITLE
pre-commit: add --fix to eslint and stylelint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,7 @@ repos:
           - eslint-plugin-no-jquery@2.6.0
           - eslint-plugin-vue@7.15.0
           - babel-eslint@10.1.0
+        args: [--fix]
 
   - repo: https://github.com/awebdeveloper/pre-commit-stylelint
     rev: 0.0.2
@@ -85,3 +86,4 @@ repos:
       additional_dependencies:
         - stylelint@13.13.1
         - stylelint-declaration-use-variable@1.7.3
+      args: [--fix]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7869 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

This PR makes it so that `--fix` is automatically applied to `eslint` and `stylelint` when running `pre-commit`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Make some changes to a CSS and JS file that will cause `eslint` and `stylelint` to raise an error, stage the changes, and run `pre-commit`.

Here's a `git diff` with changes introducing incorrect spacing in a JS file, and an unnecessary unit in a CSS file:
```
diff --git a/openlibrary/plugins/openlibrary/js/index.js b/openlibrary/plugins/openlibrary/js/index.js
index 83476abc2..135b6622f 100644
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -455,7 +455,7 @@ jQuery(function () {
             .then((module) => module.initNavbar(navbar));
         // Add sticky title component animations:
         import(/* webpackChunkName: "compact-title" */ './compact-title')
-            .then((module) => module.initCompactTitle(navbar, compactTitle))
+          .then((module) => module.initCompactTitle(navbar, compactTitle))
     }

     // Add functionality for librarian merge request table:
diff --git a/static/css/components/mybooks-list.less b/static/css/components/mybooks-list.less
index 9504e3f0f..a7b7b99e9 100644
--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -16,7 +16,7 @@
     margin: 0 !important;
   }
   h2 {
-    padding: 5px 0;
+    padding: 5px 0px;
     margin: 0;
     line-height: 1.5em;
     margin-bottom: 5px;
```

Running `pre-commit` with the 'bad' changes staged:
```
❯ pre-commit run
check toml...........................................(no files to check)Skipped
[..]
Validate pyproject.toml..............................(no files to check)Skipped
eslint...................................................................Failed
- hook id: eslint
- files were modified by this hook
stylelint................................................................Failed
- hook id: stylelint
- files were modified by this hook
```

Here's a `git diff` showing the changes that `pre-commit` with `--fix` for `eslint` and `stylelint` made to fix the mistakes I made:
```
diff --git a/openlibrary/plugins/openlibrary/js/index.js b/openlibrary/plugins/openlibrary/js/index.js
index 135b6622f..83476abc2 100644
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -455,7 +455,7 @@ jQuery(function () {
             .then((module) => module.initNavbar(navbar));
         // Add sticky title component animations:
         import(/* webpackChunkName: "compact-title" */ './compact-title')
-          .then((module) => module.initCompactTitle(navbar, compactTitle))
+            .then((module) => module.initCompactTitle(navbar, compactTitle))
     }

     // Add functionality for librarian merge request table:
diff --git a/static/css/components/mybooks-list.less b/static/css/components/mybooks-list.less
index a7b7b99e9..9504e3f0f 100644
--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -16,7 +16,7 @@
     margin: 0 !important;
   }
   h2 {
-    padding: 5px 0px;
+    padding: 5px 0;
     margin: 0;
     line-height: 1.5em;
     margin-bottom: 5px;
```

Running `pre-commit` again.
```
❯ pre-commit run
check toml...........................................(no files to check)Skipped
[...]
Validate pyproject.toml..............................(no files to check)Skipped
eslint...................................................................Passed
stylelint................................................................Passed
```

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
