### PR TITLE
use prop in correct way for mergeUI

### DIFF
--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -105,7 +105,7 @@ export default {
                     }
                 } catch (e) {
                     this.mergeOutput = e.message;
-                    this.mergeStatus = this.isSuperLibrarian() ? DO_MERGE : REQUEST_MERGE;
+                    this.mergeStatus = this.isSuperLibrarian ? DO_MERGE : REQUEST_MERGE;
                     throw e;
                 }
             } else {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
this.isSuperLibrarian() -> this.isSuperLibrarian
Just like we use in the rest of the file.

Was found as an issue via the updated linter #8312
https://eslint.vuejs.org/rules/no-use-computed-property-like-method.html

Not sure if it was actually causing a bug. But I figured we should pull it into a separate PR to avoid extra discussion there.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp can you please check this one? (Since this was your code in #6920)


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
