### PR TITLE
Added link for how to search in advanced search. Updated legacy.less …

### DIFF
--- a/openlibrary/templates/search/advancedsearch.html
+++ b/openlibrary/templates/search/advancedsearch.html
@@ -42,7 +42,8 @@
     </fieldset>
     <input type="submit" class="generic-button generic-button-primary" value="$_('Search')">
     <div class="searchPlus">
-      <a href="/search/inside">$_('Full Text Search')</a>?
+      <a href="https://openlibrary.org/search/howto">$_('How to search?')</a>
+      <a href="/search/inside">$_('Full Text Search?')</a>
     </div>
   </form>
 </div>

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -813,6 +813,10 @@ input.query {
   padding: 15px 0;
 }
 
+.searchPlus a{
+  margin-right: 20px;
+}
+
 /* DIALOGS */
 
 // openlibrary/macros/EditButtons.html


### PR DESCRIPTION
…to add margin between links already present there.

<!-- What issue does this PR close? -->
Closes #8400 Add "Open Library Search Tips" link to advanced search page

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
Added a link to 'howto' before 'Full text search' and updated corresponding css.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-10-17 19-08-04](https://github.com/internetarchive/openlibrary/assets/117163483/d54a64fb-605d-4d30-9efa-f5658f0b4ebc)

### Stakeholders
<!-- @RayBB -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
