### PR TITLE
remove duplicate author alternate names on save

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1015,7 +1015,6 @@ class author_edit(delegate.page):
                 + [
                     name.strip() for name in alternate_names.split('\n') if name.strip()
                 ],
-                key=str.lower,
             )[1:]
             author.links = author.get('links') or []
             return author

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -15,6 +15,7 @@ from infogami.utils.view import safeint, add_flash_message
 from infogami.infobase.client import ClientException
 
 from openlibrary.plugins.worksearch.search import get_solr
+from openlibrary.core.helpers import uniq
 from openlibrary.i18n import gettext as _
 from openlibrary import accounts
 import logging
@@ -1009,9 +1010,13 @@ class author_edit(delegate.page):
         if 'author' in i:
             author = trim_doc(i.author)
             alternate_names = author.get('alternate_names', None) or ''
-            author.alternate_names = [
-                name.strip() for name in alternate_names.split('\n') if name.strip()
-            ]
+            author.alternate_names = uniq(
+                [author.name]
+                + [
+                    name.strip() for name in alternate_names.split('\n') if name.strip()
+                ],
+                key=str.lower,
+            )[1:]
             author.links = author.get('links') or []
             return author
 


### PR DESCRIPTION
fixes #7845, and adds case insensitive comparison

<!-- What issue does this PR close? -->
Closes #7845

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature to remove duplicate alternative names on save, maintaining sort order. Compares case insensitively, so the first appearing case-variant will win.

### Technical
<!-- What should be noted about the implementation? -->
Possibly this change will be obsoluted by work on #8341

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Find an author with duplicate alternate names, on save check that duplicates have been removed and that otherwise the list of alternate names is intact and in order.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
