### PR TITLE
Hotfix for logout now working on two pages

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -31,6 +31,9 @@ $def field(input, suffix=''):
     </div>
 
 $if ctx.user:
+    <div class="hidden">
+        <form name="logout" action="$homepath()/account/logout" method="post"></form>
+    </div>
     $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
     <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
     <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -11,12 +11,15 @@ $var title: $("Log In")
       <p>$:_('Please enter your <a href="https://archive.org">Internet Archive</a> email and password to access your Open Library account.')</p>
 
   $if ctx.user:
+      <div class="hidden">
+        <form name="logout" action="$homepath()/account/logout" method="post"></form>
+      </div>
       <p>$:_("You are already logged into Open Library as %(user)s.", user='<a href="%s">%s</a>' % (ctx.user.key, ctx.user.displayname))</p>
       <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>
-
   $else:
       <form id="register" class="login olform" name="register" method="post">
           $if "dev" in ctx.features:
+          
               <div class="flash-messages" id="autofill-dev-credentials">
                   <div class="info">
                       <span>

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -16,10 +16,10 @@ $var title: $("Log In")
       </div>
       <p>$:_("You are already logged into Open Library as %(user)s.", user='<a href="%s">%s</a>' % (ctx.user.key, ctx.user.displayname))</p>
       <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>
+
   $else:
       <form id="register" class="login olform" name="register" method="post">
-          $if "dev" in ctx.features:
-          
+          $if "dev" in ctx.features:         
               <div class="flash-messages" id="autofill-dev-credentials">
                   <div class="info">
                       <span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8219 two pages where logout was not working.

The pages are:

- https://openlibrary.org/account/create
- https://openlibrary.org/account/login


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix that adds logout form and correct syntax for invoking the logout command.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
