### PR TITLE
Fix login json SFW

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -336,9 +336,10 @@ class account_login_json(delegate.page):
                 raise olib.code.BadRequest(error)
             expires = 3600 * 24 * 365 if remember.lower() == 'true' else ""
             web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
-            ol_account = OpenLibraryAccount.get(email=email)
-            if ol_account.get_user().get_safe_mode() == 'yes':
-                web.setcookie('sfw', 'yes', expires=expires)
+            if audit.get('ia_email'):
+                ol_account = OpenLibraryAccount.get(email=audit['ia_email'])
+                if ol_account and ol_account.get_user().get_safe_mode() == 'yes':
+                    web.setcookie('sfw', 'yes', expires=expires)
         # Fallback to infogami user/pass
         else:
             from infogami.plugins.api.code import login as infogami_login
@@ -403,7 +404,7 @@ class account_login(delegate.page):
             config.login_cookie_name, web.ctx.conn.get_auth_token(), expires=expires
         )
         ol_account = OpenLibraryAccount.get(email=email)
-        if ol_account.get_user().get_safe_mode() == 'yes':
+        if ol_account and ol_account.get_user().get_safe_mode() == 'yes':
             web.setcookie('sfw', 'yes', expires=expires)
         blacklist = [
             "/account/login",


### PR DESCRIPTION
Fixes a case where for login json endpoint `ol_account` was being fetched using an empty email as opposed to the email matched by the `audit`.

![image](https://github.com/internetarchive/openlibrary/assets/978325/67ef814e-a383-440f-bfe8-7d58c94e8e01)

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
