### PR TITLE
Remove inline JS for return forms

### DIFF
--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -44,16 +44,6 @@ $if user_loan:
   $if secondary_action:
     $:macros.ReturnForm(ocaid)
     $:macros.FormatExpiry(user_loan['expiry'])
-    $if render_once('LoanStatus:return-book-js'):
-      <script type="text/javascript">
-        window.q.push(function() {
-          \$('.return-form').on('submit', function(event) {
-            if (!confirm("$_('Really return this book?')")) {
-              event.preventDefault();
-            }
-          });
-        });
-      </script>
 
 $elif book_provider and book_provider.short_name != 'ia':
   $# Partner Trusted Book Provider Read Buttons

--- a/openlibrary/macros/ReturnForm.html
+++ b/openlibrary/macros/ReturnForm.html
@@ -1,9 +1,14 @@
 $def with (ocaid)
 
+$ i18n_strings = {
+  $ "confirm_return": _("Really return this book?")
+  $ }
+
 <form
   action="/borrow/ia/$ocaid"
   method="post"
   class="return-form"
+  data-i18n="$json_encode(i18n_strings)"
 >
   <input class="cta-btn cta-btn--vanilla" type="submit" value="$_('Return book')" />
   <input type="hidden" name="action" value="return" />

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -510,4 +510,10 @@ jQuery(function () {
         import(/* webpackChunkName: "dismissible-banner" */ './banner')
             .then(module => module.initDismissibleBanners(banners))
     }
+
+    const returnForms = document.querySelectorAll('.return-form')
+    if (returnForms.length) {
+        import(/* webpackChunkName: "return-form" */ './return-form')
+            .then(module => module.initReturnForms(returnForms))
+    }
 });

--- a/openlibrary/plugins/openlibrary/js/return-form/index.js
+++ b/openlibrary/plugins/openlibrary/js/return-form/index.js
@@ -1,0 +1,16 @@
+/**
+ * Requires confirmation whenever a patron attempts to
+ * return a book.
+ *
+ * @param {NodeList<HTMLElement>} returnForms
+ */
+export function initReturnForms(returnForms) {
+    for (const form of returnForms) {
+        const i18nStrings = JSON.parse(form.dataset.i18n)
+        form.addEventListener('submit', (event) => {
+            if (!confirm(i18nStrings['confirm_return'])) {
+                event.preventDefault();
+            }
+        })
+    }
+}


### PR DESCRIPTION
In support of #4474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Moves inline `js` for our book return forms.  This javascript is responsible for displaying the confirmation dialog that is displayed whenever a book is returned.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I tested this by checking out multiple books, navigating to the loans page, and clicking each of the return book buttons.  Afterwards, I refreshed the page to verify that the books were all returned.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
