### PR TITLE
test: add OpenLibraryAccount test

### DIFF
--- a/.github/workflows/javascript_tests.yml
+++ b/.github/workflows/javascript_tests.yml
@@ -42,3 +42,7 @@ jobs:
       - run: make git
       - run: npx concurrently --group 'make js' 'make css' 'make components'
       - run: npm run test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,9 +1,9 @@
 name: python_tests
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
       - '.github/workflows/javascript_tests.yml'
       - 'vendor/js/**'
@@ -55,3 +55,7 @@ jobs:
           make test-py
           source scripts/run_doctests.sh
           mypy --install-types --non-interactive .
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -1,7 +1,10 @@
 from openlibrary.accounts import model, InternetArchiveAccount, OpenLibraryAccount
 from requests.models import Response
-import unittest
 from unittest import mock
+
+
+def get_username(account):
+    return account and account.value
 
 
 def test_verify_hash():
@@ -10,96 +13,87 @@ def test_verify_hash():
     assert model.verify_hash(secret_key, b"foo", hash)
 
 
-class TestInternetArchiveAccount:
-    def test_xauth_http_error_without_json(self, monkeypatch):
-        xauth = InternetArchiveAccount.xauth
-        resp = Response()
-        resp.status_code = 500
-        resp._content = b'Internal Server Error'
-        monkeypatch.setattr(model.requests, 'post', lambda url, **kwargs: resp)
-        assert xauth('create', s3_key='_', s3_secret='_') == {
-            'code': 500,
-            'error': 'Internal Server Error',
-        }
-
-    def test_xauth_http_error_with_json(self, monkeypatch):
-        xauth = InternetArchiveAccount.xauth
-        resp = Response()
-        resp.status_code = 400
-        resp._content = b'{"error": "Unknown Parameter Blah"}'
-        monkeypatch.setattr(model.requests, 'post', lambda url, **kwargs: resp)
-        assert xauth('create', s3_key='_', s3_secret='_') == {
-            "error": "Unknown Parameter Blah"
-        }
+def test_xauth_http_error_without_json(monkeypatch):
+    xauth = InternetArchiveAccount.xauth
+    resp = Response()
+    resp.status_code = 500
+    resp._content = b'Internal Server Error'
+    monkeypatch.setattr(model.requests, 'post', lambda url, **kwargs: resp)
+    assert xauth('create', s3_key='_', s3_secret='_') == {
+        'code': 500,
+        'error': 'Internal Server Error',
+    }
 
 
-class OpenLibraryAccountTests(unittest.TestCase):
-    @mock.patch("openlibrary.accounts.model.web")
-    def test_get(self, mock_web):
-        test = True
+def test_xauth_http_error_with_json(monkeypatch):
+    xauth = InternetArchiveAccount.xauth
+    resp = Response()
+    resp.status_code = 400
+    resp._content = b'{"error": "Unknown Parameter Blah"}'
+    monkeypatch.setattr(model.requests, 'post', lambda url, **kwargs: resp)
+    assert xauth('create', s3_key='_', s3_secret='_') == {
+        "error": "Unknown Parameter Blah"
+    }
 
-        email = "test@example.com"
-        account = OpenLibraryAccount.get_by_email(email)
-        self.assertIsNone(account)
 
-        test_account = OpenLibraryAccount.create(
-            username="test",
-            email=email,
-            password="password",
-            displayname="Test User",
-            verified=True,
-            retries=0,
-            test=True,
-        )
+@mock.patch("openlibrary.accounts.model.web")
+def test_get(mock_web):
+    test = True
+    email = "test@example.com"
+    account = OpenLibraryAccount.get_by_email(email)
+    assert account is None
 
