### PR TITLE
Fix goodreads custom shelf bug

### DIFF
--- a/openlibrary/plugins/openlibrary/js/goodreads_import.js
+++ b/openlibrary/plugins/openlibrary/js/goodreads_import.js
@@ -30,6 +30,7 @@ export function initGoodreadsImport() {
         $('.import-submit').attr('value', `Import ${l} Books`);
     });
 
+    //updates the progress bar based on the book count
     function func1(value) {
         const l = $('.add-book[checked*="checked"]').length;
         const elem = document.getElementById('myBar');
@@ -70,16 +71,19 @@ export function initGoodreadsImport() {
             };
 
             if (!checked) {
-                return false;
+                func1(++count);
+                return;
             }
 
             if (shelves[shelf]) {
                 shelf_id = shelves[shelf];
             }
+
+            //used 'return' instead of 'return false' because the loop was being exited entirely
             if (shelf_id === 0) {
-                fail('Book in different Shelf');
+                fail('Custom shelves are not supported');
                 func1(++count);
-                return false;
+                return;
             }
 
             prevPromise = prevPromise.then(function () { // prevPromise changes in each iteration
@@ -129,7 +133,7 @@ export function initGoodreadsImport() {
                             }),
                             dataType: 'json',
                             contentType: 'application/json',
-                            beforeSend: function(xhr) {
+                            beforeSend: function (xhr) {
                                 xhr.setRequestHeader('Content-Type', 'application/json');
                                 xhr.setRequestHeader('Accept', 'application/json');
                             },


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8158 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the bug wherein an unchecked or custom shelved book causes the entire import to fail

### Technical
<!-- What should be noted about the implementation? -->
Replaced  'return false' in the unchecked or custom shelf condition with a 'return'. This statement was causing the code to break out of the loop entirely when the condition was encountered

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to ... import options.
2.  Do ... try to import Goodreads data containing a custom exclusive shelf, or an unchecked book
The bug should be fixed, and the import completes with error messages

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-09-19 15-03-38](https://github.com/internetarchive/openlibrary/assets/63901133/f8afefad-ec3d-4013-a56d-c0ed60ef653a)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp  

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
