### PR TITLE
The distutils module is removed in Python v3.12

### DIFF
--- a/scripts/solr_builder/setup.py
+++ b/scripts/solr_builder/setup.py
@@ -1,5 +1,5 @@
-from distutils.core import setup
 from pathlib import Path
+from setuptools import setup
 from Cython.Build import cythonize
 
 setup(


### PR DESCRIPTION
`distutils` was deprecated in Python 3.10 and removed in Python 3.12 by [PEP 632](https://peps.python.org/pep-0632/) “Deprecate distutils module”.

https://docs.python.org/3.12/whatsnew/3.12.html#removed

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
