### PR TITLE
Fix "Add Cover Image" Form Display

### DIFF
--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -67,7 +67,7 @@ $if status:
                 </div>
             </div>
 
-            <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '50px 0px 0px 30px;')">
+            <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '0px;')">
                 <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest">$_("Submit")</button>
                 <a class="dialog--close-parent red" href="javascript:;">$_("Cancel")</a>
             </div>

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -198,7 +198,6 @@ div.floater {
     font-size: 1.125em;
     font-family: @lucida_sans_serif-1;
     padding: 3px;
-    margin-left: 30px;
   }
   input::file-selector-button{
     cursor: pointer;
@@ -214,7 +213,6 @@ div.floater {
 }
 
 .floatform__body {
-  text-align: center;
   width: 100%;
   position: relative;
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4306

<!-- What does this PR achieve? [fix] -->

Fixes display issue on "Add Cover Image" Popup 

### Technical
<!-- What should be noted about the implementation? -->

- Modifies LESS template for form styles and inline style declaration in the add a cover template

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

- Rebuild static assets and see correct alignment on "add cover"

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Before:

<img width="1085" alt="Screenshot 2023-11-03 at 7 32 54 PM" src="https://github.com/internetarchive/openlibrary/assets/45246438/c6f4584f-7c4c-4f1e-98e1-8a68bcb4576b">

After:

<img width="870" alt="Screenshot 2023-11-03 at 9 09 18 PM" src="https://github.com/internetarchive/openlibrary/assets/45246438/2ae6b2df-f28c-459d-9b2b-ae555166d415">

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
