### PR TITLE
Make "All" search match books by an author

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -21,7 +21,6 @@ from openlibrary.solr.query_utils import (
     luqum_traverse,
     luqum_replace_field,
 )
-from openlibrary.solr.utils import get_solr_next
 from openlibrary.utils.ddc import (
     normalize_ddc,
     normalize_ddc_prefix,
@@ -345,16 +344,10 @@ class WorkSearchScheme(SearchScheme):
                 'alternative_subtitle': 'subtitle',
                 'cover_i': 'cover_i',
                 # Duplicate author fields
-                **(
-                    {
-                        'author_name': 'author_name',
-                        'author_key': 'author_key',
-                        'author_alternative_name': 'author_alternative_name',
-                        'author_facet': 'author_facet',
-                    }
-                    if get_solr_next()
-                    else {}
-                ),
+                'author_name': 'author_name',
+                'author_key': 'author_key',
+                'author_alternative_name': 'author_alternative_name',
+                'author_facet': 'author_facet',
                 # Misc useful data
                 'format': 'format',
                 'language': 'language',
@@ -479,8 +472,7 @@ class WorkSearchScheme(SearchScheme):
             ed_q = convert_work_query_to_edition_query(str(work_q_tree))
             full_ed_query = '({{!edismax bq="{bq}" v="{v}" qf="{qf}"}})'.format(
                 # See qf in work_query
-                qf='text alternative_title^4'
-                + (' author_name^4' if get_solr_next() else ''),
+                qf='text alternative_title^4 author_name^4',
                 # Because we include the edition query inside the v="..." part,
                 # we need to escape quotes. Also note that if there is no
                 # edition query (because no fields in the user's work query apply),

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -21,6 +21,7 @@ from openlibrary.solr.query_utils import (
     luqum_traverse,
     luqum_replace_field,
 )
+from openlibrary.solr.utils import get_solr_next
 from openlibrary.utils.ddc import (
     normalize_ddc,
     normalize_ddc_prefix,
@@ -343,6 +344,17 @@ class WorkSearchScheme(SearchScheme):
                 'alternative_title': 'alternative_title',
                 'alternative_subtitle': 'subtitle',
                 'cover_i': 'cover_i',
+                # Duplicate author fields
+                **(
+                    {
+                        'author_name': 'author_name',
+                        'author_key': 'author_key',
+                        'author_alternative_name': 'author_alternative_name',
+                        'author_facet': 'author_facet',
+                    }
+                    if get_solr_next()
+                    else {}
+                ),
                 # Misc useful data
                 'format': 'format',
                 'language': 'language',
@@ -467,7 +479,8 @@ class WorkSearchScheme(SearchScheme):
             ed_q = convert_work_query_to_edition_query(str(work_q_tree))
             full_ed_query = '({{!edismax bq="{bq}" v="{v}" qf="{qf}"}})'.format(
                 # See qf in work_query
-                qf='text title^4',
+                qf='text alternative_title^4'
+                + (' author_name^4' if get_solr_next() else ''),
                 # Because we include the edition query inside the v="..." part,
                 # we need to escape quotes. Also note that if there is no
                 # edition query (because no fields in the user's work query apply),
@@ -510,7 +523,16 @@ class WorkSearchScheme(SearchScheme):
                 f.split('.', 1)[1] for f in solr_fields if f.startswith('editions.')
             }
             if not edition_fields:
-                edition_fields = solr_fields - {'editions:[subquery]'}
+                edition_fields = solr_fields - {
+                    # Default to same fields as for the work...
+                    'editions:[subquery]',
+                    # but exclude the author fields since they're primarily work data;
+                    # they only exist on editions to improve search matches.
+                    'author_name',
+                    'author_key',
+                    'author_alternative_name',
+                    'author_facet',
+                }
             # The elements in _this_ edition query will match but not affect
             # whether the work appears in search results
             new_params.append(

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -262,7 +262,9 @@ class WorkSolrBuilder(AbstractSolrBuilder):
         self._ia_metadata = ia_metadata
         self._data_provider = data_provider
         self._solr_editions = [
-            EditionSolrBuilder(e, self._ia_metadata.get(e.get('ocaid', '').strip()))
+            EditionSolrBuilder(
+                e, self, self._ia_metadata.get(e.get('ocaid', '').strip())
+            )
             for e in self._editions
         ]
 
@@ -639,13 +641,13 @@ class WorkSolrBuilder(AbstractSolrBuilder):
     def author_name(self) -> list[str]:
         return [a.get('name', '') for a in self._authors]
 
-    @property
+    @cached_property
     def author_alternative_name(self) -> set[str]:
         return {
             alt_name for a in self._authors for alt_name in a.get('alternate_names', [])
         }
 
-    @property
+    @cached_property
     def author_facet(self) -> list[str]:
         return [f'{key} {name}' for key, name in zip(self.author_key, self.author_name)]
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7276 . Fix.

| **DO NOT MERGE** Want to test this during a full reindex first for perf |
| --|

Do this by including a copy of author data at the edition level. This increases the storage cost and is somewhat redundant, but the search benefits are worth it.

Will only really take effect after the next full reindex.


### Technical

- Main concern here is if this will add too much data into solr ; since this will duplicate a lot of info! Will need to test for perf once deploying, and then see.

### Testing
I tested by copydocs-ing the two clive cussler examples below, and confirming they now matched on just authors in query!

### Screenshot

Here's a simple example of searching for the author `greg`
| Before | After |
| --- | --- |
| ![image](https://github.com/internetarchive/openlibrary/assets/6251786/9bdcbc0e-bec7-49c3-8bc3-2159f47c3cc6) | ![image](https://github.com/internetarchive/openlibrary/assets/6251786/c587b66c-4ed2-4f59-9691-780722264cb1) |

| Before | After |
| --- | --- |
| ![image](https://github.com/internetarchive/openlibrary/assets/6251786/d59abf18-a8c4-421b-8be9-c6c818b17182) | ![image](https://github.com/internetarchive/openlibrary/assets/6251786/60f41654-089d-4391-be42-dd7ee3aeb134) |
| Note how only 69 books are shown, and all books are books which have "Clive Cussler" in the title. Meanwhile, there are 526 matches for `author:clive cussler`! | Now, we see a mix of books, sorted by our normal relevancy rankings. And we now have all of Cussler's books in the results (note the number, 154 is less than 526 just because I partially imported his works into my local instance. On prod all would be available. |


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
