### PR TITLE
Async functions should not call time.sleep()

### DIFF
--- a/scripts/solr_updater.py
+++ b/scripts/solr_updater.py
@@ -6,19 +6,21 @@ Changes:
 2013-02-25: First version
 2018-02-11: Use newer config method
 """
-from typing import Union
-from collections.abc import Iterator
-import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
-
-import logging
-import json
+import asyncio
 import datetime
-import time
-import web
-import sys
+import json
+import logging
 import re
 import socket
+import sys
 import urllib
+
+from typing import Union
+from collections.abc import Iterator
+
+import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
+
+import web
 
 from openlibrary.solr import update_work
 from openlibrary.config import load_config
@@ -309,7 +311,7 @@ async def main(
         # While the commit was on, some more edits might have happened.
         if count == 0:
             logger.debug("No more log records available, sleeping...")
-            time.sleep(5)
+            await asyncio.sleep(5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related to #7891

% `ruff rule ASYNC101`
# open-sleep-or-subprocess-in-async-function (ASYNC101)

Derived from the **flake8-async** linter.

## What it does
Checks that async functions do not contain calls to `open`, `time.sleep`,
or `subprocess` methods.

## Why is this bad?
Blocking an async function via a blocking call will block the entire
event loop, preventing it from executing other tasks while waiting for the
call to complete, negating the benefits of asynchronous programming.

Instead of making a blocking call, use an equivalent asynchronous library
or function.

## Example
```python
async def foo():
    time.sleep(1000)
```

Use instead:
```python
async def foo():
    await asyncio.sleep(1000)
```