### PR TITLE
Refactor test_marc.py to not use unittest.TestCase

### DIFF
--- a/openlibrary/catalog/marc/tests/test_marc.py
+++ b/openlibrary/catalog/marc/tests/test_marc.py
@@ -1,4 +1,3 @@
-import unittest
 from openlibrary.catalog.marc.get_subjects import subjects_for_work
 from openlibrary.catalog.marc.marc_base import MarcBase
 from openlibrary.catalog.marc.parse import read_isbn, read_pagination, read_title
@@ -51,156 +50,153 @@ class MockRecord(MarcBase):
             return [self.field]
 
 
-# TODO: refactor to not use unittest
-class TestMarcParse(unittest.TestCase):
-    def test_read_isbn(self):
-        data = [
-            ('0300067003 (cloth : alk. paper)', '0300067003'),
-            ('0197263771 (cased)', '0197263771'),
-            ('8831789589 (pbk.)', '8831789589'),
-            ('9788831789585 (pbk.)', '9788831789585'),
-            ('1402051891 (hd.bd.)', '1402051891'),
-            ('9061791308', '9061791308'),
-            ('9788831789530', '9788831789530'),
-            ('8831789538', '8831789538'),
-            ('0-14-118250-4', '0141182504'),
-            ('0321434250 (textbook)', '0321434250'),
-            # 12 character ISBNs currently get assigned to isbn_10
-            # unsure whether this is a common / valid usecase:
-            ('97883178953X ', '97883178953X'),
-        ]
+def test_read_isbn():
+    data = [
+        ('0300067003 (cloth : alk. paper)', '0300067003'),
+        ('0197263771 (cased)', '0197263771'),
+        ('8831789589 (pbk.)', '8831789589'),
+        ('9788831789585 (pbk.)', '9788831789585'),
+        ('1402051891 (hd.bd.)', '1402051891'),
+        ('9061791308', '9061791308'),
+        ('9788831789530', '9788831789530'),
+        ('8831789538', '8831789538'),
+        ('0-14-118250-4', '0141182504'),
+        ('0321434250 (textbook)', '0321434250'),
+        # 12 character ISBNs currently get assigned to isbn_10
+        # unsure whether this is a common / valid usecase:
+        ('97883178953X ', '97883178953X'),
+    ]
+    for value, expect in data:
+        rec = MockRecord('020', [('a', value)])
+        output = read_isbn(rec)
+        isbn_type = 'isbn_13' if len(expect) == 13 else 'isbn_10'
+        assert output[isbn_type][0] == expect
 
-        for value, expect in data:
-            rec = MockRecord('020', [('a', value)])
-            output = read_isbn(rec)
-            if len(expect) == 13:
-                isbn_type = 'isbn_13'
-            else:
-                isbn_type = 'isbn_10'
-            assert expect == output[isbn_type][0]
 
-    def test_read_pagination(self):
-        data = [
-            ('xx, 1065 , [57] p.', 1065),
-            ('193 p., 31 p. of plates', 193),
-        ]
-        for value, expect in data:
-            rec = MockRecord('300', [('a', value)])
-            output = read_pagination(rec)
-            assert output['number_of_pages'] == expect
-            assert output['pagination'] == value
+def test_read_pagination():
+    data = [
+        ('xx, 1065 , [57] p.', 1065),
+        ('193 p., 31 p. of plates', 193),
+    ]
+    for value, expect in data:
+        rec = MockRecord('300', [('a', value)])
+        output = read_pagination(rec)
+        assert output['number_of_pages'] == expect
+        assert output['pagination'] == value
 
-    def test_subjects_for_work(self):
-        data = [
-            (
-                [
-                    ('a', 'Authors, American'),
-                    ('y', '19th century'),
-                    ('x', 'Biography.'),
-                ],
-                {
-                    'subject_times': ['19th century'],
-                    'subjects': ['American Authors', 'Biography'],
-                },
-            ),
-            (
-                [('a', 'Western stories'), ('x', 'History and criticism.')],
-                {'subjects': ['Western stories', 'History and criticism']},
-            ),
-            (
-                [
-                    ('a', 'United States'),
-                    ('x', 'History'),
-                    ('y', 'Revolution, 1775-1783'),
-                    ('x', 'Influence.'),
-                ],
-                # TODO: this expectation does not capture the intent or ordering of the original MARC, investigate x subfield!
-                {
-                    'subject_times': ['Revolution, 1775-1783'],
-                    'subjects': ['United States', 'Influence', 'History'],
-                },
-            ),
-            # 'United States -- History -- Revolution, 1775-1783 -- Influence.'
-            (
-                [
-                    ('a', 'West Indies, British'),
-                    ('x', 'History'),
-                    ('y', '18th century.'),
-                ],
-                {
-                    'subject_times': ['18th century'],
-                    'subjects': ['British West Indies', 'History'],
-                },
-            ),
-            # 'West Indies, British -- History -- 18th century.'),
-            (
-                [
-                    ('a', 'Great Britain'),
-                    ('x', 'Relations'),
-                    ('z', 'West Indies, British.'),
-                ],
-                {
-                    'subject_places': ['British West Indies'],
-                    'subjects': ['Great Britain', 'Relations'],
-                },
-            ),
-            # 'Great Britain -- Relations -- West Indies, British.'),
-            (
-                [
-                    ('a', 'West Indies, British'),
-                    ('x', 'Relations'),
-                    ('z', 'Great Britain.'),
-                ],
-                {
-                    'subject_places': ['Great Britain'],
-                    'subjects': ['British West Indies', 'Relations'],
-                },
-            )
-            # 'West Indies, British -- Relations -- Great Britain.')
-        ]
-        for value, expect in data:
-            output = subjects_for_work(MockRecord('650', value))
-            assert sorted(expect) == sorted(output)
-            for key in ('subjects', 'subject_places', 'subject_times'):
-                assert sorted(expect.get(key, [])) == sorted(output.get(key, []))
 
