### PR TITLE
fix: search by author id bug

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -608,7 +608,7 @@ class author_search(delegate.page):
         q2 = f"/authors/{q}"
 
         combined_query = f"({q1}) OR ({q2})"
-        
+
         resp = run_solr_query(
             AuthorSearchScheme(),
             {'q': combined_query},

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -604,9 +604,14 @@ class author_search(delegate.page):
         return render_template('search/authors', self.get_results)
 
     def get_results(self, q, offset=0, limit=100, fields='*', sort=''):
+        q1 = q
+        q2 = f"/authors/{q}"
+
+        combined_query = f"({q1}) OR ({q2})"
+        
         resp = run_solr_query(
             AuthorSearchScheme(),
-            {'q': q},
+            {'q': combined_query},
             offset=offset,
             rows=limit,
             fields=fields,

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -51,7 +51,7 @@ class AuthorSearchScheme(SearchScheme):
             ('q', q),
             ('q.op', 'AND'),
             ('defType', 'edismax'),
-            ('qf', 'name alternate_names'),
+            ('qf', 'name alternate_names key'),
             ('pf', 'name^10 alternate_names^10'),
             ('bf', 'min(work_count,20)'),
         ]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7907

This features fixes the search by Author ID issue. Earlier to this searching by Author ID yielded no results, but now if one searches by Author ID, results are obtained and displayed.

### Technical
Since this is my first time working with the technologies in the project like Webpy, Infogami, Infobase, Infostore, and Solr, I consulted the documentation thoroughly and started tracing the URL routing.

The search for authors is done on the URL Route `/search/authors` and the handler for this is the class `author_search` located in the file `code.py`.

This class in turn uses the class `AuthorSearchScheme` located in the file `author.py`

To allow searching based on author id which in the Solr Schema is specified as `key` firstly key was added in: `('qf', 'name alternate_names key')` inside the `q_to_solr_params` method of the `AuthorSearchScheme` class.

However searching based on key was still not happening. Upon closer inspection of terminal traces, I observed that the key of an author is not just the alphanumeric id, but has the prefix `/authors/`.

Thus accordingly I made changes to `get_results` method of the class `author_search` so that now the Solr query string is not simply the one entered by user but OR combination of the original query string and orginal query string prefixed with `/authors/`.

### Testing
Navigate to the route `/search/authors` and enter the Author ID of an existing author and press Search, results for that author will be displayed.

### Screenshot
BEFORE Screenshots:

Searching by author name works fine

![ss1](https://github.com/internetarchive/openlibrary/assets/71654752/ce29ca97-cf21-4a49-90c4-864c05435fe7)

The author ID for Lewis Caroll is OL22098A, but searching by this author ID yields no result

![ss2](https://github.com/internetarchive/openlibrary/assets/71654752/85ee27ce-ee2c-4ae7-a822-d6176791aa26)

INTERMEDIATE Screenshots:

Searching for `/authors/OL22098A` which yields the results for Lewis Caroll:

![ss3](https://github.com/internetarchive/openlibrary/assets/71654752/f3ad99db-d333-4c06-8fa3-7e5f41a919d8)

AFTER Screenshot:

The author ID for Lewis Caroll is OL22098A and searching by this author ID yields valid result

![ss4](https://github.com/internetarchive/openlibrary/assets/71654752/5d1b1e11-2189-4dad-bd20-ea66e6ed2cf4)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 
@cdrini 
