### PR TITLE
8111/feature/rename and move build marc

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -36,7 +36,7 @@ import requests
 from infogami import config
 
 from openlibrary import accounts
-from openlibrary.catalog.merge.merge_marc import build_marc
+from openlibrary.catalog.merge.merge_marc import expand_record
 from openlibrary.catalog.utils import mk_norm
 from openlibrary.core import lending
 from openlibrary.plugins.upstream.utils import strip_accents
@@ -532,7 +532,7 @@ def find_enriched_match(rec, edition_pool):
     :rtype: str|None
     :return: None or the edition key '/books/OL...M' of the best edition match for enriched_rec in edition_pool
     """
-    enriched_rec = build_marc(rec)
+    enriched_rec = expand_record(rec)
     add_db_name(enriched_rec)
 
     seen = set()
@@ -728,7 +728,7 @@ def find_match(rec, edition_pool) -> str | None:
 
     if not match:
         # Add 'full_title' to the rec by conjoining 'title' and 'subtitle'.
-        # build_marc() uses this for matching.
+        # expand_record() uses this for matching.
         rec['full_title'] = rec['title']
         if subtitle := rec.get('subtitle'):
             rec['full_title'] += ' ' + subtitle

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -36,10 +36,10 @@ import requests
 from infogami import config
 
 from openlibrary import accounts
-from openlibrary.catalog.merge.merge_marc import expand_record
 from openlibrary.catalog.utils import mk_norm
 from openlibrary.core import lending
 from openlibrary.plugins.upstream.utils import strip_accents
+from openlibrary.catalog.utils import expand_record
 from openlibrary.utils import uniq, dicthash
 from openlibrary.utils.isbn import normalize_isbn
 from openlibrary.utils.lccn import normalize_lccn

--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -1,7 +1,7 @@
 import web
 from deprecated import deprecated
 from openlibrary.catalog.merge.merge_marc import (
-    build_marc,
+    expand_record,
     editions_match as threshold_match,
 )
 
@@ -30,7 +30,7 @@ def editions_match(candidate, existing):
     Used by add_book.load() -> add_book.find_match() to check whether two
     editions match.
 
-    :param dict candidate: Output of build_marc(import record candidate)
+    :param dict candidate: Output of expand_record(import record candidate)
     :param Thing existing: Edition object to be tested against candidate
     :rtype: bool
     :return: Whether candidate is sufficiently the same as the 'existing' edition
@@ -63,5 +63,5 @@ def editions_match(candidate, existing):
             if a.type.key == '/type/author':
                 assert a['name']
                 rec2['authors'].append({'name': a['name'], 'db_name': db_name(a)})
-    e2 = build_marc(rec2)
+    e2 = expand_record(rec2)
     return threshold_match(candidate, e2, threshold)

--- a/openlibrary/catalog/add_book/match.py
+++ b/openlibrary/catalog/add_book/match.py
@@ -1,9 +1,7 @@
 import web
 from deprecated import deprecated
-from openlibrary.catalog.merge.merge_marc import (
-    expand_record,
-    editions_match as threshold_match,
-)
+from openlibrary.catalog.utils import expand_record
+from openlibrary.catalog.merge.merge_marc import editions_match as threshold_match
 
 
 threshold = 875

--- a/openlibrary/catalog/add_book/tests/test_match.py
+++ b/openlibrary/catalog/add_book/tests/test_match.py
@@ -2,7 +2,7 @@ import pytest
 
 from openlibrary.catalog.add_book.match import editions_match
 from openlibrary.catalog.add_book import add_db_name, load
-from openlibrary.catalog.merge.merge_marc import build_marc
+from openlibrary.catalog.merge.merge_marc import expand_record
 
 
 def test_editions_match_identical_record(mock_site):
@@ -17,7 +17,7 @@ def test_editions_match_identical_record(mock_site):
     e = mock_site.get(ekey)
 
     rec['full_title'] = rec['title']
-    e1 = build_marc(rec)
+    e1 = expand_record(rec)
     add_db_name(e1)
     assert editions_match(e1, e) is True
 

--- a/openlibrary/catalog/add_book/tests/test_match.py
+++ b/openlibrary/catalog/add_book/tests/test_match.py
@@ -2,7 +2,7 @@ import pytest
 
 from openlibrary.catalog.add_book.match import editions_match
 from openlibrary.catalog.add_book import add_db_name, load
-from openlibrary.catalog.merge.merge_marc import expand_record
+from openlibrary.catalog.utils import expand_record
 
 
 def test_editions_match_identical_record(mock_site):

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -308,7 +308,7 @@ def compare_publisher(e1, e2):
         return ('publisher', 'either missing', 0)
 
 
-def expand_record(edition):
+def expand_record(rec: dict) -> dict[str, str | list[str]]:
     """
     Returns an expanded representation of an edition dict,
     usable for accurate comparisons between existing and new
