### PR TITLE
Remove `commify` function from global `window` object

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -17,7 +17,6 @@ import { enumerate, htmlquote, websafe, foreach, join, len, range } from './jsde
 import initAnalytics from './ol.analytics';
 import init from './ol.js';
 import * as Browser from './Browser';
-import { commify } from './python';
 import { Subject, urlencode, slice } from './subjects';
 import Template from './template.js';
 // Add $.fn.focusNextInputField
@@ -32,7 +31,6 @@ import { confirmDialog, initDialogs } from './dialog';
 // we add them to the window object for backwards compatibility.
 // closePopup used in openlibrary/templates/covers/saved.html
 window.closePopup = closePopup;
-window.commify = commify;
 window.cond = cond;
 window.enumerate = enumerate;
 window.foreach = foreach;


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the `commify` function from the global `window` object.  No templates currently use the JS `commify` function.  Each template that uses `commify` appears to be using the publicly exposed Python function.

The JS `commify` is no longer in use, but has not been removed as it could be useful in the future.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
