### PR TITLE
Python async functions should not call the sync function open()

### DIFF
--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -9,6 +9,7 @@ from statistics import median
 from typing import Literal, Optional, cast, Any, Union
 from collections.abc import Iterable
 
+import aiofiles
 import httpx
 import requests
 import sys
@@ -1495,11 +1496,10 @@ async def update_keys(
             requests += [CommitRequest()]
 
         if output_file:
-            with open(output_file, "w") as f:
+            async with aiofiles.open(output_file, "w") as f:
                 for r in requests:
                     if isinstance(r, AddRequest):
-                        f.write(r.tojson())
-                        f.write("\n")
+                        await f.write(f"{r.tojson()}\n")
         else:
             _solr_update(requests)
 
@@ -1517,11 +1517,10 @@ async def update_keys(
 
     if requests:
         if output_file:
-            with open(output_file, "w") as f:
+            async with aiofiles.open(output_file, "w") as f:
                 for r in requests:
                     if isinstance(r, AddRequest):
-                        f.write(r.tojson())
-                        f.write("\n")
+                        await f.write(f"{r.tojson()}\n")
         else:
             if commit:
                 requests += [CommitRequest()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ exclude = [
   "vendor/*",
 ]
 ignore = [
-  "ASYNC101",
   "B007",
   "B015",
   "B023",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles==23.1.0
 amightygirl.paapi5-python-sdk==1.0.0
 Babel==2.9.1
 beautifulsoup4==4.12.2

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from collections import namedtuple
 
+import aiofiles
 import psycopg2
 
 from openlibrary.core.bookshelves import Bookshelves
@@ -535,10 +536,10 @@ async def main(
 
         if progress:
             # Clear the file
-            with open(progress, 'w') as f:
-                f.write('')
-            with open(progress, 'a') as f:
-                f.write('Calculating total... ')
+            async with aiofiles.open(progress, 'w') as f:
+                await f.write('')
+            async with aiofiles.open(progress, 'a') as f:
+                await f.write('Calculating total... ')
 
         start = time.time()
         q_count = """SELECT COUNT(*) FROM(%s) AS foo""" % q
@@ -546,9 +547,9 @@ async def main(
         end = time.time()
 
         if progress:
-            with open(progress, 'a') as f:
-                f.write('%d (%.2fs)\n' % (count, end - start))
-                f.write('\t'.join(PLogEntry._fields) + '\n')
+            async with aiofiles.open(progress, 'a') as f:
+                await f.write('%d (%.2fs)\n' % (count, end - start))
+                await f.write('\t'.join(PLogEntry._fields) + '\n')
 
         plog.log(
             PLogEntry(0, count, '0.00%', 0, '?', '?', '?', '?', '?', start_at or '?')

--- a/scripts/solr_updater.py
+++ b/scripts/solr_updater.py
@@ -20,6 +20,7 @@ from collections.abc import Iterator
 
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 
+import aiofiles
 import web
 
 from openlibrary.solr import update_work
@@ -304,8 +305,8 @@ async def main(
         if logfile.tell() != offset:
             offset = logfile.tell()
             logger.info("saving offset %s", offset)
-            with open(state_file, "w") as f:
-                f.write(offset)
+            async with aiofiles.open(state_file, "w") as f:
+                await f.write(offset)
 
         # don't sleep after committing some records.
         # While the commit was on, some more edits might have happened.


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7891

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Technical
<!-- What should be noted about the implementation? -->

Adds dependency https://pypi.org/project/aiofiles to enable async file IO to avoid blocking operations in our async functions.
% `ruff rule ASYNC101`
# open-sleep-or-subprocess-in-async-function (ASYNC101)

Derived from the **flake8-async** linter.

## What it does
Checks that async functions do not contain calls to `open`, `time.sleep`,
or `subprocess` methods.

## Why is this bad?
Blocking an async function via a blocking call will block the entire
event loop, preventing it from executing other tasks while waiting for the
call to complete, negating the benefits of asynchronous programming.

Instead of making a blocking call, use an equivalent asynchronous library
or function.

## Example
```python
async def foo():
    time.sleep(1000)
```

Use instead:
```python
async def foo():
    await asyncio.sleep(1000)
```
### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
