### PR TITLE
Remove duplicate ReCaptcha script tag

### DIFF
--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -82,9 +82,4 @@ $def with (page)
     <!-- Drini, Google Search Console -->
     <meta name="google-site-verification" content="XYOJ9Uj0MBr6wk7kj1IkttXrqY-bbRstFMADTfEt354" />
 
-    $if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books', '/contact']]):
-        <!-- Must be loaded in Sign Up and Add new Books page -->
-        <!-- Must be loaded for all edit pages having link /books/*/*/edit -->
-        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-
 $putctx("sent_head", True)


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes duplicate `<script>` that fetches the ReCaptcha library.  The same code can be found in the `/site/footer.html` template, [here](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/templates/site/footer.html#L46-L49).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