@@ -321,15 +321,15 @@ def expand_record(edition):
         more titles, normalized + short
         all isbns in "isbn": []
     """
-    marc = build_titles(edition['full_title'])
-    marc['isbn'] = []
+    expanded_rec = build_titles(rec['full_title'])
+    expanded_rec['isbn'] = []
     for f in 'isbn', 'isbn_10', 'isbn_13':
-        marc['isbn'].extend(edition.get(f, []))
-    if 'publish_country' in edition and edition['publish_country'] not in (
+        expanded_rec['isbn'].extend(rec.get(f, []))
+    if 'publish_country' in rec and rec['publish_country'] not in (
         '   ',
         '|||',
     ):
-        marc['publish_country'] = edition['publish_country']
+        expanded_rec['publish_country'] = rec['publish_country']
     for f in (
         'lccn',
         'publishers',
@@ -338,9 +338,9 @@ def expand_record(edition):
         'authors',
         'contribs',
     ):
-        if f in edition:
-            marc[f] = edition[f]
-    return marc
+        if f in rec:
+            expanded_rec[f] = rec[f]
+    return expanded_rec
 
 
 def attempt_merge(e1, e2, threshold, debug=False):

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -308,41 +308,6 @@ def compare_publisher(e1, e2):
         return ('publisher', 'either missing', 0)
 
 
-def expand_record(rec: dict) -> dict[str, str | list[str]]:
-    """
-    Returns an expanded representation of an edition dict,
-    usable for accurate comparisons between existing and new
-    records.
-    Called from openlibrary.catalog.add_book.load()
-
-    :param dict edition: Import edition representation, requires 'full_title'
-    :rtype: dict
-    :return: An expanded version of an edition dict
-        more titles, normalized + short
-        all isbns in "isbn": []
-    """
-    expanded_rec = build_titles(rec['full_title'])
-    expanded_rec['isbn'] = []
-    for f in 'isbn', 'isbn_10', 'isbn_13':
-        expanded_rec['isbn'].extend(rec.get(f, []))
-    if 'publish_country' in rec and rec['publish_country'] not in (
-        '   ',
-        '|||',
-    ):
-        expanded_rec['publish_country'] = rec['publish_country']
-    for f in (
-        'lccn',
-        'publishers',
-        'publish_date',
-        'number_of_pages',
-        'authors',
-        'contribs',
-    ):
-        if f in rec:
-            expanded_rec[f] = rec[f]
-    return expanded_rec
-
-
 def attempt_merge(e1, e2, threshold, debug=False):
     """Renaming for clarity, use editions_match() instead."""
     return editions_match(e1, e2, threshold, debug=False)

--- a/openlibrary/catalog/merge/merge_marc.py
+++ b/openlibrary/catalog/merge/merge_marc.py
@@ -175,8 +175,8 @@ def compare_authors(e1, e2):
     Compares the authors of two edition representations and
     returns a evaluation and score.
 
-    :param dict e1: Edition, output of build_marc()
-    :param dict e2: Edition, output of build_marc()
+    :param dict e1: Edition, output of expand_record()
+    :param dict e2: Edition, output of expand_record()
     :rtype: tuple
     :return: str?, message, score
     """
@@ -308,7 +308,7 @@ def compare_publisher(e1, e2):
         return ('publisher', 'either missing', 0)
 
 
