### PR TITLE
Update 'all editions' url in the search work results

### DIFF
--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -23,6 +23,12 @@ $code:
     else:
       work_edition_url = book_url
 
+  work_edition_all_url = work_edition_url
+  if '?' in work_edition_url:
+    work_edition_all_url += '&mode=all'
+  else:
+    work_edition_all_url += '?mode=all'
+
   edition_work = None
   if doc_type == 'infogami_edition' and 'works' in doc:
     edition_work = doc['works'][0]
@@ -80,7 +86,7 @@ $code:
             $_('First published in %(year)s', year=doc.first_publish_year)
           </span>
         $if doc.get('edition_count'):
-          <a href="$work_edition_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
+          <a href="$work_edition_all_url#editions-list">$ungettext('%(count)s edition', '%(count)s editions', doc.edition_count, count=doc.edition_count)</a>
           $if doc.get('languages'):
             <span class="languages">
               $:ungettext('in <a class="hoverlink" title="%(langs)s">%(count)d language</a>', 'in <a class="hoverlink" title="%(langs)s">%(count)d languages</a>', len(doc.languages), count=len(doc.languages), langs=commify_list([get_language_name('/languages/' + lang) for lang in doc.languages]))


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #7961

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
**Feature**: Includes `mode=all` argument to the URL pointing to "X editions" of a work returned in the search results.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
