### PR TITLE
update node install method

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -35,8 +35,8 @@ RUN apt-get -qq update && apt-get install -y \
     lftp
 
 # Install LTS version of node.js
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
-    && apt-get install -y nodejs
+COPY scripts/install_nodejs.sh ./
+RUN ./install_nodejs.sh && rm ./install_nodejs.sh
 
 # Install Archive.org nginx w/ IP anonymization
 USER root

--- a/scripts/install_nodejs.sh
+++ b/scripts/install_nodejs.sh
@@ -1,0 +1,15 @@
+# See https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
+
+NODE_MAJOR=16
+
+# Download and import the Nodesource GPG key
+apt-get install -y ca-certificates curl gnupg
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+# Create deb repository
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+# Run Update and Install
+apt-get update
+apt-get install nodejs -y


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8255 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Needed as the old install method is deprecated.


### Technical
<!-- What should be noted about the implementation? -->
This PR just follows the exact method they recommend for installing.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Works pretty seamlessly on my machine and gitpod.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss 
Also @cdrini you might like this making the build/deploy process go about 60 seconds faster :)

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
