### PR TITLE
Fix translation error

### DIFF
--- a/openlibrary/i18n/it/messages.po
+++ b/openlibrary/i18n/it/messages.po
@@ -673,7 +673,7 @@ msgstr "Lettura in corso"
 #: books/edit/edition.html:672 books/show.html:34 trending.html:23
 #: type/list/embed.html:69 widget.html:34
 msgid "Read"
-msgstr "Letto"
+msgstr "Leggi"
 
 #: trending.html:24
 #, python-format


### PR DESCRIPTION
I found a minor error in the Italian translation.

Since _read_ is both present and past tense there is ambiguity without the contest.

<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
