### PR TITLE
add: test OpenLibraryAccount model

### DIFF
--- a/openlibrary/tests/accounts/test_models.py
+++ b/openlibrary/tests/accounts/test_models.py
@@ -1,5 +1,7 @@
-from openlibrary.accounts import model, InternetArchiveAccount
+from openlibrary.accounts import model, InternetArchiveAccount, OpenLibraryAccount
 from requests.models import Response
+import unittest
+from unittest import mock
 
 
 def test_verify_hash():
@@ -29,3 +31,73 @@ class TestInternetArchiveAccount:
         assert xauth('create', s3_key='_', s3_secret='_') == {
             "error": "Unknown Parameter Blah"
         }
+class OpenLibraryAccountTests(unittest.TestCase):
+    @mock.patch("openlibrary.accounts.model.web")
+    def test_get(self, mock_web):
+        test = True
+
+        email = "test@example.com"
+        account = OpenLibraryAccount.get_by_email(email)
+        self.assertIsNone(account)
+
+        test_account = OpenLibraryAccount.create(
+            username="test",
+            email=email,
+            password="password",
+            displayname="Test User",
+            verified=True,
+            retries=0,
+            test=True,
+        )
+
+        mock_site = mock_web.ctx.site
+        mock_site.store.get.return_value = {
+            "username": "test",
+            "itemname": "@test",
+            "email": "test@example.com",
+            "displayname": "Test User",
+            "test": True,
+        }
+
+        key = "test/test"
+        tusername = test_account.username
+
+        retrieved_account = OpenLibraryAccount.get(email=email, test=test)
+        self.assertEqual(retrieved_account, test_account)
+
+        mock_site = mock_web.ctx.site
+        mock_site.store.values.return_value = [
+            {
+                "username": "test",
+                "itemname": "@test",
+                "email": "test@example.com",
+                "displayname": "Test User",
+                "test": True,
+                "type": "account",
+                "name": "internetarchive_itemname",
+                "value": tusername,
+            }
+        ]
+
+        retrieved_account = OpenLibraryAccount.get(link=tusername, test=test)
+        self.assertIsNotNone(retrieved_account)
+        rusername = self.get_username(retrieved_account)
+        self.assertEqual(rusername, tusername)
+
+        mock_site.store.values.return_value[0]["name"] = "username"
+
+        retrieved_account = OpenLibraryAccount.get(username=tusername, test=test)
+        self.assertIsNotNone(retrieved_account)
+        rusername = self.get_username(retrieved_account)
+        self.assertEqual(rusername, tusername)
+
+        key = f'test/{rusername}'
+
+        retrieved_account = OpenLibraryAccount.get(key=key, test=test)
+        self.assertIsNotNone(retrieved_account)
+        rusername = self.get_username(retrieved_account)
+        self.assertEqual(rusername, tusername)
+
+    @staticmethod
+    def get_username(account):
+        return account.value if account is not None else None


### PR DESCRIPTION
test: method get from the class OpenLibraryAccount

Testing
Run Automatizated Test, this test is for accounts/model.py

This PR covers the method get from the class OpenLibraryAccount test that is present on the accounts/model.py file, it simulates the web case when the backend is trying to return a OpenLibraryAccount object by searching it from username, email, link or key. The test is covering 100% of the method.

**Republishing this PR as requested**: [https://github.com/internetarchive/openlibrary/pull/7981](First PR)