### PR TITLE
Simplify Python code with ruff rules SIM105 and SIM300

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -12,6 +12,7 @@ import json
 from psycopg2.errors import UndefinedTable, UniqueViolation
 
 from . import db
+import contextlib
 
 logger = logging.getLogger("openlibrary.imports")
 
@@ -89,10 +90,9 @@ class Batch(web.storage):
                 db.get_db().multiple_insert("import_item", items)
             except UniqueViolation:
                 for item in items:
-                    try:
+                    with contextlib.suppress(UniqueViolation):
                         db.get_db().insert("import_item", **item)
-                    except UniqueViolation:
-                        pass
+
             logger.info("batch %s: added %d items", self.name, len(items))
 
         return

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -14,6 +14,7 @@ from openlibrary.core import helpers as h
 from openlibrary.core import cache
 
 from openlibrary.plugins.worksearch.search import get_solr
+import contextlib
 
 logger = logging.getLogger("openlibrary.lists.model")
 
@@ -205,12 +206,10 @@ class ListMixin:
         """
         for e in editions:
             if "recent_changeset" not in e:
-                try:
+                with contextlib.suppress(IndexError):
                     e['recent_changeset'] = self._site.recentchanges(
                         {"key": e.key, "limit": 1}
                     )[0]
-                except IndexError:
-                    pass
 
     def _get_solr_query_for_subjects(self):
         terms = [seed.get_solr_query_term() for seed in self.get_seeds()]

--- a/openlibrary/core/processors/invalidation.py
+++ b/openlibrary/core/processors/invalidation.py
@@ -3,6 +3,7 @@ import datetime
 from infogami.infobase import client
 
 from openlibrary.core import helpers as h
+import contextlib
 
 __all__ = ["InvalidationProcessor"]
 
@@ -139,10 +140,9 @@ class InvalidationProcessor:
             web.ctx._invalidation_inprogress = True
             docs = web.ctx.site.get_many(keys)
             for doc in docs:
-                try:
+                with contextlib.suppress(Exception):
                     client._run_hooks("on_new_version", doc)
-                except Exception:
-                    pass
+
             self.last_update_time = max(doc.last_modified for doc in docs)
             reloaded = True
             del web.ctx._invalidation_inprogress

--- a/openlibrary/coverstore/utils.py
+++ b/openlibrary/coverstore/utils.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode as real_urlencode
 from openlibrary.coverstore import config, oldb
 
 from io import IOBase as file
+import contextlib
 
 socket.setdefaulttimeout(10.0)
 
@@ -120,10 +121,8 @@ def read_file(path, offset, size, chunk=50 * 1024):
 
 
 def rm_f(filename):
-    try:
+    with contextlib.suppress(OSError):
         os.remove(filename)
-    except OSError:
-        pass
 
 
 chars = string.ascii_letters + string.digits

--- a/openlibrary/mocks/mock_memcache.py
+++ b/openlibrary/mocks/mock_memcache.py
@@ -2,7 +2,6 @@
 """
 import memcache
 import pytest
-import contextlib
 
 
 class Client:
@@ -27,8 +26,7 @@ class Client:
             return False
 
     def delete(self, key):
-        with contextlib.suppress(KeyError):
-            del self.cache[key]
+        self.cache.pop(key, None)
 
 
 @pytest.fixture

