### PR TITLE
Add 'limit' URL parameter to /languages.json API call

### DIFF
--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -70,12 +70,8 @@ class index_json(delegate.page):
 
     @jsonapi
     def GET(self):
-        i = web.input(limit=None)
-        if i.limit is not None:
-            limit = safeint(i.limit)
-            return json.dumps(get_top_languages(limit or 15))
-        else:
-            return json.dumps(get_top_languages(15))
+        i = web.input(limit=15)
+        return json.dumps(get_top_languages(safeint(i.limit, 15)))
 
 
 class language_search(delegate.page):

--- a/openlibrary/plugins/worksearch/languages.py
+++ b/openlibrary/plugins/worksearch/languages.py
@@ -70,7 +70,12 @@ class index_json(delegate.page):
 
     @jsonapi
     def GET(self):
-        return json.dumps(get_top_languages(15))
+        i = web.input(limit=None)
+        if i.limit is not None:
+            limit = safeint(i.limit)
+            return json.dumps(get_top_languages(limit or 15))
+        else:
+            return json.dumps(get_top_languages(15))
 
 
 class language_search(delegate.page):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8133

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds support for a 'limit' URL parameter to the existing /languages.json API call rather than being locked to 15 results only. Ex: /languages.json?limit=1000


### Technical
<!-- What should be noted about the implementation? -->
Limit defaults to 15 in order to remain similar to the original behavior. Default is used if there is no limit provided or if an invalid limit is provided.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
After pulling updated code and populating solr with some language data; navigate to localhost:8080/languages.json?limit=100 and verify that more than 15 results are returned.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tfmorris @cdrini


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
