### PR TITLE
Add non-link version of 'Not in Library' Button

### DIFF
--- a/openlibrary/macros/CheckOptions.html
+++ b/openlibrary/macros/CheckOptions.html
@@ -2,5 +2,5 @@ $def with(key)
 
 <div class="cta-button-group">
     <a href="$key" class="cta-btn cta-btn--available"
-       data-ol-link-track="CTAClick|NotInLibrary">$_('Check Options')</a>
+       data-ol-link-track="CTAClick|CheckOptions">$_('Check Options')</a>
 </div>

--- a/openlibrary/macros/CheckOptions.html
+++ b/openlibrary/macros/CheckOptions.html
@@ -1,0 +1,6 @@
+$def with(key)
+
+<div class="cta-button-group">
+    <a href="$key" class="cta-btn cta-btn--available"
+       data-ol-link-track="CTAClick|NotInLibrary">$_('Check Options')</a>
+</div>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -4,11 +4,11 @@ $# * doc - Can be a Work, Edition, or solr dict.
 $# * listen - whether to display listen button
 $# * allow_expensive_availability_check - whether to check the groundtruth availability
 $#     if can't get availability from specified fields
-$# * secondary_action - whether to display elements (e.g. preview, searhc inside)
+$# * secondary_action - whether to display elements (e.g. preview, search inside)
 $#     on just e.g. editions page or within search results, editions table, etc
 $# * check_sponsorship - whether to check if the book is eligible for sponsorship
 $# * sponsorship_help - whether to show the sponsorship help text
-$# * check_loan_stSatus - whether to check the user's loan status to determine read button
+$# * check_loan_status - whether to check the user's loan status to determine read button
 
 $ loanstatus_start_time = time()
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -8,7 +8,7 @@ $# * secondary_action - whether to display elements (e.g. preview, searhc inside
 $#     on just e.g. editions page or within search results, editions table, etc
 $# * check_sponsorship - whether to check if the book is eligible for sponsorship
 $# * sponsorship_help - whether to show the sponsorship help text
-$# * check_loan_status - whether to check the user's loan status to determine read button
+$# * check_loan_stSatus - whether to check the user's loan status to determine read button
 
 $ loanstatus_start_time = time()
 
@@ -113,8 +113,11 @@ $elif ocaid and availability.get('is_previewable') and book_provider.short_name 
       $:macros.BookSearchInside(ocaid)
 
 $else:
-  $:macros.NotInLibrary(work_key)
-
+  $# We assume that we are on the Book Page if secondary_action is true  
+  $ key = doc.key if is_edition else work_key
+  $ is_rendering_hyperlink = not secondary_action
+  $:macros.NotInLibrary(key, is_rendering_hyperlink)
+  
 $:post
 
 $if query_param('debug'):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -117,7 +117,7 @@ $else:
   $# secondary_action means we're on a book page and it's the button under the cover image.
   $ key = doc.key if is_edition else work_key
   $if (is_edition and is_book_page) or secondary_action:
-      $:macros.NotInLibrary(key)
+      $:macros.NotInLibrary()
   $else:
       $:macros.CheckOptions(key)
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False, check_loan_status=False, user_lists=None, post='')
+$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False, check_loan_status=False, user_lists=None, post='', is_book_page=False)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * listen - whether to display listen button
@@ -113,11 +113,14 @@ $elif ocaid and availability.get('is_previewable') and book_provider.short_name 
       $:macros.BookSearchInside(ocaid)
 
 $else:
-  $# We assume that we are on the Book Page if secondary_action is true  
+  $# Only render NotInLibrary on an edition's page, for that specific edition.
+  $# secondary_action means we're on a book page and it's the button under the cover image.
   $ key = doc.key if is_edition else work_key
-  $ is_rendering_hyperlink = not secondary_action
-  $:macros.NotInLibrary(key, is_rendering_hyperlink)
-  
+  $if (is_edition and is_book_page) or secondary_action:
+      $:macros.NotInLibrary(key)
+  $else:
+      $:macros.CheckOptions(key)
+
 $:post
 
 $if query_param('debug'):

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,6 +1,9 @@
-$def with(work_key)
+$def with(key, is_rendering_hyperlink)
 
 <div class="cta-button-group">
