### PR TITLE
Remove unreferenced `less` variables

### DIFF
--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -2,32 +2,23 @@
 @primary-blue: hsl(202, 96%, 37%);
 @link-blue: hsl(202, 96%, 28%);
 @mid-blue: hsl(204, 70%, 53%);
-@mid-blue-highlight: hsl(204, 64%, 44%);
-@mid-blue-highlight-hover: hsl(204, 98%, 61%);
 @dark-blue: hsl(210, 100%, 20%);
 @darker-brand-blue: hsl(198, 100%, 36%);
 @header-nav-hover-color: hsl(207, 83%, 33%);
-@navy-blue: hsl(224, 83%, 23%); // one usage
 @blue-b0bed9: hsl(220, 35%, 77%);
 @count-blue-grey: hsla(211, 28%, 41%, 1);
 @grey-blue:hsl(211, 37%, 89%);
-@pale-blue:hsl(212, 100%, 95%);
 @teal: hsl(184, 100%, 21%);
 @button-hover-blue:hsl(202, 57%, 61%);
-@steel-blue:hsl(210,10%,50%);
 @dark-baby-blue: hsl(240, 100%, 75%);
 @mid-baby-blue: hsl(240, 100%, 88%);
 @baby-blue: hsl(240, 100%, 93%);
 @blue-9fafd1: hsl(221, 35%, 72%);
 @blue-3366ff: hsl(225, 100%, 60%);
-@blue-204764: hsla(206, 51%, 26%, .25);
 @blue-5e88B9: hsl(212, 39%, 55%);
 
 // green
 @green: hsl(130, 61%, 33%);
-@green-three: hsl(130, 46%, 45%);
-@green-four: hsl(130, 43%, 45%);
-@green-five: hsl(130, 51%, 42%);
 @mid-baby-green: hsl(120, 100%, 88%);
 @baby-green: hsl(120, 100%, 93%);
 @dark-green: hsl(113, 38%, 29%);
@@ -39,7 +30,6 @@
 
 // orange
 @orange: hsl(32, 100%, 61%);
-@orange-two: hsl(32, 80%, 50%);
 @orange-three: hsl(32, 100%, 78%);
 @orange-four: hsl(23, 51%, 77%);
 @orange-five: hsl(23, 100%, 50%);
@@ -57,17 +47,15 @@
 
 // beige
 @dark-yellow: hsl(57, 60%, 72%);
-@beige-two: hsl(48, 28%, 76%);
+@beige-two: hsl(63, 26%, 84%);
 @beige-three: hsl(48, 15%, 74%);
 @beige: hsl(48, 33%, 83%);
 @brown: hsl(40, 32%, 29%);
-@brown-3a301e: hsl(39, 32%, 17%); // this color is only used once
 @account-icon-border: hsl(45, 7%, 79%); // this color is only used once
 @light-yellow: hsl(58, 100%, 90%);
 @lighter-yellow: hsl(58, 92%, 95%);
 @dark-beige:hsl(64, 9%, 71%);
 @light-beige:hsl(48, 29%, 93%);
-@beige-two:hsl(63, 26%, 84%);
 @cream: hsl(49, 30%, 93%);
 @off-white: hsl(45, 100%, 98%);
 @gold: hsl(50, 100%, 50%);
@@ -92,7 +80,6 @@
 @grey-e7e7e7: hsl(0, 0%, 91%);
 @lightest-grey: hsl(0, 0%, 93%);
 @grey-f3f3f3: hsl(0, 0%, 95%);
-@grey-f4f4f4: hsl(0, 0%, 96%);
 @grey-fafafa: hsl(0, 0%, 98%);
 @white: hsl(0, 0%, 100%);
 @gray-a19b9e: hsl(330, 3%, 62%);
@@ -118,13 +105,4 @@
 @book-cover-shadow-color: hsl(48, 35%, 64%);
 
 // nagios
-@nagios-grey: hsl(0, 0%, 67%);
 @nagios-green: hsl(108, 100%, 50%);
-@nagios-orange: hsl(36, 100%, 50%);
-@nagios-yellow: hsl(60, 100%, 50%);
-@nagios-red: hsl(0, 93%, 60%);
-
-// modal
-@modal-background-color: hsl(0, 0%, 100%);
-@modal-header-background-color: hsl(0, 0%, 91%);
-@modal-header-color: hsl(0, 0%, 33%);

--- a/static/css/less/z-index.less
+++ b/static/css/less/z-index.less
@@ -6,13 +6,9 @@
 @z-index-level-5: 999;
 @z-index-level-6: 1000;
 @z-index-level-7: 1001;
-@z-index-level-8: 1002;
-@z-index-level-9: 1005;
-@z-index-level-10: 1006;
-@z-index-level-11: 2000;
-@z-index-level-12: 3000;
+
 @z-index-level-13: 9999;
 @z-index-level-14: 10000;
-@z-index-level-15: 20000;
+
 @z-index-level-16: 99999;
 @z-index-level-17: 999999;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes color and z-index Less variables that are no longer referenced in the codebase.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
