### PR TITLE
Move list sort options to be under the description

### DIFF
--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -74,7 +74,6 @@ $def seed_attrs(seed):
     data-list-key="$list.key"
 
 <div id="contentBody">
-    $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
     <div id="remove-seed-dialog" class="hidden" title="$_('Remove seed')">$_('Are you sure you want to remove this item from the list?')</div>
     <div id="delete-list-dialog" class="hidden" title="$_('Remove Seed')">
         $_('You are about to remove the last item in the list. That will delete the whole list. Are you sure you want to continue?')
@@ -92,6 +91,7 @@ $def seed_attrs(seed):
         $if list.description:
             $:format(list.description)
 
+        $:render_template("search/sort_options.html", selected_sort=sort, default_sort='index', search_scheme="lists_seeds")
         $:macros.Pager(page+1, len(list.seeds), page_size)
         <div class="clearfix"></div>
 


### PR DESCRIPTION
Currently it can appear at the top, above the description, which can be far away from the books it'll be sorting if the list description is long!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
EG random list with description: https://testing.openlibrary.org/people/pierre_bachelot/lists/OL211236L/MUST_READ

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
