### PR TITLE
fix unclosed div in MergeUI

### DIFF
--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -11,10 +11,11 @@
             <button class="reject-btn" v-if="showRejectButton" @click="rejectMerge">Reject Merge</button>
         </div>
         <div id="diffs-toggle">
-        <label>
-            <input type="checkbox" title="Show textual differences" v-model="show_diffs" />
-            Show text diffs
-        </label>
+            <label>
+                <input type="checkbox" title="Show textual differences" v-model="show_diffs" />
+                Show text diffs
+            </label>
+        </div>
     </div>
     <pre v-if="mergeOutput">{{mergeOutput}}</pre>
   </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
When trying to build vue in development mode it was failing with an error (see below).

Turns out we had an unclosed div that the IDE was complaining about too.
The production mode was swallowing the error and browsers were probably making a lucky guess of where to end the div. 

Contributes to #7547 


### Technical
<!-- What should be noted about the implementation? -->

Error I was getting
```
npx vue-cli-service build --no-clean --watch --mode development --dest static/build/components/prod
uction --target wc --name ol-MergeUI openlibrary/components/MergeUI.vue

⠋  Building for development as web component...

 ERROR  Failed to compile with 1 error                                                                                          9:32:00 AM

 error  in ./openlibrary/components/MergeUI.vue?vue&type=template&id=468bf6df&shadow

Module Error (from ./node_modules/@vue/vue-loader-v15/lib/loaders/templateLoader.js):
(Emitted value instead of an instance of Error) 

  Errors compiling template:

  tag <div> has no matching end tag.

  1  |  
     |   
  2  |  <div id="app">
     |  ^^^^^^^^^^^^^^
  3  |    <MergeTable :olids="olids" :show_diffs="show_diffs" :primary="primary" ref="mergeTable"/>
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Check that diffs option still works fine (it does)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<details>
  <summary>screenshot</summary>
  
  
<img width="1512" alt="image" src="https://github.com/internetarchive/openlibrary/assets/921217/25ee6af3-f264-4f13-a4ad-3894d02c8b63">

  
</details>

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp  


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
