### PR TITLE
ruff rule B009 Do not call  with a constant attribute value

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -498,7 +498,7 @@ class price_api(delegate.page):
             ed = web.ctx.site.get(book_key)
             if ed:
                 metadata['key'] = ed.key
-                if getattr(ed, 'ocaid'):
+                if getattr(ed, 'ocaid'):  # noqa: B009
                     metadata['ocaid'] = ed.ocaid
 
         return json.dumps(metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ exclude = [
 ignore = [
   "ASYNC101",
   "B007",
-  "B009",
   "B015",
   "B023",
   "B904",
@@ -150,6 +149,7 @@ max-statements = 70
 "openlibrary/core/ratings.py" = ["E722"]
 "openlibrary/core/sponsorships.py" = ["E722"]
 "openlibrary/core/stats.py" = ["BLE001"]
+"openlibrary/core/vendors.py" = ["B009"]
 "openlibrary/coverstore/code.py" = ["E722"]
 "openlibrary/i18n/__init__.py" = ["BLE001"]
 "openlibrary/plugins/admin/code.py" = ["E722"]


### PR DESCRIPTION
% `ruff rule B009`
# get-attr-with-constant (B009)

Derived from the **flake8-bugbear** linter.

Autofix is always available.

Message formats:
* Do not call `getattr` with a constant attribute value. It is not any safer than normal property access.