### PR TITLE
Fix implicitly concatenated string literals on one line

### DIFF
--- a/openlibrary/core/db.py
+++ b/openlibrary/core/db.py
@@ -163,7 +163,7 @@ def _proxy(method_name):
         return result
 
     f.__name__ = method_name
-    f.__doc__ = "Equivalent to get_db().%s(*args, **kwargs)." "" % method_name
+    f.__doc__ = f"Equivalent to get_db().{method_name}(*args, **kwargs)."
     return f
 
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -137,9 +137,7 @@ class internal_audit(delegate.page):
                     email=i.email, link=i.itemname, username=i.username
                 )
                 if result is None:
-                    raise ValueError(
-                        'Invalid Open Library account email ' 'or itemname'
-                    )
+                    raise ValueError('Invalid Open Library account email or itemname')
                 result.enc_password = 'REDACTED'
                 if i.new_itemname:
                     result.link(i.new_itemname)

--- a/openlibrary/plugins/upstream/tests/test_utils.py
+++ b/openlibrary/plugins/upstream/tests/test_utils.py
@@ -158,7 +158,7 @@ def test_reformat_html():
         f(multi_line_string) == 'This sentence has 32 '
         'characters.<br>This new sentence has 36 characters.'
     )
-    assert f(multi_line_string, 34) == 'This sentence has 32 ' 'characters.<br>T...'
+    assert f(multi_line_string, 34) == 'This sentence has 32 characters.<br>T...'
 
     assert f("<script>alert('hello')</script>", 34) == "alert(&#39;hello&#39;)"
     assert f("&lt;script&gt;") == "&lt;script&gt;"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ ignore = [
   "F401",
   "F841",
   "I",
+  "ISC003",
   "PERF401",
   "PIE790",
   "PLC1901",
@@ -79,6 +80,7 @@ select = [
   "I",       # isort
   "ICN",     # flake8-import-conventions
   "INT",     # flake8-gettext
+  "ISC",     # flake8-implicit-str-concat
   "PERF",    # Perflint
   "PIE",     # flake8-pie
   "PL",      # Pylint
@@ -108,7 +110,6 @@ select = [
   # "FIX",   # flake8-fixme
   # "G",     # flake8-logging-format
   # "INP",   # flake8-no-pep420
-  # "ISC",   # flake8-implicit-str-concat
   # "N",     # pep8-naming
   # "NPY",   # NumPy-specific rules
   # "PD",    # pandas-vet


### PR DESCRIPTION
<!-- What issue does this PR close? -->
% `ruff rule ISC001`
https://beta.ruff.rs/docs/rules/single-line-implicit-string-concatenation

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
