### PR TITLE
Trigger JIT imports during promise item import flow

### DIFF
--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -228,7 +228,9 @@ class ImportItem(web.storage):
             return ImportItem(result[0])
 
     @staticmethod
-    def bulk_mark_pending(identifiers : list[str], sources : Iterable[str] = STAGED_SOURCES):
+    def bulk_mark_pending(
+        identifiers: list[str], sources: Iterable[str] = STAGED_SOURCES
+    ):
         """
         Given a list of ISBNs, creates list of `ia_ids` and queries the import_item
         table the `ia_ids`.

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -228,14 +228,25 @@ class ImportItem(web.storage):
             return ImportItem(result[0])
 
     @staticmethod
-    def bulk_mark_pending(identifiers : list[str]):
+    def bulk_mark_pending(identifiers : list[str], sources : Iterable[str] = STAGED_SOURCES):
+        """
+        Given a list of ISBNs, creates list of `ia_ids` and queries the import_item
+        table the `ia_ids`.
+
+        Generated `ia_ids` have the form `{source}:{id}` for each `source` in `sources`
+        and `id` in `identifiers`.
+        """
+        ia_ids = []
+        for id in identifiers:
+            ia_ids += [f'{source}:{id}' for source in sources]
+
         query = (
             "UPDATE import_item"
-            "SET status = 'pending'"
-            "WHERE status = 'staged'"
-            "AND ia_id IN $identifiers"
+            "SET status = 'pending' "
+            "WHERE status = 'staged' "
+            "AND ia_id IN $ia_ids"
         )
-        db.query(query, vars={'identifiers': identifiers})
+        db.query(query, vars={'ia_ids': ia_ids})
 
     def set_status(self, status, error=None, ol_key=None):
         id_ = self.ia_id or f"{self.batch_id}:{self.id}"

--- a/openlibrary/core/imports.py
+++ b/openlibrary/core/imports.py
@@ -227,6 +227,16 @@ class ImportItem(web.storage):
         if result:
             return ImportItem(result[0])
 
+    @staticmethod
+    def bulk_mark_pending(identifiers : list[str]):
+        query = (
+            "UPDATE import_item"
+            "SET status = 'pending'"
+            "WHERE status = 'staged'"
+            "AND ia_id IN $identifiers"
+        )
+        db.query(query, vars={'identifiers': identifiers})
+
     def set_status(self, status, error=None, ol_key=None):
         id_ = self.ia_id or f"{self.batch_id}:{self.id}"
         logger.info("set-status %s - %s %s %s", id_, status, error, ol_key)

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -47,11 +47,7 @@ def map_book_to_olbook(book, promise_id):
         'local_id': [f"urn:bwbsku:{sku}"],
         'identifiers': {
             **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
-            **(
-                {'better_world_books': [isbn]}
-                if not is_isbn_13(isbn)
-                else {}
-            ),
+            **({'better_world_books': [isbn]} if not is_isbn_13(isbn) else {}),
         },
         **({'isbn_13': [isbn]} if is_isbn_13(isbn) else {}),
         **({'isbn_10': [book.get('ASIN')]} if asin_is_isbn_10 else {}),
@@ -71,7 +67,7 @@ def map_book_to_olbook(book, promise_id):
     return olbook
 
 
-def is_isbn_13(isbn:str):
+def is_isbn_13(isbn: str):
     """
     Naive check for ISBN-13 identifiers.
 

--- a/scripts/promise_batch_imports.py
+++ b/scripts/promise_batch_imports.py
@@ -49,11 +49,11 @@ def map_book_to_olbook(book, promise_id):
             **({'amazon': [book.get('ASIN')]} if not asin_is_isbn_10 else {}),
             **(
                 {'better_world_books': [isbn]}
-                if not (isbn and isbn[0].isdigit())
+                if not is_isbn_13(isbn)
                 else {}
             ),
         },
-        **({'isbn_13': [isbn]} if (isbn and isbn[0].isdigit()) else {}),
+        **({'isbn_13': [isbn]} if is_isbn_13(isbn) else {}),
         **({'isbn_10': [book.get('ASIN')]} if asin_is_isbn_10 else {}),
         **({'title': title} if title else {}),
         'authors': [{"name": book['ProductJSON'].get('Author') or '????'}],
@@ -71,6 +71,15 @@ def map_book_to_olbook(book, promise_id):
     return olbook
 
 
+def is_isbn_13(isbn:str):
+    """
+    Naive check for ISBN-13 identifiers.
+
+    Returns true if given isbn is in ISBN-13 format.
+    """
+    return isbn and isbn[0].isdigit()
+
+
 def get_jit_candidates(import_records:list[dict]) -> list[str]:
     id_prefixes = ['idb', 'amazon']
 
@@ -78,7 +87,7 @@ def get_jit_candidates(import_records:list[dict]) -> list[str]:
 
     for record in import_records:
         isbn = record.get('ISBN') or ' '
-        if isbn and isbn[0].isdigit():
+        if is_isbn_13(isbn):
             results += [f'{prefix}:{isbn}' for prefix in id_prefixes]
 
     return results


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In support of #7658 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Identifies JIT import candidates during the promise item import process.  Updates the `status` of all matching import items to `pending`.

Keeping this as a draft until it is properly tested.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
