### PR TITLE
bug: replaced div tag in header_dropdown.html with span

### DIFF
--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -25,7 +25,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
         $if props['name'] == 'hamburger' and ctx.user:
             <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')">
             $if is_privileged_user and cached_get_counts_by_mode(mode='open') > 0:
-              <div class="mr-notifications">$(cached_get_counts_by_mode(mode='open'))</div>
+              <span class="mr-notifications">$(cached_get_counts_by_mode(mode='open'))</span>
             <img class="$(props['image-class']) logged" src="$(props['image'])" alt="$(props['label'])"/>
         $elif 'image' in props:
             <img class="$(props['image-class'])" src="$(props['image'])" alt="$(props['label'])"/>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8109

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The badge which represents the count is originally a div tag and has been known to have invalid HTML issues as reported in #8109. I have replaced the div tag with span tag and there was no change in design when I ran it. Please review. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Inspect the badge with your browser's dev tools. Now, the count is wrapped in span tag.
### Screenshot
![openlibrary_proof](https://github.com/internetarchive/openlibrary/assets/49096143/e3716d30-b385-491c-aed5-f62b80a02f4b)
The "5" count is just a dummy count, used for testing.
### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
