### PR TITLE
On re-import, only update 'publishers' if the field is empty

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -806,7 +806,6 @@ def load(rec, account_key=None):
         'lc_classifications',
         'oclc_numbers',
         'source_records',
-        'publishers',
     ]
     for f in edition_list_fields:
         if f not in rec or not rec[f]:
@@ -824,6 +823,7 @@ def load(rec, account_key=None):
 
     other_edition_fields = [
         'number_of_pages',
+        'publishers',
         'publish_date',
     ]
     for f in other_edition_fields:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes no issue.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This PR changes the re-import behavior such that the `publishers` field is only updated if the field is currently empty.

Currently an edition's publishers field is appended to, [which can result in duplication](https://openlibrary.org/books/OL46931415M/More_Scary_Stories_to_Tell_in_the_Dark?_compare=Compare&b=5&a=4&m=diff). This PR stops that.

I know there may be other factors at play, but it was a quick change so I figured I'd just submit a PR.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

#### Trying to import an existing record using the same publisher that already exists in the record, with the current code:
❯ curl -X POST http://localhost:8080/api/import -H "Content-Type: application/json" -H "Cookie: $OL_COOKIE" -d '{
    "title": "Les noirs et les rouges",
    "source_records": ["ia:lesnoirsetlesrou0000garl"],
    "authors": [{"name": "Alberto Garlini"}],
    "publishers": ["Gallimard"],
    "isbn_13": "9782072702211",
    "publish_date": "2001-01"
}'

{"success": true, "edition": {"key": "/books/OL43522513M", **"status": "matched"}**, "work": {"key": "/works/OL31822851W", "status": "matched"}}%

#### Trying to add an additional publisher, with the existing code:
❯ curl -X POST http://localhost:8080/api/import -H "Content-Type: application/json" -H "Cookie: $OL_COOKIE" -d '{
    "title": "Les noirs et les rouges",
    "source_records": ["ia:lesnoirsetlesrou0000garl"],
    "authors": [{"name": "Alberto Garlini"}],
    "publishers": ["Gallimard Two"],
    "isbn_13": "9782072702211",
    "publish_date": "2001-01"
}'

{"success": true, "edition": {"key": "/books/OL43522513M", **"status": "modified"}**, "work": {"key": "/works/OL31822851W", "status": "matched"}}%

#### Trying to add an additional publisher with the PR's code:
❯ curl -X POST http://localhost:8080/api/import -H "Content-Type: application/json" -H "Cookie: $OL_COOKIE" -d '{
    "title": "Les noirs et les rouges",
    "source_records": ["ia:lesnoirsetlesrou0000garl"],
    "authors": [{"name": "Alberto Garlini"}],
    "publishers": ["Gallimard Three"],
    "isbn_13": "9782072702211",
    "publish_date": "2001-01"
}'

{"success": true, "edition": {"key": "/books/OL43522513M", **"status": "matched"}**, "work": {"key": "/works/OL31822851W", "status": "matched"}}%

#### After having removed all the publishers, trying to add a publisher with the PR's code:
❯ curl -X POST http://localhost:8080/api/import -H "Content-Type: application/json" -H "Cookie: $OL_COOKIE" -d '{
    "title": "Les noirs et les rouges",
    "source_records": ["ia:lesnoirsetlesrou0000garl"],
    "authors": [{"name": "Alberto Garlini"}],
    "publishers": ["Gallimard Three"],
    "isbn_13": "9782072702211",
    "publish_date": "2001-01"
}'

{"success": true, "edition": {"key": "/books/OL43522513M", **"status": "modified"}**, "work": {"key": "/works/OL31822851W", "status": "matched"}}%


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
