### PR TITLE
Make /lists/add support POST with json body

### DIFF
--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import pytest
@@ -52,6 +53,33 @@ class TestListRecord:
             }
             assert ListRecord.from_input() == ListRecord(
                 key='/lists/OL1L',
+                name='foo data',
+                description='bar',
+                seeds=[{'key': '/books/OL1M'}, {'key': '/books/OL2M'}],
+            )
+
+    def test_from_input_with_json_data(self):
+        with (
+            patch('web.input') as mock_web_input,
+            patch('web.data') as mock_web_data,
+            patch('web.ctx') as mock_web_ctx,
+        ):
+            mock_web_ctx.env = {'CONTENT_TYPE': 'application/json'}
+            mock_web_data.return_value = json.dumps(
+                {
+                    'name': 'foo data',
+                    'description': 'bar',
+                    'seeds': [{'key': '/books/OL1M'}, {'key': '/books/OL2M'}],
+                }
+            ).encode('utf-8')
+            mock_web_input.return_value = {
+                'key': None,
+                'name': 'foo',
+                'description': 'bar',
+                'seeds': [],
+            }
+            assert ListRecord.from_input() == ListRecord(
+                key=None,
                 name='foo data',
                 description='bar',
                 seeds=[{'key': '/books/OL1M'}, {'key': '/books/OL2M'}],


### PR DESCRIPTION
To support Scott Hewitt's work, and to make consistent with our other APIs, `POST /lists/add` now supports a JSON body containing the list document. Previously it only supported URL parameters.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tests added.

✅ You can test locally on the local host instance by running this in your browser console while logged in and on `localhost:8080`

```js
await fetch('/lists/add', {
    method: 'POST',
    headers: {
        'Content-Type': "application/json",
    },
    body: JSON.stringify({
        name: 'foo data',
        description: 'bar',
        seeds: [{'key': '/books/OL1M'}, {'key': '/books/OL2M'}],
    }),
}).then(r => r.json())
```

Should create the list!

✅ You can also create one using url parameters, like before:

```js
await fetch('/lists/add?name=hello&seeds=OL2M,OL3M', {
    method: 'POST',
    headers: {
        'Content-Type': "application/json",
    },
}).then(r => r.json())
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
