### PR TITLE
Reset session storage on ILE reset

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -54,5 +54,7 @@ export class IntegratedLibrarianEnvironment {
         this.$selectionActions.empty();
         this.$statusImages.empty();
         this.$actions.empty();
+
+        this.selectionManager.clearSelectedItems()
     }
 }

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.js
@@ -130,7 +130,7 @@ export default class SelectionManager {
 
         if (statusParts.length) {
             this.ile.setStatusText(`${statusParts.join(', ')} selected`);
-            this.ile.$selectionActions.append($('<a>Clear Selections</a>').on('click', this.clearSelectedItems));
+            this.ile.$selectionActions.append($('<a>Clear Selections</a>').on('click', () => this.ile.reset()));
         } else {
             this.ile.setStatusText('');
         }
@@ -177,10 +177,12 @@ export default class SelectionManager {
         return items;
     }
 
+    /**
+     * Removes all selected items from the browser's session storage.
+     */
     clearSelectedItems() {
         for (const type in this.selectedItems) this.selectedItems[type] = [];
         sessionStorage.setItem('ile-items', JSON.stringify(this.selectedItems));
-        this.ile.reset();
     }
 
     /**


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8530

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes bug where submitting subjects appears to clear the ILE, but actually does not.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in with an account that can bulk tag:
1. Go to a search result page.
2. Select two or more works.
3. Using the bulk tagger, add at least one subject to the selected works.
4. Note that the ILE blue bar is now gone.
5. Visit a book page.  Ensure that the ILE blue bar does not reappear.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
