### PR TITLE
Ossd s23 7416/feature/safe mode

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False)
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False, safe_mode="")
 
 $code:
   max_rendered_authors = 9
@@ -34,8 +34,7 @@ $code:
     full_work_title = doc.get('title', '') + (': ' + doc.subtitle if doc.get('subtitle') else '')
 
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
-  $ safe_mode = True # Placeholder variable
-  $ bookcover_class = "safe-mode-bookcover" if safe_mode else "bookcover"
+  $ bookcover_class = "safe-mode-bookcover" if safe_mode == 'yes' else "bookcover"
   <span class=$bookcover_class>
     $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
     <a href="$work_edition_url"><img
@@ -90,7 +89,7 @@ $code:
           $if doc.get('ia'):
             &mdash; $_('%s previewable', len(doc.get('ia')))
             $if len(doc.get('ia')) > 1:
-              $ preview_cover_class = "safe-mode-preview-covers" if safe_mode else "preview-covers"
+              $ preview_cover_class = "safe-mode-preview-covers" if safe_mode == 'yes' else "preview-covers"
               <span class=$preview_cover_class>
                 $for x, i in enumerate(doc.get('ia')[1:10]):
                   <a href="$(book_url)?edition=ia:$(urlquote(i))">

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -1,4 +1,4 @@
-$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False, safe_mode="")
+$def with (doc, decorations=None, cta=True, availability=None, extra=None, attrs=None, rating=None, reading_log=None, show_librarian_extras=False, blur=False)
 
 $code:
   max_rendered_authors = 9
@@ -34,7 +34,7 @@ $code:
     full_work_title = doc.get('title', '') + (': ' + doc.subtitle if doc.get('subtitle') else '')
 
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
-  $ bookcover_class = "safe-mode-bookcover" if safe_mode == 'yes' else "bookcover"
+  $ bookcover_class = "safe-mode-bookcover" if blur else "bookcover"
   <span class=$bookcover_class>
     $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
     <a href="$work_edition_url"><img
@@ -89,7 +89,7 @@ $code:
           $if doc.get('ia'):
             &mdash; $_('%s previewable', len(doc.get('ia')))
             $if len(doc.get('ia')) > 1:
-              $ preview_cover_class = "safe-mode-preview-covers" if safe_mode == 'yes' else "preview-covers"
+              $ preview_cover_class = "safe-mode-preview-covers" if blur else "preview-covers"
               <span class=$preview_cover_class>
                 $for x, i in enumerate(doc.get('ia')[1:10]):
                   <a href="$(book_url)?edition=ia:$(urlquote(i))">

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -34,7 +34,9 @@ $code:
     full_work_title = doc.get('title', '') + (': ' + doc.subtitle if doc.get('subtitle') else '')
 
 <li class="searchResultItem" itemscope itemtype="https://schema.org/Book" $:attrs>
-  <span class="bookcover">
+  $ safe_mode = True # Placeholder variable
+  $ bookcover_class = "safe-mode-bookcover" if safe_mode else "bookcover"
+  <span class=$bookcover_class>
     $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
     <a href="$work_edition_url"><img
             itemprop="image"
@@ -88,7 +90,8 @@ $code:
           $if doc.get('ia'):
             &mdash; $_('%s previewable', len(doc.get('ia')))
             $if len(doc.get('ia')) > 1:
