### PR TITLE
Add option to sort editions in search

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -218,6 +218,9 @@ def run_solr_query(
         if 'editions' in solr_fields:
             solr_fields.remove('editions')
             solr_fields.add('editions:[subquery]')
+        if ed_sort := param.get('editions.sort'):
+            # Future: This should use its own scheme not the works scheme
+            params.append(('editions.sort', scheme.process_user_sort(ed_sort)))
         params.append(('fl', ','.join(solr_fields)))
         params += scheme.q_to_solr_params(q, solr_fields, params)
 

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -23,6 +23,7 @@ from openlibrary.plugins.upstream.utils import (
     get_language_name,
     urlencode,
 )
+from openlibrary.plugins.worksearch.schemes.editions import EditionSearchScheme
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.plugins.worksearch.schemes import SearchScheme
 from openlibrary.plugins.worksearch.schemes.authors import AuthorSearchScheme
@@ -219,8 +220,9 @@ def run_solr_query(
             solr_fields.remove('editions')
             solr_fields.add('editions:[subquery]')
         if ed_sort := param.get('editions.sort'):
-            # Future: This should use its own scheme not the works scheme
-            params.append(('editions.sort', scheme.process_user_sort(ed_sort)))
+            params.append(
+                ('editions.sort', EditionSearchScheme().process_user_sort(ed_sort))
+            )
         params.append(('fl', ','.join(solr_fields)))
         params += scheme.q_to_solr_params(q, solr_fields, params)
 

--- a/openlibrary/plugins/worksearch/schemes/editions.py
+++ b/openlibrary/plugins/worksearch/schemes/editions.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+import logging
+
+from openlibrary.plugins.worksearch.schemes import SearchScheme
+
+logger = logging.getLogger("openlibrary.worksearch")
+
+
+# Kind of mostly a stub for now since you can't really search editions
+# directly, but it's still useful for somethings (eg editions have a custom
+# sort logic).
+class EditionSearchScheme(SearchScheme):
+    universe = ['type:work']
+    all_fields = {
+        "key",
+        "title",
+        "subtitle",
+        "alternative_title",
+        "alternative_subtitle",
+        "cover_i",
+        "ebook_access",
+        "publish_date",
+        "lccn",
+        "ia",
+        "isbn",
+        "publisher",
+        "has_fulltext",
+        "title_suggest",
+        "publish_year",
+        "language",
+        "publisher_facet",
+    }
+    facet_fields: set[str] = set()
+    field_name_map = {
+        'publishers': 'publisher',
+        'subtitle': 'alternative_subtitle',
+        'title': 'alternative_title',
+        # "Private" fields
+        # This is private because we'll change it to a multi-valued field instead of a
+        # plain string at the next opportunity, which will make it much more usable.
+        '_ia_collection': 'ia_collection_s',
+    }
+    sorts = {
+        'old': 'def(publish_year, 9999) asc',
+        'new': 'publish_year desc',
+        'title': 'title_sort asc',
+        # Ebook access
+        'ebook_access': 'ebook_access desc',
+        'ebook_access asc': 'ebook_access asc',
+        'ebook_access desc': 'ebook_access desc',
+        # Key
+        'key': 'key asc',
+        'key asc': 'key asc',
+        'key desc': 'key desc',
+        # Random
+        'random': 'random_1 asc',
+        'random asc': 'random_1 asc',
+        'random desc': 'random_1 desc',
+        'random.hourly': lambda: f'random_{datetime.now():%Y%m%dT%H} asc',
+        'random.daily': lambda: f'random_{datetime.now():%Y%m%d} asc',
+    }
+    default_fetched_fields: set[str] = set()
+    facet_rewrites = {}
+
+    def is_search_field(self, field: str):
+        return super().is_search_field(field) or field.startswith('id_')

--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -135,6 +135,10 @@ class WorkSearchScheme(SearchScheme):
         'ddc_sort': 'ddc_sort asc',
         'ddc_sort asc': 'ddc_sort asc',
         'ddc_sort desc': 'ddc_sort desc',
+        # Ebook access
+        'ebook_access': 'ebook_access desc',
+        'ebook_access asc': 'ebook_access asc',
+        'ebook_access desc': 'ebook_access desc',
         # Key
         'key': 'key asc',
         'key asc': 'key asc',

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -33,7 +33,7 @@ $code:
         return "SearchFacet|" + facets[key]
 
 $ param = {}
-$for p in {'q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor', 'publish_place', 'lccn', 'ia', 'first_sentence', 'publisher', 'author_key', 'debug', 'subject', 'place', 'person', 'time'} | facet_fields:
+$for p in {'q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor', 'publish_place', 'lccn', 'ia', 'first_sentence', 'publisher', 'author_key', 'debug', 'subject', 'place', 'person', 'time', 'editions.sort'} | facet_fields:
     $if p in input and input[p]:
         $ param[p] = input[p]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ max-complexity = 28
 [tool.ruff.pylint]
 allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 15
-max-branches = 22
+max-branches = 23
 max-returns = 14
 max-statements = 70
 


### PR DESCRIPTION
Feature to help with #8170 

Adds a new parameter, `editions.sort` to sort the editions displayed for each work (hence helping boost a specific edition)


### Technical
- Also add new (API only) sort option: `ebook_access` to sort by most available.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
Examples:
- Newest editions of English horror books: https://testing.openlibrary.org/search?q=subject_key%3Afiction_horror+language%3Aeng+-publisher%3A%22Independently+published%22&mode=everything&editions.sort=new

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
