### PR TITLE
get_marc_record_from_ia: use existing metadata if present

### DIFF
--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -27,14 +27,17 @@ def urlopen_keep_trying(url: str, headers=None, **kwargs):
         sleep(2)
 
 
-def get_marc_record_from_ia(identifier: str) -> MarcBinary | MarcXml | None:
+def get_marc_record_from_ia(
+    identifier: str, metadata: dict | None = None
+) -> MarcBinary | MarcXml | None:
     """
-    Takes IA identifiers and returns MARC record instance.
+    Takes IA identifiers and optional IA metadata and returns MARC record instance.
     08/2018: currently called by openlibrary/plugins/importapi/code.py
     when the /api/import/ia endpoint is POSTed to.
     """
-    metadata = ia.get_metadata(identifier)
-    filenames = metadata['_filenames']
+    if not metadata:
+        metadata = ia.get_metadata(identifier)
+    filenames = metadata['_filenames']  # type: ignore[index]
 
     marc_xml_filename = identifier + '_marc.xml'
     marc_bin_filename = identifier + '_meta.mrc'

--- a/openlibrary/catalog/get_ia.py
+++ b/openlibrary/catalog/get_ia.py
@@ -28,16 +28,19 @@ def urlopen_keep_trying(url: str, headers=None, **kwargs):
 
 
 def get_marc_record_from_ia(
-    identifier: str, metadata: dict | None = None
+    identifier: str, ia_metadata: dict | None = None
 ) -> MarcBinary | MarcXml | None:
     """
     Takes IA identifiers and optional IA metadata and returns MARC record instance.
     08/2018: currently called by openlibrary/plugins/importapi/code.py
     when the /api/import/ia endpoint is POSTed to.
+
+    :param ia_metadata: The full ia metadata; e.g. https://archive.org/metadata/goody,
+                        not https://archive.org/metadata/goody/metadata
     """
-    if not metadata:
-        metadata = ia.get_metadata(identifier)
-    filenames = metadata['_filenames']  # type: ignore[index]
+    if ia_metadata is None:
+        ia_metadata = ia.get_metadata(identifier)
+    filenames = ia_metadata['_filenames']  # type: ignore[index]
 
     marc_xml_filename = identifier + '_marc.xml'
     marc_bin_filename = identifier + '_meta.mrc'

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -230,7 +230,7 @@ class ia_importapi(importapi):
             raise BookImportError(status, 'Prohibited Item %s' % identifier)
 
         # Case 4 - Does this item have a marc record?
-        marc_record = get_marc_record_from_ia(identifier)
+        marc_record = get_marc_record_from_ia(identifier=identifier, metadata=metadata)
         if require_marc and not marc_record:
             raise BookImportError('no-marc-record')
         if marc_record:

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -230,7 +230,9 @@ class ia_importapi(importapi):
             raise BookImportError(status, 'Prohibited Item %s' % identifier)
 
         # Case 4 - Does this item have a marc record?
-        marc_record = get_marc_record_from_ia(identifier=identifier, metadata=metadata)
+        marc_record = get_marc_record_from_ia(
+            identifier=identifier, ia_metadata=metadata
+        )
         if require_marc and not marc_record:
             raise BookImportError('no-marc-record')
         if marc_record:

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -95,7 +95,7 @@ class TestGetIA:
                 '_filenames': [f'{itemid}_{s}' for s in ('marc.xml', 'meta.mrc')]
             },
         )
-        result = get_ia.get_marc_record_from_ia(item)
+        result = get_ia.get_marc_record_from_ia(item, metadata=None)
         assert isinstance(
             result, MarcBinary
         ), f"{item}: expected instanceof MarcBinary, got {type(result)}"
@@ -107,7 +107,7 @@ class TestGetIA:
         monkeypatch.setattr(
             ia, 'get_metadata', lambda itemid: {'_filenames': [f'{itemid}_marc.xml']}
         )
-        result = get_ia.get_marc_record_from_ia(item)
+        result = get_ia.get_marc_record_from_ia(item, metadata=None)
         assert isinstance(
             result, MarcXml
         ), f"{item}: expected instanceof MarcXml, got {type(result)}"
@@ -120,7 +120,7 @@ class TestGetIA:
             ia, 'get_metadata', lambda itemid: {'_filenames': [f'{itemid}_meta.mrc']}
         )
         with pytest.raises(BadLength):
-            result = get_ia.get_marc_record_from_ia(bad_marc)
+            result = get_ia.get_marc_record_from_ia(bad_marc, metadata=None)
 
     def test_bad_binary_data(self):
         with pytest.raises(BadMARC):

--- a/openlibrary/tests/catalog/test_get_ia.py
+++ b/openlibrary/tests/catalog/test_get_ia.py
@@ -95,7 +95,7 @@ class TestGetIA:
                 '_filenames': [f'{itemid}_{s}' for s in ('marc.xml', 'meta.mrc')]
             },
         )
-        result = get_ia.get_marc_record_from_ia(item, metadata=None)
+        result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(
             result, MarcBinary
         ), f"{item}: expected instanceof MarcBinary, got {type(result)}"
@@ -107,7 +107,7 @@ class TestGetIA:
         monkeypatch.setattr(
             ia, 'get_metadata', lambda itemid: {'_filenames': [f'{itemid}_marc.xml']}
         )
-        result = get_ia.get_marc_record_from_ia(item, metadata=None)
+        result = get_ia.get_marc_record_from_ia(item)
         assert isinstance(
             result, MarcXml
         ), f"{item}: expected instanceof MarcXml, got {type(result)}"
@@ -120,7 +120,7 @@ class TestGetIA:
             ia, 'get_metadata', lambda itemid: {'_filenames': [f'{itemid}_meta.mrc']}
         )
         with pytest.raises(BadLength):
-            result = get_ia.get_marc_record_from_ia(bad_marc, metadata=None)
+            result = get_ia.get_marc_record_from_ia(bad_marc)
 
     def test_bad_binary_data(self):
         with pytest.raises(BadMARC):


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

### Technical
<!-- What should be noted about the implementation? -->
Currently `ia_import()` will twice query the (memcached) Internet Archive API during the process for importing from an Internet Archive ID.

This PR passes the already-fetched `metadata` to the function that calls the metadata API again (`get_marc_record_from_ia()`), thereby avoiding the second call to the (memcached) API.

First, in "case 1", the metadata is gathered:
```
metadata = ia.get_metadata(identifier)
```

Once #8331 is merged, this will be the final query to the the IA metadata API, _if_ that IA record has data in the `openlibrary_edition` field. ("Case 2".)

However, if the IA record does not have data in `openlibrary_edition`, then there is a query for MARC data from the IA item, which calls `get_marc_record_from_ia()`, which again calls the metadata API:
```
metadata = ia.get_metadata(identifier)
```

This PR avoids that second query.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Verify already-fetch metadata is now passed into `get_marc_record_from_ia()`, and that IA imports still work as expected.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
