### PR TITLE
Reduce MARC XML exceptions

### DIFF
--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -36,7 +36,7 @@ def get_marc_record_from_ia(identifier):
     when the /api/import/ia endpoint is POSTed to.
 
     :param str identifier: ocaid
-    :rtype: MarcXML | MarcBinary
+    :rtype: MarcBinary | MarcXML
     """
     metadata = ia.get_metadata(identifier)
     filenames = metadata['_filenames']
@@ -46,7 +46,12 @@ def get_marc_record_from_ia(identifier):
 
     item_base = f'{IA_DOWNLOAD_URL}{identifier}/'
 
-    # Try marc.xml first
+    # Try marc.bin first
+    if marc_bin_filename in filenames:
+        data = urlopen_keep_trying(item_base + marc_bin_filename).content
+        return MarcBinary(data)
+
+    # If that fails, try marc.xml
     if marc_xml_filename in filenames:
         data = urlopen_keep_trying(item_base + marc_xml_filename).content
         try:
@@ -55,11 +60,6 @@ def get_marc_record_from_ia(identifier):
         except Exception as e:
             print("Unable to read MarcXML: %s" % e)
             traceback.print_exc()
-
-    # If that fails, try marc.bin
-    if marc_bin_filename in filenames:
-        data = urlopen_keep_trying(item_base + marc_bin_filename).content
-        return MarcBinary(data)
 
 
 def files(identifier):

--- a/openlibrary/catalog/marc/marc_xml.py
+++ b/openlibrary/catalog/marc/marc_xml.py
@@ -74,7 +74,8 @@ class MarcXml(MarcBase):
             leader_element = self.record[1]
         assert (
             leader_element.tag == leader_tag
-        ), f"{leader_element.tag = } != {leader_tag = }"
+        ), f'MARC XML is possibly corrupt in conversion. \
+             Unexpected non-Leader tag: {leader_element.tag}'
         return get_text(leader_element)
 
     def read_fields(self, want: list[str]) -> Iterator[tuple[str, str | DataField]]:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8022

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Try importing the original MARC Binary first to avoid encountering conversion errors in the XML.

MARC binary imports are the more tested import path. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
