### PR TITLE
ruff v0.0.285

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: pip install --user ruff==0.0.280
+    - run: pip install --user ruff==0.0.285
     - run: ruff --format=github .

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,5 +9,5 @@ pymemcache==4.0.0
 pytest==7.4.0
 pytest-asyncio==0.21.1
 pytest-cov==4.1.0
-ruff==0.0.280
+ruff==0.0.285
 safety==2.3.5


### PR DESCRIPTION
Aligns with `.pre-commit-config.yaml` which contains:
```yaml
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.0.285
    hooks:
      - id: ruff
```