### PR TITLE
Add "Read more" and "Read less" elements to tab navigation

### DIFF
--- a/openlibrary/macros/ReadMore.html
+++ b/openlibrary/macros/ReadMore.html
@@ -1,4 +1,4 @@
 $def with (label=None)
 
-<p class="$label read-more" tabindex="0"><a class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
-<p class="$label read-less hidden" tabindex="0"><a class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>
+<p class="$label read-more"><a tabindex="0" class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
+<p class="$label read-less hidden"><a tabindex="0" class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>

--- a/openlibrary/macros/ReadMore.html
+++ b/openlibrary/macros/ReadMore.html
@@ -1,4 +1,4 @@
 $def with (label=None)
 
-<p class="$label read-more"><a tabindex="0" class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
-<p class="$label read-less hidden"><a tabindex="0" class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>
+<p class="$label read-more" tabindex="0"><a class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
+<p class="$label read-less hidden" tabindex="0"><a class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>

--- a/openlibrary/macros/ReadMore.html
+++ b/openlibrary/macros/ReadMore.html
@@ -1,4 +1,4 @@
 $def with (label=None)
 
-<p class="$label read-more"><a class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
-<p class="$label read-less hidden"><a class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>
+<p class="$label read-more" tabindex="0"><a class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
+<p class="$label read-less hidden" tabindex="0"><a class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7858 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Adds tab navigation to "Read more" and "Read less" elements on book overview page to improve a11y. 

### Technical
<!-- What should be noted about the implementation? -->

Added `tabindex="0"` to Read more & Read less a tags within the ReadMore.html macro

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Navigate to any book's overview page where summary is sufficiently long enough to show "Read more" element. 
2. Starting from the top of the page keep hitting tab until the "Read more" elements is selected.
3. Click "Read more" to display "Read less" element and repeat step 2.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![IA_read_more](https://github.com/internetarchive/openlibrary/assets/35821125/55219df5-a8c2-44b5-908e-893a4c0bb57d)

![IA_read_less](https://github.com/internetarchive/openlibrary/assets/35821125/0ec45133-162c-49cf-af79-7c77b92c24a0)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
