### PR TITLE
Add generalized de-dupe for ISBN and LCCN for edit edition form

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -125,13 +125,6 @@ function validateIsbn10(data, dataConfig, label) {
     if (isFormatValidIsbn10(data.value) === false) {
         return error('#id-errors', 'id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
     }
-    // hacky special case, dupe checking needs to be here before isbnConfirmAdd
-    // if placed after, duped isbns can be entered by selecting 'Yes' from isbnConfirmAdd
-    // because the isbnConfirmAdd error text with yes/no options is overwritten by dupe error message
-    const entries = document.querySelectorAll(`.${data.name}`);
-    if (isIdDupe(entries, data.value) === true) {
-        return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
-    }
     // Here the ISBN has a valid format, but also has an invalid checksum. Give the user a chance to verify
     // the ISBN, as books sometimes issue with invalid ISBNs and we want to be able to add them.
     // See https://en-academic.com/dic.nsf/enwiki/8948#cite_ref-18 for more.
@@ -155,13 +148,6 @@ function validateIsbn13(data, dataConfig, label) {
 
     if (isFormatValidIsbn13(data.value) === false) {
         return error('#id-errors', 'id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
-    }
-    // hacky special case, dupe checking needs to be here before isbnConfirmAdd
-    // if placed after, duped isbns can be entered by selecting 'Yes' from isbnConfirmAdd
-    // because the isbnConfirmAdd error text with yes/no options is overwritten by dupe error message
-    const entries = document.querySelectorAll(`.${data.name}`);
-    if (isIdDupe(entries, data.value) === true) {
-        return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
     }
     // Here the ISBN has a valid format, but also has an invalid checksum. Give the user a chance to verify
     // the ISBN, as books sometimes issue with invalid ISBNs and we want to be able to add them.
@@ -221,14 +207,17 @@ export function validateIdentifiers(data) {
     else if (data.name === 'lccn') {
         validId = validateLccn(data, dataConfig, label);
     }
-    if (validId === false) return false;
 
     // checking for duplicate identifier entry on all identifier types
     // expects parsed ids so placed after validate
     const entries = document.querySelectorAll(`.${data.name}`);
     if (isIdDupe(entries, data.value) === true) {
+        // isbnOverride being set will override the dupe checker, so clear isbnOverride if there's a dupe.
+        if (isbnOverride.get()) {isbnOverride.clear()}
         return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
     }
+
+    if (validId === false) return false;
 
     $('#id-errors').hide();
     return true;

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -6,7 +6,8 @@ import {
     isChecksumValidIsbn13,
     isFormatValidIsbn10,
     isFormatValidIsbn13,
-    isValidLccn
+    isValidLccn,
+    isIdDupe
 } from './idValidation';
 /* global render_seed_field, render_language_field, render_lazy_work_preview, render_language_autocomplete_item, render_work_field, render_work_autocomplete_item */
 /* Globals are provided by the edit edition template */
@@ -84,28 +85,6 @@ export function initRoleValidation() {
 }
 
 /**
- * Takes an isbn string and returns true if the given ISBN is already added
- * to this edition.
- * @param {String} isbn  ISBN string duplication checking
- * @return {boolean}  true if the given ISBN is already added to the edition
- */
-function isIsbnDupe(isbn) {
-    const isbnEntries = document.querySelectorAll('.isbn_10, .isbn_13');
-    return Array.from(isbnEntries).some(entry => entry['value'] === isbn);
-}
-
-/**
- * Takes an LCCN string normalized using logic in idValidation.js and returns
- * true if the identifier has already been added
- * @param {String} lccn  LCCN string to check
- * @return {boolean}  true if given LCCN is already added to the edition
- */
-function isLccnDupe(lccn) {
-    const lccnEntries = document.querySelectorAll('.lccn');
-    return Array.from(lccnEntries).some(entry => entry['value'] === lccn);
-}
-
-/**
  * Displays a confirmation box in the error div to confirm the addition of an
  * ISBN with a valid form but which fails the checksum.
  * @param {Object} data  data from the input form, gathered via js/jquery.repeat.js
@@ -146,8 +125,9 @@ function validateIsbn10(data, dataConfig, label) {
     if (isFormatValidIsbn10(data.value) === false) {
         return error('#id-errors', 'id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
     }
-    else if (isIsbnDupe(data.value) === true) {
-        return error('#id-errors', 'id-value', dataConfig['That ISBN already exists for this edition.'].replace(/ISBN/, label));
+    const entries = document.querySelectorAll(`.${data.name}`);
+    if (isIdDupe(entries, data.value) === true) {
+        return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
     }
     // Here the ISBN has a valid format, but also has an invalid checksum. Give the user a chance to verify
     // the ISBN, as books sometimes issue with invalid ISBNs and we want to be able to add them.
@@ -173,8 +153,9 @@ function validateIsbn13(data, dataConfig, label) {
     if (isFormatValidIsbn13(data.value) === false) {
         return error('#id-errors', 'id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
     }
-    else if (isIsbnDupe(data.value) === true) {
-        return error('#id-errors', 'id-value', dataConfig['That ISBN already exists for this edition.'].replace(/ISBN/, label));
+    const entries = document.querySelectorAll(`.${data.name}`);
+    if (isIdDupe(entries, data.value) === true) {
+        return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
     }
     // Here the ISBN has a valid format, but also has an invalid checksum. Give the user a chance to verify
     // the ISBN, as books sometimes issue with invalid ISBNs and we want to be able to add them.
@@ -200,8 +181,9 @@ function validateLccn(data, dataConfig, label) {
     if (!isValidLccn(data.value)) {
         return error('#id-errors', 'id-value', dataConfig['Invalid ID format'].replace(/ID/, label));
     }
-    else if (isLccnDupe(data.value) === true) {
-        return error('#id-errors', 'id-value', dataConfig['That ISBN already exists for this edition.'].replace(/ISBN/, label));
+    const entries = document.querySelectorAll(`.${data.name}`);
+    if (isIdDupe(entries, data.value) === true) {
+        return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
     }
     return true;
 }

--- a/openlibrary/plugins/openlibrary/js/idValidation.js
+++ b/openlibrary/plugins/openlibrary/js/idValidation.js
@@ -103,3 +103,19 @@ export function isValidLccn(lccn) {
     const regex = /^([a-z]|[a-z]?([a-z]{2}|[0-9]{2})|[a-z]{2}[0-9]{2})?[0-9]{8}$/;
     return regex.test(lccn);
 }
+
+/**
+ * Given a list of identifier entries from edition page form and a new
+ * identifier, determines if the new identifier has already been entered
+ * under the same type as an existing identifier entry.
+ * Expects identifiers that have already been parsed/normalized.
+ * @param {Array} idEntries  Array of identifier entries
+ * @param {String} newId  New identifier entry to be checked
+ * @returns {boolean}  true if the new identifier has already been entered
+ */
+export function isIdDupe(idEntries, newId) {
+    // check each current entry value against new identifier
+    return Array.from(idEntries).some(
+        entry => entry['value'] === newId
+    );
+}

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -332,7 +332,6 @@ class Edition(models.Edition):
             if name == 'lccn':
                 value = normalize_lccn(value)
             # `None` in this field causes errors. See #7999.
-            # We should surface to the patron that an invalid LCCN is dropped. See #8092.
             if value is not None:
                 d.setdefault(name, []).append(value)
 

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -395,7 +395,7 @@ $ config = ({
     $ 'You need to give a value to ID.': _('You need to give a value to ID.'),
     $ 'ID ids cannot contain whitespace.': _('ID ids cannot contain whitespace.'),
     $ 'ID must be exactly 10 characters [0-9] or X.': _('ID must be exactly 10 characters [0-9] or X.'),
-    $ 'That ISBN already exists for this edition.': _('That ISBN already exists for this edition.'),
+    $ 'That ID already exists for this edition.': _('That ID already exists for this edition.'),
     $ 'ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4': _('ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'),
     $ 'Invalid ID format': _('Invalid ID format')
 $ })

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -4,7 +4,7 @@ export const editionIdentifiersSample = `
     &quot;You need to give a value to ID.&quot;: &quot;You need to give a value to ID.&quot;,
     &quot;ID ids cannot contain whitespace.&quot;: &quot;ID ids cannot contain whitespace.&quot;,
     &quot;ID must be exactly 10 characters [0-9] or X.&quot;: &quot;ID must be exactly 10 characters [0-9] or X.&quot;,
-    &quot;That ISBN already exists for this edition.&quot;: &quot;That ISBN already exists for this edition.&quot;,
+    &quot;That ID already exists for this edition.&quot;: &quot;That ID already exists for this edition.&quot;,
     &quot;ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4&quot;: &quot;ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4&quot;,
     &quot;Invalid ID format&quot;: &quot;Invalid ID format&quot;
 }">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8281 

Implements the new de-dupe function for the edit edition page that accepts any identifier type.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Add a valid identifier of any type
- Attempt to add the same identifier for each type
- Duplicate identifiers will be rejected with an informative error message
- Duplicate identifier values of different Id types will be able to be added
    - Eg. 1234567890 for ISBN 10 and 1234567890 for LCCN is allowed



### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
LCCN
![image](https://github.com/internetarchive/openlibrary/assets/29631356/4996fed4-fa88-416e-94ce-05b6d22c0c0d)
![image](https://github.com/internetarchive/openlibrary/assets/29631356/a5bef5b5-bdfc-4d9c-9372-de785c5e53c6)


ISBN 10
![image](https://github.com/internetarchive/openlibrary/assets/29631356/d08ef3e9-96a9-4fad-be6c-cf0d5e36435f)
![image](https://github.com/internetarchive/openlibrary/assets/29631356/fd7b5f9a-3093-419e-9716-0a8a44678793)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@scottbarnes 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
