### PR TITLE
Update bundlesize.config.json

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -70,7 +70,7 @@
     },
     {
       "path": "static/build/lists.*.js",
-      "maxSize": "5.5KB"
+      "maxSize": "8KB"
     },
     {
       "path": "static/build/all.js",


### PR DESCRIPTION
Failing on master https://github.com/internetarchive/openlibrary/actions/runs/6278617625/job/17052755072

Makes all other PR tests fail

@mekarpeles 


Again, not quite sure why we need this checks to have such low triggers.