### PR TITLE
add ARM64/M1 support for building olbase image

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -47,10 +47,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends nginx curl \
     logrotate \
     # rsync service for pulling monthly sitemaps from ol-home0 to ol-www0
     rsync
-RUN wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
-RUN echo "deb http://openresty.org/package/debian $(lsb_release -sc) openresty" \
-    | tee /etc/apt/sources.list.d/openresty.list
-RUN apt-get update && apt-get -y install --no-install-recommends openresty
+COPY scripts/install_openresty.sh ./
+RUN ./install_openresty.sh && rm ./install_openresty.sh
 RUN rm /usr/sbin/nginx
 RUN curl -L https://archive.org/download/nginx/nginx -o /usr/sbin/nginx
 RUN chmod +x /usr/sbin/nginx
@@ -81,7 +79,6 @@ COPY --chown=openlibrary:openlibrary package*.json ./
 RUN npm ci --no-audit
 
 COPY --chown=openlibrary:openlibrary . /openlibrary
-
 # run make to initialize git submodules, build css and js files
 RUN ln -s vendor/infogami/infogami infogami \
  && make \

--- a/scripts/install_openresty.sh
+++ b/scripts/install_openresty.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+machine=$(uname -m)
+
+if [[ "${machine}" == "aarch64" || "${machine}" == "arm64" ]]; then
+    echo "Running on ARM64 architecture (e.g., Apple M1)"
+    echo "openresty still doesn't work on arm see https://github.com/openresty/openresty/issues/840 and \
+    https://github.com/internetarchive/openlibrary/issues/6316"
+else
+    wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
+    echo "deb http://openresty.org/package/debian $(lsb_release -sc) openresty" \
+        | tee /etc/apt/sources.list.d/openresty.list
+    apt-get update && apt-get -y install --no-install-recommends openresty
+fi


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6316

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I want to be able to build on my m1 mac and this fix enables that.


### Technical
<!-- What should be noted about the implementation? -->
Solution based on discussion in the issue above.
`TARGETARCH` wasn't working so I went with `uname -m` which seems to be a common solution.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
It works on my m1 mac. I also tested it on gitpod and had no problems.
But ultimately openresty isn't used for dev so someone will need to check it on testing to be sure.

Run `docker build -t openlibrary/olbase:my-test-label -f docker/Dockerfile.olbase .`

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @cclauss 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
