### PR TITLE
Allow lists at global level (eg /lists/OL123L)

### DIFF
--- a/openlibrary/coverstore/code.py
+++ b/openlibrary/coverstore/code.py
@@ -591,7 +591,10 @@ def render_list_preview_image(lst_key):
 
     para = textwrap.wrap(lst.name, width=45)
     current_h = 42
-    author_text = f"A list by {lst.get_owner().displayname}"
+
+    author_text = "A list on Open Library"
+    if owner := lst.get_owner():
+        author_text = f"A list by {owner.displayname}"
     w, h = draw.textsize(author_text, font=font_author)
     draw.text(((W - w) / 2, current_h), author_text, font=font_author, fill=(0, 0, 0))
     current_h += h + 5

--- a/openlibrary/olbase/events.py
+++ b/openlibrary/olbase/events.py
@@ -86,11 +86,11 @@ class MemcacheInvalidater:
         seed are invalidated.
         """
         docs = changeset['docs'] + changeset['old_docs']
-        rx = web.re_compile(r"(/people/[^/]*)/lists/OL\d+L")
+        rx = web.re_compile(r"(/people/[^/]*)?/lists/OL\d+L")
         for doc in docs:
-            match = doc and rx.match(doc['key'])
-            if match:
-                yield "d" + match.group(1)  # d/users/foo
+            if match := doc and rx.match(doc['key']):
+                if owner := match.group(1):
+                    yield "d" + owner  # d/people/foo
                 for seed in doc.get('seeds', []):
                     yield "d" + self.seed_to_key(seed)
 

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -277,7 +277,11 @@ class lists_add(delegate.page):
                 f"Permission denied to edit {user_key}.",
             )
         list_record = ListRecord.from_input()
-        return render_template("type/list/edit", list_record, new=True)
+        # Only admins can add global lists for now
+        admin_only = not user_key
+        return render_template(
+            "type/list/edit", list_record, new=True, admin_only=admin_only
+        )
 
     def POST(self, user_key: str | None):  # type: ignore[override]
         return lists_edit().POST(user_key, None)

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -137,8 +137,10 @@ def get_list_data(list, seed, include_cover_url=True):
         d['cover_url'] = cover and cover.url("S") or "/images/icons/avatar_book-sm.png"
         if 'None' in d['cover_url']:
             d['cover_url'] = "/images/icons/avatar_book-sm.png"
-    owner = list.get_owner()
-    d['owner'] = web.storage(displayname=owner.displayname or "", key=owner.key)
+
+    d['owner'] = None
+    if owner := list.get_owner():
+        d['owner'] = web.storage(displayname=owner.displayname or "", key=owner.key)
     return d
 
 
@@ -220,10 +222,10 @@ class lists(delegate.page):
 
 
 class lists_edit(delegate.page):
-    path = r"(/people/[^/]+)(/lists/OL\d+L)/edit"
+    path = r"(/people/[^/]+)?(/lists/OL\d+L)/edit"
 
-    def GET(self, user_key: str, list_key: str):  # type: ignore[override]
-        key = user_key + list_key
+    def GET(self, user_key: str | None, list_key: str):  # type: ignore[override]
+        key = (user_key or '') + list_key
         if not web.ctx.site.can_write(key):
             return render_template(
                 "permission_denied",
@@ -236,10 +238,8 @@ class lists_edit(delegate.page):
             raise web.notfound()
         return render_template("type/list/edit", lst, new=False)
 
-    def POST(self, user_key: str, list_key: str | None = None):  # type: ignore[override]
-        key = user_key
-        if list_key:
-            key += list_key
+    def POST(self, user_key: str | None, list_key: str | None = None):  # type: ignore[override]
+        key = (user_key or '') + (list_key or '')
 
         if not web.ctx.site.can_write(key):
             return render_template(
@@ -256,7 +256,7 @@ class lists_edit(delegate.page):
         if not list_key:
             list_num = web.ctx.site.seq.next_value("list")
             list_key = f"/lists/OL{list_num}L"
-            list_record.key = user_key + list_key
+            list_record.key = (user_key or '') + list_key
 
         web.ctx.site.save(
             list_record.to_thing_json(),
@@ -267,10 +267,10 @@ class lists_edit(delegate.page):
 
 
 class lists_add(delegate.page):
-    path = r"(/people/[^/]+)/lists/add"
+    path = r"(/people/[^/]+)?/lists/add"
 
-    def GET(self, user_key: str):  # type: ignore[override]
-        if not web.ctx.site.can_write(user_key):
+    def GET(self, user_key: str | None):  # type: ignore[override]
+        if user_key and not web.ctx.site.can_write(user_key):
             return render_template(
                 "permission_denied",
                 web.ctx.fullpath,
@@ -279,12 +279,12 @@ class lists_add(delegate.page):
         list_record = ListRecord.from_input()
         return render_template("type/list/edit", list_record, new=True)
 
-    def POST(self, user_key: str):  # type: ignore[override]
+    def POST(self, user_key: str | None):  # type: ignore[override]
         return lists_edit().POST(user_key, None)
 
 
 class lists_delete(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/delete"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/delete"
     encoding = "json"
 
     def POST(self, key):
@@ -452,7 +452,7 @@ def get_list(key, raw=False):
 
 
 class list_view_json(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)"
     encoding = "json"
     content_type = "application/json"
 
@@ -483,7 +483,7 @@ def get_list_seeds(key):
 
 
 class list_seeds(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/seeds"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/seeds"
     encoding = "json"
 
     content_type = "application/json"
@@ -561,7 +561,7 @@ def get_list_editions(key, offset=0, limit=50, api=False):
 
 
 class list_editions_json(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/editions"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/editions"
     encoding = "json"
 
     content_type = "application/json"
@@ -607,7 +607,7 @@ def make_collection(size, entries, limit, offset, key=None):
 
 
 class list_subjects_json(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/subjects"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/subjects"
     encoding = "json"
     content_type = "application/json"
 
@@ -646,7 +646,7 @@ class list_subjects_yaml(list_subjects_json):
 
 
 class lists_embed(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/embed"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/embed"
 
     def GET(self, key):
         doc = web.ctx.site.get(key)
@@ -656,7 +656,7 @@ class lists_embed(delegate.page):
 
 
 class export(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/export"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/export"
 
     def GET(self, key):
         lst = web.ctx.site.get(key)
@@ -758,7 +758,7 @@ class export(delegate.page):
 
 
 class feeds(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/feeds/(updates).(atom)"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/feeds/(updates).(atom)"
 
     def GET(self, key, name, fmt):
         lst = web.ctx.site.get(key)
@@ -819,7 +819,8 @@ def _preload_lists(lists):
             xlist = xlist.dict()
 
         owner = xlist['key'].rsplit("/lists/", 1)[0]
-        keys.add(owner)
+        if owner:
+            keys.add(owner)
 
         for seed in xlist.get("seeds", []):
             if isinstance(seed, dict) and "key" in seed:
@@ -874,7 +875,7 @@ def get_active_lists_in_random(limit=20, preload=True):
 
 
 class lists_preview(delegate.page):
-    path = r"(/people/[^/]+/lists/OL\d+L)/preview.png"
+    path = r"((?:/people/[^/]+)?/lists/OL\d+L)/preview.png"
 
     def GET(self, lst_key):
         image_bytes = render_list_preview_image(lst_key)

--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -32,7 +32,6 @@ $var title: $_('Lists')
         <div class="listEntry">
             <div class="data">
                 <div class="name">
-                    $ owner = list.get_owner()
                     <a href="$list.key" class="title results">
                         <div class="cover">
                             $ cover = list.get_cover() or list.get_default_cover()
@@ -41,7 +40,9 @@ $var title: $_('Lists')
                         </div>
                         $list.name
                     </a>
-                    $:_('from <a href="%(key)s">%(owner)s</a>', key=owner.key, owner=owner.displayname)
+                    $ owner = list.get_owner()
+                    $if owner:
+                        $:_('from <a href="%(key)s">%(owner)s</a>', key=owner.key, owner=owner.displayname)
                 </div>
                 <div class="meta">
                     $ msg = ungettext("%(count)d item", "%(count)d items", len(list.seeds))

--- a/openlibrary/templates/lists/list_overview.html
+++ b/openlibrary/templates/lists/list_overview.html
@@ -1,7 +1,8 @@
 $def with (list, user_key, seed_info)
 
-$ remove = (list.owner.key == user_key)
-$ actionable = 'class=actionable-item' if remove else ''
+$ has_owner = list.owner
+$ is_owner = (has_owner and list.owner.key == user_key)
+$ actionable = 'class=actionable-item' if is_owner else ''
 <li $actionable>
     <span class="image">
       <a href="$list.key"><img src="$list.cover_url" alt="$_('Cover of: %(title)s', title=list.name)" title="$_('Cover of: %(title)s', title=list.name)"/></a>
@@ -9,7 +10,7 @@ $ actionable = 'class=actionable-item' if remove else ''
     <span class="data">
         <span class="label">
             <a href="$list.key" data-list-title="$(list.name)" title="$_('See this list')">$list.name</a>
-            $if remove:
+            $if is_owner:
                 $if seed_info['type'] == 'subject':
                     $ seed_key = seed_info['seed']
                 $else:
@@ -20,9 +21,7 @@ $ actionable = 'class=actionable-item' if remove else ''
 
                 <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-key="$list.key" title="$_('Remove from your list?')">[X]</a>
         </span>
-        $if remove:
-            <span class="owner">from <a href="$list.owner.key">$_('You')</a></span>
-        $else:
-            <span class="owner">from <a href="$list.owner.key">$list.owner.displayname</a></span>
+        $if has_owner:
+            <span class="owner">from <a href="$list.owner.key">$(_('You') if is_owner else list.owner.displayname)</a></span>
     </span>
 </li>

--- a/openlibrary/templates/lists/preview.html
+++ b/openlibrary/templates/lists/preview.html
@@ -5,15 +5,16 @@ $def with (list)
         <a href="$list.key"><img src="$cover_url" alt="$_('Cover of: %(title)s', title=list.name)" title="$_('Cover of: %(title)s', title=list.name)"/></a>
     </span>
     <span class="details">
-        $ owner = list.get_owner()
-        $ is_owner = ctx.user and ctx.user.key == owner.key
-        <span class="resultTitle $cond(is_owner, 'my-list')">
-            $if is_owner:
-                <h3><a href="$list.key">$list.name</a></h3>
-                <span class="list-owner small grey"> $:_('by <a href="$owner.key">You</a>')</span>
-            $else:
-                <h3><a href="$list.key">$list.name</a></h3>
-                <span class="list-owner small grey"> $_('by') <a href="$owner.key">$owner.displayname</a></span>
+        <span class="resultTitle">
+            $ owner = list.get_owner()
+            $if owner:
+                $ is_owner = ctx.user and ctx.user.key == owner.key
+                $if is_owner:
+                    <h3><a href="$list.key">$list.name</a></h3>
+                    <span class="list-owner small grey"> $:_('by <a href="$owner.key">You</a>')</span>
+                $else:
+                    <h3><a href="$list.key">$list.name</a></h3>
+                    <span class="list-owner small grey"> $_('by') <a href="$owner.key">$owner.displayname</a></span>
 
             <div class="editions smaller">
                 $ungettext("%(count)d item", "%(count)d items", len(list.seeds), count=len(list.seeds))

--- a/openlibrary/templates/lists/widget.html
+++ b/openlibrary/templates/lists/widget.html
@@ -31,7 +31,8 @@ $def render_widget_display(lists, limit, user_key, exclude_own_lists):
     $for i, list in enumerate(lists):
         $if count < limit:
             $if exclude_own_lists:
-                $if user_key != list.owner.key:
+                $ own_list = list.owner and list.owner.key == user_key
+                $if not own_list:
                     $:render_template('lists/list_overview', list, user_key, seed_info)
                     $ count = count + 1
             $else:

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -1,12 +1,21 @@
-$def with (lst, new=False)
+$def with (lst, new=False, admin_only=False)
 $putctx('cssfile', 'list-edit')
 $var title: $(_("Create a list") if new else _("Editing list: %(list_name)s", list_name=lst.name))
 
 $putctx("robots", "noindex,nofollow")
 
+$ can_save = True
+$if admin_only:
+    $ can_save = (ctx.user and ctx.user.is_admin())
+
 <div id="contentHead">
     $:macros.databarEdit(lst)
     <h1>$(_("Create a list") if new else _("Edit List"))</h1>
+
+    $if admin_only:
+        <b class="warning">
+            $_("⚠️ Saving global lists is admin-only while the feature is under development.")
+        </b>
 </div>
 
 $# Render the ith seed input field
@@ -118,7 +127,7 @@ $jsdef lazy_thing_preview(key, render_fn_name):
 
         <div class="formElement bottom">
             $if new:
-                <button type="submit" class="larger">$_('Create new list')</button>
+                <button type="submit" class="larger" $cond(not can_save, 'disabled')>$_('Create new list')</button>
             $else:
                 $:macros.EditButtons(comment=lst.comment_)
         </div>

--- a/openlibrary/templates/type/list/embed.html
+++ b/openlibrary/templates/type/list/embed.html
@@ -16,9 +16,10 @@ $def render_seed_count(seed_count):
         <a href="/" title="$_('Visit Open Library')"><img src="/images/logo_OL-sm.png" width="90" height="71" alt="$_('Open Library logo')" class="right"/></a>
 
         $ owner = list.get_owner()
-        <a href="$owner.key">$owner.displayname</a>
-        /
-        <a href="$owner.key/lists">$_('Lists')</a>
+        $if owner:
+            <a href="$owner.key">$owner.displayname</a>
+            /
+            <a href="$owner.key/lists">$_('Lists')</a>
     </div>
     <h1>
         $list.name

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -37,12 +37,13 @@ $jsdef render_seed_count(seed_count):
 
 $if not is_owner:
     <div id="contentHead" style="margin-bottom:0;">
-        $:macros.databarView(list, edit=False)
+        $ owner = list.get_owner()
+        $:macros.databarView(list, edit=not owner)
         <div class="superNav">
-            $ owner = list.get_owner()
-            <a href="$owner.key">$owner.displayname</a>
-            /
-            <a href="$owner.key/lists">$_('Lists')</a>
+            $if owner:
+                <a href="$owner.key">$owner.displayname</a>
+                /
+                <a href="$owner.key/lists">$_('Lists')</a>
         </div>
         <h1>$list.name</h1>
         <p class="collapse sansserif">
@@ -53,7 +54,8 @@ $if not is_owner:
     </div>
 
 $def remove_item_link():
-    $if ctx.user and ctx.user.key == list.get_owner().key:
+    $ owner = list.get_owner()
+    $if owner and ctx.user and ctx.user.key == owner.key:
         <span class="listDelete sansserif smaller">
             <a href="javascript:;" data-confirm-text="$:_('Yes, I\'m sure')" data-cancel-text="$_('No, cancel')"><span></span>$_('Remove this item?')</a>
         </span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7810

Feature. Makes it possible to create lists on the global namespace. No real links in the UI yet, but this will be used to support series. 

### Technical
- `/lists/add` is how you can create a new global list.
- All list APIs that work on `/people/USER/lists/OL123L` now also work on `/lists/OL123L`

### Testing
Use the little UI to try to extract a series from open library edition data! https://codepen.io/cdrini/full/xxQNbgZ

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