-def build_marc(edition):
+def expand_record(edition):
     """
     Returns an expanded representation of an edition dict,
     usable for accurate comparisons between existing and new

--- a/openlibrary/catalog/merge/tests/test_merge_marc.py
+++ b/openlibrary/catalog/merge/tests/test_merge_marc.py
@@ -1,6 +1,7 @@
 import pytest
+
+from openlibrary.catalog.utils import expand_record
 from openlibrary.catalog.merge.merge_marc import (
-    expand_record,
     build_titles,
     compare_authors,
     compare_publisher,
@@ -126,21 +127,6 @@ class TestTitles:
         # Check for duplicates:
         assert len(titles_period) == len(set(titles_period))
         # assert len(titles) == len(set(titles))
-
-
-def test_expand_record():
-    # used in openlibrary.catalog.add_book.load()
-    # when trying to find an existing edition match
-    edition = {
-        'title': 'A test title (parens)',
-        'full_title': 'A test full title : subtitle (parens).',  # required, and set by add_book.load()
-        'source_records': ['ia:test-source'],
-    }
-    result = expand_record(edition)
-    assert isinstance(result['titles'], list)
-    assert result['isbn'] == []
-    assert result['normalized_title'] == 'a test full title subtitle (parens)'
-    assert result['short_title'] == 'a test full title subtitl'
 
 
 def test_compare_publisher():

--- a/openlibrary/catalog/merge/tests/test_merge_marc.py
+++ b/openlibrary/catalog/merge/tests/test_merge_marc.py
@@ -1,6 +1,6 @@
 import pytest
 from openlibrary.catalog.merge.merge_marc import (
-    build_marc,
+    expand_record,
     build_titles,
     compare_authors,
     compare_publisher,
@@ -35,7 +35,7 @@ class TestAuthors:
             'by_statement': 'Alistair Smith.',
         }
 
-        result = compare_authors(build_marc(rec1), build_marc(rec2))
+        result = compare_authors(expand_record(rec1), expand_record(rec2))
         assert result == ('main', 'exact match', 125)
 
     def test_author_contrib(self):
@@ -76,8 +76,8 @@ class TestAuthors:
             'publishers': ['Harvard University Press'],
         }
 
-        e1 = build_marc(rec1)
-        e2 = build_marc(rec2)
+        e1 = expand_record(rec1)
+        e2 = expand_record(rec2)
 
         assert compare_authors(e1, e2) == ('authors', 'exact match', 125)
         threshold = 875
@@ -86,7 +86,7 @@ class TestAuthors:
 
 class TestTitles:
     def test_build_titles(self):
-        # Used by openlibrary.catalog.merge.merge_marc.build_marc()
+        # Used by openlibrary.catalog.merge.merge_marc.expand_record()
         full_title = 'This is a title.'
         normalized = 'this is a title'
         result = build_titles(full_title)
@@ -128,7 +128,7 @@ class TestTitles:
         # assert len(titles) == len(set(titles))
 
 
-def test_build_marc():
+def test_expand_record():
     # used in openlibrary.catalog.add_book.load()
     # when trying to find an existing edition match
     edition = {
@@ -136,7 +136,7 @@ def test_build_marc():
         'full_title': 'A test full title : subtitle (parens).',  # required, and set by add_book.load()
         'source_records': ['ia:test-source'],
     }
-    result = build_marc(edition)
+    result = expand_record(edition)
     assert isinstance(result['titles'], list)
     assert result['isbn'] == []
     assert result['normalized_title'] == 'a test full title subtitle (parens)'
@@ -214,8 +214,8 @@ class TestRecordMatching:
 
     def test_match_low_threshold(self):
         # year is off by < 2 years, counts a little
-        # build_marc() will place all isbn_ types in the 'isbn' field.
-        e1 = build_marc(
+        # expand_record() will place all isbn_ types in the 'isbn' field.
+        e1 = expand_record(
             {
                 'publishers': ['Collins'],
                 'isbn_10': ['0002167530'],
@@ -229,7 +229,7 @@ class TestRecordMatching:
             }
         )
 
-        e2 = build_marc(
+        e2 = expand_record(
             {
                 'publishers': ['Collins'],
                 'isbn_10': ['0002167530'],

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -212,16 +212,73 @@ def test_mk_norm_equality(a, b):
     assert mk_norm(a) == mk_norm(b)
 
 
+valid_edition = {
+    'title': 'A test title (parens)',
+    'full_title': 'A test full title : subtitle (parens).',  # required, and set by add_book.load()
+    'source_records': ['ia:test-source'],
+}
+
+
 def test_expand_record():
     # used in openlibrary.catalog.add_book.load()
     # when trying to find an existing edition match
-    edition = {
-        'title': 'A test title (parens)',
-        'full_title': 'A test full title : subtitle (parens).',  # required, and set by add_book.load()
-        'source_records': ['ia:test-source'],
-    }
-    result = expand_record(edition)
-    assert isinstance(result['titles'], list)
-    assert result['isbn'] == []
-    assert result['normalized_title'] == 'a test full title subtitle (parens)'
-    assert result['short_title'] == 'a test full title subtitl'
+    edition = valid_edition.copy()
+    expanded_record = expand_record(edition)
+    assert isinstance(expanded_record['titles'], list)
+    assert expanded_record['titles'] == [
+        'A test full title : subtitle (parens).',
+        'a test full title subtitle (parens)',
+        'test full title : subtitle (parens).',
+        'test full title subtitle (parens)',
+    ]
+    assert expanded_record['normalized_title'] == 'a test full title subtitle (parens)'
+    assert expanded_record['short_title'] == 'a test full title subtitl'
+
+
+def test_expand_record_publish_country():
+    # used in openlibrary.catalog.add_book.load()
+    # when trying to find an existing edition match
+    edition = valid_edition.copy()
+    expanded_record = expand_record(edition)
+    assert 'publish_country' not in expanded_record
+    for publish_country in ('   ', '|||'):
+        edition['publish_country'] = publish_country
+        assert 'publish_country' not in expand_record(edition)
+    for publish_country in ('USA', 'usa'):
+        edition['publish_country'] = publish_country
+        assert expand_record(edition)['publish_country'] == publish_country
+
+
+def test_expand_record_transfer_fields():
+    edition = valid_edition.copy()
+    expanded_record = expand_record(edition)
+    transfer_fields = (
+        'lccn',
+        'publishers',
+        'publish_date',
+        'number_of_pages',
+        'authors',
+        'contribs',
+    )
+    for field in transfer_fields:
+        assert field not in expanded_record
+    for field in transfer_fields:
+        edition[field] = field
+    expanded_record = expand_record(edition)
+    for field in transfer_fields:
+        assert field in expanded_record
+
+
+def test_expand_record_isbn():
+    edition = valid_edition.copy()
+    expanded_record = expand_record(edition)
+    assert expanded_record['isbn'] == []
+    edition.update(
+        {
+            'isbn': ['1234567890'],
+            'isbn_10': ['123', '321'],
+            'isbn_13': ['1234567890123'],
+        }
+    )
+    expanded_record = expand_record(edition)
+    assert expanded_record['isbn'] == ['1234567890', '123', '321', '1234567890123']

--- a/openlibrary/tests/catalog/test_utils.py
+++ b/openlibrary/tests/catalog/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 from openlibrary.catalog.utils import (
     author_dates_match,
+    expand_record,
     flip_name,
     pick_first_date,
     pick_best_name,
@@ -209,3 +210,18 @@ mk_norm_matches = [
 @pytest.mark.parametrize('a,b', mk_norm_matches)
 def test_mk_norm_equality(a, b):
     assert mk_norm(a) == mk_norm(b)
+
+
+def test_expand_record():
+    # used in openlibrary.catalog.add_book.load()
+    # when trying to find an existing edition match
+    edition = {
+        'title': 'A test title (parens)',
+        'full_title': 'A test full title : subtitle (parens).',  # required, and set by add_book.load()
+        'source_records': ['ia:test-source'],
+    }
+    result = expand_record(edition)
+    assert isinstance(result['titles'], list)
+    assert result['isbn'] == []
+    assert result['normalized_title'] == 'a test full title subtitle (parens)'
+    assert result['short_title'] == 'a test full title subtitl'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8111

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This renames `build_marc()` to `expand_record()`, as mentioned [here](https://github.com/internetarchive/openlibrary/pull/7940#discussion_r1228968439), and moves it to [`catalog/utils/__init__.py`](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/catalog/utils/__init__.py).

### Technical
<!-- What should be noted about the implementation? -->
I am not sure if more should be moved. I moved [`build_titles()`](https://github.com/internetarchive/openlibrary/blob/a9d297158999f2d66550c911534349e392abb96c/openlibrary/catalog/merge/merge_marc.py#L17-L53), upon which `expand_record()` depends, around repeatedly, deleted it from [`merge.py`](https://github.com/internetarchive/openlibrary/blob/a9d297158999f2d66550c911534349e392abb96c/openlibrary/catalog/merge/merge.py#L18-L47) repeatedly, moved it back. Moved it again. Then I move other things, and then moved them back. And then moved everything again, etc.. In the end, I think I was just making a mess and kept this small.

If I picked a bad new home for `expand_record()`, just let me know and I'll try another. :)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`git grep build_marc` to verify all the `build_marc()` references have been located and updated.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@hornc
@cclauss 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
