### PR TITLE
Add zero padding to last read date in client-side code

### DIFF
--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -355,9 +355,19 @@ function closeDialog(workOlid) {
 function showDateView(workOlid, year, month, day) {
     let date = year
     if (month) {
-        date += `-${month}`
+        if(month.length<2){
+            month= month.padStart(2, '0')
+            date+= `-${month}`
+        }else{
+            date += `-${month}`
+        }
         if (day) {
-            date += `-${day}`
+            if(day.length<2){
+                day= day.padStart(2, '0')
+                date+= `-${day}`
+            }else{
+                date += `-${day}`
+            }
         }
     }
     const displayElement = document.querySelector(`#check-in-display-${workOlid}`)

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -355,19 +355,9 @@ function closeDialog(workOlid) {
 function showDateView(workOlid, year, month, day) {
     let date = year
     if (month) {
-        if (month.length<2){
-            month= month.padStart(2, '0')
-            date+= `-${month}`
-        } else {
-            date += `-${month}`
-        }
+        date += `-${month.padStart(2, '0')}`
         if (day) {
-            if (day.length<2){
-                day= day.padStart(2, '0')
-                date+= `-${day}`
-            } else {
-                date += `-${day}`
-            }
+            date += `-${day.padStart(2, '0')}`
         }
     }
     const displayElement = document.querySelector(`#check-in-display-${workOlid}`)

--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -355,17 +355,17 @@ function closeDialog(workOlid) {
 function showDateView(workOlid, year, month, day) {
     let date = year
     if (month) {
-        if(month.length<2){
+        if (month.length<2){
             month= month.padStart(2, '0')
             date+= `-${month}`
-        }else{
+        } else {
             date += `-${month}`
         }
         if (day) {
-            if(day.length<2){
+            if (day.length<2){
                 day= day.padStart(2, '0')
                 date+= `-${day}`
-            }else{
+            } else {
                 date += `-${day}`
             }
         }


### PR DESCRIPTION
Closes #8521 

This PR aims to add zero padding to last read date for a book in client-side code.

### Testing
#### Steps to verify: 
1. Mark a book as "Already Read". A prompt for a read date will appear below the dropper. Click the "Other" option to manually enter a date.
2. Set a read date of 1 January 2023, and submit the form.
3. You'll see that the day and month will be zero padded wherever expected.

### Proof

![Screenshot_20231114_122109](https://github.com/internetarchive/openlibrary/assets/116485536/07d332b3-7b18-432e-afcd-045b39c9910f)

https://github.com/internetarchive/openlibrary/assets/116485536/59d4d52c-e302-453c-a88e-7e9e87102c6f


### Stakeholders
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
