### PR TITLE
7311/feature/loan history code for rendering loan_history page

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -504,7 +504,9 @@ def get_availability_of_ocaid(ocaid):
     return get_availability('identifier', [ocaid])
 
 
-def get_availability_of_ocaids(ocaids: list[str]) -> dict:
+def get_availability_of_ocaids(
+    ocaids: list[str],
+) -> dict[str, AvailabilityStatusV2]:
     """
     Retrieves availability based on ocaids/archive.org identifiers
     """

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1,6 +1,6 @@
 """Module for providing core functionality of lending on Open Library.
 """
-from typing import Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
 import web
 import datetime
@@ -20,6 +20,11 @@ from openlibrary.utils import dateutil, uniq
 
 from . import ia
 from . import helpers as h
+
+
+if TYPE_CHECKING:
+    from openlibrary.plugins.upstream.models import Edition
+
 
 logger = logging.getLogger(__name__)
 
@@ -504,13 +509,34 @@ def get_availability_of_ocaid(ocaid):
     return get_availability('identifier', [ocaid])
 
 
-def get_availability_of_ocaids(
-    ocaids: list[str],
-) -> dict[str, AvailabilityStatusV2]:
+def get_availability_of_ocaids(ocaids: list[str]) -> dict[str, AvailabilityStatusV2]:
     """
     Retrieves availability based on ocaids/archive.org identifiers
     """
     return get_availability('identifier', ocaids)
+
+
+def get_items_and_add_availability(ocaids: list[str]) -> dict[str, "Edition"]:
+    """
+    Get Editions from OCAIDs and attach their availabiliity.
+
+    Returns a dict of the form: `{"ocaid1": edition1, "ocaid2": edition2, ...}`
+    """
+    ocaid_availability = get_availability_of_ocaids(ocaids=ocaids)
+    editions = web.ctx.site.get_many(
+        [
+            f"/books/{item.get('openlibrary_edition')}"
+            for item in ocaid_availability.values()
+            if item.get('openlibrary_edition')
+        ]
+    )
+
+    # Attach availability
+    for edition in editions:
+        if edition.ocaid in ocaids:
+            edition.availability = ocaid_availability.get(edition.ocaid)
+
+    return {edition.ocaid: edition for edition in editions if edition.ocaid}
 
 
 def is_loaned_out(identifier):

--- a/openlibrary/macros/IABook.html
+++ b/openlibrary/macros/IABook.html
@@ -1,12 +1,15 @@
 $def with (doc, ia_base_url="https://archive.org")
   $ ocaid = doc.get('identifier')
   <li class="searchResultItem">
-  <span class="bookcover">
-    $ cover = "%s/services/img/%s" % (ia_base_url, ocaid)
-      <a href="$ia_base_url/details/$ocaid"><img
-              itemprop="image"
-              src="$cover"
-      /></a>
+    <span class="bookcover">
+      $ cover = "%s/services/img/%s" % (ia_base_url, ocaid)
+      <a href="$ia_base_url/details/$ocaid">
+        <img itemprop="image"
+          src="$cover"
+          alt="$_('Cover of: %(title)s', title=ocaid)"
+          title="$_('Cover of: %(title)s', title=ocaid)"
+        />
+      </a>
    </span>
 
     <div class="details">
@@ -15,6 +18,9 @@ $def with (doc, ia_base_url="https://archive.org")
              <a itemprop="url" href="$ia_base_url/details/$ocaid" class="results">Borrowed from Internet Archive: $doc.get('identifier')</a>
            </h3>
         </div>
+    </div>
+    $# The following (empty) <div> is to aid in formatting the layout.
+    <div class="searchResultItemCTA">
     </div>
   </li>
 

--- a/openlibrary/macros/IABook.html
+++ b/openlibrary/macros/IABook.html
@@ -1,8 +1,9 @@
 $def with (doc, ia_base_url="https://archive.org")
+  $ ocaid = doc.get('identifier')
   <li class="searchResultItem">
   <span class="bookcover">
-    $ cover = "/images/icons/avatar_book-sm.png"
-      <a href="$ia_base_url/details/$doc.get('identifier')"><img
+    $ cover = "%s/services/img/%s" % (ia_base_url, ocaid)
+      <a href="$ia_base_url/details/$ocaid"><img
               itemprop="image"
               src="$cover"
       /></a>
