### PR TITLE
Redesign TOC on books page

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "static/build/readmore.*.js",
-      "maxSize": "2KB"
+      "maxSize": "3KB"
     },
     {
       "path": "static/build/modal-links.*.js",
@@ -82,7 +82,7 @@
     },
     {
       "path": "static/build/page-book.css",
-      "maxSize": "13.5KB"
+      "maxSize": "14KB"
     },
     {
       "path": "static/build/page-edit.css",

--- a/openlibrary/macros/ReadMore.html
+++ b/openlibrary/macros/ReadMore.html
@@ -1,4 +1,2 @@
-$def with (label=None)
-
-<p class="$label read-more" tabindex="0"><a class="read-more-button" data-after=" &#9662">$_("Read more")</a></p>
-<p class="$label read-less hidden" tabindex="0"><a class="read-less-button" data-after=" &#9650">$_("Read less")</a></p>
+<button class="read-more__toggle read-more__toggle--more">$_("Read more") &#9662</button>
+<button class="read-more__toggle read-more__toggle--less">$_("Read less") &#9650</button>

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -2,6 +2,7 @@ $def with (edition, ocaid=None, highlighting=False, cls='', attrs='')
 
 $ table_of_contents = edition.get_table_of_contents()
 $if table_of_contents and len(table_of_contents) > 1:
+  $ min_level = min(chapter.level for chapter in table_of_contents)
   <div class="toc $cls" $:attrs>
     $for chapter in table_of_contents:
       $ is_link = chapter.pagenum and ocaid
@@ -11,7 +12,7 @@ $if table_of_contents and len(table_of_contents) > 1:
         $:cond(is_link, 'href="//archive.org/stream/%s#page/%s"' % (ocaid, chapter.pagenum))
         $:cond(is_link, 'data-ol-link-track="BookPage|TOCClick"')
         data-level="$chapter.level"
-        style="margin-left:$((chapter.level - 1) * 2)ch"
+        style="margin-left:$((chapter.level - min_level) * 2)ch"
       >
         <span class="toc__name">
           $ label = chapter.label

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -1,34 +1,32 @@
-$def with (edition, ocaid=None, highlighting=False, cls='', attrs='')
+$def with (table_of_contents, ocaid=None, highlighting=False, cls='', attrs='')
 
-$ table_of_contents = edition.get_table_of_contents()
-$if table_of_contents and len(table_of_contents) > 1:
-  $ min_level = min(chapter.level for chapter in table_of_contents)
-  <div class="toc $cls" $:attrs>
-    $for chapter in table_of_contents:
-      $ is_link = chapter.pagenum and ocaid
-      $ tag = 'a' if is_link else 'div'
-      <$tag
-        class="toc__entry"
-        $:cond(is_link, 'href="//archive.org/stream/%s#page/%s"' % (ocaid, chapter.pagenum))
-        $:cond(is_link, 'data-ol-link-track="BookPage|TOCClick"')
-        data-level="$chapter.level"
-        style="margin-left:$((chapter.level - min_level) * 2)ch"
-      >
-        <span class="toc__name">
-          $ label = chapter.label
-          $if label and not label.endswith('.'):
-            $ label = label.strip() + '. '
-          $if highlighting:
-            $# This isn't html injection, because solr returns everything
-            $# already html escaped except for the <em> of the highlight
-            $:label
-            $:chapter.title
-          $else:
-            $label
-            $chapter.title
-        </span>
-        $if chapter.pagenum:
-          <span class="toc__dots" style="flex:1; border-bottom: 1px dotted;"></span>
-          <span class="toc__pagenum">$_('Page %s', chapter.pagenum)</span>
-      </$tag>
-  </div>
+$ min_level = min(chapter.level for chapter in table_of_contents)
+<div class="toc $cls" $:attrs>
+  $for chapter in table_of_contents:
+    $ is_link = chapter.pagenum and ocaid
+    $ tag = 'a' if is_link else 'div'
+    <$tag
+      class="toc__entry"
+      $:cond(is_link, 'href="//archive.org/stream/%s#page/%s"' % (ocaid, chapter.pagenum))
+      $:cond(is_link, 'data-ol-link-track="BookPage|TOCClick"')
+      data-level="$chapter.level"
+      style="margin-left:$((chapter.level - min_level) * 2)ch"
+    >
+      <span class="toc__name">
+        $ label = chapter.label
+        $if label and not label.endswith('.'):
+          $ label = label.strip() + '. '
+        $if highlighting:
+          $# This isn't html injection, because solr returns everything
+          $# already html escaped except for the <em> of the highlight
+          $:label
+          $:chapter.title
+        $else:
+          $label
+          $chapter.title
+      </span>
+      $if chapter.pagenum:
+        <span class="toc__dots" style="flex:1; border-bottom: 1px dotted;"></span>
+        <span class="toc__pagenum">$_('Page %s', chapter.pagenum)</span>
+    </$tag>
+</div>

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -3,7 +3,7 @@ $def with (table_of_contents, ocaid=None, highlighting=False, cls='', attrs='')
 $ min_level = min(chapter.level for chapter in table_of_contents)
 <div class="toc $cls" $:attrs>
   $for chapter in table_of_contents:
-    $ is_link = chapter.pagenum and ocaid
+    $ is_link = ocaid and chapter.pagenum and chapter.pagenum.isdigit()
     $ tag = 'a' if is_link else 'div'
     <$tag
       class="toc__entry"

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -1,20 +1,33 @@
-$def with (edition, ocaid=None)
+$def with (edition, ocaid=None, highlighting=False, controls=True)
 
 $ table_of_contents = edition.get_table_of_contents()
 $if table_of_contents and len(table_of_contents) > 1:
-  <div class="section">
-    <h3 class="collapse">$_("Table of Contents")</h3>
-    <table class="meta sansserif" id="toc-table">
-      <tbody>
-        $for toc in table_of_contents:
-          <tr class="toc-level-$toc.level">
-            <td class="toc-label">$toc.label</td>
-              $if ocaid and toc.pagenum.isdigit():
-                <td class="toc-title"><a href="//archive.org/stream/$ocaid#page/$toc.pagenum" data-ol-link-track="BookPage|TOCClick">$toc.title</a></td>
-              $else:
-                <td class="toc-title">$toc.title</td>
-              <td class="toc-pagenum">$toc.pagenum</td>
-          </tr>
-      </tbody>
-    </table>
+  <div class="toc">
+    $for chapter in table_of_contents:
+      $ is_link = chapter.pagenum and ocaid
+      $ tag = 'a' if is_link else 'div'
+      <$tag
+        class="toc__entry"
+        $:cond(is_link, 'href="//archive.org/stream/%s#page/%s"' % (ocaid, chapter.pagenum))
+        $:cond(is_link, 'data-ol-link-track="BookPage|TOCClick"')
+        data-level="$chapter.level"
+        style="margin-left:$((chapter.level - 1) * 2)ch"
+      >
+        <span class="toc__name">
+          $ label = chapter.label
+          $if label and not label.endswith('.'):
+            $ label = label.strip() + '. '
+          $if highlighting:
+            $# This isn't html injection, because solr returns everything
+            $# already html escaped except for the <em> of the highlight
+            $:label
+            $:chapter.title
+          $else:
+            $label
+            $chapter.title
+        </span>
+        $if chapter.pagenum:
+          <span class="toc__dots" style="flex:1; border-bottom: 1px dotted;"></span>
+          <span class="toc__pagenum">$_('Page %s', chapter.pagenum)</span>
+      </$tag>
   </div>

--- a/openlibrary/macros/TableOfContents.html
+++ b/openlibrary/macros/TableOfContents.html
@@ -1,8 +1,8 @@
-$def with (edition, ocaid=None, highlighting=False, controls=True)
+$def with (edition, ocaid=None, highlighting=False, cls='', attrs='')
 
 $ table_of_contents = edition.get_table_of_contents()
 $if table_of_contents and len(table_of_contents) > 1:
-  <div class="toc">
+  <div class="toc $cls" $:attrs>
     $for chapter in table_of_contents:
       $ is_link = chapter.pagenum and ocaid
       $ tag = 'a' if is_link else 'div'

--- a/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
+++ b/openlibrary/plugins/openlibrary/js/edition-nav-bar/EditionNavBar.js
@@ -88,7 +88,8 @@ export default class EdtionNavBar {
         const navbarHeight = this.navbarWrapper.getBoundingClientRect().height
         if (navbarHeight > 0) {
             let i = this.navItems.length
-            while (--i > 0 && this.navbarWrapper.offsetTop + navbarHeight < this.targetAnchors[i].offsetTop) {}
+            // 10 is for a little bit of padding
+            while (--i > 0 && this.navbarWrapper.offsetTop + navbarHeight < (this.targetAnchors[i].offsetTop - 10)) {}
             if (i !== this.selectedIndex) {
                 this.selectedIndex = i
                 this.selectElement(this.navItems[i])

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -207,14 +207,14 @@ jQuery(function () {
         import(/* webpackChunkName: "realtime-account-validation" */'./realtime_account_validation.js')
             .then(module => module.initRealTimeValidation());
     }
-    // conditionally load readmore button based on class in the page
-    const readMoreButtons = document.getElementsByClassName('read-more-button');
+    // conditionally load clamping components
+    const readMoreComponents = document.getElementsByClassName('read-more');
     const clampers = document.querySelectorAll('.clamp');
-    if (readMoreButtons.length || clampers.length) {
+    if (readMoreComponents.length || clampers.length) {
         import(/* webpackChunkName: "readmore" */ './readmore.js')
             .then(module => {
-                if (readMoreButtons.length) {
-                    module.initReadMoreButton();
+                if (readMoreComponents.length) {
+                    module.ReadMoreComponent.init();
                 }
                 if (clampers.length) {
                     module.initClampers(clampers);

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -12,7 +12,8 @@ export class ReadMoreComponent {
         this.$readMoreButton = container.querySelector('.read-more__toggle--more');
         this.$readLessButton = container.querySelector('.read-more__toggle--less');
 
-        this.maxHeight = parseFloat(this.$content.style.height);
+        this.collapsedHeight = parseFloat(this.$content.style.height);
+        this.fullHeight = this.$content.scrollHeight;
     }
 
     attach() {
@@ -25,18 +26,19 @@ export class ReadMoreComponent {
 
     expand() {
         this.$container.classList.add('read-more--expanded');
-        this.$content.style.height = 'auto';
+        this.$content.style.height = `${this.fullHeight}px`;
     }
 
     collapse() {
         this.$container.classList.remove('read-more--expanded');
-        this.$content.style.height = `${this.maxHeight}px`;
+        this.$content.style.height = `${this.collapsedHeight}px`;
     }
 
     reset() {
+        this.fullHeight = this.$content.scrollHeight;
         // Fudge factor to account for non-significant read/more
         // (e.g missing a bit of padding)
-        if (this.$content.scrollHeight <= (this.maxHeight + 1)) {
+        if (this.$content.scrollHeight <= (this.collapsedHeight + 1)) {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -12,7 +12,7 @@ export class ReadMoreComponent {
         this.$readMoreButton = container.querySelector('.read-more__toggle--more');
         this.$readLessButton = container.querySelector('.read-more__toggle--less');
 
-        this.collapsedHeight = parseFloat(this.$content.style.height);
+        this.collapsedHeight = parseFloat(this.$content.style.maxHeight);
         this.fullHeight = this.$content.scrollHeight;
     }
 
@@ -26,12 +26,12 @@ export class ReadMoreComponent {
 
     expand() {
         this.$container.classList.add('read-more--expanded');
-        this.$content.style.height = `${this.fullHeight}px`;
+        this.$content.style.maxHeight = `${this.fullHeight}px`;
     }
 
     collapse() {
         this.$container.classList.remove('read-more--expanded');
-        this.$content.style.height = `${this.collapsedHeight}px`;
+        this.$content.style.maxHeight = `${this.collapsedHeight}px`;
     }
 
     reset() {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -32,6 +32,13 @@ export class ReadMoreComponent {
     readLessClick = () => {
         this.collapse();
         this.manuallyExpanded = false;
+        // scroll top of the read-more container into view if the top is not visible
+        if (this.$container.getBoundingClientRect().top < 0) {
+            this.$container.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+            });
+        }
     }
 
     expand() {

--- a/openlibrary/plugins/openlibrary/js/readmore.js
+++ b/openlibrary/plugins/openlibrary/js/readmore.js
@@ -17,11 +17,21 @@ export class ReadMoreComponent {
     }
 
     attach() {
-        this.$readMoreButton.addEventListener('click', () => this.expand());
-        this.$readLessButton.addEventListener('click', () => this.collapse());
+        this.$readMoreButton.addEventListener('click', this.readMoreClick);
+        this.$readLessButton.addEventListener('click', this.readLessClick);
         window.addEventListener('resize', debounce(() => this.reset()), 50);
 
         this.reset();
+    }
+
+    readMoreClick = () => {
+        this.expand();
+        this.manuallyExpanded = true;
+    }
+
+    readLessClick = () => {
+        this.collapse();
+        this.manuallyExpanded = false;
     }
 
     expand() {
@@ -42,7 +52,11 @@ export class ReadMoreComponent {
             this.expand();
             this.$container.classList.add('read-more--unnecessary');
         } else {
-            this.collapse();
+            // Don't collapse if the user has manually expanded. Fixes
+            // issue where user e.g. presses ctrl-f, triggering a resize
+            if (!this.manuallyExpanded) {
+                this.collapse();
+            }
             this.$container.classList.remove('read-more--unnecessary');
         }
     }

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -38,6 +38,15 @@ $def with (page)
           -webkit-line-clamp: unset !important;
         }
 
+        /* Don't show read-more sections collapsed */
+        .read-more__content {
+          height: auto !important;
+        }
+        /* Don't show read-more toggle buttons */
+        .read-more__toggle {
+          display: none !important;
+        }
+
         /* @width-breakpoint-tablet media query: */
         @media only screen and (min-width: 768px) {
           /* Sticky navbar to top of screen if compact title cannot be stickied */

--- a/openlibrary/templates/site/head.html
+++ b/openlibrary/templates/site/head.html
@@ -40,7 +40,7 @@ $def with (page)
 
         /* Don't show read-more sections collapsed */
         .read-more__content {
-          height: auto !important;
+          max-height: unset !important;
         }
         /* Don't show read-more toggle buttons */
         .read-more__toggle {

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -243,7 +243,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $else:
           $ overview_desc = work.description
         <div class="book-description read-more">
-            <div class="read-more__content" style="height:58px">
+            <div class="read-more__content" style="max-height:58px">
                 $:sanitize(format(overview_desc))
             </div>
             $:macros.ReadMore()
@@ -375,7 +375,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             <div class="section read-more">
               <h3>$_("Table of Contents")</h3>
               $ component_times['TableOfContents'] = time()
-              $:macros.TableOfContents(table_of_contents, ocaid, cls='read-more__content', attrs='style="height:350px"')
+              $:macros.TableOfContents(table_of_contents, ocaid, cls='read-more__content', attrs='style="max-height:350px"')
               $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
               $:macros.ReadMore()
             </div>
@@ -468,7 +468,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             $if work.description and work.description != overview_desc:
               <h4>$_("Work Description")</h4>
               <div class="work-description read-more">
-                <div class="read-more__content" style="height:58px">
+                <div class="read-more__content" style="max-height:58px">
                   $:sanitize(format(work.description))
                 </div>
                 $:macros.ReadMore()

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -370,13 +370,15 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             <p>"$(edition.first_sentence)"</p>
             </div>
 
-          <div class="section read-more">
-            <h3>$_("Table of Contents")</h3>
-            $ component_times['TableOfContents'] = time()
-            $:macros.TableOfContents(edition, ocaid, cls='read-more__content', attrs='style="height:350px"')
-            $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
-            $:macros.ReadMore()
-          </div>
+          $ table_of_contents = edition.get_table_of_contents()
+          $if table_of_contents and len(table_of_contents) > 1:
+            <div class="section read-more">
+              <h3>$_("Table of Contents")</h3>
+              $ component_times['TableOfContents'] = time()
+              $:macros.TableOfContents(table_of_contents, ocaid, cls='read-more__content', attrs='style="height:350px"')
+              $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
+              $:macros.ReadMore()
+            </div>
 
           $if edition.notes or edition.series or edition.volume or edition.genres or edition.other_titles or edition.copyright_date or edition.translation_of or edition.translated_from:
             <div class="section">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -370,9 +370,12 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             <p>"$(edition.first_sentence)"</p>
             </div>
 
-          $ component_times['TableOfContents'] = time()
-          $:macros.TableOfContents(edition, ocaid)
-          $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
+          <div class="section">
+            <h3>$_("Table of Contents")</h3>
+            $ component_times['TableOfContents'] = time()
+            $:macros.TableOfContents(edition, ocaid)
+            $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
+          </div>
 
           $if edition.notes or edition.series or edition.volume or edition.genres or edition.other_titles or edition.copyright_date or edition.translation_of or edition.translated_from:
             <div class="section">

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -242,11 +242,11 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
           $ overview_desc = edition.description
         $else:
           $ overview_desc = work.description
-        <div class="book-description">
-            <div class="book-description-content restricted-view">
+        <div class="book-description read-more">
+            <div class="read-more__content" style="height:58px">
                 $:sanitize(format(overview_desc))
             </div>
-            $:macros.ReadMore("book-description")
+            $:macros.ReadMore()
         </div>
       $elif edition:
         <div class="book-description">
@@ -370,11 +370,12 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             <p>"$(edition.first_sentence)"</p>
             </div>
 
-          <div class="section">
+          <div class="section read-more">
             <h3>$_("Table of Contents")</h3>
             $ component_times['TableOfContents'] = time()
-            $:macros.TableOfContents(edition, ocaid)
+            $:macros.TableOfContents(edition, ocaid, cls='read-more__content', attrs='style="height:350px"')
             $ component_times['TableOfContents'] = time() - component_times['TableOfContents']
+            $:macros.ReadMore()
           </div>
 
           $if edition.notes or edition.series or edition.volume or edition.genres or edition.other_titles or edition.copyright_date or edition.translation_of or edition.translated_from:
@@ -464,11 +465,11 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
             $if work.description and work.description != overview_desc:
               <h4>$_("Work Description")</h4>
-              <div class="work-description">
-                <div class="work-description-content restricted-view">
+              <div class="work-description read-more">
+                <div class="read-more__content" style="height:58px">
                   $:sanitize(format(work.description))
                 </div>
-                $:macros.ReadMore('work-description')
+                $:macros.ReadMore()
               </div>
 
             $if work.original_languages:

--- a/static/css/base/helpers-common.less
+++ b/static/css/base/helpers-common.less
@@ -51,14 +51,6 @@
   left: -10000px !important;
 }
 
-.read-more-button, .read-less-button {
-  cursor: pointer;
-  color: @link-blue;
-}
-.read-more-button::after, .read-less-button::after {
-  content: attr(data-after);
-}
-
 a.hoverlink {
   text-decoration: underline;
   text-decoration-style: dotted;

--- a/static/css/components/header.less
+++ b/static/css/components/header.less
@@ -2,11 +2,21 @@
 @import (less) "components/iaBar.less";
 @import (less) "components/page-banner.less";
 
+// Mobile
+html {
+  // Take into account sticky header bar
+  scroll-padding-top: 60px;
+}
+
+// Tablet
 @media only screen and (min-width: @width-breakpoint-tablet) {
   @import (less) "components/header-bar--tablet.less";
   @import (less) "components/page-banner--tablet.less";
+  html { scroll-padding-top: 70px; }
 }
 
+// Desktop
 @media all and ( min-width: @width-breakpoint-desktop ) {
   @import (less) "components/header-bar--desktop.less";
+  html { scroll-padding-top: 0; }
 }

--- a/static/css/components/read-more.less
+++ b/static/css/components/read-more.less
@@ -1,0 +1,39 @@
+@import (reference) "../less/z-index.less";
+
+.read-more {
+  z-index: @z-index-level-1;
+
+  .read-more__content {
+    overflow: hidden;
+  }
+
+  &.read-more--expanded {
+    .read-more__toggle--more {
+      display: none;
+    }
+  }
+
+  &:not(.read-more--expanded) {
+    .read-more__toggle--less {
+      display: none;
+    }
+  }
+
+  &.read-more--unnecessary .read-more__toggle {
+    display: none;
+  }
+
+  .read-more__toggle {
+    cursor: pointer;
+    color: @link-blue;
+    // Reset button
+    background: transparent;
+    border: 0;
+    font-family: inherit;
+
+    @media only screen and (max-width: @width-breakpoint-desktop) {
+      text-align: center;
+      width: 100%;
+    }
+  }
+}

--- a/static/css/components/read-more.less
+++ b/static/css/components/read-more.less
@@ -19,10 +19,6 @@
     }
   }
 
-  &.read-more--unnecessary .read-more__toggle {
-    display: none;
-  }
-
   .read-more__toggle {
     cursor: pointer;
     color: @link-blue;
@@ -30,10 +26,16 @@
     background: transparent;
     border: 0;
     font-family: inherit;
+    width: 100%;
+    padding: 10px;
+    text-align: left;
 
     @media only screen and (max-width: @width-breakpoint-desktop) {
       text-align: center;
-      width: 100%;
     }
+  }
+
+  &.read-more--unnecessary .read-more__toggle {
+    display: none;
   }
 }

--- a/static/css/components/read-more.less
+++ b/static/css/components/read-more.less
@@ -6,7 +6,7 @@
 
   .read-more__content {
     overflow: hidden;
-    transition: height .2s ease-in-out;
+    transition: max-height .2s ease-in-out;
   }
 
   .read-more__toggle {

--- a/static/css/components/read-more.less
+++ b/static/css/components/read-more.less
@@ -12,13 +12,17 @@
   .read-more__toggle {
     cursor: pointer;
     color: @link-blue;
+
     // Reset button
     border: 0;
-    font-family: inherit;
+    font: inherit;
+
     width: 100%;
     padding: 10px;
     text-align: left;
-    background: linear-gradient(transparent 0, @white 10px);
+    // Note: we use a white with opacity=0 because Safari otherwise
+    // transitions the gradient from white through grey to transparent.
+    background: linear-gradient(rgba(255,255,255,0) 0, @white 10px);
     padding-top: 15px;
 
     @media only screen and (max-width: @width-breakpoint-desktop) {

--- a/static/css/components/read-more.less
+++ b/static/css/components/read-more.less
@@ -1,10 +1,43 @@
 @import (reference) "../less/z-index.less";
+@import (reference) "../less/colors.less";
 
 .read-more {
   z-index: @z-index-level-1;
 
   .read-more__content {
     overflow: hidden;
+    transition: height .2s ease-in-out;
+  }
+
+  .read-more__toggle {
+    cursor: pointer;
+    color: @link-blue;
+    // Reset button
+    border: 0;
+    font-family: inherit;
+    width: 100%;
+    padding: 10px;
+    text-align: left;
+    background: linear-gradient(transparent 0, @white 10px);
+    padding-top: 15px;
+
+    @media only screen and (max-width: @width-breakpoint-desktop) {
+      text-align: center;
+    }
+  }
+
+  &.read-more--unnecessary .read-more__toggle {
+    display: none;
+  }
+
+  .read-more__toggle--more {
+    margin-top: -10px;
+  }
+
+  // Make the read less button easy to find after expanding
+  .read-more__toggle--less {
+    position: sticky;
+    bottom: 0;
   }
 
   &.read-more--expanded {
@@ -17,25 +50,5 @@
     .read-more__toggle--less {
       display: none;
     }
-  }
-
-  .read-more__toggle {
-    cursor: pointer;
-    color: @link-blue;
-    // Reset button
-    background: transparent;
-    border: 0;
-    font-family: inherit;
-    width: 100%;
-    padding: 10px;
-    text-align: left;
-
-    @media only screen and (max-width: @width-breakpoint-desktop) {
-      text-align: center;
-    }
-  }
-
-  &.read-more--unnecessary .read-more__toggle {
-    display: none;
   }
 }

--- a/static/css/components/toc.less
+++ b/static/css/components/toc.less
@@ -1,0 +1,48 @@
+@import (reference) "../less/breakpoints.less";
+@import (reference) "../less/colors.less";
+
+.toc__entry {
+  border-radius: 4px;
+  padding: 3px 8px;
+  @media only screen and (hover: none) {
+    padding: 6px 8px; /* Increase padding for touch-only devices */
+  }
+  display: flex;
+  gap: 4px;
+  line-height: 1.2em;
+  transition: background-color .2s;
+
+  em {
+    font-weight: bold;
+  }
+}
+
+a.toc__entry {
+  text-decoration: none;
+  .toc__name {
+    text-decoration: underline;
+  }
+  &:hover {
+    background: rgba(0, 124, 255, .2);
+  }
+}
+
+.toc__pagenum {
+  white-space: nowrap;
+}
+
+@media (max-width: @width-breakpoint-mobile) {
+  .toc__entry {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .toc__dots {
+    display: none;
+  }
+
+  .toc__pagenum {
+    font-size: .9em;
+    color: @accessible-grey;
+  }
+}

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -146,7 +146,6 @@ h3.edition-header {
 }
 
 a.section-anchor {
-  scroll-margin-top: 70px;
   height: 20px;
   display: block;
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -118,14 +118,41 @@ div.editionAbout {
   content: attr(data-before);
 }
 
-.restricted-view{
-  display: block;
+.read-more {
   z-index: @z-index-level-1;
-}
 
-.restricted-height{
-  overflow: hidden;
-  height: 57px;
+  .read-more__content {
+    overflow: hidden;
+  }
+
+  &.read-more--expanded {
+    .read-more__toggle--more { display: none; }
+  }
+
+  &:not(.read-more--expanded) {
+    .read-more__toggle--less {
+      display: none;
+    }
+  }
+
+  &.read-more--unnecessary .read-more__toggle {
+    display: none;
+  }
+
+  .read-more__toggle {
+    cursor: pointer;
+    color: @link-blue;
+    // Reset button
+    background: transparent;
+    border: 0;
+    font-family: inherit;
+
+    @media only screen and (max-width: @width-breakpoint-desktop) {
+      text-align: center;
+      width: 100%;
+    }
+  }
+
 }
 
 .section, .section h6 {
@@ -318,16 +345,8 @@ div.editionTools {
   color: @link-blue;
 }
 @media only screen and (max-width: @width-breakpoint-desktop){
-  div.editionAbout {
-    /* stylelint-disable selector-max-specificity */
-    .book-description.read-more,
-    .book-description.read-less {
-      text-align: center;
-    }
-    .book-description {
-      padding-top: 1em;
-    }
-    /* stylelint-enable selector-max-specificity */
+  div.editionAbout .book-description {
+    padding-top: 1em;
   }
 }
 

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -118,43 +118,6 @@ div.editionAbout {
   content: attr(data-before);
 }
 
-.read-more {
-  z-index: @z-index-level-1;
-
-  .read-more__content {
-    overflow: hidden;
-  }
-
-  &.read-more--expanded {
-    .read-more__toggle--more { display: none; }
-  }
-
-  &:not(.read-more--expanded) {
-    .read-more__toggle--less {
-      display: none;
-    }
-  }
-
-  &.read-more--unnecessary .read-more__toggle {
-    display: none;
-  }
-
-  .read-more__toggle {
-    cursor: pointer;
-    color: @link-blue;
-    // Reset button
-    background: transparent;
-    border: 0;
-    font-family: inherit;
-
-    @media only screen and (max-width: @width-breakpoint-desktop) {
-      text-align: center;
-      width: 100%;
-    }
-  }
-
-}
-
 .section, .section h6 {
   font-size: .8em;
 }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1294,30 +1294,6 @@ div.books {
   }
 }
 
-td {
-  // openlibrary/templates/type/edition/view.html
-  &.toc-label {
-    white-space: pre-wrap;
-  }
-  // openlibrary/templates/type/edition/view.html
-  &.toc-pagenum {
-    text-align: right;
-  }
-}
-
-tr {
-  &.toc-level-2 {
-    td.toc-label {
-      padding-left: 15px !important;
-    }
-  }
-  &.toc-level-3 {
-    td.toc-label {
-      padding-left: 30px !important;
-    }
-  }
-}
-
 #tabsAdd {
   // openlibrary/templates/books/edit.html
   &book {

--- a/static/css/page-book.less
+++ b/static/css/page-book.less
@@ -34,6 +34,22 @@
 @import (less) "components/buttonBtn.less";
 @import (less) "components/modal-links.less";
 
+// Mobile
+html {
+  // Take into account the header bar + tab bar
+  scroll-padding-top: 100px;
+
+  // Tablet
+  @media only screen and (min-width: @width-breakpoint-tablet) {
+    scroll-padding-top: 110px;
+  }
+
+  // Desktop
+  @media all and ( min-width: @width-breakpoint-desktop ) {
+    scroll-padding-top: 0;
+  }
+}
+
 @media only screen and (min-width: @width-breakpoint-tablet) {
   @import (less) "components/edit-toolbar--tablet.less";
 }

--- a/static/css/page-book.less
+++ b/static/css/page-book.less
@@ -28,6 +28,7 @@
 @import (less) "components/donate.less";
 
 @import (less) "components/metadata-form.less";
+@import (less) "components/toc.less";
 @import (less) "components/observationStats.less";
 @import (less) "components/buttonBtn.less";
 @import (less) "components/modal-links.less";

--- a/static/css/page-book.less
+++ b/static/css/page-book.less
@@ -27,6 +27,7 @@
 @import (less) "components/editions.less";
 @import (less) "components/donate.less";
 
+@import (less) "components/read-more.less";
 @import (less) "components/metadata-form.less";
 @import (less) "components/toc.less";
 @import (less) "components/observationStats.less";

--- a/tests/unit/js/readmore.test.js
+++ b/tests/unit/js/readmore.test.js
@@ -26,7 +26,7 @@ describe('ReadMoreComponent', () => {
         readMore.reset();
         expect(readMore.$container.classList.contains('read-more--unnecessary')).toBe(false);
         expect(readMore.$container.classList.contains('read-more--expanded')).toBe(false);
-        expect(readMore.$content.style.height).not.toBe('auto');
+        expect(readMore.$content.style.height).toBe('40px');
     });
 
     test('expanded if small scroll height', () => {
@@ -34,7 +34,7 @@ describe('ReadMoreComponent', () => {
         readMore.reset();
         expect(readMore.$container.classList.contains('read-more--unnecessary')).toBe(true);
         expect(readMore.$container.classList.contains('read-more--expanded')).toBe(true);
-        expect(readMore.$content.style.height).toBe('auto');
+        expect(readMore.$content.style.height).not.toBe('40px');
     });
 });
 

--- a/tests/unit/js/readmore.test.js
+++ b/tests/unit/js/readmore.test.js
@@ -9,7 +9,7 @@ describe('ReadMoreComponent', () => {
         readMore = new ReadMoreComponent(
             $(`
                 <div class="read-more">
-                    <div class="read-more__content" style="height:40px">
+                    <div class="read-more__content" style="max-height:40px">
                     </div>
                 </div>
             `)
@@ -26,7 +26,7 @@ describe('ReadMoreComponent', () => {
         readMore.reset();
         expect(readMore.$container.classList.contains('read-more--unnecessary')).toBe(false);
         expect(readMore.$container.classList.contains('read-more--expanded')).toBe(false);
-        expect(readMore.$content.style.height).toBe('40px');
+        expect(readMore.$content.style.maxHeight).toBe('40px');
     });
 
     test('expanded if small scroll height', () => {
@@ -34,7 +34,7 @@ describe('ReadMoreComponent', () => {
         readMore.reset();
         expect(readMore.$container.classList.contains('read-more--unnecessary')).toBe(true);
         expect(readMore.$container.classList.contains('read-more--expanded')).toBe(true);
-        expect(readMore.$content.style.height).not.toBe('40px');
+        expect(readMore.$content.style.maxHeight).not.toBe('40px');
     });
 });
 

--- a/tests/unit/js/readmore.test.js
+++ b/tests/unit/js/readmore.test.js
@@ -1,23 +1,40 @@
-import { initClampers, resetReadMoreButtons } from '../../../openlibrary/plugins/openlibrary/js/readmore';
+import { initClampers, ReadMoreComponent } from '../../../openlibrary/plugins/openlibrary/js/readmore';
 import {clamperSample} from './html-test-data'
 
-describe('resetReadMoreButtons', () => {
-    const $dummyEl = $('<div class="a-parent"><div class="restricted-view"></div></div>');
-    $dummyEl.appendTo(document.body);
+describe('ReadMoreComponent', () => {
+    /** @type {ReadMoreComponent} */
+    let readMore;
 
-    test('restricted view if big scroll height', () => {
-        const restrictedViewEl = $dummyEl.find('.restricted-view')[0];
-        jest.spyOn(restrictedViewEl, 'scrollHeight', 'get').mockImplementation(() => 100);
-        resetReadMoreButtons();
-        expect(restrictedViewEl.classList.contains('restricted-height')).toBe(true);
+    beforeEach(() => {
+        readMore = new ReadMoreComponent(
+            $(`
+                <div class="read-more">
+                    <div class="read-more__content" style="height:40px">
+                    </div>
+                </div>
+            `)
+                .appendTo(document.body)[0]
+        );
     });
 
-    test('no restricted view if small scroll height', () => {
-        const restrictedViewEl = $dummyEl.find('.restricted-view')[0];
-        jest.spyOn(restrictedViewEl, 'scrollHeight', 'get').mockImplementation(() => 50);
-        resetReadMoreButtons();
-        expect(restrictedViewEl.classList.contains('restricted-height')).toBe(false);
-        $dummyEl.remove();
+    afterEach(() => {
+        readMore.$container.remove();
+    });
+
+    test('collapsed if big scroll height', () => {
+        jest.spyOn(readMore.$content, 'scrollHeight', 'get').mockImplementation(() => 100);
+        readMore.reset();
+        expect(readMore.$container.classList.contains('read-more--unnecessary')).toBe(false);
+        expect(readMore.$container.classList.contains('read-more--expanded')).toBe(false);
+        expect(readMore.$content.style.height).not.toBe('auto');
+    });
+
+    test('expanded if small scroll height', () => {
+        jest.spyOn(readMore.$content, 'scrollHeight', 'get').mockImplementation(() => 30);
+        readMore.reset();
+        expect(readMore.$container.classList.contains('read-more--unnecessary')).toBe(true);
+        expect(readMore.$container.classList.contains('read-more--expanded')).toBe(true);
+        expect(readMore.$content.style.height).toBe('auto');
     });
 });
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6171 

Feature. Redesign table of contents to be easier to read and better match our design aesthetic.


### Technical
- refactor read-more component to support customizeable height
- read-more component now animates
- read-more component not doesn't cause as big a page-shift since it begins with the content collapsed

### Testing
- ✅ Books with TOC:
    - https://testing.openlibrary.org/books/OL7596598M/Digital_Photography
    - https://testing.openlibrary.org/books/OL27371038M
    - https://testing.openlibrary.org/books/OL26234146M
- ✅ Books without TOC: 
    - https://testing.openlibrary.org/works/OL25312237W/Control_Your_Mind_and_Master_Your_Feelings

### Screenshot
| Before | After |
| ------- | ------- |
| ![image](https://github.com/internetarchive/openlibrary/assets/6251786/e1f8c427-ecb6-45c7-b0b4-7270543ed33b) | ![image](https://github.com/internetarchive/openlibrary/assets/6251786/e7c4582a-47d8-44ec-806f-4253d74143e6) |
| ![image](https://github.com/internetarchive/openlibrary/assets/6251786/ed2dc0ef-3261-4c26-974b-1a2549c55bd3) | ![image](https://github.com/internetarchive/openlibrary/assets/6251786/3861b793-0ef7-484d-987c-4a6f6eae387c) |




### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
