### PR TITLE
Fix banner import bug

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -506,7 +506,7 @@ jQuery(function () {
 
     // Allow banner announcements to be dismissed by logged-in users:
     const banners = document.querySelectorAll('.page-banner--dismissable')
-    if (banners) {
+    if (banners.length) {
         import(/* webpackChunkName: "dismissible-banner" */ './banner')
             .then(module => module.initDismissibleBanners(banners))
     }


### PR DESCRIPTION
Noticed that we were always importing the dismissible banner `js` code, as empty arrays (or, in this case, array-like objects) are truthy.  This PR corrects the issue.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
