### PR TITLE
Add types with MonkeyType

### DIFF
--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -4,6 +4,8 @@ import web
 from sqlite3 import IntegrityError
 from psycopg2.errors import UniqueViolation
 from infogami.utils import stats
+from typing import Callable
+from web.db import PostgresDB
 
 
 @web.memoize
@@ -11,7 +13,7 @@ def _get_db():
     return web.database(**web.config.db_parameters)
 
 
-def get_db():
+def get_db() -> PostgresDB:
     """Returns an instance of webpy database object.
 
     The database object is cached so that one object is used everywhere.
@@ -145,7 +147,7 @@ class CommonExtras:
         return rows_deleted
 
 
-def _proxy(method_name):
+def _proxy(method_name: str) -> Callable:
     """Create a new function that call method with given name on the
     database object.
 

--- a/openlibrary/core/middleware.py
+++ b/openlibrary/core/middleware.py
@@ -3,15 +3,19 @@
 import web
 from io import BytesIO
 import gzip
+from itertools import chain
+from typing import Any, Callable, Dict, List, Union
 
 
 class GZipMiddleware:
     """WSGI middleware to gzip the response."""
 
-    def __init__(self, app):
+    def __init__(self, app: Callable) -> None:
         self.app = app
 
-    def __call__(self, environ, start_response):
+    def __call__(
+        self, environ: dict[str, Any], start_response: Callable
+    ) -> Union[chain, list[bytes]]:
         accept_encoding = environ.get("HTTP_ACCEPT_ENCODING", "")
         if 'gzip' not in accept_encoding:
             return self.app(environ, start_response)

