### PR TITLE
Add Imports and Exports option to MyBooks page dropper

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -55,9 +55,19 @@ $var title: $header_title
 
 $ url_prefix = "/people/" + username
 $ readlog_url = url_prefix + "/books/%s/"
-$ options = [(_("Want to Read (%(count)d)", count=shelf_counts['want-to-read']), readlog_url % "want-to-read"), (_("Currently Reading (%(count)d)", count=shelf_counts['currently-reading']), readlog_url % "currently-reading"), (_("Already Read (%(count)d)", count=shelf_counts['already-read']), readlog_url % "already-read"), (_("My Lists (%(count)d)" if owners_page else "Lists (%(count)d)", count=len(lists)) , url_prefix + "/lists")]
+$ options = [
+$   (_("Want to Read (%(count)d)", count=shelf_counts['want-to-read']), readlog_url % "want-to-read"),
+$   (_("Currently Reading (%(count)d)", count=shelf_counts['currently-reading']), readlog_url % "currently-reading"),
+$   (_("Already Read (%(count)d)", count=shelf_counts['already-read']), readlog_url % "already-read"),
+$   (_("My Lists (%(count)d)" if owners_page else "Lists (%(count)d)", count=len(lists)) , url_prefix + "/lists")
+$ ]
 $if owners_page:
-  $ options = [("My Loans", "/account/loans")] + options + [(_("My Notes"), url_prefix + "/books/notes"), (_("My Reviews"), url_prefix + "/books/observations")]
+  $ options += [
+  $   (_("My Loans"), "/account/loans"),
+  $   (_("My Notes"), url_prefix + "/books/notes"),
+  $   (_("My Reviews"), url_prefix + "/books/observations"),
+  $   (_("Imports and Exports"), "/account/import")
+  $ ]
 
 <div class="mybooks">
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8304

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Add an 'Imports and Exports' option to the MyBooks navigation dropper. Previously the dropper had no option for the imports/exports page and the dropper showed an empty value.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Login and navigate to to MyBooks page. Verify that the 'Imports and Exports' value is displayed in the navigation dropper when on the imports/exports page and verify that selecting 'Imports and Exports' send the user to the proper page (account/import).

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/29631356/fa5db425-74eb-44c3-b100-46f0fd897063)
![image](https://github.com/internetarchive/openlibrary/assets/29631356/4c98c31f-cc42-4963-bc75-80f2d684b334)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