-    def test_read_title(self):
-        data = [
-            (
-                [
-                    ('a', 'Railroad construction.'),
-                    ('b', 'Theory and practice.'),
-                    (
-                        'b',
-                        'A textbook for the use of students in colleges and technical schools.',
-                    ),
-                ],
-                {
-                    'title': 'Railroad construction',
-                    # TODO: Investigate whether this colon between subtitles is spaced correctly
-                    'subtitle': 'Theory and practice : A textbook for the use of students in colleges and technical schools',
-                },
-            )
-        ]
+def test_subjects_for_work():
+    data = [
+        (
+            [
+                ('a', 'Authors, American'),
+                ('y', '19th century'),
+                ('x', 'Biography.'),
+            ],
+            {
+                'subject_times': ['19th century'],
+                'subjects': ['American Authors', 'Biography'],
+            },
+        ),
+        (
+            [('a', 'Western stories'), ('x', 'History and criticism.')],
+            {'subjects': ['Western stories', 'History and criticism']},
+        ),
+        (
+            [
+                ('a', 'United States'),
+                ('x', 'History'),
+                ('y', 'Revolution, 1775-1783'),
+                ('x', 'Influence.'),
+            ],
+            # TODO: this expectation does not capture the intent or ordering of the original MARC, investigate x subfield!
+            {
+                'subject_times': ['Revolution, 1775-1783'],
+                'subjects': ['United States', 'Influence', 'History'],
+            },
+        ),
+        # 'United States -- History -- Revolution, 1775-1783 -- Influence.'
+        (
+            [
+                ('a', 'West Indies, British'),
+                ('x', 'History'),
+                ('y', '18th century.'),
+            ],
+            {
+                'subject_times': ['18th century'],
+                'subjects': ['British West Indies', 'History'],
+            },
+        ),
+        # 'West Indies, British -- History -- 18th century.'),
+        (
+            [
+                ('a', 'Great Britain'),
+                ('x', 'Relations'),
+                ('z', 'West Indies, British.'),
+            ],
+            {
+                'subject_places': ['British West Indies'],
+                'subjects': ['Great Britain', 'Relations'],
+            },
+        ),
+        # 'Great Britain -- Relations -- West Indies, British.'),
+        (
+            [
+                ('a', 'West Indies, British'),
+                ('x', 'Relations'),
+                ('z', 'Great Britain.'),
+            ],
+            {
+                'subject_places': ['Great Britain'],
+                'subjects': ['British West Indies', 'Relations'],
+            },
+        )
+        # 'West Indies, British -- Relations -- Great Britain.')
+    ]
+    for value, expect in data:
+        output = subjects_for_work(MockRecord('650', value))
+        assert sorted(output) == sorted(expect)
+        for key in ('subjects', 'subject_places', 'subject_times'):
+            assert sorted(output.get(key, [])) == sorted(expect.get(key, []))
 
-        for value, expect in data:
-            output = read_title(MockRecord('245', value))
-            assert expect == output
 
-    def test_by_statement(self):
-        data = [
-            (
-                [
-                    ('a', 'Trois contes de No\u0308el'),
-                    ('c', '[par] Madame Georges Renard,'),
-                    ('c', 'edited by F. Th. Meylan ...'),
-                ],
-                {
-                    'title': 'Trois contes de No\u0308el',
-                    'by_statement': '[par] Madame Georges Renard, edited by F. Th. Meylan ...',
-                },
-            )
-        ]
-        for value, expect in data:
-            output = read_title(MockRecord('245', value))
-            assert expect == output
+def test_read_title():
+    data = [
+        (
+            [
+                ('a', 'Railroad construction.'),
+                ('b', 'Theory and practice.'),
+                (
+                    'b',
+                    'A textbook for the use of students in colleges and technical schools.',
+                ),
+            ],
+            {
+                'title': 'Railroad construction',
+                # TODO: Investigate whether this colon between subtitles is spaced correctly
+                'subtitle': 'Theory and practice : A textbook for the use of students in colleges and technical schools',
+            },
+        )
+    ]
+    for value, expect in data:
+        output = read_title(MockRecord('245', value))
+        assert output == expect
+
+
+def test_by_statement():
+    data = [
+        (
+            [
+                ('a', 'Trois contes de No\u0308el'),
+                ('c', '[par] Madame Georges Renard,'),
+                ('c', 'edited by F. Th. Meylan ...'),
+            ],
+            {
+                'title': 'Trois contes de No\u0308el',
+                'by_statement': '[par] Madame Georges Renard, edited by F. Th. Meylan ...',
+            },
+        )
+    ]
+    for value, expect in data:
+        output = read_title(MockRecord('245', value))
+        assert output == expect


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Migrate from class-based tests to function-based tests.
> ~# TODO: refactor to not use unittest~

Before and after: `5 passed, 1 warning in 0.11s`
* `docker compose run --rm home pytest openlibrary/catalog/marc/tests/test_marc.py`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What do you think should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to ensure that relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
