### PR TITLE
Add shift+click selection support

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -125,7 +125,7 @@ export default class SelectionManager {
      * @param {HTMLElement} clicked
      * @return {JQuery<HTMLElement>}
      */
-    getSiblingSet(clicked) {
+    getSelectableRange(clicked) {
         const lastParents = $(this.lastClicked).parents();
         const clickedParents = $(clicked).parents();
         let commonParent = undefined;

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -128,12 +128,11 @@ export default class SelectionManager {
         const lastParents = $(this.lastClicked).parents();
         const clickedParents = $(clicked).parents();
         let commonParent = undefined;
-        for (let i = 0; i < lastParents.length; i++) {
+        for (let i = 0; i < 2 && i < lastParents.length; i++) {
             if (clickedParents.is(lastParents[i])) {
                 commonParent = lastParents[i];
                 break;
             }
-            if (i > 1) { break; }
         }
         if (commonParent) {
             return $(commonParent).find('.ile-selectable');

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -123,6 +123,7 @@ export default class SelectionManager {
      * clicked element and generating a set of siblings from that information
      *
      * @param {HTMLElement} clicked
+     * @return {JQuery<HTMLElement>}
      */
     getSiblingSet(clicked) {
         const lastParents = $(this.lastClicked).parents();

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -154,8 +154,7 @@ export default class SelectionManager {
         const olid = provider.data(el);
         const img_src = this.getType(olid)?.image(olid);
 
-        if ((forceSelected === true && isCurSelected) || (forceSelected === false && !isCurSelected)) return;
-        this.setElementSelectionAttributes(el, !isCurSelected);
+        this.setElementSelectionAttributes(el, forceSelected == null ? !isCurSelected : forceSelected);
         if (isCurSelected) {
             this.removeSelectedItem(olid);
             const img_el = $('#ile-drag-status .images img').toArray().find(el => el.src === img_src);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8212

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR implements support for using shift+click to select/deselect ranges of items in the ILE.

There are different models for how shift+click selection works in interfaces, particularly with regard to how intermediate toggled items are handled; e.g. If a list is unselected except for item 3, and you click on 1 to select it and then shift+click on 5 to extend the selection, does 3 switch states or remain selected? I judged that the most common use case would be selecting or deselecting all the items in a range, and implemented accordingly.

The shift+click function requires two clicks, one to establish the starting point and the action (select/deselect) and one (with the shift key) to indicate the end of the range. Ranges may be selected in either direction. If the shifted click is a different action than the previous click, no range will be set (e.g. item 5 is already selected; you click to select item 1, then shift+click to deselect item 5. Only item 5 is affected)

Because the ILE remembers selections, a user might load a list that already has item 1 selected, and attempt to shift+click on item 5 to extend the range. Accommodating that use case introduces the possibility of other unwanted behaviors, so I did not address it.

### Technical
Lists of selectable items in OL don't follow any consistent HTML pattern, so in order to determine the range of selectable items on various pages, I've had to do some on-the-fly tree traversal. It works in all current contexts, and probably will in any new ones that show up.

Shift+clicking on a web page often triggers extended text selections which are unwelcome in this context. It's possible to disable text selection altogether, but that's obviously not appropriate. After some lengthy searching, I was unable to come up with a solution that worked cross-browser to disable selections only in a shift+click context. As a second-best solution, this code clears any text selections that are accidentally created. You may see a brief flash of the selection in the interface.

### Testing
This should be tested in the following contexts:
Author pages ( /OL18319A/Mark_Twain )
Work pages ( /books/OL7652865M/Adventures_of_Tom_Sawyer_(Webster's_French_Thesaurus_Edition )
Book search ( /search?q=a )
Author search ( /search/authors?q=t* )

### Stakeholders
@cdrini @mheiman
