### PR TITLE
set content type for list seeds json api

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -531,7 +531,10 @@ class list_seeds(delegate.page):
         lst = get_list_seeds(key)
         if not lst:
             raise web.notfound()
-        return delegate.RawText(formats.dump(lst, self.encoding))
+
+        return delegate.RawText(
+            formats.dump(lst, self.encoding), content_type=self.content_type
+        )
 
     def POST(self, key):
         site = web.ctx.site


### PR DESCRIPTION
<!-- What issue does this PR close? -->
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Noticed we weren't setting the content-type for the seeds api in lists.

Relevant urls
http://localhost:8080/people/openlibrary/lists/OL1L.json - currently sets correct content-type
http://localhost:8080/people/openlibrary/lists/OL1L/seeds.json - doesn't currently set correct content type

Prod urls:
https://openlibrary.org/people/raybb/lists/OL235745L.json - sets content type
https://openlibrary.org/people/raybb/lists/OL235745L/seeds.json - doesn't

This PR fixes that.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See lomo

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
https://www.loom.com/share/a02c06360ce5422595daf078e5c1f99f

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cclauss maybe since you're more on the backend side.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
