### PR TITLE
Correct unique visitor counts - Use graphite summerize, not hitcount

### DIFF
--- a/openlibrary/core/admin.py
+++ b/openlibrary/core/admin.py
@@ -116,7 +116,7 @@ def _get_visitor_counts_from_graphite(self, ndays: int = 28) -> list[list[int]]:
         response = requests.get(
             "http://graphite.us.archive.org/render/",
             params={
-                "target": "hitcount(stats.uniqueips.openlibrary, '1d')",
+                "target": "summarize(stats.uniqueips.openlibrary, '1d')",
                 "from": f"-{ndays}days",
                 "tz": "UTC",
                 "format": "json",
@@ -132,7 +132,7 @@ def _get_visitor_counts_from_graphite(self, ndays: int = 28) -> list[list[int]]:
 class VisitorStats(Stats):
     def get_counts(self, ndays: int = 28, times: bool = False) -> list[tuple[int, int]]:
         visitors = _get_visitor_counts_from_graphite(ndays)
-        # Flip the order, convert timestamp to msec and convert count==None to zero
+        # Flip the order, convert timestamp to msec, and convert count==None to zero
         return [
             (int(timestamp * 1000), int(count or 0)) for count, timestamp in visitors
         ]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7936
![Screenshot 2023-06-29 at 13 46 40](https://github.com/internetarchive/openlibrary/assets/3709715/cdc12e8e-8ca7-4c7a-b379-bccf9f9fa9bd)
As discussed at https://github.com/internetarchive/openlibrary/issues/7936#issuecomment-1602849387 switching from graphite `hitcount` to `summerize` makes the graph match with 
![image](https://github.com/internetarchive/openlibrary/assets/3709715/d7505807-9f6f-4140-8115-4f8ee3a0f631)
https://graphite.us.archive.org/render/?min=0&template=plain&lineMode=staircase&areaMode=stacked&areaAlpha=0.5&yAxisSide=right&title=openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)&hideLegend=true&target=cactiStyle(alias(summarize(sumSeries(group(stats.uniqueips.openlibrary)),%221day%22),%22openlibrary+++Unique+IPs+per+day+++(uip_openlibrary)%22))&colorList=00ff00&height=200&width=900&from=-28days

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
