### PR TITLE
Ability to edit list item order + New lists/add UI-API

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -78,7 +78,7 @@
     },
     {
       "path": "static/build/page-admin.css",
-      "maxSize": "25KB"
+      "maxSize": "26KB"
     },
     {
       "path": "static/build/page-book.css",

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -1,4 +1,4 @@
-$def with (page, edition=None)
+$def with (page, edition=None, edit=True)
 
 $if page.type.key in ["/type/work", "/type/edition", "/type/author"]:
     $if edition and page.type.key in ["/type/work"]:
@@ -24,7 +24,7 @@ $else:
         $else:
             <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$changequery(m='history')" rel="nofollow" title="View this template's edit history">$_('History')</a></div>
     </div>
-    $if not page.is_fake_record():
+    $if edit and not page.is_fake_record():
         <div class="editButton">
           <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
           <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -186,9 +186,13 @@ export default function($) {
 
         if (ol_ac_opts.sortable) {
             container.sortable({
+                handle: '.mia__reorder',
                 items: '.mia__input',
                 update: function() {
                     container.find('.mia__input').each(function(index) {
+                        $(this).find('.mia__index').each(function () {
+                            $(this).text($(this).text().replace(/\d+/, index + 1));
+                        });
                         $(this).find('[name]').each(function() {
                             // this won't behave nicely with nested numeric things, if that ever happens
                             if ($(this).attr('name').match(/\d+/)?.length > 1) {

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -91,6 +91,10 @@ export default function($) {
                 var item = ui.item;
                 var $this = $(this);
                 $this.closest('.ac-input').find('.ac-input__value').val(item.key);
+                const $preview = $this.closest('.ac-input').find('.ac-input__preview');
+                if ($preview.length) {
+                    $preview.html(item.label);
+                }
                 setTimeout(function() {
                     $this.addClass('accept');
                 }, 0);

--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -186,29 +186,31 @@ export default function($) {
             }
         }
 
+        function update_indices() {
+            container.find('.mia__input').each(function(index) {
+                $(this).find('.mia__index').each(function () {
+                    $(this).text($(this).text().replace(/\d+/, index + 1));
+                });
+                $(this).find('[name]').each(function() {
+                    // this won't behave nicely with nested numeric things, if that ever happens
+                    if ($(this).attr('name').match(/\d+/)?.length > 1) {
+                        throw new Error('nested numeric names not supported');
+                    }
+                    $(this).attr('name', $(this).attr('name').replace(/\d+/, index));
+                    if ($(this).attr('id')) {
+                        $(this).attr('id', $(this).attr('id').replace(/\d+/, index));
+                    }
+                });
+            });
+        }
+
         update_visible();
 
         if (ol_ac_opts.sortable) {
             container.sortable({
                 handle: '.mia__reorder',
                 items: '.mia__input',
-                update: function() {
-                    container.find('.mia__input').each(function(index) {
-                        $(this).find('.mia__index').each(function () {
-                            $(this).text($(this).text().replace(/\d+/, index + 1));
-                        });
-                        $(this).find('[name]').each(function() {
-                            // this won't behave nicely with nested numeric things, if that ever happens
-                            if ($(this).attr('name').match(/\d+/)?.length > 1) {
-                                throw new Error('nested numeric names not supported');
-                            }
-                            $(this).attr('name', $(this).attr('name').replace(/\d+/, index));
-                            if ($(this).attr('id')) {
-                                $(this).attr('id', $(this).attr('id').replace(/\d+/, index));
-                            }
-                        });
-                    });
-                }
+                update: update_indices,
             });
         }
 
@@ -216,6 +218,7 @@ export default function($) {
             if (allow_empty || container.find('.mia__input').length > 1) {
                 $(this).closest('.mia__input').remove();
                 update_visible();
+                update_indices();
             }
         });
 

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -1,5 +1,5 @@
 import { isbnOverride } from './isbnOverride';
-/* global render_language_field, render_work_autocomplete_item, render_language_autocomplete_item, render_work_field */
+/* global render_seed_field, render_language_field, render_work_autocomplete_item, render_language_autocomplete_item, render_work_field */
 /* Globals are provided by the edit edition template */
 
 /* global render_author, render_author_autocomplete_item */
@@ -287,6 +287,29 @@ export function initWorksMultiInputAutocomplete() {
                     addnew: dataConfig['addnew'] || false,
                     new_name: dataConfig['new_name'] || '',
                     allow_empty: dataConfig['allow_empty'] || false,
+                },
+                {
+                    minChars: 2,
+                    max: 11,
+                    matchSubset: false,
+                    autoFill: true,
+                    formatItem: render_work_autocomplete_item,
+                });
+        });
+    });
+}
+
+export function initSeedsMultiInputAutocomplete() {
+    $(function() {
+        getJqueryElements('.multi-input-autocomplete--seeds').forEach(jqueryElement => {
+            /* Values in the html passed from Python code */
+            jqueryElement.setup_multi_input_autocomplete(
+                render_seed_field,
+                {
+                    endpoint: '/works/_autocomplete',
+                    addnew: false,
+                    allow_empty: true,
+                    sortable: true,
                 },
                 {
                     minChars: 2,

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -1,5 +1,5 @@
 import { isbnOverride } from './isbnOverride';
-/* global render_seed_field, render_language_field, render_work_autocomplete_item, render_language_autocomplete_item, render_work_field */
+/* global render_seed_field, render_language_field, render_lazy_work_preview, render_language_autocomplete_item, render_work_field, render_work_autocomplete_item */
 /* Globals are provided by the edit edition template */
 
 /* global render_author, render_author_autocomplete_item */
@@ -316,7 +316,7 @@ export function initSeedsMultiInputAutocomplete() {
                     max: 11,
                     matchSubset: false,
                     autoFill: true,
-                    formatItem: render_work_autocomplete_item,
+                    formatItem: render_lazy_work_preview,
                 });
         });
     });

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -268,6 +268,11 @@ jQuery(function () {
             });
     }
 
+    if ($('.lazy-thing-preview').length) {
+        import(/* webpackChunkName: "lazy-thing-preview" */ './lazy-thing-preview')
+            .then((module) => new module.LazyThingPreview().init());
+    }
+
     const $observationModalLinks = $('.observations-modal-link');
     const $notesModalLinks = $('.notes-modal-link');
     const $notesPageButtons = $('.note-page-buttons');

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -125,21 +125,24 @@ jQuery(function () {
 
     const edition = document.getElementById('tabsAddbook');
     const autocompleteAuthor = document.querySelector('.multi-input-autocomplete--author');
+    const autocompleteLanguage = document.querySelector('.multi-input-autocomplete--language');
+    const autocompleteWorks = document.querySelector('.multi-input-autocomplete--works');
+    const autocompleteSeeds = document.querySelector('.multi-input-autocomplete--seeds');
+    const autocompleteSubjects = document.querySelector('.csv-autocomplete--subjects');
     const addRowButton = document.getElementById('add_row_button');
     const roles = document.querySelector('#roles');
     const identifiers = document.querySelector('#identifiers');
     const classifications = document.querySelector('#classifications');
-    const autocompleteLanguage = document.querySelector('.multi-input-autocomplete--language');
-    const autocompleteWorks = document.querySelector('.multi-input-autocomplete--works');
-    const autocompleteSubjects = document.querySelector('.csv-autocomplete--subjects');
     const excerpts = document.getElementById('excerpts');
     const links = document.getElementById('links');
 
     // conditionally load for user edit page
     if (
         edition ||
-        autocompleteAuthor || addRowButton || roles || identifiers || classifications ||
-        autocompleteLanguage || autocompleteWorks || excerpts || links
+        autocompleteAuthor || autocompleteLanguage || autocompleteWorks ||
+        autocompleteSeeds || autocompleteSubjects ||
+        addRowButton || roles || identifiers || classifications ||
+        excerpts || links
     ) {
         import(/* webpackChunkName: "user-website" */ './edit')
             .then(module => {
@@ -175,6 +178,9 @@ jQuery(function () {
                 }
                 if (autocompleteSubjects) {
                     module.initSubjectsAutocomplete();
+                }
+                if (autocompleteSeeds) {
+                    module.initSeedsMultiInputAutocomplete();
                 }
             });
     }

--- a/openlibrary/plugins/openlibrary/js/jsdef.js
+++ b/openlibrary/plugins/openlibrary/js/jsdef.js
@@ -141,3 +141,7 @@ export function htmlquote(text) {
     text = text.replace(/"/g, '&quot;');
     return text;
 }
+
+export function is_jsdef() {
+    return true;
+}

--- a/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
@@ -1,0 +1,122 @@
+// @ts-check
+import debounce from 'lodash/debounce';
+
+/**
+ * Responds to HTML like:
+ * ```html
+ *  <div
+ *      class="lazy-thing-preview"
+ *      data-key="/works/OL123W"
+ *      data-render-fn="$render_fn_name"
+ * ></div>
+ * ```
+ *
+ * And then calls `$render_fn_name` with the response from search engine.
+ * Bundles/dedupes requests throughout the page and does other smart things.
+ * Someday: Only load if in viewport.
+ * Currently only works with works/editions.
+ */
+export class LazyThingPreview {
+    constructor() {
+        /** @type {Array<{key: string, render_fn: Function}>} */
+        this.queue = [];
+        /** @type {Object<string, object>} */
+        this.cache = {};
+
+        this.renderDebounced = debounce(this.render.bind(this), 100);
+    }
+
+    init() {
+        $('.lazy-thing-preview').each((i, el) => {
+            this.push({
+                key: el.dataset.key,
+                render_fn_name: el.dataset.renderFn,
+            });
+        });
+    }
+
+    /**
+     * @param {{key: string, render_fn_name: string}} arg0
+     */
+    push({key, render_fn_name}) {
+        const render_fn = window[render_fn_name];
+        if (this.cache[key]) {
+            this.renderKey(key, render_fn, this.cache[key]);
+        } else {
+            this.queue.push({key, render_fn});
+            this.renderDebounced();
+        }
+    }
+
+    /**
+     * @param {string} key
+     * @param {Function} render_fn
+     * @param {object} book
+     */
+    renderKey(key, render_fn, book) {
+        const $el = $(`.lazy-thing-preview[data-key="${key}"]`);
+        $el.html(render_fn(book));
+    }
+
+    /**
+     * @param {string[]} keys
+     * @returns {Promise<object[]>}
+     */
+    async getThings(keys) {
+        const workKeys = keys.filter(key => key.startsWith('/works/'));
+        const editionKeys = keys.filter(key => key.startsWith('/books/'));
+        const authorKeys = keys.filter(key => key.startsWith('/authors/'));
+        const fields = 'key,cover_i,first_publish_year,author_name,title,subtitle,edition_count,editions';
+        let docs = [];
+        if (workKeys.length) {
+            const resp = await fetch(`/search.json?${new URLSearchParams({
+                q: `key:(${workKeys.join(' OR ')})`,
+                fields,
+            })}`).then(r => r.json());
+            docs = docs.concat(resp.docs);
+        }
+        if (editionKeys.length) {
+            const resp = await fetch(`/search.json?${new URLSearchParams({
+                q: `edition_key:(${editionKeys
+                    .map(key => key.split('/').pop())
+                    .join(' OR ')})`,
+                fields,
+            })}`).then(r => r.json());
+            docs = docs.concat(resp.docs);
+        }
+        if (authorKeys.length) {
+            const resp = await fetch(`/search/authors.json?${new URLSearchParams({
+                q: `key:(${authorKeys.join(' OR ')})`,
+                fields: 'key,type,name,top_work,top_subjects,birth_date,death_date',
+            })}`).then(r => r.json());
+            docs = docs.concat(resp.docs);
+        }
+
+        return docs;
+    }
+
+    async render() {
+        const keys = this.queue.map(({key}) => key);
+        const books = await this.getThings(keys);
+        for (const book of books) {
+            this.cache[book.key] = book;
+            book.full_title = book.subtitle ? `${book.title}: ${book.subtitle}` : book.title;
+            if (book.editions.docs.length) {
+                const ed = book.editions.docs[0];
+                ed.full_title = ed.subtitle ? `${ed.title}: ${ed.subtitle}` : ed.title;
+                ed.author_name = book.author_name;
+                ed.edition_count = book.edition_count;
+                this.cache[ed.key] = ed;
+            }
+        }
+
+        const missingKeys = keys.filter(key => !this.cache[key]);
+        // eslint-disable-next-line no-console
+        console.warn('Books missing from cache', missingKeys);
+
+        for (const {key, render_fn} of this.queue) {
+            this.renderKey(key, render_fn, this.cache[key]);
+        }
+        this.queue = [];
+    }
+}

--- a/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
@@ -72,6 +72,7 @@ export class LazyThingPreview {
             const resp = await fetch(`/search.json?${new URLSearchParams({
                 q: `key:(${workKeys.join(' OR ')})`,
                 fields,
+                limit: '100',
             })}`).then(r => r.json());
             docs = docs.concat(resp.docs);
         }
@@ -81,6 +82,7 @@ export class LazyThingPreview {
                     .map(key => key.split('/').pop())
                     .join(' OR ')})`,
                 fields,
+                limit: '100',
             })}`).then(r => r.json());
             docs = docs.concat(resp.docs);
         }
@@ -88,6 +90,7 @@ export class LazyThingPreview {
             const resp = await fetch(`/search/authors.json?${new URLSearchParams({
                 q: `key:(${authorKeys.join(' OR ')})`,
                 fields: 'key,type,name,top_work,top_subjects,birth_date,death_date',
+                limit: '100',
             })}`).then(r => r.json());
             for (const doc of resp.docs) {
                 // This API returns keys without the /authors/ prefix 😭
@@ -122,7 +125,9 @@ export class LazyThingPreview {
         console.warn('Books missing from cache', missingKeys);
 
         for (const {key, render_fn} of this.queue) {
-            this.renderKey(key, render_fn, this.cache[key]);
+            if (this.cache[key]) {
+                this.renderKey(key, render_fn, this.cache[key]);
+            }
         }
         this.queue = [];
     }

--- a/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
+++ b/openlibrary/plugins/openlibrary/js/lazy-thing-preview.js
@@ -14,7 +14,7 @@ import debounce from 'lodash/debounce';
  * And then calls `$render_fn_name` with the response from search engine.
  * Bundles/dedupes requests throughout the page and does other smart things.
  * Someday: Only load if in viewport.
- * Currently only works with works/editions.
+ * Currently only works with works, editions, and authors.
  */
 export class LazyThingPreview {
     constructor() {

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -35,7 +35,7 @@ class ListRecord:
     seeds: list[SeedDict | str] = field(default_factory=list)
 
     @staticmethod
-    def normalize_input_seed(seed: dict | str) -> SeedDict | str:
+    def normalize_input_seed(seed: SeedDict | str) -> SeedDict | str:
         if isinstance(seed, str):
             if seed.startswith('/subjects/'):
                 return seed

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -234,7 +234,7 @@ class lists_edit(delegate.page):
         lst = web.ctx.site.get(key)
         if lst is None:
             raise web.notfound()
-        return render_template("type/list/edit", lst, edit=True)
+        return render_template("type/list/edit", lst, new=False)
 
     def POST(self, user_key: str, list_key: str | None = None):  # type: ignore[override]
         key = user_key
@@ -277,7 +277,7 @@ class lists_add(delegate.page):
                 f"Permission denied to edit {user_key}.",
             )
         list_record = ListRecord.from_input()
-        return render_template("type/list/edit", list_record, edit=False)
+        return render_template("type/list/edit", list_record, new=True)
 
     def POST(self, user_key: str):  # type: ignore[override]
         return lists_edit().POST(user_key, None)

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -1,11 +1,13 @@
 """Lists implementation.
 """
+from dataclasses import dataclass, field
 import json
 import random
+from typing import TypedDict
 import web
 
 from infogami.utils import delegate
-from infogami.utils.view import render_template, public
+from infogami.utils.view import render_template, public, require_login
 from infogami.infobase import client, common
 
 from openlibrary.accounts import get_current_user
@@ -13,11 +15,76 @@ from openlibrary.core import formats, cache
 from openlibrary.core.lists.model import ListMixin
 import openlibrary.core.helpers as h
 from openlibrary.i18n import gettext as _
-from openlibrary.utils import dateutil
-from openlibrary.plugins.upstream import spamcheck
+from openlibrary.plugins.upstream.addbook import safe_seeother
+from openlibrary.utils import dateutil, olid_to_key
+from openlibrary.plugins.upstream import spamcheck, utils
 from openlibrary.plugins.upstream.account import MyBooksTemplate
 from openlibrary.plugins.worksearch import subjects
 from openlibrary.coverstore.code import render_list_preview_image
+
+
+class SeedDict(TypedDict):
+    key: str
+
+
+@dataclass
+class ListRecord:
+    key: str | None = None
+    name: str = ''
+    description: str = ''
+    seeds: list[SeedDict | str] = field(default_factory=list)
+
+    @staticmethod
+    def normalize_input_seed(seed: dict | str) -> SeedDict | str:
+        if isinstance(seed, str):
+            if seed.startswith('/subjects/'):
+                return seed
+            else:
+                return {'key': seed if seed.startswith('/') else olid_to_key(seed)}
+        else:
+            if seed['key'].startswith('/subjects/'):
+                return seed['key'].split('/', 2)[-1]
+            else:
+                return seed
+
+    @staticmethod
+    def from_input():
+        i = utils.unflatten(
+            web.input(
+                key=None,
+                name='',
+                description='',
+                seeds=[],
+            )
+        )
+
+        normalized_seeds = [
+            ListRecord.normalize_input_seed(seed)
+            for seed_list in i.seeds
+            for seed in (
+                seed_list.split(',') if isinstance(seed_list, str) else [seed_list]
+            )
+        ]
+        normalized_seeds = [
+            seed
+            for seed in normalized_seeds
+            if seed and (isinstance(seed, str) or seed.get('key'))
+        ]
+        return ListRecord(
+            key=i.key,
+            name=i.name,
+            description=i.description,
+            seeds=normalized_seeds,
+        )
+
+    def to_thing_json(self):
+        return {
+            "key": self.key,
+            "type": {"key": "/type/list"},
+            "name": self.name,
+            "description": self.description,
+            "seeds": self.seeds,
+        }
 
 
 class lists_home(delegate.page):
@@ -150,6 +217,64 @@ class lists(delegate.page):
 
     def render(self, doc, lists):
         return render_template("lists/lists.html", doc, lists)
+
+
+class lists_edit(delegate.page):
+    path = r"(/people/[^/]+/lists/OL\d+L)/edit"
+
+    @require_login
+    def GET(self, key: str):  # type: ignore[override]
+        if not web.ctx.site.can_write(key):
+            return render_template(
+                "permission_denied",
+                web.ctx.fullpath,
+                f"Permission denied to edit {key}.",
+            )
+
+        lst = web.ctx.site.get(key)
+        if lst is None:
+            raise web.notfound()
+        return render_template("type/list/edit", lst, edit=True)
+
+    @require_login
+    def POST(self, key: str):  # type: ignore[override]
+        if not web.ctx.site.can_write(key):
+            return render_template(
+                "permission_denied",
+                web.ctx.fullpath,
+                f"Permission denied to edit {key}.",
+            )
+
+        list_record = ListRecord.from_input()
+        if not list_record.name:
+            raise web.badrequest()
+
+        user = get_current_user()
+        if not user:
+            raise web.seeother("/account/login?redirect=/lists/add")
+
+        web.ctx.site.save(
+            list_record.to_thing_json(),
+            action="lists",
+            comment="Added list.",
+        )
+        return safe_seeother(key)
+
+
+class lists_add(lists_edit):
+    path = r"/lists/add"
+
+    @require_login
+    def GET(self):
+        list_record = ListRecord.from_input()
+        return render_template("type/list/edit", list_record, edit=False)
+
+    @require_login
+    def POST(self):
+        user = get_current_user()
+        list_num = web.ctx.site.seq.next_value("list")
+        key = f"{user.key}/lists/OL{list_num}L"
+        return super().POST(key)
 
 
 class lists_delete(delegate.page):

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -258,7 +258,11 @@ class lists_edit(delegate.page):
             list_key = f"/lists/OL{list_num}L"
             list_record.key = user_key + list_key
 
-        web.ctx.site.save(list_record.to_thing_json(), action="lists")
+        web.ctx.site.save(
+            list_record.to_thing_json(),
+            action="lists",
+            comment=web.input(_comment="")._comment or None,
+        )
         return safe_seeother(list_record.key)
 
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -69,8 +69,10 @@ class edit(core.edit):
 
     def GET(self, key):
         page = web.ctx.site.get(key)
-
-        if web.re_compile('/(authors|books|works)/OL.*').match(key):
+        editable_keys_re = web.re_compile(
+            r"/(authors|books|works|people/[^/]+/lists)/OL.*"
+        )
+        if editable_keys_re.match(key):
             if page is None:
                 raise web.seeother(key)
             else:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -290,7 +290,9 @@ def unflatten(d: Storage, separator: str = "--") -> Storage:
             k, k2 = k.split(separator, 1)
             setvalue(data.setdefault(k, {}), k2, v)
         else:
-            data[k] = v
+            # Don't overwrite if the key already exists
+            if k not in data:
+                data[k] = v
 
     def makelist(d):
         """Convert d into a list if all the keys of d are integers."""

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1081,6 +1081,11 @@ _get_blog_feeds = cache.memcache_memoize(
 
 
 @public
+def is_jsdef():
+    return False
+
+
+@public
 def get_donation_include() -> str:
     ia_host = get_ia_host(allow_dev=True)
     # The following allows archive.org staff to test banners without

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -3,6 +3,9 @@ $# :param list[dict] authors: e.g. {name: str, key: str}
 $# :param str name_path: form path for the user-visible author name
 $# :param str dict_path: form path for the author dict
 
+$# Import for side-effect of defining jsdef functions
+$:render_template('jsdef/LazyAuthorPreview', None)
+
 $jsdef render_author_autocomplete_item(item):
     $if item.key == "__new__":
         <div class="ac_author ac_addnew" title="Add a new author">
@@ -10,26 +13,7 @@ $jsdef render_author_autocomplete_item(item):
             <span class="name">$item.name</span>
         </div>
     $else:
-        <div class="ac_author" title="Select this author">
-            <span class="name">
-                $item.name
-                $if item.birth_date or item.death_date:
-                    (${item.birth_date or ' '}&ndash;${item.death_date or ' '})
-            </span>
-            <span class="olid">$item.key.split('/')[2]</span>
-            &bull;
-            $if item.work_count == 0:
-                <span class="work">No books associated with $item.name</span>
-            $elif item.work_count == 1:
-                <span class="books">1 book</span>
-                <span class="work">titled <i>$item.works[0]</i></span>
-            $else:
-                <span class="books">$item.work_count books</span>
-                <span class="work">including <i>$item.works[0]</i></span>
-
-            $if item.subjects:
-                <span class="subject">Subjects: ${', '.join(item.subjects)}</span>
-        </div>
+        $:render_lazy_author_preview(item)
 
 $jsdef render_author(name_path, dict_path, readonly, i, author):
     <div class="input ac-input mia__input">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -42,33 +42,16 @@ $jsdef render_work_field(i, work):
         <a class="mia__remove hidden" href="javascript:;" title="$_('Remove this work')">[x]</a>
     </div>
 
+$# Import the side-effect of the jsdef function
+$:render_template('jsdef/LazyWorkPreview', None)
+
 $jsdef render_work_autocomplete_item(item):
     $if item.key == "__new__":
         <div class="ac_work ac_addnew">
             <span class="action">$_('-- Move to a new work')</span>
         </div>
     $else:
-        <div class="ac_work" title="Select this work">
-            <div class="cover">
-                $if item.cover_i:
-                    <img src="https://covers.openlibrary.org/b/id/$(item.cover_i)-M.jpg" alt="$_('Cover of: %(title)s', title=item.title)">
-            </div>
-            <span class="olid">$item.key.split('/')[2]</span>
-            <span class="name">
-                <span class="title">$item.full_title</span>
-                $if item.first_publish_year:
-                <span class="first_publish_year">($item.first_publish_year)</span>
-            </span>
-            <span class="byline">
-                $if item.author_name:
-                    $_('by') <span class="authors">${', '.join(item.author_name)}</span>
-            </span>
-            &bull;
-            $if item.edition_count == 1:
-                <span class="edition_count">$item.edition_count edition</span>
-            $else:
-                <span class="edition_count">$item.edition_count editions</span>
-        </div>
+        $:render_lazy_work_preview(item)
 
 
 <fieldset class="major">

--- a/openlibrary/templates/jsdef/LazyAuthorPreview.html
+++ b/openlibrary/templates/jsdef/LazyAuthorPreview.html
@@ -1,0 +1,26 @@
+$def with (author)
+
+$jsdef render_lazy_author_preview(item):
+    $if item:
+        <div class="ac_author" title="Select this author">
+            <div class="olid">$item['key']</div>
+            <span class="name">
+                $item['name']
+                $if item['birth_date'] or item['death_date']:
+                    ($(item['birth_date'] or ' ')&ndash;$(item['death_date'] or ' '))
+            </span>
+            $if item['work_count'] == 0:
+                <span class="work">No books associated with $item['name']</span>
+            $elif item['work_count'] == 1:
+                <span class="books">1 book</span>
+                <span class="work">titled <i>$item['top_work']</i></span>
+            $else:
+                <span class="books">$item['work_count'] books</span>
+                <span class="work">including <i>$item['top_work']</i></span>
+
+            $if item['subjects']:
+                <span class="subject">Subjects: $(', '.join(item['subjects']))</span>
+        </div>
+
+$if author:
+    $:render_lazy_author_preview(author)

--- a/openlibrary/templates/jsdef/LazyWorkPreview.html
+++ b/openlibrary/templates/jsdef/LazyWorkPreview.html
@@ -1,0 +1,32 @@
+$def with (work)
+
+$jsdef render_lazy_work_preview(work):
+    <div class="ac_work" title="Select this work">
+        <div class="cover">
+            $if work['cover_i']:
+                <img
+                    src="https://covers.openlibrary.org/b/id/$(work['cover_i'])-M.jpg"
+                    alt="$_('Cover of: %(title)s', title=work['title'])"
+                    loading="lazy"
+                >
+        </div>
+        <div class="olid">$work['key']</div>
+        <span class="name">
+            <span class="title">$work['full_title']</span>
+            $if 'first_publish_year' in work:
+                <span class="first_publish_year">($work['first_publish_year'])</span>
+        </span>
+        <span class="byline">
+            $if work['author_name']:
+                $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
+        </span>
+        &bull;
+        $if work['edition_count'] == 1:
+            <span class="edition_count">$work['edition_count'] edition</span>
+        $else:
+            <span class="edition_count">$work['edition_count'] editions</span>
+        <div class="clear"></div>
+    </div>
+
+$if work:
+    $:render_lazy_work_preview(work)

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -27,7 +27,8 @@ $jsdef render_seed_field(i, seed):
                     type="hidden"
             />
             <div class="ac-input__preview">
-                $if seed['key'] and seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books':
+                $# Note: Cannot use "in" because this is a jsdef function
+                $if seed['key'] and (seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books'):
                     $:lazy_thing_preview(seed['key'], 'render_work_autocomplete_item')
                 $else:
                     $seed['key']
@@ -46,7 +47,7 @@ $jsdef render_work_autocomplete_item(work):
                         loading="lazy"
                     >
             </div>
-            <span class="olid">$work['key']</span>
+            <div class="olid">$work['key']</div>
             <span class="name">
                 <span class="title">$work['full_title']</span>
                 $if 'first_publish_year' in work:

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -23,18 +23,23 @@ $putctx("robots", "noindex,nofollow")
             this.renderDebounced = debounce(this.render.bind(this), 100);
         }
 
-        push({key, render_fn_name}) {
+        /**
+         * @param {string} key
+         * @param {string | Function} render_fn
+         */
+        push({key, render_fn}) {
+            render_fn = typeof render_fn == 'string' ? window[render_fn] : render_fn;
             if (this.cache[key]) {
-                this.renderKey(key, render_fn_name, this.cache[key]);
+                this.renderKey(key, render_fn, this.cache[key]);
             } else {
-                this.queue.push({key, render_fn_name});
+                this.queue.push({key, render_fn});
                 this.renderDebounced();
             }
         }
 
-        renderKey(key, render_fn_name, book) {
+        renderKey(key, render_fn, book) {
             const $$el = $$(`[data-key="$${key}"]`);
-            $$el.html(window[render_fn_name](book));
+            $$el.html(render_fn(book));
         }
 
         async getThings(keys) {
@@ -93,8 +98,8 @@ $putctx("robots", "noindex,nofollow")
             const missingKeys = keys.filter(key => !this.cache[key]);
             console.warn('Missing books', missingKeys);
 
-            for (const {key, render_fn_name} of this.queue) {
-                this.renderKey(key, render_fn_name, this.cache[key]);
+            for (const {key, render_fn} of this.queue) {
+                this.renderKey(key, render_fn, this.cache[key]);
             }
             this.queue = [];
         }
@@ -113,7 +118,7 @@ $jsdef render_seed_field(i, seed):
             <div class="mia__reorder mia__index">≡ #$(i + 1)</div>
             <button class="mia__remove" href="javascript:;">Remove</button>
         </div>
-        <div class="mia__preview">
+        <main>
             <input class="ac-input__value" name="seeds--$i--key" type="hidden" value="$seed['key']" />
             $# Displayed
             <input
@@ -123,11 +128,13 @@ $jsdef render_seed_field(i, seed):
                 $if seed['key']:
                     type="hidden"
             />
-            $if seed['key'] and seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books':
-                $:render_lazy_preview(seed['key'], 'render_work_autocomplete_item')
-            $else:
-                $seed['key']
-        </div>
+            <div class="ac-input__preview">
+                $if seed['key'] and seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books':
+                    $:render_lazy_preview(seed['key'], 'render_work_autocomplete_item')
+                $else:
+                    $seed['key']
+            </div>
+        </main>
     </li>
 
 $jsdef render_work_autocomplete_item(work):
@@ -174,7 +181,7 @@ $jsdef render_lazy_preview(key, render_fn_name):
         $:render_work_autocomplete_item(fake_item)
     </div>
     <script>
-        window.LAZY_BOOK_QUEUE.push({ key: '$key', render_fn_name: '$render_fn_name' });
+        window.LAZY_BOOK_QUEUE.push({ key: '$key', render_fn: '$render_fn_name' });
     </script>
 
 <div id="contentBody">

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -29,42 +29,15 @@ $jsdef render_seed_field(i, seed):
             <div class="ac-input__preview">
                 $# Note: Cannot use "in" because this is a jsdef function
                 $if seed['key'] and (seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books'):
-                    $:lazy_thing_preview(seed['key'], 'render_work_autocomplete_item')
+                    $:lazy_thing_preview(seed['key'], 'render_lazy_work_preview')
                 $else:
                     $seed['key']
             </div>
         </main>
     </li>
 
-$jsdef render_work_autocomplete_item(work):
-    $if work:
-        <div class="ac_work" title="Select this work">
-            <div class="cover">
-                $if work['cover_i']:
-                    <img
-                        src="https://covers.openlibrary.org/b/id/$(work['cover_i'])-M.jpg"
-                        alt="$_('Cover of: %(title)s', title=work['title'])"
-                        loading="lazy"
-                    >
-            </div>
-            <div class="olid">$work['key']</div>
-            <span class="name">
-                <span class="title">$work['full_title']</span>
-                $if 'first_publish_year' in work:
-                    <span class="first_publish_year">($work['first_publish_year'])</span>
-            </span>
-            <span class="byline">
-                $if work['author_name']:
-                    $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
-            </span>
-            &bull;
-            $if work['edition_count'] == 1:
-                <span class="edition_count">$work['edition_count'] edition</span>
-            $else:
-                <span class="edition_count">$work['edition_count'] editions</span>
-            <div class="clear"></div>
-        </div>
-
+$# import the side-effect of the jsdef function
+$:render_template('jsdef/LazyWorkPreview', None)
 
 $jsdef lazy_thing_preview(key, render_fn_name):
     <div class="lazy-thing-preview" data-key="$key" data-render-fn="$render_fn_name">
@@ -77,7 +50,8 @@ $jsdef lazy_thing_preview(key, render_fn_name):
                 'edition_count': '_',
                 'cover_i': None,
              }
-        $:render_work_autocomplete_item(fake_item)
+        $if not is_jsdef():
+            $:render_template('jsdef/LazyWorkPreview', fake_item)
     </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -1,12 +1,12 @@
-$def with (lst, edit=False)
+$def with (lst, new=False)
 $putctx('cssfile', 'list-edit')
-$var title: $(_("Create a list") if not edit else _("Editing list: %(list_name)s", list_name=lst.name))
+$var title: $(_("Create a list") if new else _("Editing list: %(list_name)s", list_name=lst.name))
 
 $putctx("robots", "noindex,nofollow")
 
 <div id="contentHead">
     $:macros.databarEdit(lst)
-    <h1>$(_("Edit List") if edit else _("Create a list"))</h1>
+    <h1>$(_("Create a list") if new else _("Edit List"))</h1>
 </div>
 
 $# Render the ith seed input field
@@ -77,7 +77,7 @@ $jsdef lazy_thing_preview(key, render_fn_name):
 
 <div id="contentBody">
     <form method="post" id="list-edit" class="olform" $:cond(query_param('debug'), 'action="?debug=true"')>
-        $if edit:
+        $if not new:
             <input
                 required
                 type="hidden"
@@ -117,10 +117,10 @@ $jsdef lazy_thing_preview(key, render_fn_name):
         <hr />
 
         <div class="formElement bottom">
-            $if edit:
-                $:macros.EditButtons(comment=lst.comment_)
+            $if new:
+                <button type="submit" class="larger">$_('Create new list')</button>
             $else:
-            <button type="submit" class="larger">$_('Create new list')</button>
+                $:macros.EditButtons(comment=lst.comment_)
         </div>
     </form>
 </div>

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -1,43 +1,235 @@
-$def with (page)
-
-$var title: $page.name
+$def with (lst, edit=False)
+$putctx('cssfile', 'list-edit')
+$var title: $(_("Create a list") if not edit else _("Editing list: %(list_name)s", list_name=lst.name))
 
 $putctx("robots", "noindex,nofollow")
 
 <div id="contentHead">
-    $:macros.databarEdit(page)
-
-    <h1>$_("Edit List")</h1>
+    $:macros.databarEdit(lst)
+    <h1>$(_("Edit List") if edit else _("Create a list"))</h1>
 </div>
 
+<script>
+    window.LAZY_BOOK_QUEUE = [];
+</script>
+<script type="module">
+    import debounce from 'https://esm.sh/lodash@4.17.21/debounce';
+
+    class LazyBookQueue {
+        constructor() {
+            this.queue = [];
+            this.cache = {};
+
+            this.renderDebounced = debounce(this.render.bind(this), 100);
+        }
+
+        push({key, render_fn_name}) {
+            if (this.cache[key]) {
+                this.renderKey(key, render_fn_name, this.cache[key]);
+            } else {
+                this.queue.push({key, render_fn_name});
+                this.renderDebounced();
+            }
+        }
+
+        renderKey(key, render_fn_name, book) {
+            const $$el = $$(`[data-key="$${key}"]`);
+            $$el.html(window[render_fn_name](book));
+        }
+
+        async getThings(keys) {
+            const workKeys = keys.filter(key => key.startsWith('/works/'));
+            const editionKeys = keys.filter(key => key.startsWith('/books/'));
+            const authorKeys = keys.filter(key => key.startsWith('/authors/'));
+            const fields = 'key,cover_i,first_publish_year,author_name,title,subtitle,edition_count,editions';
+            let docs = [];
+            if (workKeys.length) {
+                const resp = await fetch(`/search.json?$${new URLSearchParams({
+                    q: `key:($${workKeys.join(' OR ')})`,
+                    fields,
+                })}`).then(r => r.json());
+                docs = docs.concat(resp.docs);
+            }
+            if (editionKeys.length) {
+                const resp = await fetch(`/search.json?$${new URLSearchParams({
+                    q: `edition_key:($${editionKeys
+                        .map(key => key.split('/').pop())
+                        .join(' OR ')})`,
+                    fields,
+                })}`).then(r => r.json());
+                docs = docs.concat(resp.docs);
+            }
+            if (authorKeys.length) {
+                const resp = await fetch(`/search/authors.json?$${new URLSearchParams({
+                    q: `key:($${authorKeys.join(' OR ')})`,
+                    fields: 'key,type,name,top_work,top_subjects,birth_date,death_date',
+                })}`).then(r => r.json());
+                docs = docs.concat(resp.docs);
+            }
+
+            return docs;
+        }
+
+        async render() {
+            const keys = this.queue.map(({key}) => key);
+            const books = await this.getThings(keys);
+            for (const thing of books) {
+                this.cache[thing.key] = thing;
+                if (thing.type == 'author') {
+                    const author = thing;
+                } else {
+                    const book = thing;
+                    book.full_title = book.subtitle ? `$${book.title}: $${book.subtitle}` : book.title;
+                    if (book.editions.docs.length) {
+                        const ed = book.editions.docs[0];
+                        ed.full_title = ed.subtitle ? `$${ed.title}: $${ed.subtitle}` : ed.title;
+                        ed.author_name = book.author_name;
+                        ed.edition_count = book.edition_count;
+                        this.cache[ed.key] = ed;
+                    }
+                }
+            }
+
+            const missingKeys = keys.filter(key => !this.cache[key]);
+            console.warn('Missing books', missingKeys);
+
+            for (const {key, render_fn_name} of this.queue) {
+                this.renderKey(key, render_fn_name, this.cache[key]);
+            }
+            this.queue = [];
+        }
+    }
+    const pre_queue = window.LAZY_BOOK_QUEUE;
+    window.LAZY_BOOK_QUEUE = new LazyBookQueue();
+    for (const item of pre_queue) {
+        window.LAZY_BOOK_QUEUE.push(item);
+    }
+</script>
+
+$# Render the ith seed input field
+$jsdef render_seed_field(i, seed):
+    $ type = 'works'
+    $if seed['key']:
+        $ typ = seed['key'].split('/')[1]
+    <li class="mia__input ac-input">
+        <div class="mia__reorder">≡</div>
+        $# Displayed
+        <input class="ac-input__visible" value="$seed['key'].split('/')[-1]" placeholder="$_('Search for a book')" />
+        $# Actual value
+        <input class="ac-input__value" name="seeds--$i--key" type="hidden" value="$seed['key']" />
+        <a class="mia__remove" href="javascript:;" title="$_('Remove this item')">[x]</a>
+        <hr />
+        <div class="mia__preview">
+            <div>
+                $if typ == 'works':
+                    $_('📘 Work')
+                $elif typ == 'books':
+                    $_('📗 Edition')
+                $elif typ == 'authors':
+                    $_('🖋️ Author')
+                $elif typ == 'subjects':
+                    $_('🏷️ Subject')
+                $else:
+                    $typ
+            </div>
+            $if seed['key'] and seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books':
+                $:render_lazy_preview(seed['key'], 'render_work_autocomplete_item')
+        </div>
+    </li>
+
+$jsdef render_work_autocomplete_item(work):
+    $if work:
+        <div class="ac_work" title="Select this work">
+            <div class="cover">
+                $if work['cover_i']:
+                    <img
+                        src="https://covers.openlibrary.org/b/id/$(work['cover_i'])-M.jpg"
+                        alt="$_('Cover of: %(title)s', title=work['title'])"
+                        loading="lazy"
+                    >
+            </div>
+            <span class="olid">$work['key'].split('/')[2]</span>
+            <span class="name">
+                <span class="title">$work['full_title']</span>
+                $if 'first_publish_year' in work:
+                    <span class="first_publish_year">($work['first_publish_year'])</span>
+            </span>
+            <span class="byline">
+                $if work['author_name']:
+                    $_('by') <span class="authors">${', '.join(work['author_name'])}</span>
+            </span>
+            &bull;
+            $if work['edition_count'] == 1:
+                <span class="edition_count">$work['edition_count'] edition</span>
+            $else:
+                <span class="edition_count">$work['edition_count'] editions</span>
+            <div class="clear"></div>
+        </div>
+
+
+$jsdef render_lazy_preview(key, render_fn_name):
+    <div data-key="$key">
+        $code:
+            fake_item = {
+                'key': key,
+                'title': '...',
+                'full_title': '...',
+                'author_name': ['...'],
+                'edition_count': '_',
+                'cover_i': None,
+             }
+        $:render_work_autocomplete_item(fake_item)
+    </div>
+    <script>
+        window.LAZY_BOOK_QUEUE.push({ key: '$key', render_fn_name: '$render_fn_name' });
+    </script>
 
 <div id="contentBody">
+    <form method="post" id="list-edit" class="olform" $:cond(query_param('debug'), 'action="?debug=true"')>
+        $if edit:
+            <input
+                required
+                type="hidden"
+                name="key"
+                value="$lst.key"
+            />
 
-    <form id="editList" name="edit" method="post" action="" class="olform validate">
+        <input
+            required
+            placeholder="$_('List Name')"
+            name="name"
+            value="$lst.name"
+        />
 
-
-        <div class="formElement">
-            <div class="label">
-                <label for="name">$_("Label")</label>
-            </div>
-            <div class="input">
-                <input type="text" name="name" id="name" value="$page.name" />
-            </div>
+        <div>
+            <textarea
+                placeholder="$_('Description (optional)')"
+                class="markdown"
+                name="description"
+                rows="3" cols="30"
+            >$lst.description</textarea>
         </div>
 
-        <div class="formElement">
-            <div class="label">
-                <label for="list_description">$_("Description")</label>
-            </div>
-            <div class="input">
-                <textarea id="list_description" name="description" class="markdown" rows="5" cols="80" style="width: 100%">$page.description</textarea>
-            </div>
-        </div>
+        <hr />
 
-        <div class="clearfix"></div>
+        <ol class="list-edit__items multi-input-autocomplete--seeds">
+            $if lst.seeds:
+                $for i, seed in enumerate(lst.seeds):
+                    $if isinstance(seed, str):
+                        $ seed = {'key': '/subjects/' + seed}
+                    $:render_seed_field(i, seed)
+            $else:
+                $:render_seed_field(0, {'key': ''})
+            <a href="javascript:;" class="mia__add">$_('Add another book')</a>
+        </ol>
+
+        <hr />
 
         <div class="formElement bottom">
-            $:macros.EditButtons(comment=page.comment_)
+            $if edit:
+                $:macros.EditButtons(comment=lst.comment_)
+            $else:
+            <button type="submit" class="larger">$_('Create new list')</button>
         </div>
     </form>
 </div>

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -28,8 +28,14 @@ $jsdef render_seed_field(i, seed):
             />
             <div class="ac-input__preview">
                 $# Note: Cannot use "in" because this is a jsdef function
-                $if seed['key'] and (seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books'):
-                    $:lazy_thing_preview(seed['key'], 'render_lazy_work_preview')
+                $if seed['key']:
+                    $ prefix = seed['key'].split('/')[1]
+                    $if prefix == 'works' or prefix == 'books':
+                        $:lazy_thing_preview(seed['key'], 'render_lazy_work_preview')
+                    $elif prefix == 'authors':
+                        $:lazy_thing_preview(seed['key'], 'render_lazy_author_preview')
+                    $else:
+                        $seed['key']
                 $else:
                     $seed['key']
             </div>
@@ -38,20 +44,35 @@ $jsdef render_seed_field(i, seed):
 
 $# import the side-effect of the jsdef function
 $:render_template('jsdef/LazyWorkPreview', None)
+$:render_template('jsdef/LazyAuthorPreview', None)
 
 $jsdef lazy_thing_preview(key, render_fn_name):
     <div class="lazy-thing-preview" data-key="$key" data-render-fn="$render_fn_name">
-        $code:
-            fake_item = {
-                'key': key,
-                'title': '...',
-                'full_title': '...',
-                'author_name': ['...'],
-                'edition_count': '_',
-                'cover_i': None,
-             }
         $if not is_jsdef():
-            $:render_template('jsdef/LazyWorkPreview', fake_item)
+            $ prefix = key.split('/')[1]
+            $if prefix == 'works' or prefix == 'books':
+                $code:
+                    fake_book = {
+                        'key': key,
+                        'title': '...',
+                        'full_title': '...',
+                        'author_name': ['...'],
+                        'edition_count': '_',
+                        'cover_i': None,
+                    }
+                $:render_template('jsdef/LazyWorkPreview', fake_book)
+            $elif prefix == 'authors':
+                $code:
+                    fake_author = {
+                        'key': key,
+                        'name': '...',
+                        'birth_date': None,
+                        'death_date': None,
+                        'work_count': '_',
+                        'top_work': ['...'],
+                        'subjects': ['...'],
+                    }
+                $:render_template('jsdef/LazyAuthorPreview', fake_author)
     </div>
 
 <div id="contentBody">

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -108,32 +108,25 @@ $putctx("robots", "noindex,nofollow")
 
 $# Render the ith seed input field
 $jsdef render_seed_field(i, seed):
-    $ type = 'works'
-    $if seed['key']:
-        $ typ = seed['key'].split('/')[1]
     <li class="mia__input ac-input">
-        <div class="mia__reorder">≡</div>
-        $# Displayed
-        <input class="ac-input__visible" value="$seed['key'].split('/')[-1]" placeholder="$_('Search for a book')" />
-        $# Actual value
-        <input class="ac-input__value" name="seeds--$i--key" type="hidden" value="$seed['key']" />
-        <a class="mia__remove" href="javascript:;" title="$_('Remove this item')">[x]</a>
-        <hr />
+        <div class="seed--controls">
+            <div class="mia__reorder mia__index">≡ #$(i + 1)</div>
+            <button class="mia__remove" href="javascript:;">Remove</button>
+        </div>
         <div class="mia__preview">
-            <div>
-                $if typ == 'works':
-                    $_('📘 Work')
-                $elif typ == 'books':
-                    $_('📗 Edition')
-                $elif typ == 'authors':
-                    $_('🖋️ Author')
-                $elif typ == 'subjects':
-                    $_('🏷️ Subject')
-                $else:
-                    $typ
-            </div>
+            <input class="ac-input__value" name="seeds--$i--key" type="hidden" value="$seed['key']" />
+            $# Displayed
+            <input
+                class="ac-input__visible"
+                value="$seed['key'].split('/')[-1]"
+                placeholder="$_('Search for a book')"
+                $if seed['key']:
+                    type="hidden"
+            />
             $if seed['key'] and seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books':
                 $:render_lazy_preview(seed['key'], 'render_work_autocomplete_item')
+            $else:
+                $seed['key']
         </div>
     </li>
 
@@ -148,7 +141,7 @@ $jsdef render_work_autocomplete_item(work):
                         loading="lazy"
                     >
             </div>
-            <span class="olid">$work['key'].split('/')[2]</span>
+            <span class="olid">$work['key']</span>
             <span class="name">
                 <span class="title">$work['full_title']</span>
                 $if 'first_publish_year' in work:

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -9,108 +9,6 @@ $putctx("robots", "noindex,nofollow")
     <h1>$(_("Edit List") if edit else _("Create a list"))</h1>
 </div>
 
-<script>
-    window.LAZY_BOOK_QUEUE = [];
-</script>
-<script type="module">
-    import debounce from 'https://esm.sh/lodash@4.17.21/debounce';
-
-    class LazyBookQueue {
-        constructor() {
-            this.queue = [];
-            this.cache = {};
-
-            this.renderDebounced = debounce(this.render.bind(this), 100);
-        }
-
-        /**
-         * @param {string} key
-         * @param {string | Function} render_fn
-         */
-        push({key, render_fn}) {
-            render_fn = typeof render_fn == 'string' ? window[render_fn] : render_fn;
-            if (this.cache[key]) {
-                this.renderKey(key, render_fn, this.cache[key]);
-            } else {
-                this.queue.push({key, render_fn});
-                this.renderDebounced();
-            }
-        }
-
-        renderKey(key, render_fn, book) {
-            const $$el = $$(`[data-key="$${key}"]`);
-            $$el.html(render_fn(book));
-        }
-
-        async getThings(keys) {
-            const workKeys = keys.filter(key => key.startsWith('/works/'));
-            const editionKeys = keys.filter(key => key.startsWith('/books/'));
-            const authorKeys = keys.filter(key => key.startsWith('/authors/'));
-            const fields = 'key,cover_i,first_publish_year,author_name,title,subtitle,edition_count,editions';
-            let docs = [];
-            if (workKeys.length) {
-                const resp = await fetch(`/search.json?$${new URLSearchParams({
-                    q: `key:($${workKeys.join(' OR ')})`,
-                    fields,
-                })}`).then(r => r.json());
-                docs = docs.concat(resp.docs);
-            }
-            if (editionKeys.length) {
-                const resp = await fetch(`/search.json?$${new URLSearchParams({
-                    q: `edition_key:($${editionKeys
-                        .map(key => key.split('/').pop())
-                        .join(' OR ')})`,
-                    fields,
-                })}`).then(r => r.json());
-                docs = docs.concat(resp.docs);
-            }
-            if (authorKeys.length) {
-                const resp = await fetch(`/search/authors.json?$${new URLSearchParams({
-                    q: `key:($${authorKeys.join(' OR ')})`,
-                    fields: 'key,type,name,top_work,top_subjects,birth_date,death_date',
-                })}`).then(r => r.json());
-                docs = docs.concat(resp.docs);
-            }
-
-            return docs;
-        }
-
-        async render() {
-            const keys = this.queue.map(({key}) => key);
-            const books = await this.getThings(keys);
-            for (const thing of books) {
-                this.cache[thing.key] = thing;
-                if (thing.type == 'author') {
-                    const author = thing;
-                } else {
-                    const book = thing;
-                    book.full_title = book.subtitle ? `$${book.title}: $${book.subtitle}` : book.title;
-                    if (book.editions.docs.length) {
-                        const ed = book.editions.docs[0];
-                        ed.full_title = ed.subtitle ? `$${ed.title}: $${ed.subtitle}` : ed.title;
-                        ed.author_name = book.author_name;
-                        ed.edition_count = book.edition_count;
-                        this.cache[ed.key] = ed;
-                    }
-                }
-            }
-
-            const missingKeys = keys.filter(key => !this.cache[key]);
-            console.warn('Missing books', missingKeys);
-
-            for (const {key, render_fn} of this.queue) {
-                this.renderKey(key, render_fn, this.cache[key]);
-            }
-            this.queue = [];
-        }
-    }
-    const pre_queue = window.LAZY_BOOK_QUEUE;
-    window.LAZY_BOOK_QUEUE = new LazyBookQueue();
-    for (const item of pre_queue) {
-        window.LAZY_BOOK_QUEUE.push(item);
-    }
-</script>
-
 $# Render the ith seed input field
 $jsdef render_seed_field(i, seed):
     <li class="mia__input ac-input">
@@ -130,7 +28,7 @@ $jsdef render_seed_field(i, seed):
             />
             <div class="ac-input__preview">
                 $if seed['key'] and seed['key'].split('/')[1] == 'works' or seed['key'].split('/')[1] == 'books':
-                    $:render_lazy_preview(seed['key'], 'render_work_autocomplete_item')
+                    $:lazy_thing_preview(seed['key'], 'render_work_autocomplete_item')
                 $else:
                     $seed['key']
             </div>
@@ -167,8 +65,8 @@ $jsdef render_work_autocomplete_item(work):
         </div>
 
 
-$jsdef render_lazy_preview(key, render_fn_name):
-    <div data-key="$key">
+$jsdef lazy_thing_preview(key, render_fn_name):
+    <div class="lazy-thing-preview" data-key="$key" data-render-fn="$render_fn_name">
         $code:
             fake_item = {
                 'key': key,
@@ -180,9 +78,6 @@ $jsdef render_lazy_preview(key, render_fn_name):
              }
         $:render_work_autocomplete_item(fake_item)
     </div>
-    <script>
-        window.LAZY_BOOK_QUEUE.push({ key: '$key', render_fn: '$render_fn_name' });
-    </script>
 
 <div id="contentBody">
     <form method="post" id="list-edit" class="olform" $:cond(query_param('debug'), 'action="?debug=true"')>

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -37,7 +37,7 @@ $jsdef render_seed_count(seed_count):
 
 $if not is_owner:
     <div id="contentHead" style="margin-bottom:0;">
-        $:macros.databarView(list)
+        $:macros.databarView(list, edit=False)
         <div class="superNav">
             $ owner = list.get_owner()
             <a href="$owner.key">$owner.displayname</a>

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -163,11 +163,14 @@ def olid_to_key(olid: str) -> str:
     '/authors/OL123A'
     >>> olid_to_key('OL123M')
     '/books/OL123M'
+    >>> olid_to_key("OL123L")
+    '/lists/OL123L'
     """
     typ = {
         'A': 'authors',
         'W': 'works',
         'M': 'books',
+        'L': 'lists',
     }[olid[-1]]
     if not typ:
         raise ValueError(f"Invalid olid: {olid}")
@@ -188,29 +191,6 @@ def extract_numeric_id_from_olid(olid):
     if not is_number(olid[-1].lower()):
         olid = olid[:-1]
     return olid
-
-
-def olid_to_key(olid: str) -> str:
-    """
-    >>> olid_to_key("OL123W")
-    '/works/OL123W'
-    >>> olid_to_key("OL123A")
-    '/authors/OL123A'
-    >>> olid_to_key("OL123M")
-    '/books/OL123M'
-    >>> olid_to_key("OL123L")
-    '/lists/OL123L'
-    """
-    if olid.endswith("M"):
-        return f"/books/{olid}"
-    elif olid.endswith("W"):
-        return f"/works/{olid}"
-    elif olid.endswith("A"):
-        return f"/authors/{olid}"
-    elif olid.endswith("L"):
-        return f"/lists/{olid}"
-    else:
-        raise ValueError(f"Invalid OLID: {olid}")
 
 
 def is_number(s):

--- a/openlibrary/utils/__init__.py
+++ b/openlibrary/utils/__init__.py
@@ -190,6 +190,29 @@ def extract_numeric_id_from_olid(olid):
     return olid
 
 
+def olid_to_key(olid: str) -> str:
+    """
+    >>> olid_to_key("OL123W")
+    '/works/OL123W'
+    >>> olid_to_key("OL123A")
+    '/authors/OL123A'
+    >>> olid_to_key("OL123M")
+    '/books/OL123M'
+    >>> olid_to_key("OL123L")
+    '/lists/OL123L'
+    """
+    if olid.endswith("M"):
+        return f"/books/{olid}"
+    elif olid.endswith("W"):
+        return f"/works/{olid}"
+    elif olid.endswith("A"):
+        return f"/authors/{olid}"
+    elif olid.endswith("L"):
+        return f"/lists/{olid}"
+    else:
+        raise ValueError(f"Invalid OLID: {olid}")
+
+
 def is_number(s):
     """
     >>> all(is_number(n) for n in (1234, "1234", -1234, "-1234", 123.4, -123.4))

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -48,10 +48,36 @@
   }
 
   .multi-input-autocomplete--seeds {
-    counter-reset: list-seeds;
-    li.mia__input::before {
-      counter-increment: list-seeds;
-      content: counters(list-seeds, ".") ".";
+    li.mia__input {
+      list-style: none;
+    }
+
+    .seed--controls {
+      display: flex;
+      flex-direction: column;
+      padding-right: 4px;
+      border-right: 1px solid #aaa;
+      margin-right: 4px;
+
+      .mia__reorder {
+        flex: 1;
+        text-align: left;
+      }
+    }
+
+    @media (max-width: @width-breakpoint-mobile) {
+      li.mia__input {
+        flex-direction: column;
+      }
+      .seed--controls {
+        flex-direction: row;
+        padding-right: 0;
+        border-right: 0;
+        margin-right: 0;
+        padding-bottom: 4px;
+        border-bottom: 1px solid #aaa;
+        margin-bottom: 4px;
+      }
     }
 
     .mia__preview .ac_work .cover {
@@ -86,7 +112,7 @@
     }
 
     .mia__preview {
-      width: 100%;
+      flex: 1;
     }
 
     // Weird glitch where while dragging the element is very offset

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -47,44 +47,6 @@
     }
   }
 
-  .multi-input-autocomplete--seeds {
-    li.mia__input {
-      list-style: none;
-    }
-
-    .seed--controls {
-      display: flex;
-      flex-direction: column;
-      padding-right: 4px;
-      border-right: 1px solid #aaa;
-      margin-right: 4px;
-
-      .mia__reorder {
-        flex: 1;
-        text-align: left;
-      }
-    }
-
-    @media (max-width: @width-breakpoint-mobile) {
-      li.mia__input {
-        flex-direction: column;
-      }
-      .seed--controls {
-        flex-direction: row;
-        padding-right: 0;
-        border-right: 0;
-        margin-right: 0;
-        padding-bottom: 4px;
-        border-bottom: 1px solid #aaa;
-        margin-bottom: 4px;
-      }
-    }
-
-    .mia__preview .ac_work .cover {
-      margin-right: 9px;
-    }
-  }
-
   .mia__input {
     display: flex;
     flex-flow: wrap;

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -47,6 +47,18 @@
     }
   }
 
+  .multi-input-autocomplete--seeds {
+    counter-reset: list-seeds;
+    li.mia__input::before {
+      counter-increment: list-seeds;
+      content: counters(list-seeds, ".") ".";
+    }
+
+    .mia__preview .ac_work .cover {
+      margin-right: 9px;
+    }
+  }
+
   .mia__input {
     display: flex;
     flex-flow: wrap;
@@ -71,6 +83,10 @@
     .mia__remove {
       color: @red;
       text-decoration: none;
+    }
+
+    .mia__preview {
+      width: 100%;
     }
 
     // Weird glitch where while dragging the element is very offset
@@ -107,8 +123,6 @@
   }
 
   select {
-    width: 100%;
-    font-size: 1.125em;
     font-family: @lucida_sans_serif-1;
     padding: 3px;
   }

--- a/static/css/components/jquery.autocomplete.less
+++ b/static/css/components/jquery.autocomplete.less
@@ -47,7 +47,7 @@
   color: @black;
 }
 
-.ac_results .ac_author {
+.ac_author {
   .action {
     font-size: 9px;
     color: @olive;

--- a/static/css/components/jquery.autocomplete.less
+++ b/static/css/components/jquery.autocomplete.less
@@ -84,7 +84,7 @@
   }
 }
 
-.ac_results .ac_work {
+.ac_work {
   .cover {
     float: left;
     margin-right: 5px;
@@ -113,6 +113,7 @@
 
   .name {
     display: block;
+    line-height: 1.1em;
   }
 
   .title {

--- a/static/css/legacy-jquery-ui.less
+++ b/static/css/legacy-jquery-ui.less
@@ -24,7 +24,7 @@
   border: 1px dotted @mid-grey;
   visibility: visible !important;
   border-radius: 6px;
-  * {
+  *, &:before, &:after {
     visibility: hidden;
   }
 }

--- a/static/css/legacy-jquery-ui.less
+++ b/static/css/legacy-jquery-ui.less
@@ -23,6 +23,7 @@
 .ui-sortable-placeholder {
   border: 1px dotted @mid-grey;
   visibility: visible !important;
+  filter: brightness(0.8);
   border-radius: 6px;
   *, &:before, &:after {
     visibility: hidden;

--- a/static/css/legacy-jquery-ui.less
+++ b/static/css/legacy-jquery-ui.less
@@ -23,7 +23,7 @@
 .ui-sortable-placeholder {
   border: 1px dotted @mid-grey;
   visibility: visible !important;
-  filter: brightness(0.8);
+  filter: brightness(.85);
   border-radius: 6px;
   *, &:before, &:after {
     visibility: hidden;

--- a/static/css/page-list-edit.less
+++ b/static/css/page-list-edit.less
@@ -1,0 +1,56 @@
+/**
+ * Stylesheet entry point for pages with body-edit
+
+ * Used in templates:
+ * - openlibrary/templates/type/list/edit.html
+ * Used on pages:
+ * - /list/add
+ */
+@import (less) "less/colors.less";
+@import (less) "less/breakpoints.less";
+@import (less) "less/mixins.less";
+@import (less) "less/font-families.less";
+@import (less) "legacy.less";
+
+#list-edit {
+    max-width: 800px;
+
+    [name=name] {
+        font-size: 1.5em;
+    }
+
+    > *:not(div), textarea {
+        display: block;
+        width: 100%;
+    }
+
+    textarea, input {
+        padding: 4px;
+        max-width: 800px;
+    }
+
+    > *:not(:first-child) {
+        margin-top: 6px;
+    }
+
+    .mia__input {
+        width: 90%;
+        margin-top: 6px;
+        border: 1px solid #bbb;
+        border-radius: 4px;
+        padding: 8px;
+        background: #f8f8f8;
+
+        hr {
+            width: calc(100% - 20px);
+        }
+    }
+}
+
+.new-list__seed__position {
+    font-size: 0.9em;
+}
+
+.work-autocomplete {
+    width: calc(100% - 8ch);
+}

--- a/static/css/page-list-edit.less
+++ b/static/css/page-list-edit.less
@@ -13,48 +13,88 @@
 @import (less) "legacy.less";
 
 #list-edit {
+  max-width: 800px;
+
+  [name=name] {
+    font-size: 1.5em;
+  }
+
+  > *:not(div), textarea {
+    display: block;
+    width: 100%;
+  }
+
+  textarea, input {
+    padding: 4px;
     max-width: 800px;
+  }
 
-    [name=name] {
-        font-size: 1.5em;
+  > *:not(:first-child) {
+    margin-top: 6px;
+  }
+
+  .multi-input-autocomplete--seeds {
+    .seed--controls {
+      display: flex;
+    }
+    .mia__reorder {
+      flex: 1;
+      text-align: left;
     }
 
-    > *:not(div), textarea {
-        display: block;
-        width: 100%;
+    @media (max-width: @width-breakpoint-mobile) {
+      li.mia__input {
+        flex-direction: column;
+      }
+      .seed--controls {
+        flex-direction: row;
+        padding-bottom: 4px;
+        border-bottom: 1px solid @light-mid-grey;
+        margin-bottom: 4px;
+      }
     }
 
-    textarea, input {
-        padding: 4px;
-        max-width: 800px;
+    @media (min-width: @width-breakpoint-mobile) {
+      li.mia__input {
+        flex-direction: row;
+      }
+
+      .seed--controls {
+        flex-direction: column;
+        padding-right: 4px;
+        border-right: 1px solid @light-mid-grey;
+        margin-right: 4px;
+      }
     }
 
-    > *:not(:first-child) {
-        margin-top: 6px;
+    .mia__preview .ac_work .cover {
+      margin-right: 9px;
+    }
+  }
+
+  .mia__input {
+    list-style: none;
+    width: 90%;
+    margin-top: 6px;
+    border: 1px solid @light-grey;
+    border-radius: 4px;
+    padding: 8px;
+    background: @grey-fafafa;
+
+    main {
+      flex: 1;
     }
 
-    .mia__input {
-        width: 90%;
-        margin-top: 6px;
-        border: 1px solid #bbb;
-        border-radius: 4px;
-        padding: 8px;
-        background: #f8f8f8;
-
-        main {
-            flex: 1;
-        }
-
-        .ac-input__visible.accept {
-            display: none;
-        }
+    .ac-input__visible.accept {
+      display: none;
     }
+  }
 }
 
 .new-list__seed__position {
-    font-size: 0.9em;
+  font-size: .9em;
 }
 
 .work-autocomplete {
-    width: calc(100% - 8ch);
+  width: calc(100% - 8ch);
 }

--- a/static/css/page-list-edit.less
+++ b/static/css/page-list-edit.less
@@ -41,8 +41,12 @@
         padding: 8px;
         background: #f8f8f8;
 
-        hr {
-            width: calc(100% - 20px);
+        main {
+            flex: 1;
+        }
+
+        .ac-input__visible.accept {
+            display: none;
         }
     }
 }

--- a/static/css/page-list-edit.less
+++ b/static/css/page-list-edit.less
@@ -85,6 +85,10 @@
       flex: 1;
     }
 
+    .ac-input__visible {
+      width: 100%;
+    }
+
     .ac-input__visible.accept {
       display: none;
     }


### PR DESCRIPTION
Closes #7808

- The "edit" button on your lists now lets you re-order or add works to the list
- New API: `/people/{USERNAME}/lists/add` endpoint let's you create a new list under your namespace
- e.g. (change the username to avoid permission issues)  https://testing.openlibrary.org/people/ScarTissue/lists/add?seeds=OL23553W

### Technical
- You can only add works to a list from the edit page ; authors/etc display correctly (ish) , but can't be added from here
- Note admins can create lists under other users
- Future work:
    - List edit page should support more than 100 book previews
    - List edit page should show preview cards for redirects

### Testing
- Go to one of your lists and try to edit it!
- NOTE: Because testing.openlibrary.org cache issues, you might not see your edits reflected immediately.
- [x] Cannot edit other people's lists
- [x] Cannot create a new list on another person's page


### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/6251786/2ad53580-3578-41d1-87c3-3047d8822365)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/1ecdca6a-cd75-4ce2-ad6d-689a2fd343b3)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/7a978eba-bbb1-49c4-b0dd-aa8d40749b73)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
