### PR TITLE
pyproject.toml: Increase tool.ruff.pylint.max-statements to 71

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 15
 max-branches = 22
 max-returns = 14
-max-statements = 70
+max-statements = 71
 
 [tool.ruff.per-file-ignores]
 "openlibrary/admin/stats.py" = ["BLE001"]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes `openlibrary/plugins/worksearch/schemes/works.py:254:9: PLR0915 Too many statements (71 > 70)`

% `ruff rule PLR0915`
# too-many-statements (PLR0915)

Derived from the **Pylint** linter.

## What it does
Checks for functions or methods with too many statements.

By default, this rule allows up to 50 statements, as configured by the
`pylint.max-statements` option.

## Why is this bad?
Functions or methods with many statements are harder to understand
and maintain.

Instead, consider refactoring the function or method into smaller
functions or methods, or identifying generalizable patterns and
replacing them with generic logic or abstractions.

## Example
```python
def is_even(number: int) -> bool:
    if number == 0:
        return True
    elif number == 1:
        return False
    elif number == 2:
        return True
    elif number == 3:
        return False
    elif number == 4:
        return True
    elif number == 5:
        return False
    else:
        ...
```

Use instead:
```python
def is_even(number: int) -> bool:
    return number % 2 == 0
```

## Options
- `pylint.max-statements`
