### PR TITLE
Remove unnecessary imports from tests

### DIFF
--- a/openlibrary/plugins/importapi/tests/test_code.py
+++ b/openlibrary/plugins/importapi/tests/test_code.py
@@ -1,5 +1,5 @@
 from .. import code
-from openlibrary.catalog.add_book.tests.conftest import add_languages
+from openlibrary.catalog.add_book.tests.conftest import add_languages  # noqa: F401
 import web
 import pytest
 

--- a/openlibrary/plugins/importapi/tests/test_code_ils.py
+++ b/openlibrary/plugins/importapi/tests/test_code_ils.py
@@ -1,6 +1,5 @@
 import datetime
 from openlibrary.plugins.importapi import code
-from openlibrary.mocks.mock_infobase import MockSite
 
 """Tests for Koha ILS (Integrated Library System) code.
 """

--- a/openlibrary/plugins/openlibrary/tests/test_home.py
+++ b/openlibrary/plugins/openlibrary/tests/test_home.py
@@ -1,14 +1,10 @@
 import datetime
-import pytest
 import web
 
-from infogami.utils import template, context
-from openlibrary.i18n import gettext
 from openlibrary.core.admin import Stats
 from openlibrary.mocks.mock_infobase import MockSite
 from bs4 import BeautifulSoup
 
-from openlibrary import core
 from openlibrary.plugins.openlibrary import home
 
 

--- a/openlibrary/plugins/openlibrary/tests/test_listapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_listapi.py
@@ -1,5 +1,4 @@
 # from py.test import config
-import web
 import json
 
 import cookielib

--- a/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
+++ b/openlibrary/plugins/openlibrary/tests/test_ratingsapi.py
@@ -1,11 +1,9 @@
 # from py.test import config
-import web
 import json
 
 import cookielib
 import urllib
 
-from openlibrary.plugins.openlibrary.api import ratings
 from openlibrary import accounts
 from openlibrary.core import models
 

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -1,1 +1,0 @@
-"""py.test tests for borrow.py"""

--- a/openlibrary/plugins/upstream/tests/test_borrow.py
+++ b/openlibrary/plugins/upstream/tests/test_borrow.py
@@ -1,3 +1,1 @@
 """py.test tests for borrow.py"""
-import web
-from .. import borrow

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -1,6 +1,6 @@
 from openlibrary.mocks.mock_infobase import MockSite
 from .. import utils
-from openlibrary.catalog.add_book.tests.conftest import add_languages
+from openlibrary.catalog.add_book.tests.conftest import add_languages  # noqa: F401
 import web
 import pytest
 

--- a/scripts/tests/test_solr_updater.py
+++ b/scripts/tests/test_solr_updater.py
@@ -1,4 +1,3 @@
-from importlib import import_module
 import sys
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->

Use [`ruff rule F401`](https://beta.ruff.rs/docs/rules/#pyflakes-f) to find unnecessary imports in test files.  If the tests continue to pass then the imports are indeed unnecessary.  This process makes it clear that `add_languages` is an import that has useful side effects.

Should `openlibrary/plugins/upstream/tests/test_borrow.py` just be deleted?

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What do you think should be noted about the implementation? -->

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to ensure that relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
