### PR TITLE
More Python f-strings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.277
+    rev: v0.0.278
     hooks:
       - id: ruff
 

--- a/openlibrary/plugins/admin/services.py
+++ b/openlibrary/plugins/admin/services.py
@@ -54,10 +54,8 @@ class Service:
         self.nagios = nagios.get_service_status(name)
 
     def __repr__(self):
-        return "Service(name = '{}', node = '{}', logs = '{}')".format(
-            self.name,
-            self.node,
-            self.logs,
+        return (
+            f"Service(name = '{self.name}', node = '{self.node}', logs = '{self.logs}')"
         )
 
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -146,8 +146,8 @@ class borrow(delegate.page):
             s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
         if not user or not ia_itemname or not s3_keys:
             web.setcookie(config.login_cookie_name, "", expires=-1)
-            redirect_url = "/account/login?redirect={}/borrow?action={}".format(
-                edition_redirect, action
+            redirect_url = (
+                f"/account/login?redirect={edition_redirect}/borrow?action={action}"
             )
             if i._autoReadAloud is not None:
                 redirect_url += '&_autoReadAloud=' + i._autoReadAloud

--- a/scripts/sponsor_update_prices.py
+++ b/scripts/sponsor_update_prices.py
@@ -47,9 +47,7 @@ if __name__ == "__main__":
         orders = session.get('%s/services/orders.aspx?op=History' % BWB_URL).json()
         order_ids = [order['OrderID'] for order in orders['Orders']]
         # NB: We select the *last
-        order_url = '{}/services/orders.aspx?op=Details&OrderID={}'.format(
-            BWB_URL, order_ids[0]
-        )
+        order_url = f'{BWB_URL}/services/orders.aspx?op=Details&OrderID={order_ids[0]}'
         order = session.get(order_url).json()
 
     for orderitem in order['Items']:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
[ruff v0.0.278](https://github.com/astral-sh/ruff/releases/tag/v0.0.278) adds ruff rule UP032.
```
openlibrary/plugins/admin/services.py:57:16: UP032 [*] Use f-string instead of `format` call
openlibrary/plugins/upstream/borrow.py:149:28: UP032 [*] Use f-string instead of `format` call
scripts/sponsor_update_prices.py:50:21: UP032 [*] Use f-string instead of `format` call
```
https://beta.ruff.rs/docs/rules/f-string/#f-string-up032