### PR TITLE
pyproject.toml: project.requires-python = ">=3.11.1,<3.11.2"

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,10 +17,6 @@ permissions:
 
 jobs:
   python_tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version-file: pyproject.toml
       - uses: actions/cache@v3
         with:
           path: ${{ env.pythonLocation }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [project]
-requires-python = "3.11.1"
+requires-python = '3.11.1'
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [project]
-requires-python = 3.11
+requires-python = "3.11"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [project]
-requires-python = 3.11.1
+requires-python = "3.11.1"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@
 # character.
 
 [project]
-requires-python = "==3.11.1"
+name = "openlibrary"
+version = "1.0.0"
+requires-python = "~=3.11.1"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [project]
-requires-python = "3.11"
+requires-python = "==3.11.1"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [project]
-requires-python = '3.11.1'
+requires-python = 3.11
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [project]
 name = "openlibrary"
 version = "1.0.0"
-requires-python = "== 3.11.1"
+requires-python = ">=3.11.1,<3.11.2"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [project]
 name = "openlibrary"
 version = "1.0.0"
-requires-python = "~=3.11.1"
+requires-python = "==3.11.1"
 
 [tool.black]
 skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@
 # verbose regular expressions by Black.  Use [ ] to denote a significant space
 # character.
 
+[project]
+requires-python = 3.11.1
+
 [tool.black]
 skip-string-normalization = true
 target-version = ["py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [project]
 name = "openlibrary"
 version = "1.0.0"
-requires-python = "==3.11.1"
+requires-python = "== 3.11.1"
 
 [tool.black]
 skip-string-normalization = true


### PR DESCRIPTION
Ensure GitHub Actions are testing on the same version of Python as production.
* https://github.com/actions/setup-python/releases/tag/v4.7.0
```yaml
      - uses: actions/setup-python@v4
        with:
          python-version-file: pyproject.toml
```
Arrgghh...
```
Run actions/setup-python@v4
  with:
    python-version-file: pyproject.toml
    check-latest: false
    token: ***
    update-environment: true
    allow-prereleases: false
Extracted ~=3.11.1 from pyproject.toml
Installed versions
  Successfully set up CPython (3.11.4)
```
@dariocurr I would like to leverage actions/setup-python#669 to set `project.requires-python` in `pyproject.toml` to exactly match `3.11.1` so that our GitHub Actions are testing on the same version of Python as [production](https://github.com/internetarchive/openlibrary/blob/master/docker/Dockerfile.olbase#L1).

`pyproject.toml` seems to only be able to parse `project.requires-python = "~=3.11.1"` (see commits) which given the `~`, allows the GitHub Action to upgrade to `3.11.4`.  Is there any way to _force_ the Action to use `3.11.1`?