### PR TITLE
Fix a variable name in the Italian translation

### DIFF
--- a/openlibrary/i18n/it/messages.po
+++ b/openlibrary/i18n/it/messages.po
@@ -1366,7 +1366,7 @@ msgid ""
 "%(username)s is reading %(total)d books. Join %(username)s on "
 "OpenLibrary.org and tell the world what you're reading."
 msgstr ""
-"%(username)s sta leggendo %(total)d libri. Unisciti a %(usernam)s su "
+"%(username)s sta leggendo %(total)d libri. Unisciti a %(username)s su "
 "OpenLibrary.org e fai sapere al mondo che stai leggendo."
 
 #: account/reading_log.html:15


### PR DESCRIPTION
Related to #7986

`(username)` is used earlier on this line and also twice a few lines above.

@ormai Your review, please.

@cdrini Fixes https://sentry.archive.org/organizations/ia-ux/issues/363456

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