--- a/openlibrary/core/schema.py
+++ b/openlibrary/core/schema.py
@@ -2,9 +2,10 @@
 """
 from infogami.infobase import dbstore
 import web
+from infogami.infobase._dbstore.schema import Schema
 
 
-def get_schema():
+def get_schema() -> Schema:
     schema = dbstore.Schema()
     schema.add_table_group('type', '/type/type')
     schema.add_table_group('type', '/type/property')
@@ -105,7 +106,7 @@ def get_schema():
     return schema
 
 
-def register_schema():
+def register_schema() -> None:
     """Register the schema defined in this module as the default schema."""
     dbstore.default_schema = get_schema()
 

--- a/openlibrary/core/stats.py
+++ b/openlibrary/core/stats.py
@@ -36,7 +36,7 @@ def create_stats_client(cfg=config):
         return False
 
 
-def put(key, value, rate=1.0):
+def put(key: str, value: float, rate: float = 1.0) -> None:
     "Records this ``value`` with the given ``key``. It is stored as a millisecond count"
     global client
     if client:
@@ -44,7 +44,7 @@ def put(key, value, rate=1.0):
         client.timing(key, value, rate)
 
 
-def increment(key, n=1, rate=1.0):
+def increment(key: str, n: int = 1, rate: float = 1.0) -> None:
     "Increments the value of ``key`` by ``n``"
     global client
     if client:

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -14,6 +14,7 @@ from babel.messages.mofile import write_mo
 from babel.messages.extract import extract_from_file, extract_from_dir, extract_python
 
 from .validators import validate
+from typing import Callable, Union
 
 root = os.path.dirname(__file__)
 
@@ -305,7 +306,7 @@ def load_locale(lang):
 
 
 class GetText:
-    def __call__(self, string, *args, **kwargs):
+    def __call__(self, string: str, *args, **kwargs) -> str:
         """Translate a given string to the language of the current locale."""
         # Get the website locale from the global ctx.lang variable, set in i18n_loadhook
         translations = load_translations(web.ctx.lang)
@@ -326,13 +327,13 @@ class GetText:
 
 
 class LazyGetText:
-    def __call__(self, string, *args, **kwargs):
+    def __call__(self, string: str, *args, **kwargs) -> "LazyObject":
         """Translate a given string lazily."""
         return LazyObject(lambda: GetText()(string, *args, **kwargs))
 
 
 class LazyObject:
-    def __init__(self, creator):
+    def __init__(self, creator: Callable) -> None:
         self._creator = creator
 
     def __str__(self):
@@ -348,7 +349,7 @@ class LazyObject:
         return other + self._creator()
 
 
-def ungettext(s1, s2, _n, *a, **kw):
+def ungettext(s1: str, s2: str, _n: Union[float, int], *a, **kw) -> str:
     # Get the website locale from the global ctx.lang variable, set in i18n_loadhook
     translations = load_translations(web.ctx.lang)
     value = translations and translations.ungettext(s1, s2, _n)

--- a/openlibrary/olbase/__init__.py
+++ b/openlibrary/olbase/__init__.py
@@ -5,6 +5,6 @@ from . import events
 from ..plugins import ol_infobase
 
 
-def init_plugin():
+def init_plugin() -> None:
     ol_infobase.init_plugin()
     events.setup()

--- a/openlibrary/olbase/events.py
+++ b/openlibrary/olbase/events.py
@@ -17,11 +17,11 @@ from openlibrary.utils import olmemcache
 logger = logging.getLogger("openlibrary.olbase")
 
 
-def setup():
+def setup() -> None:
     setup_event_listener()
 
 
-def setup_event_listener():
+def setup_event_listener() -> None:
     logger.info("setting up infobase events for Open Library")
 
     ol = server.get_site('openlibrary.org')

--- a/openlibrary/plugins/admin/graphs.py
+++ b/openlibrary/plugins/admin/graphs.py
@@ -77,7 +77,7 @@ class Series:
         return ""
 
 
-def setup():
+def setup() -> None:
     web.template.Template.globals.update(
         {
             'GraphiteGraph': GraphiteGraph,

--- a/openlibrary/plugins/openlibrary/authors.py
+++ b/openlibrary/plugins/openlibrary/authors.py
@@ -2,7 +2,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template
 
 
-def setup():
+def setup() -> None:
     pass
 
 

--- a/openlibrary/plugins/openlibrary/borrow_home.py
+++ b/openlibrary/plugins/openlibrary/borrow_home.py
@@ -91,6 +91,6 @@ def _get_loan_key(loan):
     return "loans/" + loan.get("uuid") or loan["_key"]
 
 
-def setup():
+def setup() -> None:
     eventer.bind("loan-created", on_loan_created_statsdb)
     eventer.bind("loan-completed", on_loan_completed_statsdb)

--- a/openlibrary/plugins/openlibrary/design.py
+++ b/openlibrary/plugins/openlibrary/design.py
@@ -14,5 +14,5 @@ class home(delegate.page):
         return render_template("design")
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -5,6 +5,10 @@ import web
 from openlibrary.core.processors import ReadableUrlProcessor
 
 from openlibrary.core import helpers as h
+from infogami.utils.delegate import RawText
+from typing import Callable, Optional, Set, Union
+from web.template import TemplateResult
+from web.webapi import OK
 
 urlsafe = h.urlsafe
 _safepath = h.urlsafe
@@ -13,7 +17,7 @@ _safepath = h.urlsafe
 class ProfileProcessor:
     """Processor to profile the webpage when ?_profile=true is added to the url."""
 
-    def __call__(self, handler):
+    def __call__(self, handler: Callable) -> Union[RawText, TemplateResult, OK]:
         i = web.input(_method="GET", _profile="")
         if i._profile.lower() == "true":
             out, result = web.profile(handler)()
@@ -45,10 +49,10 @@ class CORSProcessor:
     Cross Origin Resource Sharing.
     """
 
-    def __init__(self, cors_prefixes=None):
+    def __init__(self, cors_prefixes: Optional[set[str]] = None) -> None:
         self.cors_prefixes = cors_prefixes
 
-    def __call__(self, handler):
+    def __call__(self, handler: Callable) -> Union[RawText, TemplateResult, OK]:
         if self.is_cors_path():
             self.add_cors_headers()
         if web.ctx.method == "OPTIONS":
@@ -56,14 +60,14 @@ class CORSProcessor:
         else:
             return handler()
 
-    def is_cors_path(self):
+    def is_cors_path(self) -> bool:
         if self.cors_prefixes is None or web.ctx.path.endswith(".json"):
             return True
         return any(
             web.ctx.path.startswith(path_segment) for path_segment in self.cors_prefixes
         )
 
-    def add_cors_headers(self):
+    def add_cors_headers(self) -> None:
         # Allow anyone to access GET and OPTIONS requests
         allowed = "GET, OPTIONS"
         # unless the path is /account/* or /admin/*

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -7,7 +7,7 @@ from openlibrary.utils.sentry import Sentry, SentryProcessor
 sentry: Optional[Sentry] = None
 
 
-def setup():
+def setup() -> None:
     global sentry
     sentry = Sentry(getattr(infogami.config, 'sentry', {}))
 

