### PR TITLE
let list creation use url params

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -276,6 +276,10 @@ def unflatten(d: Storage, separator: str = "--") -> Storage:
     >>> unflatten({"a--0--x": 1, "a--0--y": 2, "a--1--x": 3, "a--1--y": 4})
     {'a': [{'x': 1, 'y': 2}, {'x': 3, 'y': 4}]}
 
+    if a simple param name matches the unflattened one, it'll get overwritten
+    >>> unflatten({"a": 1, "a--0--x": 2, "a--1--x": 3})
+    {'a': [{'x': 2}, {'x': 3}]} # note "a": 1 has been lost.
+
     """
 
     def isint(k):
@@ -288,6 +292,8 @@ def unflatten(d: Storage, separator: str = "--") -> Storage:
     def setvalue(data, k, v):
         if '--' in k:
             k, k2 = k.split(separator, 1)
+            if not isinstance(data, dict):
+                data = {}
             setvalue(data.setdefault(k, {}), k2, v)
         else:
             # Don't overwrite if the key already exists


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8245

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

small feature

### Technical
<!-- What should be noted about the implementation? -->

It feels slightly hacky to use ? as the action rather than the full url to clear out any exitsing url params, but not sure if that's just me.

### Testing

1. Go to the "create a list" UI to start creating an empty list.
2. Add the following to the URL `?name=Flatland&description=list-testing-desc&seeds=OL118388W`
3. Load that url and it should create a list with a title, description and book pre-populated.
4. Submitting the form should succeed in creating the list.

(I don't know much about how the debug mode works, but I believe the above should also work when in debug mode) 

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
