### PR TITLE
Create lists dump file

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -45,8 +45,12 @@ def print_dump(json_records, filter=None):
 
         key = web.safestr(d["key"])
 
-        # skip user and admin pages
-        if key.startswith(("/people/", "/admin/")):
+        # skip user pages
+        if key.startswith("/people/") and not re.match(r"^/people/[^/]+/lists/OL\d+L$", key):
+            continue
+
+        # skip admin pages
+        if key.startswith("/admin/"):
             continue
 
         # skip obsolete pages. Obsolete pages include volumes, scan_records and users
@@ -206,7 +210,13 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
     """Split dump into authors, editions and works."""
     log(f"split_dump({dump_file}, format={format})")
     start_time = datetime.now()
-    types = ("/type/edition", "/type/author", "/type/work", "/type/redirect")
+    types = (
+        "/type/edition",
+        "/type/author",
+        "/type/work",
+        "/type/redirect",
+        "/type/list",
+    )
     files = {}
     for t in types:
         tname = t.split("/")[-1] + "s"
@@ -236,7 +246,7 @@ def make_index(dump_file):
         if type in ("/type/edition", "/type/work"):
             title = data.get("title", "untitled")
             path = key + "/" + urlsafe(title)
-        elif type == "/type/author":
+        elif type in ("/type/author", "/type/list"):
             title = data.get("name", "unnamed")
             path = key + "/" + urlsafe(title)
         else:

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -46,7 +46,9 @@ def print_dump(json_records, filter=None):
         key = web.safestr(d["key"])
 
         # skip user pages
-        if key.startswith("/people/") and not re.match(r"^/people/[^/]+/lists/OL\d+L$", key):
+        if key.startswith("/people/") and not re.match(
+            r"^/people/[^/]+/lists/OL\d+L$", key
+        ):
             continue
 
         # skip admin pages


### PR DESCRIPTION
Closes #2609 creates a new dump file for lists.

### Technical
I'm thinking it makes more sense to leave the user name in the key ; usernames and lists are both public after all? I think this will make things easier down the road as well, since solr will have to know how to link to these things.

### Testing
Running `docker compose exec web scripts/oldump.sh $(date +%Y-%m-%d)` locally successfully generates a lists dump file.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
