### PR TITLE
Fix broken logout link in create.html and login.html

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -37,7 +37,7 @@ $def field(input, suffix=''):
 $if ctx.user:
     $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
     <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
-    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[1].submit()">log out</a> and start the signup process afresh.')</p>
+    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
 $else:
     <form class="olform create validate" name="signup" method="post" action="">
         $if form.note:

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -37,7 +37,7 @@ $def field(input, suffix=''):
 $if ctx.user:
     $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
     <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
-    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>
+    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[1].submit()">log out</a> and start the signup process afresh.')</p>
 $else:
     <form class="olform create validate" name="signup" method="post" action="">
         $if form.note:

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -57,8 +57,9 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
               </li>
             $else:
               <li>
-              $if 'post' in link:
-                <form action="$(link['post'])" method="post">
+              $if 'name' in link:
+                $ name = 'name=%s' % link['name']
+                <form $name action="$(link['post'])" method="post">
                   <button $(tracker)>$(link["text"])</button>
                 </form>
               $else:

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -57,8 +57,8 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
               </li>
             $else:
               <li>
-              $if 'name' in link:
-                $ name = 'name=%s' % link['name']
+              $if 'post' in link:
+                $ name = 'name=%s' % link['name'] if 'name' in link else ''
                 <form $name action="$(link['post'])" method="post">
                   <button $(tracker)>$(link["text"])</button>
                 </form>

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -9,7 +9,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
     $     { "href": "/account/books", "text": _("My Books"), "track": "MyBooks", "subheading": _("Loans, Reading Log, Lists, Stats") },
     $     { "href": ctx.user.key, "text": _("My Profile"), "track": "MyProfile" },
     $     { "href": homepath() + "/account", "text": _("Settings"), "track": "MySettings" },
-    $     { "post": "/account/logout", "text": _("Log out"), "track": "Logout" },
+    $     { "post": "/account/logout", "text": _("Log out"), "track": "Logout", "name":"hamburger-logout" },
     $ ]
       $if is_privileged_user:
         $ loginLinks.insert(2, { "href": homepath() + "/merges", "text": _("Pending Merge Requests"),"track": "MyRequests", "badge": True })

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -15,7 +15,7 @@ $var title: $("Log In")
 
   $if ctx.user:
       <p>$:_("You are already logged into Open Library as %(user)s.", user='<a href="%s">%s</a>' % (ctx.user.key, ctx.user.displayname))</p>
-      <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[1].submit()">log out</a> and start the signup process afresh.')</p>
+      <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
 
   $else:
       <form id="register" class="login olform" name="register" method="post">

--- a/openlibrary/templates/login.html
+++ b/openlibrary/templates/login.html
@@ -15,7 +15,7 @@ $var title: $("Log In")
 
   $if ctx.user:
       <p>$:_("You are already logged into Open Library as %(user)s.", user='<a href="%s">%s</a>' % (ctx.user.key, ctx.user.displayname))</p>
-      <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'logout\'].submit()">log out</a> and start the signup process afresh.')</p>
+      <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[1].submit()">log out</a> and start the signup process afresh.')</p>
 
   $else:
       <form id="register" class="login olform" name="register" method="post">

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "jquery": "3.6.0",
         "jquery-colorbox": "1.6.4",
         "jquery-ui": "1.13.2",
-        "jquery-ui-touch-punch": "0.2.3",
+        "jquery-ui-touch-punch": "^0.2.3",
         "jquery-validation": "1.19.3",
         "less": "4.1.3",
         "less-loader": "7.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "jquery": "3.6.0",
         "jquery-colorbox": "1.6.4",
         "jquery-ui": "1.13.2",
-        "jquery-ui-touch-punch": "^0.2.3",
+        "jquery-ui-touch-punch": "0.2.3",
         "jquery-validation": "1.19.3",
         "less": "4.1.3",
         "less-loader": "7.3.0",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8219

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Fixes logout not working for these pages:

-     https://openlibrary.org/account/create
-     https://openlibrary.org/account/login

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
