### PR TITLE
feat(add-book-detect): add Auto-detect entered edition ID type #8424

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -30,6 +30,7 @@ export function initAddBookImport () {
     invalidIsbn13 = i18nStrings.invalid_isbn13;
     invalidLccn = i18nStrings.invalid_lccn;
 
+    $('#id_value').on('change',autoCompleteIdName);
     $('#addbook').on('submit', parseAndValidateId);
     $('#id_value').on('input', clearErrors);
     $('#id_name').on('change', clearErrors);
@@ -115,4 +116,25 @@ function parseAndValidateLccn(event, idValue) {
         return displayLccnError(event, invalidLccn);
     }
     document.getElementById('id_value').value = idValue;
+}
+
+function autoCompleteIdName(){
+    const idValue = document.querySelector('input#id_value').value.trim();
+    const idValueIsbn = parseIsbn(idValue);
+
+    if (isFormatValidIsbn10(idValueIsbn) && isChecksumValidIsbn10(idValueIsbn)){
+        document.getElementById('id_name').value = 'isbn_10';
+    }
+
+    else if (isFormatValidIsbn13(idValueIsbn) && isChecksumValidIsbn13(idValueIsbn)){
+        document.getElementById('id_name').value = 'isbn_13';
+    }
+
+    else if ((isValidLccn(parseLccn(idValue)))){
+        document.getElementById('id_name').value = 'lccn';
+    }
+
+    else {
+        document.getElementById('id_name').value = '';
+    }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8424

When adding a new book, it would be great if the ID type be automatically selected when entering the ID.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<img width="670" alt="image" src="https://github.com/internetarchive/openlibrary/assets/15892424/928c78a5-a5e1-4a3a-b395-213c9923f4e1">

<img width="680" alt="image" src="https://github.com/internetarchive/openlibrary/assets/15892424/b358d0cd-ddd7-4693-9227-dffdf0e061ea">

<img width="676" alt="image" src="https://github.com/internetarchive/openlibrary/assets/15892424/e2979f75-f1e0-4e83-977a-77b598018d00">



### Stakeholders
@scottbarnes 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