-        mock_site = mock_web.ctx.site
-        mock_site.store.get.return_value = {
+    test_account = OpenLibraryAccount.create(
+        username="test",
+        email=email,
+        password="password",
+        displayname="Test User",
+        verified=True,
+        retries=0,
+        test=True,
+    )
+
+    mock_site = mock_web.ctx.site
+    mock_site.store.get.return_value = {
+        "username": "test",
+        "itemname": "@test",
+        "email": "test@example.com",
+        "displayname": "Test User",
+        "test": test,
+    }
+
+    key = "test/test"
+    test_username = test_account.username
+
+    retrieved_account = OpenLibraryAccount.get(email=email, test=test)
+    assert retrieved_account == test_account
+
+    mock_site = mock_web.ctx.site
+    mock_site.store.values.return_value = [
+        {
             "username": "test",
             "itemname": "@test",
             "email": "test@example.com",
             "displayname": "Test User",
-            "test": True,
+            "test": test,
+            "type": "account",
+            "name": "internetarchive_itemname",
+            "value": test_username,
         }
+    ]
 
-        key = "test/test"
-        tusername = test_account.username
+    retrieved_account = OpenLibraryAccount.get(link=test_username, test=test)
+    assert retrieved_account
+    retrieved_username = get_username(retrieved_account)
+    assert retrieved_username == test_username
 
-        retrieved_account = OpenLibraryAccount.get(email=email, test=test)
-        self.assertEqual(retrieved_account, test_account)
+    mock_site.store.values.return_value[0]["name"] = "username"
 
-        mock_site = mock_web.ctx.site
-        mock_site.store.values.return_value = [
-            {
-                "username": "test",
-                "itemname": "@test",
-                "email": "test@example.com",
-                "displayname": "Test User",
-                "test": True,
-                "type": "account",
-                "name": "internetarchive_itemname",
-                "value": tusername,
-            }
-        ]
+    retrieved_account = OpenLibraryAccount.get(username=test_username, test=test)
+    assert retrieved_account
+    retrieved_username = get_username(retrieved_account)
+    assert retrieved_username == test_username
 
-        retrieved_account = OpenLibraryAccount.get(link=tusername, test=test)
-        self.assertIsNotNone(retrieved_account)
-        rusername = self.get_username(retrieved_account)
-        self.assertEqual(rusername, tusername)
-
-        mock_site.store.values.return_value[0]["name"] = "username"
-
-        retrieved_account = OpenLibraryAccount.get(username=tusername, test=test)
-        self.assertIsNotNone(retrieved_account)
-        rusername = self.get_username(retrieved_account)
-        self.assertEqual(rusername, tusername)
-
-        key = f'test/{rusername}'
-
-        retrieved_account = OpenLibraryAccount.get(key=key, test=test)
-        self.assertIsNotNone(retrieved_account)
-        rusername = self.get_username(retrieved_account)
-        self.assertEqual(rusername, tusername)
-
-    @staticmethod
-    def get_username(account):
-        return account.value if account is not None else None
+    key = f'test/{retrieved_username}'
+    retrieved_account = OpenLibraryAccount.get(key=key, test=test)
+    assert retrieved_account

--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -1,5 +1,7 @@
-from openlibrary.accounts import model, InternetArchiveAccount
+from openlibrary.accounts import model, InternetArchiveAccount, OpenLibraryAccount
 from requests.models import Response
+import unittest
+from unittest import mock
 
 
 def test_verify_hash():
@@ -29,3 +31,75 @@ class TestInternetArchiveAccount:
         assert xauth('create', s3_key='_', s3_secret='_') == {
             "error": "Unknown Parameter Blah"
         }
+
+
+class OpenLibraryAccountTests(unittest.TestCase):
+    @mock.patch("openlibrary.accounts.model.web")
+    def test_get(self, mock_web):
+        test = True
+
+        email = "test@example.com"
+        account = OpenLibraryAccount.get_by_email(email)
+        self.assertIsNone(account)
+
+        test_account = OpenLibraryAccount.create(
+            username="test",
+            email=email,
+            password="password",
+            displayname="Test User",
+            verified=True,
+            retries=0,
+            test=True,
+        )
+
+        mock_site = mock_web.ctx.site
+        mock_site.store.get.return_value = {
+            "username": "test",
+            "itemname": "@test",
+            "email": "test@example.com",
+            "displayname": "Test User",
+            "test": True,
+        }
+
+        key = "test/test"
+        tusername = test_account.username
+
+        retrieved_account = OpenLibraryAccount.get(email=email, test=test)
+        self.assertEqual(retrieved_account, test_account)
+
+        mock_site = mock_web.ctx.site
+        mock_site.store.values.return_value = [
+            {
+                "username": "test",
+                "itemname": "@test",
+                "email": "test@example.com",
+                "displayname": "Test User",
+                "test": True,
+                "type": "account",
+                "name": "internetarchive_itemname",
+                "value": tusername,
+            }
+        ]
+
+        retrieved_account = OpenLibraryAccount.get(link=tusername, test=test)
+        self.assertIsNotNone(retrieved_account)
+        rusername = self.get_username(retrieved_account)
+        self.assertEqual(rusername, tusername)
+
+        mock_site.store.values.return_value[0]["name"] = "username"
+
+        retrieved_account = OpenLibraryAccount.get(username=tusername, test=test)
+        self.assertIsNotNone(retrieved_account)
+        rusername = self.get_username(retrieved_account)
+        self.assertEqual(rusername, tusername)
+
+        key = f'test/{rusername}'
+
+        retrieved_account = OpenLibraryAccount.get(key=key, test=test)
+        self.assertIsNotNone(retrieved_account)
+        rusername = self.get_username(retrieved_account)
+        self.assertEqual(rusername, tusername)
+
+    @staticmethod
+    def get_username(account):
+        return account.value if account is not None else None

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,5 +8,6 @@ mypy==1.3.0
 pymemcache==4.0.0
 pytest==7.3.2
 pytest-asyncio==0.21.0
+pytest-cov==4.1.0
 ruff==0.0.275
 safety==2.3.5


### PR DESCRIPTION
Fixes #8023

test: method get from the class OpenLibraryAccount 

Testing
Run Automatizated Test, this test is for accounts/model.py

This PR covers the method get from the class OpenLibraryAccount test that is present on the accounts/model.py file, it simulates the web case when the backend is trying to return a OpenLibraryAccount object by searching it from username, email, link or key. The test is covering 100% of the method.