### PR TITLE
Moved "add a book" to the "help" section of footer

### DIFF
--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -34,7 +34,6 @@ $def with (page)
           <li><a href="/developers/api" title="$_('Explore Open Library APIs')">$_('API Documentation')</a></li>
           <li><a href="/developers/dumps" title="$_('Bulk Open Library data')">$_('Bulk Data Dumps')</a></li>
           <li><a href="https://github.com/internetarchive/openlibrary/wiki/Writing-Bots" title="$_('Write a bot')">$_('Writing Bots')</a></li>
-          <li><a href="/books/add" title="$_('Add a new book to Open Library')">$_('Add a Book')</a></li>
         </ul>
       </div>
       <div>
@@ -43,6 +42,7 @@ $def with (page)
           <li><a href="/help">$_('Help Center')</a></li>
           <li><a href="/contact?$urlencode(dict(path=request.fullpath))" title="$_('Problems')">$_('Report A Problem')</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_('Suggesting Edits')</a></li>
+	  <li><a href="/books/add" title="$_('Add a new book to Open Library')">$_('Add a Book')</a></li>
         </ul>
         <aside id="footer-icons">
           <a class="footer-icons__twitter" href="https://twitter.com/OpenLibrary">twitter</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8213 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: Moved "add a book" to the "help" section rather than "develop" of footer

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