-              <span class="preview-covers">
+              $ preview_cover_class = "safe-mode-preview-covers" if safe_mode else "preview-covers"
+              <span class=$preview_cover_class>
                 $for x, i in enumerate(doc.get('ia')[1:10]):
                   <a href="$(book_url)?edition=ia:$(urlquote(i))">
                     <img width="30" height="45" loading="lazy" src="//archive.org/services/img/$i" alt="Cover of edition $i">

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -287,6 +287,11 @@ def do_search(
     :param sort: csv sort ordering
     :param spellcheck_count: Not really used; should probably drop
     """
+    
+    if web.cookies(sfw="").sfw == 'yes':
+        fields=list(WorkSearchScheme.default_fetched_fields | {'editions'} | {'subject_key'})
+    else: 
+        fields=list(WorkSearchScheme.default_fetched_fields | {'editions'})
     return run_solr_query(
         WorkSearchScheme(),
         param,
@@ -294,7 +299,7 @@ def do_search(
         page,
         sort,
         spellcheck_count,
-        fields=list(WorkSearchScheme.default_fetched_fields | {'editions'}),
+        fields=fields
     )
 
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -443,6 +443,7 @@ class search(delegate.page):
         for k in ('title', 'author', 'isbn', 'subject', 'place', 'person', 'publisher'):
             if k in i:
                 q_list.append(f'{k}:{fully_escape_query(i[k].strip())}')
+        safe_mode_cookie = web.cookies(sfw="")
         return render.work_search(
             i,
             ' '.join(q_list),
@@ -450,6 +451,7 @@ class search(delegate.page):
             get_doc,
             fulltext_search,
             WorkSearchScheme.facet_fields,
+            safe_mode_cookie.sfw,
         )
 
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -287,19 +287,15 @@ def do_search(
     :param sort: csv sort ordering
     :param spellcheck_count: Not really used; should probably drop
     """
-    
+
     if web.cookies(sfw="").sfw == 'yes':
-        fields=list(WorkSearchScheme.default_fetched_fields | {'editions'} | {'subject_key'})
-    else: 
-        fields=list(WorkSearchScheme.default_fetched_fields | {'editions'})
+        fields = list(
+            WorkSearchScheme.default_fetched_fields | {'editions'} | {'subject_key'}
+        )
+    else:
+        fields = list(WorkSearchScheme.default_fetched_fields | {'editions'})
     return run_solr_query(
-        WorkSearchScheme(),
-        param,
-        rows,
-        page,
-        sort,
-        spellcheck_count,
-        fields=fields
+        WorkSearchScheme(), param, rows, page, sort, spellcheck_count, fields=fields
     )
 
 
@@ -456,7 +452,7 @@ class search(delegate.page):
             get_doc,
             fulltext_search,
             WorkSearchScheme.facet_fields,
-            safe_mode_cookie.sfw,
+            safe_mode_cookie.sfw == 'yes',
         )
 
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -196,16 +196,19 @@ $ )
         <div id="searchResults">
           <ul class="list-books">
             $ works = [get_doc(d) for d in docs]
+            $ subject_keys = [d['subject_key'] for d in docs]
             $ add_availability([(w.get('editions') or [None])[0] or w for w in works])
             $ username = ctx.user and ctx.user.key.split('/')[-1]
             $if username:
                 $ works = add_read_statuses(username, works)
             $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
 
-            $for work in works:
+            $for work,subject_key in zip(works,subject_keys):
                 $ read_status = work.get('readinglog', None)
                 $ dropper = macros.ReadingLogDropper([], work=work, include_lists=False, page_url="/search", users_work_read_status=read_status)
-                $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras, safe_mode=safe_mode)
+                $ content_warning = len([s for s in subject_key if s.startswith("content_warning")]) != 0
+                $ blur = True if content_warning and safe_mode else False
+                $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras, blur=blur)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -1,4 +1,4 @@
-$def with (input, q_param, do_search, get_doc, fulltext_search, facet_fields)
+$def with (input, q_param, do_search, get_doc, fulltext_search, facet_fields, safe_mode)
 
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
 
@@ -205,7 +205,7 @@ $ )
             $for work in works:
                 $ read_status = work.get('readinglog', None)
                 $ dropper = macros.ReadingLogDropper([], work=work, include_lists=False, page_url="/search", users_work_read_status=read_status)
-                $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras)
+                $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras, safe_mode=safe_mode)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -196,19 +196,24 @@ $ )
         <div id="searchResults">
           <ul class="list-books">
             $ works = [get_doc(d) for d in docs]
-            $ subject_keys = [d['subject_key'] for d in docs]
             $ add_availability([(w.get('editions') or [None])[0] or w for w in works])
             $ username = ctx.user and ctx.user.key.split('/')[-1]
             $if username:
                 $ works = add_read_statuses(username, works)
             $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
 