@@ -11,7 +12,7 @@ $def with (doc, ia_base_url="https://archive.org")
     <div class="details">
         <div class="resultTitle">
            <h3 itemprop="name" class="booktitle">
-             <a itemprop="url" href="$ia_base_url/details/$doc.get('identifier')" class="results">Borrowed from Internet Archive: $doc.get('identifier')</a>
+             <a itemprop="url" href="$ia_base_url/details/$ocaid" class="results">Borrowed from Internet Archive: $doc.get('identifier')</a>
            </h3>
         </div>
     </div>

--- a/openlibrary/macros/IABook.html
+++ b/openlibrary/macros/IABook.html
@@ -1,5 +1,5 @@
 $def with (doc, ia_base_url="https://archive.org")
-  $ ocaid = doc.get('identifier')
+  $ ocaid = doc.get('ocaid')
   <li class="searchResultItem">
     <span class="bookcover">
       $ cover = "%s/services/img/%s" % (ia_base_url, ocaid)
@@ -15,7 +15,7 @@ $def with (doc, ia_base_url="https://archive.org")
     <div class="details">
         <div class="resultTitle">
            <h3 itemprop="name" class="booktitle">
-             <a itemprop="url" href="$ia_base_url/details/$ocaid" class="results">Borrowed from Internet Archive: $doc.get('identifier')</a>
+             <a itemprop="url" href="$ia_base_url/details/$ocaid" class="results">Borrowed from Internet Archive: $ocaid</a>
            </h3>
         </div>
     </div>

--- a/openlibrary/macros/IABook.html
+++ b/openlibrary/macros/IABook.html
@@ -1,0 +1,19 @@
+$def with (doc, ia_base_url="https://archive.org")
+  <li class="searchResultItem">
+  <span class="bookcover">
+    $ cover = "/images/icons/avatar_book-sm.png"
+      <a href="$ia_base_url/details/$doc.get('identifier')"><img
+              itemprop="image"
+              src="$cover"
+      /></a>
+   </span>
+
+    <div class="details">
+        <div class="resultTitle">
+           <h3 itemprop="name" class="booktitle">
+             <a itemprop="url" href="$ia_base_url/details/$doc.get('identifier')" class="results">Borrowed from Internet Archive: $doc.get('identifier')</a>
+           </h3>
+        </div>
+    </div>
+  </li>
+

--- a/openlibrary/macros/Pager_loanhistory.html
+++ b/openlibrary/macros/Pager_loanhistory.html
@@ -1,0 +1,9 @@
+$def with (page, num_found, results_per_page=25, show_next=True)
+    <div class="clearfix"></div>
+    <div class="pagination">
+    $if page != 1:
+        <a href="$changequery(page=None)" class="ChoosePage">&laquo;&nbsp;$_('First')</a>
+        <a href="$changequery(page=page-1)" class="ChoosePage">&lt;&nbsp;$_('Previous')</a>
+    $if show_next:
+        <a href="$changequery(page=page+1)" class="ChoosePage">$_('Next')&nbsp;&gt;</a>
+    </div>

--- a/openlibrary/macros/Pager_loanhistory.html
+++ b/openlibrary/macros/Pager_loanhistory.html
@@ -1,4 +1,4 @@
-$def with (page, num_found, results_per_page=25, show_next=True)
+$def with (page, show_next=True)
     <div class="clearfix"></div>
     <div class="pagination">
     $if page != 1:

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1084,38 +1084,39 @@ class account_loans_json(delegate.page):
 
 
 class account_loan_history(delegate.page):
-    path = "/people/([^/]+)/loan-history"
+    path = "/account/loan-history"
 
     @require_login
-    def GET(self, username):
+    def GET(self):
         i = web.input(page=1)
         page = int(i.page)
+        user = accounts.get_current_user()
+        username = user['key'].split('/')[-1]
         mb = MyBooksTemplate(username, key='loan_history')
