### PR TITLE
7160/fix/ia batch import missing batch

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -58,7 +58,7 @@ class Batch(web.storage):
 
     def normalize_items(self, items):
         return [
-            {'ia_id': item}
+            {'batch_id': self.id, 'ia_id': item}
             if type(item) is str
             else {
                 'batch_id': self.id,

--- a/openlibrary/tests/core/test_imports.py
+++ b/openlibrary/tests/core/test_imports.py
@@ -1,47 +1,58 @@
+from typing import Final
 import web
 
 from openlibrary.core.db import get_db
-from openlibrary.core.imports import ImportItem
+from openlibrary.core.imports import Batch, ImportItem
+
+
+IMPORT_ITEM_DDL: Final = """
+CREATE TABLE import_item (
+    id serial primary key,
+    batch_id integer,
+    status text default 'pending',
+    error text,
+    ia_id text,
+    data text,
+    ol_key text,
+    comments text,
+    UNIQUE (batch_id, ia_id)
+);
+"""
+
+IMPORT_BATCH_DDL: Final = """
+CREATE TABLE import_batch (
+    id integer primary key,
+    name text,
+    submitter text,
+    submit_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+IMPORT_ITEM_DATA = [
+    {
+        'id': 1,
+        'batch_id': 1,
+        'ia_id': 'unique_id_1',
+    },
+    {
+        'id': 2,
+        'batch_id': 1,
+        'ia_id': 'unique_id_2',
+    },
+    {
+        'id': 3,
+        'batch_id': 2,
+        'ia_id': 'unique_id_1',
+    },
+]
 
 
 class TestImportItem:
-    IMPORT_ITEM_DDL = """
-    CREATE TABLE import_item (
-        id serial primary key,
-        batch_id integer,
-        status text default 'pending',
-        error text,
-        ia_id text,
-        data text,
-        ol_key text,
-        comments text,
-        UNIQUE (batch_id, ia_id)
-    );
-    """
-
-    IMPORT_ITEM_DATA = [
-        {
-            'id': 1,
-            'batch_id': 1,
-            'ia_id': 'unique_id_1',
-        },
-        {
-            'id': 2,
-            'batch_id': 1,
-            'ia_id': 'unique_id_2',
-        },
-        {
-            'id': 3,
-            'batch_id': 2,
-            'ia_id': 'unique_id_1',
-        },
-    ]
-
     @classmethod
     def setup_class(cls):
         web.config.db_parameters = {'dbn': 'sqlite', 'db': ':memory:'}
         db = get_db()
-        db.query(cls.IMPORT_ITEM_DDL)
+        db.query(IMPORT_ITEM_DDL)
 
     @classmethod
     def teardown_class(cls):
@@ -50,7 +61,7 @@ class TestImportItem:
 
     def setup_method(self):
         self.db = get_db()
-        self.db.multiple_insert('import_item', self.IMPORT_ITEM_DATA)
+        self.db.multiple_insert('import_item', IMPORT_ITEM_DATA)
 
     def teardown_method(self):
         self.db.query('delete from import_item;')
@@ -69,3 +80,26 @@ class TestImportItem:
 
         ImportItem.delete_items(['unique_id_1'], batch_id=2)
         assert len(list(self.db.select('import_item'))) == 1
+
+
+class TestBatchItem:
+    @classmethod
+    def setup_class(cls):
+        web.config.db_parameters = dict(dbn='sqlite', db=':memory:')
+        db = get_db()
+        db.query(IMPORT_BATCH_DDL)
+
+    @classmethod
+    def teardown_class(cls):
+        db = get_db()
+        db.query('delete from import_batch;')
+
+    def test_add_items_legacy(self):
+        """This tests the legacy format of list[str] for items."""
+        legacy_items = ["ocaid_1", "ocaid_2"]
+        batch = Batch.new("test-legacy-batch")
+        result = batch.normalize_items(legacy_items)
+        assert result == [
+            {'batch_id': 1, 'ia_id': 'ocaid_1'},
+            {'batch_id': 1, 'ia_id': 'ocaid_2'},
+        ]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7160 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

This PR merely provides a fix for the issue going forward. Separate action is necessary to add `batch_id`s to items which now lack them.

**Note**: for ease of review, the three commits here correspond to:
1. adding a test;
2. adding the fix; and
3. refactoring the tests to `pytest`. 

The refactor to `pytest` may be out of place here and I can drop that commit if desired.

### Technical
<!-- What should be noted about the implementation? -->
#### The short of it
`Batch.normalize_items` was not setting `batch_id` for "legacy" items. This PR fixes that.

#### The longer explanation
First, I should note all of this testing was done locally, save for generating `items` with `ia.get_candidate_ocaids()`. With that caveat out of the way, on with the show.

`ia.get_candidate_ocaids()` generates a list of `items` for `Batch.add_items()` to ingest, and in doing so it returns a list of (string) OCAIDs:
```
>>> get_candidate_ocaids(since_date=date)[:3]
['isbn_0125882807', 'fateoffreedomels0000schm', 'isbn_9780199734566']
```

Then, `Batch.add_items()` imports these items, here a list of strings, into the database, but not before running `Batch.normalize_items()` on them.

Crucially, `Batch.normalize_items()` has two code paths:
- one for "legacy" lists of strings; and
- one for lists of dictionaries.

Hitherto, only the `list[dict]` code path was setting `batch_id`. But as previously noted, `ia.get_candidate_ocaids()` returns `list[str]` in this case, so `batch_id` was not being set.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try adding an item via `Batch.add_items()` without this PR applied, and then check the database:

```
>>> batch = Batch.new('test-scans')
>>> batch
<Storage {'id': 3, 'name': 'test-scans', 'submitter': None, 'submit_time': datetime.datetime(2023, 7, 20, 1, 21, 41, 917237)}>
>>> batch.add_items(["howtowriteyourfi0000grub"])
2023-07-20 04:49:25 [openlibrary.imports] [INFO] batch test-scans: adding 1 items
0.0 (1): SELECT ia_id FROM import_item WHERE ia_id IN ('howtowriteyourfi0000grub')
```

Now, note the lack of a `batch_id` for `howtowriteyourfi0000grub`, which was added *prior* to the application of this PR.
```
openlibrary=# select * from import_item where ia_id = 'howtowriteyourfi0000grub';
-[ RECORD 1 ]---------------------------
id          | 6396
batch_id    | 
added_time  | 2023-07-20 01:46:18.879977
import_time | 
status      | pending
error       | 
ia_id       | howtowriteyourfi0000grub
data        | 
ol_key      | 
comments    | 
```

Next, note the presence of `batch_id` for `asianartindiachi0000geof`, which was added *with* this PR applied:
```
openlibrary=# select * from import_item where ia_id = 'asianartindiachi0000geof';
-[ RECORD 1 ]---------------------------
id          | 6397
batch_id    | 3
added_time  | 2023-07-20 01:51:23.130868
import_time | 
status      | pending
error       | 
ia_id       | asianartindiachi0000geof
data        | 
ol_key      | 
comments    | 
```

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
