### PR TITLE
work doesnt get selected when want to read button is pressed

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -85,6 +85,7 @@ export default class SelectionManager {
     toggleSelected(clickEvent) {
         // If there is text selection or the click is on a link that isn't a select handle, don't do anything
         if (window.getSelection()?.toString() !== '' ||
+            $(clickEvent.target).closest('.searchResultItemCTA').length > 0 ||
             ($(clickEvent.target).closest('a').is('a') &&
             $(clickEvent.target).not('.ile-select-handle').length > 0)) return;
 

--- a/tests/unit/js/SelectionManager.test.js
+++ b/tests/unit/js/SelectionManager.test.js
@@ -26,4 +26,31 @@ describe('SelectionManager', () => {
             author: [],
         });
     });
+
+    test('toggleSelected', () => {
+        const sm = new SelectionManager(null, '/search');
+        sm.ile = { $statusImages: { append: jest.fn() } };
+        const el = document.createElement('div');
+        el.classList.add('ile-selectable');
+        sm.getProvider = jest.fn().mockReturnValue({ data: () => 'OL1W' });
+        sm.getType = jest.fn().mockReturnValue({ singular: 'work', image: () => 'image_url' });
+        sm.setElementSelectionAttributes = jest.fn();
+        sm.addSelectedItem = jest.fn();
+        sm.removeSelectedItem = jest.fn();
+        sm.updateToolbar = jest.fn();
+
+        // Test selecting an unselected element
+        el.classList.remove('ile-selected');
+        sm.toggleSelected({ currentTarget: el });
+        expect(sm.setElementSelectionAttributes).toHaveBeenCalledWith(el, true);
+        expect(sm.addSelectedItem).toHaveBeenCalledWith('OL1W');
+        expect(sm.updateToolbar).toHaveBeenCalled();
+
+        // Test selecting a selected element
+        el.classList.add('ile-selected');
+        sm.toggleSelected({ currentTarget: el });
+        expect(sm.setElementSelectionAttributes).toHaveBeenCalledWith(el, false);
+        expect(sm.removeSelectedItem).toHaveBeenCalledWith('OL1W');
+        expect(sm.updateToolbar).toHaveBeenCalled();
+      });
 });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #6881 

<!-- What does this PR achieve? [fix] -->
It fixes the bug that was causing to select the work when pressed on the Want to Read button.

also, I have added a test case for toggelSelected method

### Testing
1. setup locally and login as admin
2. go to search result and press want to read button

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/internetarchive/openlibrary/assets/90760974/a59c628c-6768-4ea7-906a-bdcffb4304ae



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@scottbarnes 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
