### PR TITLE
Remove inline JS from readinglog_stats.html

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -251,9 +251,9 @@ jQuery(function () {
             .then((module) => module.init());
     }
 
-    if (window.READINGLOG_STATS_CONFIG) {
+    if ($('div.readinglog-charts').length) {
         import(/* webpackChunkName: "readinglog-stats" */ './readinglog_stats')
-            .then(module => module.init(window.READINGLOG_STATS_CONFIG));
+            .then(module => module.init($('div.readinglog-charts').data('config')));
     }
 
     const pageEl = $('#page-barcodescanner');

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -251,9 +251,11 @@ jQuery(function () {
             .then((module) => module.init());
     }
 
-    if ($('div.readinglog-charts').length) {
+    const readingLogCharts = document.querySelector('.readinglog-charts')
+    if (readingLogCharts) {
+        const readingLogConfig = JSON.parse(readingLogCharts.dataset.config)
         import(/* webpackChunkName: "readinglog-stats" */ './readinglog_stats')
-            .then(module => module.init($('div.readinglog-charts').data('config')));
+            .then(module => module.init(readingLogConfig));
     }
 
     const pageEl = $('#page-barcodescanner');

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -155,8 +155,8 @@ class readinglog_stats(delegate.page):
             for a in web.ctx.site.get_many(list(author_keys))
         ]
         return render['account/readinglog_stats'](
-            json.dumps(works_json),
-            json.dumps(authors_json),
+            works_json,
+            authors_json,
             len(works_json),
             user.key,
             user.displayname,

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -1,5 +1,12 @@
 $def with (works_json, authors_json, works_count, owner_key, owner_name, shelf_path, shelf_key, lang='en')
 
+$ reading_log_stats_config = {
+$    'works': works_json,
+$    'authors': authors_json,
+$    'lang': lang,
+$    'charts_selector': '.readinglog-stats-chart'
+$ }
+
 $ shelf_name = unicode(render_template('account/readinglog_shelf_name', shelf_key)).strip();
 $var title: $_('My %(shelf_name)s Stats', shelf_name=shelf_name)
 
@@ -96,7 +103,7 @@ $jsdef render_excluded_works_list(works, total):
     <p>$:_('Displaying stats about <strong>%d</strong> books. Note all charts show only the top 20 bars. Note reading log stats are private.', works_count)</p>
 </div>
 
-<div class="readinglog-charts" style="padding: 12px;">
+<div class="readinglog-charts" data-config="$dumps(reading_log_stats_config)" style="padding: 12px;">
 
     <h2>$_('Author Stats')</h2>
 
@@ -147,12 +154,3 @@ $jsdef render_excluded_works_list(works, total):
         </div>
     </main>
 </details>
-
-<script>
-    window.READINGLOG_STATS_CONFIG = {
-        works: $:works_json,
-        authors: $:authors_json,
-        lang: $:dumps(lang),
-        charts_selector: '.readinglog-stats-chart',
-    };
-</script>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8382 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes the inline JS from readinglog-stats.html. 

### Technical
<!-- What should be noted about the implementation? -->
Passes data through data-config in html instead.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to reading log, verify that log stats display correctly.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
