### PR TITLE
Make solr queries use boost instead of bf

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -277,7 +277,7 @@ class WorkSearchScheme(SearchScheme):
         # query, but much more flexible. We wouldn't be able to do our
         # complicated parent/child queries with defType!
 
-        full_work_query = '({{!edismax q.op="AND" qf="{qf}" bf="{bf}" v={v}}})'.format(
+        full_work_query = '({{!edismax q.op="AND" qf="{qf}" boost="{boost}" v={v}}})'.format(
             # qf: the fields to query un-prefixed parts of the query.
             # e.g. 'harry potter' becomes
             # 'text:(harry potter) OR alternative_title:(harry potter)^20 OR ...'
@@ -286,7 +286,7 @@ class WorkSearchScheme(SearchScheme):
             # field. I.e. results with more editions get boosted, upto a
             # max of 100, after which we don't see it as good signal of
             # quality.
-            bf='min(100,edition_count)',
+            boost='min(100,edition_count)',
             # v: the query to process with the edismax query parser. Note
             # we are using a solr variable here; this reads the url parameter
             # arbitrarily called workQuery.


### PR DESCRIPTION
This recommended and a new option available to use now we use edismax! This performs multiplicative boosting as opposed to additive boosting, making the boosts behave more predictably.

See https://solr.apache.org/guide/solr/latest/query-guide/edismax-query-parser.html#examples-of-edismax-queries:~:text=includes%20improved%20boost%20function%3A%20in%20Extended%20DisMax%2C%20the%20boost%20function%20is%20a%20multiplier%20rather%20than%20an%20addend%2C%20improving%20your%20boost%20results%3B%20the%20additive%20boost%20functions%20of%20DisMax%20(bf%20and%20bq)%20are%20also%20supported.

<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
