### PR TITLE
Add link for Debugging in Docker Installation Guide

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -227,6 +227,10 @@ docker compose run --rm home npm run build-assets
 ```
 Note: This is only if you already have an existing docker image, this command is unnecessary the first time you build.
 
+## Debugging and Profiling the Docker Image
+
+See [Debugging and Performance Profiling](https://github.com/internetarchive/openlibrary/wiki/Debugging-and-Performance-Profiling) for more information on how to attach a debugger when running in the Docker Container.
+
 ## Other Commands
 
 https://github.com/internetarchive/openlibrary/wiki/Deployment-Guide#ol-web1


### PR DESCRIPTION
This adds a hotlink to the Debugging page in the documentation.

<!-- What issue does this PR close? -->
Closes  #8512

<!-- What does this PR achieve? [doc] -->
This adds a hotlink and a section on how to run the debugger and profile the docker container, which is very useful information.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
