### PR TITLE
fix #8323 title work break

### DIFF
--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -58,6 +58,8 @@ table#editions,
   div.title {
     font-size: 1.0em;
     padding: 10px 0;
+    min-width: 1%;
+    overflow-wrap: break-word;
   }
 
   div.links {

--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -6,6 +6,9 @@
     display: none;
   }
 
+  & > span {
+    min-width: 1%;
+  }
   & h1 {
     line-height: normal;
     &.work-title {
@@ -13,6 +16,7 @@
       margin: 10px 0 0;
       color: @dark-grey;
       font-size: 2em;
+      overflow-wrap: break-word;
     }
   }
   & h2 {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -37,6 +37,7 @@
 // Center (editionAbout)
 div.editionAbout {
   margin-bottom: 20px;
+  min-width: 1%;
 
   p {
     margin: 1em 0;


### PR DESCRIPTION
Closes #8323

Adds word break in two places, work and edition title (and same again in mobile view)when a word in the title exceeds the space available.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="848" alt="Screenshot 2023-09-27 at 11 35 24" src="https://github.com/internetarchive/openlibrary/assets/7288187/9ffa2de1-08d8-49cf-8235-29c176f25b04">
<img width="526" alt="Screenshot 2023-09-27 at 11 36 11" src="https://github.com/internetarchive/openlibrary/assets/7288187/a393db44-35ca-488e-a95b-2cc9da5ccfd6">
<img width="526" alt="Screenshot 2023-09-27 at 11 36 24" src="https://github.com/internetarchive/openlibrary/assets/7288187/0b2c0b71-6ad9-4724-86b5-281181bfb0f2">

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->

