### PR TITLE
Fix 500 when saving /lists/add with URL parameters + fix global lists editing

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -2,6 +2,7 @@
 """
 from dataclasses import dataclass, field
 import json
+from urllib.parse import parse_qs
 import random
 from typing import TypedDict
 import web
@@ -49,18 +50,27 @@ class ListRecord:
 
     @staticmethod
     def from_input():
-        i = utils.unflatten(
-            web.input(
-                key=None,
-                name='',
-                description='',
-                seeds=[],
-            )
-        )
+        DEFAULTS = {
+            'key': None,
+            'name': '',
+            'description': '',
+            'seeds': [],
+        }
+        if data := web.data():
+            # If the requests has data, parse it and use it to populate the list
+            form_data = {
+                # By default all the values are lists
+                k: v[0]
+                for k, v in parse_qs(bytes.decode(data)).items()
+            }
+            i = {} | DEFAULTS | utils.unflatten(form_data)
+        else:
+            # Otherwise read from the query string
+            i = utils.unflatten(web.input(**DEFAULTS))
 
         normalized_seeds = [
             ListRecord.normalize_input_seed(seed)
-            for seed_list in i.seeds
+            for seed_list in i['seeds']
             for seed in (
                 seed_list.split(',') if isinstance(seed_list, str) else [seed_list]
             )
@@ -71,9 +81,9 @@ class ListRecord:
             if seed and (isinstance(seed, str) or seed.get('key'))
         ]
         return ListRecord(
-            key=i.key,
-            name=i.name,
-            description=i.description,
+            key=i['key'],
+            name=i['name'],
+            description=i['description'],
             seeds=normalized_seeds,
         )
 

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -1,4 +1,9 @@
+from unittest.mock import patch
+
+import pytest
+
 from openlibrary.plugins.openlibrary import lists
+from openlibrary.plugins.openlibrary.lists import ListRecord
 
 
 def test_process_seeds():
@@ -11,3 +16,70 @@ def test_process_seeds():
     assert f({"key": "/books/OL1M"}) == {"key": "/books/OL1M"}
     assert f("/subjects/love") == "subject:love"
     assert f("subject:love") == "subject:love"
+
+
+class TestListRecord:
+    def test_from_input_no_data(self):
+        with (
+            patch('web.input') as mock_web_input,
+            patch('web.data') as mock_web_data,
+        ):
+            mock_web_data.return_value = b''
+            mock_web_input.return_value = {
+                'key': None,
+                'name': 'foo',
+                'description': 'bar',
+                'seeds': [],
+            }
+            assert ListRecord.from_input() == ListRecord(
+                key=None,
+                name='foo',
+                description='bar',
+                seeds=[],
+            )
+
+    def test_from_input_with_data(self):
+        with (
+            patch('web.input') as mock_web_input,
+            patch('web.data') as mock_web_data,
+        ):
+            mock_web_data.return_value = b'key=/lists/OL1L&name=foo+data&description=bar&seeds--0--key=/books/OL1M&seeds--1--key=/books/OL2M'
+            mock_web_input.return_value = {
+                'key': None,
+                'name': 'foo',
+                'description': 'bar',
+                'seeds': [],
+            }
+            assert ListRecord.from_input() == ListRecord(
+                key='/lists/OL1L',
+                name='foo data',
+                description='bar',
+                seeds=[{'key': '/books/OL1M'}, {'key': '/books/OL2M'}],
+            )
+
+    SEED_TESTS = [
+        ([], []),
+        (['OL1M'], [{'key': '/books/OL1M'}]),
+        (['OL1M', 'OL2M'], [{'key': '/books/OL1M'}, {'key': '/books/OL2M'}]),
+        (['OL1M,OL2M'], [{'key': '/books/OL1M'}, {'key': '/books/OL2M'}]),
+    ]
+
+    @pytest.mark.parametrize('seeds,expected', SEED_TESTS)
+    def test_from_input_seeds(self, seeds, expected):
+        with (
+            patch('web.input') as mock_web_input,
+            patch('web.data') as mock_web_data,
+        ):
+            mock_web_data.return_value = b''
+            mock_web_input.return_value = {
+                'key': None,
+                'name': 'foo',
+                'description': 'bar',
+                'seeds': seeds,
+            }
+            assert ListRecord.from_input() == ListRecord(
+                key=None,
+                name='foo',
+                description='bar',
+                seeds=expected,
+            )

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -74,9 +74,9 @@ class edit(core.edit):
         )
         if editable_keys_re.match(key):
             if page is None:
-                raise web.seeother(key)
+                return web.seeother(key)
             else:
-                raise web.seeother(page.url(suffix="/edit"))
+                return addbook.safe_seeother(page.url(suffix="/edit"))
         else:
             return core.edit.GET(self, key)
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -70,7 +70,7 @@ class edit(core.edit):
     def GET(self, key):
         page = web.ctx.site.get(key)
         editable_keys_re = web.re_compile(
-            r"/(authors|books|works|people/[^/]+/lists)/OL.*"
+            r"/(authors|books|works|(people/[^/]+/)?lists)/OL.*"
         )
         if editable_keys_re.match(key):
             if page is None:

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -288,9 +288,7 @@ def unflatten(d: Storage, separator: str = "--") -> Storage:
             k, k2 = k.split(separator, 1)
             setvalue(data.setdefault(k, {}), k2, v)
         else:
-            # Don't overwrite if the key already exists
-            if k not in data:
-                data[k] = v
+            data[k] = v
 
     def makelist(d):
         """Convert d into a list if all the keys of d are integers."""

--- a/openlibrary/templates/type/list/edit.html
+++ b/openlibrary/templates/type/list/edit.html
@@ -23,7 +23,7 @@ $jsdef render_seed_field(i, seed):
     <li class="mia__input ac-input">
         <div class="seed--controls">
             <div class="mia__reorder mia__index">≡ #$(i + 1)</div>
-            <button class="mia__remove" href="javascript:;">Remove</button>
+            <button class="mia__remove" type="button">Remove</button>
         </div>
         <main>
             <input class="ac-input__value" name="seeds--$i--key" type="hidden" value="$seed['key']" />


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8245 . Closes #8246 .

Fix. Saving from the /lists/add endpoint was erroring when used with url parameters to pre-populate the form. This was because these url parameters would be forwarded along with the POST request when the form was submitted (since the `action` was unset on the form). The endpoint now checks the request body independently/separately (by default, `web.input()` combines data from both).

Fix. Global lists (eg `/lists/OL1L`) were erroring when edited due to the `?m=edit` → `/edit` rewrite rule not triggering, causing the endpoint to be handled by infogami instead of our custom code. Fixed the rewrite rule.

Fix. The `/edit` rewrite rule was erroring for users when a list had unicode characters in its url (see this [users unfortunate list description](https://openlibrary.org/people/stillme/lists/OL224655L/Oops)!). Use the `safe_seeother` that performs url encoding.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested locally:
- [x] Create global list without url params
- [x] Create global list with url params
- [x] Edit global list
- [x] Add emoji to list name + edit list
- [x] Create personal list via lists/add
- [x] Edit personal list

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@davidscotson 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
