### PR TITLE
work title now displays on author page

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=True)
 
 $code:
   max_rendered_authors = 9

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=True)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False)
 
 $code:
   max_rendered_authors = 9

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -142,8 +142,9 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
                 <div id="searchResults">
                     <ul class="list-books">
+                      $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
                       $for doc in books.docs:
-                         $:macros.SearchResultsWork(doc)
+                         $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras)
                     </ul>
                 </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes # #7525

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Feature - The work title of a book now shows on both the search results page and author page.

### Testing
Search for a book/author, then visit their author page. The search results and their individual page will display the work title in each book. 

### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/20419658/9958bfc9-0370-4a37-826a-ccb73a986fbc)

### Stakeholders
@bicolino34 @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
