### PR TITLE
Add Library of Congress Control Number format validation

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -31,8 +31,8 @@ export function initAddBookImport () {
     invalidLccn = i18nStrings.invalid_lccn;
 
     $('#addbook').on('submit', parseAndValidateId);
-    $('#id_value').on('input', clearIsbnError);
-    $('#id_name').on('change', clearIsbnError);
+    $('#id_value').on('input', clearErrors);
+    $('#id_name').on('change', clearErrors);
 }
 
 // a flag to make raiseIsbnError perform differently upon subsequent calls
@@ -63,7 +63,7 @@ function displayLccnError(event, errorMessage) {
     return;
 }
 
-function clearIsbnError() {
+function clearErrors() {
     addBookWithIsbnErrors = false;
     const errorDiv = document.getElementById('id-errors');
     errorDiv.classList.add('hidden');
@@ -71,22 +71,17 @@ function clearIsbnError() {
     confirm.classList.add('hidden');
 }
 
-function clearLccnError() {
-    const errorDiv = document.getElementById('id-errors');
-    errorDiv.classList.add('hidden');
-}
-
 function parseAndValidateId(event) {
     const fieldName = document.getElementById('id_name').value;
-    let idValue = document.getElementById('id_value').value;
+    const idValue = document.getElementById('id_value').value;
 
-    if (fieldName == 'isbn_10') {
+    if (fieldName === 'isbn_10') {
         parseAndValidateIsbn10(event, idValue);
     }
-    else if (fieldName == 'isbn_13') {
+    else if (fieldName === 'isbn_13') {
         parseAndValidateIsbn13(event, idValue);
     }
-    else if (fieldName == 'lccn') {
+    else if (fieldName === 'lccn') {
         parseAndValidateLccn(event, idValue);
     }
 }

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -1,4 +1,10 @@
-import {parseIsbn, isFormatValidIsbn10, isChecksumValidIsbn10, isFormatValidIsbn13, isChecksumValidIsbn13} from './edit.js'
+import {
+    parseIsbn,
+    isChecksumValidIsbn10,
+    isChecksumValidIsbn13,
+    isFormatValidIsbn10,
+    isFormatValidIsbn13
+} from './idValidation.js'
 
 let invalidChecksum;
 let invalidIsbn10;

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -1,14 +1,17 @@
 import {
     parseIsbn,
+    parseLccn,
     isChecksumValidIsbn10,
     isChecksumValidIsbn13,
     isFormatValidIsbn10,
-    isFormatValidIsbn13
+    isFormatValidIsbn13,
+    isValidLccn
 } from './idValidation.js'
 
 let invalidChecksum;
 let invalidIsbn10;
 let invalidIsbn13;
+let invalidLccn;
 
 export function initAddBookImport () {
     $('.list-books a').on('click', function() {
@@ -22,11 +25,12 @@ export function initAddBookImport () {
     });
 
     const i18nStrings = JSON.parse(document.querySelector('#id-errors').dataset.i18n)
-    invalidChecksum = i18nStrings.invalid_checksum
-    invalidIsbn10 = i18nStrings.invalid_isbn10
-    invalidIsbn13 = i18nStrings.invalid_isbn13
+    invalidChecksum = i18nStrings.invalid_checksum;
+    invalidIsbn10 = i18nStrings.invalid_isbn10;
+    invalidIsbn13 = i18nStrings.invalid_isbn13;
+    invalidLccn = i18nStrings.invalid_lccn;
 
-    $('#addbook').on('submit', parseAndValidateIsbn);
+    $('#addbook').on('submit', parseAndValidateId);
     $('#id_value').on('input', clearIsbnError);
     $('#id_name').on('change', clearIsbnError);
 }
@@ -51,6 +55,14 @@ function displayIsbnError(event, errorMessage) {
     document.getElementById('id_value').value = parseIsbn(document.getElementById('id_value').value);
 }
 
+function displayLccnError(event, errorMessage) {
+    const errorDiv = document.getElementById('id-errors');
+    errorDiv.classList.remove('hidden');
+    errorDiv.textContent = errorMessage;
+    event.preventDefault();
+    return;
+}
+
 function clearIsbnError() {
     addBookWithIsbnErrors = false;
     const errorDiv = document.getElementById('id-errors');
@@ -59,27 +71,53 @@ function clearIsbnError() {
     confirm.classList.add('hidden');
 }
 
-function parseAndValidateIsbn(event) {
+function clearLccnError() {
+    const errorDiv = document.getElementById('id-errors');
+    errorDiv.classList.add('hidden');
+}
+
+function parseAndValidateId(event) {
     const fieldName = document.getElementById('id_name').value;
     let idValue = document.getElementById('id_value').value;
-    // parsing valid ISBN that passes checks
-    if (fieldName === 'isbn_10') {
-        idValue = parseIsbn(idValue);
-        if (!isFormatValidIsbn10(idValue)) {
-            return displayIsbnError(event, invalidIsbn10);
-        }
-        if (!isChecksumValidIsbn10(idValue)) {
-            return displayIsbnError(event, invalidChecksum);
-        }
+
+    if (fieldName == 'isbn_10') {
+        parseAndValidateIsbn10(event, idValue);
     }
-    else if (fieldName === 'isbn_13') {
-        idValue = parseIsbn(idValue);
-        if (!isFormatValidIsbn13(idValue)) {
-            return displayIsbnError(event, invalidIsbn13);
-        }
-        if (!isChecksumValidIsbn13(idValue)) {
-            return displayIsbnError(event, invalidChecksum);
-        }
+    else if (fieldName == 'isbn_13') {
+        parseAndValidateIsbn13(event, idValue);
+    }
+    else if (fieldName == 'lccn') {
+        parseAndValidateLccn(event, idValue);
+    }
+}
+
+function parseAndValidateIsbn10(event, idValue) {
+    // parsing valid ISBN that passes checks
+    idValue = parseIsbn(idValue);
+    if (!isFormatValidIsbn10(idValue)) {
+        return displayIsbnError(event, invalidIsbn10);
+    }
+    if (!isChecksumValidIsbn10(idValue)) {
+        return displayIsbnError(event, invalidChecksum);
+    }
+    document.getElementById('id_value').value = idValue;
+}
+
+function parseAndValidateIsbn13(event, idValue) {
+    idValue = parseIsbn(idValue);
+    if (!isFormatValidIsbn13(idValue)) {
+        return displayIsbnError(event, invalidIsbn13);
+    }
+    if (!isChecksumValidIsbn13(idValue)) {
+        return displayIsbnError(event, invalidChecksum);
+    }
+    document.getElementById('id_value').value = idValue;
+}
+
+function parseAndValidateLccn(event, idValue) {
+    idValue = parseLccn(idValue);
+    if (!isValidLccn(idValue)) {
+        return displayLccnError(event, invalidLccn);
     }
     document.getElementById('id_value').value = idValue;
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -181,8 +181,8 @@ export function isbnConfirmAdd(data) {
  * Called by validateIdentifiers(), validates the addition of new
  * ISBN 10 to an edition.
  * @params {Object} data  data from the input form
- * @params {Object} dataConfig
- * @params {String} label formatted value of the identifier type name
+ * @params {Object} dataConfig  object mapping error messages to their string values
+ * @params {String} label  formatted value of the identifier type name (ISBN 10)
  * @returns {boolean}  true if ISBN passes validation
  */
 function validateIsbn10(data, dataConfig, label) {
@@ -208,8 +208,8 @@ function validateIsbn10(data, dataConfig, label) {
  * Called by validateIdentifiers(), validates the addition of new
  * ISBN 13 to an edition.
  * @params {Object} data  data from the input form
- * @params {Object} dataConfig
- * @params {String} label formatted value of the identifier type name
+ * @params {Object} dataConfig  object mapping error messages to their string values
+ * @params {String} label  formatted value of the identifier type name (ISBN 13)
  * @returns {boolean}  true if ISBN passes validation
  */
 function validateIsbn13(data, dataConfig, label) {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -175,11 +175,19 @@ function validateIsbn13(data, dataConfig, label) {
     return true;
 }
 
-function validateLccn(data) {
+/**
+ * Called by validateIdentifiers(), validates the addition of new
+ * LCCN to an edition.
+ * @param {Object} data  data from the input form
+ * @param {Object} dataConfig  object mapping error messages to their string values
+ * @param {String} label  formatted value of the identifier type name (LCCN)
+ * @returns {boolean}  true if LCCN passes validation, else returns false and displays appropriate error
+ */
+function validateLccn(data, dataConfig, label) {
     data.value = parseLccn(data.value);
 
     if (!isValidLccn(data.value)) {
-        return error('#id-errors', 'id-value', 'Invalid format for LCCN.');
+        return error('#id-errors', 'id-value', dataConfig['Invalid ID format'].replace(/ID/, label));
     }
     return true;
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -224,7 +224,7 @@ export function validateIdentifiers(data) {
     else if (data.name === 'lccn') {
         validId = validateLccn(data, dataConfig, label);
     }
-    
+
     if (validId) $('#id-errors').hide();
     return validId;
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -95,6 +95,17 @@ function isIsbnDupe(isbn) {
 }
 
 /**
+ * Takes an LCCN string normalized using logic in idValidation.js and returns
+ * true if the identifier has already been added
+ * @param {String} lccn  LCCN string to check
+ * @return {boolean}  true if given LCCN is already added to the edition
+ */
+function isLccnDupe(lccn) {
+    const lccnEntries = document.querySelectorAll('.lccn');
+    return Array.from(lccnEntries).some(entry => entry['value'] === lccn);
+}
+
+/**
  * Displays a confirmation box in the error div to confirm the addition of an
  * ISBN with a valid form but which fails the checksum.
  * @param {Object} data  data from the input form, gathered via js/jquery.repeat.js
@@ -188,6 +199,9 @@ function validateLccn(data, dataConfig, label) {
 
     if (!isValidLccn(data.value)) {
         return error('#id-errors', 'id-value', dataConfig['Invalid ID format'].replace(/ID/, label));
+    }
+    else if (isLccnDupe(data.value) === true) {
+        return error('#id-errors', 'id-value', dataConfig['That ISBN already exists for this edition.'].replace(/ISBN/, label));
     }
     return true;
 }

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -1,4 +1,11 @@
 import { isbnOverride } from './isbnOverride';
+import {
+    parseIsbn,
+    isChecksumValidIsbn10,
+    isChecksumValidIsbn13,
+    isFormatValidIsbn10,
+    isFormatValidIsbn13
+} from './idValidation';
 /* global render_seed_field, render_language_field, render_lazy_work_preview, render_language_autocomplete_item, render_work_field, render_work_autocomplete_item */
 /* Globals are provided by the edit edition template */
 
@@ -83,71 +90,6 @@ export function initRoleValidation() {
 function isIsbnDupe(isbn) {
     const isbnEntries = document.querySelectorAll('.isbn_10, .isbn_13');
     return Array.from(isbnEntries).some(entry => entry['value'] === isbn);
-}
-
-/**
- * Takes an ISBN 10 string and verifies that is the correct length and has the
- * correct characters for an ISBN. It does not verify the checksum.
- * @param {String} isbn  ISBN string to check
- * returns {boolean}  true if the isbn has a valid format
- */
-export function isFormatValidIsbn10(isbn) {
-    const regex = /^[0-9]{9}[0-9X]$/;
-    return regex.test(isbn);
-}
-
-/**
- * Verify the checksum for ISBN 10.
- * Adapted from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s13.html
- * @param {String} isbn  ISBN string for validating
- * @returns {boolean}  true if ISBN string is a valid ISBN 10
- */
-export function isChecksumValidIsbn10(isbn) {
-    const chars = isbn.replace('X', 'A').split('');
-
-    chars.reverse();
-    const sum = chars
-        .map((char, idx) => ((idx + 1) * parseInt(char, 16)))
-        .reduce((acc, sum) => acc + sum, 0);
-
-    // The ISBN 10 is valid if the checksum mod 11 is 0.
-    return sum % 11 === 0;
-}
-
-/**
- * Takes an isbn string and verifies that is the correct length and has the
- * correct characters for an ISBN. It does not verify the checksum.
- * @param {String} isbn  ISBN string to check
- * returns {boolean}  true if the isbn has a valid format
- */
-export function isFormatValidIsbn13(isbn) {
-    const regex = /^[0-9]{13}$/
-    return regex.test(isbn)
-}
-
-/**
- * Verify the checksum for ISBN 13.
- * Adapted from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s13.html
- * @param {String} isbn  ISBN string for validating
- * @returns {Boolean}  true if ISBN string is a valid ISBN 13
- */
-export function isChecksumValidIsbn13(isbn) {
-    const chars = isbn.split('');
-    const sum = chars
-        .map((char, idx) => ((idx % 2 * 2 + 1) * parseInt(char, 10)))
-        .reduce((sum, num) => sum + num, 0);
-
-    // The ISBN 13 is valid if the checksum mod 10 is 0.
-    return sum % 10 === 0;
-}
-
-/**
- * Removes spaces and hyphens from an ISBN string and returns it.
- * @param {String} isbn  ISBN string for parsing
- * @returns {String}  parsed isbn string
- */
-export function parseIsbn(isbn) {
-    return isbn.replace(/[ -]/g, '');
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -180,9 +180,9 @@ export function isbnConfirmAdd(data) {
 /**
  * Called by validateIdentifiers(), validates the addition of new
  * ISBN 10 to an edition.
- * @params {Object} data  data from the input form
- * @params {Object} dataConfig  object mapping error messages to their string values
- * @params {String} label  formatted value of the identifier type name (ISBN 10)
+ * @param {Object} data  data from the input form
+ * @param {Object} dataConfig  object mapping error messages to their string values
+ * @param {String} label  formatted value of the identifier type name (ISBN 10)
  * @returns {boolean}  true if ISBN passes validation
  */
 function validateIsbn10(data, dataConfig, label) {
@@ -207,9 +207,9 @@ function validateIsbn10(data, dataConfig, label) {
 /**
  * Called by validateIdentifiers(), validates the addition of new
  * ISBN 13 to an edition.
- * @params {Object} data  data from the input form
- * @params {Object} dataConfig  object mapping error messages to their string values
- * @params {String} label  formatted value of the identifier type name (ISBN 13)
+ * @param {Object} data  data from the input form
+ * @param {Object} dataConfig  object mapping error messages to their string values
+ * @param {String} label  formatted value of the identifier type name (ISBN 13)
  * @returns {boolean}  true if ISBN passes validation
  */
 function validateIsbn13(data, dataConfig, label) {
@@ -235,7 +235,7 @@ function validateIsbn13(data, dataConfig, label) {
  * Called by initIdentifierValidation(), along with tests in
  * tests/unit/js/editEditionsPage.test.js, to validate the addition of new
  * identifiers (ISBN, LCCN) to an edition.
- * @params {Object} data  data from the input form
+ * @param {Object} data  data from the input form
  * @returns {boolean}  true if ISBN passes validation
  */
 export function validateIdentifiers(data) {

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -1,10 +1,12 @@
 import { isbnOverride } from './isbnOverride';
 import {
     parseIsbn,
+    parseLccn,
     isChecksumValidIsbn10,
     isChecksumValidIsbn13,
     isFormatValidIsbn10,
-    isFormatValidIsbn13
+    isFormatValidIsbn13,
+    isValidLccn
 } from './idValidation';
 /* global render_seed_field, render_language_field, render_lazy_work_preview, render_language_autocomplete_item, render_work_field, render_work_autocomplete_item */
 /* Globals are provided by the edit edition template */
@@ -125,7 +127,7 @@ export function isbnConfirmAdd(data) {
  * @param {Object} data  data from the input form
  * @param {Object} dataConfig  object mapping error messages to their string values
  * @param {String} label  formatted value of the identifier type name (ISBN 10)
- * @returns {boolean}  true if ISBN passes validation
+ * @returns {boolean}  true if ISBN passes validation, else returns false and displays appropriate error
  */
 function validateIsbn10(data, dataConfig, label) {
     data.value = parseIsbn(data.value);
@@ -152,7 +154,7 @@ function validateIsbn10(data, dataConfig, label) {
  * @param {Object} data  data from the input form
  * @param {Object} dataConfig  object mapping error messages to their string values
  * @param {String} label  formatted value of the identifier type name (ISBN 13)
- * @returns {boolean}  true if ISBN passes validation
+ * @returns {boolean}  true if ISBN passes validation, else returns false and displays appropriate error
  */
 function validateIsbn13(data, dataConfig, label) {
     data.value = parseIsbn(data.value);
@@ -173,12 +175,21 @@ function validateIsbn13(data, dataConfig, label) {
     return true;
 }
 
+function validateLccn(data) {
+    data.value = parseLccn(data.value);
+
+    if (!isValidLccn(data.value)) {
+        return error('#id-errors', 'id-value', 'Invalid format for LCCN.');
+    }
+    return true;
+}
+
 /**
  * Called by initIdentifierValidation(), along with tests in
  * tests/unit/js/editEditionsPage.test.js, to validate the addition of new
  * identifiers (ISBN, LCCN) to an edition.
  * @param {Object} data  data from the input form
- * @returns {boolean}  true if ISBN passes validation
+ * @returns {boolean}  true if identifier passes validation
  */
 export function validateIdentifiers(data) {
     const dataConfig = JSON.parse(document.querySelector('#identifiers').dataset.config);
@@ -201,6 +212,9 @@ export function validateIdentifiers(data) {
     }
     else if (data.name === 'isbn_13') {
         validId = validateIsbn13(data, dataConfig, label);
+    }
+    else if (data.name === 'lccn') {
+        validId = validateLccn(data, dataConfig, label);
     }
     
     if (validId) $('#id-errors').hide();

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -227,7 +227,7 @@ export function validateIdentifiers(data) {
         return error('#id-errors', 'id-value', dataConfig['ID ids cannot contain whitespace.'].replace(/ID/, label));
     }
 
-    let validId = false;
+    let validId = true;
 
     if (data.name === 'isbn_10') {
         validId = validateIsbn10(data, dataConfig, label);

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -4,7 +4,7 @@
  * @returns {String}  parsed isbn string
  */
 export function parseIsbn(isbn) {
-  return isbn.replace(/[ -]/g, '');
+    return isbn.replace(/[ -]/g, '');
 }
 
 /**
@@ -14,8 +14,8 @@ export function parseIsbn(isbn) {
  * @returns {boolean}  true if the isbn has a valid format
  */
 export function isFormatValidIsbn10(isbn) {
-  const regex = /^[0-9]{9}[0-9X]$/;
-  return regex.test(isbn);
+    const regex = /^[0-9]{9}[0-9X]$/;
+    return regex.test(isbn);
 }
 
 /**
@@ -25,15 +25,15 @@ export function isFormatValidIsbn10(isbn) {
  * @returns {boolean}  true if ISBN string is a valid ISBN 10
  */
 export function isChecksumValidIsbn10(isbn) {
-  const chars = isbn.replace('X', 'A').split('');
+    const chars = isbn.replace('X', 'A').split('');
 
-  chars.reverse();
-  const sum = chars
-      .map((char, idx) => ((idx + 1) * parseInt(char, 16)))
-      .reduce((acc, sum) => acc + sum, 0);
+    chars.reverse();
+    const sum = chars
+        .map((char, idx) => ((idx + 1) * parseInt(char, 16)))
+        .reduce((acc, sum) => acc + sum, 0);
 
-  // The ISBN 10 is valid if the checksum mod 11 is 0.
-  return sum % 11 === 0;
+    // The ISBN 10 is valid if the checksum mod 11 is 0.
+    return sum % 11 === 0;
 }
 
 /**
@@ -43,8 +43,8 @@ export function isChecksumValidIsbn10(isbn) {
  * @returns {boolean}  true if the isbn has a valid format
  */
 export function isFormatValidIsbn13(isbn) {
-  const regex = /^[0-9]{13}$/;
-  return regex.test(isbn);
+    const regex = /^[0-9]{13}$/;
+    return regex.test(isbn);
 }
 
 /**
@@ -54,13 +54,13 @@ export function isFormatValidIsbn13(isbn) {
 * @returns {Boolean}  true if ISBN string is a valid ISBN 13
 */
 export function isChecksumValidIsbn13(isbn) {
-  const chars = isbn.split('');
-  const sum = chars
-      .map((char, idx) => ((idx % 2 * 2 + 1) * parseInt(char, 10)))
-      .reduce((sum, num) => sum + num, 0);
+    const chars = isbn.split('');
+    const sum = chars
+        .map((char, idx) => ((idx % 2 * 2 + 1) * parseInt(char, 10)))
+        .reduce((sum, num) => sum + num, 0);
 
-  // The ISBN 13 is valid if the checksum mod 10 is 0.
-  return sum % 10 === 0;
+    // The ISBN 13 is valid if the checksum mod 10 is 0.
+    return sum % 10 === 0;
 }
 
 /**
@@ -70,25 +70,25 @@ export function isChecksumValidIsbn13(isbn) {
  * @returns {String}  parsed LCCN string
  */
 export function parseLccn(lccn) {
-  // cleaning initial lccn entry
-  let parsed = lccn
-    // any alpha characters need to be lowercase
-    .toLowerCase()
-    // remove any whitespace
-    .replace(/\s/g, '')
-    // remove leading and trailing dashes
-    .replace(/^[-]+/, '').replace(/[-]+$/, '')
-    // remove any revised text
-    .replace(/rev.*/g, '')
-    // remove first forward slash and everything to its right
-    .replace(/[\/]+.*$/, '');
-  
-  // splitting at hyphen and padding the right hand value with zeros up to 6 characters
-  let groups = parsed.match(/(.+)-+([0-9]+)/)
-  if (groups && groups.length == 3) {
-    return groups[1] + groups[2].padStart(6, '0');
-  }
-  return parsed;
+    // cleaning initial lccn entry
+    const parsed = lccn
+        // any alpha characters need to be lowercase
+        .toLowerCase()
+        // remove any whitespace
+        .replace(/\s/g, '')
+        // remove leading and trailing dashes
+        .replace(/^[-]+/, '').replace(/[-]+$/, '')
+        // remove any revised text
+        .replace(/rev.*/g, '')
+        // remove first forward slash and everything to its right
+        .replace(/[/]+.*$/, '');
+
+    // splitting at hyphen and padding the right hand value with zeros up to 6 characters
+    const groups = parsed.match(/(.+)-+([0-9]+)/)
+    if (groups && groups.length === 3) {
+        return groups[1] + groups[2].padStart(6, '0');
+    }
+    return parsed;
 }
 
 /**
@@ -98,8 +98,8 @@ export function parseLccn(lccn) {
  * @returns {boolean}  true if given LCCN is valid syntax, false otherwise
  */
 export function isValidLccn(lccn) {
-  // matching parsed entry to regex representing valid lccn
-  // regex taken from /openlibrary/utils/lccn.py
-  const regex = /^([a-z]|[a-z]?([a-z]{2}|[0-9]{2})|[a-z]{2}[0-9]{2})?[0-9]{8}$/;
-  return regex.test(lccn);
+    // matching parsed entry to regex representing valid lccn
+    // regex taken from /openlibrary/utils/lccn.py
+    const regex = /^([a-z]|[a-z]?([a-z]{2}|[0-9]{2})|[a-z]{2}[0-9]{2})?[0-9]{8}$/;
+    return regex.test(lccn);
 }

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -43,8 +43,8 @@ export function isChecksumValidIsbn10(isbn) {
  * @returns {boolean}  true if the isbn has a valid format
  */
 export function isFormatValidIsbn13(isbn) {
-  const regex = /^[0-9]{13}$/
-  return regex.test(isbn)
+  const regex = /^[0-9]{13}$/;
+  return regex.test(isbn);
 }
 
 /**
@@ -61,4 +61,44 @@ export function isChecksumValidIsbn13(isbn) {
 
   // The ISBN 13 is valid if the checksum mod 10 is 0.
   return sum % 10 === 0;
+}
+
+/**
+ * JS re-write of the existing python LCCN parsing found in /openlibrary/utils/lccn.py.
+ * Validates the syntax described at https://www.loc.gov/marc/lccn-namespace.html
+ * @param {String} lccn  LCCN string for parsing
+ * @returns {String}  parsed LCCN string, returns empty string if given LCCN fails parsing
+ */
+export function parseLccn(lccn) {
+  // cleaning initial lccn entry
+  let parsed = lccn
+    // any alpha characters need to be lowercase
+    .toLowerCase()
+    // remove any whitespace
+    .replace(/\s/g, '')
+    // remove leading and trailing dashes
+    .replace(/^[-]+/, '').replace(/[-]+$/, '')
+    // remove any revised text
+    .replace(/rev.*/g, '')
+    // remove first forward slash and everything to its right
+    .replace(/[\/]+.*$/, '');
+  
+  // splitting at hyphen and padding the right hand value with zeros up to 6 characters
+  let groups = parsed.match(/(.+)-+([0-9]+)/)
+  if (groups && groups.length == 3) {
+    return groups[1] + groups[2].padStart(6, '0');
+  }
+  return '';
+}
+
+/**
+ * Verify LCCN syntax. Based on instructions from https://www.loc.gov/marc/lccn-namespace.html.
+ * @param {String} lccn  LCCN string to test for valid syntax
+ * @returns {boolean}  true if given LCCN is valid syntax, false otherwise
+ */
+export function isValidLccn(lccn) {
+  // matching parsed entry to regex representing valid lccn
+  // regex taken from /openlibrary/utils/lccn.py
+  const regex = /([a-z]|[a-z]?([a-z]{2}|[0-9]{2})|[a-z]{2}[0-9]{2})?[0-9]{8}$/;
+  return regex.test(lccn);
 }

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -100,6 +100,6 @@ export function parseLccn(lccn) {
 export function isValidLccn(lccn) {
   // matching parsed entry to regex representing valid lccn
   // regex taken from /openlibrary/utils/lccn.py
-  const regex = /([a-z]|[a-z]?([a-z]{2}|[0-9]{2})|[a-z]{2}[0-9]{2})?[0-9]{8}$/;
+  const regex = /^([a-z]|[a-z]?([a-z]{2}|[0-9]{2})|[a-z]{2}[0-9]{2})?[0-9]{8}$/;
   return regex.test(lccn);
 }

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -67,7 +67,7 @@ export function isChecksumValidIsbn13(isbn) {
  * JS re-write of the existing python LCCN parsing found in /openlibrary/utils/lccn.py.
  * Validates the syntax described at https://www.loc.gov/marc/lccn-namespace.html
  * @param {String} lccn  LCCN string for parsing
- * @returns {String}  parsed LCCN string, returns empty string if given LCCN fails parsing
+ * @returns {String}  parsed LCCN string
  */
 export function parseLccn(lccn) {
   // cleaning initial lccn entry
@@ -88,7 +88,7 @@ export function parseLccn(lccn) {
   if (groups && groups.length == 3) {
     return groups[1] + groups[2].padStart(6, '0');
   }
-  return '';
+  return parsed;
 }
 
 /**

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -92,7 +92,8 @@ export function parseLccn(lccn) {
 }
 
 /**
- * Verify LCCN syntax. Based on instructions from https://www.loc.gov/marc/lccn-namespace.html.
+ * Verify LCCN syntax. Regex taken from /openlibrary/utils/lccn.py.
+ * Based on instructions from https://www.loc.gov/marc/lccn-namespace.html.
  * @param {String} lccn  LCCN string to test for valid syntax
  * @returns {boolean}  true if given LCCN is valid syntax, false otherwise
  */

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -1,0 +1,64 @@
+/**
+ * Removes spaces and hyphens from an ISBN string and returns it.
+ * @param {String} isbn  ISBN string for parsing
+ * @returns {String}  parsed isbn string
+ */
+export function parseIsbn(isbn) {
+  return isbn.replace(/[ -]/g, '');
+}
+
+/**
+ * Takes an ISBN 10 string and verifies that is the correct length and has the
+ * correct characters for an ISBN. It does not verify the checksum.
+ * @param {String} isbn  ISBN string to check
+ * @returns {boolean}  true if the isbn has a valid format
+ */
+export function isFormatValidIsbn10(isbn) {
+  const regex = /^[0-9]{9}[0-9X]$/;
+  return regex.test(isbn);
+}
+
+/**
+ * Verify the checksum for ISBN 10.
+ * Adapted from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s13.html
+ * @param {String} isbn  ISBN string for validating
+ * @returns {boolean}  true if ISBN string is a valid ISBN 10
+ */
+export function isChecksumValidIsbn10(isbn) {
+  const chars = isbn.replace('X', 'A').split('');
+
+  chars.reverse();
+  const sum = chars
+      .map((char, idx) => ((idx + 1) * parseInt(char, 16)))
+      .reduce((acc, sum) => acc + sum, 0);
+
+  // The ISBN 10 is valid if the checksum mod 11 is 0.
+  return sum % 11 === 0;
+}
+
+/**
+ * Takes an isbn string and verifies that is the correct length and has the
+ * correct characters for an ISBN. It does not verify the checksum.
+ * @param {String} isbn  ISBN string to check
+ * @returns {boolean}  true if the isbn has a valid format
+ */
+export function isFormatValidIsbn13(isbn) {
+  const regex = /^[0-9]{13}$/
+  return regex.test(isbn)
+}
+
+/**
+* Verify the checksum for ISBN 13.
+* Adapted from https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s13.html
+* @param {String} isbn  ISBN string for validating
+* @returns {Boolean}  true if ISBN string is a valid ISBN 13
+*/
+export function isChecksumValidIsbn13(isbn) {
+  const chars = isbn.split('');
+  const sum = chars
+      .map((char, idx) => ((idx % 2 * 2 + 1) * parseInt(char, 10)))
+      .reduce((sum, num) => sum + num, 0);
+
+  // The ISBN 13 is valid if the checksum mod 10 is 0.
+  return sum % 10 === 0;
+}

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -5,7 +5,8 @@ $var title: $_("Add a book")
 $ i18n_strings = {
     $ "invalid_checksum": _("Invalid ISBN checksum digit"),
     $ "invalid_isbn10": _("ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"),
-    $ "invalid_isbn13": _("ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100")
+    $ "invalid_isbn13": _("ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"),
+    $ "invalid_lccn": _("Invalid LC Control Number format")
     $ }
 
 <div id="contentHead">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -390,7 +390,15 @@ $jsdef render_work_autocomplete_item(item):
     </div>
 
 </fieldset>
-$ config = ({'Please select an identifier.': _('Please select an identifier.'), 'You need to give a value to ID.': _('You need to give a value to ID.'), 'ID ids cannot contain whitespace.': _('ID ids cannot contain whitespace.'), 'ID must be exactly 10 characters [0-9] or X.': _('ID must be exactly 10 characters [0-9] or X.'), 'That ISBN already exists for this edition.': _('That ISBN already exists for this edition.'), 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4': _('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4')})
+$ config = ({
+    $ 'Please select an identifier.': _('Please select an identifier.'),
+    $ 'You need to give a value to ID.': _('You need to give a value to ID.'),
+    $ 'ID ids cannot contain whitespace.': _('ID ids cannot contain whitespace.'),
+    $ 'ID must be exactly 10 characters [0-9] or X.': _('ID must be exactly 10 characters [0-9] or X.'),
+    $ 'That ISBN already exists for this edition.': _('That ISBN already exists for this edition.'),
+    $ 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4': _('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'),
+    $ 'Invalid ID format': _('Invalid ID format')
+$ })
 <fieldset class="major" id="identifiers" data-config="$dumps(config)">
     <legend>$_("ID Numbers")</legend>
     <div class="formBack">

--- a/tests/unit/js/editionsEditPage.test.js
+++ b/tests/unit/js/editionsEditPage.test.js
@@ -1,4 +1,3 @@
-import { isChecksumValidIsbn10, isChecksumValidIsbn13 } from '../../../openlibrary/plugins/openlibrary/js/idValidation.js';
 import { validateIdentifiers } from '../../../openlibrary/plugins/openlibrary/js/edit.js';
 import sinon from 'sinon';
 import * as testData from './html-test-data';
@@ -6,36 +5,6 @@ import { htmlquote } from '../../../openlibrary/plugins/openlibrary/js/jsdef';
 import jQueryRepeat from '../../../openlibrary/plugins/openlibrary/js/jquery.repeat';
 
 let sandbox;
-
-describe('isChecksumValidIsbn10', () => {
-    it('returns true with valid ISBN 10 (X check character)', () => {
-        expect(isChecksumValidIsbn10('080442957X')).toBe(true);
-    });
-    it('returns true with valid ISBN 10 (numerical check character, check 1)', () => {
-        expect(isChecksumValidIsbn10('1593279280')).toBe(true);
-    });
-    it('returns true with valid ISBN 10 (numerical check character, check 2)', () => {
-        expect(isChecksumValidIsbn10('1617295981')).toBe(true);
-    });
-    it('returns false with an invalid ISBN 10', () => {
-        expect(isChecksumValidIsbn10('1234567890')).toBe(false);
-    });
-})
-
-describe('isChecksumValidIsbn13', () => {
-    it('returns true with valid ISBN 13 (check 1)', () => {
-        expect(isChecksumValidIsbn13('9781789801217')).toBe(true);
-    });
-    it('returns true with valid ISBN 13 (check 2)', () => {
-        expect(isChecksumValidIsbn13('9798430918002')).toBe(true);
-    });
-    it('returns false with an invalid ISBN 13 (check 1)', () => {
-        expect(isChecksumValidIsbn13('1234567890123')).toBe(false);
-    });
-    it('returns false with an invalid ISBN 13 (check 2)', () => {
-        expect(isChecksumValidIsbn13('9790000000000')).toBe(false);
-    });
-})
 
 /**
  * Test various patterns with the editions identifier parsing function,

--- a/tests/unit/js/editionsEditPage.test.js
+++ b/tests/unit/js/editionsEditPage.test.js
@@ -9,15 +9,17 @@ let sandbox;
 /**
  * Test various patterns with the editions identifier parsing function,
  * validateIdentifiers(), that initIdentifierValidation() calls when
- * attempting to add and validate a new ISBN to an edition.
- * These tests are meant to make sure that when adding ISBN 10 and ISBN 13:
- * - valid numbers are accepted;
- * - duplicate numbers are not;
- * - formally valid numbers (correct number of digits) but with a failed
+ * attempting to add and validate a new ISBN or LCCN to an edition.
+ * These tests are meant to make sure that when adding ISBN 10, ISBN 13, and LCCN:
+ * - valid identifiers are accepted;
+ * - duplicate identifiers are not;
+ * - formally valid ISBNs (correct number of digits) but with a failed
  *   check digit calculation can be added with a user override.
- * - numbers can be entered with spaces and hyphens;
- * - any numbers or hyphens are stripped before passing to the back end; and
- * - stripped and unstripped numbers are treated equally as identical.
+ * - ISBNs can be entered with spaces and hyphens;
+ * - any numbers or hyphens are stripped before passing to the back end;
+ * - stripped and unstripped identifiers are treated equally as identical;
+ * - LCCNs are properly normalized and
+ * - normalized LCCNs are treated the same as non-normalized after entry.
  */
 
 // Adapted from jquery.repeat.test.js
@@ -173,6 +175,48 @@ describe('initIdentifierValidation', () => {
         $('.repeat-add').trigger('click');
         $('#select-id').val('isbn_13');
         $('#id-value').val('9798664653403');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(6);
+    });
+
+    //LCCN
+    it('does add a valid LCCN', () => {
+        $('#select-id').val('lccn');
+        $('#id-value').val('n78-890351');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(6);
+    });
+
+    it('does NOT add an invalid LCCN', () => {
+        $('#select-id').val('lccn');
+        $('#id-value').val('12345');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(5);
+    });
+
+    it('does NOT add a duplicate LCCN', () => {
+        $('#select-id').val('lccn');
+        $('#id-value').val('n78-890351');
+        $('.repeat-add').trigger('click');
+        $('#select-id').val('lccn');
+        $('#id-value').val('n78-890351');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(6);
+    });
+
+    it('does properly normalize a valid LCCN and add it', () => {
+        $('#select-id').val('lccn');
+        $('#id-value').val(' 75-425165//r75');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(6);
+    })
+
+    it('does count identical normalized and non-normalized LCCNs as the same LCCN', () => {
+        $('#select-id').val('lccn');
+        $('#id-value').val(' 75-425165//r75');
+        $('.repeat-add').trigger('click');
+        $('#select-id').val('lccn');
+        $('#id-value').val('75425165');
         $('.repeat-add').trigger('click');
         expect($('.repeat-item').length).toBe(6);
     });

--- a/tests/unit/js/editionsEditPage.test.js
+++ b/tests/unit/js/editionsEditPage.test.js
@@ -1,4 +1,4 @@
-import { isChecksumValidIsbn10, isChecksumValidIsbn13 } from '../../../openlibrary/plugins/openlibrary/js/edit.js';
+import { isChecksumValidIsbn10, isChecksumValidIsbn13 } from '../../../openlibrary/plugins/openlibrary/js/idValidation.js';
 import { validateIdentifiers } from '../../../openlibrary/plugins/openlibrary/js/edit.js';
 import sinon from 'sinon';
 import * as testData from './html-test-data';

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -1,4 +1,13 @@
-export const editionIdentifiersSample = `<fieldset id="identifiers" data-config="{&quot;Please select an identifier.&quot;: &quot;Please select an identifier.&quot;, &quot;You need to give a value to ID.&quot;: &quot;You need to give a value to ID.&quot;, &quot;ID ids cannot contain whitespace.&quot;: &quot;ID ids cannot contain whitespace.&quot;, &quot;ID must be exactly 10 characters [0-9] or X.&quot;: &quot;ID must be exactly 10 characters [0-9] or X.&quot;, &quot;That ISBN already exists for this edition.&quot;: &quot;That ISBN already exists for this edition.&quot;, &quot;ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4&quot;: &quot;ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4&quot;}">
+export const editionIdentifiersSample = `
+<fieldset id="identifiers" data-config="{
+    &quot;Please select an identifier.&quot;: &quot;Please select an identifier.&quot;,
+    &quot;You need to give a value to ID.&quot;: &quot;You need to give a value to ID.&quot;,
+    &quot;ID ids cannot contain whitespace.&quot;: &quot;ID ids cannot contain whitespace.&quot;,
+    &quot;ID must be exactly 10 characters [0-9] or X.&quot;: &quot;ID must be exactly 10 characters [0-9] or X.&quot;,
+    &quot;That ISBN already exists for this edition.&quot;: &quot;That ISBN already exists for this edition.&quot;,
+    &quot;ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4&quot;: &quot;ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4&quot;,
+    &quot;Invalid ID format&quot;: &quot;Invalid ID format&quot;
+}">
 <div id="id-errors" class="note" style="display: none"></div>
 <table class="identifiers">
     <tbody><tr id="identifiers-form">
@@ -9,6 +18,7 @@ export const editionIdentifiersSample = `<fieldset id="identifiers" data-config=
                 <option value="goodreads">Goodreads</option>
                 <option value="isbn_10">ISBN 10</option>
                 <option value="isbn_13">ISBN 13</option>
+                <option value="lccn">LC Control Number</option>
             </select>
         </td>
         <td>

--- a/tests/unit/js/idValidation.test.js
+++ b/tests/unit/js/idValidation.test.js
@@ -110,6 +110,9 @@ describe('isFormatValidIsbn13', () => {
     });
 })
 
+// testing from examples listed here:
+// https://www.loc.gov/marc/lccn-namespace.html
+// https://www.oclc.org/bibformats/en/0xx/010.html
 describe('isValidLccn', () => {
     it('returns true for LCCN of length 8', () => {
         expect(isValidLccn('85000002')).toBe(true);
@@ -133,4 +136,22 @@ describe('isValidLccn', () => {
         expect(isValidLccn('mm2002084896')).toBe(true);
     });
 
+    it('returns false for LCCN below minimum length', () => {
+        expect(isValidLccn('8500002')).toBe(false);
+    });
+    it('returns false for LCCN of length 9 with all digits', () => {
+        expect(isValidLccn('178890351')).toBe(false);
+    });
+    it('returns false for LCCN of length 10 with alpha characters', () => {
+        expect(isValidLccn('a001000002')).toBe(false);
+    });
+    it('returns false for LCCN of length 11 with all digits', () => {
+        expect(isValidLccn('12500000003')).toBe(false);
+    });
+    it('returns false for LCCN of length 12 with all digits', () => {
+        expect(isValidLccn('125000000003')).toBe(false);
+    });
+    it('returns false for LCCN of length 13', () => {
+        expect(isValidLccn('1250000000003')).toBe(false);
+    });
 })

--- a/tests/unit/js/idValidation.test.js
+++ b/tests/unit/js/idValidation.test.js
@@ -8,7 +8,43 @@ import {
     isValidLccn
 } from '../../../openlibrary/plugins/openlibrary/js/idValidation.js';
 
-//TODO: Add tests for the rest of the functions in idValidation.js
+describe('parseIsbn', () => {
+    it('correctly parses ISBN 10 with dashes', () => {
+        expect(parseIsbn('0-553-38168-7')).toBe('0553381687');
+    });
+    it('correctly parses ISBN 13 with dashes', () => {
+        expect(parseIsbn('978-0-553-38168-9')).toBe('9780553381689');
+    })
+})
+
+// testing from examples listed here:
+// https://www.loc.gov/marc/lccn-namespace.html
+describe('parseLccn', () => {
+    it('correctly parses LCCN example 1', () => {
+        expect(parseLccn('n78-890351')).toBe('n78890351');
+    });
+    it('correctly parses LCCN example 2', () => {
+        expect(parseLccn('n78-89035')).toBe('n78089035');
+    });
+    it('correctly parses LCCN example 3', () => {
+        expect(parseLccn('n 78890351 ')).toBe('n78890351');
+    });
+    it('correctly parses LCCN example 4', () => {
+        expect(parseLccn(' 85000002')).toBe('85000002');
+    });
+    it('correctly parses LCCN example 5', () => {
+        expect(parseLccn('85-2 ')).toBe('85000002');
+    });
+    it('correctly parses LCCN example 6', () => {
+        expect(parseLccn('2001-000002')).toBe('2001000002');
+    });
+    it('correctly parses LCCN example 7', () => {
+        expect(parseLccn('75-425165//r75')).toBe('75425165');
+    });
+    it('correctly parses LCCN example 8', () => {
+        expect(parseLccn(' 79139101 /AC/r932')).toBe('79139101');
+    });
+})
 
 describe('isChecksumValidIsbn10', () => {
     it('returns true with valid ISBN 10 (X check character)', () => {
@@ -38,4 +74,16 @@ describe('isChecksumValidIsbn13', () => {
     it('returns false with an invalid ISBN 13 (check 2)', () => {
         expect(isChecksumValidIsbn13('9790000000000')).toBe(false);
     });
+})
+
+describe('isFormatValidIsbn10', () => {
+    
+})
+
+describe('isFormatValidIsbn13', () => {
+    
+})
+
+describe('isValidLccn', () => {
+    
 })

--- a/tests/unit/js/idValidation.test.js
+++ b/tests/unit/js/idValidation.test.js
@@ -1,0 +1,41 @@
+import {
+    parseIsbn,
+    parseLccn,
+    isChecksumValidIsbn10,
+    isChecksumValidIsbn13,
+    isFormatValidIsbn10,
+    isFormatValidIsbn13,
+    isValidLccn
+} from '../../../openlibrary/plugins/openlibrary/js/idValidation.js';
+
+//TODO: Add tests for the rest of the functions in idValidation.js
+
+describe('isChecksumValidIsbn10', () => {
+    it('returns true with valid ISBN 10 (X check character)', () => {
+        expect(isChecksumValidIsbn10('080442957X')).toBe(true);
+    });
+    it('returns true with valid ISBN 10 (numerical check character, check 1)', () => {
+        expect(isChecksumValidIsbn10('1593279280')).toBe(true);
+    });
+    it('returns true with valid ISBN 10 (numerical check character, check 2)', () => {
+        expect(isChecksumValidIsbn10('1617295981')).toBe(true);
+    });
+    it('returns false with an invalid ISBN 10', () => {
+        expect(isChecksumValidIsbn10('1234567890')).toBe(false);
+    });
+})
+
+describe('isChecksumValidIsbn13', () => {
+    it('returns true with valid ISBN 13 (check 1)', () => {
+        expect(isChecksumValidIsbn13('9781789801217')).toBe(true);
+    });
+    it('returns true with valid ISBN 13 (check 2)', () => {
+        expect(isChecksumValidIsbn13('9798430918002')).toBe(true);
+    });
+    it('returns false with an invalid ISBN 13 (check 1)', () => {
+        expect(isChecksumValidIsbn13('1234567890123')).toBe(false);
+    });
+    it('returns false with an invalid ISBN 13 (check 2)', () => {
+        expect(isChecksumValidIsbn13('9790000000000')).toBe(false);
+    });
+})

--- a/tests/unit/js/idValidation.test.js
+++ b/tests/unit/js/idValidation.test.js
@@ -14,7 +14,7 @@ describe('parseIsbn', () => {
     });
     it('correctly parses ISBN 13 with dashes', () => {
         expect(parseIsbn('978-0-553-38168-9')).toBe('9780553381689');
-    })
+    });
 })
 
 // testing from examples listed here:
@@ -56,6 +56,7 @@ describe('isChecksumValidIsbn10', () => {
     it('returns true with valid ISBN 10 (numerical check character, check 2)', () => {
         expect(isChecksumValidIsbn10('1617295981')).toBe(true);
     });
+
     it('returns false with an invalid ISBN 10', () => {
         expect(isChecksumValidIsbn10('1234567890')).toBe(false);
     });
@@ -68,6 +69,7 @@ describe('isChecksumValidIsbn13', () => {
     it('returns true with valid ISBN 13 (check 2)', () => {
         expect(isChecksumValidIsbn13('9798430918002')).toBe(true);
     });
+
     it('returns false with an invalid ISBN 13 (check 1)', () => {
         expect(isChecksumValidIsbn13('1234567890123')).toBe(false);
     });
@@ -77,13 +79,58 @@ describe('isChecksumValidIsbn13', () => {
 })
 
 describe('isFormatValidIsbn10', () => {
-    
+    it('returns true with valid ISBN 10 (X check character)', () => {
+        expect(isFormatValidIsbn10('080442957X')).toBe(true);
+    });
+    it('returns true with valid ISBN 10', () => {
+        expect(isFormatValidIsbn10('1593279280')).toBe(true);
+    });
+
+    it('returns false with invalid ISBN 10', () => {
+        expect(isFormatValidIsbn10('a234567890')).toBe(false);
+    });
+    it('returns false with blank value', () => {
+        expect(isFormatValidIsbn10('')).toBe(false);
+    });
 })
 
 describe('isFormatValidIsbn13', () => {
-    
+    it('returns true with valid ISBN 13', () => {
+        expect(isFormatValidIsbn13('9781789801217')).toBe(true);
+    });
+
+    it('returns false with invalid ISBN 13 (too long)', () => {
+        expect(isFormatValidIsbn13('97918430918002')).toBe(false);
+    });
+    it('returns false with invalid ISBN 13 (too short)', () => {
+        expect(isFormatValidIsbn13('979843091802')).toBe(false);
+    });
+    it('returns false with invalis ISBN 13 (non-numeric)', () => {
+        expect(isFormatValidIsbn13('979a430918002')).toBe(false);
+    });
 })
 
 describe('isValidLccn', () => {
-    
+    it('returns true for LCCN of length 8', () => {
+        expect(isValidLccn('85000002')).toBe(true);
+    });
+    it('returns true for LCCN of length 9', () => {
+        expect(isValidLccn('n78890351')).toBe(true);
+    });
+    it('returns true for LCCN of length 10 (all digits)', () => {
+        expect(isValidLccn('2001000002')).toBe(true);
+    });
+    it('returns true for LCCN of length 10 (alpha prefix)', () => {
+        expect(isValidLccn('sn85000678')).toBe(true);
+    });
+    it('returns true for LCCN of length 11 (alpha-numeric prefix)', () => {
+        expect(isValidLccn('a2500000003')).toBe(true);
+    });
+    it('returns true for LCCN of length 11 (alpha prefix)', () => {
+        expect(isValidLccn('agr25000003')).toBe(true);
+    });
+    it('returns true for LCCN of length 12', () => {
+        expect(isValidLccn('mm2002084896')).toBe(true);
+    });
+
 })


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8092

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds front-end validation and normalization for Library of Congress Control Number (LCCN) ID types within edit edition and add book forms. Previously the invalid LCCNs were silently dropped after submission. This feature normalizes the IDs on add and validates correct format according to the guidelines found [here](https://www.loc.gov/marc/lccn-namespace.html), [here](https://www.loc.gov/marc/lccn_structure.html), and [here](https://www.oclc.org/bibformats/en/0xx/010.html) as well as the existing python LCCN validation in [lccn.py.](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/utils/lccn.py) New error messages have also been added to notify the user that an incorrectly formatted LCCN has been entered.

### Technical
<!-- What should be noted about the implementation? -->
Validation has been added in the JavaScript that runs on edit and add pages ([edit.js](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/openlibrary/js/edit.js) and [add-book.js](https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/openlibrary/js/add-book.js)). The existing ISBN validation helpers were moved to a new file named idValidation.js which also holds the new LCCN validation functions. This allows edit.js and add-book.js to both independently import the validation functions for all ID types from one place rather than edit.js holding all validation. ID validation in both files has also been reorganized to accommodate LCCNs. Finally, existing JS unit tests hitting functions in the new idValidation.js file have been moved to their own location (idValidation.test.js) and new unit tests have been written to cover all validation functions.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Attempt to add LC Control Number IDs to existing editions and to new books. Verify that incorrectly formatted LCCNs are not accepted and an appropriate error message is displayed to the user. Valid LCCNs should be normalized according to Library of Congress guidelines.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
LCCN ID entry while adding book
![image](https://github.com/internetarchive/openlibrary/assets/29631356/aa02dfd1-6e57-4f10-a23e-ad9f3c860978)

LCCN after submission and normalization
![image](https://github.com/internetarchive/openlibrary/assets/29631356/8cac2a6f-42bf-4cd0-bfce-20a38786f267)

Invalid LCCN on add book page
![image](https://github.com/internetarchive/openlibrary/assets/29631356/7d059f76-c0a2-4105-8f2a-f8a33ed8eadc)

Invalid LCCN on edit edition
![image](https://github.com/internetarchive/openlibrary/assets/29631356/936d5257-cada-460b-87dd-0c5123925775)

Complex LCCN after normalization
![image](https://github.com/internetarchive/openlibrary/assets/29631356/f1dd9323-0f7c-4fe0-9afa-62bb33d8b91a)
![image](https://github.com/internetarchive/openlibrary/assets/29631356/0e668add-5186-4cdb-a338-54f658a34bef)


### Notes
Guidelines for LCCN normalization and format are obviously very complicated so I would very much appreciate extra eyes taking a look at the new validation functions and tests to ensure that they are behaving like they should. The error messages are a little vague too, but since the format is so complex I wasn't sure how many cases should be covered within those. Also I was trying to leave things better than I found them within the existing validation code so if I missed any comments or anything please feel free to drop some suggestions! Thanks to the OpenLibrary team for reading through this giant PR!


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@scottbarnes @mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->