### PR TITLE
fix borrowing bloat by removing duplicate/unnecessary queries

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -528,7 +528,7 @@ def create_loan(identifier, resource_type, user_key, book_key=None):
 NOT_INITIALIZED = object()
 
 
-def sync_loan(identifier, loan=NOT_INITIALIZED):
+def sync_loan(identifier, loan=NOT_INITIALIZED, ia_availability=None, borrowed=False):
     """Updates the loan info stored in openlibrary.
 
     The loan records are stored at the Internet Archive. There is no way for
@@ -552,8 +552,13 @@ def sync_loan(identifier, loan=NOT_INITIALIZED):
         book=loan['book'],
     )
 
-    responses = get_availability_of_ocaid(identifier)
-    response = responses[identifier] if responses else {}
+    response = {}
+    if ia_availability:
+        response = ia_availability
+    else:
+        responses = get_availability_of_ocaid(identifier)
+        response = responses[identifier] if responses else {}
+
     if response:
         num_waiting = int(response.get('num_waitlist', 0) or 0)
 
@@ -572,7 +577,7 @@ def sync_loan(identifier, loan=NOT_INITIALIZED):
         "type": "ebook",
         "identifier": identifier,
         "loan": ebook_loan_data,
-        "borrowed": str(response['status'] not in ['open', 'borrow_available']).lower(),
+        "borrowed": 'true' if borrowed else str(response['status'] not in ['open', 'borrow_available']).lower(),
         "wl_size": num_waiting,
     }
     try:

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -265,10 +265,13 @@ class Edition(models.Edition):
 
         return loans
 
-    def update_loan_status(self):
-        """Update the loan status"""
+    def update_loan_status(self, loan=None, ia_availability=None, borrowed=False):
+        """
+        Update the loan status of this edition.
+        Loan's availability is optional, and if not provided, will be fetched from archive.org
+        """
         if self.ocaid:
-            lending.sync_loan(self.ocaid)
+            lending.sync_loan(self.ocaid, loan, ia_availability, borrowed)
 
     def _process_identifiers(self, config_, names, values):
         id_map = {}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7726 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Looking at the code and sentry logs, there are a few duplicate/unnecessary actions such as fetching availability twice and fetching loans of user multiple times. This PR removes these actions. But I'll still need another eye to check if I missed out on anything.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/90945854/8753d660-9dd3-44c8-8e3b-984a11ed8f02)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
