### PR TITLE
expand solr query escape flow to include single quotes

### DIFF
--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -131,6 +131,8 @@ def fully_escape_query(query: str) -> str:
     'x\\\\:\\\\[A TO Z\\\\}'
     >>> fully_escape_query('foo AND bar')
     'foo and bar'
+    >>> fully_escape_query("foo's bar")
+    "foo\\\\'s bar"
     """
     escaped = query
     # Escape special characters

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -134,7 +134,7 @@ def fully_escape_query(query: str) -> str:
     """
     escaped = query
     # Escape special characters
-    escaped = re.sub(r'[\[\]\(\)\{\}:"\-+?~^/\\,]', r'\\\g<0>', escaped)
+    escaped = re.sub(r'[\[\]\(\)\{\}:"\-+?~^/\\,\']', r'\\\g<0>', escaped)
     # Remove boolean operators by making them lowercase
     escaped = re.sub(r'AND|OR|NOT', lambda _1: _1.group(0).lower(), escaped)
     return escaped


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7618 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I have expanded the `fully_escaped_query` function to include queries with single quotes.

### Technical
<!-- What should be noted about the implementation? -->
Please note that this is a temporary fix for now as the luqum parser should be accepting single quote characters in the first place. I will try to make a PR on the https://github.com/jurismarches/luqum repo for this issue. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This following query should no longer have an error:
https://openlibrary.org/search?q=Cornell+%2777%3A+The+Music%2C+the+Myth+and+the+Magnificence+of+the+Grateful+Dead+Show+at+Barton+Hall&mode=everything

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No longer facing `IllegalCharacterError`
<img width="1122" alt="image" src="https://github.com/internetarchive/openlibrary/assets/90945854/99163322-01d1-42ed-8b0d-1da92ae8eb09">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
