### PR TITLE
Autocomplete refactor + add ability to reorder

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -74,7 +74,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "122KB"
+      "maxSize": "128KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -50,6 +50,7 @@ export default function($) {
      *     element in the autocomplete list. The function takes the query and should return a boolean.
      *     a boolean.
      * @property{string} [new_name] - name to display when __new__ selected. Defaults to the query
+     * @property {boolean} [allow_empty] - whether to allow empty list. Only applies to multi-select
      */
 
     /**
@@ -144,46 +145,45 @@ export default function($) {
     /**
      * @this HTMLElement - the element that contains the different inputs.
      * @param {string} autocomplete_selector - selector to find the input element use for autocomplete.
-     * @param {Function} input_renderer - ((index, item) -> html_string) render the ith div.input.
+     * @param {Function} input_renderer - ((index, item) -> html_string) render the ith .input.
      * @param {OpenLibraryAutocompleteOptions} ol_ac_opts
      * @param {Object} ac_opts - options given to override defaults of $.autocomplete; see that.
      */
     $.fn.setup_multi_input_autocomplete = function(autocomplete_selector, input_renderer, ol_ac_opts, ac_opts) {
+        /** @type {JQuery<HTMLElement>} */
         var container = $(this);
 
         // first let's init any pre-existing inputs
         container.find(autocomplete_selector).each(function() {
             setup_autocomplete(this, ol_ac_opts, ac_opts);
         });
+        const allow_empty = ol_ac_opts.allow_empty;
 
         function update_visible() {
-            if (container.find('div.input').length > 1) {
-                container.find('a.remove').show();
+            if (allow_empty || container.find('.mia__input').length > 1) {
+                container.find('.mia__remove').show();
             }
             else {
-                container.find('a.remove').hide();
+                container.find('.mia__remove').hide();
             }
-
-            container.find('a.add:not(:last)').hide();
-            container.find('a.add:last').show();
         }
 
         update_visible();
 
-        container.on('click', 'a.remove', function() {
-            if (container.find('div.input').length > 1) {
-                $(this).closest('div.input').remove();
+        container.on('click', '.mia__remove', function() {
+            if (allow_empty || container.find('.mia__input').length > 1) {
+                $(this).closest('.mia__input').remove();
                 update_visible();
             }
         });
 
-        container.on('click', 'a.add', function(event) {
+        container.on('click', '.mia__add', function(event) {
             var next_index, new_input;
             event.preventDefault();
 
-            next_index = container.find('div.input').length;
+            next_index = container.find('.mia__input').length;
             new_input = $(input_renderer(next_index, {key: '', name: ''}));
-            container.append(new_input);
+            new_input.insertBefore(container.find('.mia__add'));
             setup_autocomplete(
                 new_input.find(autocomplete_selector)[0],
                 ol_ac_opts,

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -90,7 +90,7 @@ export default function($) {
             select: function (_event, ui) {
                 var item = ui.item;
                 var $this = $(this);
-                $(`#${_this.id}-key`).val(item.key);
+                $this.closest('.ac-input').find('.ac-input__value').val(item.key);
                 setTimeout(function() {
                     $this.addClass('accept');
                 }, 0);
@@ -149,17 +149,26 @@ export default function($) {
 
     /**
      * @this HTMLElement - the element that contains the different inputs.
-     * @param {string} autocomplete_selector - selector to find the input element use for autocomplete.
+     * Expects an html structure like:
+     * <div class="multi-input-autocomplete">
+     *   <div class="ac-input mia__input">
+     *      <div class="mia__reorder">≡</div>
+     *      <input class="ac-input__visible" type="text" name="fake_name--0" value="Author 1" />
+     *      <input class="ac-input__value" type="hidden" name="author--0" value="/authors/OL1234A" />
+     *      <a class="mia__remove" href="javascript:;">[x]</a>
+     *   </div>
+     *  ...
+     * < /div>
      * @param {Function} input_renderer - ((index, item) -> html_string) render the ith .input.
      * @param {OpenLibraryAutocompleteOptions} ol_ac_opts
      * @param {Object} ac_opts - options given to override defaults of $.autocomplete; see that.
      */
-    $.fn.setup_multi_input_autocomplete = function(autocomplete_selector, input_renderer, ol_ac_opts, ac_opts) {
+    $.fn.setup_multi_input_autocomplete = function(input_renderer, ol_ac_opts, ac_opts) {
         /** @type {JQuery<HTMLElement>} */
         var container = $(this);
 
         // first let's init any pre-existing inputs
-        container.find(autocomplete_selector).each(function() {
+        container.find('.ac-input__visible').each(function() {
             setup_autocomplete(this, ol_ac_opts, ac_opts);
         });
         const allow_empty = ol_ac_opts.allow_empty;
@@ -210,7 +219,7 @@ export default function($) {
             new_input = $(input_renderer(next_index, {key: '', name: ''}));
             new_input.insertBefore(container.find('.mia__add'));
             setup_autocomplete(
-                new_input.find(autocomplete_selector)[0],
+                new_input.find('.ac-input__visible')[0],
                 ol_ac_opts,
                 ac_opts);
             update_visible();

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -1,4 +1,8 @@
 // jquery plugins to provide author, language, and subject autocompletes.
+import 'jquery-ui/ui/widget';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui/ui/widgets/sortable';
+
 /**
  * Port of code in vendor/js/jquery-autocomplete removed in e91119b
  * @param {string} value
@@ -51,6 +55,7 @@ export default function($) {
      *     a boolean.
      * @property{string} [new_name] - name to display when __new__ selected. Defaults to the query
      * @property {boolean} [allow_empty] - whether to allow empty list. Only applies to multi-select
+     * @property {boolean} [sortable=false]
      */
 
     /**
@@ -169,6 +174,26 @@ export default function($) {
         }
 
         update_visible();
+
+        if (ol_ac_opts.sortable) {
+            container.sortable({
+                items: '.mia__input',
+                update: function() {
+                    container.find('.mia__input').each(function(index) {
+                        $(this).find('[name]').each(function() {
+                            // this won't behave nicely with nested numeric things, if that ever happens
+                            if ($(this).attr('name').match(/\d+/)?.length > 1) {
+                                throw new Error('nested numeric names not supported');
+                            }
+                            $(this).attr('name', $(this).attr('name').replace(/\d+/, index));
+                            if ($(this).attr('id')) {
+                                $(this).attr('id', $(this).attr('id').replace(/\d+/, index));
+                            }
+                        });
+                    });
+                }
+            });
+        }
 
         container.on('click', '.mia__remove', function() {
             if (allow_empty || container.find('.mia__input').length > 1) {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -263,7 +263,10 @@ export function initLanguageMultiInputAutocomplete() {
             jqueryElement.setup_multi_input_autocomplete(
                 'input.language-autocomplete',
                 render_language_field,
-                {endpoint: '/languages/_autocomplete'},
+                {
+                    endpoint: '/languages/_autocomplete',
+                    sortable: true,
+                },
                 {
                     max: 6,
                     formatItem: render_language_autocomplete_item
@@ -309,6 +312,7 @@ export function initAuthorMultiInputAutocomplete() {
                 endpoint: '/authors/_autocomplete',
                 // Don't render "Create new author" if searching by key
                 addnew: query => !/OL\d+A/i.test(query),
+                sortable: true,
             },
             {
                 minChars: 2,

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -277,21 +277,22 @@ export function initWorksMultiInputAutocomplete() {
     $(function() {
         getJqueryElements('.multi-input-autocomplete--works').forEach(jqueryElement => {
             /* Values in the html passed from Python code */
-            const dataConfig = JSON.parse(jqueryElement[0].dataset.config);
+            const dataConfig = JSON.parse(jqueryElement[0].dataset.config || '{}');
             jqueryElement.setup_multi_input_autocomplete(
                 'input.work-autocomplete',
                 render_work_field,
                 {
                     endpoint: '/works/_autocomplete',
-                    addnew: dataConfig['isPrivilegedUser'] === 'true',
-                    new_name: dataConfig['-- Move to a new work'],
+                    addnew: dataConfig['addnew'] || false,
+                    new_name: dataConfig['new_name'] || '',
+                    allow_empty: dataConfig['allow_empty'] || false,
                 },
                 {
                     minChars: 2,
                     max: 11,
                     matchSubset: false,
                     autoFill: true,
-                    formatItem: render_work_autocomplete_item
+                    formatItem: render_work_autocomplete_item,
                 });
         });
     });

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -261,7 +261,6 @@ export function initLanguageMultiInputAutocomplete() {
     $(function() {
         getJqueryElements('.multi-input-autocomplete--language').forEach(jqueryElement => {
             jqueryElement.setup_multi_input_autocomplete(
-                'input.language-autocomplete',
                 render_language_field,
                 {
                     endpoint: '/languages/_autocomplete',
@@ -282,7 +281,6 @@ export function initWorksMultiInputAutocomplete() {
             /* Values in the html passed from Python code */
             const dataConfig = JSON.parse(jqueryElement[0].dataset.config || '{}');
             jqueryElement.setup_multi_input_autocomplete(
-                'input.work-autocomplete',
                 render_work_field,
                 {
                     endpoint: '/works/_autocomplete',
@@ -306,7 +304,6 @@ export function initAuthorMultiInputAutocomplete() {
         /* Values in the html passed from Python code */
         const dataConfig = JSON.parse(jqueryElement[0].dataset.config);
         jqueryElement.setup_multi_input_autocomplete(
-            'input.author-autocomplete',
             render_author.bind(null, dataConfig.name_path, dataConfig.dict_path, false),
             {
                 endpoint: '/authors/_autocomplete',

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1,7 +1,6 @@
 """Handlers for adding and editing books."""
 
 import io
-import itertools
 import web
 import json
 import csv
@@ -10,15 +9,12 @@ import datetime
 from typing import Literal, overload, NoReturn
 
 from infogami import config
-from infogami.core import code as core
 from infogami.core.db import ValidationException
 from infogami.utils import delegate
 from infogami.utils.view import safeint, add_flash_message
 from infogami.infobase.client import ClientException
 
-from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.worksearch.search import get_solr
-from openlibrary.utils import find_author_olid_in_string, find_work_olid_in_string
 from openlibrary.i18n import gettext as _
 from openlibrary import accounts
 import logging
@@ -1033,140 +1029,6 @@ class daisy(delegate.page):
             raise web.notfound()
 
         return render_template("books/daisy", page)
-
-
-def to_json(d):
-    web.header('Content-Type', 'application/json')
-    return delegate.RawText(json.dumps(d))
-
-
-class languages_autocomplete(delegate.page):
-    path = "/languages/_autocomplete"
-
-    def GET(self):
-        i = web.input(q="", limit=5)
-        i.limit = safeint(i.limit, 5)
-        return to_json(
-            list(itertools.islice(utils.autocomplete_languages(i.q), i.limit))
-        )
-
-
-class works_autocomplete(delegate.page):
-    path = "/works/_autocomplete"
-
-    def GET(self):
-        i = web.input(q="", limit=5)
-        i.limit = safeint(i.limit, 5)
-
-        solr = get_solr()
-
-        # look for ID in query string here
-        q = solr.escape(i.q).strip()
-        embedded_olid = find_work_olid_in_string(q)
-        if embedded_olid:
-            solr_q = 'key:"/works/%s"' % embedded_olid
-        else:
-            solr_q = f'title:"{q}"^2 OR title:({q}*)'
-
-        params = {
-            'q_op': 'AND',
-            'sort': 'edition_count desc',
-            'rows': i.limit,
-            'fq': 'type:work',
-            # limit the fields returned for better performance
-            'fl': 'key,title,subtitle,cover_i,first_publish_year,author_name,edition_count',
-        }
-
-        data = solr.select(solr_q, **params)
-        # exclude fake works that actually have an edition key
-        docs = [d for d in data['docs'] if d['key'][-1] == 'W']
-
-        if embedded_olid and not docs:
-            # Grumble! Work not in solr yet. Create a dummy.
-            key = '/works/%s' % embedded_olid
-            work = web.ctx.site.get(key)
-            if work:
-                docs = [work.as_fake_solr_record()]
-
-        for d in docs:
-            # Required by the frontend
-            d['name'] = d['key'].split('/')[-1]
-            d['full_title'] = d['title']
-            if 'subtitle' in d:
-                d['full_title'] += ": " + d['subtitle']
-
-        return to_json(docs)
-
-
-class authors_autocomplete(delegate.page):
-    path = "/authors/_autocomplete"
-
-    def GET(self):
-        i = web.input(q="", limit=5)
-        i.limit = safeint(i.limit, 5)
-
-        solr = get_solr()
-
-        q = solr.escape(i.q).strip()
-        embedded_olid = find_author_olid_in_string(q)
-        if embedded_olid:
-            solr_q = 'key:"/authors/%s"' % embedded_olid
-        else:
-            prefix_q = q + "*"
-            solr_q = f'name:({prefix_q}) OR alternate_names:({prefix_q})'
-
-        params = {
-            'q_op': 'AND',
-            'sort': 'work_count desc',
-            'rows': i.limit,
-            'fq': 'type:author',
-        }
-
-        data = solr.select(solr_q, **params)
-        docs = data['docs']
-
-        if embedded_olid and not docs:
-            # Grumble! Must be a new author. Fetch from db, and build a "fake" solr resp
-            key = '/authors/%s' % embedded_olid
-            author = web.ctx.site.get(key)
-            if author:
-                docs = [author.as_fake_solr_record()]
-
-        for d in docs:
-            if 'top_work' in d:
-                d['works'] = [d.pop('top_work')]
-            else:
-                d['works'] = []
-            d['subjects'] = d.pop('top_subjects', [])
-
-        return to_json(docs)
-
-
-class subjects_autocomplete(delegate.page):
-    path = "/subjects_autocomplete"
-    # can't use /subjects/_autocomplete because the subjects endpoint = /subjects/[^/]+
-
-    def GET(self):
-        i = web.input(q="", type="", limit=5)
-        i.limit = safeint(i.limit, 5)
-
-        solr = get_solr()
-        prefix_q = solr.escape(i.q).strip()
-        solr_q = f'name:({prefix_q}*)'
-        fq = f'type:subject AND subject_type:{i.type}' if i.type else 'type:subject'
-
-        params = {
-            'fl': 'key,name,subject_type,work_count',
-            'q_op': 'AND',
-            'fq': fq,
-            'sort': 'work_count desc',
-            'rows': i.limit,
-        }
-
-        data = solr.select(solr_q, **params)
-        docs = [{'key': d['key'], 'name': d['name']} for d in data['docs']]
-
-        return to_json(docs)
 
 
 class work_identifiers(delegate.view):

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -1,0 +1,149 @@
+import itertools
+import web
+import json
+
+
+from infogami.utils import delegate
+from infogami.utils.view import safeint
+from openlibrary.plugins.upstream import utils
+from openlibrary.plugins.worksearch.search import get_solr
+from openlibrary.utils import find_author_olid_in_string, find_work_olid_in_string
+
+
+def to_json(d):
+    web.header('Content-Type', 'application/json')
+    return delegate.RawText(json.dumps(d))
+
+
+class languages_autocomplete(delegate.page):
+    path = "/languages/_autocomplete"
+
+    def GET(self):
+        i = web.input(q="", limit=5)
+        i.limit = safeint(i.limit, 5)
+        return to_json(
+            list(itertools.islice(utils.autocomplete_languages(i.q), i.limit))
+        )
+
+
+class works_autocomplete(delegate.page):
+    path = "/works/_autocomplete"
+
+    def GET(self):
+        i = web.input(q="", limit=5)
+        i.limit = safeint(i.limit, 5)
+
+        solr = get_solr()
+
+        # look for ID in query string here
+        q = solr.escape(i.q).strip()
+        embedded_olid = find_work_olid_in_string(q)
+        if embedded_olid:
+            solr_q = 'key:"/works/%s"' % embedded_olid
+        else:
+            solr_q = f'title:"{q}"^2 OR title:({q}*)'
+
+        params = {
+            'q_op': 'AND',
+            'sort': 'edition_count desc',
+            'rows': i.limit,
+            'fq': 'type:work',
+            # limit the fields returned for better performance
+            'fl': 'key,title,subtitle,cover_i,first_publish_year,author_name,edition_count',
+        }
+
+        data = solr.select(solr_q, **params)
+        # exclude fake works that actually have an edition key
+        docs = [d for d in data['docs'] if d['key'][-1] == 'W']
+
+        if embedded_olid and not docs:
+            # Grumble! Work not in solr yet. Create a dummy.
+            key = '/works/%s' % embedded_olid
+            work = web.ctx.site.get(key)
+            if work:
+                docs = [work.as_fake_solr_record()]
+
+        for d in docs:
+            # Required by the frontend
+            d['name'] = d['key'].split('/')[-1]
+            d['full_title'] = d['title']
+            if 'subtitle' in d:
+                d['full_title'] += ": " + d['subtitle']
+
+        return to_json(docs)
+
+
+class authors_autocomplete(delegate.page):
+    path = "/authors/_autocomplete"
+
+    def GET(self):
+        i = web.input(q="", limit=5)
+        i.limit = safeint(i.limit, 5)
+
+        solr = get_solr()
+
+        q = solr.escape(i.q).strip()
+        embedded_olid = find_author_olid_in_string(q)
+        if embedded_olid:
+            solr_q = 'key:"/authors/%s"' % embedded_olid
+        else:
+            prefix_q = q + "*"
+            solr_q = f'name:({prefix_q}) OR alternate_names:({prefix_q})'
+
+        params = {
+            'q_op': 'AND',
+            'sort': 'work_count desc',
+            'rows': i.limit,
+            'fq': 'type:author',
+        }
+
+        data = solr.select(solr_q, **params)
+        docs = data['docs']
+
+        if embedded_olid and not docs:
+            # Grumble! Must be a new author. Fetch from db, and build a "fake" solr resp
+            key = '/authors/%s' % embedded_olid
+            author = web.ctx.site.get(key)
+            if author:
+                docs = [author.as_fake_solr_record()]
+
+        for d in docs:
+            if 'top_work' in d:
+                d['works'] = [d.pop('top_work')]
+            else:
+                d['works'] = []
+            d['subjects'] = d.pop('top_subjects', [])
+
+        return to_json(docs)
+
+
+class subjects_autocomplete(delegate.page):
+    path = "/subjects_autocomplete"
+    # can't use /subjects/_autocomplete because the subjects endpoint = /subjects/[^/]+
+
+    def GET(self):
+        i = web.input(q="", type="", limit=5)
+        i.limit = safeint(i.limit, 5)
+
+        solr = get_solr()
+        prefix_q = solr.escape(i.q).strip()
+        solr_q = f'name:({prefix_q}*)'
+        fq = f'type:subject AND subject_type:{i.type}' if i.type else 'type:subject'
+
+        params = {
+            'fl': 'key,name,subject_type,work_count',
+            'q_op': 'AND',
+            'fq': fq,
+            'sort': 'work_count desc',
+            'rows': i.limit,
+        }
+
+        data = solr.select(solr_q, **params)
+        docs = [{'key': d['key'], 'name': d['name']} for d in data['docs']]
+
+        return to_json(docs)
+
+
+def setup():
+    """Do required setup."""
+    pass

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -37,7 +37,10 @@ class autocomplete(delegate.page):
         if 'name' not in doc:
             doc['name'] = doc.get('title')
 
-    def GET(self, fq: list[str] | None = None):
+    def GET(self):
+        return self.direct_get()
+
+    def direct_get(self, fq: list[str] | None = None):
         i = web.input(q="", limit=5)
         i.limit = safeint(i.limit, 5)
 
@@ -135,7 +138,7 @@ class subjects_autocomplete(autocomplete):
         if i.type:
             fq = fq + [f'subject_type:{i.type}']
 
-        return super().GET(fq=fq)
+        return super().direct_get(fq=fq)
 
 
 def setup():

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -5,14 +5,77 @@ import json
 
 from infogami.utils import delegate
 from infogami.utils.view import safeint
+from openlibrary.core.models import Thing
 from openlibrary.plugins.upstream import utils
 from openlibrary.plugins.worksearch.search import get_solr
-from openlibrary.utils import find_author_olid_in_string, find_work_olid_in_string
+from openlibrary.utils import (
+    find_olid_in_string,
+    olid_to_key,
+)
 
 
 def to_json(d):
     web.header('Content-Type', 'application/json')
     return delegate.RawText(json.dumps(d))
+
+
+class autocomplete(delegate.page):
+    path = "/_autocomplete"
+    fq = ['-type:edition']
+    fl = 'key,type,name,title,score'
+    olid_suffix: str | None = None
+    query = 'title:"{q}"^2 OR title:({q}*) OR name:"{q}"^2 OR name:({q}*)'
+
+    def db_fetch(self, key: str) -> Thing | None:
+        if thing := web.ctx.site.get(key):
+            return thing.as_fake_solr_record()
+        else:
+            return None
+
+    def doc_wrap(self, doc: dict):
+        """Modify the returned solr document in place."""
+        if 'name' not in doc:
+            doc['name'] = doc.get('title')
+
+    def GET(self, fq: list[str] | None = None):
+        i = web.input(q="", limit=5)
+        i.limit = safeint(i.limit, 5)
+
+        solr = get_solr()
+
+        # look for ID in query string here
+        q = solr.escape(i.q).strip()
+        embedded_olid = None
+        if self.olid_suffix:
+            embedded_olid = find_olid_in_string(q, self.olid_suffix)
+
+        if embedded_olid:
+            solr_q = f'key:"{olid_to_key(embedded_olid)}"'
+        else:
+            solr_q = self.query.format(q=q)
+
+        fq = fq or self.fq
+        params = {
+            'q_op': 'AND',
+            'rows': i.limit,
+            **({'fq': fq} if fq else {}),
+            # limit the fields returned for better performance
+            'fl': self.fl,
+        }
+
+        data = solr.select(solr_q, **params)
+        docs = data['docs']
+
+        if embedded_olid and not docs:
+            # Grumble! Work not in solr yet. Create a dummy.
+            fake_doc = self.db_fetch(olid_to_key(embedded_olid))
+            if fake_doc:
+                docs = [fake_doc]
+
+        for d in docs:
+            self.doc_wrap(d)
+
+        return to_json(docs)
 
 
 class languages_autocomplete(delegate.page):
@@ -26,122 +89,53 @@ class languages_autocomplete(delegate.page):
         )
 
 
-class works_autocomplete(delegate.page):
+class works_autocomplete(autocomplete):
     path = "/works/_autocomplete"
+    fq = [
+        'type:work',
+        # Exclude orphaned editions from search results
+        'key:*W',
+    ]
+    fl = 'key,title,subtitle,cover_i,first_publish_year,author_name,edition_count'
+    olid_suffix = 'W'
+    query = 'title:"{q}"^2 OR title:({q}*)'
 
-    def GET(self):
-        i = web.input(q="", limit=5)
-        i.limit = safeint(i.limit, 5)
-
-        solr = get_solr()
-
-        # look for ID in query string here
-        q = solr.escape(i.q).strip()
-        embedded_olid = find_work_olid_in_string(q)
-        if embedded_olid:
-            solr_q = 'key:"/works/%s"' % embedded_olid
-        else:
-            solr_q = f'title:"{q}"^2 OR title:({q}*)'
-
-        params = {
-            'q_op': 'AND',
-            'sort': 'edition_count desc',
-            'rows': i.limit,
-            'fq': 'type:work',
-            # limit the fields returned for better performance
-            'fl': 'key,title,subtitle,cover_i,first_publish_year,author_name,edition_count',
-        }
-
-        data = solr.select(solr_q, **params)
-        # exclude fake works that actually have an edition key
-        docs = [d for d in data['docs'] if d['key'][-1] == 'W']
-
-        if embedded_olid and not docs:
-            # Grumble! Work not in solr yet. Create a dummy.
-            key = '/works/%s' % embedded_olid
-            work = web.ctx.site.get(key)
-            if work:
-                docs = [work.as_fake_solr_record()]
-
-        for d in docs:
-            # Required by the frontend
-            d['name'] = d['key'].split('/')[-1]
-            d['full_title'] = d['title']
-            if 'subtitle' in d:
-                d['full_title'] += ": " + d['subtitle']
-
-        return to_json(docs)
+    def doc_wrap(self, doc: dict):
+        doc['full_title'] = doc['title']
+        if 'subtitle' in doc:
+            doc['full_title'] += ": " + doc['subtitle']
+        doc['name'] = doc.get('title')
 
 
-class authors_autocomplete(delegate.page):
+class authors_autocomplete(autocomplete):
     path = "/authors/_autocomplete"
+    fq = ['type:author']
+    fl = 'key,name,alternate_names,birth_date,death_date,work_count,works,subjects'
+    olid_suffix = 'A'
+    query = 'name:({q}*) OR alternate_names:({q}*)'
 
-    def GET(self):
-        i = web.input(q="", limit=5)
-        i.limit = safeint(i.limit, 5)
-
-        solr = get_solr()
-
-        q = solr.escape(i.q).strip()
-        embedded_olid = find_author_olid_in_string(q)
-        if embedded_olid:
-            solr_q = 'key:"/authors/%s"' % embedded_olid
+    def doc_wrap(self, doc: dict):
+        if 'top_work' in doc:
+            doc['works'] = [doc.pop('top_work')]
         else:
-            prefix_q = q + "*"
-            solr_q = f'name:({prefix_q}) OR alternate_names:({prefix_q})'
-
-        params = {
-            'q_op': 'AND',
-            'sort': 'work_count desc',
-            'rows': i.limit,
-            'fq': 'type:author',
-        }
-
-        data = solr.select(solr_q, **params)
-        docs = data['docs']
-
-        if embedded_olid and not docs:
-            # Grumble! Must be a new author. Fetch from db, and build a "fake" solr resp
-            key = '/authors/%s' % embedded_olid
-            author = web.ctx.site.get(key)
-            if author:
-                docs = [author.as_fake_solr_record()]
-
-        for d in docs:
-            if 'top_work' in d:
-                d['works'] = [d.pop('top_work')]
-            else:
-                d['works'] = []
-            d['subjects'] = d.pop('top_subjects', [])
-
-        return to_json(docs)
+            doc['works'] = []
+        doc['subjects'] = doc.pop('top_subjects', [])
 
 
-class subjects_autocomplete(delegate.page):
-    path = "/subjects_autocomplete"
+class subjects_autocomplete(autocomplete):
     # can't use /subjects/_autocomplete because the subjects endpoint = /subjects/[^/]+
+    path = "/subjects_autocomplete"
+    fq = ['type:subject']
+    fl = 'key,name'
+    query = 'name:({q}*)'
 
     def GET(self):
-        i = web.input(q="", type="", limit=5)
-        i.limit = safeint(i.limit, 5)
+        i = web.input(type="")
+        fq = self.fq
+        if i.type:
+            fq = fq + [f'subject_type:{i.type}']
 
-        solr = get_solr()
-        prefix_q = solr.escape(i.q).strip()
-        solr_q = f'name:({prefix_q}*)'
-        fq = f'type:subject AND subject_type:{i.type}' if i.type else 'type:subject'
-
-        params = {
-            'fl': 'key,name,subject_type,work_count',
-            'q_op': 'AND',
-            'fq': fq,
-            'sort': 'work_count desc',
-            'rows': i.limit,
-        }
-
-        data = solr.select(solr_q, **params)
-        docs = [{'key': d['key'], 'name': d['name']} for d in data['docs']]
-
-        return to_json(docs)
+        return super().GET(fq=fq)
 
 
 def setup():

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -783,8 +783,14 @@ class search_json(delegate.page):
 
 
 def setup():
-    from openlibrary.plugins.worksearch import subjects, languages, publishers
+    from openlibrary.plugins.worksearch import (
+        autocomplete,
+        subjects,
+        languages,
+        publishers,
+    )
 
+    autocomplete.setup()
     subjects.setup()
     publishers.setup()
     languages.setup()

--- a/openlibrary/plugins/worksearch/tests/test_autocomplete.py
+++ b/openlibrary/plugins/worksearch/tests/test_autocomplete.py
@@ -1,0 +1,104 @@
+import json
+from unittest.mock import patch
+from openlibrary.plugins.worksearch.autocomplete import autocomplete, works_autocomplete
+import web
+
+from openlibrary.utils.solr import Solr
+
+
+def test_autocomplete():
+    ac = autocomplete()
+    with (
+        patch('web.input') as mock_web_input,
+        patch('web.header'),
+        patch('openlibrary.utils.solr.Solr.select') as mock_solr_select,
+        patch('openlibrary.plugins.worksearch.autocomplete.get_solr') as mock_get_solr,
+    ):
+        mock_get_solr.return_value = Solr('http://foohost:8983/solr')
+        mock_web_input.return_value = web.storage(q='foo', limit=5)
+        mock_solr_select.return_value = {'docs': []}
+        ac.GET()
+        # assert solr_select called with correct params
+        assert (
+            mock_solr_select.call_args[0][0]
+            == 'title:"foo"^2 OR title:(foo*) OR name:"foo"^2 OR name:(foo*)'
+        )
+        # check kwargs
+        assert mock_solr_select.call_args.kwargs['fq'] == ['-type:edition']
+        assert mock_solr_select.call_args.kwargs['q_op'] == 'AND'
+        assert mock_solr_select.call_args.kwargs['rows'] == 5
+
+
+def test_works_autocomplete():
+    ac = works_autocomplete()
+    with (
+        patch('web.input') as mock_web_input,
+        patch('web.header'),
+        patch('openlibrary.utils.solr.Solr.select') as mock_solr_select,
+        patch('openlibrary.plugins.worksearch.autocomplete.get_solr') as mock_get_solr,
+    ):
+        mock_get_solr.return_value = Solr('http://foohost:8983/solr')
+        mock_web_input.return_value = web.storage(q='foo', limit=5)
+        mock_solr_select.return_value = {
+            'docs': [
+                {
+                    'key': '/works/OL123W',
+                    'type': 'work',
+                    'title': 'Foo Bar',
+                    'subtitle': 'Baz',
+                },
+                {
+                    'key': '/works/OL456W',
+                    'type': 'work',
+                    'title': 'Foo Baz',
+                },
+            ]
+        }
+        result = json.loads(ac.GET().rawtext)
+        # assert solr_select called with correct params
+        assert mock_solr_select.call_args[0][0] == 'title:"foo"^2 OR title:(foo*)'
+        # check kwargs
+        assert mock_solr_select.call_args.kwargs['fq'] == ['type:work', 'key:*W']
+        # check result
+        assert result == [
+            {
+                'key': '/works/OL123W',
+                'type': 'work',
+                'title': 'Foo Bar',
+                'subtitle': 'Baz',
+                'full_title': 'Foo Bar: Baz',
+                'name': 'Foo Bar',
+            },
+            {
+                'key': '/works/OL456W',
+                'type': 'work',
+                'title': 'Foo Baz',
+                'full_title': 'Foo Baz',
+                'name': 'Foo Baz',
+            },
+        ]
+
+        # Test searching for OLID
+        mock_web_input.return_value = web.storage(q='OL123W', limit=5)
+        mock_solr_select.return_value = {
+            'docs': [
+                {
+                    'key': '/works/OL123W',
+                    'type': 'work',
+                    'title': 'Foo Bar',
+                },
+            ]
+        }
+        ac.GET()
+        # assert solr_select called with correct params
+        assert mock_solr_select.call_args[0][0] == 'key:"/works/OL123W"'
+
+        # Test searching for OLID missing from solr
+        mock_web_input.return_value = web.storage(q='OL123W', limit=5)
+        mock_solr_select.return_value = {'docs': []}
+        with patch(
+            'openlibrary.plugins.worksearch.autocomplete.autocomplete.db_fetch'
+        ) as db_fetch:
+            db_fetch.return_value = {'key': '/works/OL123W', 'title': 'Foo Bar'}
+            ac.GET()
+            db_fetch.assert_called_once_with('/works/OL123W')

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -33,6 +33,7 @@ $jsdef render_author_autocomplete_item(item):
 
 $jsdef render_author(name_path, dict_path, readonly, i, author):
     <div class="input mia__input">
+        <div class="mia__reorder">≡</div>
         <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" $cond(readonly, 'readonly', '')>
         <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
         <a href="javascript:;" class="mia__remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -32,14 +32,14 @@ $jsdef render_author_autocomplete_item(item):
         </div>
 
 $jsdef render_author(name_path, dict_path, readonly, i, author):
-    <div class="input">
+    <div class="input mia__input">
         <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" $cond(readonly, 'readonly', '')>
         <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
-        <a href="javascript:;" class="remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
-        <a href="javascript:;" class="add">$_("Add another author?")</a>
+        <a href="javascript:;" class="mia__remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
     </div>
 $ config = {'name_path': name_path, 'dict_path': dict_path}
 <div class="multi-input-autocomplete--author" data-config="$dumps(config)">
     $for author in (authors or [storage(name="", key="")]):
         $:render_author(name_path, dict_path, readonly, loop.index0, author)
+    <a href="javascript:;" class="mia__add">$_("Add another author?")</a>
 </div>

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -32,12 +32,13 @@ $jsdef render_author_autocomplete_item(item):
         </div>
 
 $jsdef render_author(name_path, dict_path, readonly, i, author):
-    <div class="input mia__input">
+    <div class="input ac-input mia__input">
         <div class="mia__reorder">≡</div>
-        <input name="$name_path--$i" class="author author-autocomplete" type="text" id="author-$i" value="$author.name" $cond(readonly, 'readonly', '')>
-        <input name="$dict_path--$i--author--key" type="hidden" id="author-$i-key" value="$author.key" />
-        <a href="javascript:;" class="mia__remove red plain" title="$_('Remove this author')">[&times;]</a>&nbsp;
+        <input class="ac-input__visible" name="$name_path--$i" type="text" value="$author.name" $cond(readonly, 'readonly', '')>
+        <input class="ac-input__value" name="$dict_path--$i--author--key" type="hidden" value="$author.key" />
+        <a class="mia__remove" href="javascript:;" title="$_('Remove this author')">[&times;]</a>&nbsp;
     </div>
+
 $ config = {'name_path': name_path, 'dict_path': dict_path}
 <div class="multi-input-autocomplete--author" data-config="$dumps(config)">
     $for author in (authors or [storage(name="", key="")]):

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -20,6 +20,7 @@ $# Render the ith language input field
 $jsdef render_language_field(i, language, i18n_name):
     $ lang_name = i18n_name or language.name
     <div class="input mia__input">
+      <div class="mia__reorder">≡</div>
       <input name="languages--$i" class="language language-autocomplete" type="text" id="language-$i" value="$lang_name"/>
       <input name="edition--languages--$i--key" type="hidden" id="language-$i-key" value="$language.key" />
       <a href="javascript:;" class="mia__remove red plain" title="$_('Remove this language')">[x]</a>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -19,11 +19,10 @@ $jsdef render_language_autocomplete_item(item):
 $# Render the ith language input field
 $jsdef render_language_field(i, language, i18n_name):
     $ lang_name = i18n_name or language.name
-    <div class="input">
+    <div class="input mia__input">
       <input name="languages--$i" class="language language-autocomplete" type="text" id="language-$i" value="$lang_name"/>
       <input name="edition--languages--$i--key" type="hidden" id="language-$i-key" value="$language.key" />
-      <a href="javascript:;" class="remove red plain" title="$_('Remove this language')">[x]</a>
-      <hr /><a href="javascript:;" class="add small">$_('Add another language?')</a>
+      <a href="javascript:;" class="mia__remove red plain" title="$_('Remove this language')">[x]</a>
     </div>
 
 $# Render the ith translated_from language input field
@@ -31,9 +30,7 @@ $jsdef render_translated_from_language_field(i, language):
     <div class="input">
       <input type="text" name="translated_from--$i" class="language language-autocomplete" id="edition-translated_from-$i" value="$language.name"/>
       <input type="hidden" name="edition--translated_from--$i--key"  id="edition-translated_from-$i-key" value="$language.key" />
-      <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this language')">[x]</a>
-      $# Limit to only 1
-      $# <br/><a href="javascript:;" class="add small">Add another language?</a>
+      <a href="javascript:;" class="mia__remove red plain hidden" title="$_('Remove this language')">[x]</a>
     </div>
 
 
@@ -42,9 +39,7 @@ $jsdef render_work_field(i, work):
     <div class="input">
         <input name="works--$i" class="work work-autocomplete" type="text" id="work-$i" value="$work.key.split('/')[-1]"/>
         <input name="edition--works--$i--key" type="hidden" id="work-$i-key" value="$work.key" />
-        <a href="javascript:;" class="remove red plain hidden" title="$_('Remove this work')">[x]</a>
-        $# Limit to only 1
-        $# <a href="javascript:;" class="add hidden">Add another work?</a>
+        <a href="javascript:;" class="mia__remove red plain hidden" title="$_('Remove this work')">[x]</a>
     </div>
 
 $jsdef render_work_autocomplete_item(item):
@@ -285,6 +280,7 @@ $jsdef render_work_autocomplete_item(item):
                         $:render_language_field(i, lang, get_language_name(lang))
                 $else:
                     $:render_language_field(0, storage(name="", key=""), None)
+                <a href="javascript:;" class="mia__add small">$_('Add another language?')</a>
             </div>
 
             <div class="formElement" id="translated-from">
@@ -398,7 +394,7 @@ $jsdef render_work_autocomplete_item(item):
                     $_("WARNING: Any edits made to the work from this page will be ignored.")
                 </span>
             </div>
-            $ config = {'isPrivilegedUser': cond(is_privileged_user, 'true', 'false'), '-- Move to a new work': _('-- Move to a new work')}
+            $ config = {'addnew': is_privileged_user, 'new_name': _('-- Move to a new work')}
             <div class="multi-input-autocomplete--works" data-config="$dumps(config)">
                 $if book.works:
                     $for i, work in enumerate(book.works):

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -19,28 +19,27 @@ $jsdef render_language_autocomplete_item(item):
 $# Render the ith language input field
 $jsdef render_language_field(i, language, i18n_name):
     $ lang_name = i18n_name or language.name
-    <div class="input mia__input">
+    <div class="input ac-input mia__input">
       <div class="mia__reorder">≡</div>
-      <input name="languages--$i" class="language language-autocomplete" type="text" id="language-$i" value="$lang_name"/>
-      <input name="edition--languages--$i--key" type="hidden" id="language-$i-key" value="$language.key" />
-      <a href="javascript:;" class="mia__remove red plain" title="$_('Remove this language')">[x]</a>
+      <input class="ac-input__visible" name="languages--$i" type="text" value="$lang_name"/>
+      <input class="ac-input__value" name="edition--languages--$i--key" type="hidden" value="$language.key" />
+      <a class="mia__remove" href="javascript:;" title="$_('Remove this language')">[x]</a>
     </div>
 
 $# Render the ith translated_from language input field
 $jsdef render_translated_from_language_field(i, language):
-    <div class="input">
-      <input type="text" name="translated_from--$i" class="language language-autocomplete" id="edition-translated_from-$i" value="$language.name"/>
-      <input type="hidden" name="edition--translated_from--$i--key"  id="edition-translated_from-$i-key" value="$language.key" />
-      <a href="javascript:;" class="mia__remove red plain hidden" title="$_('Remove this language')">[x]</a>
+    <div class="input ac-input">
+      <input class="ac-input__visible" type="text" name="translated_from--$i" value="$language.name"/>
+      <input class="ac-input__value" type="hidden" name="edition--translated_from--$i--key" value="$language.key" />
     </div>
 
 
 $# Render the ith work input field
 $jsdef render_work_field(i, work):
-    <div class="input">
-        <input name="works--$i" class="work work-autocomplete" type="text" id="work-$i" value="$work.key.split('/')[-1]"/>
-        <input name="edition--works--$i--key" type="hidden" id="work-$i-key" value="$work.key" />
-        <a href="javascript:;" class="mia__remove red plain hidden" title="$_('Remove this work')">[x]</a>
+    <div class="input ac-input">
+        <input class="ac-input__visible" name="works--$i" type="text" value="$work.key.split('/')[-1]"/>
+        <input class="ac-input__value" name="edition--works--$i--key" type="hidden" value="$work.key" />
+        <a class="mia__remove hidden" href="javascript:;" title="$_('Remove this work')">[x]</a>
     </div>
 
 $jsdef render_work_autocomplete_item(item):

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -132,34 +132,46 @@ def dicthash(d):
         return d
 
 
-author_olid_embedded_re = re.compile(r'OL\d+A', re.IGNORECASE)
+olid_re = re.compile(r'OL\d+[A-Z]', re.IGNORECASE)
 
 
-def find_author_olid_in_string(s):
+def find_olid_in_string(s: str, olid_suffix: str | None = None) -> str | None:
     """
-    >>> find_author_olid_in_string("ol123a")
-    'OL123A'
-    >>> find_author_olid_in_string("/authors/OL123A/edit")
-    'OL123A'
-    >>> find_author_olid_in_string("some random string")
-    """
-    found = re.search(author_olid_embedded_re, s)
-    return found and found.group(0).upper()
-
-
-work_olid_embedded_re = re.compile(r'OL\d+W', re.IGNORECASE)
-
-
-def find_work_olid_in_string(s):
-    """
-    >>> find_work_olid_in_string("ol123w")
+    >>> find_olid_in_string("ol123w")
     'OL123W'
-    >>> find_work_olid_in_string("/works/OL123W/Title_of_book")
-    'OL123W'
-    >>> find_work_olid_in_string("some random string")
+    >>> find_olid_in_string("/authors/OL123A/DAVIE_BOWIE")
+    'OL123A'
+    >>> find_olid_in_string("/authors/OL123A/DAVIE_BOWIE", "W")
+    >>> find_olid_in_string("some random string")
     """
-    found = re.search(work_olid_embedded_re, s)
-    return found and found.group(0).upper()
+    found = re.search(olid_re, s)
+    if not found:
+        return None
+    olid = found.group(0).upper()
+
+    if olid_suffix and not olid.endswith(olid_suffix):
+        return None
+
+    return olid
+
+
+def olid_to_key(olid: str) -> str:
+    """
+    >>> olid_to_key('OL123W')
+    '/works/OL123W'
+    >>> olid_to_key('OL123A')
+    '/authors/OL123A'
+    >>> olid_to_key('OL123M')
+    '/books/OL123M'
+    """
+    typ = {
+        'A': 'authors',
+        'W': 'works',
+        'M': 'books',
+    }[olid[-1]]
+    if not typ:
+        raise ValueError(f"Invalid olid: {olid}")
+    return f"/{typ}/{olid}"
 
 
 def extract_numeric_id_from_olid(olid):

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "moduleNameMapper": {
       "\\.(css|less)$": "<rootDir>/tests/unit/js/styleMock.js"
     },
+    "setupFiles": [
+      "<rootDir>/tests/unit/js/setup.js"
+    ],
     "testEnvironment": "jsdom",
     "collectCoverageFrom": [
       "openlibrary/plugins/openlibrary/js/**/*.js"

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -39,7 +39,7 @@
   }
 
   .multi-input-autocomplete--language {
-    div{
+    .mia__input {
       display: flex;
       flex-flow: wrap;
       flex: 1
@@ -53,6 +53,15 @@
       margin: 0;
       border: 0;
     }
+  }
+
+  // Spacing is controlled by parent not individual input elements
+  .mia__input > input {
+    padding: 0;
+  }
+
+  .mia__input.ui-sortable-helper {
+    margin-top: -20px;
   }
 
   input[type=number],

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -39,14 +39,6 @@
   }
 
   .multi-input-autocomplete--language {
-    .mia__input {
-      display: flex;
-      flex-flow: wrap;
-      flex: 1
-    }
-    input {
-      flex: 1;
-    }
     hr {
       flex-basis: 100%;
       height: 0;
@@ -55,13 +47,36 @@
     }
   }
 
-  // Spacing is controlled by parent not individual input elements
-  .mia__input > input {
-    padding: 0;
-  }
+  .mia__input {
+    display: flex;
+    flex-flow: wrap;
+    flex: 1;
 
-  .mia__input.ui-sortable-helper {
-    margin-top: -20px;
+    & + .mia__input {
+      margin-top: 3px;
+    }
+
+    .ac-input__visible {
+      flex: 1;
+      // Spacing is controlled by parent not individual input elements
+      margin: 0;
+    }
+
+    .mia__reorder {
+      cursor: move;
+      min-width: 24px;
+      text-align: center;
+    }
+
+    .mia__remove {
+      color: @red;
+      text-decoration: none;
+    }
+
+    // Weird glitch where while dragging the element is very offset
+    &.ui-sortable-helper {
+      margin-top: -20px;
+    }
   }
 
   input[type=number],

--- a/static/css/legacy-jquery-ui.less
+++ b/static/css/legacy-jquery-ui.less
@@ -21,7 +21,6 @@
   z-index: @z-index-level-13 !important;
 }
 .ui-sortable {
-  min-height: 90px;
   max-height: 270px;
   overflow: auto;
   &-placeholder {

--- a/static/css/legacy-jquery-ui.less
+++ b/static/css/legacy-jquery-ui.less
@@ -27,7 +27,6 @@
   &-placeholder {
     border: 1px dotted @mid-grey;
     visibility: visible !important;
-    height: 70px !important;
     border-radius: 6px;
     * {
       visibility: hidden;

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -117,15 +117,6 @@ div.lists{
   .mia__input {
     display: flex;
   }
-  input.author.author-autocomplete{
-    flex: 1;
-  }
-}
-
-.mia__reorder {
-  cursor: move;
-  min-width: 24px;
-  text-align: center;
 }
 
 th.toggle-all {

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -114,12 +114,18 @@ div.lists{
 }
 
 .multi-input-autocomplete--author{
-  div{
+  .mia__input {
     display: flex;
   }
   input.author.author-autocomplete{
     flex: 1;
   }
+}
+
+.mia__reorder {
+  cursor: move;
+  min-width: 24px;
+  text-align: center;
 }
 
 th.toggle-all {

--- a/tests/unit/js/SearchBar.test.js
+++ b/tests/unit/js/SearchBar.test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 import { SearchBar } from '../../../openlibrary/plugins/openlibrary/js/SearchBar';
-import $ from 'jquery';
 import * as SearchUtils from '../../../openlibrary/plugins/openlibrary/js/SearchUtils';
 import * as nonjquery_utils from '../../../openlibrary/plugins/openlibrary/js/nonjquery_utils.js';
 

--- a/tests/unit/js/autocomplete.test.js
+++ b/tests/unit/js/autocomplete.test.js
@@ -1,15 +1,5 @@
 import { highlight, mapApiResultsToAutocompleteSuggestions } from '../../../openlibrary/plugins/openlibrary/js/autocomplete.js';
 
-const sinon = require('sinon');
-const jquery = require('jquery');
-let sandbox;
-
-beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    global.$ = jquery;
-    sandbox.stub(global, '$').callsFake(jquery);
-});
-
 describe('highlight', () => {
 
     test('Highlights terms with strong tag', () => {

--- a/tests/unit/js/droppers.test.js
+++ b/tests/unit/js/droppers.test.js
@@ -1,15 +1,8 @@
-import jquery from 'jquery';
 import sinon from 'sinon';
 import { initDroppers } from '../../../openlibrary/plugins/openlibrary/js/droppers';
 import { bookDropdownSample } from './html-test-data'
 import * as nonjquery_utils from '../../../openlibrary/plugins/openlibrary/js/nonjquery_utils.js';
-let sandbox;
 
-beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    global.$ = jquery;
-    sandbox.stub(global, '$').callsFake(jquery);
-});
 
 describe('initDroppers', () => {
     test.only('dropdown changes arrow direction on click', () => {

--- a/tests/unit/js/editionsEditPage.test.js
+++ b/tests/unit/js/editionsEditPage.test.js
@@ -1,6 +1,5 @@
 import { isChecksumValidIsbn10, isChecksumValidIsbn13 } from '../../../openlibrary/plugins/openlibrary/js/edit.js';
 import { validateIdentifiers } from '../../../openlibrary/plugins/openlibrary/js/edit.js';
-import jquery from 'jquery';
 import sinon from 'sinon';
 import * as testData from './html-test-data';
 import { htmlquote } from '../../../openlibrary/plugins/openlibrary/js/jsdef';
@@ -57,11 +56,9 @@ describe('isChecksumValidIsbn13', () => {
 beforeEach(() => {
     // Clear session storage
     sandbox = sinon.createSandbox();
-    global.$ = jquery;
     global.htmlquote = htmlquote;
     // htmlquote is used inside an eval expression (yuck) so is an implied dependency
     sandbox.stub(global, 'htmlquote').callsFake(htmlquote);
-    sandbox.stub(global, '$').callsFake(jquery);
     // setup Query repeat
     jQueryRepeat(global.$);
     // setup the HTML

--- a/tests/unit/js/jquery.repeat.test.js
+++ b/tests/unit/js/jquery.repeat.test.js
@@ -1,4 +1,3 @@
-import jquery from 'jquery';
 import sinon from 'sinon';
 import * as testData from './html-test-data';
 import { htmlquote } from '../../../openlibrary/plugins/openlibrary/js/jsdef';
@@ -8,11 +7,9 @@ let sandbox;
 
 beforeEach(() => {
     sandbox = sinon.createSandbox();
-    global.$ = jquery;
     global.htmlquote = htmlquote;
     // htmlquote is used inside an eval expression (yuck) so is an implied dependency
     sandbox.stub(global, 'htmlquote').callsFake(htmlquote);
-    sandbox.stub(global, '$').callsFake(jquery);
 });
 
 test('identifiers of repeated elements are never the same.', () => {

--- a/tests/unit/js/readmore.test.js
+++ b/tests/unit/js/readmore.test.js
@@ -1,5 +1,4 @@
 import { initClampers, resetReadMoreButtons } from '../../../openlibrary/plugins/openlibrary/js/readmore';
-import $ from 'jquery';
 import {clamperSample} from './html-test-data'
 
 describe('resetReadMoreButtons', () => {

--- a/tests/unit/js/search.test.js
+++ b/tests/unit/js/search.test.js
@@ -1,4 +1,3 @@
-import jquery from 'jquery';
 import { more, less } from '../../../openlibrary/plugins/openlibrary/js/search.js';
 
 /** Creates a dummy search facets section with a list of 'facetEntry' element and a
@@ -136,10 +135,6 @@ const _stubbedGetClientRects = function() {
     }
     return [{width: 1, height: 1}];
 };
-
-beforeAll(() => {
-    global.$ = jquery;
-});
 
 describe('more', () => {
     [

--- a/tests/unit/js/setup.js
+++ b/tests/unit/js/setup.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+
+// Make jQuery available globally for tests
+import $ from 'jquery';
+window.jQuery = $;
+window.$ = $;
+
+// Improve error reporting for unhandled promise rejections
+process.on('unhandledRejection', (error) => {
+    throw error;
+});

--- a/tests/unit/js/subjects.test.js
+++ b/tests/unit/js/subjects.test.js
@@ -1,14 +1,6 @@
-const sinon = require('sinon');
-const jquery = require('jquery');
 const { urlencode, Subject,
     renderTag, slice } = require('../../../openlibrary/plugins/openlibrary/js/subjects');
-let sandbox;
 
-beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    global.$ = jquery;
-    sandbox.stub(global, '$').callsFake(jquery);
-});
 
 describe('urlencode', () => {
     test('empty array', () => {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7805 . Preparation for list edit UI.

- DRY up the autocomplete endpoints
- Make it possible to reorder multinput autocompletes


### Technical
- Added some python tests for the autocomplete endpoint
- Had to make some updates the way jquery was added into jest. Made it a global inside jest for easier testing. Otherwise testing the jquery-ui, which requires jquery already be at the global, kind of annoying.
- Note reordering does not work on touchscreens

### Testing
Manually verified:
- autocomplete for authors, works, languages work when editing
- Reordering works for authors, languages
- Reordering covers still works.

### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/6251786/5ef30875-2596-4754-beea-589228054f73)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
