### PR TITLE
Use dismissible banner for yearly reading goals

### DIFF
--- a/openlibrary/templates/account/books.html
+++ b/openlibrary/templates/account/books.html
@@ -81,9 +81,13 @@ $if owners_page:
 
       $# Is date between 1 Dec and 1 Feb?
       $if not current_goal and within_date_range(12, 1, 2, 1):
-        <div class="page-banner page-banner-body page-banner-mybooks">
-          $_('Set your %(year)s Yearly Reading Goal:', year=year) <a class="btn primary set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">$:_('Set my goal')</a>
-        </div>
+        $ cta_copy = _('Set your %(year)s Yearly Reading Goal:', year=year)
+        $ btn_copy = _('Set my goal')
+        $ announcement =  '%s <a class="btn primary set-reading-goal-link" data-ol-link-track="MyBooksLandingPage|SetReadingGoal"href="javascript:;">%s</a>' % (cta_copy, btn_copy)
+
+        $ cookie_name = 'yrg'
+
+        $:render_template('site/banner', announcement, cookie_name, cookie_duration_days=65)
       $ component_times['Yearly Goal Banner'] = time() - component_times['Yearly Goal Banner']
 
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the Yearly Reading Goals banner dismissible.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-11-08 17-19-22](https://github.com/internetarchive/openlibrary/assets/28732543/4f29c05a-1d93-4a58-acd9-a1a815a277e5)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
