### PR TITLE
Don't set edition LCCNs to None

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -331,6 +331,8 @@ class Edition(models.Edition):
             name, value = id['name'], id['value']
             if name == 'lccn':
                 value = normalize_lccn(value)
+            # `None` in this field causes errors. See #7999.
+            # We should surface to the patron that an invalid LCCN is dropped. See #8092.
             if value is not None:
                 d.setdefault(name, []).append(value)
 
@@ -464,9 +466,8 @@ class Edition(models.Edition):
             }
         )
 
-        if self.lccn:
-            if lccn := normalize_lccn(self.lccn[0]):
-                citation['lccn'] = lccn
+        if self.lccn and (lccn := normalize_lccn(self.lccn[0])):
+            citation['lccn'] = lccn
         if self.get('oclc_numbers'):
             citation['oclc'] = self.oclc_numbers[0]
         citation['ol'] = str(self.get_olid())[2:]

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -331,7 +331,8 @@ class Edition(models.Edition):
             name, value = id['name'], id['value']
             if name == 'lccn':
                 value = normalize_lccn(value)
-            d.setdefault(name, []).append(value)
+            if value is not None:
+                d.setdefault(name, []).append(value)
 
         # clear existing value first
         for name in names:
@@ -464,7 +465,8 @@ class Edition(models.Edition):
         )
 
         if self.lccn:
-            citation['lccn'] = normalize_lccn(self.lccn[0])
+            if lccn := normalize_lccn(self.lccn[0]):
+                citation['lccn'] = lccn
         if self.get('oclc_numbers'):
             citation['oclc'] = self.oclc_numbers[0]
         citation['ol'] = str(self.get_olid())[2:]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7943

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Entering an invalid LCCN while editing an edition causes a null LCCN
#### Steps to reproduce
- Patron edits an edition via `/books/OL123M/book_title/edit`
- Patron enters invalid LCCN.
- Page chokes on reload.

#### Explanation
- Saving on this page goes through `SaveBookHelper` in `openlibrary/plugins/upstream/addbook.py`.
- This calls `self.edition.set_identifiers(identifiers)`, and an LCCN is one of the identifiers.
- `set_identifiers` is defined in the `Edition` model in `openlibrary/plugins/upstream/models.py`, and it calls `normalize_lccn` on the identifier when setting the object's LCCN.
- `normalize_lccn()` returns `None` for an invalid LCCN, and that's what leads to `null` in the template view.
- Because this all happens on the backend, the patron (1) has no idea their LCCN is invalid, and (2) no way to fix things once they've submitted the bad LLCN, unless they can use `.yml?m=edit`.

### Fix
- Only set an edition identifier, LCCN or otherwise, if it is truthy. This PR uses this approach.

### This approach fixes the issue for books added via /books/add as well
I tested this to be sure, but `/books/add` and editing an edition both use `SaveBookHelper`.

### /api/import properly handles `None` returned from `normalize_lccn`
The catalog import API already handles this case.

Specifically, in `normalize_record_bibids`, the LCCN is only set if it's truthy.
```python
if rec.get('lccn'):
    rec['lccn'] = [
        normalize_lccn(lccn) for lccn in rec.get('lccn') if normalize_lccn(lccn)
    ]
```

That said, it's still good to check the API.

Invalid LCCN
```
❯ curl -X POST http://localhost:8080/api/import -H "Content-Type: application/json" -H "Cookie: $OL_COOKIE" -d '{
    "title": "LCCN Test 3",
    "source_records": ["ia:lccntest3"],
    "authors": [{"name": "Captn LCCN"}],
    "publishers": ["Gallimard"],
    "isbn_13": ["1234567890125"],
    "publish_date": "2001-01",
    "lccn": ["123"]
}'

{"authors": [{"key": "/authors/OL14A", "name": "Captn LCCN", "status": "matched"}], "success": true, "edition": {"key": "/books/OL18M", "status": "created"}, "work": {"key": "/works/OL9W", "status": "created"}}%
```

The LCCN is not set with this invalid LCCN:
```json
{
  "type": {
    "key": "/type/edition"
  },
  "title": "LCCN Test 3",
  "source_records": [
    "ia:lccntest3"
  ],
  "authors": [
    {
      "key": "/authors/OL14A"
    }
  ],
  "publishers": [
    "Gallimard"
  ],
  "isbn_13": [
    "1234567890125"
  ],
  "publish_date": "2001-01",
  "works": [
    {
      "key": "/works/OL9W"
    }
  ],
  "key": "/books/OL18M",
  "latest_revision": 1,
  "revision": 1,
  "created": {
    "type": "/type/datetime",
    "value": "2023-06-26T04:19:48.827813"
  },
  "last_modified": {
    "type": "/type/datetime",
    "value": "2023-06-26T04:19:48.827813"
  }
}
```

A valid LCCN:
```
❮ curl -X POST http://localhost:8080/api/import -H "Content-Type: application/json" -H "Cookie: $OL_COOKIE" -d '{
    "title": "LCCN Test 4",
    "source_records": ["ia:lccntest4"],
    "authors": [{"name": "Captn LCCN"}],
    "publishers": ["Gallimard"],
    "isbn_13": ["1234567890126"],
    "publish_date": "2001-01",
    "lccn": ["2001000123"]
}'

{"authors": [{"key": "/authors/OL14A", "name": "Captn LCCN", "status": "matched"}], "success": true, "edition": {"key": "/books/OL19M", "status": "created"}, "work": {"key": "/works/OL10W", "status": "created"}}%
```

The LCCN is properly set with a valid LCCN:
```json
{
  "type": {
    "key": "/type/edition"
  },
  "title": "LCCN Test 4",
  "source_records": [
    "ia:lccntest4"
  ],
  "authors": [
    {
      "key": "/authors/OL14A"
    }
  ],
  "publishers": [
    "Gallimard"
  ],
  "isbn_13": [
    "1234567890126"
  ],
  "publish_date": "2001-01",
  "lccn": [
    "2001000123"
  ],
  "works": [
    {
      "key": "/works/OL10W"
    }
  ],
  "key": "/books/OL19M",
  "latest_revision": 1,
  "revision": 1,
  "created": {
    "type": "/type/datetime",
    "value": "2023-06-26T04:20:57.547973"
  },
  "last_modified": {
    "type": "/type/datetime",
    "value": "2023-06-26T04:20:57.547973"
  }
}
```

### Testing
Add/edit a book with a valid/invalid LCCN via:
- `/books/add`,
- `/api/import`, or
- the edition edit page.

Then verify that there are no LCCN issues, with either bad LCCNs breaking the page, or valid LCCNs not being saved.


### Future
It may make sense to validate LCCN on front end and notify the patron if it's not going to be accepted. Good first issue?



### Technical
<!-- What should be noted about the implementation? -->



### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
