### PR TITLE
If there are no user_settings then there is no safe_mode

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -833,7 +833,7 @@ class User(models.User):
             lending.sync_loan(loan['ocaid'])
 
     def get_safe_mode(self):
-        return self.get_users_settings().get('safe_mode', "").lower()
+        return (self.get_users_settings() or {}).get('safe_mode', "").lower()
 
 
 class UnitParser:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
A fix for https://sentry.archive.org/organizations/ia-ux/issues/356335 which has happened seven times since [deploy-2023-05-23](https://github.com/internetarchive/openlibrary/releases/tag/deploy-2023-05-23).

Currently, `self.get_users_settings()` is returning `None` in rare instances, and then `None.get()` is raising an `AttributeError`.  This pull request recommends using `(self.get_users_settings() or {})` which will provide a dict in all cases.

`{}.get('safe_mode', "").lower()` will then return an empty str which means if there are no `user_settings` then there is no `safe_mode`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
