### PR TITLE
Hyphenate ISBNs in Wikipedia cite book templates

### DIFF
--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -6,7 +6,7 @@ import sys
 import web
 
 from collections import defaultdict
-from isbnlib import canonical
+from isbnlib import canonical, mask
 
 from infogami import config
 from infogami.infobase import client
@@ -450,7 +450,7 @@ class Edition(models.Edition):
                 else None,
                 'publication-place': self.get('publish_places', [None])[0],
                 'publisher': self.get('publishers', [None])[0],
-                'isbn': isbns[0],
+                'isbn': mask(isbns[0]),
                 'issn': self.get('identifiers', {}).get('issn', [None])[0],
             }
         )

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -110,7 +110,7 @@ class Edition(models.Edition):
             isbn = mask(isbns[0])
         except NotValidISBNError:
             return isbns[0]
-        return isbn if isbn else isbns[0]
+        return isbn or isbns[0]
 
     def get_identifiers(self):
         """Returns (name, value) pairs of all available identifiers."""
@@ -445,8 +445,8 @@ class Edition(models.Edition):
         if len(authors) == 1:
             citation['author'] = authors[0].name
         else:
-            for i, a in enumerate(authors):
-                citation[f'author{i + 1}'] = a.name
+            for i, a in enumerate(authors, 1):
+                citation[f'author{i}'] = a.name
 
         citation.update(
             {


### PR DESCRIPTION

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Hyphenates the record's ISBN when generating a Wikipedia citation.

Adds a `get_isbnmask()` method to the model to return one masked (if possible) ISBN.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/905545/23ad2e42-f3b0-4f35-ae32-045fef090adc)

```
{{cite book|author=Lawrence Lessig |date=2008 |title=Remix |url=https://archive.org/details/remixmakingartco01lessrich |publication-place=London |publisher=Bloomsbury Academic |isbn=978-1-4081-1347-9 |oclc=263296519 |ol=24218235M}}
```
### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
