### PR TITLE
add a grid mode to the carousel macro

### DIFF
--- a/openlibrary/macros/ListCarousel.html
+++ b/openlibrary/macros/ListCarousel.html
@@ -1,4 +1,4 @@
-$def with (list_key, title=None, sort='new', key='', limit=20, has_fulltext_only=True, url=None)
+$def with (list_key, title=None, sort='new', key='', limit=20, has_fulltext_only=True, url=None, layout='carousel')
 
 $# Takes following parameters
 $# * list_key (str) -- A list key e.g. /people/mekBot/lists/OL104041L
@@ -8,5 +8,6 @@ $# * key (str) -- unique name of the carousel in analytics
 $# * limit (int) -- initial number of books to pull
 $# * has_fulltext_only (bool) -- only include readable titles
 $# * url (str) -- whether to make title a link to url
+$# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
 
-$:macros.QueryCarousel(query=list_key, title=title, sort=sort, key=key, limit=limit, has_fulltext_only=has_fulltext_only, url=url)
+$:macros.QueryCarousel(query=list_key, title=title, sort=sort, key=key, limit=limit, has_fulltext_only=has_fulltext_only, url=url, layout=layout)

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -1,4 +1,4 @@
-$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None)
+$def with(query, title=None, sort='new', key='', limit=20, search=False, has_fulltext_only=True, url=None, layout='carousel')
 
 $# Takes following parameters
 $# * query (str) -- Any arbitrary Open Library search query, e.g. subject:"Textbooks"
@@ -7,6 +7,7 @@ $# * sort (str) -- optional sort param defined within work_search.py `work_searc
 $# * key (str) -- unique name of the carousel in analytics
 $# * limit (int) -- initial number of books to pull
 $# * search (bool) -- whether to include search within collection
+$# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
 
 $# Set default for key
 $ key = key or str(abs(hash(query)))
@@ -33,4 +34,4 @@ $code:
   books = [storage(b) for b in (results.get('docs', []))]
   load_more = {"url": "/search.json?" + urlencode(params), "limit": limit }
 
-$:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more)
+$:render_template("books/custom_carousel", books=books, title=title, url=url, key=key, load_more=load_more, layout=layout)

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -1,12 +1,13 @@
-$def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False, compact_mode=False, secondary_action=False)
+$def with(books=[], title="", url="", key="", min_books=1, load_more=None, test=False, compact_mode=False, secondary_action=False, layout='carousel')
 
-$ ctx.setdefault("links", [])
-$# Apparently fonts always need crossorigin for some reason
-$ slick_font = '<link rel="preload" href="/static/css/fonts/slick.woff" as="font" type="font/woff" crossorigin>'
-$if slick_font not in ctx.links:
-  $ ctx.links.append(slick_font)
+$if layout == 'carousel':
+  $ ctx.setdefault("links", [])
+  $# Apparently fonts always need crossorigin for some reason
+  $ slick_font = '<link rel="preload" href="/static/css/fonts/slick.woff" as="font" type="font/woff" crossorigin>'
+  $if slick_font not in ctx.links:
+    $ ctx.links.append(slick_font)
 
-$def render_carousel_cover(book, lazy):
+$def render_carousel_cover(book, lazy, layout):
   $ fallback_cover = 'https://openlibrary.org/images/icons/avatar_book.png'
   $ cover_host = '//covers.openlibrary.org'
   $ url = book.get('key') or book.url
@@ -46,7 +47,7 @@ $def render_carousel_cover(book, lazy):
           <img class="bookcover" loading="lazy"
             title="$('%s%s'%(title,byline))"
             alt="$('%s%s'%(title,byline))"
-          $if lazy:
+          $if lazy and layout == 'carousel':
             data-lazy="$(cover_url)"
             src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="/>
           $else:
@@ -85,10 +86,12 @@ $if test or (books and len(books) >= min_books):
         $else:
           $ config = ['.carousel-' + key, 6, 5, 4, 3, 2, 1, load_more_config ]
         $ compact = "carousel--compact" if compact_mode else ""
-        <div class="carousel $compact carousel-$key carousel--progressively-enhanced"
+        $ grid = "carousel--grid" if layout == 'grid' else ""
+        $ loadjs = "carousel--progressively-enhanced" if layout == 'carousel' else ""
+        <div class="carousel $grid $compact carousel-$key $loadjs"
           data-config="$json_encode(config)">
           $for index, book in enumerate(books or []):
-              $:render_carousel_cover(book, index > 5)
+              $:render_carousel_cover(book, index > 5, layout)
         </div>
       </div>
     </div>

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -28,9 +28,14 @@
 
   &.carousel--grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    grid-gap: 30px;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    grid-gap: 30px 20px;
+    padding: 10px;
+
+    // Fallback for non-grid browsers
+    flex-wrap: wrap;
   }
+
   a,
   a:link {
     text-decoration: none;
@@ -53,6 +58,10 @@
       border: 5px solid @orange;
       outline: 0;
     }
+  }
+
+  &.carousel--grid .carousel__item {
+    margin: 0;  // Handled by grid gap
   }
 
   // Modifiers

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -26,6 +26,11 @@
   overflow-x: scroll;
   padding: 10px 20px;
 
+  &.carousel--grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-gap: 30px;
+  }
   a,
   a:link {
     text-decoration: none;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7778 (or at least provides an alternative way for librarians to achieve their goals)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

feature: add grid_mode=True to the Carousel macros to get a grid view instead.

### Technical
<!-- What should be noted about the implementation? -->
1. this basically ignores the load_more code path. So you need to load your full grid in one go.
2. I've not tested in IE11, but it should be relatively simple to tweak the grid stuff to work if there's issues. Might just need `display: -ms-grid;` but not sure if prefixing is already automated in webpack.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Find/create a page with a Carousel macro and add `grid_mode=True` e.g.

```
{{ListCarousel("/people/openlibrary/lists/OL1L", limit=20, has_fulltext_only=False, url='https://openlibrary.org/people/openlibrary/lists/OL1L', grid_mode=True)}}
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="700" alt="Screenshot 2023-10-04 at 20 58 15" src="https://github.com/internetarchive/openlibrary/assets/7288187/77bbbbee-9e85-4b49-93e1-0042e37d8c01">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini, @digitals82

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
