### PR TITLE
Add required attribute to file input for Goodreads import

### DIFF
--- a/openlibrary/templates/account/import.html
+++ b/openlibrary/templates/account/import.html
@@ -10,7 +10,7 @@ $def with (books=None, books_wo_isbns=None)
         <form method="POST" action="/account/import/goodreads"
             enctype="multipart/form-data" class="olform olform--decoration">
           <div>
-            <input type="file" name="csv" />
+            <input required type="file" name="csv" />
             <br>$_("File size limit 10MB and .csv file type only")
           </div>
           <div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7924

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes error redirect on Goodreads book import when no file selected


### Technical
<!-- What should be noted about the implementation? -->
Required attribute added to file input prevents bad submission from happening

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Attempt import with no file selected

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/29631356/d9e76ceb-2744-4b5f-9a9b-447ca733e685)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
