### PR TITLE
Fix/my book dropper btn overflow

### DIFF
--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -8,6 +8,10 @@
   }
 }
 
+.btn-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .generic-dropper {
   position: absolute;
   width: 100%;
@@ -26,9 +30,13 @@
       color: @dark-grey;
       background-color: @lightest-grey;
     }
-
+    .generic-dropper__actions {
+      display: flex;
+    }
     .generic-dropper__primary {
       flex: 1;
+      overflow: hidden;
+      white-space: nowrap;
       margin: auto;
       height: inherit;
 

--- a/static/css/components/generic-dropper.less
+++ b/static/css/components/generic-dropper.less
@@ -8,10 +8,6 @@
   }
 }
 
-.btn-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 .generic-dropper {
   position: absolute;
   width: 100%;
@@ -30,9 +26,7 @@
       color: @dark-grey;
       background-color: @lightest-grey;
     }
-    .generic-dropper__actions {
-      display: flex;
-    }
+
     .generic-dropper__primary {
       flex: 1;
       overflow: hidden;
@@ -89,4 +83,8 @@
     border-top: 1px solid @lighter-grey;
     position: absolute;
   }
+}
+.book-progress-btn {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

fixes book dropper button text overflow wrapping 

### Technical
<!-- What should be noted about the implementation? -->

* .generic-dropper__primary class was updated to keep the nowrap text from shrinking the dropdown button.
* .book-progress-btn class was utilized to add overflow ellipsis when button shrinks


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

go to /works page and adjust screen width to see fix


### Screenshot
#### Before
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="254" alt="Screenshot 2023-11-14 at 3 51 04 PM" src="https://github.com/internetarchive/openlibrary/assets/28990037/34d06204-5507-4a02-bbe0-078988f670c3">

#### After   
<img width="263" alt="Screenshot 2023-11-14 at 3 50 30 PM" src="https://github.com/internetarchive/openlibrary/assets/28990037/d4116fe9-6359-46c8-9f9c-eb9e8cdd40b7">


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
