### PR TITLE
Make covers.py compatible with web.py cgi.FieldStorage removal

### DIFF
--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -60,8 +60,8 @@ class add_cover(delegate.page):
         """Uploads a cover to coverstore and returns the response."""
         olid = key.split("/")[-1]
 
-        if i.file is not None and hasattr(i.file, 'value'):
-            data = i.file.value
+        if i.file is not None and hasattr(i.file, 'file'):
+            data = i.file.file.read()
         else:
             data = None
 

--- a/openlibrary/plugins/upstream/covers.py
+++ b/openlibrary/plugins/upstream/covers.py
@@ -61,7 +61,7 @@ class add_cover(delegate.page):
         olid = key.split("/")[-1]
 
         if i.file is not None and hasattr(i.file, 'file'):
-            data = i.file.file.read()
+            data = i.file.file
         else:
             data = None
 
@@ -82,7 +82,7 @@ class add_cover(delegate.page):
             upload_url = "http:" + upload_url
 
         try:
-            files = {'data': BytesIO(data)}
+            files = {'data': data}
             response = requests.post(upload_url, data=params, files=files)
             return web.storage(response.json())
         except requests.HTTPError as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ internetarchive==3.5.0
 isbnlib==3.10.14
 luqum==0.11.0
 lxml==4.9.3
+multipart==0.2.4
 Pillow==10.0.1
 psycopg2==2.9.6
 pydantic==2.1.0
@@ -26,4 +27,4 @@ sentry-sdk==1.28.1
 simplejson==3.19.1
 statsd==4.0.1
 validate_email==1.3
-web.py==0.62
+git+https://github.com/webpy/webpy.git@ed3e92cceb6ed870b224107ea653f48fa7fc2d0a#egg=web-py


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8147

~~NOTE: This is blocked pending an update to `web.py`. We have a few proposed solutions for that. Here's one: webpy/webpy#773.~~

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

This changes `covers.py` to reflect the changed field names brought on by `web.py`'s switch to [`multipart`](https://github.com/defnull/multipart/).

### Deploy Notes

This will affect every request made on the website + cover uploads. We'll want to monitor after deploying (and also try on staging)

### Technical
<!-- What should be noted about the implementation? -->
Some field names changed, as the diff will show.

Additionally, the `web.py` version in `requirements.txt` has been pinned to the commit with the `cgi.FieldStorage` change: https://github.com/webpy/webpy/commit/ed3e92cceb6ed870b224107ea653f48fa7fc2d0a.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Add a cover;
- Delete a cover; and
- Generally use the site every page load goes through the changes to `web.py`, and although all the tests pass here, it's possible there's some changed functionality somewhere.


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles
@tfmorris 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
