### PR TITLE
import api: use edition ID from IA metadata if it exists

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -215,9 +215,12 @@ class ia_importapi(importapi):
         # The scan operators search OL before loading the book and add the
         # OL key if a match is found. We can trust them and attach the item
         # to that edition.
-        if metadata.get('mediatype') == 'texts' and metadata.get('openlibrary_edition'):
+        edition_olid = metadata.get('openlibrary_edition') or metadata.get(
+            'openlibrary'
+        )
+        if metadata.get('mediatype') == 'texts' and edition_olid:
             edition_data = cls.get_ia_record(metadata)
-            edition_data['openlibrary'] = metadata['openlibrary_edition']
+            edition_data['openlibrary'] = edition_olid
             edition_data = cls.populate_edition_data(edition_data, identifier)
             return cls.load_book(edition_data)
 

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -215,9 +215,9 @@ class ia_importapi(importapi):
         # The scan operators search OL before loading the book and add the
         # OL key if a match is found. We can trust them and attach the item
         # to that edition.
-        if metadata.get('mediatype') == 'texts' and metadata.get('openlibrary'):
+        if metadata.get('mediatype') == 'texts' and metadata.get('openlibrary_edition'):
             edition_data = cls.get_ia_record(metadata)
-            edition_data['openlibrary'] = metadata['openlibrary']
+            edition_data['openlibrary'] = metadata['openlibrary_edition']
             edition_data = cls.populate_edition_data(edition_data, identifier)
             return cls.load_book(edition_data)
 


### PR DESCRIPTION
Related: #8290 #8289 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
Currently `ia_import()` in the import API does not use Open Library edition IDs from Internet Archive metadata because it is using the wrong field -- `metadata['openlibrary']` instead of `metadata[openlibrary_edition]`.

This PR fixes that, and ensures we won't make a new edition when trying to import an IA record. Additionally, it avoids at least two further database calls that would have been made in an attempt to find a match.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try to import an IA record and see that 'step 2' now works as intended and gets the existing Open Library edition ID from the Internet Archive metadata, rather than relying on finding a match by searching the Open Library database.
```
❯ http POST http://localhost:8080/api/import/ia identifier==007exoticlocatio0000arno Cookie:$OL_COOKIE
HTTP/1.1 200 OK
[...]

{
    "edition": {
        "key": "/books/OL8582004M",
        "status": "modified"
    },
    "success": true,
    "work": {
        "key": "/works/OL8839644W",
        "status": "matched"
    }
}
```

@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