--- a/openlibrary/plugins/openlibrary/status.py
+++ b/openlibrary/plugins/openlibrary/status.py
@@ -8,6 +8,7 @@ from infogami.utils import delegate
 from infogami.utils.view import render_template, public
 from openlibrary.core import stats
 from openlibrary.utils import get_software_version
+from web.utils import Storage
 
 status_info: dict[str, Any] = {}
 feature_flagso: dict[str, Any] = {}
@@ -19,7 +20,7 @@ class status(delegate.page):
 
 
 @public
-def get_git_revision_short_hash():
+def get_git_revision_short_hash() -> str:
     return (
         status_info.get('Software version')
         if status_info and isinstance(status_info, dict)
@@ -27,11 +28,11 @@ def get_git_revision_short_hash():
     )
 
 
-def get_features_enabled():
+def get_features_enabled() -> Storage:
     return config.features
 
 
-def setup():
+def setup() -> None:
     "Basic startup status for the server"
     global status_info, feature_flags
     host = socket.gethostname()

--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -89,5 +89,5 @@ class ol_cdumps(delegate.page):
             raise web.found(download_url(item, item + ".txt.gz"))
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -8,6 +8,7 @@ from openlibrary import accounts
 from openlibrary.core.edits import CommunityEditsQueue, get_status_for_view
 from infogami.utils import delegate
 from infogami.utils.view import render_template
+from web.template import TemplateResult
 
 
 def response(status='ok', **kwargs):
@@ -30,7 +31,7 @@ def process_merge_request(rtype, data):
 class community_edits_queue(delegate.page):
     path = '/merges'
 
-    def GET(self):
+    def GET(self) -> TemplateResult:
         i = web.input(
             page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc'
         )
@@ -198,5 +199,5 @@ class ui_partials(delegate.page):
             return delegate.RawText(component)
 
 
-def setup():
+def setup() -> None:
     pass

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -2,7 +2,7 @@ import web
 from infogami.infobase.client import ClientException
 from infogami.core import forms
 
-from openlibrary.i18n import lgettext as _
+from openlibrary.i18n import LazyObject, lgettext as _
 from openlibrary.utils.form import (
     Form,
     Textbox,
@@ -61,7 +61,7 @@ vemail = RegexpValidator(r".*@.*", _("Must be a valid email address"))
 
 
 class EqualToValidator(Validator):
-    def __init__(self, fieldname, message):
+    def __init__(self, fieldname: str, message: LazyObject) -> None:
         Validator.__init__(self, message, None)
         self.fieldname = fieldname
         self.form = None
@@ -121,7 +121,7 @@ class RegisterForm(Form):
         ),
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         Form.__init__(self, *self.INPUTS)
 
     def validates(self, source):

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -782,7 +782,7 @@ class search_json(delegate.page):
         return delegate.RawText(json.dumps(response, indent=4))
 
 
-def setup():
+def setup() -> None:
     from openlibrary.plugins.worksearch import subjects, languages, publishers
 
     subjects.setup()

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -120,7 +120,7 @@ class LanguageEngine(subjects.SubjectEngine):
         return counts.get('true')
 
 
