### PR TITLE
8137/fix/readinglog rate component fix

### DIFF
--- a/openlibrary/macros/StarRatings.html
+++ b/openlibrary/macros/StarRatings.html
@@ -45,6 +45,6 @@ $ form_id = "ratingsForm%s" % id
   $ class_list = "star-messaging"
   $if not rating:
     $ class_list = "%s hidden" % (class_list)
-    <span class="star-rating__not-rated">Rate</span>
+    <!-- <span class="star-rating__not-rated">Rate</span> -->
   <button type="submit" class="$class_list">$_("Clear my rating")</button>
 </form>

--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -117,7 +117,7 @@
   }
 
   .carousel-section-header {
-    border-bottom: 1px solid @light-mid-grey;
+    border-top: 1px solid @light-mid-grey;
   }
 
   .showcase {

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -38,6 +38,7 @@
     max-height: unset;
     overflow: auto;
   }
+  
   ul:last-child {
     border-bottom: none;
   }
@@ -182,15 +183,13 @@
     }
     /*all uls */
     .sidebar-section {
-      padding: 0 0 20px;
+      margin: 0 0 20px;
+      border-bottom: 1px solid @light-mid-grey;
     }
 
     .sidebar-section .list-overflow {
       max-height: unset;
       overflow: auto;
-    }
-    ul:last-child {
-      border-bottom: none;
     }
 
     ul li {

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -38,7 +38,7 @@
     max-height: unset;
     overflow: auto;
   }
-  
+
   ul:last-child {
     border-bottom: none;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8137 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Deletes 'Rate' label from below star rating component

### Technical
<!-- What should be noted about the implementation? -->
The span containing 'Rate' was commented out, not deleted. This is just in case we do want to include the label (perhaps centered above the stars)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to Already Read page from My Books, make sure there's at least one book in it

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="790" alt="Screenshot 2023-08-08 at 11 38 13 AM" src="https://github.com/internetarchive/openlibrary/assets/69476557/8ec90716-0b7f-4144-99d3-3eeb21ead66d">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @jimchamp @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
