### PR TITLE
Ruff rule B015: Do not forget to assert in pytests

### DIFF
--- a/openlibrary/olbase/tests/test_events.py
+++ b/openlibrary/olbase/tests/test_events.py
@@ -92,4 +92,4 @@ class TestMemcacheInvalidater:
                 }
             ],
         }
-        m.find_keys(changeset) == ["d/sandbox"]
+        assert m.find_keys(changeset) == ["d/sandbox"]

--- a/openlibrary/plugins/openlibrary/tests/test_stats.py
+++ b/openlibrary/plugins/openlibrary/tests/test_stats.py
@@ -21,26 +21,22 @@ class MockDoc(dict):
 
 def test_format_stats_entry():
     "Tests the stats performance entries"
-    stats.process_stats({"total": {"time": 0.1}}) == [("TT", 0, 0.1)]
-    stats.process_stats({"total": {"time": 0.1346}}) == [("TT", 0, 0.135)]
+    ps = stats.process_stats
+    assert ps({"total": {"time": 0.1}}) == [("TT", 0, 0.1)]
+    assert ps({"total": {"time": 0.1346}}) == [("TT", 0, 0.135)]
 
-    stats.process_stats({"memcache": {"count": 2, "time": 0.1}}) == [("MC", 2, 0.100)]
-    stats.process_stats({"infobase": {"count": 2, "time": 0.1}}) == [("IB", 2, 0.100)]
-    stats.process_stats({"couchdb": {"count": 2, "time": 0.1}}) == [("CD", 2, 0.100)]
-    stats.process_stats({"solr": {"count": 2, "time": 0.1}}) == [("SR", 2, 0.100)]
-    stats.process_stats({"archive.org": {"count": 2, "time": 0.1}}) == [
-        ("IA", 2, 0.100)
-    ]
-    stats.process_stats({"something-else": {"count": 2, "time": 0.1}}) == [
-        ("OT", 2, 0.100)
-    ]
+    assert ps({"memcache": {"count": 2, "time": 0.1}}) == [("MC", 2, 0.100)]
+    assert ps({"infobase": {"count": 2, "time": 0.1}}) == [("IB", 2, 0.100)]
+    assert ps({"couchdb": {"count": 2, "time": 0.1}}) == [("CD", 2, 0.100)]
+    assert ps({"solr": {"count": 2, "time": 0.1}}) == [("SR", 2, 0.100)]
+    assert ps({"archive.org": {"count": 2, "time": 0.1}}) == [("IA", 2, 0.100)]
+    assert ps({"something-else": {"count": 2, "time": 0.1}}) == [("OT", 2, 0.100)]
 
 
 def test_format_stats():
     "Tests whether the performance status are output properly in the the X-OL-Stats header"
-    stats.format_stats(
-        {"total": {"time": 0.2}, "infobase": {"count": 2, "time": 0.13}}
-    ) == '"IB 2 0.130 TT 0 0.200"'
+    performance_stats = {"total": {"time": 0.2}, "infobase": {"count": 2, "time": 0.13}}
+    assert stats.format_stats(performance_stats) == '"IB 2 0.130 TT 0 0.200"'
 
 
 def test_stats_container():

--- a/openlibrary/plugins/openlibrary/tests/test_stats.py
+++ b/openlibrary/plugins/openlibrary/tests/test_stats.py
@@ -23,13 +23,13 @@ def test_format_stats_entry():
     "Tests the stats performance entries"
     ps = stats.process_stats
     assert ps({"total": {"time": 0.1}}) == [("TT", 0, 0.1)]
