### PR TITLE
Fix outdated references to early_exit() and find_match()

### DIFF
--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -982,9 +982,9 @@ def test_subtitle_gets_split_from_title(mock_site) -> None:
 
 def test_find_match_is_used_when_looking_for_edition_matches(mock_site) -> None:
     """
-    This tests the case where there is an edition_pool, but `early_exit()`
+    This tests the case where there is an edition_pool, but `find_quick_match()`
     and `find_exact_match()` find no matches, so this should return a
-    match from `find_match()`.
+    match from `find_enriched_match()`.
 
     This also indirectly tests `merge_marc.editions_match()` (even though it's
     not a MARC record.


### PR DESCRIPTION
This merely fixes lingering references to old function names in the docstrings of a test.

In #7940 the 'match' functions that look for matching editions were renamed for clarity. `find_match()` became an 'umbrella' function that called three matching functions. With old and new names, they are:

- `early_exit()` -> `find_quick_match()`
- `find_exact_match()` -> `find_exact_match()` (no change)
- `find_match()` -> `find_enriched_match()`

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
