### PR TITLE
remove ia extra get_metadata calls

### DIFF
--- a/openlibrary/core/fulltext.py
+++ b/openlibrary/core/fulltext.py
@@ -56,7 +56,7 @@ def fulltext_search(q, page=1, limit=100, js=False, facets=False):
             if ed.ocaid in ocaids:
                 idx = ocaids.index(ed.ocaid)
                 ia_results['hits']['hits'][idx]['edition'] = (
-                    format_book_data(ed, False) if js else ed
+                    format_book_data(ed, fetch_availability=False) if js else ed
                 )
                 ia_results['hits']['hits'][idx]['availability'] = availability[ed.ocaid]
     return ia_results

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,4 +1,4 @@
-$def with (ocaid, linkback=True)
+$def with (ocaid)
 $# :param str ocaid:
 
   <div class="cta-button-group">
@@ -19,13 +19,6 @@ $if render_once('book-preview-floater'):
         <div class="iframe-container">
           <iframe style="width:100%; height:515px"></iframe>
         </div>
-        <p class="learn-more">
-          <a data-key="book_preview_learn_more"
-             data-ol-link-track="book_preview_learn_more">
-	    $if linkback:
-              $_("See more about this book on Archive.org")
-          </a>
-        </p>
       </div>
     </div>
   </div>

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -18,6 +18,11 @@ $if render_once('book-preview-floater'):
         </div>
         <div class="iframe-container">
           <iframe style="width:100%; height:515px"></iframe>
+          <p class="learn-more">
+            <a data-key="book_preview_learn_more"
+             data-ol-link-track="book_preview_learn_more">
+            </a>
+          </p>
         </div>
       </div>
     </div>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -15,7 +15,6 @@ $ loanstatus_start_time = time()
 $ availability = (doc.availability or {}) if hasattr(doc, 'availability') else {}
 $ ocaid = doc.get('ocaid') or availability.get('identifier')
 $ work_key = work_key or (doc.get('works') and doc.works[0].key)
-$ no_index = hasattr(doc, 'get_ia_meta_fields') and doc.get_ia_meta_fields().get('noindex', False)
 
 $ waiting_loan_start_time = time()
 $ waiting_loan = check_loan_status and ocaid and ctx.user and ctx.user.get_waiting_loan_for(ocaid)
@@ -76,12 +75,12 @@ $elif ocaid and ctx.user and ctx.user.is_printdisabled():
   $ pd_eligible = availability and availability.get('is_printdisabled')
   $ std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
   $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
-    $:macros.BookPreview(ocaid, linkback=not no_index)
+    $:macros.BookPreview(ocaid)
   $:macros.ReadButton(ocaid, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen)
 
 $elif availability.get('is_lendable'):
   $if secondary_action:
-    $:macros.BookPreview(ocaid, linkback=not no_index)
+    $:macros.BookPreview(ocaid)
   $if availability.get("available_to_borrow") or availability.get("available_to_browse"):
     $:macros.ReadButton(ocaid, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
@@ -124,7 +123,7 @@ $elif availability.get('is_lendable'):
     </div>
 
 $elif ocaid and availability.get('is_previewable') and book_provider.short_name == 'ia':
-  $:macros.BookPreview(ocaid, linkback=not no_index)
+  $:macros.BookPreview(ocaid)
   $if secondary_action:
       $:macros.BookSearchInside(ocaid)
 

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -14,13 +14,14 @@ $code:
     selected_ed = doc.get('editions')[0]
 
   book_url = doc.url() if doc_type.startswith('infogami_') else doc.key
-  book_provider = get_book_provider(doc)
   if doc_type == 'solr_edition':
     work_edition_url = book_url + '?edition=' + urlquote('key:' + selected_ed.key)
-  elif book_provider and doc_type.endswith('_work'):
-    work_edition_url = book_url + '?edition=' + urlquote(book_provider.get_best_identifier_slug(doc))
   else:
-    work_edition_url = book_url
+    book_provider = get_book_provider(doc)
+    if book_provider and doc_type.endswith('_work'):
+      work_edition_url = book_url + '?edition=' + urlquote(book_provider.get_best_identifier_slug(doc))
+    else:
+      work_edition_url = book_url
 
   edition_work = None
   if doc_type == 'infogami_edition' and 'works' in doc:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Contributed towards fixing #7861 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->
What was happening is plugins/inside/code.py was calling the search/inside.tmpl which called macros/SearchResults which looped over each book/results doc and called macros/SearchResultsWork which was making calls to get_data_provider which was performing an ia.get_metadata lookup.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
