### PR TITLE
7259/fix/update merge author UI

### DIFF
--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -263,6 +263,9 @@ class merge_authors(delegate.page):
         # filter bad keys
         keys = self.filter_authors(keys)
 
+        # sort keys by lowest OL number
+        keys = sorted(keys, key=lambda key: int(key[2:-1]))
+
         user = get_current_user()
         can_merge = user and (
             user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -15,7 +15,7 @@ $if not keys:
 
 $if formdata:
     $if not formdata.master:
-        <div class="note">$_("Please select a primary author record.")</div> 
+        <div class="note">$_("Please select a primary author record.")</div>
     $if len(formdata.selected) == 0:
         <div class="note">$_("Please select some authors to merge.")</div>
 
@@ -54,7 +54,7 @@ $if can_merge:
             <div class="data count">&nbsp;</div>
         </div>
 
-        $if keys: 
+        $if keys:
             $ master = formdata and formdata.master or keys[0]
         $else:
             $ master = None

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -70,7 +70,7 @@ $if can_merge:
                     <input type="checkbox" value="$k" name="merge_key" id="$k" $cond(formdata and k in formdata.selected, 'checked="checked"', '')/>
                 </div>
                 <div class="data record">
-                    <span class="metaDate"> ${k} </span>
+                    <span class="ol-num"> ${k} </span>
                     <label for="$k">
                         <span class="name">$a.name</span>
                         $if a.birth_date or a.death_date:

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -15,12 +15,12 @@ $if not keys:
 
 $if formdata:
     $if not formdata.master:
-        <div class="note">$_("Please select a primary author record.")</div>
+        <div class="note">$_("Please select a primary author record.")</div> 
     $if len(formdata.selected) == 0:
         <div class="note">$_("Please select some authors to merge.")</div>
 
 <ol class="sansserif">
-    <li>$_('Select a "primary" record that best represents the author -')
+    <li>$_('Chose the oldest profile as primary -')
         <input type="radio" name="radio" id="radio" checked="checked"/>
     </li>
     <li>$_('Select author records which should be merged with the primary')
@@ -54,7 +54,7 @@ $if can_merge:
             <div class="data count">&nbsp;</div>
         </div>
 
-        $if keys:
+        $if keys: 
             $ master = formdata and formdata.master or keys[0]
         $else:
             $ master = None
@@ -70,6 +70,7 @@ $if can_merge:
                     <input type="checkbox" value="$k" name="merge_key" id="$k" $cond(formdata and k in formdata.selected, 'checked="checked"', '')/>
                 </div>
                 <div class="data record">
+                    <span class="metaDate"> ${k} </span>
                     <label for="$k">
                         <span class="name">$a.name</span>
                         $if a.birth_date or a.death_date:

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -20,7 +20,7 @@ $if formdata:
         <div class="note">$_("Please select some authors to merge.")</div>
 
 <ol class="sansserif">
-    <li>$_('Chose the oldest profile as primary -')
+    <li>$_('Select the oldest profile as primary -')
         <input type="radio" name="radio" id="radio" checked="checked"/>
     </li>
     <li>$_('Select author records which should be merged with the primary')

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -65,6 +65,10 @@ div.merge {
     font-size: .8125em;
     display: block;
   }
+  .ol-num {
+    color: @brown;
+    font-family: monospace;
+  }
 
   .name {
     font-weight: 700;

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -67,7 +67,7 @@ div.merge {
   }
   .ol-num {
     color: @brown;
-    font-family: monospace;
+    font-family: @monospace;
   }
 
   .name {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7259

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the merge author UI to reflect the current merge guidelines: the oldest record is listed first and automatically selected as the default record to be merged into. The author's OL number is displayed above the author name.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
On this page: "search/authors?q=key%3A*&mode=everything" select multiple authors to merge. When you click 'Merge', it should list the oldest author as the default to be merged into, which you can verify by the OL number (will be the lowest OL number) that now shows above the author name.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1183" alt="Screenshot 2023-06-19 at 3 55 34 PM" src="https://github.com/internetarchive/openlibrary/assets/106851247/42e06193-7949-4734-88ac-9ca358787ed0">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
Librarians


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