-        if mb.is_my_page:
-            loan_history_data = get_loan_history_data(page=page, mb=mb)
-            template = render['account/loan_history'](
-                docs=loan_history_data['docs'],
-                current_page=page,
-                show_next=loan_history_data['show_next'],
-                ia_base_url=CONFIG_IA_DOMAIN,
-            )
-            return mb.render(header_title=_("Loan History"), template=template)
-        raise web.seeother(mb.user.key)
+        loan_history_data = get_loan_history_data(page=page, mb=mb)
+        template = render['account/loan_history'](
+            docs=loan_history_data['docs'],
+            current_page=page,
+            show_next=loan_history_data['show_next'],
+            ia_base_url=CONFIG_IA_DOMAIN,
+        )
+        return mb.render(header_title=_("Loan History"), template=template)
 
 
 class account_loan_history_json(delegate.page):
     encoding = "json"
-    path = "/people/([^/]+)/loan-history"
+    path = "/account/loan-history"
 
     @require_login
-    def GET(self, username):
+    def GET(self):
         i = web.input(page=1)
         page = int(i.page)
+        user = accounts.get_current_user()
+        username = user['key'].split('/')[-1]
         mb = MyBooksTemplate(username, key='loan_history')
-        if mb.is_my_page:
-            loan_history_data = get_loan_history_data(page=page, mb=mb)
-            web.header('Content-Type', 'application/json')
-            return delegate.RawText(json.dumps({"loans_history": loan_history_data}))
+        loan_history_data = get_loan_history_data(page=page, mb=mb)
+        web.header('Content-Type', 'application/json')
+        return delegate.RawText(json.dumps({"loans_history": loan_history_data}))
 
 
 class account_waitlist(delegate.page):

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -148,7 +148,7 @@ class mybooks_loan_history(delegate.page):
         mb = MyBooksTemplate(username, key='loan_history')
         if mb.is_my_page:
             loan_history_data = get_loan_history_data(page=i.page, mb=mb)
-            template = render['account/books'](
+            template = render['account/mybooks'](
                 loan_history_data['docs'],
                 mb.user,
                 loan_history_data['doc_count'],

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -9,11 +9,12 @@ from infogami.utils.view import public, safeint, render
 from openlibrary.i18n import gettext as _
 
 from openlibrary import accounts
+from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.utils import extract_numeric_id_from_olid
 from openlibrary.utils.dateutil import current_year
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
-from openlibrary.core.lending import add_availability, get_loans_of_user
+from openlibrary.core.lending import add_availability, get_availability_of_ocaids, get_loans_of_user, s3_loan_api
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.core.sponsorships import get_sponsored_editions
 from openlibrary.core.models import LoggedBooksData
@@ -84,6 +85,77 @@ class mybooks_home(delegate.page):
             lists=mb.lists,
             component_times=mb.component_times,
         )
+
+
+def get_loan_history_data(page: int, mb: "MyBooksTemplate") -> dict[str, str | int]:
+    if not (account := OpenLibraryAccount.get(username=mb.username)):
+        raise render.notfound("Account for not found for %s" % mb.username, create=False)
+    s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
+    limit = RESULTS_PER_PAGE
+    offset = page * limit - limit
+    loan_history = s3_loan_api(
+        s3_keys=s3_keys,
+        action='user_borrow_history',
+        limit=limit + 1,
+        offset=offset,
+        newest=True,
+    ).json()['history']['items']
+
+    show_next = len(loan_history) == limit + 1
+    # Drop 'extra' item (used to determine show_next) from results.
+    if show_next:
+        loan_history.pop()
+
+    ocaids = [loan_record['identifier'] for loan_record in loan_history]
+    availability = get_availability_of_ocaids(ocaids)
+    loan_history_map = {
+        loan_record['identifier']: loan_record for loan_record in loan_history
+    }
+    editions = web.ctx.site.get_many(
+        [
+            '/books/%s' % availability[ocaid].get('openlibrary_edition')
+            for ocaid in availability
+            if availability[ocaid].get('openlibrary_edition')
+        ]
+    )
+
+    # Handle case where no loaned books on this page are in OL and there are more pages.
+    if not editions and show_next:
+        return get_loan_history_data(page=page + 1, mb=mb)
+
+    for i, ed in enumerate(editions):
+        if ed.ocaid in ocaids:
+            # attach availability and loan to edition
+            editions[i].availability = availability.get(ed.ocaid)
+            editions[i].loan = loan_history_map[ed.ocaid]
+
+    result = {
+        'docs': editions,
+        'doc_count': len(loan_history_map),
+        'show_next': show_next,
+        'limit': limit,
+        'page': page,
+    }
+
+    return result
+
+
+class mybooks_loan_history(delegate.page):
+    path = "/people/([^/]+)/loan-history"
+
+    def GET(self, username):
+        i = web.input(page=1)
+        mb = MyBooksTemplate(username, key='loan_history')
+        if mb.is_my_page:
+            loan_history_data = get_loan_history_data(page=i.page, mb=mb)
+            template = render['account/books'](
+                loan_history_data['docs'],
+                mb.user,
+                loan_history_data['doc_count'],
+                page=i.page,
+                show_next=loan_history_data['show_next'],
+            )
+            return mb.render(header_title=_("Loan History"), template=template)
 
 
 class mybooks_notes(delegate.page):

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -17,9 +17,7 @@ from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
 from openlibrary.core.lending import (
     add_availability,
-    get_availability_of_ocaids,
     get_loans_of_user,
-    s3_loan_api,
 )
 from openlibrary.core.observations import Observations, convert_observation_ids
 from openlibrary.core.sponsorships import get_sponsored_editions
@@ -27,7 +25,6 @@ from openlibrary.core.models import LoggedBooksData
 from openlibrary.core.yearly_reading_goals import YearlyReadingGoals
 
 
-CONFIG_IA_DOMAIN: Final = config.get('ia_base_url', 'https://archive.org')
 RESULTS_PER_PAGE: Final = 25
 
 
@@ -92,24 +89,6 @@ class mybooks_home(delegate.page):
             lists=mb.lists,
             component_times=mb.component_times,
         )
