### PR TITLE
Fix promise future dates

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -785,8 +785,9 @@ def normalize_import_record(rec: dict) -> None:
     if not isinstance(rec['source_records'], list):
         rec['source_records'] = [rec['source_records']]
 
-    if published_in_future_year(rec['publication_date']):
-        del rec['publication_date']
+    if publication_year := get_publication_year(rec.get('publish_date')):
+        if published_in_future_year(publication_year):
+            del rec['publication_date']
 
     # Split subtitle if required and not already present
     if ':' in rec.get('title', '') and not rec.get('subtitle'):

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -785,6 +785,9 @@ def normalize_import_record(rec: dict) -> None:
     if not isinstance(rec['source_records'], list):
         rec['source_records'] = [rec['source_records']]
 
+    if published_in_future_year(rec['publication_date']):
+        del rec['publication_date']
+
     # Split subtitle if required and not already present
     if ':' in rec.get('title', '') and not rec.get('subtitle'):
         title, subtitle = split_subtitle(rec.get('title'))

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -787,7 +787,7 @@ def normalize_import_record(rec: dict) -> None:
 
     publication_year = get_publication_year(rec.get('publish_date'))
     if publication_year and published_in_future_year(publication_year):
-        del rec['publication_date']
+        del rec['publish_date']
 
     # Split subtitle if required and not already present
     if ':' in rec.get('title', '') and not rec.get('subtitle'):

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -785,9 +785,9 @@ def normalize_import_record(rec: dict) -> None:
     if not isinstance(rec['source_records'], list):
         rec['source_records'] = [rec['source_records']]
 
-    if publication_year := get_publication_year(rec.get('publish_date')):
-        if published_in_future_year(publication_year):
-            del rec['publication_date']
+    publication_year = get_publication_year(rec.get('publish_date'))
+    if publication_year and published_in_future_year(publication_year):
+        del rec['publication_date']
 
     # Split subtitle if required and not already present
     if ':' in rec.get('title', '') and not rec.get('subtitle'):

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from copy import deepcopy
+from datetime import datetime
 from infogami.infobase.client import Nothing
 
 from infogami.infobase.core import Text
@@ -18,6 +19,7 @@ from openlibrary.catalog.add_book import (
     isbns_from_record,
     load,
     load_data,
+    normalize_import_record,
     should_overwrite_promise_item,
     split_subtitle,
     RequiredField,
@@ -1451,3 +1453,24 @@ class TestLoadDataWithARev1PromiseItem:
             'ia:newlyscannedpromiseitem',
         ]
         assert edition.works[0]['key'] == '/works/OL1W'
+
+
+class TestNormalizeImportRecord:
+    @pytest.mark.parametrize(
+        'year, expected',
+        [
+            ("2000-11-11", True),
+            (str(datetime.now().year), True),
+            (str(datetime.now().year + 1), False),
+        ],
+    )
+    def test_future_publication_dates_are_deleted(self, year, expected):
+        rec = {
+            'title': 'test book',
+            'source_records': ['ia:blob'],
+            'publish_date': year,
+        }
+        normalize_import_record(rec=rec)
+        print(rec)
+        result = 'publish_date' in rec
+        assert result == expected

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1462,9 +1462,11 @@ class TestNormalizeImportRecord:
             ("2000-11-11", True),
             (str(datetime.now().year), True),
             (str(datetime.now().year + 1), False),
+            ("9999-01-01", False),
         ],
     )
     def test_future_publication_dates_are_deleted(self, year, expected):
+        """It should be impossible to import books publish_date in a future year."""
         rec = {
             'title': 'test book',
             'source_records': ['ia:blob'],

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1473,6 +1473,5 @@ class TestNormalizeImportRecord:
             'publish_date': year,
         }
         normalize_import_record(rec=rec)
-        print(rec)
         result = 'publish_date' in rec
         assert result == expected


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8351

The PR makes a statement that no created record from any source should have a future date.

Most records with future dates will fail to import because of the validation step. Records from sources that are exempt from validation, like bwb promise items, will have certain fields checked/pruned during the normalize stage. 

## Technical notes

All API imports (I'm not sure about /addbook though, which does have front-end validation) seemingly go through https://github.com/internetarchive/openlibrary/pull/8367/files#diff-2f9a6b1879442fc58af3064df91b70cd3138d6da15003d0d3127ecf05098386cL975-R997. Everything goes through `validate` _unless_ (currently) it's a promise item, in which case `validate` is skipped. Everything should go through `normalize` after, including promise items.

## TODO

- [ ] ⚠️  /addbook should fail gracefully if/when a POST with future date. Currently id **doesn't** 
    * This shouldn't be a blocker because https://github.com/internetarchive/openlibrary/blob/master/openlibrary/plugins/upstream/addbook.py#L78-L95 doesn't seem to use the catalog flow and instead seemingly just creates new documents. We may want to DRY up these flows as per #7701 
    * This seems like a separate task and the current PR seems to do what we want.
- [x] A test would be useful (of a promise item that includes invalid date) getting created w/ invalid date removed

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
