### PR TITLE
Update instructions in admin "Spam Words" template

### DIFF
--- a/openlibrary/templates/admin/spamwords.html
+++ b/openlibrary/templates/admin/spamwords.html
@@ -9,7 +9,10 @@ $var title: [Admin Center] Spam Words
 
 <div id="contentBody">
     <h2>Spam Words</h2>
-    <p>Please enter the SPAM words in the textarea below, one per line.</p>
+    <p>
+        Please enter the SPAM regular expressions in the textarea below, one per line.<br>
+        Be sure to escape any meta characters that are meant to be character literals.
+    </p>
 
     <div>
         <form name="spamform" class="olform" method="POST">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Follow-up for #7967

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates instructions in the admin "Spam Words" page.  New instructions note that the spam words are, in fact, regex patterns.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

![Screenshot from 2023-06-14 15-37-07](https://github.com/internetarchive/openlibrary/assets/28732543/13d0e99f-c1c4-4f6e-9bf9-170ba7857821)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