--- a/openlibrary/mocks/mock_memcache.py
+++ b/openlibrary/mocks/mock_memcache.py
@@ -2,6 +2,7 @@
 """
 import memcache
 import pytest
+import contextlib
 
 
 class Client:
@@ -26,10 +27,8 @@ class Client:
             return False
 
     def delete(self, key):
-        try:
+        with contextlib.suppress(KeyError):
             del self.cache[key]
-        except KeyError:
-            pass
 
 
 @pytest.fixture

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -77,13 +77,13 @@ def parse_data(data: bytes) -> tuple[dict | None, str | None]:
     data = data.strip()
     if b'<?xml' in data[:10]:
         root = etree.fromstring(data)
-        if '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF' == root.tag:
+        if root.tag == '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}RDF':
             edition_builder = import_rdf.parse(root)
             format = 'rdf'
-        elif '{http://www.w3.org/2005/Atom}entry' == root.tag:
+        elif root.tag == '{http://www.w3.org/2005/Atom}entry':
             edition_builder = import_opds.parse(root)
             format = 'opds'
-        elif '{http://www.loc.gov/MARC21/slim}record' == root.tag:
+        elif root.tag == '{http://www.loc.gov/MARC21/slim}record':
             if root.tag == '{http://www.loc.gov/MARC21/slim}collection':
                 root = root[0]
             rec = MarcXml(root)

--- a/openlibrary/plugins/importapi/import_opds.py
+++ b/openlibrary/plugins/importapi/import_opds.py
@@ -24,9 +24,9 @@ def parse_identifier(e, key):
     ia_str = 'http://www.archive.org/details/'
     if val.startswith(isbn_str):
         isbn = val[len(isbn_str) :]
-        if 10 == len(isbn):
+        if len(isbn) == 10:
             return ('isbn_10', isbn)
-        elif 13 == len(isbn):
+        elif len(isbn) == 13:
             return ('isbn_13', isbn)
     elif val.startswith(ia_str):
         return ('ocaid', val[len(ia_str) :])

--- a/openlibrary/plugins/importapi/import_rdf.py
+++ b/openlibrary/plugins/importapi/import_rdf.py
@@ -24,10 +24,10 @@ def parse_subject(e, key):
         '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}resource'
     )
     val = e.find('.//{http://www.w3.org/1999/02/22-rdf-syntax-ns#}value')
-    if 'http://purl.org/dc/terms/DDC' == resource_type:
+    if resource_type == 'http://purl.org/dc/terms/DDC':
         new_key = 'dewey_decimal_class'
         return (new_key, val.text)
-    elif 'http://purl.org/dc/terms/LCC' == resource_type:
+    elif resource_type == 'http://purl.org/dc/terms/LCC':
         new_key = 'lc_classification'
         return (new_key, val.text)
     else:
@@ -44,9 +44,9 @@ def parse_identifier(e, key):
     ia_str = 'http://www.archive.org/details/'
     if val.startswith(isbn_str):
         isbn = val[len(isbn_str) :]
-        if 10 == len(isbn):
+        if len(isbn) == 10:
             return ('isbn_10', isbn)
-        elif 13 == len(isbn):
+        elif len(isbn) == 13:
             return ('isbn_13', isbn)
     elif val.startswith(ia_str):
         return ('ocaid', val[len(ia_str) :])

--- a/openlibrary/plugins/importapi/metaxml_to_json.py
+++ b/openlibrary/plugins/importapi/metaxml_to_json.py
@@ -46,9 +46,9 @@ def parse_collection(collection):
 
 
 def parse_isbn(isbn):
-    if 13 == len(isbn):
+    if len(isbn) == 13:
         return ('isbn_13', [isbn])
-    elif 10 == len(isbn):
+    elif len(isbn) == 10:
         return ('isbn_10', [isbn])
     else:
         return ('isbn', [])
@@ -67,10 +67,10 @@ def metaxml_to_edition_dict(root):
     for element in root.iter():
         # print("got %s -> %s" % (element.tag, element.text))
 
-        if 'collection' == element.tag:
+        if element.tag == 'collection':
             key = 'subject'
             values = parse_collection(element.text)
-        elif 'isbn' == element.tag:
+        elif element.tag == 'isbn':
             key, values = parse_isbn(element.text)
         elif element.tag in ia_to_ol_map:
             key = ia_to_ol_map[element.tag]
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     from lxml import etree
     import sys
 
-    assert 2 == len(sys.argv)
+    assert len(sys.argv) == 2
 
     tree = etree.parse(sys.argv[1])
     root = tree.getroot()

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -412,8 +412,7 @@ class WorkSearchScheme(SearchScheme):
                 if param_name != 'fq' or param_value.startswith('type:'):
                     continue
                 field_name, field_val = param_value.split(':', 1)
-                ed_field = convert_work_field_to_edition_field(field_name)
-                if ed_field:
+                if ed_field := convert_work_field_to_edition_field(field_name):
                     editions_fq.append(f'{ed_field}:{field_val}')
             for fq in editions_fq:
                 new_params.append(('editions.fq', fq))
@@ -445,10 +444,7 @@ class WorkSearchScheme(SearchScheme):
         if ed_q or len(editions_fq) > 1:
             # The elements in _this_ edition query should cause works not to
             # match _at all_ if matching editions are not found
-            if ed_q:
-                new_params.append(('edQuery', full_ed_query))
-            else:
-                new_params.append(('edQuery', '*:*'))
+            new_params.append(('edQuery', full_ed_query if ed_q else '*:*'))
             q = (
                 f'+{full_work_query} '
                 # This is using the special parent query syntax to, on top of

--- a/openlibrary/tests/solr/test_update_work.py
+++ b/openlibrary/tests/solr/test_update_work.py
@@ -579,7 +579,7 @@ class Test_update_items:
     def test_delete_requests(self):
         olids = ['/works/OL1W', '/works/OL2W', '/works/OL3W']
         json_command = update_work.DeleteRequest(olids).to_json_command()
-        assert '"delete": ["/works/OL1W", "/works/OL2W", "/works/OL3W"]' == json_command
+        assert json_command == '"delete": ["/works/OL1W", "/works/OL2W", "/works/OL3W"]'
 
 
 class TestUpdateWork:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,8 @@ ignore = [
   "PLW2901",
   "RSE102",
   "SIM102",
-  "SIM105",
   "SIM108",
   "SIM115",
-  "SIM300",
   "SLF001",
   "UP007",
   "UP031",
@@ -134,7 +132,7 @@ allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 15
 max-branches = 22
 max-returns = 14
-max-statements = 71
+max-statements = 70
 
 [tool.ruff.per-file-ignores]
 "openlibrary/admin/stats.py" = ["BLE001"]
@@ -146,6 +144,7 @@ max-statements = 71
 "openlibrary/catalog/utils/query.py" = ["E722"]
 "openlibrary/core/booknotes.py" = ["E722"]
 "openlibrary/core/bookshelves.py" = ["BLE001"]
+"openlibrary/core/db.py" = ["SIM105"]
 "openlibrary/core/helpers.py" = ["BLE001"]
 "openlibrary/core/processors/invalidation.py" = ["BLE001"]
 "openlibrary/core/ratings.py" = ["E722"]
@@ -170,6 +169,7 @@ max-statements = 71
 "openlibrary/plugins/upstream/utils.py" = ["BLE001"]
 "openlibrary/solr/update_work.py" = ["C901", "E722", "PLR0912", "PLR0915"]
 "openlibrary/utils/retry.py" = ["BLE001"]
+"scripts/affiliate_server*.py" = ["SIM105"]
 "scripts/copydocs.py" = ["BLE001"]
 "scripts/delete_import_items.py" = ["BLE001"]
 "scripts/import_book_covers.py" = ["BLE001"]


### PR DESCRIPTION
% `ruff rule SIM105`
# suppressible-exception (SIM105)

Derived from the **flake8-simplify** linter.

Autofix is sometimes available.

Message formats:
* Use `contextlib.suppress({exception})` instead of `try`-`except`-`pass`
---
% `ruff rule SIM300`
# yoda-conditions (SIM300)

Derived from the **flake8-simplify** linter.

Autofix is sometimes available.

Message formats:
* Yoda conditions are discouraged, use `{suggestion}` instead
* Yoda conditions are discouraged