### PR TITLE
Docker compose: Add hostnames

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -8,6 +8,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+    hostname: docker-openlibrary-web-1
     ports:
       # Debugger
       - 3000:3000
@@ -26,6 +27,7 @@ services:
       - infobase
 
   solr:
+    hostname: docker-openlibrary-solr-1
     ports:
       - 8983:8983
 
@@ -35,6 +37,7 @@ services:
       dockerfile: docker/Dockerfile.oldev
     environment:
       - EXTRA_OPTS=--solr-next
+    hostname: docker-openlibrary-solr-updater-1
     volumes:
       # Persistent volume mount for installed git submodules
       - ol-vendor:/openlibrary/vendor
@@ -48,6 +51,7 @@ services:
       # This is okay for dev, but may need to be explored for prod
       # This allows postgres access for psql user w/o password required
       - POSTGRES_HOST_AUTH_METHOD=trust
+    hostname: docker-openlibrary-db-1
     volumes:
       - .:/openlibrary
       # Any files inside /docker-entrypoint-initdb.d/ will get run by postgres
@@ -59,6 +63,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+    hostname: docker-openlibrary-covers-1
     ports:
       - 7075:7075
     volumes:
@@ -69,6 +74,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+    hostname: docker-openlibrary-infobase-1
     # Commented out because not needed for most dev work, and 7000 conflicts
     # with OS port on Mac. Uncomment if you need to test infobase directly.
     # Mac users can do eg "7070:7000" to change the port used on the host
