### PR TITLE
Add librarian-only sort option for work title

### DIFF
--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -35,12 +35,11 @@ $code:
             ]
           },
          { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
-         { 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title', 'show': ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))  },
        ]
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians')):
+      $ sort_options.append({ 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title' })
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:
-        $continue
-      $if not sort_option.get('show', True):
         $continue
       $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort or (selected_sort is None and sort_option['sort'] == default_sort)
       $if is_selected:

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -19,6 +19,7 @@ $code:
        sort_options = [
          { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
          { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
+         { 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title', 'show': ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))  },
          { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
          { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
          { 'sort': 'rating', 'name': _("Top Rated"), 'ga_key': 'Rating' },
@@ -38,6 +39,8 @@ $code:
        ]
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:
+        $continue
+      $if sort_option['sort'] == 'title' and not sort_option['show']:
         $continue
       $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort or (selected_sort is None and sort_option['sort'] == default_sort)
       $if is_selected:

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -19,7 +19,6 @@ $code:
        sort_options = [
          { 'sort': 'relevance', 'name': _("Relevance"), 'ga_key': 'Relevance' },
          { 'sort': 'editions', 'name': _("Most Editions"), 'ga_key': 'Editions' },
-         { 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title', 'show': ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))  },
          { 'sort': 'old', 'name': _("First Published"), 'ga_key': 'Old' },
          { 'sort': 'new', 'name': _("Most Recent"), 'ga_key': 'New' },
          { 'sort': 'rating', 'name': _("Top Rated"), 'ga_key': 'Rating' },
@@ -36,11 +35,12 @@ $code:
             ]
           },
          { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
+         { 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title', 'show': ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))  },
        ]
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:
         $continue
-      $if sort_option['sort'] == 'title' and not sort_option['show']:
+      $if not sort_option.get('show', True):
         $continue
       $ is_selected = sort_option.get('selected') or sort_option['sort'] == selected_sort or (selected_sort is None and sort_option['sort'] == default_sort)
       $if is_selected:


### PR DESCRIPTION
Adds an alphabetic search to any search other than author and list searches.

Note: Sorts on work title, which may not reflect the edition title shown to the user.

<!-- What issue does this PR close? -->
Work towards #2796 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

feature

### Technical
<!-- What should be noted about the implementation? -->

Sorts on work title, which isn't shown to the ordinary user and may vary from what is shown e.g. searching for a title in a specific language will display that edition, but the work may be titled, and therefore sorted, in a different language.

The sort code has references to ga_key, which don't seem to be used in the code, so I just used "Alphabetical". I'm assuming this is something tracked by Google Analytics?

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

The author page book list and Book search results should now show an "Alphabetical" option.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="653" alt="Screenshot 2023-10-27 at 12 34 21" src="https://github.com/internetarchive/openlibrary/assets/7288187/ba83aace-55a0-4937-baa6-d06b3eb5d230">

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
