### PR TITLE
Fix bulk tagging count update bug

### DIFF
--- a/openlibrary/plugins/openlibrary/js/initTaggingSearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/initTaggingSearchBar.js
@@ -43,9 +43,10 @@ function newSubjectRowHtml(subjectName, subjectType, workCount) {
 
     const workCountDiv = document.createElement('div');
     if (workCount > 1000) {
-        workCount.innerText = '1000+';
+        workCountDiv.innerText = 'works: 1000+';
+    } else {
+        workCountDiv.innerText = `works: ${workCount}`;
     }
-    workCountDiv.innerText = `works: ${workCount}`;
     workCountDiv.className = 'search-subject-work-count';
     subjectInfoDiv.appendChild(workCountDiv);
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8417

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that the `workCountDiv`'s innerText is being set when a subject has more than 1,000 works.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try adding a common subject to some works on testing.openlibrary.org

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
