### PR TITLE
Restrict ILE dragging to ile-selectable items

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -198,7 +198,7 @@ export default class SelectionManager {
             items: this.getOlidsFromSelectionList(items)
         };
         ev.dataTransfer.setData('text/plain', JSON.stringify(data));
-        ev.dataTransfer.setData('application/ile', JSON.stringify(data));
+        ev.dataTransfer.setData('application/x.ile+json', JSON.stringify(data));
     }
 
     dragEnd() {
@@ -211,7 +211,7 @@ export default class SelectionManager {
     onDrop(ev) {
         ev.preventDefault();
         const handler = this.getHandler();
-        const data = JSON.parse(ev.dataTransfer.getData('application/ile'));
+        const data = JSON.parse(ev.dataTransfer.getData('application/x.ile+json'));
         handler.ondrop(data);
         document.getElementById('test-body-mobile').classList.remove('ile-drag-over');
     }
@@ -220,7 +220,7 @@ export default class SelectionManager {
      * @param {DragEvent} ev
      */
     allowDrop(ev) {
-        if (!ev.dataTransfer?.types.includes('application/ile') || $('.ile-selected').length) return;
+        if (!ev.dataTransfer?.types.includes('application/x.ile+json') || $('.ile-selected').length) return;
         const handler = this.getHandler();
         if (!handler) return;
 

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -197,7 +197,8 @@ export default class SelectionManager {
             from: (from ? from[0] : null),
             items: this.getOlidsFromSelectionList(items)
         };
-        ev.dataTransfer.setData('text', JSON.stringify(data));
+        ev.dataTransfer.setData('text/plain', JSON.stringify(data));
+        ev.dataTransfer.setData('application/ile', JSON.stringify(data));
     }
 
     dragEnd() {
@@ -210,16 +211,18 @@ export default class SelectionManager {
     onDrop(ev) {
         ev.preventDefault();
         const handler = this.getHandler();
-        const data = JSON.parse(ev.dataTransfer.getData('text'));
+        const data = JSON.parse(ev.dataTransfer.getData('application/ile'));
         handler.ondrop(data);
+        document.getElementById('test-body-mobile').classList.remove('ile-drag-over');
     }
 
     /**
      * @param {DragEvent} ev
      */
     allowDrop(ev) {
+        if (!ev.dataTransfer?.types.includes('application/ile') || $('.ile-selected').length) return;
         const handler = this.getHandler();
-        if ($('.ile-selected').length || !handler) return;
+        if (!handler) return;
 
         ev.preventDefault();
         this.ile.setStatusText(handler.message);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8481

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Addresses the issue where dragging content other than ILE selectable elements would trigger ILE drop target behavior.

Any content can still be dragged, but now only ILE elements will trigger ILE behaviors.

While I was testing, I also noticed that the drag target highlighting wasn't deactivating after the drag was complete, so I fixed that as well.

### Technical
The challenge here is that the dragover event doesn't have any visibility into the elements being dragged; all it can see is the data payload attached to the dataTransfer object during the dragstart event.  One solution would be to unserialize that data during dragover and examine it to see if it contains the kind of data we want. However, dragover is fired every time the mouse moves with a dragged item, so that's a potential performance issue. 

The dataTransfer object allows for assigning a MIME type to attached data, and application-specific types are entirely appropriate. We can therefore assign a custom "application/ile" type for our ILE data, and simply check to see if that type is present on the event to determine whether the ILE should respond to the drag or not.

However, only drag events that contain plan text type data will permit dragging between browser tabs.  Fortunately, it's [recommended](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types) that if you attach data as a custom type, you also should attach a plain text alternative. That's why you see two apparently redundant setData calls in dragStart.

### Testing
Try dragging links or arbitrary text selections around in the browser, or between tabs. the ILE should not respond.  Normal ILE drag behaviors are unaffected.

### Stakeholders
@mheiman @cdrini @onnotasler 

