### PR TITLE
Add type hints to upstream/utils.py

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1,6 +1,6 @@
 import functools
-from typing import Any
-from collections.abc import Iterable, Iterator
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable, Iterable, Iterator
 import unicodedata
 
 import web
@@ -33,12 +33,26 @@ from infogami import config
 from infogami.utils import view, delegate, stats
 from infogami.utils.view import render, get_template, public, query_param
 from infogami.utils.macro import macro
-from infogami.utils.context import context
-from infogami.infobase.client import Thing, Changeset, storify
+from infogami.utils.context import InfogamiContext, context
+from infogami.infobase.client import Nothing, storify
 
 from openlibrary.core.helpers import commify, parse_datetime, truncate
 from openlibrary.core.middleware import GZipMiddleware
 from openlibrary.core import cache
+
+from web.utils import Storage
+from web.template import TemplateResult
+
+if TYPE_CHECKING:
+    from openlibrary.core.models import Thing, List
+    from openlibrary.plugins.upstream.models import (
+        AddBookChangeset,
+        Changeset,
+        ListChangeset,
+        Work,
+        Author,
+        Edition,
+    )
 
 
 STRIP_CHARS = ",'\" "
@@ -62,6 +76,9 @@ class LanguageNoMatchError(Exception):
 class MultiDict(MutableMapping):
     """Ordered Dictionary that can store multiple values.
 
+    Must be initialized without an `items` parameter, or `items` must be an
+    iterable of two-value sequences. E.g., items=(('a', 1), ('b', 2))
+
     >>> d = MultiDict()
     >>> d['x'] = 1
     >>> d['x'] = 2
@@ -80,10 +97,12 @@ class MultiDict(MutableMapping):
     [('x', 1), ('x', 2), ('y', 3)]
     >>> list(d.multi_items())
     [('x', [1, 2]), ('y', [3])]
+    >>> d1 = MultiDict(items=(('a', 1), ('b', 2)), a=('x', 10, 11, 12))
+    [('a', [1, ('x', 10, 11, 12)]), ('b', [2])]
     """
 
-    def __init__(self, items=(), **kw):
-        self._items = []
+    def __init__(self, items: Iterable[tuple[Any, Any]] = (), **kw) -> None:
+        self._items: list = []
 
         for k, v in items:
             self[k] = v
@@ -95,7 +114,7 @@ class MultiDict(MutableMapping):
         else:
             raise KeyError(key)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         self._items.append((key, value))
 
     def __delitem__(self, key):
@@ -111,18 +130,21 @@ class MultiDict(MutableMapping):
         return [v for k, v in self._items if k == key]
 
     def keys(self):
-        return [k for k, v in self._items]
+        return [k for k, _ in self._items]
 
-    def values(self):
-        return [v for k, v in self._items]
+    # Subclasses of MutableMapping should return a dictionary view object for
+    # the values() method, but this implementation returns a list.
+    # https://docs.python.org/3/library/stdtypes.html#dict-views
+    def values(self) -> list[Any]:  # type: ignore[override]
+        return [v for _, v in self._items]
 
     def items(self):
         return self._items[:]
 
-    def multi_items(self):
-        """Returns items as tuple of key and a list of values."""
+    def multi_items(self) -> list[tuple[str, list]]:
+        """Returns items as list of tuples of key and a list of values."""
         items = []
-        d = {}
+        d: dict = {}
 
         for k, v in self._items:
             if k not in d:
@@ -134,7 +156,7 @@ class MultiDict(MutableMapping):
 
 @macro
 @public
-def render_template(name, *a, **kw):
+def render_template(name: str, *a, **kw) -> TemplateResult:
     if "." in name:
         name = name.rsplit(".", 1)[0]
     return render[name](*a, **kw)
@@ -155,7 +177,9 @@ def kebab_case(upper_camel_case: str) -> str:
 
 
 @public
