### PR TITLE
Disable new ruff rule PERF401

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.275
+    rev: v0.0.276
     hooks:
       - id: ruff
 
@@ -66,7 +66,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.43.0
+    rev: v8.44.0
     hooks:
       - id: eslint
         types: [file]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ ignore = [
   "F401",
   "F841",
   "I",
+  "PERF401",
   "PIE790",
   "PLC1901",
   "PLR5501",
@@ -175,6 +176,7 @@ max-statements = 70
 "openlibrary/plugins/upstream/utils.py" = ["BLE001"]
 "openlibrary/solr/update_work.py" = ["C901", "E722", "PLR0912", "PLR0915"]
 "openlibrary/utils/retry.py" = ["BLE001"]
+"openlibrary/utils/schema.py" = ["PERF402"]
 "openlibrary/utils/tests/test_retry.py" = ["PT012", "PT017"]
 "scripts/affiliate_server*.py" = ["SIM105"]
 "scripts/copydocs.py" = ["BLE001"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,5 +9,5 @@ pymemcache==4.0.0
 pytest==7.3.2
 pytest-asyncio==0.21.0
 pytest-cov==4.1.0
-ruff==0.0.275
+ruff==0.0.276
 safety==2.3.5


### PR DESCRIPTION
[ruff v0.0.276](https://github.com/astral-sh/ruff/releases) adds:
* `PERF401` Use a list comprehension to create a transformed list
* `PERF402` Use `list` or `list.copy` to create a copy of a list

Let's temporarily disable these rules until we can provide proper fixes.

% `ruff .`
```
openlibrary/catalog/add_book/__init__.py:329:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/marc/marc_base.py:46:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/marc/parse.py:125:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/marc/parse.py:486:21: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/marc/parse.py:499:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/marc/tests/test_marc.py:11:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/marc/tests/test_marc.py:17:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/catalog/utils/__init__.py:237:9: PERF401 Use a list comprehension to create a transformed list
openlibrary/core/lending.py:165:9: PERF401 Use a list comprehension to create a transformed list
openlibrary/core/observations.py:586:21: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/admin/mem.py:62:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/admin/mem.py:66:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/admin/services.py:73:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/importapi/import_rdf.py:15:9: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/upstream/utils.py:329:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/upstream/utils.py:1293:21: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/worksearch/code.py:445:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/plugins/worksearch/schemes/works.py:418:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/solr/data_provider.py:449:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/solr/data_provider.py:457:17: PERF401 Use a list comprehension to create a transformed list
openlibrary/solr/data_provider.py:505:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/solr/data_provider.py:539:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/solr/types_generator.py:70:9: PERF401 Use a list comprehension to create a transformed list
openlibrary/solr/update_work.py:1298:13: PERF401 Use a list comprehension to create a transformed list
openlibrary/utils/bulkimport.py:307:21: PERF401 Use a list comprehension to create a transformed list
openlibrary/utils/schema.py:254:17: PERF402 Use `list` or `list.copy` to create a copy of a list
scripts/affiliate_server.py:122:13: PERF401 Use a list comprehension to create a transformed list
scripts/copydocs.py:210:17: PERF401 Use a list comprehension to create a transformed list
Found 28 errors.
```