### PR TITLE
i18n: install web.py and Babel globally

### DIFF
--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -10,6 +10,8 @@ RUN python -m pip install -r requirements_test.txt \
 # that causes headaches with su, cron, etc.
 USER root
 RUN ln -s /home/openlibrary/.local/bin/pytest /usr/local/bin/pytest
+# For i18n scripts, which run as root (to modify the host filesystem) and need these packages.
+RUN pip install $(grep -E 'web\.py==|Babel==' requirements.txt)
 USER openlibrary
 
 COPY --chown=openlibrary:openlibrary package*.json ./


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8002

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This adds a few packages globally to the local Docker development environment.

Obviously doubling packages is potentially pointless duplication, though it draws from the same source in `requirements.txt` and installs as few packages as possible.

This increases the size of `site-packages` on the development containers from 13 megabytes to 55 megabytes:
```
❯ docker compose run --rm -uroot home du -ch /usr/local/lib/python3.11/site-packages
...
55M total
```

Thoughts?

Before:
```
❯ docker compose run --rm -uroot home pip list                                                                                                                                                                                                                                              
WARN[0000] The "HOST" variable is not set. Defaulting to a blank string.                                                                                                                                                                                                                    
Package    Version                                                                                                                                                                                                                                                                          
---------- -------                                                                                                                                                                                                                                                                          
pip        22.3.1                                                                                                                                                                                                                                                                           
setuptools 65.5.1                                                                                                                                                                                                                                                                           
wheel      0.38.4    
```

After
```
❯ docker compose run --rm -uroot home pip list
WARN[0000] The "HOST" variable is not set. Defaulting to a blank string. 
Package          Version
---------------- -------
Babel            2.12.1
cheroot          10.0.0
jaraco.functools 3.9.0
more-itertools   10.1.0
pip              22.3.1
setuptools       65.5.1
web.py           0.62
wheel            0.38.4
```

That said, it does fix the issue:
```
❯ docker compose run --rm -uroot home ./scripts/i18n-messages update ja
WARN[0000] The "HOST" variable is not set. Defaulting to a blank string. 
Updating ['ja']
updated /openlibrary/openlibrary/i18n/ja/messages.po
compiled /openlibrary/openlibrary/i18n/ja/messages.po
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
`docker compose build`
`docker compose run --rm -uroot home ./scripts/i18n-messages update <language code>`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@cacaoMath


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
