### PR TITLE
make add_db_name handle an authors value of None

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -558,7 +558,7 @@ def find_enriched_match(rec, edition_pool):
                 return edition_key
 
 
-def add_db_name(rec):
+def add_db_name(rec: dict) -> None:
     """
     db_name = Author name followed by dates.
     adds 'db_name' in place for each author.
@@ -566,7 +566,7 @@ def add_db_name(rec):
     if 'authors' not in rec:
         return
 
-    for a in rec['authors']:
+    for a in rec['authors'] or []:
         date = None
         if 'date' in a:
             assert 'birth_date' not in a

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -537,6 +537,11 @@ def test_add_db_name():
     add_db_name(rec)
     assert rec == {}
 
+    # Handle `None` authors values.
+    rec = {'authors': None}
+    add_db_name(rec)
+    assert rec == {'authors': None}
+
 
 def test_extra_author(mock_site, add_languages):
     mock_site.save(


### PR DESCRIPTION
Fix for `rec`s with `None` as the `authors` value.

### Technical
<!-- What should be noted about the implementation? -->
`add_db_name` tries to iterate over `rec['authors']`, but sometimes `authors` has a value of `None`, as opposed to an iterable. This handles those cases.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See added tests in `pytest`, or just add a malformed `rec` such that `rec = {'authors': None}`.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