-  <a href="$work_key" class="cta-btn cta-btn--missing"
-     data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+  $if is_rendering_hyperlink:
+    <a href="$key" class="cta-btn cta-btn--missing"
+       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
+  $else:
+  <p class="cta-btn cta-btn--no-pointer">$_('Not in Library')</a>    
 </div>

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,4 +1,4 @@
-$def with(key)
+$def with()
 
 <div class="cta-button-group">
   <a class="cta-btn cta-btn--no-pointer">$_('Not in Library')</a>

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,9 +1,5 @@
-$def with(key, is_rendering_hyperlink)
+$def with(key)
 
 <div class="cta-button-group">
-  $if is_rendering_hyperlink:
-    <a href="$key" class="cta-btn cta-btn--missing"
-       data-ol-link-track="CTAClick|NotInLibrary">$_('Not in Library')</a>
-  $else:
-  <p class="cta-btn cta-btn--no-pointer">$_('Not in Library')</a>    
+  <a class="cta-btn cta-btn--no-pointer">$_('Not in Library')</a>
 </div>

--- a/openlibrary/templates/books/edition-sort.html
+++ b/openlibrary/templates/books/edition-sort.html
@@ -88,7 +88,8 @@ $ url = book.get_cover_url("S") or "/images/icons/avatar_book-sm.png"
       <div class="hidden">$availability_class</div>
       <div class="links">
         <ul class="read">
-          <li class="read-option">$:macros.LoanStatus(book)</li>
+          $# render_first is only true on the book page for an edition.
+          <li class="read-option">$:macros.LoanStatus(book, is_book_page=render_first)</li>
         </ul>
         $if oclc_numbers or isbn:
           <div class="editions-table__links">

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -116,6 +116,10 @@ a.cta-btn {
     color: @white;
   }
 
+  &--no-pointer {
+    cursor:default;
+  }
+
   &__badge {
     background-color: darken(@burnt-sienna, 20%);
     padding: 4px 7px;

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -46,7 +46,7 @@ a.cta-btn {
   }
 
   &--no-pointer {
-    cursor:default;
+    cursor: not-allowed;
   }
 
   &--available, &--preview, &--primary {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -45,6 +45,10 @@ a.cta-btn {
     text-decoration: none;
   }
 
+  &--no-pointer {
+    cursor:default;
+  }
+
   &--available, &--preview, &--primary {
     background-color: @primary-blue;
     color: @white;
@@ -114,10 +118,6 @@ a.cta-btn {
     border: 2px solid @link-blue;
     background-color: @link-blue;
     color: @white;
-  }
-
-  &--no-pointer {
-    cursor:default;
   }
 
   &__badge {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8492 but does so by not rendering the link as clickable, rather than by triggering a pop-up.

<!-- What does this PR achieve? [hotfix] -->
This pull request is a partial hotfix for the the listed issue by creating an alternate class version of the 'Not in Library' button that does not allow the page to be reloaded when clicked. This Pull Request, however, was only able to fix it partially. I was only able to get the button to show a 'non hyperlink' version on the left screen but not in the table. Need to improve this PR further and get some help for that before then.


### Technical
This uses the 'secondary_action' check in order to verify whether the link should be rendered. It makes the assumption that if 'secondary_action' is enabled, we do not have to render the link.

```
 $# We assume that we are on the Book Page if secondary_action is true  

  $ key = doc.key if is_edition else work_key
  $ is_rendering_hyperlink = not secondary_action
  $:macros.NotInLibrary(key, is_rendering_hyperlink)
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
(View video for demonstration)
1. Use the book on Docker at the following link http://localhost:8080/books/OL9M/Ra%CC%84gare%CC%84khalu
2. Verify that buttons on the book page have the 'cannot click' pointer and do not reload the page
3. Search for the book using the search bar.

### Video Demonstration and Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/internetarchive/openlibrary/assets/26779639/b3bd5286-3e12-4021-95f0-0833c3fedfa9

![image](https://github.com/internetarchive/openlibrary/assets/26779639/fe479a85-11e1-4eb5-81ab-1b53de5b8ea1)
(Expected behavior for 'no reload')

One issue I am having is being able to set the 'cannot link' trigger for this button. I tried to check for 'is_edition' but that caused the search page to also have a non-link version, which is a worse bug.

![image](https://github.com/internetarchive/openlibrary/assets/26779639/132974c4-dd2f-428e-bcc5-6279681e9844)
I think this button also should not be rendered as a link. But I am unable to figure out how to do that.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@scottbarnes helped mentor me for this problem and provided a near complete solution on Slack when I seek help. I still took the initiative of the earlier attempt and testing out the fix. I also chose the idea of using the 'not-allowed' pointer.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->