### PR TITLE
Retain selections on bulk subject submission

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/ile/BulkTagger.js
@@ -273,8 +273,6 @@ export class BulkTagger {
                     this.hideTaggingMenu()
                     this.resetTaggingMenu()
                     new FadingToast('Subjects successfully updated.').show()
-                    // Deselect search items:
-                    window.ILE.reset()
                 }
             })
     }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Modifies bulk tag submission handler to prevent clearing selected works on successful submission.  @mheiman mentions that this is likely the preferred experience, [here](https://github.com/internetarchive/openlibrary/issues/8530#issuecomment-1815282306).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged in with an account that can bulk tag works:
1. Go to a search page.
2. Select two or more items.
3. Using the bulk tagger, add at least one subject to the selected works.
4. Ensure that the selected works are still selected on success response.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
