### PR TITLE
Add description to works and editions on reimport if absent

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -851,6 +851,7 @@ def update_edition_with_rec_data(
             need_edition_save = True
 
     other_edition_fields = [
+        'description',
         'number_of_pages',
         'publishers',
         'publish_date',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially closes #7521

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
This will add a description to a work or edition if:
- there is a description in the incoming record ("`rec`"); and
- there is no `description` field in the respective work or edition.

Currently, on re-import, if a work is missing a description and edition has a description, the description will be copied from the edition to the work.

However, if the incoming record ("`rec`") has a description and the edition does not, that data is ignored and not set on either the work or edition. This PR will addresses that by setting a description if the criteria above are met.

### Questions
Would it make more sense to limit this change to apply _only_ when the incoming record has a MARC record?

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Take a work or edition without a description, and re-import it from a record that has a description. See the `pytest` tests for a demonstration.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
A description is now added to the work:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/a8486588-dc48-4fcc-becc-ef57a7e96331)

And a description is now added to the edition:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/0c73e737-5f6c-46d6-923c-f778408c39d5)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@tfmorris 
@hornc 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