@@ -87,6 +93,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.oldev
+    hostname: docker-openlibrary-home-1
     command: docker/ol-home-start.sh
     networks:
       - webnet

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -10,8 +10,8 @@ services:
   web:
     profiles: ["ol-web1", "ol-web2"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    hostname: docker-openlibrary-web-1
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 50 --timeout 300 --max-requests 500
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
@@ -23,6 +23,7 @@ services:
 
   solr:
     profiles: ["ol-solr0"]
+    hostname: docker-openlibrary-sorl-1
     environment:
       # More memory for production
       - SOLR_JAVA_MEM=-Xms10g -Xmx10g
@@ -36,6 +37,7 @@ services:
       - webnet
     volumes:
       - ./conf/solr/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+    hostname: docker-openlibrary-solr_haproxy-1
     ports:
       - 8984:8984
     logging:
@@ -45,6 +47,7 @@ services:
 
   solr_restarter:
     profiles: ["ol-solr0"]
+    hostname: docker-openlibrary-solr_restarter-1
     build: scripts/solr_restarter
     restart: unless-stopped
     environment:
@@ -65,8 +68,8 @@ services:
   covers:
     profiles: ["ol-covers0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    hostname: docker-openlibrary-covers-1
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - GUNICORN_OPTS= --workers 30 --max-requests 500
       - COVERSTORE_CONFIG=/olsystem/etc/coverstore.yml
@@ -79,12 +82,12 @@ services:
   covers_nginx:
     profiles: ["ol-covers0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    hostname: docker-openlibrary-covers_nginx-1
     user: root
     command: docker/ol-nginx-start.sh
     environment:
       - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     depends_on:
       - covers
     volumes:
@@ -123,7 +126,7 @@ services:
   cron-jobs:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
-    hostname: "$HOSTNAME"
+    hostname: docker-openlibrary-cron-jobs-1
     user: root
     command: docker/ol-cron-start.sh
     restart: unless-stopped
@@ -140,8 +143,8 @@ services:
   infobase:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    hostname: docker-openlibrary-infobase-1
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - INFOBASE_OPTS=fastcgi
       - INFOBASE_CONFIG=/olsystem/etc/infobase.yml
@@ -149,21 +152,23 @@ services:
       - ../olsystem:/olsystem
       - infobase-writelog:/1/var/lib/openlibrary/infobase/log
       - infobase-errorlog:/1/var/log/openlibrary/infobase-errors
+
   web_haproxy:
     profiles: ["ol-www0"]
     image: haproxy:2.3.5
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     networks:
       - webnet
     volumes:
       - ../olsystem/etc/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+    hostname: docker-openlibrary-web_haproxy-1
     expose:
       - 7072
     logging:
       options:
         max-size: "512m"
         max-file: "4"
+
   web_nginx:
     profiles: ["ol-www0"]
     restart: unless-stopped
@@ -218,6 +223,7 @@ services:
       - ../olsystem:/olsystem
       # Log rotation
       - ../olsystem/etc/logrotate.d/nginx:/etc/logrotate.d/nginx
+    hostname: docker-openlibrary-infobase_nginx-1
     ports:
       - 7000:7000
     networks:
@@ -227,10 +233,10 @@ services:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - AFFILIATE_CONFIG=/openlibrary.yml
     command: docker/ol-affiliate-server-start.sh
+    hostname: docker-openlibrary-affiliate-server-1
     ports:
       - 31337:31337
     volumes:
@@ -247,8 +253,8 @@ services:
   solr-updater:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    hostname: docker-openlibrary-solr-updater-1
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OL_URL=https://openlibrary.org/
@@ -267,8 +273,8 @@ services:
     # explicitly start it (usually only when a solr reindex project is in progress)
     profiles: ["ol-never"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
+    hostname: docker-openlibrary-solr-next-updater-1
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OL_URL=https://openlibrary.org/
@@ -287,8 +293,8 @@ services:
     profiles: ["ol-home0"]
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     command: docker/ol-importbot-start.sh
+    hostname: docker-openlibrary-importbot-1
     restart: unless-stopped
-    hostname: "$HOSTNAME"
     environment:
       - OL_CONFIG=/olsystem/etc/openlibrary.yml
       - OPENLIBRARY_RCFILE=/olsystem/etc/olrc-importbot

--- a/compose.staging.yaml
+++ b/compose.staging.yaml
@@ -12,7 +12,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.oldev
     restart: unless-stopped
-    hostname: "$HOSTNAME"
+    hostname: docker-openlibrary-web-1
     environment:
       - GUNICORN_OPTS= --workers 4 --timeout 180
       - OL_CONFIG=/olsystem/etc/openlibrary.yml

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ services:
       - OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 4 --timeout 180}
     command: docker/ol-web-start.sh
+    hostname: docker-openlibrary-web-1
     ports:
       - ${WEB_PORT:-8080}:8080
     networks:
@@ -18,6 +19,7 @@ services:
 
   solr:
     image: solr:8.10.1
+    hostname: docker-openlibrary-solr-1
     expose:
       - 8983
     environment:
@@ -47,8 +49,8 @@ services:
 
   solr-updater:
     image: "${OLIMAGE:-oldev:latest}"
+    hostname: docker-openlibrary-solr-updater-1
     command: docker/ol-solr-updater-start.sh
-    hostname: "${HOSTNAME:-$HOST}"
     environment:
       - OL_CONFIG=conf/openlibrary.yml
       - OL_URL=http://web:8080/
@@ -61,6 +63,7 @@ services:
 
   memcached:
     image: memcached
+    hostname: docker-openlibrary-memcached-1
     networks:
       - webnet
 
@@ -70,6 +73,7 @@ services:
       - COVERSTORE_CONFIG=${COVERSTORE_CONFIG:-/openlibrary/conf/coverstore.yml}
       - GUNICORN_OPTS=${GUNICORN_OPTS:- --reload --workers 1 --max-requests 250}
     command: docker/ol-covers-start.sh
+    hostname: docker-openlibrary-covers-1
     expose:
       - 7075
     networks:
@@ -86,6 +90,7 @@ services:
       - INFOBASE_CONFIG=${INFOBASE_CONFIG:-/openlibrary/conf/infobase.yml}
       - INFOBASE_OPTS=${INFOBASE_OPTS:-}
     command: docker/ol-infobase-start.sh
+    hostname: docker-openlibrary-infobase-1
     expose:
       - 7000
     networks:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8091

In Docker compose, give each container a `hostname` that is aligned with the container in `docker ps`

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Problems:
* [ ] Docker replicas `openlibrary-covers-1` and `openlibrary-covers-2` have the same hostname.
    * Both bard and chatGPT hallucinated that there was a way to use `$replica-index` to give them different hostnames but I could not make that work.
* On localhost, I am unable to ping these hostnames

Questions:
* [ ] Do we care if our two `covers` replica containers share a hostname?
    * Docker `run` and `exec`, etc. access uses the container name, not the hostname.
* [ ] Do we need the changes to `compose.override.yaml` or not?
* [ ] Should we use `ol-` or `openlibrary-` as the hostname prefix?  Which container hostname should we use?
    * [ ] `docker-ol-covers` 
    * [ ] `docker-ol-covers-1` 
    * [ ] `docker-openlibrary-covers` 
    * [ ] `docker-openlibrary-covers-1` 
### Testing
<!-- Steps for a reviewer to reproduce/verify what this PR does/fixes. -->
On localhost:
* terminal tab 1: % `docker compose up`
* terminal tab 2: % `docker ps | rev | cut -w -f1 | rev | sort`
```
openlibrary-covers-1
openlibrary-db-1
openlibrary-home-1
openlibrary-infobase-1
openlibrary-memcached-1
openlibrary-solr-1
openlibrary-solr-updater-1
openlibrary-web-1
```
* terminal tab 2: % `docker inspect openlibrary-web-1 | grep '"Hostname"'`
```
            "Hostname": "docker-openlibrary-web-1",
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@robertkeizer

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made the best effort and exercised my discretion to make sure relevant sections of this code that substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
