### PR TITLE
Feature add ids to works

### DIFF
--- a/openlibrary/plugins/openlibrary/js/idDetection.js
+++ b/openlibrary/plugins/openlibrary/js/idDetection.js
@@ -1,0 +1,35 @@
+const commonRegex  = {
+    wikidata: /^Q[1-9]\d+$/, // ignore single digit matches to reduce false positives
+    storygraph: /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i,
+    amazon: /^B[0-9A-Za-z]{9}$/,
+
+}
+const workIdentifierPatterns  = {
+    wikidata: commonRegex.wikidata,
+    amazon: commonRegex.amazon,
+    storygraph: commonRegex.storygraph,
+}
+
+/**
+ * Compares url string against regex patters to extract work identifier.
+ * @param {String} id string to test
+ * @returns {String} identifier type name e.g. 'wikidata' or null
+ */
+export function detectTypeFromWorkId(id) {
+    return detectTypeFromId(id, workIdentifierPatterns);
+}
+/**
+ * Compares url string against regex patters to extract identifier.
+ * @param {String} id string to test
+ * @param {Object} named regexs to match against
+ * @returns {String} identifier type name e.g. 'wikidata' or null
+ */
+function detectTypeFromId(id, patterns) {
+    for (const idtype in patterns) {
+        const detectPattern = patterns[idtype];
+        if (detectPattern.test(id) === true) {
+            return idtype;
+        }
+    }
+    return null;
+}

