### PR TITLE
Fix list of authors rendering only first author when creating a new edition

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -193,14 +193,14 @@ class addbook(delegate.page):
         if not self.has_permission():
             return safe_seeother(f"/account/login?redirect={self.path}")
 
-        i = web.input(work=None, author=None)
+        i = web.input(work=None)
         work = i.work and web.ctx.site.get(i.work)
-        print('DEBUG work: ', work.authors, file=web.debug)
-        author = i.author and web.ctx.site.get(i.author)
-        print('DEBUG author: ', author, file=web.debug)
+        authors = (work and work.authors) or []
+        if work and authors:
+            authors = [a.author for a in authors]
 
         return render_template(
-            'books/add', work=work, authors=work.authors, author=author, recaptcha=get_recaptcha()
+            'books/add', work=work, authors=authors, recaptcha=get_recaptcha()
         )
 
     def has_permission(self) -> bool:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -195,10 +195,12 @@ class addbook(delegate.page):
 
         i = web.input(work=None, author=None)
         work = i.work and web.ctx.site.get(i.work)
+        print('DEBUG work: ', work.authors, file=web.debug)
         author = i.author and web.ctx.site.get(i.author)
+        print('DEBUG author: ', author, file=web.debug)
 
         return render_template(
-            'books/add', work=work, author=author, recaptcha=get_recaptcha()
+            'books/add', work=work, authors=work.authors, author=author, recaptcha=get_recaptcha()
         )
 
     def has_permission(self) -> bool:

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -1,4 +1,4 @@
-$def with (work=None, authors=None, author=None, recaptcha=None)
+$def with (work=None, authors=None, recaptcha=None)
 
 $var title: $_("Add a book")
 
@@ -20,8 +20,6 @@ $ i18n_strings = {
 <div id="contentBody">
 
     <form method="post" action="" id="addbook" class="olform addbook1 validate" name="edit">
-
-        $ author = (work and work.authors and work.authors[0].author) or author
         <div class="formElement">
             <div class="label">
                 <label for="title">$_("Title")</label> <span class="tip">$:_("Use <b><i>Title: Subtitle</i></b> to add a subtitle.")</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
@@ -36,7 +34,7 @@ $ i18n_strings = {
         </div>
         <div class="formElement">
             <div class="label"><label for="author">$_("Author")</label> <span class="smaller lighter">$_('Like, "Agatha Christie" or "Jean-Paul Sartre." We\'ll also do a live check to see if we already know the author.')</span></div>
-            $:render_template("books/author-autocomplete", cond(authors, authors, [author]), "author_names", "authors", readonly=work is not None)
+            $:render_template("books/author-autocomplete", authors, "author_names", "authors", readonly=work is not None)
         </div>
 
         <div class="formElement">

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -1,4 +1,4 @@
-$def with (work=None, author=None, recaptcha=None)
+$def with (work=None, authors=None, author=None, recaptcha=None)
 
 $var title: $_("Add a book")
 
@@ -36,7 +36,7 @@ $ i18n_strings = {
         </div>
         <div class="formElement">
             <div class="label"><label for="author">$_("Author")</label> <span class="smaller lighter">$_('Like, "Agatha Christie" or "Jean-Paul Sartre." We\'ll also do a live check to see if we already know the author.')</span></div>
-            $:render_template("books/author-autocomplete", cond(author, [author], []), "author_names", "authors", readonly=work is not None)
+            $:render_template("books/author-autocomplete", cond(authors, authors, [author]), "author_names", "authors", readonly=work is not None)
         </div>
 
         <div class="formElement">

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -26,6 +26,6 @@ $jsdef render_author(name_path, dict_path, readonly, i, author):
 $ config = {'name_path': name_path, 'dict_path': dict_path}
 <div class="multi-input-autocomplete--author" data-config="$dumps(config)">
     $for author in (authors or [storage(name="", key="")]):
-        $:render_author(name_path, dict_path, readonly, loop.index0, author.author)
+        $:render_author(name_path, dict_path, readonly, loop.index0, author)
     <a href="javascript:;" class="mia__add">$_("Add another author?")</a>
 </div>

--- a/openlibrary/templates/books/author-autocomplete.html
+++ b/openlibrary/templates/books/author-autocomplete.html
@@ -26,6 +26,6 @@ $jsdef render_author(name_path, dict_path, readonly, i, author):
 $ config = {'name_path': name_path, 'dict_path': dict_path}
 <div class="multi-input-autocomplete--author" data-config="$dumps(config)">
     $for author in (authors or [storage(name="", key="")]):
-        $:render_author(name_path, dict_path, readonly, loop.index0, author)
+        $:render_author(name_path, dict_path, readonly, loop.index0, author.author)
     <a href="javascript:;" class="mia__add">$_("Add another author?")</a>
 </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8161

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the add book page by rendering all authors when creating a new edition for a work with more than one author.

### Technical
<!-- What should be noted about the implementation? -->
Only the first author was passed to [templates/books/add.html](https://github.com/internetarchive/openlibrary/blob/6f755aee7115c668ae3ce078a4209ecd7a400cb5/openlibrary/templates/books/add.html#L39) from [upstream/addbook.py](https://github.com/internetarchive/openlibrary/blob/6f755aee7115c668ae3ce078a4209ecd7a400cb5/openlibrary/plugins/upstream/addbook.py#L201). Updated addbook.py to pull all authors and pass them instead since [templates/books/author-autocomplete.py](https://github.com/internetarchive/openlibrary/blob/6f755aee7115c668ae3ce078a4209ecd7a400cb5/openlibrary/templates/books/author-autocomplete.html#L28) was already attempting to render a list of authors.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Attempt to create a new edition for a work with more than one author (Ex. https://openlibrary.org/books/add?work=/works/OL15130687W). Verify that all of the pre-existing authors are rendered as read-only fields within the form.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Book page with multiple authors.
![image](https://github.com/internetarchive/openlibrary/assets/29631356/69cd9214-49b7-40d3-9065-3500545ad120)

On page to create a new edition showing all authors rendered.
![image](https://github.com/internetarchive/openlibrary/assets/29631356/424711dc-aa3e-4e21-9c0a-b954f6b80b2f)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp  @mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
