### PR TITLE
Switch alternate names editor delimiter to newline instead of semicolon

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1010,9 +1010,7 @@ class author_edit(delegate.page):
             author = trim_doc(i.author)
             alternate_names = author.get('alternate_names', None) or ''
             author.alternate_names = [
-                name.strip()
-                for name in alternate_names.split('\n')
-                if name.strip()
+                name.strip() for name in alternate_names.split('\n') if name.strip()
             ]
             author.links = author.get('links') or []
             return author

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -1011,7 +1011,7 @@ class author_edit(delegate.page):
             alternate_names = author.get('alternate_names', None) or ''
             author.alternate_names = [
                 name.strip()
-                for name in alternate_names.replace("\n", ";").split(';')
+                for name in alternate_names.split('\n')
                 if name.strip()
             ]
             author.links = author.get('links') or []

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -109,7 +109,7 @@ $:macros.HiddenSaveButton("addAuthor")
                                 <span class="tip">$_("For example:") Lev Nikolayevich Tolstoy; Yasnaya Polyana</span>
                             </div>
                             <div class="input">
-                                <textarea name="author--alternate_names" id="alternate_names" rows="6">$"; ".join(page.alternate_names)</textarea>
+                                <textarea name="author--alternate_names" id="alternate_names" rows="6">$"\n".join(page.alternate_names)</textarea>
                             </div>
                         </div>
                         <div class="label">Identifiers <a href="/help/faq/editing.en#author-identifiers-purpose"><img src="/images/icons/icon_help.png" alt="$_('Author Identifiers Purpose')"/></a> </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8183 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Alternate names are separated by newlines instead of semicolons for easier editing.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to the author edit page, add and remove values separated by newlines and save to verify results.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/29631356/8111e6d6-37db-4899-8240-6c667b6dc2a6)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
