### PR TITLE
Add daily PR slack digest for staff PRs

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -127,6 +127,8 @@ services:
     user: root
     command: docker/ol-cron-start.sh
     restart: unless-stopped
+    env_file:
+      - ../olsystem/etc/cron-jobs.env
     volumes:
       - ../olsystem/etc/cron.d/openlibrary.ol_home0:/etc/cron.d/openlibrary.ol_home0:ro
       - ../olsystem:/olsystem

--- a/scripts/pr_slack_digest.py
+++ b/scripts/pr_slack_digest.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+import requests
+import os
+
+
+def send_slack_message(message: str):
+    response = requests.post(
+        'https://slack.com/api/chat.postMessage',
+        headers={
+            'Authorization': f"Bearer {os.environ.get('SLACK_TOKEN')}",
+            'Content-Type': 'application/json;  charset=utf-8',
+        },
+        json={
+            'channel': '#team-abc-plus',
+            'text': message,
+        },
+    )
+    if response.status_code != 200:
+        print(f"Failed to send message to Slack. Status code: {response.status_code}")
+    else:
+        print("Message sent to Slack successfully!")
+        print(response.content)
+
+
+if __name__ == "__main__":
+    GH_LOGIN_TO_SLACK = {
+        'cdrini': '<@cdrini>',
+        'jimchamp': '<@U01ARTHG9EV>',
+        'mekarpeles': '<@mek>',
+        'scottbarnes': '<@U03MNR6T7FH>',
+    }
+    LABEL_EMOJI = {
+        'Priority: 0': '🚨 ',
+        'Priority: 1': '❗️ ',
+    }
+    # apparently `author` acts like an OR in this API and only this API -_-
+    query = "repo:internetarchive/openlibrary is:open is:pr author:cdrini author:jimchamp author:mekarpeles author:scottbarnes -is:draft"
+    prs = requests.get(
+        "https://api.github.com/search/issues",
+        params={
+            "q": query,
+        },
+    ).json()["items"]
+
+    message = f"{len(prs)} open staff PRs:\n\n"
+    for pr in prs:
+        pr_url = pr['html_url']
+        pr_age_days = (
+            datetime.now() - datetime.strptime(pr['created_at'], '%Y-%m-%dT%H:%M:%SZ')
+        ).days
+        message += f"<{pr_url}|#{pr['number']}>: {pr['title']}\n"
+        message += ' | '.join(
+            [
+                f"by {pr['user']['login']} {pr_age_days} days ago",
+                f"Assigned: {GH_LOGIN_TO_SLACK[pr['assignee']['login']] if pr['assignee'] else '⚠️ None'}",
+                f"{', '.join(LABEL_EMOJI.get(label['name'], '') + label['name'] for label in pr['labels'])}\n\n",
+            ]
+        )
+
+    send_slack_message(message)


### PR DESCRIPTION
One of the pieces of feedback we went through was the staff PRs tend to often get stuck for long periods of time. To attempt to rectify this let's try a daily digest of staff PRs!

Note although all PRs would in theory be useful, there are just too many for a daily digest to help there.


### Technical
- Corresponding olsystem changes: https://github.com/internetarchive/olsystem/pull/190

### Testing
I've tested the script but not the cron-linking

### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/6251786/6d102a9b-97fa-4e5d-b4ca-2d9bbb7289ca)


### Stakeholders

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