-
-
-class mybooks_loan_history(delegate.page):
-    path = "/people/([^/]+)/loan-history"
-
-    def GET(self, username):
-        i = web.input(page=1)
-        page = int(i.page)
-        mb = MyBooksTemplate(username, key='loan_history')
-        if mb.is_my_page:
-            loan_history_data = get_loan_history_data(page=page, mb=mb)
-            template = render['account/loan_history'](
-                docs=loan_history_data['docs'],
-                current_page=page,
-                show_next=loan_history_data['show_next'],
-                ia_base_url=CONFIG_IA_DOMAIN,
-            )
-            return mb.render(header_title=_("Loan History"), template=template)
 
 
 class mybooks_notes(delegate.page):
@@ -634,83 +613,3 @@ class PatronBooknotes:
             'notes': Booknotes.count_works_with_notes_by_user(username),
             'observations': Observations.count_distinct_observations(username),
         }
-
-
-def get_loan_history_data(page: int, mb: "MyBooksTemplate") -> dict[str, str | int]:
-    """
-    Retrieve IA loan history data for page `page` of the patron's history.
-
-    This will use a patron's S3 keys to query the IA loan history API,
-    get the IA IDs, get the OLIDs if available, and and then convert this
-    into editions and IA-only items for display in the loan history.
-
-    This returns both editions and IA-only items because the loan history API
-    includes items that are not in Open Library, and displaying only IA
-    items creates pagination and navigation issues. For further discussion,
-    see https://github.com/internetarchive/openlibrary/pull/8375.
-    """
-    if not (account := OpenLibraryAccount.get(username=mb.username)):
-        raise render.notfound(
-            "Account for not found for %s" % mb.username, create=False
-        )
-    s3_keys = web.ctx.site.store.get(account._key).get('s3_keys')
-    limit = RESULTS_PER_PAGE
-    offset = page * limit - limit
-    loan_history = s3_loan_api(
-        s3_keys=s3_keys,
-        action='user_borrow_history',
-        limit=limit + 1,
-        offset=offset,
-        newest=True,
-    ).json()['history']['items']
-
-    # We request limit+1 to see if there is another page of history to display,
-    # and then pop the +1 off if it's present.
-    show_next = len(loan_history) == limit + 1
-    if show_next:
-        loan_history.pop()
-
-    ocaids = [loan_record['identifier'] for loan_record in loan_history]
-    availability = get_availability_of_ocaids(ocaids)
-    loan_history_map = {
-        loan_record['identifier']: loan_record for loan_record in loan_history
-    }
-    editions = web.ctx.site.get_many(
-        [
-            '/books/%s' % availability[ocaid].get('openlibrary_edition')
-            for ocaid in availability
-            if availability[ocaid].get('openlibrary_edition')
-        ]
-    )
-
-    # Create 'placeholder' editions for items in the Internet Archive loan
-    # history, but absent from Open Library.
-    ia_only_loans = [
-        loan for loan in availability.values() if not loan.get('openlibrary_edition')
-    ]
-
-    # Attach availability and loan to both editions and ia-only items.
-    for ed in editions:
-        if ed.ocaid in ocaids:
-            ed.availability = availability.get(ed.ocaid)
-            ed.loan = loan_history_map[ed.ocaid]
-            ed.last_loan_date = ed.loan.get('updatedate')
-
-    for ia_only in ia_only_loans:
-        loan = loan_history_map[ia_only['identifier']]
-        ia_only['last_loan_date'] = loan.get('updatedate', '')
-        ia_only['ia_only'] = True  # Determines which macro to load.
-
-    editions_and_ia_loans = editions + ia_only_loans
-    editions_and_ia_loans.sort(
-        key=lambda item: item.get('last_loan_date', ''), reverse=True
-    )
-
-    result = {
-        'docs': editions_and_ia_loans,
-        'show_next': show_next,
-        'limit': limit,
-        'page': page,
-    }
-
-    return result