-            $for work,subject_key in zip(works,subject_keys):
-                $ read_status = work.get('readinglog', None)
-                $ dropper = macros.ReadingLogDropper([], work=work, include_lists=False, page_url="/search", users_work_read_status=read_status)
-                $ content_warning = len([s for s in subject_key if s.startswith("content_warning")]) != 0
-                $ blur = True if content_warning and safe_mode else False
-                $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras, blur=blur)
+            $if safe_mode:
+                $ subject_keys = [d['subject_key'] for d in docs]
+                $for work,subject_key in zip(works,subject_keys):
+                    $ read_status = work.get('readinglog', None)
+                    $ dropper = macros.ReadingLogDropper([], work=work, include_lists=False, page_url="/search", users_work_read_status=read_status)
+                    $ content_warning = len([s for s in subject_key if s.startswith("content_warning")]) != 0
+                    $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras, blur=content_warning)
+            $else:
+                $for work in works:
+                    $ read_status = work.get('readinglog', None)
+                    $ dropper = macros.ReadingLogDropper([], work=work, include_lists=False, page_url="/search", users_work_read_status=read_status)
+                    $:macros.SearchResultsWork(work, reading_log=dropper, show_librarian_extras=show_librarian_extras, blur=False)
           </ul>
           $:macros.Pager(page, num_found, rows)
         </div>

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -71,6 +71,16 @@
     border-radius: 4px;
     opacity: .7;
   }
+  .safe-mode-preview-covers {
+    display: block;
+    height: 45px;
+    overflow: hidden;
+  }
+  .safe-mode-preview-covers img {
+    border-radius: 4px;
+    opacity: .7;
+    filter: blur(2px)
+  }
   .bookcover {
     width: 100%;
     margin: 10px 10px 0 5px;
@@ -82,6 +92,20 @@
       max-height: 300px;
       width: 175px;
     }
+  }
+  .safe-mode-bookcover {
+    width: 100%;
+    margin: 10px 10px 0 5px;
+    text-align: center;
+    overflow: hidden;
+    img {
+      border-radius: 4px;
+      max-width: 100%;
+      max-height: 300px;
+      width: 175px;
+      filter: blur(4px)
+    }
+
   }
   .imageLg {
     text-align: center;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7850, cleans up git history

From #7850:

<!-- What issue does this PR close? -->
Follow-Up to PR #7775 and Issue #7416 (part 2) to blur covers containing nsfw content.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR implements the blurring functionality of the opt-in safe-mode feature. Books tagged as nsfw/containing inappropriate content via a `content_warnings:*` subject will have their covers blurred if the user has enabled Safe Mode in 'Manage Privacy and Content Moderation Settings' on the Settings page. 

### Technical
<!-- What should be noted about the implementation? -->

When Safe Mode is enabled, an `sfw` cookie is set to 'yes' and a list of subjects is retrieved  when a search is entered. If a `content_warnings:*` subject is present for that book, a blurred book cover appears else the original book cover is displayed. This also works for the small book previews as shown in the screenshots. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Go to `conf/openlibrary.yml` and change line 18 `coverstore_url: http://covers:7075` to `coverstore_url: covers.openlibrary.org` 
2. Remake css: Enter `docker compose run --rm home make css` in the terminal after 'docker compose up' 
3. Restart memcached in docker: `docker compose restart memcached` 
4. Enable safe mode (from Privacy and Content Moderation Settings) 
5. Search for a book (type the book title or any search term) and press Enter. Currently, any book with a cover or preview will be blurred for testing purposes, but this will be adjusted for only books with the `content-warnings:*` subject. 
7. On the search results page on the top right, just above the displayed book components, uncheck the 'Solr Editions Beta' checkbox. 
8. The book cover and/or preview should be blurred. 

### Screenshots
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="630" alt="bookcover_blur" src="https://user-images.githubusercontent.com/123398993/236555484-5554924a-6afe-4309-9537-90c125c685ab.png">

<img width="658" alt="preview_blur" src="https://user-images.githubusercontent.com/123398993/236555559-26dccce0-4791-40e5-b1a7-873795402271.png">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@rs1dev @SivanC @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