-def render_component(name: str, attrs: dict | None = None, json_encode: bool = True):
+def render_component(
+    name: str, attrs: dict | None = None, json_encode: bool = True
+) -> str:
     """
     :param str name: Name of the component (excluding extension)
     :param dict attrs: attributes to add to the component element
@@ -196,12 +220,14 @@ def get_error(name, *args):
 
 
 @public
-def get_message(name, *args):
+def get_message(name: str, *args) -> str:
     """Return message with given name from messages.tmpl template"""
     return get_message_from_template("messages", name, args)
 
 
-def get_message_from_template(template_name, name, args):
+def get_message_from_template(
+    template_name: str, name: str, args: tuple[(Any, ...)]
+) -> str:
     d = render_template(template_name).get("messages", {})
     msg = d.get(name) or name.lower().replace("_", " ")
 
@@ -231,7 +257,7 @@ def list_recent_pages(path, limit=100, offset=0):
 
 
 @public
-def commify_list(items: Iterable[Any]):
+def commify_list(items: Iterable[Any]) -> str:
     # Not sure why lang is sometimes ''
     lang = web.ctx.lang or 'en'
     # If the list item is a template/html element, we strip it
@@ -244,7 +270,7 @@ def json_encode(d):
     return json.dumps(d)
 
 
-def unflatten(d, separator="--"):
+def unflatten(d: Storage, separator: str = "--") -> Storage:
     """Convert flattened data into nested form.
 
     >>> unflatten({"a": 1, "b--x": 2, "b--y": 3, "c--0": 4, "c--1": 5})
@@ -274,11 +300,11 @@ def unflatten(d, separator="--"):
             if all(isint(k) for k in d):
                 return [makelist(d[k]) for k in sorted(d, key=int)]
             else:
-                return web.storage((k, makelist(v)) for k, v in d.items())
+                return Storage((k, makelist(v)) for k, v in d.items())
         else:
             return d
 
-    d2 = {}
+    d2: dict = {}
     for k, v in d.items():
         setvalue(d2, k, v)
     return makelist(d2)
@@ -333,7 +359,9 @@ def get_coverstore_public_url() -> str:
     return config.get('coverstore_public_url', get_coverstore_url()).rstrip('/')
 
 
-def _get_changes_v1_raw(query, revision=None):
+def _get_changes_v1_raw(
+    query: dict[str, str | int], revision: int | None = None
+) -> list[Storage]:
     """Returns the raw versions response.
 
     Revision is taken as argument to make sure a new cache entry is used when a new revision of the page is created.
@@ -348,17 +376,19 @@ def _get_changes_v1_raw(query, revision=None):
         v.author = v.author and v.author.key
 
         # XXX-Anand: hack to avoid too big data to be stored in memcache.
-        # v.changes is not used and it contrinutes to memcache bloat in a big way.
+        # v.changes is not used and it contributes to memcache bloat in a big way.
         v.changes = '[]'
 
     return versions
 
 
-def get_changes_v1(query, revision=None):
+def get_changes_v1(
+    query: dict[str, str | int], revision: int | None = None
+) -> list[Storage]:
     # uses the cached function _get_changes_v1_raw to get the raw data
     # and processes to before returning.
     def process(v):
-        v = web.storage(v)
+        v = Storage(v)
         v.created = parse_datetime(v.created)
         v.author = v.author and web.ctx.site.get(v.author, lazy=True)
         return v
@@ -366,7 +396,9 @@ def get_changes_v1(query, revision=None):
     return [process(v) for v in _get_changes_v1_raw(query, revision)]
 
 
-def _get_changes_v2_raw(query, revision=None):
+def _get_changes_v2_raw(
+    query: dict[str, str | int], revision: int | None = None
+) -> list[dict]:
     """Returns the raw recentchanges response.
 
     Revision is taken as argument to make sure a new cache entry is used when a new revision of the page is created.
@@ -382,7 +414,9 @@ def _get_changes_v2_raw(query, revision=None):
 # _get_changes_v2_raw = cache.memcache_memoize(_get_changes_v2_raw, key_prefix="upstream._get_changes_v2_raw", timeout=10*60)
 
 
-def get_changes_v2(query, revision=None):
+def get_changes_v2(
+    query: dict[str, str | int], revision: int | None = None
+) -> list["Changeset | AddBookChangeset | ListChangeset"]:
     page = web.ctx.site.get(query['key'])
 
     def first(seq, default=None):
@@ -415,13 +449,15 @@ def get_changes_v2(query, revision=None):
     return [process_change(c) for c in changes]
 
 
-def get_changes(query, revision=None):
+def get_changes(
+    query: dict[str, str | int], revision: int | None = None
+) -> list["Changeset | AddBookChangeset | ListChangeset"]:
     return get_changes_v2(query, revision=revision)
 
 
 @public