-def setup():
+def setup() -> None:
     d = web.storage(
         name="language",
         key="languages",

--- a/openlibrary/plugins/worksearch/publishers.py
+++ b/openlibrary/plugins/worksearch/publishers.py
@@ -105,7 +105,7 @@ class PublisherEngine(subjects.SubjectEngine):
         return counts.get('true')
 
 
-def setup():
+def setup() -> None:
     d = web.storage(
         name="publisher",
         key="publishers",

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -427,7 +427,7 @@ class SubjectEngine:
         )
 
 
-def setup():
+def setup() -> None:
     """Placeholder for doing any setup required.
 
     This function is called from code.py.

--- a/openlibrary/utils/compress.py
+++ b/openlibrary/utils/compress.py
@@ -34,7 +34,7 @@ some_record, and restored_record being identical to some_record.
 
 
 class Compressor:
-    def __init__(self, seed):
+    def __init__(self, seed: str) -> None:
         c = zlib.compressobj(9)
         d_seed = c.compress(seed.encode())
         d_seed += c.flush(zlib.Z_SYNC_FLUSH)

--- a/openlibrary/utils/dateutil.py
+++ b/openlibrary/utils/dateutil.py
@@ -8,6 +8,7 @@ from sys import stderr
 from time import perf_counter
 
 from infogami.utils.view import public
+from typing import Optional
 
 
 MINUTE_SECS = 60
@@ -18,7 +19,7 @@ DAY_SECS = HOUR_SECS * 24
 WEEK_SECS = DAY_SECS * 7
 
 
-def days_in_current_month():
+def days_in_current_month() -> int:
     now = datetime.datetime.now()
     return calendar.monthrange(now.year, now.month)[1]
 
@@ -27,7 +28,7 @@ def todays_date_minus(**kwargs):
     return datetime.date.today() - datetime.timedelta(**kwargs)
 
 
-def date_n_days_ago(n=None, start=None):
+def date_n_days_ago(n: Optional[int] = None, start: None = None) -> datetime.date:
     """
     Args:
         n (int) - number of days since start

--- a/openlibrary/utils/form.py
+++ b/openlibrary/utils/form.py
@@ -7,6 +7,8 @@ import copy
 import re
 
 from infogami.utils.view import render
+from openlibrary.i18n import LazyObject
+from typing import Callable, Optional, Type, Union
 
 
 class AttributeList(dict):
@@ -28,7 +30,13 @@ class AttributeList(dict):
 
 
 class Input:
-    def __init__(self, name, description=None, value=None, **kw):
+    def __init__(
+        self,
+        name: str,
+        description: Optional[LazyObject] = None,
+        value: None = None,
+        **kw,
+    ) -> None:
         self.name = name
         self.description = description or ""
         self.value = value
@@ -124,7 +132,7 @@ class Hidden(Input):
 
 
 class Form:
-    def __init__(self, *inputs, **kw):
+    def __init__(self, *inputs, **kw) -> None:
         self.inputs = inputs
         self.validators = kw.pop('validators', [])
         self.note = None
@@ -174,7 +182,9 @@ class Form:
 
 
 class Validator:
-    def __init__(self, msg, test):
+    def __init__(
+        self, msg: Union[LazyObject, str], test: Optional[Union[Callable, type[bool]]]
+    ) -> None:
         self.msg = msg
         self.test = test
 
@@ -196,7 +206,7 @@ notnull = Validator("Required", bool)
 
 
 class RegexpValidator(Validator):
-    def __init__(self, rexp, msg):
+    def __init__(self, rexp: str, msg: LazyObject) -> None:
         self.rexp = re.compile(rexp)
         self.msg = msg
 

--- a/openlibrary/utils/olcompress.py
+++ b/openlibrary/utils/olcompress.py
@@ -15,6 +15,6 @@ seed4 = '{"name": "Alberto Tebechrani", "personal_name": "Alberto Tebechrani", "
 seed = seed1 + seed2 + seed3 + seed4
 
 
-def OLCompressor():
+def OLCompressor() -> Compressor:
     """Create a compressor object for compressing OL data."""
     return Compressor(seed)

--- a/openlibrary/utils/olmemcache.py
+++ b/openlibrary/utils/olmemcache.py
@@ -3,6 +3,7 @@
 import memcache
 from openlibrary.utils.olcompress import OLCompressor
 import web
+from typing import List
 
 
 class Client:
@@ -10,7 +11,7 @@ class Client:
     Compatible with memcache Client API.
     """
 
-    def __init__(self, servers):
+    def __init__(self, servers: list[str]) -> None:
         self._client = memcache.Client(servers)
         compressor = OLCompressor()
         self.compress = compressor.compress


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes no issue

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
This hypothetical PR is based on output from [MonkeyType](https://github.com/Instagram/MonkeyType), which can add type hints based on the types used at runtime (although in this draft it is based on the runtime of the Docker container).

I am curious if it is worth pursuing MonkeyType further. On the one hand, it looks as if it would be a pretty good way to get type information for a large part of the code base, based on the types actually used. 

On the other hand, this didn't run perfectly. There were some issues with circular imports, and something about `Couldn't find statsd_server section in config`. Those issues appear to have prevented the collection of any type information whatsoever for modules so affected. So to get more types, these errors would need to be addressed.

Further, the type hints don't follow the style we use (e.g. MonkeyType generates `Union[str, int]` instead of `str | int`), so those would need updating, though likely that could be scripted.

Additionally, adding these hints led to 65 new `mypy` errors. So even thtough MonkeyType can identify some types for us, more work would need to be done to resolve type issues that the new additions lead to.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
