### PR TITLE
Fix public lists page error

### DIFF
--- a/openlibrary/templates/lists/lists.html
+++ b/openlibrary/templates/lists/lists.html
@@ -12,6 +12,7 @@ $if doc.key.startswith("/subjects/"):
 $else:
     $ seed = {"key": doc.key}
 
+$ deleteType = ''
 
 $if "type" in doc and doc.type.key == "/type/user":
     <style type="text/css">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Previously, `deleteType` was not being set if the patron visiting the `/lists` page was not the page's owner.  Now, `deleteType` will always have an assigned string.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in:
1. Visit your own /lists page.  Does it work as expected?
2. Visit another patron's /lists page.  Does it also work as expected?

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