-def get_history(page):
-    h = web.storage(
+def get_history(page: "Work | Author | Edition") -> Storage:
+    h = Storage(
         revision=page.revision, lastest_revision=page.revision, created=page.created
     )
     if h.revision < 5:
@@ -447,12 +483,13 @@ def get_version(key, revision):
 
 
 @public
-def get_recent_author(doc):
+def get_recent_author(doc: "Work") -> "Thing | None":
     versions = get_changes_v1(
         {'key': doc.key, 'limit': 1, "offset": 0}, revision=doc.revision
     )
     if versions:
         return versions[0].author
+    return None
 
 
 @public
@@ -471,13 +508,19 @@ def get_locale():
 
 
 @public
-def process_version(v):
+def process_version(
+    v: "List | AddBookChangeset | Changeset | ListChangeset",
+) -> "List | AddBookChangeset | Changeset | ListChangeset":
     """Looks at the version and adds machine_comment required for showing "View MARC" link."""
     comments = [
         "found a matching marc record",
         "add publisher and source",
     ]
-    if v.key.startswith('/books/') and not v.get('machine_comment'):
+    if (
+        isinstance(v, List)
+        and v.key.startswith('/books/')
+        and not v.get('machine_comment')
+    ):
         thing = v.get('thing') or web.ctx.site.get(v.key, v.revision)
         if (
             thing.source_records
@@ -498,18 +541,18 @@ def is_thing(t):
 
 
 @public
-def putctx(key, value):
+def putctx(key: str, value: str | bool) -> str:
     """Save a value in the context."""
     context[key] = value
     return ""
 
 
 class Metatag:
-    def __init__(self, tag="meta", **attrs):
+    def __init__(self, tag: str = "meta", **attrs) -> None:
         self.tag = tag
         self.attrs = attrs
 
-    def __str__(self):
+    def __str__(self) -> str:
         attrs = ' '.join(f'{k}="{websafe(v)}"' for k, v in self.attrs.items())
         return f'<{self.tag} {attrs} />'
 
@@ -518,13 +561,13 @@ class Metatag:
 
 
 @public
-def add_metatag(tag="meta", **attrs):
+def add_metatag(tag: str = "meta", **attrs) -> None:
     context.setdefault('metatags', [])
     context.metatags.append(Metatag(tag, **attrs))
 
 
 @public
-def url_quote(text):
+def url_quote(text: str | bytes) -> str:
     if isinstance(text, str):
         text = text.encode('utf8')
     return urllib.parse.quote_plus(text)
@@ -546,12 +589,14 @@ def urlencode(dict_or_list_of_tuples: dict | list[tuple[str, Any]]) -> str:
 
 
 @public
-def entity_decode(text):
+def entity_decode(text: str) -> str:
     return unescape(text)
 
 
 @public
-def set_share_links(url='#', title='', view_context=None):
+def set_share_links(
+    url: str = '#', title: str = '', view_context: InfogamiContext | None = None
+) -> None:
     """
     Constructs list share links for social platforms and assigns to view context attribute
 
@@ -576,7 +621,8 @@ def set_share_links(url='#', title='', view_context=None):
             'url': f'https://pinterest.com/pin/create/link/?url={encoded_url}&description={text}',
         },
     ]
-    view_context.share_links = links
+    if view_context is not None:
+        view_context.share_links = links
 
 
 def pad(seq, size, e=None):
@@ -618,19 +664,19 @@ def parse_toc_row(line):
         title = text
         label = page = ""
 
-    return web.storage(
+    return Storage(
         level=len(level), label=label.strip(), title=title.strip(), pagenum=page.strip()
     )
 
 
-def parse_toc(text):
+def parse_toc(text: None) -> list[Any]:
     """Parses each line of toc"""
     if text is None:
         return []
     return [parse_toc_row(line) for line in text.splitlines() if line.strip(" |")]
 
 
-def safeget(func):
+def safeget(func: Callable) -> Any:
     """
     TODO: DRY with solrbuilder copy
     >>> safeget(lambda: {}['foo'])
@@ -665,7 +711,7 @@ def get_languages() -> dict:
     return {lang.key: lang for lang in web.ctx.site.get_many(keys)}
 
 
-def autocomplete_languages(prefix: str) -> Iterator[web.storage]:
+def autocomplete_languages(prefix: str) -> Iterator[Storage]:
     """
     Given, e.g., "English", this returns an iterator of:
         <Storage {'key': '/languages/ang', 'code': 'ang', 'name': 'English, Old (ca. 450-1100)'}>
@@ -681,7 +727,7 @@ def autocomplete_languages(prefix: str) -> Iterator[web.storage]:
     for lang in get_languages().values():
         user_lang_name = safeget(lambda: lang['name_translated'][user_lang][0])
         if user_lang_name and normalize(user_lang_name).startswith(prefix):
-            yield web.storage(
+            yield Storage(
                 key=lang.key,
                 code=lang.code,
                 name=user_lang_name,
@@ -691,7 +737,7 @@ def autocomplete_languages(prefix: str) -> Iterator[web.storage]:
         lang_iso_code = safeget(lambda: lang['identifiers']['iso_639_1'][0])
         native_lang_name = safeget(lambda: lang['name_translated'][lang_iso_code][0])
         if native_lang_name and normalize(native_lang_name).startswith(prefix):
-            yield web.storage(
+            yield Storage(
                 key=lang.key,
                 code=lang.code,
                 name=native_lang_name,
@@ -699,7 +745,7 @@ def autocomplete_languages(prefix: str) -> Iterator[web.storage]:
             continue
 
         if normalize(lang.name).startswith(prefix):
-            yield web.storage(
+            yield Storage(
                 key=lang.key,
                 code=lang.code,
                 name=lang.name,
@@ -745,7 +791,7 @@ def get_abbrev_from_full_lang_name(input_lang_name: str, languages=None) -> str:
     return target_abbrev
 
 
-def get_language(lang_or_key: Thing | str) -> Thing | None:
+def get_language(lang_or_key: str) -> "None | Thing | Nothing":
     if isinstance(lang_or_key, str):
         return get_languages().get(lang_or_key)
     else:
@@ -753,7 +799,7 @@ def get_language(lang_or_key: Thing | str) -> Thing | None:
 
 
 @public
-def get_language_name(lang_or_key: Thing | str):
+def get_language_name(lang_or_key: "Nothing | str | Thing") -> Nothing | str:
     if isinstance(lang_or_key, str):
         lang = get_language(lang_or_key)
         if not lang:
@@ -762,7 +808,7 @@ def get_language_name(lang_or_key: Thing | str):
         lang = lang_or_key
 
     user_lang = web.ctx.lang or 'en'
-    return safeget(lambda: lang['name_translated'][user_lang][0]) or lang.name
+    return safeget(lambda: lang['name_translated'][user_lang][0]) or lang.name  # type: ignore[index]
 
 
 @functools.cache
@@ -792,14 +838,14 @@ def _get_author_config():
     """
     thing = web.ctx.site.get('/config/author')
     if hasattr(thing, "identifiers"):
-        identifiers = [web.storage(t.dict()) for t in thing.identifiers if 'name' in t]
+        identifiers = [Storage(t.dict()) for t in thing.identifiers if 'name' in t]
     else:
         identifiers = {}
-    return web.storage(identifiers=identifiers)
+    return Storage(identifiers=identifiers)
 
 
 @public
-def get_edition_config():
+def get_edition_config() -> Storage:
     return _get_edition_config()
 
 
@@ -812,12 +858,10 @@ def _get_edition_config():
     This is is cached because fetching and creating the Thing object was taking about 20ms of time for each book request.
     """
     thing = web.ctx.site.get('/config/edition')
-    classifications = [
-        web.storage(t.dict()) for t in thing.classifications if 'name' in t
-    ]
-    identifiers = [web.storage(t.dict()) for t in thing.identifiers if 'name' in t]
+    classifications = [Storage(t.dict()) for t in thing.classifications if 'name' in t]
+    identifiers = [Storage(t.dict()) for t in thing.identifiers if 'name' in t]
     roles = thing.roles
-    return web.storage(
+    return Storage(
         classifications=classifications, identifiers=identifiers, roles=roles
     )
 
@@ -825,7 +869,7 @@ def _get_edition_config():
 from openlibrary.core.olmarkdown import OLMarkdown
 
 
-def get_markdown(text, safe_mode=False):
+def get_markdown(text: str, safe_mode: bool = False) -> OLMarkdown:
     md = OLMarkdown(source=text, safe_mode=safe_mode)
     view._register_mdx_extensions(md)
     md.postprocessors += view.wiki_processors
@@ -845,10 +889,10 @@ class HTML(str):
 _websafe = web.websafe
 
 
-def websafe(text):
+def websafe(text: str) -> str:
     if isinstance(text, HTML):
         return text
-    elif isinstance(text, web.template.TemplateResult):
+    elif isinstance(text, TemplateResult):
         return web.safestr(text)
     else:
         return _websafe(text)
@@ -933,10 +977,10 @@ def _get_recent_changes():
     result = result[:50]
 
     def process_thing(thing):
-        t = web.storage()
+        t = Storage()
         for k in ["key", "title", "name", "displayname"]:
             t[k] = thing[k]
-        t['type'] = web.storage(key=thing.type.key)
+        t['type'] = Storage(key=thing.type.key)
         return t
 
     for r in result:
@@ -1032,7 +1076,7 @@ _get_blog_feeds = cache.memcache_memoize(
 
 
 @public
-def get_donation_include():
+def get_donation_include() -> str:
     ia_host = get_ia_host(allow_dev=True)
     # The following allows archive.org staff to test banners without
     # needing to reload openlibrary services
@@ -1059,7 +1103,7 @@ def get_donation_include():
 
 
 @public
-def get_ia_host(allow_dev=False):
+def get_ia_host(allow_dev: bool = False) -> str:
     if allow_dev:
         web_input = web.input()
         dev_host = web_input.pop("dev_host", "")  # e.g. `www-user`
@@ -1070,7 +1114,7 @@ def get_ia_host(allow_dev=False):
 
 
 @public
-def item_image(image_path, default=None):
+def item_image(image_path: str | None, default: str | None = None) -> str | None:
     if image_path is None:
         return default
     if image_path.startswith('https:'):
@@ -1079,9 +1123,9 @@ def item_image(image_path, default=None):
 
 
 @public
-def get_blog_feeds():
+def get_blog_feeds() -> list[Storage]:
     def process(post):
-        post = web.storage(post)
+        post = Storage(post)
         post.pubdate = parse_datetime(post.pubdate)
         return post
 
@@ -1095,7 +1139,7 @@ class Request:
     fullpath = property(lambda self: web.ctx.fullpath)
 
     @property
-    def canonical_url(self):
+    def canonical_url(self) -> str:
         """Returns the https:// version of the URL.
 
         Used for adding <meta rel="canonical" ..> tag in all web pages.
@@ -1124,7 +1168,7 @@ class Request:
 
 
 @public
-def render_once(key):
+def render_once(key: str) -> bool:
     rendered = web.ctx.setdefault('render_once', {})
     if key in rendered:
         return False
@@ -1260,7 +1304,7 @@ def get_location_and_publisher(loc_pub: str) -> tuple[list[str], list[str]]:
     return ([], [loc_pub.strip(STRIP_CHARS)])
 
 
-def setup():
+def setup() -> None:
     """Do required initialization"""
     # monkey-patch get_markdown to use OL Flavored Markdown
     view.get_markdown = get_markdown


### PR DESCRIPTION
Related: #8028 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix for a pair of errors introduced in #7998 that caused a template error when processing a work.

The two errors I introduced came about because of reliance on `if TYPE_CHECKING: ...` to get around circular imports errors. However, two of the items so imported were actually called, rather than merely being used for type checking. This PR fixes that.

I reverted #7998 rather than create a new PR to fix the two import errors because I couldn't decide on a good way to handle typing `process_version`, where one of the errors was introduced.

I opted here to use composition with `Protocol`, such that `process_version` will type check with model that satisfies the following interface:
```python
class HasGetKeyRevision(Protocol):
    key: str
    revision: int

    def get(self, item) -> Any:
        ...
```
For reference, `process_version` is as follows:
```python
@public
def process_version(v: HasGetKeyRevision) -> HasGetKeyRevision:
    """Looks at the version and adds machine_comment required for showing "View MARC" link."""
    comments = [
        "found a matching marc record",
        "add publisher and source",
    ]

    if v.key.startswith('/books/') and not v.get('machine_comment'):
        thing = v.get('thing') or web.ctx.site.get(v.key, v.revision)
        if (
            thing.source_records
            and v.revision == 1
            or (v.comment and v.comment.lower() in comments)  # type: ignore [attr-defined]
        ):
            marc = thing.source_records[-1]
            if marc.startswith('marc:'):
                v.machine_comment = marc[len("marc:") :]  # type: ignore [attr-defined]
            else:
                v.machine_comment = marc  # type: ignore [attr-defined]
    return v
```
The types that go through `process_version` currently include `openlibrary.core.models.List`, `openlibrary.plugins.upstream.models.Changeset` (and not `infogami.infobase.client.Changeset`, used elsewhere the file), along with `Storage`, and `AddBookChangeset` and `ListChangeset`, both from `openlibrary.plugins.upstream.models`. But this list may not be exhaustive.

Because the list might not be exhaustive, I figured I'd use `Protocol` so the type checker could verify the passed object has a `get` method and `key` and `revision` attributes.

However, this isn't perfect because `process_version` still _conditionally_ uses other attributes which may not yet exist on the object, such as `machine_comment`, which doesn't exist on all `Storage` items that are passed to this function. Hence the use of `# type: ignore [attr-defined]`, rather than adding those as requirements of the interface. The interface is limited to attributes and methods that _will_ be called on anything passed to `process_version`.

Thoughts?

Note: for anyone looking at this, the relevant changes are applied in the second commit of the two included here. See [this diff](https://github.com/internetarchive/openlibrary/pull/8035/commits/c1550425404b58fded13294eea425c4203538669).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I tested this by loading the site locally, opening an edition, viewing the history, and looking at the MARC record.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
