### PR TITLE
Add Want to Read dropper to lists

### DIFF
--- a/openlibrary/templates/my_books/dropper.html
+++ b/openlibrary/templates/my_books/dropper.html
@@ -1,8 +1,7 @@
 $def with(page, edition_key=None, async_load=False)
 
-$if not edition_key:
-  $ edition = page if page.key.startswith("/books/") else None
-  $ edition_key = edition and edition.key
+$ edition = page if page.key.startswith("/books/") else None
+$ edition_key = edition and edition.key
 
 $ work = page if page.key.startswith('/works/') else page.works[0] if edition and page.works else None
 $ work_key = work and work.key

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -120,8 +120,9 @@ $def seed_attrs(seed):
                 $ cover_url = default_image
 
             $if seed.type in ['edition', 'work']:
+                $ use_my_books_droppers = 'my_books_dropper' in ctx.features
                 $ doc = solr_works.get(seed.key) or seed.document
-                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=availabilities.get(seed.key), decorations=remove_item_link(), extra=seed_meta_line(seed))
+                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=availabilities.get(seed.key), decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=use_my_books_droppers)
             $else:
                 <li class="searchResultItem" $:seed_attrs(seed)>
                     <span class="bookcover">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8206 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds the Want to Read dropper to book options within lists.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Go to a list with books added.
2. The Want to Read dropper should display underneath the existing Read/Listen button.
3. Selecting the dropper when logged out should redirect the user to the login page.
4. Selecting options from the dropper while logged in should update the user's reading log as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
While logged in:

![image](https://github.com/internetarchive/openlibrary/assets/29631356/ccf0ce75-e203-42bc-a86e-9f8d6d34e6e3)

While logged out:
![image](https://github.com/internetarchive/openlibrary/assets/29631356/b0960793-c159-44dd-b96e-4b06babbb4b3)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
