### PR TITLE
Refactor language search autocomplete and add inner word matching

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -722,7 +722,7 @@ def _normalize(s: str) -> str:
 def _matches_lang_name(
     word_prefix: str, language: dict, prefix_language: str | None = None
 ) -> Storage | None:
-    lang_name = language["name"]
+    lang_name = language['name]
     if prefix_language is not None:
         lang_name = safeget(lambda: language['name_translated'][prefix_language][0])
     # Compare to each inner word of language name for more accurate matching
@@ -730,8 +730,8 @@ def _matches_lang_name(
     for inner in lang_name.split(' '):
         if inner and _normalize(inner).startswith(word_prefix):
             return Storage(
-                key=language["key'],
-                code=language["code"],
+                key=language['key'],
+                code=language['code'],
                 name=lang_name,
             )
     return None

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -722,7 +722,7 @@ def _normalize(s: str) -> str:
 def _matches_lang_name(
     word_prefix: str, language: dict, prefix_language: str | None = None
 ) -> Storage | None:
-    lang_name = language['name]
+    lang_name = language['name']
     if prefix_language is not None:
         lang_name = safeget(lambda: language['name_translated'][prefix_language][0])
     # Compare to each inner word of language name for more accurate matching

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -730,8 +730,8 @@ def _matches_lang_name(
     for inner in lang_name.split(' '):
         if inner and _normalize(inner).startswith(word_prefix):
             return Storage(
-                key=language.key,
-                code=language.code,
+                key=language["key'],
+                code=language["code"],
                 name=lang_name,
             )
     return None

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -722,7 +722,7 @@ def _normalize(s: str) -> str:
 def _matches_lang_name(
     word_prefix: str, language: dict, prefix_language: str | None = None
 ) -> Storage | None:
-    lang_name = language.name
+    lang_name = language["name"]
     if prefix_language is not None:
         lang_name = safeget(lambda: language['name_translated'][prefix_language][0])
     # Compare to each inner word of language name for more accurate matching

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -720,7 +720,7 @@ def _normalize(s: str) -> str:
 
 
 def _matches_lang_name(
-    prefix: str, language, translation: str | None = None
+    word_prefix: str, language, translation: str | None = None
 ) -> Storage | None:
     lang_name = language.name
     if translation is not None:
@@ -728,7 +728,7 @@ def _matches_lang_name(
     # Compare to each inner word of language name for more accurate matching
     # Eg. for prefix 'greek' will match with 'Ancient Greek' as well as 'Greek'
     for inner in lang_name.split(' '):
-        if inner and _normalize(inner).startswith(prefix):
+        if inner and _normalize(inner).startswith(word_prefix):
             return Storage(
                 key=language.key,
                 code=language.code,

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -731,6 +731,7 @@ def _matches_lang_name(prefix: str, language, translation: str | None = None) ->
                 code=language.code,
                 name=lang_name,
             )
+    return None
 
 def autocomplete_languages(prefix: str, limit: int) -> Iterator[Storage]:
     """

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -718,7 +718,10 @@ def get_languages(limit: int = 1000) -> dict:
 def _normalize(s: str) -> str:
     return strip_accents(s).lower()
 
-def _matches_lang_name(prefix: str, language, translation: str | None = None) -> Storage | None:
+
+def _matches_lang_name(
+    prefix: str, language, translation: str | None = None
+) -> Storage | None:
     lang_name = language.name
     if translation is not None:
         lang_name = safeget(lambda: language['name_translated'][translation][0])
@@ -732,6 +735,7 @@ def _matches_lang_name(prefix: str, language, translation: str | None = None) ->
                 name=lang_name,
             )
     return None
+
 
 def autocomplete_languages(prefix: str, limit: int) -> Iterator[Storage]:
     """
@@ -754,7 +758,7 @@ def autocomplete_languages(prefix: str, limit: int) -> Iterator[Storage]:
         #     The language's name translated into its native name (lang_iso_code)
         #     The language's name as it was fetched from get_languages() (None)
         # First matching result is yielded to the autocomplete iterator results
-        for translation in [ user_lang, lang_iso_code, None ]:
+        for translation in [user_lang, lang_iso_code, None]:
             match = _matches_lang_name(prefix, language, translation=translation)
             if match is not None:
                 matches += 1

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -96,9 +96,7 @@ class languages_autocomplete(delegate.page):
     def GET(self):
         i = web.input(q="", limit=5)
         i.limit = safeint(i.limit, 5)
-        return to_json(
-            list(utils.autocomplete_languages(i.q, i.limit))
-        )
+        return to_json(list(utils.autocomplete_languages(i.q, i.limit)))
 
 
 class works_autocomplete(autocomplete):

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -97,7 +97,7 @@ class languages_autocomplete(delegate.page):
         i = web.input(q="", limit=5)
         i.limit = safeint(i.limit, 5)
         return to_json(
-            list(itertools.islice(utils.autocomplete_languages(i.q), i.limit))
+            list(utils.autocomplete_languages(i.q, i.limit))
         )
 
 

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -96,7 +96,9 @@ class languages_autocomplete(delegate.page):
     def GET(self):
         i = web.input(q="", limit=5)
         i.limit = safeint(i.limit, 5)
-        return to_json(list(utils.autocomplete_languages(i.q, i.limit)))
+        return to_json(
+            list(itertools.islice(utils.autocomplete_languages(i.q), i.limit))
+        )
 
 
 class works_autocomplete(autocomplete):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8146

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor the current [autocomplete_languages](https://github.com/internetarchive/openlibrary/blob/dc35977560ae0ca752eda36017769fdd82f15daa/openlibrary/plugins/upstream/utils.py#L717) util function to include a limit parameter as well as add prefix matching of inner language name words. For example, '/languages/_autocomplete?q=greek' will match with 'Ancient Greek', 'Modern Greek', and 'Greek' rather than just 'Greek' as it does now.


### Technical
<!-- What should be noted about the implementation? -->
Consolidates existing match checks into a more generic matching function that allows for optional translation id.

A limit parameter was also added which controls how many results will be added to the returned iterator. Previously autocomplete_languages would return the total number of matches then was truncated down to a default limit of 5 when called in [autocomplete.py](https://github.com/internetarchive/openlibrary/blob/dc35977560ae0ca752eda36017769fdd82f15daa/openlibrary/plugins/worksearch/autocomplete.py#L98). This default limit is preserved, but now it is possible to request more than 5 language matches.

Additionally, a small change was made to the supporting [get_languages](https://github.com/internetarchive/openlibrary/blob/dc35977560ae0ca752eda36017769fdd82f15daa/openlibrary/plugins/upstream/utils.py#L712) function which adds an optional limit parameter that defaults to the previous hard-coded value of 1000. This should clarify that a limit is being used within that function without changing any existing behavior.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to /languages/_autocomplete and attempt to search with queries like ?q=greek&limit=10. Verify that at least one inner word of the returned language names match the prefix given (q=greek). Also verify that the limit param accurately controls how many languages are returned.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @tfmorris 



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
