### PR TITLE
autodetect author ASIN, Youtube, storygraph ids

### DIFF
--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -84,6 +84,7 @@ export default {
             // See https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats
             this.$set(this.assignedIdentifiers, this.selectedIdentifier, this.inputValue);
             this.inputValue = '';
+            this.selectedIdentifier = '';
         },
         /** Removes an identifier with value from memory and it will be deleted from database on save */
         removeIdentifier: function(identifierName){

--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -29,6 +29,10 @@
 </template>
 
 <script>
+const identifier_regex  = {
+    wikidata: /^Q[1-9]\d*$/i,
+    isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
+}
 export default {
     // Props are for external options; if a subelement of this is modified,
     // the view automatically re-renders
@@ -102,14 +106,11 @@ export default {
             document.querySelector(this.output_selector).innerHTML = html;
         },
         selectIdentifierByInputValue: function() {
-            // Selects the dropdown identifier based on the input value
-            // Only supports wikidata and isni because the other identifiers are just numbers
-            const wikiDatas = this.inputValue.match(/^Q[1-9]\d*$/i);
-            const isnis = this.inputValue.match(/^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i);
-            if (wikiDatas?.length > 0){
-                this.selectedIdentifier = 'wikidata';
-            } else if (isnis?.length > 0){
-                this.selectedIdentifier = 'isni';
+            // Selects the dropdown identifier based on the input value when possible
+            for (const idtype in identifier_regex) {
+                if (this.inputValue.match(identifier_regex[idtype])){
+                    this.selectedIdentifier = idtype;
+                }
             }
         }
     },

--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-const identifier_regex  = {
+const identifierPatterns  = {
     wikidata: /^Q[1-9]\d*$/i,
     isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
     storygraph: /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i,
@@ -110,8 +110,8 @@ export default {
         },
         selectIdentifierByInputValue: function() {
             // Selects the dropdown identifier based on the input value when possible
-            for (const idtype in identifier_regex) {
-                if (this.inputValue.match(identifier_regex[idtype])){
+            for (const idtype in identifierPatterns) {
+                if (this.inputValue.match(identifierPatterns[idtype])){
                     this.selectedIdentifier = idtype;
                     break;
                 }

--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -32,6 +32,9 @@
 const identifier_regex  = {
     wikidata: /^Q[1-9]\d*$/i,
     isni: /^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i,
+    storygraph: /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i,
+    amazon: /^B[0-9A-Za-z]{9}$/,
+    youtube: /^@[A-Za-z0-9_\-.]{3,30}/,
 }
 export default {
     // Props are for external options; if a subelement of this is modified,
@@ -110,6 +113,7 @@ export default {
             for (const idtype in identifier_regex) {
                 if (this.inputValue.match(identifier_regex[idtype])){
                     this.selectedIdentifier = idtype;
+                    break;
                 }
             }
         }

--- a/openlibrary/components/AuthorIdentifiers.vue
+++ b/openlibrary/components/AuthorIdentifiers.vue
@@ -105,7 +105,7 @@ export default {
             // Selects the dropdown identifier based on the input value
             // Only supports wikidata and isni because the other identifiers are just numbers
             const wikiDatas = this.inputValue.match(/^Q[1-9]\d*$/i);
-            const isnis = this.inputValue.match(/^\d{15}[\dX]$/i);
+            const isnis = this.inputValue.match(/^[0]{4} ?[0-9]{4} ?[0-9]{4} ?[0-9]{3}[0-9X]$/i);
             if (wikiDatas?.length > 0){
                 this.selectedIdentifier = 'wikidata';
             } else if (isnis?.length > 0){


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8202

<!-- What does this PR achieve? [feature] -->

Autodects ASIN, Youtube and storygraph identifiers on the Author edit page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Pasting in (or typing) one of the above ids should automatically set the dropdown to the appropriate id type. Wikidata and ISNI types should continue to be detected.

One note for testing, if the contents doesn't change, the code isn't triggered, so if you paste in a storygraph id, manually change the type of id in the selector to something else, then paste in the exact same storygraph id then it'll not do anything. Not an issue for real users but something that testers might do and wonder if it is a bug.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
