### PR TITLE
Make are_servers_in_sync output emptyline if no olbase

### DIFF
--- a/scripts/deployment/are_servers_in_sync.sh
+++ b/scripts/deployment/are_servers_in_sync.sh
@@ -20,5 +20,5 @@ done
 echo "---"
 
 for SERVER in $SERVERS; do
-    ssh $SERVER "hostname | docker image ls | grep olbase | grep latest"
+    echo "$SERVER: $(ssh $SERVER 'hostname | docker image ls | grep olbase | grep latest')"
 done


### PR DESCRIPTION
Part of #8361


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested on ol-home0

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
