### PR TITLE
Make reordering covers/authors/etc work on touch screens

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -2,6 +2,7 @@
 import 'jquery-ui/ui/widget';
 import 'jquery-ui/ui/widgets/mouse';
 import 'jquery-ui/ui/widgets/sortable';
+import 'jquery-ui-touch-punch'; // this makes drag-to-reorder work on touch devices
 
 /**
  * Port of code in vendor/js/jquery-autocomplete removed in e91119b

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -2,6 +2,7 @@
  * Functionality for templates/covers
  */
 import 'jquery-ui/ui/widgets/sortable';
+import 'jquery-ui-touch-punch'; // this makes drag-to-reorder work on touch devices
 
 //cover/change.html
 export function initCoversChange() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "jquery": "3.6.0",
         "jquery-colorbox": "1.6.4",
         "jquery-ui": "1.13.2",
+        "jquery-ui-touch-punch": "^0.2.3",
         "jquery-validation": "1.19.3",
         "less": "4.1.3",
         "less-loader": "7.3.0",
@@ -27794,6 +27795,12 @@
       "dependencies": {
         "jquery": ">=1.8.0 <4.0.0"
       }
+    },
+    "node_modules/jquery-ui-touch-punch": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/jquery-ui-touch-punch/-/jquery-ui-touch-punch-0.2.3.tgz",
+      "integrity": "sha512-Q/7aAd+SjbV0SspHO7Kuk96NJIbLwJAS0lD81U1PKcU2T5ZKayXMORH+Y5qvYLuy41xqVQbWimsRKDn1v3oI2Q==",
+      "dev": true
     },
     "node_modules/jquery-validation": {
       "version": "1.19.3",
@@ -63113,6 +63120,12 @@
       "requires": {
         "jquery": ">=1.8.0 <4.0.0"
       }
+    },
+    "jquery-ui-touch-punch": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/jquery-ui-touch-punch/-/jquery-ui-touch-punch-0.2.3.tgz",
+      "integrity": "sha512-Q/7aAd+SjbV0SspHO7Kuk96NJIbLwJAS0lD81U1PKcU2T5ZKayXMORH+Y5qvYLuy41xqVQbWimsRKDn1v3oI2Q==",
+      "dev": true
     },
     "jquery-validation": {
       "version": "1.19.3",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "jquery": "3.6.0",
     "jquery-colorbox": "1.6.4",
     "jquery-ui": "1.13.2",
+    "jquery-ui-touch-punch": "0.2.3",
     "jquery-validation": "1.19.3",
     "less": "4.1.3",
     "less-loader": "7.3.0",

--- a/static/css/page-list-edit.less
+++ b/static/css/page-list-edit.less
@@ -38,7 +38,6 @@
       display: flex;
     }
     .mia__reorder {
-      flex: 1;
       text-align: left;
     }
 
@@ -51,6 +50,7 @@
         padding-bottom: 4px;
         border-bottom: 1px solid @light-mid-grey;
         margin-bottom: 4px;
+        justify-content: space-between;
       }
     }
 
@@ -58,7 +58,9 @@
       li.mia__input {
         flex-direction: row;
       }
-
+      .mia__reorder {
+        flex: 1;
+      }
       .seed--controls {
         flex-direction: column;
         padding-right: 4px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #905

~Blocked waiting on #8113~


### Technical
- Also reduced the size of the reorder hit region for lists to make accidentally reordering less likely.

### Testing
1. Try dragging around the covers here, or dragging them to the trash region: https://testing.openlibrary.org/works/OL257943W/A_Game_of_Thrones/manage-covers

- [x] drag/drop of covers works on Android
- [x] drag/drop of list items works on Android

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
