### PR TITLE
Refactor lists template file to move inline JavaScript

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -223,8 +223,8 @@ jQuery(function () {
         import(/* webpackChunkName: "carousels-partials" */'./carousels_partials.js')
             .then(module => module.initCarouselsPartials());
     }
-    // conditionally load list seed item deletion dialog functionality based on class in the page
-    if (document.getElementsByClassName('listDelete').length) {
+    // conditionally load list seed item deletion dialog functionality based on id on lists pages
+    if (document.getElementById('listResults')) {
         import(/* webpackChunkName: "ListViewBody" */'./lists/ListViewBody.js');
     }
     // Enable any carousels in the page

--- a/openlibrary/plugins/openlibrary/js/lists/ListViewBody.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListViewBody.js
@@ -1,7 +1,18 @@
 /**
- * Defines functions used in 'view_body' template for Lists.
+ * Defines functions used in the 'lists' and 'view_body' templates for Lists.
  * @module lists/ListViewBody
  */
+
+/**
+ * Adds the delete link HTML to individual lists (i.e. on My Lists page) where the 'deleteList' class appears
+ */
+const itemsWithDeleteList = $('.deleteList .resultTitle');
+if (itemsWithDeleteList.length) {
+    const deleteListLink = $('.listDelete--myLists');
+    itemsWithDeleteList.each(function() {
+        $(deleteListLink).clone().prependTo(this).removeClass('hidden');
+    });
+}
 
 /**
  * Makes a POST to a `.json` endpoint to remove a seed item from a list.
@@ -55,8 +66,9 @@ const getConfirmButtonLabelText = () => {
 };
 
 // Add listeners to each .listDelete link element
-$('.listDelete a').on('click', function() {
-    if (get_seed_count() > 1) {
+// Sometimes .listDelete is dynamically added to the DOM, so we'll add the listener to a parent element
+$('#listResults').on('click', '.listDelete a', function() {
+    if (get_seed_count() > 1 && !$(this).parent().hasClass('listDelete--myLists')) {
         $('#remove-seed-dialog')
             .data('seed-key', $(this).closest('[data-seed-key]').data('seed-key'))
             .data('list-key', $(this).closest('[data-list-key]').data('list-key'))

--- a/openlibrary/plugins/openlibrary/js/lists/ListViewBody.js
+++ b/openlibrary/plugins/openlibrary/js/lists/ListViewBody.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * Adds the delete link HTML to individual lists (i.e. on My Lists page) where the 'deleteList' class appears
+ * Adds the delete list link HTML to individual lists (i.e. on My Lists page) where the 'deleteList' class appears (from lists.html template)
  */
 const itemsWithDeleteList = $('.deleteList .resultTitle');
 if (itemsWithDeleteList.length) {
@@ -12,6 +12,23 @@ if (itemsWithDeleteList.length) {
     itemsWithDeleteList.each(function() {
         $(deleteListLink).clone().prependTo(this).removeClass('hidden');
     });
+
+    // Clean up and remove placeholder element
+    $('.listDelete--myLists.hidden').remove();
+}
+
+/**
+ * Adds the delete seed link HTML to individual items where the 'deleteSeed' class appears (from lists.html template)
+ */
+const itemsWithDeleteSeed = $('.deleteSeed .resultTitle');
+if (itemsWithDeleteSeed.length) {
+    const deleteSeedLink = $('.seedDelete--myLists');
+    itemsWithDeleteSeed.each(function() {
+        $(deleteSeedLink).clone().prependTo(this).removeClass('hidden');
+    });
+
+    // Clean up and remove placeholder element
+    $('.seedDelete--myLists.hidden').remove();
 }
 
 /**

--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -18,43 +18,11 @@ $if "type" in doc and doc.type.key == "/type/user":
         span.list-owner { display: none; }
     </style>
     $if ctx.user and ctx.user.key == doc.key:
-        <script type="text/javascript">
-            window.q.push(function() {
-                \$("#listResults .resultTitle")
-                    .prepend('' +
-                        '<span class="listDelete sansserif small">' +
-                            '<a href="javascript:;"><span></span>$_("Delete this list")</a>' +
-                        '</span>')
-                    .find(".listDelete a")
-                    .on('click', function() {
-                        \$('#delete-dialog')
-                            .ol_confirm_dialog(function(){},
-                            {
-                                buttons: {
-                                    "$:_('Yes, I\'m sure')": function() {
-                                        var list_id = "#" + \$(this).data("list-id");
-                                        var key = \$(list_id + " a:first").attr("href");
-                                        var dialog = this;
-
-                                        \$.post(key + "/delete.json", function() {
-                                            \$(list_id).remove();
-                                            \$(dialog).dialog("close");
-                                            \$("#list_count").load(location.href + " #list_count");
-                                            });
-                                    },
-                                    "$_('No, cancel')": function() {
-                                        \$(this).dialog("close");
-                                    }
-                                },
-                                closeText: "$_('Close')"
-                            })
-                            .data("list-id", \$(this).closest("li").attr("id"))
-                            .dialog('open');
-                        return false;
-                    });
-            });
-        </script>
-        <div id="delete-dialog" class="hidden" title="$_('Delete list')">$_('Are you sure you want to delete this list?')</div>
+        $ deleteType = 'deleteList'
+        <span class="listDelete sansserif smaller listDelete--myLists hidden">
+            <a href="javascript:;" data-confirm-text="$:_('Yes, I\'m sure')" data-cancel-text="$_('No, cancel')"><span></span>$_('Delete this list')</a>
+        </span>
+        <div id="delete-list-dialog" class="hidden" title="$_('Delete list')">$_('Are you sure you want to delete this list?')</div>
 $else:
     <script type="text/javascript">
         window.q.push(function() {
@@ -102,15 +70,19 @@ $else:
             });
         }
     </script>
+    $ deleteType = 'deleteSeed'
     <div id="remove-dialog" class="hidden" title="Remove">$:_('Are you sure you want to remove <strong>%(title)s</strong> from this list?', title=header.title)</div>
+
+$def seed_attrs(seed):
+  data-list-key="$list.key"
 
 <div id="contentBody">
     $if lists:
         <div class="mybooks-list">
             <ul class="list-results" id="listResults">
             $for list in lists:
-                <li class="searchResultItem"
-                    id="list-$loop.index">$:render_template("lists/preview", list)</li>
+                <li class="searchResultItem $deleteType"
+                    id="list-$loop.index" $:seed_attrs(seed)>$:render_template("lists/preview", list)</li>
             </ul>
         </div>
     $elif not ctx.user or ctx.user.key != doc.key:

--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -19,59 +19,18 @@ $if "type" in doc and doc.type.key == "/type/user":
     </style>
     $if ctx.user and ctx.user.key == doc.key:
         $ deleteType = 'deleteList'
+        $# The link below is a placeholder that gets inserted into the correct place in the DOM on page load via ListViewBody.js
         <span class="listDelete sansserif smaller listDelete--myLists hidden">
             <a href="javascript:;" data-confirm-text="$:_('Yes, I\'m sure')" data-cancel-text="$_('No, cancel')"><span></span>$_('Delete this list')</a>
         </span>
         <div id="delete-list-dialog" class="hidden" title="$_('Delete list')">$_('Are you sure you want to delete this list?')</div>
 $else:
-    <script type="text/javascript">
-        window.q.push(function() {
-            \$("#listResults .resultTitle.my-list")
-            .prepend('' +
-                '<span class="listDelete sansserif smaller">' +
-                    '<a href="javascript:;"><span></span>$_("Remove this seed?")</a>' +
-                '</span>')
-            .find(".listDelete a")
-            .on('click', function() {
-                \$('#remove-dialog')
-                    .ol_confirm_dialog(function() {
-                        var seed = $:json_encode(seed);
-                        var list_id = "#" + \$(this).data("list-id");
-                        var key = \$(list_id + " a:first").attr("href");
-
-                        var dialog = this;
-
-                        remove_seed(key, seed, function() {
-                            \$(list_id).remove();
-                            \$(dialog).dialog("×");
-                        });
-                    })
-                    .data("list-id", \$(this).closest("li").attr("id"))
-                    .dialog('open');
-                return false;
-            });
-        });
-
-        function remove_seed(list_key, seed, success) {
-            \$.ajax({
-                type: "POST",
-                url: list_key + "/seeds.json",
-                contentType: "application/json",
-                data: JSON.stringify({
-                    "remove": [seed]
-                }),
-                dataType: "json",
-
-                beforeSend: function(xhr) {
-                    xhr.setRequestHeader("Content-Type", "application/json");
-                    xhr.setRequestHeader("Accept", "application/json");
-                },
-                success: success
-            });
-        }
-    </script>
     $ deleteType = 'deleteSeed'
-    <div id="remove-dialog" class="hidden" title="Remove">$:_('Are you sure you want to remove <strong>%(title)s</strong> from this list?', title=header.title)</div>
+    $# The link below is a placeholder that gets inserted into the correct place in the DOM on page load via ListViewBody.js
+    <span class="listDelete sansserif smaller seedDelete--myLists hidden">
+        <a href="javascript:;" data-confirm-text="$:_('Yes, I\'m sure')" data-cancel-text="$_('No, cancel')"><span></span>$_('Remove this seed?')</a>
+    </span>
+    <div id="remove-seed-dialog" class="hidden" title="Remove">$:_('Are you sure you want to remove <strong>%(title)s</strong> from this list?', title=header.title)</div>
 
 $def seed_attrs(seed):
   data-list-key="$list.key"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #2468 (final subtask in this issue)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
JS in `openlibrary/plugins/openlibrary/js/lists/ListViewBody.js` has been updated to handle the functionality that was previously inline in `openlibrary/templates/lists/lists.html`, and all inline JS has been removed.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
There should be no visible change to the My Lists page after this update. To test that no functionality is broken, please:
* Visit My Lists (`/people/openlibrary/lists`)
* Verify that a "Delete this list" link appears for each list
* Upon clicking "Delete this list":
  * Verify that dialog text is unchanged from current prod version
  * Verify that "No, cancel" button successfully cancels the action and that "Yes, I'm sure" button successfully deletes the list
* Additionally, it would be good to run through the test cases in my previous PR #7765 to make sure that updating `ListViewBody.js` didn't break anything on individual list pages.

Note: "Remove this seed?" JS present in `lists.html` was also refactored as part of this PR, but I'm not sure how to trigger this link to appear (i.e. which page or data conditions will cause it to show up). I'll work with @jimchamp on how to test this condition.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1411" alt="Screen Shot 2023-05-18 at 3 17 47 PM" src="https://github.com/internetarchive/openlibrary/assets/13765801/0ffe327a-1f18-4cc5-9ce3-90356a56c9fc">

<img width="1411" alt="Screen Shot 2023-05-18 at 3 12 28 PM" src="https://github.com/internetarchive/openlibrary/assets/13765801/db5ffee4-3797-4bc2-8cf5-1859928402fa">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jdlrobson and @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
