### PR TITLE
7542/fix/remove non isbn hyphens

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -55,23 +55,25 @@ function clearIsbnError() {
 
 function parseAndValidateIsbn(event) {
     const fieldName = document.getElementById('id_name').value;
-    const isbn = parseIsbn(document.getElementById('id_value').value);
+    let idValue = document.getElementById('id_value').value;
+    // parsing valid ISBN that passes checks
     if (fieldName === 'isbn_10') {
-        if (!isFormatValidIsbn10(isbn)) {
+        idValue = parseIsbn(idValue);
+        if (!isFormatValidIsbn10(idValue)) {
             return displayIsbnError(event, invalidIsbn10);
         }
-        if (!isChecksumValidIsbn10(isbn)) {
+        if (!isChecksumValidIsbn10(idValue)) {
             return displayIsbnError(event, invalidChecksum);
         }
     }
     else if (fieldName === 'isbn_13') {
-        if (!isFormatValidIsbn13(isbn)) {
+        idValue = parseIsbn(idValue);
+        if (!isFormatValidIsbn13(idValue)) {
             return displayIsbnError(event, invalidIsbn13);
         }
-        if (!isChecksumValidIsbn13(isbn)) {
+        if (!isChecksumValidIsbn13(idValue)) {
             return displayIsbnError(event, invalidChecksum);
         }
     }
-    // parsing valid ISBN that passes checks
-    document.getElementById('id_value').value = isbn;
+    document.getElementById('id_value').value = idValue;
 }

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -218,9 +218,6 @@ class addbook(delegate.page):
             _test="false",
         )
 
-        print('debug id_value: ' + i.id_value)
-        print('debug id_name: ' + i.id_name)
-
         if spamcheck.is_spam(i, allow_privileged_edits=True):
             return render_template(
                 "message.html", "Oops", 'Something went wrong. Please try again later.'

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -218,6 +218,9 @@ class addbook(delegate.page):
             _test="false",
         )
 
+        print('debug id_value: ' + i.id_value)
+        print('debug id_name: ' + i.id_name)
+
         if spamcheck.is_spam(i, allow_privileged_edits=True):
             return render_template(
                 "message.html", "Oops", 'Something went wrong. Please try again later.'


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7542

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: Preserves dashes in non-ISBN Id values in add book form.


### Technical
<!-- What should be noted about the implementation? -->
Updated add-book.js to stop filtering dashes out of non-ISBN Ids before submitting form.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Submit an Id value with dashes included on the [add book form](https://openlibrary.org/books/add) under a non-ISBN value (Internet Archive, LCCN).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
