### PR TITLE
Naive solution for patron editing issues

### DIFF
--- a/openlibrary/plugins/upstream/spamcheck.py
+++ b/openlibrary/plugins/upstream/spamcheck.py
@@ -56,7 +56,7 @@ def is_spam(i=None, allow_privileged_edits: bool = False) -> bool:
     if i is None:
         i = web.input()
     text = str(dict(i)).lower()
-    return any(re.search(w.lower(), text) for w in spamwords)
+    return any(re.search(w.lower().replace('.', '\.'), text) for w in spamwords)
 
 
 def is_spam_email(email: str) -> bool:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7967

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Our spam words check is treating every "." character within the spam word as the `.` regex metacharacter, which matches any single character (excluding newlines).

This solution replaces any dot characters in a spam word with the escaped dot character, ensuring that dots are correctly matched by the `re.search()` call.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
