### PR TITLE
Remove `closePopup()` function from global `window` object

### DIFF
--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -4,6 +4,8 @@
 import 'jquery-ui/ui/widgets/sortable';
 import 'jquery-ui-touch-punch'; // this makes drag-to-reorder work on touch devices
 
+import { closePopup } from './utils';
+
 //cover/change.html
 export function initCoversChange() {
     // Pull data from data-config of class "manageCovers" in covers/manage.html
@@ -107,7 +109,7 @@ export function initCoversSaved() {
     const image = $('.imageSaved').data('imageId');
     var cover_url;
 
-    $('.formButtons button').on('click', parent.closePopup);
+    $('.formButtons button').on('click', closePopup);
 
     // Update the image for the cover
     if (['/type/edition', '/type/work', '/edit'].includes(doc_type_key)) {

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -21,7 +21,7 @@ import { commify } from './python';
 import { Subject, urlencode, slice } from './subjects';
 import Template from './template.js';
 // Add $.fn.focusNextInputField
-import { closePopup, truncate, cond } from './utils';
+import { truncate, cond } from './utils';
 import initValidate from './validate';
 import '../../../../static/css/js-all.less';
 // polyfill Promise support for IE11
@@ -30,8 +30,6 @@ import { confirmDialog, initDialogs } from './dialog';
 
 // Eventually we will export all these to a single global ol, but in the mean time
 // we add them to the window object for backwards compatibility.
-// closePopup used in openlibrary/templates/covers/saved.html
-window.closePopup = closePopup;
 window.commify = commify;
 window.cond = cond;
 window.enumerate = enumerate;

--- a/openlibrary/plugins/openlibrary/js/utils.js
+++ b/openlibrary/plugins/openlibrary/js/utils.js
@@ -11,7 +11,6 @@ $.fn.focusNextInputField = function() {
 };
 
 // closes active popup
-// used in templates/covers/saved.html
 export function closePopup() {
     parent.jQuery.fn.colorbox.close();
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The `closePopup()` JS function is used to close Colorbox modals.  Since there are no references to `closePopup` in our templates, it seems appropriate to remove this function from the global `window` object.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
