### PR TITLE
Add PWA shortcuts to main pages

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -37,5 +37,39 @@
         "params": {
             "text": "q"
         }
-    }
+    },
+    "shortcuts": [
+      {
+        "name": "My Books",
+        "url": "/account/books"
+      }
+      {
+        "name": "Subjects",
+        "url": "/subjects"
+      },
+      {
+        "name": "Trending",
+        "url": "/trending"
+      },
+      {
+        "name": "Explore",
+        "url": "/explore"
+      },
+      {
+        "name": "Lists",
+        "url": "/lists"
+      },
+      {
+        "name": "Collections",
+        "url": "/lists"
+      },
+      {
+        "name": "Random Book",
+        "url": "/random"
+      },
+      {
+        "name": "Advanced Search",
+        "url": "/advancedsearch"
+      }
+  ]
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add Progressive Web Apps shortcuts to the main pages of the web app. Shortcuts allow users to quickly open these pages from the OS without launching the browser.

[See docs for `shortcuts` at MDN](https://developer.mozilla.org/en-US/docs/Web/Manifest/shortcuts).

### Technical
<!-- What should be noted about the implementation? -->
This shouldn't affect the rest of the web app.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Run `openlibrary` locally and install the PWA. Verify if the shortcuts come up on the app's context menu.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
