### PR TITLE
Merge request table : Add new status dot color for merged requests

### DIFF
--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -120,6 +120,13 @@ $else:
         <tr>
           <td colspan="5">$_('No entries here!')</td>
         </tr>
+      $code:
+        # Maps request statuses to status dot class names
+        status_dot_mapping = {
+          0: 'dot--closed',
+          1: 'dot--open',
+          2: 'dot--merged'
+        }
       $for r in merge_requests:
         $ request_title = r.get('title', _('An untitled work') if r['mr_type'] != 2 else _('An unnamed author'))
         $ comments = r.get('comments', {}).get('comments', [])
@@ -130,7 +137,7 @@ $else:
         <tr id="mrid-$(r['id'])" class="mr-table-row" data-mrid="$(r['id'])">
           <td class="mr-info">
             $# Start : Status dot indicator
-            $ dot_status_class = 'dot--open' if is_open else 'dot--closed'
+            $ dot_status_class = status_dot_mapping[r['status']]
             $ status = _('Open request') if is_open else _('Closed request')
             <div class="dot $dot_status_class" title="$status"></div>
             $# End : Status dot indicator

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -187,6 +187,10 @@
     &--closed {
       background-color: @closed-red;
     }
+
+    &--merged {
+      background-color: @merged-purple;
+    }
   }
 }
 

--- a/static/css/less/colors.less
+++ b/static/css/less/colors.less
@@ -19,7 +19,6 @@
 
 // green
 @green: hsl(130, 61%, 33%);
-@open-green: hsl(126, 100%, 30%);
 @mid-baby-green: hsl(120, 100%, 88%);
 @baby-green: hsl(120, 100%, 93%);
 @dark-green: hsl(113, 38%, 29%);
@@ -39,7 +38,6 @@
 
 // reds
 @red: hsl(8, 78%, 49%);
-@closed-red: hsl(0, 100%, 50%);
 @dark-red: hsl(8, 70%, 44%);
 @red-two:hsl(4, 90%, 58%);
 @red-three: hsl(0, 100%, 50%);
@@ -111,3 +109,8 @@
 
 // nagios
 @nagios-green: hsl(108, 100%, 50%);
+
+// merge request table
+@open-green: hsl(126, 100%, 30%);
+@closed-red: hsl(0, 100%, 50%);
+@merged-purple: hsl(266, 100%, 75%);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds new color for merge requests that have been merged.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-09-07 11-19-02](https://github.com/internetarchive/openlibrary/assets/28732543/b1bf2119-eab3-4d43-bdfc-c10e13094792)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
