### PR TITLE
Handle gitpod dynamic repo root

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,11 +16,11 @@ tasks:
 - name: Start App
   before: |
     # run chown because https://github.com/gitpod-io/gitpod/issues/4851
-    sudo chown -R gitpod:999 /workspace/openlibrary
+    sudo chown -R gitpod:999 $GITPOD_REPO_ROOT
     # Give container (ie group) write access to this volume
-    sudo chmod g+w -R /workspace/openlibrary/
+    sudo chmod g+w -R $GITPOD_REPO_ROOT
     # because: https://github.com/gitpod-io/gitpod/issues/9311
-    chmod o+rx /workspace/openlibrary
+    chmod o+rx $GITPOD_REPO_ROOT
   # init runs once for each commit to the default branch
   init: docker compose up --no-start && gp sync-done docker-up
   # command runs each time a user starts their workspace


### PR DESCRIPTION
Sometimes the repo will be at /workspace/openlibrary-1


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
