### PR TITLE
Fix author not pre-filling on new work

### DIFF
--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -193,11 +193,17 @@ class addbook(delegate.page):
         if not self.has_permission():
             return safe_seeother(f"/account/login?redirect={self.path}")
 
-        i = web.input(work=None)
+        i = web.input(work=None, author=None)
         work = i.work and web.ctx.site.get(i.work)
+        author = i.author and web.ctx.site.get(i.author)
+
+        # pre-filling existing author(s) if adding new edition from existing work page
         authors = (work and work.authors) or []
         if work and authors:
             authors = [a.author for a in authors]
+        # pre-filling existing author if adding new work from author page
+        if author and author not in authors:
+            authors.append(author)
 
         return render_template(
             'books/add', work=work, authors=authors, recaptcha=get_recaptcha()


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8422 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prefills author name on add book page when adding a new work from the author page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Go to an author's page. Select 'Add another?'. Verify that the author's name is already included in the author field for the new work. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mheiman @lephemere 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