--- a/openlibrary/plugins/openlibrary/js/idExtraction.js
+++ b/openlibrary/plugins/openlibrary/js/idExtraction.js
@@ -1,0 +1,43 @@
+const commonRegex = {
+    wikidata: /^https?:\/\/www\.wikidata\.org\/wiki\/(Q[1-9]\d*)$/,
+    // viaf regex from https://www.wikidata.org/wiki/Property:P214#P8966
+    viaf: /^https?:\/\/(?:www\.)?viaf\.org\/viaf\/([1-9]\d(?:\d{0,7}|\d{17,20}))($|\/|\?|#)/,
+    // note: storygraph seems to use the same format for works and editions
+    storygraph: /^https?:\/\/app\.thestorygraph\.com\/books\/([0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12})$/,
+
+}
+const workIdentifierExtractionPatterns = {
+    wikidata: commonRegex.wikidata,
+    viaf: commonRegex.viaf,
+    storygraph: commonRegex.storygraph,
+    // librarything regex from https://www.wikidata.org/wiki/Property:P1085#P8966
+    librarything: /^https?:\/\/www\.librarything\.(?:com|nl)\/work\/(\d+)/,
+    // goodreads regex from https://www.wikidata.org/wiki/Property:P8383#P8966
+    goodreads: /^https?:\/\/www\.goodreads\.com\/work\/editions\/(\d+)/,
+
+}
+
+/**
+ * Compares url string against regex patters to extract work identifier.
+ * @param {String} url
+ * @returns {Array} [work identifier, identifier type] or null, null
+ */
+export function extractWorkIdFromUrl(url) {
+    return extractIdFromUrl(url, workIdentifierExtractionPatterns);
+}
+/**
+ * Compares url string against regex patters to extract identifier.
+ * @param {String} url
+ * @param {Object} patters - object of regex patterns
+ * @returns {Array} [identifier, identifier type] or null, null
+ */
+function extractIdFromUrl(url, patterns) {
+    for (const idtype in patterns) {
+        const extractPattern = patterns[idtype];
+        const id = extractPattern.exec(url);
+        if (id && id[1]) {
+            return [id[1], idtype];
+        }
+    }
+    return [null, null];
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -127,6 +127,7 @@ jQuery(function () {
     const addRowButton = document.getElementById('add_row_button');
     const roles = document.querySelector('#roles');
     const identifiers = document.querySelector('#identifiers');
+    const workIdentifiers = document.querySelector('#workidentifiers');
     const classifications = document.querySelector('#classifications');
     const excerpts = document.getElementById('excerpts');
     const links = document.getElementById('links');
@@ -161,6 +162,9 @@ jQuery(function () {
                 }
                 if (identifiers) {
                     module.initIdentifierValidation();
+                }
+                if (workIdentifiers) {
+                    module.initWorkIdentifierValidation();
                 }
                 if (classifications) {
                     module.initClassificationValidation();

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -606,6 +606,9 @@ class SaveBookHelper:
                     edition_data.works = [{'key': self.work.key}]
 
             if self.work is not None:
+                identifiers = work_data.pop('identifiers', [])
+                self.work.set_identifiers(identifiers)
+
                 self.work.update(work_data)
                 saveutil.save(self.work)
 

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -847,6 +847,27 @@ def _get_author_config():
 
 
 @public
+def get_work_config() -> Storage:
+    return _get_work_config()
+
+
+@web.memoize
+def _get_work_config():
+    """Returns the work config.
+
+    The results are cached on the first invocation. Any changes to /config/work page require restarting the app.
+
+    This is is cached because fetching and creating the Thing object was taking about 20ms of time for each book request.
+    """
+    thing = web.ctx.site.get('/config/work')
+    if hasattr(thing, "identifiers"):
+        identifiers = [Storage(t.dict()) for t in thing.identifiers if 'name' in t]
+    else:
+        identifiers = {}
+    return Storage(identifiers=identifiers)
+
+
+@public
 def get_edition_config() -> Storage:
     return _get_edition_config()
 

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -2,6 +2,8 @@ $def with (work, edition=None, recaptcha=None)
 
 $ this_title = work.title + ': ' + work.subtitle if work.get('subtitle', None) else work.title
 
+$ work_config = get_work_config()
+
 $var title: $this_title
 $putctx("robots", "noindex,nofollow")
 
@@ -102,6 +104,73 @@ $:macros.HiddenSaveButton("addWork")
                                 </div>
                             </div>
                             $:render_template("books/edit/about", work)
+                        </div>
+                    </div>
+                </fieldset>
+                $ config = ({
+                    $ 'Please select an identifier.': _('Please select an identifier.'),
+                    $ 'You need to give a value to ID.': _('You need to give a value to ID.'),
+                    $ 'ID ids cannot contain whitespace.': _('ID ids cannot contain whitespace.'),
+                    $ 'That ID already exists for this work.': _('That ID already exists for this work.'),
+                    $ 'Invalid ID format': _('Invalid ID format')
+                $ })
+                <fieldset class="major" id="workidentifiers" data-config="$dumps(config)">
+                    <legend>$_("ID Numbers")</legend>
+                    <div class="formBack">
+
+                        <div id="workid-errors" class="note" style="display: none"></div>
+                        <div class="formElement">
+                            <div class="label">
+                                <label for="workselect-id">$_("Do you know any identifiers for this work?")</label>
+                                <span class="tip">$_("Like, VIAF?")</span>
+                            </div>
+                            <div class="input">
+                                <table class="identifiers">
+                                    <tr id="workidentifiers-form">
+                                        <td align="right">
+                                            <select name="name" id="workselect-id">
+                                            $ id_labels = dict((d.name, d.label) for d in work_config.identifiers)
+                                            $ id_dict = dict((id.name, id) for id in work_config.identifiers)
+
+                                            <option value="">$_('Select one of many...')</option>
+                                            $for id in work_config.identifiers:
+                                                <option value="$id.name">$id.label</option>
+
+                                            </select>
+                                        </td>
+                                        <td>
+                                            <input type="text" name="value" id="workid-value"/>
+                                        </td>
+                                        <td>
+                                            <button type="button" name="add" class="repeat-add larger">$_("Add")</button>
+                                        </td>
+                                    </tr>
+                                    <tbody id="workidentifiers-display">
+                                        <tr id="workidentifiers-template" style="display: none;" class="repeat-item">
+                                            <td align="right"><strong>{{\$("#workselect-id").find("option[value='" + name + "']").html()}}</strong></td>
+                                            <td>{{value}}
+                                                <input type="hidden" name="{{prefix}}identifiers--{{index}}--name" value="{{name}}"/>
+                                                <input type="hidden" name="{{prefix}}identifiers--{{index}}--value" value="{{value}}" class="{{name}}"/>
+                                            </td>
+                                            <td><a href="javascript:;" class="repeat-remove red plain" title="Remove this identifier">[x]</a></td>
+                                        </tr>
+                                        <tr>
+                                            <td align="right">Open Library</td>
+                                            <td>$work.key.split("/")[-1]</td>
+                                            <td></td>
+                                        </tr>
+                                        $for i, id in enumerate(work.get_identifiers().values()):
+                                        <tr id="workidentifiers--$i" class="repeat-item">
+                                            <td align="right"><strong>$id_labels.get(id.name, id.name)</strong></td>
+                                            <td>$id.value
+                                                <input type="hidden" name="work--identifiers--${i}--name" value="$id.name"/>
+                                                <input type="hidden" name="work--identifiers--${i}--value" value="$id.value" class="$id.name"/>
+                                            </td>
+                                            <td><a href="javascript:;" class="repeat-remove red plain" title="Remove this identifier">[x]</a></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
                 </fieldset>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -512,6 +512,20 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
                   <li><a href="$link.url">$link.title</a></li>
                 </ul>
               </div>
+
+            <div class="section">
+              <h3 class="list-header collapse">$_("Work ID Numbers")</h3>
+              <dl class="meta">
+                  $:display_identifiers("Open Library", [storage(url=None, value=work.key.split("/")[-1])])
+                  $for name, values in work.get_identifiers().multi_items():
+                    $ identifier_label = values[0].label
+                    $:display_identifiers(identifier_label, values)
+
+                  $:display_goodreads("Open Library", [storage(url=None, value=work.key.split("/")[-1])])
+                  $for name, values in work.get_identifiers().multi_items():
+                    $:display_goodreads(values[0].label, values)
+              </dl>
+            </div>
       </div>
 
       $if show_observations:

--- a/tests/unit/js/html-test-data.js
+++ b/tests/unit/js/html-test-data.js
@@ -77,6 +77,54 @@ export const editionIdentifiersSample = `
 </table>
 </fieldset>`;
 
+export const workIdentifiersSample = `
+<fieldset class="major" id="workidentifiers" data-config="{
+&quot;Please select an identifier.&quot;: &quot;Please select an identifier.&quot;,
+&quot;You need to give a value to ID.&quot;: &quot;You need to give a value to ID.&quot;,
+&quot;ID ids cannot contain whitespace.&quot;: &quot;ID ids cannot contain whitespace.&quot;,
+&quot;That ID already exists for this work.&quot;: &quot;That ID already exists for this work.&quot;,
+&quot;Invalid ID format&quot;: &quot;Invalid ID format&quot;
+}">
+  <legend>ID Numbers</legend>
+  <!-- skipped the label html to match edition test sample above -->
+  <table class="identifiers">
+      <tbody><tr id="workidentifiers-form">
+          <td align="right">
+              <select name="name" id="workselect-id">
+              <option value="">Select one of many...</option>
+              <option value="viaf">VIAF</option>
+              <option value="wikidata">Wikidata</option>
+              <option value="storygraph">Storygraph</option>
+              <option value="librarything">Library Thing</option>
+              <option value="goodreads">Goodreads</option>
+              </select>
+          </td>
+          <td>
+              <input type="text" name="value" id="workid-value">
+          </td>
+          <td>
+              <button type="button" name="add" class="repeat-add larger">Add</button>
+          </td>
+      </tr>
+      </tbody><tbody id="workidentifiers-display">
+          <tr id="workidentifiers-template" style="display: none;" class="repeat-item">
+              <td align="right"><strong>{{$("#workselect-id").find("option[value='" + name + "']").html()}}</strong></td>
+              <td>{{value}}
+                  <input type="hidden" name="{{prefix}}identifiers--{{index}}--name" value="{{name}}">
+                  <input type="hidden" name="{{prefix}}identifiers--{{index}}--value" value="{{value}}" class="{{name}}">
+              </td>
+              <td><a href="javascript:;" class="repeat-remove red plain" title="Remove this identifier">[x]</a></td>
+          </tr>
+          <tr>
+              <td align="right">Open Library</td>
+              <td>OL8193465W</td>
+              <td></td>
+          </tr>
+      </tbody>
+  </table>
+</fieldset>
+`;
+
 export const clamperSample = `
       <span class='clamp' data-before='▾  ' style='display: unset;'>
           <h6>Subjects</h6>

--- a/tests/unit/js/idDetectionWork.test.js
+++ b/tests/unit/js/idDetectionWork.test.js
@@ -1,0 +1,42 @@
+import {
+    detectTypeFromWorkId
+} from '../../../openlibrary/plugins/openlibrary/js/idDetection.js';
+
+const validWorkData = [
+    {
+        id: 'Q53828903',
+        type: 'wikidata',
+        comment: '',
+    },
+    {
+        id: 'ba4d2cfd-4ed5-4b59-a1d5-0aaebbef005f',
+        type: 'storygraph',
+        comment: '',
+    },
+];
+
+const invalidWorkData = [
+    {
+        id: 'Q5',
+        comment: 'a valid wikidata id but too short/generic to match'
+    },
+    {
+        id: '5976042',
+        comment: 'a valid librarything work, but too generic to match'
+    },
+];
+
+describe('detectTypeFromWorkId', () => {
+    for (let i = 0; i < validWorkData.length; i += 1) {
+        const testcase = validWorkData[i];
+        it(`detect ${testcase.id} as ${testcase.type} ${testcase.comment}`, () => {
+            expect(detectTypeFromWorkId(testcase.id)).toBe(testcase.type);
+        });
+    }
+    for (let i = 0; i < invalidWorkData.length; i += 1) {
+        const testcase = invalidWorkData[i];
+        it(`not detect ${testcase.id} as a known id type ${testcase.comment}`, () => {
+            expect(detectTypeFromWorkId(testcase.id)).toBe(null);
+        });
+    }
+})

--- a/tests/unit/js/idExtractionWork.test.js
+++ b/tests/unit/js/idExtractionWork.test.js
@@ -1,0 +1,91 @@
+import {
+    extractWorkIdFromUrl,
+} from '../../../openlibrary/plugins/openlibrary/js/idExtraction.js';
+
+const validWorkData = [
+    {
+        desc: 'wikidata url',
+        url: 'https://www.wikidata.org/wiki/Q42',
+        type: 'wikidata',
+        id: 'Q42',
+    },
+    {
+        desc: 'viaf url with #',
+        url: 'https://viaf.org/viaf/113230702/#Adams,_Douglas,_1952-2001.',
+        type: 'viaf',
+        id: '113230702',
+    },
+    {
+        desc: 'viaf url with /',
+        url: 'https://viaf.org/viaf/113230702/',
+        type: 'viaf',
+        id: '113230702',
+    },
+    {
+        desc: 'viaf url without /',
+        url: 'https://viaf.org/viaf/113230702',
+        type: 'viaf',
+        id: '113230702',
+    },
+    {
+        desc: 'storygraph work',
+        url: 'https://app.thestorygraph.com/books/1df3abd0-184c-4016-8fe7-8e22d7fcb265',
+        type: 'storygraph',
+        id: '1df3abd0-184c-4016-8fe7-8e22d7fcb265',
+    },
+    {
+        desc: 'goodreads work',
+        url: 'https://www.goodreads.com/work/editions/54031496-rotherweird',
+        type: 'goodreads',
+        id: '54031496',
+    },
+    {
+        desc: 'librarything work',
+        url: 'https://www.librarything.com/work/12241832',
+        type: 'librarything',
+        id: '12241832',
+    },
+];
+
+const invalidWorkData = [
+    {
+        desc: 'storygraph author',
+        url: 'https://app.thestorygraph.com/authors/79e1fcbf-ab67-4e33-a8bd-9ecf3caf5a9c',
+        comment: 'not a work so should return null',
+    },
+    {
+        desc: 'goodreads edition',
+        url: 'https://www.goodreads.com/en/book/show/33299154',
+        comment: 'not a work so should return null',
+    },
+    {
+        desc: 'random string',
+        url: 'Anything random',
+        comment: 'not a url so should return null',
+    },
+    {
+        desc: 'goodreads author',
+        url: 'https://www.goodreads.com/author/show/16616431.Andrew_Caldecott',
+        comment: 'not a work so should return null',
+    },
+    {
+        desc: 'librarything author',
+        url: 'https://www.librarything.com/author/faganjenni',
+        comment: 'not a work so should return null',
+    },
+];
+
+describe('extractWorkIdFromUrl', () => {
+    for (let i = 0; i < validWorkData.length; i += 1) {
+        const testcase = validWorkData[i];
+        it(`parse ${testcase.desc} e.g. ${testcase.url}`, () => {
+            expect(extractWorkIdFromUrl(testcase.url)).toStrictEqual([testcase.id, testcase.type]);
+        });
+    }
+    for (let i = 0; i < invalidWorkData.length; i += 1) {
+        const testcase = invalidWorkData[i];
+        it(`reject ${testcase.desc} e.g. ${testcase.url}`, () => {
+            expect(extractWorkIdFromUrl(testcase.url)).toStrictEqual([null, null]);
+        });
+    }
+})

--- a/tests/unit/js/worksEditPage.test.js
+++ b/tests/unit/js/worksEditPage.test.js
@@ -1,0 +1,108 @@
+import { initWorkIdentifierValidation } from '../../../openlibrary/plugins/openlibrary/js/edit.js';
+import sinon from 'sinon';
+import * as testData from './html-test-data';
+import { htmlquote } from '../../../openlibrary/plugins/openlibrary/js/jsdef';
+import jQueryRepeat from '../../../openlibrary/plugins/openlibrary/js/jquery.repeat';
+
+let sandbox;
+
+/**
+ *
+ * Test various patterns with the work identifier parsing function,
+ * validateIdentifiers(), that initIdentifierValidation() calls when
+ * attempting to add and validate a new id e.g. wikidata to an work.
+ * These tests are meant to make sure that when adding ids:
+ * - valid identifiers are accepted;
+ * - duplicate identifiers are not;
+ * - any spaces are stripped before passing to the back end;
+ * - stripped and unstripped identifiers are treated equally as identical;
+ */
+
+// Adapted from jquery.repeat.test.js
+
+beforeEach(() => {
+    // Clear session storage
+    sandbox = sinon.createSandbox();
+    global.htmlquote = htmlquote;
+    // htmlquote is used inside an eval expression (yuck) so is an implied dependency
+    sandbox.stub(global, 'htmlquote').callsFake(htmlquote);
+    // setup Query repeat
+    jQueryRepeat(global.$);
+    // setup the HTML
+    $(document.body).html(testData.workIdentifiersSample);
+    initWorkIdentifierValidation()
+});
+
+// Per the test data used, and beforeEach(), the length always starts out at 5.
+describe('initWorkIdentifierValidation', () => {
+    // ISBN 10
+    it('does add a valid Wikidata ID starting in Q', () => {
+        $('#workid-value').val('Q24').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('');
+    });
+
+    it('does add a valid Wikidata url', () => {
+        $('#workid-value').val('https://www.wikidata.org/wiki/Q46248').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        expect($('#workid-value').val()).toBe('Q46248');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('');
+    });
+
+    it('does add a valid viaf ', () => {
+        $('#workselect-id').val('viaf');
+        $('#workid-value').val('0596520689');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('');
+    });
+
+    it('does NOT add a duplicate wikidata ID', () => {
+        $('#workid-value').val('Q42').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        $('.repeat-add').trigger('click');
+        $('#workid-value').val('Q42').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(2);
+    });
+
+    it('does properly trim spaces from a valid wikidata ID', () => {
+        $('#workid-value').val('   Q1711833   ').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        expect($('#workid-value').val()).toBe('Q1711833');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('');
+    })
+
+    it('does count identical trimmed and untrimmed wikidata and urls as the same', () => {
+        $('#workid-value').val('   Q1711833   ').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        expect($('#workid-value').val()).toBe('Q1711833');
+        $('.repeat-add').trigger('click');
+        expect($('#workid-value').val()).toBe('');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('');
+
+        $('#workid-value').val('Q1711833').trigger('input');
+        expect($('#workselect-id').trigger('change').val()).toBe('wikidata');
+        expect($('#workid-value').val()).toBe('Q1711833');
+        $('.repeat-add').trigger('click');
+        expect($('#workid-value').val()).toBe('');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('wikidata');
+
+        $('#workid-value').val('https://www.wikidata.org/wiki/Q1711833').trigger('input');
+        expect($('#workselect-id').val()).toBe('wikidata');
+        expect($('#workid-value').val()).toBe('Q1711833');
+        $('.repeat-add').trigger('click');
+        expect($('.repeat-item').length).toBe(2);
+        expect($('#workselect-id').trigger('change').val()).toBe('wikidata');
+    });
+
+});


### PR DESCRIPTION
fixes #3430 and #1797

Mostly re-using code from Edition ids and tweaking it for Works.

On top of that adds the auto detection of some ids (e.g. pasting in a wikidata or amazon id will auto-select that entry for you), similar to functionality on current Author id entry.

Also, adds the ability to paste in entire urls, which will then detect the right type of id and extract the specific id.

Note:

Displays the ids on the work/edition page though #3430 currently suggests this is optional, but I think the display is fairly inoffensive and would do for now.


<!-- What issue does this PR close? -->
Closes #3430
 and
Closes #1797

Partially addresses #866 for this specific area.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

feature

### Technical
<!-- What should be noted about the implementation? -->
Requires server side set up to work, similar to the edition identifiers, it gets the list of ids to use from config stored on server, see instructions below.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
You need to configure config/works with identifiers via:

/config/work.yml?m=edit

Before you can save any IDs.

Once you do you can add and remove IDs from works.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="707" alt="Screenshot 2023-10-01 at 17 00 53" src="https://github.com/internetarchive/openlibrary/assets/7288187/22d57513-9044-4b11-8f5c-01a645118396">
<img width="824" alt="Screenshot 2023-10-01 at 17 01 34" src="https://github.com/internetarchive/openlibrary/assets/7288187/faa7c655-3fc4-4395-a8a6-c4a0e9ed14cc">

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
