### PR TITLE
Use ruff to find Python code complexity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.267
+    rev: v0.0.269
     hooks:
       - id: ruff
 
@@ -61,12 +61,12 @@ repos:
           - types-all
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.2
+    rev: v0.13
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.40.0
+    rev: v8.41.0
     hooks:
       - id: eslint
         types: [file]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ ignore = [
   "E741",
   "F401",
   "F841",
+  "FLY002",
   "I",
   "PIE790",
   "PIE804",
@@ -75,6 +76,8 @@ select = [
   "C90",     # McCabe cyclomatic complexity
   "E",       # pycodestyle
   "F",       # Pyflakes
+  "FA",      # flake8-future-annotations
+  "FLY",     # flynt
   "G010",    # flake8-logging-format
   "I",       # isort
   "ICN",     # flake8-import-conventions
@@ -92,6 +95,7 @@ select = [
   # "A",     # flake8-builtins
   # "ANN",   # flake8-annotations
   # "ARG",   # flake8-unused-arguments
+  # "ASYNC", # flake8-async
   # "COM",   # flake8-commas
   # "D",     # pydocstyle
   # "DJ",    # flake8-django
@@ -115,6 +119,7 @@ select = [
   # "S",     # flake8-bandit
   # "T20",   # flake8-print
   # "TCH",   # flake8-type-checking
+  # "TD",    # flake8-todos
   # "TID",   # flake8-tidy-imports
   # "TRY",   # tryceratops
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,18 +121,20 @@ select = [
 target-version = "py311"
 
 [tool.ruff.mccabe]
-max-complexity = 41
+max-complexity = 28
 
 [tool.ruff.pylint]
 allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 15
-max-branches = 42
+max-branches = 22
 max-returns = 14
-max-statements = 106
+max-statements = 70
 
 [tool.ruff.per-file-ignores]
 "openlibrary/admin/stats.py" = ["BLE001"]
+"openlibrary/catalog/add_book/__init__.py" = ["C901", "PLR0912", "PLR0915"]
 "openlibrary/catalog/get_ia.py" = ["BLE001", "E722"]
+"openlibrary/catalog/marc/get_subjects.py" = ["C901", "PLR0912", "PLR0915"]
 "openlibrary/catalog/marc/marc_binary.py" = ["BLE001"]
 "openlibrary/catalog/utils/edit.py" = ["E722"]
 "openlibrary/catalog/utils/query.py" = ["E722"]
@@ -160,7 +162,7 @@ max-statements = 106
 "openlibrary/plugins/upstream/borrow.py" = ["BLE001", "E722"]
 "openlibrary/plugins/upstream/models.py" = ["BLE001"]
 "openlibrary/plugins/upstream/utils.py" = ["BLE001"]
-"openlibrary/solr/update_work.py" = ["E722"]
+"openlibrary/solr/update_work.py" = ["C901", "E722", "PLR0912", "PLR0915"]
 "openlibrary/utils/retry.py" = ["BLE001"]
 "scripts/copydocs.py" = ["BLE001"]
 "scripts/delete_import_items.py" = ["BLE001"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,5 +8,5 @@ mypy==1.3.0
 pymemcache==4.0.0
 pytest==7.2.2
 pytest-asyncio==0.21.0
-ruff==0.0.267
+ruff==0.0.269
 safety==2.3.5


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[Ruff](https://beta.ruff.rs) helps us to find Python __code complexity__ with five key rules:
* `C901` McCabe code complexity
* `PLR0911` Too many return statements
* `PLR0912` Too many branches
* `PLR0913` Too many arguments to function call
* `PLR0915` Too many statements

This pull request sets up ruff `per-file-ignores` for our three most complex Python functions:
```
"openlibrary/catalog/add_book/__init__.py" = ["C901", "PLR0912", "PLR0915"]
"openlibrary/catalog/marc/get_subjects.py" = ["C901", "PLR0912", "PLR0915"]
"openlibrary/solr/update_work.py" = ["C901", "E722", "PLR0912", "PLR0915"]
```
Doing so allows us to:
1. substantially lower our ruff `max-complexity`, `max-branches`, and `max-statements` thresholds to spot any new attempts to increase code complexity.
2. create new issues to address the code complexity of these three functions.
    * [ ] #7884 --> @scottbarnes 
    * [ ] #7885
    * [ ] #7886

### Technical
<!-- What do you think should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to make certain relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
