### PR TITLE
set last_login on login

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -885,6 +885,8 @@ def audit_accounts(
     # web.ctx.site.login method (which requires OL credentials), and directly set an
     # auth_token to enable the user's session.
     web.ctx.conn.set_auth_token(ol_account.generate_login_code())
+    ol_account['last_login'] = datetime.datetime.utcnow().isoformat()
+    ol_account._save()
     return {
         'authenticated': True,
         'special_access': getattr(ia_account, 'has_disability_access', False),

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -573,6 +573,13 @@ class OpenLibraryAccount(Account):
         web.ctx.site.store[self._key] = _ol_account
         self.s3_keys = s3_keys
 
+    def update_last_login(self):
+        _ol_account = web.ctx.site.store.get(self._key)
+        last_login = datetime.datetime.utcnow().isoformat()
+        _ol_account['last_login'] = last_login
+        web.ctx.site.store[self._key] = _ol_account
+        self.last_login = last_login
+
     @classmethod
     def authenticate(cls, email, password, test=False):
         ol_account = cls.get(email=email, test=test)
@@ -885,8 +892,7 @@ def audit_accounts(
     # web.ctx.site.login method (which requires OL credentials), and directly set an
     # auth_token to enable the user's session.
     web.ctx.conn.set_auth_token(ol_account.generate_login_code())
-    ol_account['last_login'] = datetime.datetime.utcnow().isoformat()
-    ol_account._save()
+    ol_account.update_last_login()
     return {
         'authenticated': True,
         'special_access': getattr(ia_account, 'has_disability_access', False),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8179

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

In ~2016 or 2017 when we switched from Open Library authentication to archive.org auth via the xauthn bridge, we somehow dropped a codepath which set/updated the `last_login` value on the patron's Open Library account. This adds back a `last_login` set in the `audit` authentication path.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Minimal test:
```
import web
import infogami
from openlibrary.config import load_config
load_config('/olsystem/etc/openlibrary.yml')
infogami._setup()
from infogami import config;
a = OpenLibraryAccount.get(email='michael.karpeles@gmail.com')
a['last_login'] = '2023-08-17T08:22:28.788221'  # for example
a._save()
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
