### PR TITLE
add_book.load(): add function to overwrite v1 promise items with MARC data

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -206,11 +206,11 @@ def build_query(rec):
                     east = east_in_by_statement(rec, author)
                     book['authors'].append(import_author(author, eastern=east))
             continue
-        if k == 'languages':
+        if k in ('languages', 'translated_from'):
             for language in v:
                 if web.ctx.site.get('/languages/' + language) is None:
                     raise InvalidLanguage(language)
-            book['languages'] = [{'key': '/languages/' + language} for language in v]
+            book[k] = [{'key': '/languages/' + language} for language in v]
             continue
         if k in type_map:
             t = '/type/' + type_map[k]

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -52,6 +52,7 @@ def test_build_query(add_languages):
     rec = {
         'title': 'magic',
         'languages': ['eng', 'fre'],
+        'translated_from': ['yid'],
         'authors': [{'name': 'Surname, Forename'}],
         'description': 'test',
     }
@@ -61,5 +62,6 @@ def test_build_query(add_languages):
     assert q['description'] == {'type': '/type/text', 'value': 'test'}
     assert q['type'] == {'key': '/type/edition'}
     assert q['languages'] == [{'key': '/languages/eng'}, {'key': '/languages/fre'}]
+    assert q['translated_from'] == [{'key': '/languages/yid'}]
 
     pytest.raises(InvalidLanguage, build_query, {'languages': ['wtf']})

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -1,6 +1,5 @@
 """Open Library Import API
 """
-
 from infogami.plugins.api.code import add_hook
 from infogami.infobase.client import ClientException
 
@@ -205,6 +204,8 @@ class ia_importapi(importapi):
         :param bool force_import: force import of this record
         :returns: the data of the imported book or raises  BookImportError
         """
+        from_marc_record = False
+
         # Case 1 - Is this a valid Archive.org item?
         metadata = ia.get_metadata(identifier)
         if not metadata:
@@ -230,6 +231,8 @@ class ia_importapi(importapi):
         if require_marc and not marc_record:
             raise BookImportError('no-marc-record')
         if marc_record:
+            from_marc_record = True
+
             if not force_import:
                 raise_non_book_marc(marc_record)
             try:
@@ -247,7 +250,7 @@ class ia_importapi(importapi):
 
         # Add IA specific fields: ocaid, source_records, and cover
         edition_data = cls.populate_edition_data(edition_data, identifier)
-        return cls.load_book(edition_data)
+        return cls.load_book(edition_data, from_marc_record)
 
     def POST(self):
         web.header('Content-Type', 'application/json')
@@ -410,15 +413,16 @@ class ia_importapi(importapi):
         return d
 
     @staticmethod
-    def load_book(edition_data: dict) -> str:
+    def load_book(edition_data: dict, from_marc_record: bool = False) -> str:
         """
         Takes a well constructed full Edition record and sends it to add_book
         to check whether it is already in the system, and to add it, and a Work
         if they do not already exist.
 
         :param dict edition_data: Edition record
+        :param bool from_marc_record: whether the record is based on a MARC record.
         """
-        result = add_book.load(edition_data)
+        result = add_book.load(edition_data, from_marc_record=from_marc_record)
         return json.dumps(result)
 
     @staticmethod

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Protocol, TYPE_CHECKING
+from typing import Any, Protocol, TYPE_CHECKING, TypeVar
 from collections.abc import Callable, Iterable, Iterator
 import unicodedata
 
@@ -679,7 +679,10 @@ def parse_toc(text: None) -> list[Any]:
     return [parse_toc_row(line) for line in text.splitlines() if line.strip(" |")]
 
 
-def safeget(func: Callable) -> Any:
+T = TypeVar('T')
+
+
+def safeget(func: Callable[[], T], default=None) -> T:
     """
     TODO: DRY with solrbuilder copy
     >>> safeget(lambda: {}['foo'])
@@ -692,7 +695,7 @@ def safeget(func: Callable) -> Any:
     try:
         return func()
     except (KeyError, IndexError, TypeError):
-        return None
+        return default
 
 
 def strip_accents(s: str) -> str:


### PR DESCRIPTION
Closes #7521 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
If successful, this PR will overwrite v1 promise items with MARC data. After #7490 became a mess, I am trying to more targeted approach to get a PR through to address #7521.

This is a work in progress.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
