### PR TITLE
Restore work_count sort to subjects and authors

### DIFF
--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -127,7 +127,6 @@ class authors_autocomplete(autocomplete):
     fl = 'key,name,alternate_names,birth_date,death_date,work_count,top_work,top_subjects'
     olid_suffix = 'A'
     query = 'name:({q}*) OR alternate_names:({q}*) OR name:"{q}"^2 OR alternate_names:"{q}"^2'
-    sort = 'work_count desc'
 
     def doc_wrap(self, doc: dict):
         if 'top_work' in doc:

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -24,7 +24,7 @@ class autocomplete(delegate.page):
     fq = ['-type:edition']
     fl = 'key,type,name,title,score'
     olid_suffix: str | None = None
-    sort: str = None
+    sort: str | None = None
     query = 'title:"{q}"^2 OR title:({q}*) OR name:"{q}"^2 OR name:({q}*)'
 
     def db_fetch(self, key: str) -> Thing | None:

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -24,6 +24,7 @@ class autocomplete(delegate.page):
     fq = ['-type:edition']
     fl = 'key,type,name,title,score'
     olid_suffix: str | None = None
+    sort: str = None
     query = 'title:"{q}"^2 OR title:({q}*) OR name:"{q}"^2 OR name:({q}*)'
 
     def db_fetch(self, key: str) -> Thing | None:
@@ -68,6 +69,7 @@ class autocomplete(delegate.page):
             **({'fq': fq} if fq else {}),
             # limit the fields returned for better performance
             'fl': self.fl,
+            **({'sort': self.sort} if self.sort else {}),
         }
 
         data = solr.select(solr_q, **params)
@@ -125,6 +127,7 @@ class authors_autocomplete(autocomplete):
     fl = 'key,name,alternate_names,birth_date,death_date,work_count,top_work,top_subjects'
     olid_suffix = 'A'
     query = 'name:({q}*) OR alternate_names:({q}*) OR name:"{q}"^2 OR alternate_names:"{q}"^2'
+    sort = 'work_count desc'
 
     def doc_wrap(self, doc: dict):
         if 'top_work' in doc:
@@ -138,8 +141,9 @@ class subjects_autocomplete(autocomplete):
     # can't use /subjects/_autocomplete because the subjects endpoint = /subjects/[^/]+
     path = "/subjects_autocomplete"
     fq = ['type:subject']
-    fl = 'key,name'
+    fl = 'key,name,work_count'
     query = 'name:({q}*)'
+    sort = 'work_count desc'
 
     def GET(self):
         i = web.input(type="")


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8344

Restores the sorting by work count that existing in the subjects and authors autocomplete before the autocomplete refactoring.


### Technical
This fix adds an optional sort attribute to the autocomplete base class, and populates that with a work_count sort for the subject and author subclasses.

### Testing
On a work editing page, type author and subject names in the appropriate fields and observe that the choices are ordered by work count, descending. Other autocompletes (languages and works) should be unaffected.


### Stakeholders
@mheiman, @cdrini, @seabelis 

