### PR TITLE
Add capability to delete a work with over 1000 editions

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -609,14 +609,14 @@ class work_delete(delegate.page):
             if len(keys) == limit:
                 if not i.bulk:
                     raise web.HTTPError(
-                    '400 Bad Request',
-                    data=json.dumps(
-                        {
-                            'error': f'API can only delete {limit} editions per work.',
-                        }
-                    ),
-                    headers={"Content-Type": "application/json"},
-                )
+                        '400 Bad Request',
+                        data=json.dumps(
+                            {
+                                'error': f'API can only delete {limit} editions per work.',
+                            }
+                        ),
+                        headers={"Content-Type": "application/json"},
+                    )
                 else:
                     offset += limit
             else:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -591,21 +591,42 @@ class work_delete(delegate.page):
     path = r"/works/(OL\d+W)/[^/]+/delete"
 
     def get_editions_of_work(self, work: Work) -> list[dict]:
+        i = web.input(bulk=False)
         limit = 1_000  # This is the max limit of the things function
-        keys: list = web.ctx.site.things(
-            {"type": "/type/edition", "works": work.key, "limit": limit}
-        )
-        if len(keys) == limit:
-            raise web.HTTPError(
-                '400 Bad Request',
-                data=json.dumps(
+        all_keys: list = []
+
+        if i.bulk:
+            offset = 0
+
+            while True:
+                keys: list = web.ctx.site.things(
                     {
-                        'error': f'API can only delete {limit} editions per work',
+                        "type": "/type/edition",
+                        "works": work.key,
+                        "limit": limit,
+                        "offset": offset,
                     }
-                ),
-                headers={"Content-Type": "application/json"},
+                )
+                all_keys.extend(keys)
+                if len(keys) == limit:
+                    offset += limit
+                else:
+                    break
+        else:
+            all_keys: list = web.ctx.site.things(
+                {"type": "/type/edition", "works": work.key, "limit": limit}
             )
-        return web.ctx.site.get_many(keys, raw=True)
+            if len(all_keys) == limit:
+                raise web.HTTPError(
+                    '400 Bad Request',
+                    data=json.dumps(
+                        {
+                            'error': f'API can only delete {limit} editions per work.',
+                        }
+                    ),
+                    headers={"Content-Type": "application/json"},
+                )
+        return web.ctx.site.get_many(all_keys, raw=True)
 
     def POST(self, work_id: str):
         if not can_write():

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -613,7 +613,7 @@ class work_delete(delegate.page):
                 else:
                     break
         else:
-            all_keys: list = web.ctx.site.things(
+            all_keys = web.ctx.site.things(
                 {"type": "/type/edition", "works": work.key, "limit": limit}
             )
             if len(all_keys) == limit:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5949 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
If 'bulk=True' is in the URL, every edition of the selected work will be deleted. The original functionality of returning an error remains for works with over 1000 editions if 'bulk=True' is not in the URL.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Currently there is no UI attached to this functionality. Testing can be done through running the following JavaScript in the browser:

```js
await fetch('https://openlibrary.org/works/OL24314717W/College_Ruled_Line_Paper/delete.json', {method: 'POST'})
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
