### PR TITLE
Submit bulk tag updates asynchronously

### DIFF
--- a/openlibrary/plugins/openlibrary/js/initTaggingSearchBar.js
+++ b/openlibrary/plugins/openlibrary/js/initTaggingSearchBar.js
@@ -1,4 +1,5 @@
 import { debounce } from './nonjquery_utils';
+import { FadingToast } from './Toast'
 
 const subjectTypeColors = {
     subject: 'subject-blue',
@@ -121,6 +122,35 @@ export function initSubjectTagsSearchBox() {
         const searchTerm = this.value.trim();
         debouncedFetchSubjects(searchTerm);
     });
+
+    const submitButton = document.querySelector('.bulk-tagging-submit')
+    submitButton.addEventListener('click', (event) => {
+        event.preventDefault()
+        submitBatch()
+    })
+}
+
+function submitBatch() {
+    const bulkTaggingForm = document.querySelector('.bulk-tagging-form')
+    const url = bulkTaggingForm.action
+    const formData = new FormData(bulkTaggingForm)
+
+    fetch(url, {
+        method: 'post',
+        body: formData
+    })
+        .then(response => {
+            if (!response.ok) {
+                // XXX : Is a persistant toast message better for failure cases?
+                new FadingToast('Batch subject update failed. Please try again in a few minutes.').show()
+            } else {
+                hideTaggingMenu()
+                resetTaggingMenu()
+                new FadingToast('Subjects successfully updated.').show()
+                // Deselect search items:
+                window.ILE.reset()
+            }
+        })
 }
 
 function handleSelectSubject(name, rawSubjectType) {
@@ -172,4 +202,24 @@ function hideTaggingMenu() {
     if (form) {
         form.style.display = 'none';
     }
+}
+
+/**
+ * Clears the bulk tagger form.
+ */
+function resetTaggingMenu() {
+    const searchInput = document.querySelector('.subjects-search-input')
+    searchInput.value = ''
+
+    const resultsContainer = document.querySelector('.subjects-search-results')
+    resultsContainer.innerHTML = ''
+
+    const createSubjectContainer = document.querySelector('.create-new-subject-tag')
+    createSubjectContainer.innerHTML = ''
+
+    const selectedTagsContainer = document.querySelector('.selected-tag-subjects')
+    selectedTagsContainer.innerHTML = ''
+
+    const hiddenSubjectInput = document.querySelector('.tag-subjects')
+    hiddenSubjectInput.value = ''
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8433

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The bulk tagger tool now submits data to the backend server asynchronously.  On failure, a toast message is displayed to the librarian.
On successful update, the following occurs, in order:
1. The bulk tagging affordance is hidden.
2. The bulk tagging affordance is reset.
3. A success message is displayed as a toast.
4. The ILE is reset (search items are deselected).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
