### PR TITLE
Avoid rendering duplicate Vue-related script elements on book pages

### DIFF
--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -1,4 +1,4 @@
-$def with (page, worldcat_links, affiliate_links, editions_page=False, render_times={}, modal_links=None)
+$def with (page, worldcat_links, affiliate_links, editions_page=False, render_times={})
 
 $if page.type.key == '/type/work' and page.edition_count == 1:
     $ edit_url = page.editions[0].key + '?m=edit'
@@ -46,17 +46,21 @@ $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
         $:macros.LoanStatus(page, allow_expensive_availability_check=expensive_check, secondary_action=editions_page, check_sponsorship=editions_page, sponsorship_help=editions_page, check_loan_status=editions_page, post=lists_widget)
         $ render_times['databarWork: LoanStatus'] = time() - render_times['databarWork: LoanStatus']
 
-        $if modal_links:
-          <hr>
-          $:modal_links
+        <hr>
+        $ share_url = request.home + (edition or work).key
+
+        $ render_times['databarWork: Modal Links - Desktop'] = time()
+        $:render_template("type/edition/modal_links", work, edition, share_url)
+        $ render_times['databarWork: Modal Links - Desktop'] = time() - render_times['databarWork: Modal Links - Desktop']
 
         <div class="readers-stats__wrapper mobile">
           $ star_ratings_stats = macros.StarRatingsStats(work)
           $:star_ratings_stats
 
-          $if modal_links:
-            <hr>
-            $:modal_links
+          <hr>
+          $ render_times['databarWork: Modal Links - Mobile'] = time()
+          $:render_template("type/edition/modal_links", work, edition, share_url)
+          $ render_times['databarWork: Modal Links - Mobile'] = time() - render_times['databarWork: Modal Links - Mobile']
         </div>
 
         $if editions_page:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -207,13 +207,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
     <a id="overview-mobile" name="overview-mobile" class="section-anchor section-anchor--no-height"></a>
     $:render_template("type/edition/title_and_author", page, work, edition, ocaid, work_title, star_ratings_stats, for_desktop=False)
     <div class="editionCover">
-      $ share_url = request.home + (edition or work).key
-
-      $ component_times['databarWork: Modal Links'] = time()
-      $ modal_links = render_template("type/edition/modal_links", work, edition, share_url)
-      $ component_times['databarWork: Modal Links'] = time() - component_times['databarWork: Modal Links']
-
-      $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times, modal_links=modal_links)
+      $:macros.databarWork(edition or work, worldcat_links, affiliate_links, editions_page=True, render_times=component_times)
     </div>
 
     <div class="editionAbout">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8493

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The `render_component` function, when called for the first time, appends a `script` element which pulls in Vue.  It also renders a `script` element for the specific component the first time that component is rendered on a page.

The first time that `render_component` is called on the book page is in the `edition/modal_links` template.  Prior to these code changes, the rendered modal links were stored in a variable which was rendered twice in `databarWork.html`, resulting in duplicate `script` tags.

Since rendering the `edition/modal_links` template takes very little time, `render_template` is now called both times the modal links are rendered.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
