### PR TITLE
Add last page shortcut to Author works list

### DIFF
--- a/openlibrary/macros/Pager.html
+++ b/openlibrary/macros/Pager.html
@@ -26,6 +26,10 @@ $if pages != 1:
             <span class="this">$p</span>
         $else:
             <a href="$changequery(page=p)" class="ChoosePage">$p</a>
+    $if last_page_in_set != pages:
+        $if last_page_in_set != pages-1:
+            <span class="ellipsis">...</span>
+        <a href="$changequery(page=pages)" class="ChoosePage">$pages</a>
     $if page < pages:
         <a href="$changequery(page=page+1)" class="ChoosePage">$_('Next')&nbsp;&gt;</a>
     </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8420 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds a shortcut to the last page of an author's works on the author page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
On an author record that has more than 10 pages of works, verify that the last page number is shown separated by an ellipsis.
Additionally, verify that the ellipsis is not present when the last page would normally be shown.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
The last page being shown as an option at the beginning of the works.
(For testing, the number of works per page was set to 10 instead of 20)
![image](https://github.com/internetarchive/openlibrary/assets/29631356/55625331-40ab-4acb-8b63-5045df6ec78f)

When towards the back pages, the shortcut is not displayed.
![image](https://github.com/internetarchive/openlibrary/assets/29631356/c2783f7a-bb36-475d-884b-4854e4b88aea)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
