### PR TITLE
DRY account validation unit tests

### DIFF
--- a/tests/unit/js/realtime_account_validation.test.js
+++ b/tests/unit/js/realtime_account_validation.test.js
@@ -14,80 +14,66 @@ beforeEach(() => {
 });
 
 describe('Password tests', () => {
-    test('validatePassword should update elements correctly on success', () => {
+    let label, passwordField, passwordField2, passwordMessage2
+
+    beforeEach(() => {
         // call the function
         initRealTimeValidation();
 
         //declare the elements
-        const label = document.querySelector('label[for="password2"]');
-        const passwordField = document.getElementById('password');
-        const password2Field = document.getElementById('password2');
-        const password2Message = document.getElementById('password2Message');
+        label = document.querySelector('label[for="password2"]');
+        passwordField = document.getElementById('password');
+        passwordField2 = document.getElementById('password2');
+        passwordMessage2 = document.getElementById('password2Message');
+    })
 
+    test('validatePassword should update elements correctly on success', () => {
         // set the password values
         passwordField.value = 'password123';
-        password2Field.value = 'password123';
+        passwordField2.value = 'password123';
 
         // Trigger the blur event on the password fields
         passwordField.dispatchEvent(new Event('blur'));
-        password2Field.dispatchEvent(new Event('blur'));
+        passwordField2.dispatchEvent(new Event('blur'));
 
         // Assert that the elements have the expected classes
-        expect(password2Field.classList.contains('required')).toBe(true);
-        expect(password2Field.classList.contains('invalid')).toBe(false);
+        expect(passwordField2.classList.contains('required')).toBe(true);
+        expect(passwordField2.classList.contains('invalid')).toBe(false);
         expect(label.classList.length).toBe(0);
-        expect(password2Message.classList.contains('darkgreen')).toBe(true);
+        expect(passwordMessage2.classList.contains('darkgreen')).toBe(true);
     });
 
     test('validatePassword should update elements correctly for empty fields', () => {
-        // call the function
-        initRealTimeValidation();
-
-        //declare the elements
-        const label = document.querySelector('label[for="password2"]');
-        const passwordField = document.getElementById('password');
-        const password2Field = document.getElementById('password2');
-        const password2Message = document.getElementById('password2Message');
-
         // set the password values
         passwordField.value = '';
-        password2Field.value = '';
+        passwordField2.value = '';
 
         // Trigger the blur event on the password fields
         passwordField.dispatchEvent(new Event('blur'));
-        password2Field.dispatchEvent(new Event('blur'));
+        passwordField2.dispatchEvent(new Event('blur'));
 
         // Assert that the elements have the expected classes
-        expect(password2Field.classList.contains('required')).toBe(true);
-        expect(password2Field.classList.contains('invalid')).toBe(false);
+        expect(passwordField2.classList.contains('required')).toBe(true);
+        expect(passwordField2.classList.contains('invalid')).toBe(false);
         expect(label.classList.length).toBe(0);
-        expect(password2Message.textContent).toBe('');
+        expect(passwordMessage2.textContent).toBe('');
     });
 
     test('validatePassword should update elements correctly for passwords not matching', () => {
-        // call the function
-        initRealTimeValidation();
-
-        //declare the elements
-        const label = document.querySelector('label[for="password2"]');
-        const passwordField = document.getElementById('password');
-        const password2Field = document.getElementById('password2');
-        const password2Message = document.getElementById('password2Message');
-
         // set the password values
         passwordField.value = 'password123';
-        password2Field.value = 'password321';
+        passwordField2.value = 'password321';
 
         // Trigger the blur event on the password fields
         passwordField.dispatchEvent(new Event('blur'));
-        password2Field.dispatchEvent(new Event('blur'));
+        passwordField2.dispatchEvent(new Event('blur'));
 
         // Assert that the elements have the expected classes
-        expect(password2Field.classList.contains('required')).toBe(true);
-        expect(password2Field.classList.contains('invalid')).toBe(true);
+        expect(passwordField2.classList.contains('required')).toBe(true);
+        expect(passwordField2.classList.contains('invalid')).toBe(true);
         expect(label.classList.contains('default')).toBe(false);
         expect(label.classList.contains('invalid')).toBe(true);
-        expect(password2Message.classList.contains('invalid')).toBe(true);
-        expect(password2Message.textContent).toBe('Passwords didnt match');
+        expect(passwordMessage2.classList.contains('invalid')).toBe(true);
+        expect(passwordMessage2.textContent).toBe('Passwords didnt match');
     });
 });


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
DRYs recently added realtime account validation unit tests by adding a nested `beforeEach` call.  Renamed some variables.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@vnsrz 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
