### PR TITLE
fix mybooks-dropper overflow

### DIFF
--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -9,8 +9,6 @@
 }
 
 .generic-dropper {
-  box-shadow: 0 0 0 1px @mid-grey;
-  border-radius: 4px;
   position: absolute;
   width: 100%;
   z-index: @z-index-level-14;
@@ -20,6 +18,9 @@
     flex-direction: row;
     align-items: stretch;
     cursor: pointer;
+    border-radius: 4px;
+    border: 1px solid @mid-grey;
+    overflow: hidden;
 
     * {
       color: @dark-grey;
@@ -33,27 +34,23 @@
 
       /* stylelint-disable max-nesting-depth */
       button {
-        border: 2px solid @grey-f3f3f3;
-        border-right: 1px solid @lighter-grey;
-        border-bottom-right-radius: 0;
-        border-top-right-radius: 0;
+        border: none;
         cursor: pointer;
         font-size: 1em;
+        height: 100%;
         width: 100%;
-        padding: 7px 0;
-        margin: 0;
       }
       /* stylelint-enable max-nesting-depth */
     }
     .generic-dropper__dropclick {
-      border-radius: 4px;
-      border-bottom-left-radius: 0;
-      border-top-left-radius: 0;
-      padding: 5px;
+      border-left: 1px solid @lighter-grey;
       text-decoration: none;
       height: inherit;
+      width: 40px;
 
       .display-flex();
+      justify-content: center;
+      align-items: center;
 
       /* stylelint-disable max-nesting-depth */
       h3 {
@@ -62,6 +59,7 @@
 
       .arrow {
         width: 23px;
+        height: 23px;
         background-image: url(/images/icons/icon_dropit.png);
         background-repeat: no-repeat;
         filter: grayscale(100%);

--- a/static/css/components/mybooks-dropper.less
+++ b/static/css/components/mybooks-dropper.less
@@ -46,6 +46,8 @@
 
 .generic-dropper__primary {
   .reading-log {
+    height: 100%;
+
     .activated-check {
       color: @green;
       margin-right: 2px;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It has been bothering me for a while that the want to read button looks funny in the corners of the button.

It looks like this:
<img width="975" alt="image" src="https://github.com/internetarchive/openlibrary/assets/921217/abb2844c-cccd-44c1-991e-83c473af6da1">

After my PR it looks like this:
<img width="965" alt="image" src="https://github.com/internetarchive/openlibrary/assets/921217/e0a347fc-e88b-426b-bc17-7075713f02fd">

PS: I set the width of the dropdown button to match the width of the listen button. But I'm not attached to that change.
<details>
  <summary>screenshot of listen button.</summary>
  
  
<img width="1001" alt="image" src="https://github.com/internetarchive/openlibrary/assets/921217/ccefa37b-1580-4274-b475-50d256c5a1a5">

  
</details>



### Technical
<!-- What should be noted about the implementation? -->
Had to move the border radius code one level down to be able to hide overflow.

Did a few more small css cleanups while I was in there.

I explain more in the demo video below.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
To see this change locally on search results you might need to enable `my_books_dropper` in `openlibrary.yml`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Demo and code walkthrough: https://www.loom.com/share/b571d2aefbf4443890f9a9a345f14646


### Stakeholders
<!-- @ tag stakeholders of this bug -->
Related to #8181 so I'll tag @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
