### PR TITLE
ruff rule UP035: Import from `collections.abc` instead: `Callable`

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 from openlibrary.catalog.marc.get_subjects import subjects_for_work
 from openlibrary.catalog.marc.marc_base import (

--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -5,7 +5,8 @@ import string
 import time
 import threading
 import functools
-from typing import Callable, Literal
+from typing import Literal
+from collections.abc import Callable
 
 import memcache
 import json

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import json
 import logging
 import re
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from collections.abc import Iterable, Mapping
 
 import web

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Callable, Optional, Union
+from typing import Optional, Union
+from collections.abc import Callable
 
 import luqum.tree
 from luqum.exceptions import ParseError

--- a/openlibrary/plugins/worksearch/schemes/authors.py
+++ b/openlibrary/plugins/worksearch/schemes/authors.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
-from typing import Callable, Union
+from typing import Union
+from collections.abc import Callable
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 

--- a/openlibrary/plugins/worksearch/schemes/subjects.py
+++ b/openlibrary/plugins/worksearch/schemes/subjects.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import logging
-from typing import Callable, Union
+from typing import Union
+from collections.abc import Callable
 
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import logging
 import re
 import sys
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 import luqum.tree
 import web

--- a/openlibrary/solr/query_utils.py
+++ b/openlibrary/solr/query_utils.py
@@ -1,4 +1,5 @@
-from typing import Callable, Literal, Optional
+from typing import Literal, Optional
+from collections.abc import Callable
 from luqum.parser import parser
 from luqum.tree import Item, SearchField, BaseOperation, Group, Word, Unary
 import re

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ ignore = [
   "SLF001",
   "UP007",
   "UP031",
-  "UP035",
   "UP038",
 ]
 line-length = 162


### PR DESCRIPTION
% `ruff --select=UP035 .`
```
openlibrary/catalog/marc/parse.py:2:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/core/cache.py:8:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/plugins/upstream/account.py:5:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/plugins/worksearch/schemes/__init__.py:2:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/plugins/worksearch/schemes/authors.py:3:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/plugins/worksearch/schemes/subjects.py:3:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/plugins/worksearch/schemes/works.py:5:1: UP035 [*] Import from `collections.abc` instead: `Callable`
openlibrary/solr/query_utils.py:1:1: UP035 [*] Import from `collections.abc` instead: `Callable`
Found 8 errors.
[*] 8 potentially fixable with the --fix option.
```
% `ruff --select=UP035 --fix .`
```
Found 8 errors (8 fixed, 0 remaining).
```
% `ruff rule UP035`
# deprecated-import (UP035)

Derived from the **pyupgrade** linter.

Autofix is sometimes available.

## What it does
Checks for uses of deprecated imports based on the minimum supported
Python version.

## Why is this bad?
Deprecated imports may be removed in future versions of Python, and
should be replaced with their new equivalents.

Note that, in some cases, it may be preferable to continue importing
members from `typing_extensions` even after they're added to the Python
standard library, as `typing_extensions` can backport bugfixes and
optimizations from later Python versions. This rule thus avoids flagging
imports from `typing_extensions` in such cases.

## Example
```python
from typing import Callable
```

Use instead:
```python
from collections.abc import Callable
```