### PR TITLE
Change white-space to normal and text align center

### DIFF
--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -127,7 +127,6 @@ a.cta-btn {
 }
 
 .waitinglist-message {
-  white-space: normal;
   text-align: center;
 }
 

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -127,7 +127,8 @@ a.cta-btn {
 }
 
 .waitinglist-message {
-  white-space: nowrap;
+  white-space: normal;
+  text-align: center;
 }
 
 .cta-button-group {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8376

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Changed `white-space` to normal, but we could omit the attribute all together. `text-align` centered was just because everything else in that container is centered but I'm not hip to the design principles. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I've been unable to replicate a waiting list in my local environment. I know borrowing is not possible in the local environment but not sure if I'm missing any contributor docs to mock the waiting list info or force it in the local db. It's a fairly small change so I checked against the prod site for now

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
This is on the live prod site, using Firefox developer tools to toggle / change `waitinglist-message`.

Before:
<img width="1049" alt="image" src="https://github.com/internetarchive/openlibrary/assets/7049943/341951e7-ebb2-4cc0-9636-d93324c6f406">

After:
<img width="1049" alt="image" src="https://github.com/internetarchive/openlibrary/assets/7049943/93720240-bce6-4e06-8c10-439cf7c304d2">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
