### PR TITLE
add share_target for progressive web app

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -30,5 +30,12 @@
     "scope": "/",
     "background_color": "#e2dcc5",
     "display": "standalone",
-    "theme_color": "#e2dcc5"
+    "theme_color": "#e2dcc5",
+    "share_target": {
+        "action": "/search",
+        "method": "GET",
+        "params": {
+            "text": "q"
+        }
+    }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8197

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This will make it so if someone highlights text on their phone and hit's share they have the option to share it to OL (if they have the PWA installed).

### Technical
<!-- What should be noted about the implementation? -->
Just following the guide here: https://developer.chrome.com/en/articles/web-share-target/

`"text": "q"` is so that the text shared has a `q` query param which is what our search page uses.

# Browser Compatibility
This doesn't work if you "Install" the PWA from FF or Safari but you can happily share from them if you use install the pas via other browsers.
https://developer.mozilla.org/en-US/docs/Web/Manifest/share_target#browser_compatibility

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
PWAs need to be installed on https so can we please put this on the OL test env?
However, I created my own PWA to play around with the APIs so I'm confident this will work.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<details>
  <summary>Video of it working on testing!</summary>
  
  

https://github.com/internetarchive/openlibrary/assets/921217/f6f6d219-9725-47aa-8ae9-9965ffd65a51


  
</details>

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@Yashs911 and maybe @jimchamp ?

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
