### PR TITLE
fix TypeChanger bug

### DIFF
--- a/openlibrary/macros/TypeChanger.html
+++ b/openlibrary/macros/TypeChanger.html
@@ -3,12 +3,6 @@ $# Used on http://localhost:8080/about?m=edit for blank page
 $# and any generic page in the admin UI; e.g. creating a page.
 $if ctx.user and ctx.user.is_admin():
     <div class="formElement pagetype collapse adminOnly" id="pageType">
-        <script>
-        function changeTemplate() {
-            var t = document.edit['type.key'].value;
-            document.location.href += '&t=' + t;
-        }
-        </script>
         <div class="label">
             <label for="type.key">$_("Page Type")</label>
             <span class="small gray">&nbsp;<a href="javascript:;"
@@ -18,7 +12,7 @@ $if ctx.user and ctx.user.is_admin():
             <p class="smaller">$_("Every piece of Open Library is defined by the type of content it displays, usually by content definition (e.g. Authors, Editions, Works) but sometimes by content use (e.g. macro, template, rawtext). Changing this for an existing page will alter its presentation and the data fields available for editing its content.") <span class="red">$_("Please use caution changing Page Type!")</span></p><p class="smaller">$_("(Simplest solution: If you aren't sure whether this should be changed, don't change it.)")</p>
         </div>
         <div class="input">
-            $:thinginput(type, name="type.key", id="type.key", expected_type="/type/type", kind="regular",  onchange="changeTemplate();")
+            $:thinginput(type, name="type.key", id="type.key", expected_type="/type/type", kind="regular")
         </div>
     </div>
 $else:

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -196,9 +196,10 @@ jQuery(function () {
     }
 
     // conditionally load for type changing input
-    if (document.getElementById('type.key')) {
+    const typeChanger = document.getElementById('type.key')
+    if (typeChanger) {
         import(/* webpackChunkName: "type-changer" */ './type_changer.js')
-            .then(module => module.initTypeChanger());
+            .then(module => module.initTypeChanger(typeChanger));
     }
 
     // conditionally load real time signup functionality based on class in the page

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -195,6 +195,12 @@ jQuery(function () {
             });
     }
 
+    // conditionally load for type changing input
+    if (document.getElementById('type.key')) {
+        import(/* webpackChunkName: "type-changer" */ './type_changer.js')
+            .then(module => module.initTypeChanger());
+    }
+
     // conditionally load real time signup functionality based on class in the page
     if (document.getElementsByClassName('olform create validate').length) {
         import(/* webpackChunkName: "realtime-account-validation" */'./realtime_account_validation.js')

--- a/openlibrary/plugins/openlibrary/js/type_changer.js
+++ b/openlibrary/plugins/openlibrary/js/type_changer.js
@@ -2,13 +2,12 @@
  * Functionality for TypeChanger.html
  */
 
-
 export function initTypeChanger() {
-    // /about?m=edit
+    // /about?m=edit - where this code is run
 
     //console.log('JS script loaded')
     function changeTemplate() {
-        // If change the template of the page based on the selected value
+        // Change the template of the page based on the selected value
         const searchParams = new URLSearchParams(window.location.search);
         const t = document.getElementById('type.key').value;
         searchParams.set('t', t);

--- a/openlibrary/plugins/openlibrary/js/type_changer.js
+++ b/openlibrary/plugins/openlibrary/js/type_changer.js
@@ -2,15 +2,15 @@
  * Functionality for TypeChanger.html
  */
 
-export function initTypeChanger() {
+export function initTypeChanger(elem) {
     // /about?m=edit - where this code is run
 
     function changeTemplate() {
         // Change the template of the page based on the selected value
         const searchParams = new URLSearchParams(window.location.search);
-        const t = document.getElementById('type.key').value;
+        const t = elem.value
         searchParams.set('t', t);
         window.location.search = searchParams.toString();
     }
-    document.getElementById('type.key').onchange = changeTemplate;
+    elem.addEventListener('change', () => changeTemplate())
 }

--- a/openlibrary/plugins/openlibrary/js/type_changer.js
+++ b/openlibrary/plugins/openlibrary/js/type_changer.js
@@ -1,0 +1,18 @@
+/**
+ * Functionality for TypeChanger.html
+ */
+
+
+export function initTypeChanger() {
+    // /about?m=edit
+
+    //console.log('JS script loaded')
+    function changeTemplate() {
+        // If change the template of the page based on the selected value
+        const searchParams = new URLSearchParams(window.location.search);
+        const t = document.getElementById('type.key').value;
+        searchParams.set('t', t);
+        window.location.search = searchParams.toString();
+    }
+    document.getElementById('type.key').onchange = changeTemplate;
+}

--- a/openlibrary/plugins/openlibrary/js/type_changer.js
+++ b/openlibrary/plugins/openlibrary/js/type_changer.js
@@ -8,9 +8,12 @@ export function initTypeChanger(elem) {
     function changeTemplate() {
         // Change the template of the page based on the selected value
         const searchParams = new URLSearchParams(window.location.search);
-        const t = elem.value
+        const t = elem.value;
         searchParams.set('t', t);
+
+        // Update the URL and navigate to the new page
         window.location.search = searchParams.toString();
     }
-    elem.addEventListener('change', () => changeTemplate())
+
+    elem.addEventListener('change', changeTemplate);
 }

--- a/openlibrary/plugins/openlibrary/js/type_changer.js
+++ b/openlibrary/plugins/openlibrary/js/type_changer.js
@@ -5,7 +5,6 @@
 export function initTypeChanger() {
     // /about?m=edit - where this code is run
 
-    //console.log('JS script loaded')
     function changeTemplate() {
         // Change the template of the page based on the selected value
         const searchParams = new URLSearchParams(window.location.search);

--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -125,9 +125,11 @@ div#databar {
 }
 /* stylelint-enable selector-max-specificity */
 
-.formElement.pagetype,
-.formElement.pagetype select {
+.formElement.pagetype {
   width: 300px;
+  #type\.key {
+    width: 100%;
+  }
 }
 /* stylelint-disable selector-max-specificity */
 div#revertNotice,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Contributes to #4474 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I was investigating moving the JS to be inline but couldn't figure out how the functionality works.
Turns out it didn't work at all. Perhaps because the code is [12 years old](https://github.com/internetarchive/openlibrary/blame/35d6b72c7851f260d673fbcd9ce3f95b0e9c3169/openlibrary/macros/TypeChanger.html#L21) and not used too frequently.
This PR makes the code actually work and moves it away from being inline js.

### Technical
<!-- What should be noted about the implementation? -->
thinginput comes from [here](https://github.com/infogami/infogami/blob/3e9357c0184cd51921e198762c9f7d03b4589cf1/infogami/utils/view.py#L185-L195). It doesn't seem to pass the "onclick" field currently, hence the code wasn't working.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See video

### Screenshot

https://github.com/internetarchive/openlibrary/assets/921217/b2c2d172-7faf-444e-852c-9867bf6169a9


<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp are you interested in reviewing? Since you've helped with this epic before

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
