### PR TITLE
Add "Status" filter to merge request table

### DIFF
--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -122,6 +122,11 @@ class CommunityEditsQueue:
                 if kwargs.get("submitter") is None
                 else "submitter=$submitter"
             )
+        # If status not specified, don't include it
+        if 'status' in kwargs and kwargs.get('status'):
+            wheres.append(
+                'status=$status'
+            )
         if "url" in kwargs:
             wheres.append("url=$url")
         if "id" in kwargs:

--- a/openlibrary/core/edits.py
+++ b/openlibrary/core/edits.py
@@ -124,9 +124,7 @@ class CommunityEditsQueue:
             )
         # If status not specified, don't include it
         if 'status' in kwargs and kwargs.get('status'):
-            wheres.append(
-                'status=$status'
-            )
+            wheres.append('status=$status')
         if "url" in kwargs:
             wheres.append("url=$url")
         if "id" in kwargs:

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -32,7 +32,7 @@ class community_edits_queue(delegate.page):
 
     def GET(self):
         i = web.input(
-            page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc'
+            page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc', status=None
         )
         merge_requests = CommunityEditsQueue.get_requests(
             page=int(i.page),
@@ -41,6 +41,7 @@ class community_edits_queue(delegate.page):
             submitter=i.submitter,
             reviewer=i.reviewer,
             order=f'updated {i.order}',
+            status=i.status
         ).list()
 
         total_found = {

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -32,7 +32,13 @@ class community_edits_queue(delegate.page):
 
     def GET(self):
         i = web.input(
-            page=1, limit=25, mode="open", submitter=None, reviewer=None, order='desc', status=None
+            page=1,
+            limit=25,
+            mode="open",
+            submitter=None,
+            reviewer=None,
+            order='desc',
+            status=None,
         )
         merge_requests = CommunityEditsQueue.get_requests(
             page=int(i.page),
@@ -41,7 +47,7 @@ class community_edits_queue(delegate.page):
             submitter=i.submitter,
             reviewer=i.reviewer,
             order=f'updated {i.order}',
-            status=i.status
+            status=i.status,
         ).list()
 
         total_found = {

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -47,8 +47,8 @@ $else:
   </div>
   <div class="librarian-queue-wrapper" data-username="$username" data-i18n="$json_encode(i18n_strings)">
     <div class="table-header">
-      <a class="$(mode=='open' and 'selected' or '') mode-open" href="$changequery(mode='open', page=None)">$total['open'] $_('Open')</a>
-      <a class="$(mode=='closed' and 'selected' or '') mode-closed" href="$changequery(mode='closed', page=None)">$total['closed'] $_('Closed')</a>
+      <a class="$(mode=='open' and 'selected' or '') mode-open" href="$changequery(mode='open', status=None, page=None)">$total['open'] $_('Open')</a>
+      <a class="$(mode=='closed' and 'selected' or '') mode-closed" href="$changequery(mode='closed', status=None, page=None)">$total['closed'] $_('Closed')</a>
       <div class="flex-auto"></div>
       $if mode != 'open':
         $# Add filter for request status

--- a/openlibrary/templates/merge_queue/merge_queue.html
+++ b/openlibrary/templates/merge_queue/merge_queue.html
@@ -16,6 +16,7 @@ $ reviewer = query_param('reviewer', None)
 $ submitter = query_param('submitter', None)
 $ mode = query_param('mode', 'open')
 $ order = query_param('order', 'desc')
+$ status = query_param('status', None)
 
 $if submitter:
   $ desc = _("Showing %(username)s's requests only.", username=submitter)
@@ -49,6 +50,27 @@ $else:
       <a class="$(mode=='open' and 'selected' or '') mode-open" href="$changequery(mode='open', page=None)">$total['open'] $_('Open')</a>
       <a class="$(mode=='closed' and 'selected' or '') mode-closed" href="$changequery(mode='closed', page=None)">$total['closed'] $_('Closed')</a>
       <div class="flex-auto"></div>
+      $if mode != 'open':
+        $# Add filter for request status
+        <div class="mr-dropdown">$_('Status ▾')
+          <div class="mr-dropdown-menu sort hidden">
+            <header class="dropdown-header">
+              <span>$_('Request Status')</span>
+              <button class="dropdown-close">&times;</button>
+            </header>
+            $ merged_href = changequery(status='2', page=None) if status!='2' else changequery(status=None, page=None)
+            <a href="$merged_href" class="dropdown-item">
+              <span class="$('' if status=='2' else 'invisible') item-checked">✓</span>
+              <span>$_('Merged')
+              </span>
+            </a>
+            $ declined_href = changequery(status='0', page=None) if status!='0' else changequery(status=None, page=None)
+            <a href="$declined_href" class="dropdown-item">
+              <span class="$('' if status=='0' else 'invisible') item-checked">✓</span>
+              <span>$_('Declined')</span>
+            </a>
+          </div>
+        </div>
       <div class="mr-dropdown" id="submitter-menu-button">$_('Submitter ▾')
         <div class="mr-dropdown-menu hidden">
           <header class="dropdown-header">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8195

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds "Status" filter to merge request table when selected mode is not "open".  This filter allows librarians to filter closed requests that have been "Merged" or "Declined"

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Ensure that the new filter is not rendered when `mode` is `open`.
Ensure that the new filter is present when perusing "Closed" requests.
Ensure that the filter works properly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-09-07 11-58-25](https://github.com/internetarchive/openlibrary/assets/28732543/8a7bc964-2173-4c21-8a6e-f903c7f35e90)

![Screenshot from 2023-09-07 11-58-43](https://github.com/internetarchive/openlibrary/assets/28732543/da37a7a7-b120-48b8-b88b-72fe9e552d0c)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
