### PR TITLE
Deal with get_version() returning None in diff of /feed

### DIFF
--- a/openlibrary/templates/diff.html
+++ b/openlibrary/templates/diff.html
@@ -32,10 +32,13 @@ $def display_revision(page):
     <div class="small sansserif">
         <a href="$changequery({}, v=page.revision)"><span class="uppercase"><strong>$_("Revision %d", page.revision)</strong></span></a>
         $ v = get_version(page.key, page.revision)
-        $if v and v.author:
-            <span class="brown">$_('by') <a href="$v.author.key">$v.author.displayname</a> $datestr(v.created)</span>
+        $if v:
+            $if v.author:
+                <span class="brown">$_('by') <a href="$v.author.key">$v.author.displayname</a> $datestr(v.created)</span>
+            $else:
+                <span class="brown">$_('by Anonymous') $datestr(v.created)</span>
         $else:
-            <span class="brown">$_('by Anonymous') $datestr(v.created)</span>
+            <span class="brown">$_('by Anonymous')</span>
     </div>
 
 $def diff_covers(p, a, b):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes [`AttributeError /feed 'NoneType' object has no attribute 'created'`](https://sentry.archive.org/organizations/ia-ux/issues/81/) which is currently our most frequent Sentry error happening 1.1k times in the past 24 hours and 28k times in the last 30 days

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds an `else` branch that deals with `get_version(page.key, page.revision)` returning `None` so that the diff is shown to the user with no created date displayed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
