### PR TITLE
Fixed boston public library url in config_edition.page

### DIFF
--- a/openlibrary/plugins/openlibrary/pages/config_edition.page
+++ b/openlibrary/plugins/openlibrary/pages/config_edition.page
@@ -401,7 +401,7 @@
             "label": "Books For You"
         },
         {
-            "url": "https://bostonpl.bibliocommons.com/item/show/@@@",
+            "url": "https://bostonpl.bibliocommons.com/v2/record/@@@",
             "website": " https://bostonpl.bibliocommons.com",
             "notes": "",
             "name": "boston_public_library",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7824

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: fixes the url for the boston public library

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
