### PR TITLE
reduce size of admin additional metadata textarea

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -672,20 +672,6 @@ $if is_privileged_user:
         <a href="javascript:;" id="add-new-provider-row" data-index="$provider_index">$_("Add a provider")</a>
     </fieldset>
 
-$if ctx.user and ctx.user.is_admin():
-    <fieldset class="major adminOnly">
-        <legend>$_("Admin Only")</legend>
-        <div class="formElement">
-            <div class="label">
-                <label for="additional_metadata">$_("Additional Metadata")</label>
-                <span class="tip">$_('This field can accept arbitrary key:value pairs')</span>
-            </div>
-            <div class="input">
-                <textarea name="additional_metadata" id="additional_metadata" rows="15" cols="50">foo:bar</textarea>
-            </div>
-        </div>
-    </fieldset>
-
 $if ctx.user:
     <fieldset class="major">
         <div class="formElement">
@@ -695,6 +681,20 @@ $if ctx.user:
             </div>
             <div class="input">
                 <textarea name="edition--first_sentence" id="edition-first_sentence" rows="3" cols="50">$book.first_sentence</textarea>
+            </div>
+        </div>
+    </fieldset>
+
+$if ctx.user and ctx.user.is_admin():
+    <fieldset class="major adminOnly">
+        <legend>$_("Admin Only")</legend>
+        <div class="formElement">
+            <div class="label">
+                <label for="additional_metadata">$_("Additional Metadata")</label>
+                <span class="tip">$_('This field can accept arbitrary key:value pairs')</span>
+            </div>
+            <div class="input">
+                <textarea name="additional_metadata" id="additional_metadata" rows="4" placeholder="foo:bar"></textarea>
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The Edit book admin only additional metadata textarea is currently huge on the edit book page, I don't even know if it functions correctly or is particularly useful (I have never used it). It was very distracting, and took up a lot of space on the form for something never used.

Example URL: https://openlibrary.org/books/OL2058361M/The_wit_wisdom_of_Mark_Twain/edit

It also came before the 'First sentence' entry, which seems odd.

This PR reduces the size, moves it to the end of the form, and tidies up the suggested value.

BEFORE:

![image](https://github.com/internetarchive/openlibrary/assets/905545/1a8c5d8a-ae6d-4e6e-8eaf-e9a1cc4b9b6e)

AFTER:
![image](https://github.com/internetarchive/openlibrary/assets/905545/2208b767-9a65-4056-a487-7160dcb077b6)



### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
