### PR TITLE
Improve lending error handling

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -213,7 +213,10 @@ def s3_loan_api(s3_keys, ocaid=None, action='browse', **kwargs):
     data = s3_keys | kwargs
 
     response = requests.post(url + params, data=data)
-    if response.status_code == 409:
+    # We want this to be just `409` but first
+    # `www/common/Lending.inc#L111-114` needs to 
+    # be updated on petabox
+    if response.status_code in [400, 409]:
         raise PatronAccessException()
     response.raise_for_status()
     return response

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -213,7 +213,7 @@ def s3_loan_api(s3_keys, ocaid=None, action='browse', **kwargs):
     data = s3_keys | kwargs
 
     response = requests.post(url + params, data=data)
-    if response.status_code == 429:
+    if response.status_code == 409:
         raise PatronAccessException()
     response.raise_for_status()
     return response

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -41,10 +41,12 @@ BOOKREADER_STREAM_URL_PATTERN = "https://{0}/stream/{1}"
 DEFAULT_IA_RESULTS = 42
 MAX_IA_RESULTS = 1000
 
+
 class PatronAccessException(Exception):
     def __init__(self, message="Access to this book is temporarily forbidden (403)."):
         self.message = message
         super().__init__(self.message)
+
 
 config_ia_loan_api_url = None
 config_ia_xauth_api_url = None

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -214,7 +214,7 @@ def s3_loan_api(s3_keys, ocaid=None, action='browse', **kwargs):
 
     response = requests.post(url + params, data=data)
     # We want this to be just `409` but first
-    # `www/common/Lending.inc#L111-114` needs to 
+    # `www/common/Lending.inc#L111-114` needs to
     # be updated on petabox
     if response.status_code in [400, 409]:
         raise PatronAccessException()

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -43,7 +43,7 @@ MAX_IA_RESULTS = 1000
 
 
 class PatronAccessException(Exception):
-    def __init__(self, message="Access to this book is temporarily forbidden (403)."):
+    def __init__(self, message="Access to this item is temporarily locked."):
         self.message = message
         super().__init__(self.message)
 
@@ -213,7 +213,7 @@ def s3_loan_api(s3_keys, ocaid=None, action='browse', **kwargs):
     data = s3_keys | kwargs
 
     response = requests.post(url + params, data=data)
-    if response.status_code == 403:
+    if response.status_code == 429:
         raise PatronAccessException()
     response.raise_for_status()
     return response

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -41,6 +41,10 @@ BOOKREADER_STREAM_URL_PATTERN = "https://{0}/stream/{1}"
 DEFAULT_IA_RESULTS = 42
 MAX_IA_RESULTS = 1000
 
+class PatronAccessException(Exception):
+    def __init__(self, message="Access to this book is temporarily forbidden (403)."):
+        self.message = message
+        super().__init__(self.message)
 
 config_ia_loan_api_url = None
 config_ia_xauth_api_url = None
@@ -207,6 +211,8 @@ def s3_loan_api(s3_keys, ocaid=None, action='browse', **kwargs):
     data = s3_keys | kwargs
 
     response = requests.post(url + params, data=data)
+    if response.status_code == 403:
+        raise PatronAccessException()
     response.raise_for_status()
     return response
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -173,7 +173,6 @@ class borrow(delegate.page):
             stats.increment('ol.loans.leaveWaitlist')
             raise web.redirect(edition_redirect)
 
-
         elif user.has_borrowed(edition):
             action = 'read'
 

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -173,29 +173,28 @@ class borrow(delegate.page):
             stats.increment('ol.loans.leaveWaitlist')
             raise web.redirect(edition_redirect)
 
-        # Intercept a 'borrow' action if the user has already
-        # borrowed the book and convert to a 'read' action.
-        # Added so that direct bookreader links being routed through
-        # here can use a single action of 'borrow', regardless of
-        # whether the book has been checked out or not.
+
         elif user.has_borrowed(edition):
             action = 'read'
 
         elif action in ('borrow', 'browse'):
-            borrow_access = user_can_borrow_edition(user, edition)
+            if not user.has_borrowed(edition):
+                borrow_access = user_can_borrow_edition(user, edition)
 
-            if not (s3_keys and borrow_access):
-                stats.increment('ol.loans.outdatedAvailabilityStatus')
-                raise web.seeother(error_redirect)
+                if not (s3_keys and borrow_access):
+                    stats.increment('ol.loans.outdatedAvailabilityStatus')
+                    raise web.seeother(error_redirect)
 
-            lending.s3_loan_api(
-                s3_keys, ocaid=edition.ocaid, action='%s_book' % borrow_access
-            )
-            stats.increment('ol.loans.bookreader')
-            stats.increment('ol.loans.%s' % borrow_access)
-            action = 'read'
+                try:
+                    lending.s3_loan_api(
+                        s3_keys, ocaid=edition.ocaid, action='%s_book' % borrow_access
+                    )
+                    stats.increment('ol.loans.bookreader')
+                    stats.increment('ol.loans.%s' % borrow_access)
+                except PatronAccessException as e:
+                    stats.increment('ol.loans.blocked')
 
-        if action == 'read':
+        if action in ('borrow', 'browse', 'read'):
             bookPath = '/stream/' + edition.ocaid
             if i._autoReadAloud is not None:
                 bookPath += '?_autoReadAloud=show'

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -190,7 +190,7 @@ class borrow(delegate.page):
                     )
                     stats.increment('ol.loans.bookreader')
                     stats.increment('ol.loans.%s' % borrow_access)
-                except PatronAccessException as e:
+                except lending.PatronAccessException as e:
                     stats.increment('ol.loans.blocked')
 
         if action in ('borrow', 'browse', 'read'):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8372. Loosely related to #3429, we think we're seeing an uptick of lending error exception cases perhaps related to system limit. We want to add more specific reporting (e.g. response `429` instead of generic `400` or `401`) so we know internally where these error cases are coming from and how to deal with them gracefully for patrons. 

EDIT: I think we may have converged on `409` HTTP Response: **Conflict** or `429`.

This PR likely depends on changes being made internally within petabox, perhaps near:
https://git.archive.org/ia/petabox/-/blob/master/www/common/Lending.inc#L111-114

Which also pertains to https://git.archive.org/ia/petabox/-/blob/master/www/common/Lending/BookLoanService.inc#L525-534 and https://git.archive.org/ia/petabox/-/blob/master/www/common/Lending/BookLoanService.inc#L570-586

### Technical Notes

With this PR, when a 400 or 409 is encountered, we won't perform the borrow and will redirect the patron to archive.org (which isn't great -- they'll re-attempt to borrow and then see a indescript archive.org error -- but this is better than Open Library's stacktrace / generic see: `123871281.html` page)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis @judec @bfalling 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