--- a/openlibrary/templates/account/loan_history.html
+++ b/openlibrary/templates/account/loan_history.html
@@ -1,31 +1,19 @@
-$def with (docs, key, shelf_count, doc_count, owners_page, current_page, sort_order='desc', user=None, include_ratings=False, q=None, results_per_page=25, ratings=[], checkin_year=None, show_next=False)
-
-$if key == 'loan_history':
-  $ og_title = _("History of books loaned")
-  $ og_description = _("loaned %(total)d books.", total=10)
-
-$putctx("description", og_description)
-$add_metatag(property="og:title", content=og_title)
-$add_metatag(property="og:url", content=request.canonical_url)
-$add_metatag(property="og:site_name", content="Open Library")
-$add_metatag(property="og:description", content=og_description)
-
+$def with (docs, current_page, include_ratings=False, ratings=[], show_next=False, ia_base_url="")
 <div class="mybooks-list">
 
   $if len(docs) > 0:
-    $:macros.Pager_loanhistory(current_page, doc_count, results_per_page=results_per_page,show_next=show_next)
+    $:macros.Pager_loanhistory(page=current_page, show_next=show_next)
     <ul class="list-books">
       $if docs:
-        $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
-        $ doc_number = 1
         $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
         $for idx, doc in enumerate(docs):
-          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], include_lists=False, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id)
-          $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
-          $:macros.SearchResultsWork(doc, availability=doc.get('availability'), rating=star_rating)
-          $ doc_number = doc_number + 1
+          $if doc.get('ia_only'):
+            $:macros.IABook(doc=doc, ia_base_url=ia_base_url)
+          $else:
+            $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=idx+1, rating=ratings[idx]) if include_ratings else None
+            $:macros.SearchResultsWork(doc, availability=doc.get('availability'), rating=star_rating)
     </ul>
-    $:macros.Pager_loanhistory(current_page, doc_count, results_per_page=results_per_page, show_next=show_next)
+    $:macros.Pager_loanhistory(page=current_page, show_next=show_next)
   $else:
     <ul class="list-books">
         <p>$_("No loans found in your borrow history.")</p>

