### PR TITLE
Use same WorldCat and affiliate links in mobile, desktop

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -1,4 +1,4 @@
-$def with (page, editions_page=False, render_times={}, modal_links=None)
+$def with (page, worldcat_links, affiliate_links, editions_page=False, render_times={}, modal_links=None)
 
 $if page.type.key == '/type/work' and page.edition_count == 1:
     $ edit_url = page.editions[0].key + '?m=edit'
@@ -8,19 +8,6 @@ $else:
     $ edit_url = page.key + "?m=edit"
 
 $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
-$ prices = page.key.startswith('/books/')
-
-$ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
-$ isbn_13 = page.get_isbn13()
-$ isbn_10 = page.get_isbn10()
-
-$ asin = None
-$if page.get('identifiers'):
-    $if page.identifiers.get('amazon'):
-        $ asin = page.identifiers.amazon[0]
-
-$if isbn_10 and not asin:
-    $ asin = isbn_10
 
 <div class="Tools">
   <div id="read">
@@ -81,28 +68,13 @@ $if isbn_10 and not asin:
       </div>
     </div>
 
-    $ prices = page.key.startswith('/books/')
-
-    $ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
-    $ isbn_13 = page.get_isbn13()
-    $ isbn_10 = page.get_isbn10()
-
-    $ asin = None
-    $if page.get('identifiers'):
-        $if page.identifiers.get('amazon'):
-            $ asin = page.identifiers.amazon[0]
-
-    $if isbn_10 and not asin:
-        $ asin = isbn_10
     <div class="panel desktop-vendor">
       <div class="btn-notice">
-        $:macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+        $:worldcat_links
 
         <div class="cta-section">
           <p class="cta-section-title">$_('Buy this book')</p>
-          $ render_times['databarWork: AffiliateLinks'] = time()
-          $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
-          $ render_times['databarWork: AffiliateLinks'] = time() - render_times['databarWork: AffiliateLinks']
+          $:affiliate_links
         </div>
       </div>
     </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -177,6 +177,26 @@ $ component_times['get_observation_metrics'] = time()
 $ reader_observations = get_observation_metrics(work['key']) if show_observations else {}
 $ component_times['get_observation_metrics'] = time() - component_times['get_observation_metrics']
 
+$ component_times['affiliate_links component'] = time()
+$ prices = page.key.startswith('/books/')
+
+$ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
+$ isbn_13 = page.get_isbn13()
+$ isbn_10 = page.get_isbn10()
+
+$ asin = None
+$if page.get('identifiers'):
+    $if page.identifiers.get('amazon'):
+        $ asin = page.identifiers.amazon[0]
+
+$if isbn_10 and not asin:
+    $ asin = isbn_10
+
+$ affiliate_links = macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+$ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
+
+$ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+
 <div id="contentBody" role="main" itemscope itemtype="https://schema.org/Book">
   <div class="workDetails">
     $if work and work.key:
@@ -193,7 +213,7 @@ $ component_times['get_observation_metrics'] = time() - component_times['get_obs
       $ modal_links = render_template("type/edition/modal_links", work, edition, share_url)
       $ component_times['databarWork: Modal Links'] = time() - component_times['databarWork: Modal Links']
 
-      $:macros.databarWork(edition or work, editions_page=True, render_times=component_times, modal_links=modal_links)
+      $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times, modal_links=modal_links)
     </div>
 
     <div class="editionAbout">
