### PR TITLE
Enable My Books Droppers for devs

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -73,8 +73,7 @@ features:
     support: admin
     undo: enabled
     upstream: enabled
-    # Uncomment below line to enable the My Books Dropper
-    # my_books_dropper: enabled
+    my_books_dropper: enabled
 
 upstream_to_www_migration: true
 default_template_root: /upstream


### PR DESCRIPTION
This enables the My Books Droppers by default in local dev environments.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