--- a/openlibrary/templates/account/loan_history.html
+++ b/openlibrary/templates/account/loan_history.html
@@ -1,0 +1,33 @@
+$def with (docs, key, shelf_count, doc_count, owners_page, current_page, sort_order='desc', user=None, include_ratings=False, q=None, results_per_page=25, ratings=[], checkin_year=None, show_next=False)
+
+$if key == 'loan_history':
+  $ og_title = _("History of books loaned")
+  $ og_description = _("loaned %(total)d books.", total=10)
+
+$putctx("description", og_description)
+$add_metatag(property="og:title", content=og_title)
+$add_metatag(property="og:url", content=request.canonical_url)
+$add_metatag(property="og:site_name", content="Open Library")
+$add_metatag(property="og:description", content=og_description)
+
+<div class="mybooks-list">
+
+  $if len(docs) > 0:
+    $:macros.Pager_loanhistory(current_page, doc_count, results_per_page=results_per_page,show_next=show_next)
+    <ul class="list-books">
+      $if docs:
+        $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
+        $ doc_number = 1
+        $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
+        $for idx, doc in enumerate(docs):
+          $ dropper = (bookshelf_id and owners_page) and macros.ReadingLogDropper([], include_lists=False, work=doc, edition_key=doc.logged_edition, users_work_read_status=bookshelf_id)
+          $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
+          $:macros.SearchResultsWork(doc, availability=doc.get('availability'), rating=star_rating)
+          $ doc_number = doc_number + 1
+    </ul>
+    $:macros.Pager_loanhistory(current_page, doc_count, results_per_page=results_per_page, show_next=show_next)
+  $else:
+    <ul class="list-books">
+        <p>$_("No loans found in your borrow history.")</p>
+        <p>$:_('<a href="/search">Search for a book</a> to borrow.')</p>
+    </ul>

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -167,7 +167,7 @@ $def empty_mobile_carousel(data):
         </li>
         <li>
           <div class="carousel-section-header">
-            <a class="external-link" data-ol-link-track="MyBooksSidebar|LoanHistory" href="https://archive.org/account/?tab=loans#loans-history">
+            <a data-ol-link-track="MyBooksSidebar|LoanHistory" href="/people/$username/loan-history">
               $_('Loan History')
               <img class="icon-link__image li-count" src="/static/images/icons/right-chevron.svg">
             </a>

--- a/openlibrary/templates/account/mybooks.html
+++ b/openlibrary/templates/account/mybooks.html
@@ -167,7 +167,7 @@ $def empty_mobile_carousel(data):
         </li>
         <li>
           <div class="carousel-section-header">
-            <a data-ol-link-track="MyBooksSidebar|LoanHistory" href="/people/$username/loan-history">
+            <a data-ol-link-track="MyBooksSidebar|LoanHistory" href="/account/loan-history">
               $_('Loan History')
               <img class="icon-link__image li-count" src="/static/images/icons/right-chevron.svg">
             </a>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -6,10 +6,12 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
       <ul class="sidebar-section">
         <li class="section-header">$username</li>
         <li>
-          <a class="li-title-desktop" href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('My Loans')</a>
+          <a class="li-title-desktop" href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('Loans')</a>
         </li>
-        <li><a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a></li>
-      </ul>
+        <li>
+          <a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="/people/$username/loan-history">$_('Loan History')</a>
+        </li>
+    </ul>
     $if public or owners_page:
       <ul class="sidebar-section">
         <li class="section-header">$_('Reading Log')</li>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -6,7 +6,7 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
       <ul class="sidebar-section">
         <li class="section-header">$username</li>
         <li>
-          <a class="li-title-desktop" href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('Loans')</a>
+          <a class="li-title-desktop" href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('My Loans')</a>
         </li>
         <li>
           <a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="/people/$username/loan-history">$_('Loan History')</a>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -9,7 +9,7 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
           <a class="li-title-desktop" href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('My Loans')</a>
         </li>
         <li>
-          <a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="/people/$username/loan-history">$_('Loan History')</a>
+          <a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="/account/loan-history">$_('Loan History')</a>
         </li>
     </ul>
     $if public or owners_page:

--- a/openlibrary/templates/books/mybooks_breadcrumb_select.html
+++ b/openlibrary/templates/books/mybooks_breadcrumb_select.html
@@ -13,6 +13,7 @@ $ options += [(_("Lists (%(count)d)", count=len(mb.lists)) , url_prefix + "/list
 $if mb.is_my_page:
   $ options += [
   $   (_("Loans"), "/account/loans"),
+  $   (_("Loan History"), "/account/loan-history"),
   $   (_("Notes"), url_prefix + "/books/notes"),
   $   (_("Notes"), url_prefix + "/books/notes"),
   $   (_("Reviews"), url_prefix + "/books/observations"),

--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -42,7 +42,7 @@
     margin-bottom: 28px;
   }
 
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .mybooks-list--clean {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7311

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: This is a draft PR to create a borrow history page on openlibrary.org instead of being redirected to the internetarchive.org currently.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
