### PR TITLE
border fixes for my books mobile showcase section divisions

### DIFF
--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -117,7 +117,7 @@
   }
 
   .carousel-section-header {
-    border-bottom: 1px solid @light-mid-grey;
+    border-top: 1px solid @light-mid-grey;
   }
 
   .showcase {

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -38,6 +38,7 @@
     max-height: unset;
     overflow: auto;
   }
+  
   ul:last-child {
     border-bottom: none;
   }
@@ -182,15 +183,13 @@
     }
     /*all uls */
     .sidebar-section {
-      padding: 0 0 20px;
+      margin: 0 0 20px;
+      border-bottom: 1px solid @light-mid-grey;
     }
 
     .sidebar-section .list-overflow {
       max-height: unset;
       overflow: auto;
-    }
-    ul:last-child {
-      border-bottom: none;
     }
 
     ul li {

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -38,7 +38,7 @@
     max-height: unset;
     overflow: auto;
   }
-  
+
   ul:last-child {
     border-bottom: none;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8156 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Borders on tops of the showcase section headers in My Books mobile instead of bottoms, clarifies delineation between book showcase sections. Also adds border to bottom of each menu section for self-contained look

### Technical
<!-- What should be noted about the implementation? -->
Just some small CSS changes (border-bottom now border-top, adding bottom borders to sidebar-section class on My Books Mobile, changing padding to margin so borders are in right place)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
View My Books mobile with books added to some reading logs

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="372" alt="Screenshot 2023-08-08 at 11 28 42 AM" src="https://github.com/internetarchive/openlibrary/assets/69476557/bb8c2e89-13a5-4791-bf4a-b09d4e6953c6">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @mekarpeles @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
