### PR TITLE
Hide ILE on pop-ups

### DIFF
--- a/openlibrary/templates/site/body.html
+++ b/openlibrary/templates/site/body.html
@@ -4,7 +4,7 @@ $ bodyclass = ctx.get('bodyclass', [])
 $ show_ol_shell = ctx.get('show_ol_shell', True)
 $ bodyattrs = ctx.get('bodyattrs', [])
 
-$if ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ctx.path.startswith('/books/OL') or ctx.path.startswith('/search'):
+$if show_ol_shell and (ctx.path.startswith('/works/OL') or ctx.path.startswith('/authors/OL') or ctx.path.startswith('/books/OL') or ctx.path.startswith('/search')):
   $if ctx.user and ((ctx.user.is_librarian() or ctx.user.is_admin())):
     $bodyclass.append('show-librarian-tools')
     $bodyattrs.append('data-username="%s"' % ctx.user.key.split('/')[-1])


### PR DESCRIPTION
<!-- What issue does this PR close? -->
I could have sworn I saw an issue for this, but now I can't find it anywhere.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The ILE blue bar appears on popups like the cover manager, when it should only show up on full pages. This PR adds a check to make sure this happens correctly.

### Testing
Add some items to the blue bar, then (in the same tab) open the Manage Covers popup. Blue bar should not appear.

### Screenshot
Before: 
<img width="947" alt="Screenshot 2023-10-30 at 4 44 26 PM" src="https://github.com/internetarchive/openlibrary/assets/886889/d4b6e126-3560-4122-b76e-29e37f270336">

After:
<img width="908" alt="Screenshot 2023-10-30 at 4 45 54 PM" src="https://github.com/internetarchive/openlibrary/assets/886889/4441d562-d631-4e7c-b126-ff5422289715">

### Stakeholders
@mheiman @cdrini @seabelis 

