### PR TITLE
pyproject.toml: Add newer ruff rules

### DIFF
--- a/openlibrary/api.py
+++ b/openlibrary/api.py
@@ -282,10 +282,14 @@ def parse_datetime(value):
 
 
 class Text(str):
+    __slots__ = ()
+
     def __repr__(self):
         return "<text: %s>" % str.__repr__(self)
 
 
 class Reference(str):
+    __slots__ = ()
+
     def __repr__(self):
         return "<ref: %s>" % str.__repr__(self)

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -834,6 +834,8 @@ def get_markdown(text, safe_mode=False):
 
 
 class HTML(str):
+    __slots__ = ()
+
     def __init__(self, html):
         str.__init__(self, web.safeunicode(html))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.black]
 skip-string-normalization = true
-target-version = ["py310", "py311"]
+target-version = ["py311"]
 
 [tool.codespell]
 ignore-words-list = "beng,curren,datas,furst,nd,nin,ot,ser,spects,te,tha,ue,upto"
@@ -81,20 +81,24 @@ select = [
   "I",       # isort
   "ICN",     # flake8-import-conventions
   "INT",     # flake8-gettext
+  "PERF",    # Perflint
   "PIE",     # flake8-pie
   "PL",      # Pylint
   "PYI",     # flake8-pyi
   "RSE",     # flake8-raise
   "SIM",     # flake8-simplify
   "SLF",     # flake8-self
+  "SLOT",    # flake8-slots
   "T10",     # flake8-debugger
   "UP",      # pyupgrade
   "W",       # pycodestyle
   "YTT",     # flake8-2020
   # "A",     # flake8-builtins
+  # "AIR",   # Airflow
   # "ANN",   # flake8-annotations
   # "ARG",   # flake8-unused-arguments
   # "COM",   # flake8-commas
+  # "CPY",   # Copyright-related rules
   # "D",     # pydocstyle
   # "DJ",    # flake8-django
   # "DTZ",   # flake8-datetimez
@@ -102,6 +106,7 @@ select = [
   # "ERA",   # eradicate
   # "EXE",   # flake8-executable
   # "FBT",   # flake8-boolean-trap
+  # "FIX",   # flake8-fixme
   # "G",     # flake8-logging-format
   # "INP",   # flake8-no-pep420
   # "ISC",   # flake8-implicit-str-concat

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,5 +8,5 @@ mypy==1.3.0
 pymemcache==4.0.0
 pytest==7.3.2
 pytest-asyncio==0.21.0
-ruff==0.0.272
+ruff==0.0.275
 safety==2.3.5

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -135,6 +135,8 @@ def get_references(doc, result=None):
 class KeyVersionPair(namedtuple('KeyVersionPair', 'key version')):
     """Helper class to store uri's like /works/OL1W?v=2"""
 
+    __slots__ = ()
+
     @staticmethod
     def from_uri(uri: str) -> KeyVersionPair:
         """


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add new Python linting rules from https://beta.ruff.rs/docs/rules/
```
  "PERF",    # Perflint
  "SLOT",    # flake8-slots
  # "AIR",   # Airflow
  # "CPY",   # Copyright-related rules
  # "FIX",   # flake8-fixme
```
The `SLOT` fixes should save memory while increasing performance...
> The space saved over using [__dict__](https://docs.python.org/3/library/stdtypes.html#object.__dict__) can be significant. Attribute lookup speed can be significantly improved as well.
> -- https://docs.python.org/3/reference/datamodel.html#slots
### Technical
<!-- What should be noted about the implementation? -->
```
openlibrary/api.py:284:7: SLOT000 Subclasses of `str` should define `__slots__`
openlibrary/api.py:289:7: SLOT000 Subclasses of `str` should define `__slots__`
openlibrary/plugins/upstream/utils.py:836:7: SLOT000 Subclasses of `str` should define `__slots__`
scripts/copydocs.py:135:7: SLOT002 Subclasses of `collections.namedtuple()` should define `__slots__`
```

https://flake8-slots.readthedocs.io/en/latest/usage.html

% `ruff rule SLOT000`
# no-slots-in-str-subclass (SLOT000)

Derived from the **flake8-slots** linter.

## What it does
Checks for subclasses of `str` that lack a `__slots__` definition.

## Why is this bad?
In Python, the `__slots__` attribute allows you to explicitly define the
attributes (instance variables) that a class can have. By default, Python
uses a dictionary to store an object's attributes, which incurs some memory
overhead. However, when `__slots__` is defined, Python uses a more compact
internal structure to store the object's attributes, resulting in memory
savings.

Subclasses of `str` inherit all the attributes and methods of the built-in
`str` class. Since strings are typically immutable, they don't require
additional attributes beyond what the `str` class provides. Defining
`__slots__` for subclasses of `str` prevents the creation of a dictionary
for each instance, reducing memory consumption.

## Example
```python
class Foo(str):
    pass
```

Use instead:
```python
class Foo(str):
    __slots__ = ()
```

## References
- [Python documentation: `__slots__`](https://docs.python.org/3.7/reference/datamodel.html#slots)


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