-    assert ps({"total": {"time": 0.1346}}) == [("TT", 0, 0.135)]
+    # assert ps({"total": {"time": 0.1346}}) == [("TT", 0, 0.135)]  # FIXME
 
     assert ps({"memcache": {"count": 2, "time": 0.1}}) == [("MC", 2, 0.100)]
     assert ps({"infobase": {"count": 2, "time": 0.1}}) == [("IB", 2, 0.100)]
     assert ps({"couchdb": {"count": 2, "time": 0.1}}) == [("CD", 2, 0.100)]
     assert ps({"solr": {"count": 2, "time": 0.1}}) == [("SR", 2, 0.100)]
-    assert ps({"archive.org": {"count": 2, "time": 0.1}}) == [("IA", 2, 0.100)]
+    # assert ps({"archive.org": {"count": 2, "time": 0.1}}) == [("IA", 2, 0.100)]  # FIXME
     assert ps({"something-else": {"count": 2, "time": 0.1}}) == [("OT", 2, 0.100)]
 
 

--- a/openlibrary/tests/core/test_i18n.py
+++ b/openlibrary/tests/core/test_i18n.py
@@ -48,8 +48,8 @@ class Test_ungettext:
     def test_ungettext(self, monkeypatch):
         self.setup_monkeypatch(monkeypatch)
 
-        i18n.ungettext("book", "books", 1) == "book"
-        i18n.ungettext("book", "books", 2) == "books"
+        assert i18n.ungettext("book", "books", 1) == "book"
+        assert i18n.ungettext("book", "books", 2) == "books"
 
         web.ctx.lang = 'fr'
         self.d.init(
@@ -60,18 +60,18 @@ class Test_ungettext:
             },
         )
 
-        i18n.ungettext("book", "books", 1) == "libre"
-        i18n.ungettext("book", "books", 2) == "libres"
+        assert i18n.ungettext("book", "books", 1) == "libre"
+        assert i18n.ungettext("book", "books", 2) == "libres"
 
         web.ctx.lang = 'te'
-        i18n.ungettext("book", "books", 1) == "book"
-        i18n.ungettext("book", "books", 2) == "books"
+        assert i18n.ungettext("book", "books", 1) == "book"
+        assert i18n.ungettext("book", "books", 2) == "books"
 
     def test_ungettext_with_args(self, monkeypatch):
         self.setup_monkeypatch(monkeypatch)
 
-        i18n.ungettext("one book", "%(n)d books", 1, n=1) == "one book"
-        i18n.ungettext("one book", "%(n)d books", 2, n=2) == "2 books"
+        assert i18n.ungettext("one book", "%(n)d books", 1, n=1) == "one book"
+        assert i18n.ungettext("one book", "%(n)d books", 2, n=2) == "2 books"
 
         web.ctx.lang = 'fr'
         self.d.init(
@@ -82,5 +82,5 @@ class Test_ungettext:
             },
         )
 
-        i18n.ungettext("one book", "%(n)d books", 1, n=1) == "un libre"
-        i18n.ungettext("one book", "%(n)d books", 2, n=2) == "2 libres"
+        assert i18n.ungettext("one book", "%(n)d books", 1, n=1) == "un libre"
+        assert i18n.ungettext("one book", "%(n)d books", 2, n=2) == "2 libres"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ extend-exclude = [
 ]
 ignore = [
   "B007",
-  "B015",
   "B023",
   "B904",
   "B905",


### PR DESCRIPTION
Ruff calls rule **B015** a `useless comparison` but I call it "Do not forget to `assert` in pytests."

Enable these tests have been passing but two of them actually fail when an `assert` is added.  Let's enable this rule.
% `ruff rule B015`
# useless-comparison (B015)

Derived from the **flake8-bugbear** linter.

## What it does
Checks for useless comparisons.

## Why is this bad?
Useless comparisons have no effect on the program, and are often included
by mistake. If the comparison is intended to enforce an invariant, prepend
the comparison with an `assert`. Otherwise, remove it entirely.

## Example
```python
foo == bar
```

Use instead:
```python
assert foo == bar, "`foo` and `bar` should be equal."
```

## References
- [Python documentation: `assert` statement](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement)
