### PR TITLE
Fix type hints and rename w and e to work and edition within load()

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -23,7 +23,7 @@ A record is loaded by calling the load function.
 
 """
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import web
 
@@ -53,7 +53,7 @@ from openlibrary.catalog.add_book.load_book import (
 from openlibrary.catalog.add_book.match import editions_match
 
 if TYPE_CHECKING:
-    from openlibrary.core.models import Edition, Work
+    from openlibrary.plugins.upstream.models import Edition
 
 re_normalize = re.compile('[^[:alphanum:] ]', re.U)
 re_lang = re.compile('^/languages/([a-z]{3})$')
@@ -809,7 +809,7 @@ def update_edition_with_rec_data(
 
 
 def update_work_with_rec_data(
-    rec: dict, e: "Edition", w: "Work", need_work_save: bool
+    rec: dict, e: "Edition", w: dict[str, Any], need_work_save: bool
 ) -> bool:
     """
     Enrich the Work by adding certain fields present in rec but absent
@@ -881,9 +881,8 @@ def load(rec, account_key=None):
 
     # We have an edition match at this point
     need_work_save = need_edition_save = False
-    # w = None
-    w: Work
-    e: Edition = web.ctx.site.get(match)
+    w: dict[str, Any]
+    e: "Edition" = web.ctx.site.get(match)
     # check for, and resolve, author redirects
     for a in e.authors:
         while is_redirect(a):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor.

### Technical
<!-- What should be noted about the implementation? -->
Though this should be perhaps two PRs, with respect to `add_book.load()`, one commit fixes the type hints used for imports, as it was importing from `core.models` rather than `upstream.models`, as it should have been, and the other commit changes the `w` and `e` variables to `work` and `edition` respectively.

I know it has been that way for a long time, but as @cclauss has pointed out, it's idiomatic to use `e` for errors in Python. But then if changing `e` to `edition`, it looks a bit odd to have `w` instead of `work.

If only one of these commits looks mergeable, let me know and I can break it out separately.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This should have no functional changes. The import change only affects type hinting, and the variable rename was done using an IDE.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@cclauss 
@hornc 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