@@ -293,27 +313,14 @@ $ component_times['get_observation_metrics'] = time() - component_times['get_obs
           </div>
       </div>
 
-      $ prices = page.key.startswith('/books/')
-
-      $ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
-      $ isbn_13 = page.get_isbn13()
-      $ isbn_10 = page.get_isbn10()
-
-      $ asin = None
-      $if page.get('identifiers'):
-          $if page.identifiers.get('amazon'):
-              $ asin = page.identifiers.amazon[0]
-
-      $if isbn_10 and not asin:
-          $ asin = isbn_10
       <div class="Tools">
         <div class="panel mobile-vendor">
           <div class="btn-notice">
-            $:macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
+            $:worldcat_links
 
             <div class="cta-section">
               <p class="cta-section-title">$_('Buy this book')</p>
-              $:macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+              $:affiliate_links
             </div>
           </div>
         </div>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -192,7 +192,7 @@ $if edition.get('identifiers'):
 $if isbn_10 and not asin:
     $ asin = isbn_10
 
-$ affiliate_links = macros.AffiliateLinks(edition), {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+$ affiliate_links = macros.AffiliateLinks(edition, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
 $ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
 
 $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -178,21 +178,21 @@ $ reader_observations = get_observation_metrics(work['key']) if show_observation
 $ component_times['get_observation_metrics'] = time() - component_times['get_observation_metrics']
 
 $ component_times['affiliate_links component'] = time()
-$ prices = page.key.startswith('/books/')
+$ prices = (edition or work).key.startswith('/books/')
 
-$ oclc_numbers = (page.oclc_numbers and page.oclc_numbers[0]) or ""
-$ isbn_13 = page.get_isbn13()
-$ isbn_10 = page.get_isbn10()
+$ oclc_numbers = ((edition or work).oclc_numbers and (edition or work).oclc_numbers[0]) or ""
+$ isbn_13 = (edition or work).get_isbn13()
+$ isbn_10 = (edition or work).get_isbn10()
 
 $ asin = None
-$if page.get('identifiers'):
-    $if page.identifiers.get('amazon'):
-        $ asin = page.identifiers.amazon[0]
+$if (edition or work).get('identifiers'):
+    $if (edition or work).identifiers.get('amazon'):
+        $ asin = (edition or work).identifiers.amazon[0]
 
 $if isbn_10 and not asin:
     $ asin = isbn_10
 
-$ affiliate_links = macros.AffiliateLinks(page, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+$ affiliate_links = macros.AffiliateLinks((edition or work), {'isbn': isbn_13, 'asin': asin, 'prices': prices})
 $ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
 
 $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -178,21 +178,21 @@ $ reader_observations = get_observation_metrics(work['key']) if show_observation
 $ component_times['get_observation_metrics'] = time() - component_times['get_observation_metrics']
 
 $ component_times['affiliate_links component'] = time()
-$ prices = (edition or work).key.startswith('/books/')
+$ prices = edition.key.startswith('/books/')
 
-$ oclc_numbers = ((edition or work).oclc_numbers and (edition or work).oclc_numbers[0]) or ""
-$ isbn_13 = (edition or work).get_isbn13()
-$ isbn_10 = (edition or work).get_isbn10()
+$ oclc_numbers = (edition.oclc_numbers and edition.oclc_numbers[0]) or ""
+$ isbn_13 = edition.get_isbn13()
+$ isbn_10 = edition.get_isbn10()
 
 $ asin = None
-$if (edition or work).get('identifiers'):
-    $if (edition or work).identifiers.get('amazon'):
-        $ asin = (edition or work).identifiers.amazon[0]
+$if edition.get('identifiers'):
+    $if edition.identifiers.get('amazon'):
+        $ asin = edition.identifiers.amazon[0]
 
 $if isbn_10 and not asin:
     $ asin = isbn_10
 
-$ affiliate_links = macros.AffiliateLinks((edition or work), {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+$ affiliate_links = macros.AffiliateLinks(edition), {'isbn': isbn_13, 'asin': asin, 'prices': prices})
 $ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
 
 $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that same WorldCat and affiliate links appear in both mobile and desktop views on the book page.  These links are now rendered in the `edition/view.html` template and passed to `databarWork`, as opposed to being rendered in both templates using potentially different data as inputs.

### Technical
<!-- What should be noted about the implementation? -->
Before DRYing this code, price info was prepared in both templates using `page`.  The issue was that `edition or work` is passed to `databarWork` as `page`, while the `edition/view.html` `page` could be either and is missing the enrichments that `edition` and `work` undergo before being passed to `databarWork`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Once this has been deployed to `testing`:
1. Navigate to a book page where the links are inconsistent between mobile and desktop views.
2. Ensure that the same WorldCat and affiliate links are present in both views.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
