### PR TITLE
Experiment: Switch to yacron

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -125,12 +125,10 @@ services:
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     hostname: "$HOSTNAME"
     user: root
-    command: docker/ol-cron-start.sh
+    command: yacron -c /etc/yacron.yaml
     restart: unless-stopped
-    env_file:
-      - ../olsystem/etc/cron-jobs.env
     volumes:
-      - ../olsystem/etc/cron.d/openlibrary.ol_home0:/etc/cron.d/openlibrary.ol_home0:ro
+      - ../olsystem/etc/yacron.yml:/etc/yacron.yml:ro
       - ../olsystem:/olsystem
       - /1/var/tmp:/1/var/tmp
     networks:

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -63,6 +63,9 @@ RUN mkdir -p /var/log/openlibrary /var/lib/openlibrary && chown openlibrary:open
  && mkdir -p /solr-updater-data && chown openlibrary:openlibrary /solr-updater-data
 WORKDIR /openlibrary
 
+# Install this as root since it runs as root
+RUN python -m pip install --upgrade pip wheel yacron==0.19.0
+
 USER openlibrary
 COPY --chown=openlibrary:openlibrary requirements*.txt ./
 RUN python -m pip install --upgrade pip wheel \

--- a/docker/ol-cron-start.sh
+++ b/docker/ol-cron-start.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-crontab /etc/cron.d/openlibrary.ol_home0
-cron -f -L2


### PR DESCRIPTION
Making changes to our cron is a nightmare. There is zero transparency, and the syntax is super archaic and error-prone.

yacron offers a yaml format for the file, and logs things regularly so you can see what things ran or didn't run. It also prefixes all the output with the command name so it's much easier to grep/read.

Corresponding olsystem PR: https://github.com/internetarchive/olsystem/pull/193

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
