### PR TITLE
Async functions should not call blocking HTTP methods

### DIFF
--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -360,7 +360,9 @@ class ExternalDataProvider(DataProvider):
         return resp['entries']
 
     async def get_document(self, key: str):
-        return requests.get(f"http://{self.ol_host}{key}.json").json()
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://{self.ol_host}{key}.json")
+            return response.json()
 
 
 class BetterDataProvider(LegacyDataProvider):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -1276,20 +1276,22 @@ async def update_author(
     facet_fields = ['subject', 'time', 'person', 'place']
     base_url = get_solr_base_url() + '/select'
 
-    reply = requests.get(
-        base_url,
-        params=[  # type: ignore[arg-type]
-            ('wt', 'json'),
-            ('json.nl', 'arrarr'),
-            ('q', 'author_key:%s' % author_id),
-            ('sort', 'edition_count desc'),
-            ('rows', 1),
-            ('fl', 'title,subtitle'),
-            ('facet', 'true'),
-            ('facet.mincount', 1),
-        ]
-        + [('facet.field', '%s_facet' % field) for field in facet_fields],
-    ).json()
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            base_url,
+            params=[  # type: ignore[arg-type]
+                ('wt', 'json'),
+                ('json.nl', 'arrarr'),
+                ('q', 'author_key:%s' % author_id),
+                ('sort', 'edition_count desc'),
+                ('rows', 1),
+                ('fl', 'title,subtitle'),
+                ('facet', 'true'),
+                ('facet.mincount', 1),
+            ]
+            + [('facet.field', '%s_facet' % field) for field in facet_fields],
+        )
+        reply = response.json()
     work_count = reply['response']['numFound']
     docs = reply['response'].get('docs', [])
     top_work = None

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -560,8 +560,17 @@ class Test_update_items:
             }
         )
 
-        mock_get = MagicMock(return_value=empty_solr_resp)
-        monkeypatch.setattr(httpx, 'get', mock_get)
+        class MockAsyncClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            async def get(self, url, params):
+                return empty_solr_resp
+
+        monkeypatch.setattr(httpx, 'AsyncClient', MockAsyncClient)
         requests = await update_work.update_author('/authors/OL25A')
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.AddRequest)

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -560,9 +560,8 @@ class Test_update_items:
             }
         )
 
-        monkeypatch.setattr(
-            update_work.requests, 'get', lambda url, **kwargs: empty_solr_resp
-        )
+        mock_get = MagicMock(return_value=empty_solr_resp)
+        monkeypatch.setattr(httpx, 'get', mock_get)
         requests = await update_work.update_author('/authors/OL25A')
         assert len(requests) == 1
         assert isinstance(requests[0], update_work.AddRequest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ exclude = [
   "vendor/*",
 ]
 ignore = [
+  "ASYNC101",
   "B007",
   "B009",
   "B015",
@@ -70,6 +71,7 @@ ignore = [
 ]
 line-length = 162
 select = [
+  "ASYNC",   # flake8-async
   "B",       # flake8-bugbear
   "BLE",     # flake8-blind-except
   "C4",      # flake8-comprehensions
@@ -95,7 +97,6 @@ select = [
   # "A",     # flake8-builtins
   # "ANN",   # flake8-annotations
   # "ARG",   # flake8-unused-arguments
-  # "ASYNC", # flake8-async
   # "COM",   # flake8-commas
   # "D",     # pydocstyle
   # "DJ",    # flake8-django


### PR DESCRIPTION
Related to #7891 

% `ruff rule ASYNC100`
# blocking-http-call-in-async-function (ASYNC100)

Derived from the **flake8-async** linter.

## What it does
Checks that async functions do not contain blocking HTTP calls.

## Why is this bad?
Blocking an async function via a blocking HTTP call will block the entire
event loop, preventing it from executing other tasks while waiting for the
HTTP response, negating the benefits of asynchronous programming.

Instead of making a blocking HTTP call, use an asynchronous HTTP client
library such as `aiohttp` or `httpx`.

## Example
```python
async def fetch():
    urllib.request.urlopen("https://example.com/foo/bar").read()
```

Use instead:
```python
async def fetch():
    async with aiohttp.ClientSession() as session:
        async with session.get("https://example.com/foo/bar") as resp:
            ...
```