### PR TITLE
Upgrade to ruff v0.0.280

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Run tests
         run: |
           git fetch --no-tags --prune --depth=1 origin master
-          make lint
           make test-py
           source scripts/run_doctests.sh
           mypy --install-types --non-interactive .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: pip install --user ruff==0.0.277
+    - run: pip install --user ruff==0.0.280
     - run: ruff --format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: auto-walrus
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.0.280
     hooks:
       - id: ruff
 

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -488,7 +488,7 @@ def find_exact_match(rec, edition_pool):
     :return: edition key
     """
     seen = set()
-    for field, editions in edition_pool.items():
+    for editions in edition_pool.values():
         for ekey in editions:
             if ekey in seen:
                 continue
@@ -882,8 +882,8 @@ def load(rec, account_key=None):
     # We have an edition match at this point
     need_work_save = need_edition_save = False
     # w = None
-    w: "Work"
-    e: "Edition" = web.ctx.site.get(match)
+    w: Work
+    e: Edition = web.ctx.site.get(match)
     # check for, and resolve, author redirects
     for a in e.authors:
         while is_redirect(a):

--- a/openlibrary/catalog/marc/marc_xml.py
+++ b/openlibrary/catalog/marc/marc_xml.py
@@ -81,7 +81,7 @@ class MarcXml(MarcBase):
     def read_fields(self, want: list[str]) -> Iterator[tuple[str, str | DataField]]:
         non_digit = False
         for f in self.record:
-            if f.tag != data_tag and f.tag != control_tag:
+            if f.tag not in {data_tag, control_tag}:
                 continue
             tag = f.attrib['tag']
             if tag == '':

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -413,9 +413,10 @@ def read_author_person(field: MarcFieldBase, tag: str = '100') -> dict | None:
     if 'q' in contents:
         author['fuller_name'] = ' '.join(contents['q'])
     if '6' in contents:  # noqa: SIM102 - alternate script name exists
-        if link := field.rec.get_linkage(tag, contents['6'][0]):
-            if alt_name := link.get_subfield_values('a'):
-                author['alternate_names'] = [name_from_list(alt_name)]
+        if (link := field.rec.get_linkage(tag, contents['6'][0])) and (
+            alt_name := link.get_subfield_values('a')
+        ):
+            author['alternate_names'] = [name_from_list(alt_name)]
     return author
 
 

--- a/openlibrary/catalog/marc/tests/test_marc_binary.py
+++ b/openlibrary/catalog/marc/tests/test_marc_binary.py
@@ -23,9 +23,9 @@ def test_wrapped_lines():
     a, b = ret
     assert a[0] == '520'
     assert b[0] == '520'
-    a_content = list(a[1].get_all_subfields())[0][1]
+    a_content = next(iter(a[1].get_all_subfields()))[1]
     assert len(a_content) == 2290
-    b_content = list(b[1].get_all_subfields())[0][1]
+    b_content = next(iter(b[1].get_all_subfields()))[1]
     assert len(b_content) == 243
 
 

--- a/openlibrary/catalog/merge/names.py
+++ b/openlibrary/catalog/merge/names.py
@@ -223,8 +223,7 @@ def match_surname(surname, name):
 
 
 def amazon_spaced_name(amazon, marc):
-    len_amazon = len(amazon)
-    if len_amazon != 30 and len_amazon != 31:
+    if len(amazon) not in {30, 31}:
         return False
     m = re_amazon_space_name.search(amazon)
     if not m:

--- a/openlibrary/catalog/utils/__init__.py
+++ b/openlibrary/catalog/utils/__init__.py
@@ -239,7 +239,7 @@ def strip_count(counts):
             (i, j)
         )
     ret = {}
-    for k, v in foo.items():
+    for v in foo.values():
         m = max(v, key=lambda x: len(x[1]))[0]
         bar = []
         for i, j in v:

--- a/openlibrary/plugins/books/readlinks.py
+++ b/openlibrary/plugins/books/readlinks.py
@@ -244,7 +244,7 @@ class ReadProcessor:
 
         def sortfn(sortitem):
             iaid, status, date = sortitem
-            if iaid == orig_iaid and (status == 'full access' or status == 'lendable'):
+            if iaid == orig_iaid and status in {'full access', 'lendable'}:
                 isexact = '000'
             else:
                 isexact = '999'
@@ -253,7 +253,7 @@ class ReadProcessor:
                 date = 5000
             date = int(date)
             # reverse-sort modern works by date
-            if status == 'lendable' or status == 'checked out':
+            if status in {'lendable', 'checked out'}:
                 date = 10000 - date
             statusvals = {
                 'full access': 1,

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -778,14 +778,14 @@ class SaveBookHelper:
             return
 
         # read ocaid from form data
-        try:
-            ocaid = [
-                id['value']
-                for id in edition.get('identifiers', [])
-                if id['name'] == 'ocaid'
-            ][0]
-        except IndexError:
-            ocaid = None
+        ocaid = next(
+            (
+                id_['value']
+                for id_ in edition.get('identifiers', [])
+                if id_['name'] == 'ocaid'
+            ),
+            None,
+        )
 
         # 'self.edition' is the edition doc from the db and 'edition' is the doc from formdata
         if (

--- a/openlibrary/records/driver.py
+++ b/openlibrary/records/driver.py
@@ -112,7 +112,7 @@ def run_filter(matched_keys, params):
             # In case of the 'title' and 'authors', if it's there in
             # the search params, it *should* match.
             for k in i2:
-                if k == "title" or k == "authors":
+                if k in {"title", "authors"}:
                     # Special case title and authors. Return False if not present in thing
                     # TODO: Convert author names to keys.
                     if k not in i1 or not compare(i1[k], i2[k]):

--- a/openlibrary/solr/update_work.py
+++ b/openlibrary/solr/update_work.py
@@ -325,7 +325,7 @@ class SolrProcessor:
                 if 'ia_box_id' in e and isinstance(e['ia_box_id'], str):
                     e['ia_box_id'] = [e['ia_box_id']]
                 if ia_meta_fields.get('boxid'):
-                    box_id = list(ia_meta_fields['boxid'])[0]
+                    box_id = next(iter(ia_meta_fields['boxid']))
                     e.setdefault('ia_box_id', [])
                     if box_id.lower() not in [x.lower() for x in e['ia_box_id']]:
                         e['ia_box_id'].append(box_id)

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -556,39 +556,51 @@ class TestYearlyReadingGoals:
 
     def test_update_current_count(self):
         assert (
-            list(
-                self.db.select(
-                    self.TABLENAME, where={'username': '@billy_pilgrim', 'year': 2023}
+            next(
+                iter(
+                    self.db.select(
+                        self.TABLENAME,
+                        where={'username': '@billy_pilgrim', 'year': 2023},
+                    )
                 )
-            )[0]['current']
+            )['current']
             == 0
         )
         YearlyReadingGoals.update_current_count('@billy_pilgrim', 2023, 10)
         assert (
-            list(
-                self.db.select(
-                    self.TABLENAME, where={'username': '@billy_pilgrim', 'year': 2023}
+            next(
+                iter(
+                    self.db.select(
+                        self.TABLENAME,
+                        where={'username': '@billy_pilgrim', 'year': 2023},
+                    )
                 )
-            )[0]['current']
+            )['current']
             == 10
         )
 
     def test_update_target(self):
         assert (
-            list(
-                self.db.select(
-                    self.TABLENAME, where={'username': '@billy_pilgrim', 'year': 2023}
+            next(
+                iter(
+                    self.db.select(
+                        self.TABLENAME,
+                        where={'username': '@billy_pilgrim', 'year': 2023},
+                    )
                 )
-            )[0]['target']
+            )['target']
             == 7
         )
         YearlyReadingGoals.update_target('@billy_pilgrim', 2023, 14)
         assert (
-            list(
-                self.db.select(
-                    self.TABLENAME, where={'username': '@billy_pilgrim', 'year': 2023}
+            next(
+                iter(
+                    self.db.select(
+                        self.TABLENAME,
+                        where={'username': '@billy_pilgrim', 'year': 2023},
+                    )
                 )
-            )[0]['target']
+            )['target']
             == 14
         )
 

--- a/openlibrary/utils/bulkimport.py
+++ b/openlibrary/utils/bulkimport.py
@@ -310,7 +310,7 @@ class Reindexer:
                 if table in all_tables:
                     data[table].append(doc['id'])
 
-        for table, thing_ids in data.items():
+        for table in data:
             self.db.delete(table, where="thing_id IN $thing_ids", vars=locals())
 
     def create_new_index(self, documents, tables=None):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,5 +9,5 @@ pymemcache==4.0.0
 pytest==7.4.0
 pytest-asyncio==0.21.1
 pytest-cov==4.1.0
-ruff==0.0.277
+ruff==0.0.280
 safety==2.3.5

--- a/scripts/copydocs.py
+++ b/scripts/copydocs.py
@@ -127,7 +127,7 @@ def get_references(doc, result=None):
         if 'key' in doc and len(doc) == 1:
             result.append(doc['key'])
 
-        for k, v in doc.items():
+        for v in doc.values():
             get_references(v, result)
     return result
 

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -145,33 +145,29 @@ class LocalPostgresDataProvider(DataProvider):
         cur.close()
 
     def cache_edition_works(self, lo_key, hi_key):
-        q = """
+        q = f"""
             SELECT works."Key", works."JSON"
             FROM "test" editions
             INNER JOIN test works
                 ON editions."JSON" -> 'works' -> 0 ->> 'key' = works."Key"
             WHERE editions."Type" = '/type/edition'
-                AND '{}' <= editions."Key" AND editions."Key" <= '{}'
-        """.format(
-            lo_key, hi_key
-        )
+                AND '{lo_key}' <= editions."Key" AND editions."Key" <= '{hi_key}'
+        """
         self.query_all(q, json_cache=self.cache)
 
     def cache_work_editions(self, lo_key, hi_key):
-        q = """
+        q = f"""
             SELECT "Key", "JSON"
             FROM "test"
             WHERE "Type" = '/type/edition'
-                AND '{}' <= "JSON" -> 'works' -> 0 ->> 'key'
-                AND "JSON" -> 'works' -> 0 ->> 'key' <= '{}'
-        """.format(
-            lo_key, hi_key
-        )
+                AND '{lo_key}' <= "JSON" -> 'works' -> 0 ->> 'key'
+                AND "JSON" -> 'works' -> 0 ->> 'key' <= '{hi_key}'
+        """
         self.query_all(q, json_cache=self.cache)
         self.cached_work_editions_ranges.append((lo_key, hi_key))
 
     def cache_edition_authors(self, lo_key, hi_key):
-        q = """
+        q = f"""
             SELECT authors."Key", authors."JSON"
             FROM "test" editions
             INNER JOIN test works
@@ -180,15 +176,13 @@ class LocalPostgresDataProvider(DataProvider):
                 ON works."JSON" -> 'authors' -> 0 -> 'author' ->> 'key' = authors."Key"
             WHERE editions."Type" = '/type/edition'
                 AND editions."JSON" -> 'works' -> 0 ->> 'key' IS NULL
-                AND '{}' <= editions."Key" AND editions."Key" <= '{}'
-        """.format(
-            lo_key, hi_key
-        )
+                AND '{lo_key}' <= editions."Key" AND editions."Key" <= '{hi_key}'
+        """
         self.query_all(q, json_cache=self.cache)
 
     def cache_work_authors(self, lo_key, hi_key):
         # Cache upto first five authors
-        q = """
+        q = f"""
             SELECT authors."Key", authors."JSON"
             FROM "test" works
             INNER JOIN "test" authors ON (
@@ -199,10 +193,8 @@ class LocalPostgresDataProvider(DataProvider):
                 works."JSON" -> 'authors' -> 4 -> 'author' ->> 'key' = authors."Key"
             )
             WHERE works."Type" = '/type/work'
-            AND '{}' <= works."Key" AND works."Key" <= '{}'
-        """.format(
-            lo_key, hi_key
-        )
+            AND '{lo_key}' <= works."Key" AND works."Key" <= '{hi_key}'
+        """
         self.query_all(q, json_cache=self.cache)
 
     def cache_work_ratings(self, lo_key, hi_key):


### PR DESCRIPTION
Fixes #8125
Fixes #8129

% `ruff --statistics .`
```
8	RUF015 	[*] Prefer `next(...)` over single element slice
5	PLR1714	[ ] Consider merging multiple comparisons: `f.tag not in (data_tag, control_tag)`. Use a `set` if the elements are hashable.
4	PERF102	[*] When using only the keys of a dict use the `keys()` method
4	UP032  	[*] Use f-string instead of `format` call
2	UP037  	[*] Remove quotes from type annotation
1	SIM102 	[*] Use a single `if` statement instead of nested `if` statements
```
% `ruff --fix .`
```
openlibrary/catalog/marc/marc_xml.py:84:16: PLR1714 Consider merging multiple comparisons: `f.tag not in (data_tag, control_tag)`. Use a `set` if the elements are hashable.
openlibrary/catalog/merge/names.py:227:8: PLR1714 Consider merging multiple comparisons: `len_amazon not in (30, 31)`. Use a `set` if the elements are hashable.
openlibrary/plugins/books/readlinks.py:247:39: PLR1714 Consider merging multiple comparisons: `status in ('full access', 'lendable')`. Use a `set` if the elements are hashable.
openlibrary/plugins/books/readlinks.py:256:16: PLR1714 Consider merging multiple comparisons: `status in ('lendable', 'checked out')`. Use a `set` if the elements are hashable.
openlibrary/records/driver.py:115:20: PLR1714 Consider merging multiple comparisons: `k in ("title", "authors")`. Use a `set` if the elements are hashable.
Found 25 errors (20 fixed, 5 remaining).
```
Update `.pre-commit-config.yaml` and manual fixes for `ruff rule PLR1714` repeated-equality-comparison-target.

Remove `make lint` from tests GitHub Action because we do not need to run ruff three times on every pull request.

Modify `openlibrary/plugins/upstream/addbook.py` to use `StopIteration` instead of `IndexError` as discussed in
`ruff rule RUF015`
> `list(...)[0]` will raise `IndexError` if the collection is empty, while `next(iter(...))` will raise `StopIteration`.
