### PR TITLE
Improve contrast of subject pills in bulk tagger

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/ile/BulkTagger.js
@@ -8,10 +8,10 @@ import { FadingToast } from '../Toast'
 const maxDisplayResults = 25;
 
 const subjectTypeClasses = {
-    subject: 'subject-blue',
-    person: 'subject-purple',
-    place: 'subject-red',
-    time: 'subject-yellow'
+    subject: 'subject-type-option--subject',
+    person: 'subject-type-option--person',
+    place: 'subject-type-option--place',
+    time: 'subject-type-option--time'
 };
 
 const subjectTypeMapping = {

--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -108,20 +108,28 @@
   cursor: pointer;
 }
 
-.subject-red {
-  background-color: @dark-red;
-}
+.subject-type-option {
+  font-size: 11px;
+  color: @white;
+  font-weight: 700;
+  width: fit-content;
+  padding: 3px 6px;
+  border-radius: 8px;
+  cursor: pointer;
 
-.subject-purple {
-  background-color: @purple;
-}
-
-.subject-yellow {
-  background-color: @dark-yellow;
-}
-
-.subject-blue {
-  background-color: @primary-blue;
+  &--place {
+    background-color: @dark-red;
+  }
+  &--person {
+    background-color: @dark-green;
+  }
+  &--time {
+    background-color: @dark-yellow;
+    color: @black;
+  }
+  &--subject {
+    background-color: @primary-blue;
+  }
 }
 
 .search-subject-row-name {
@@ -151,16 +159,6 @@
       display: flex;
       flex-direction: row;
       gap: 5px;
-    }
-
-    .subject-type-option {
-      font-size: 11px;
-      color: @white;
-      font-weight: 400;
-      width: fit-content;
-      padding: 3px 6px;
-      border-radius: 8px;
-      cursor: pointer;
     }
   }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Improves contrast of the subject type pills, found in the "Create new subject" section of the bulk tagger.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
Before:
![image](https://github.com/internetarchive/openlibrary/assets/6251786/abe918f7-c9c3-453a-9260-2cdd4cb85a19)

After:
![Screenshot from 2023-11-17 09-41-55](https://github.com/internetarchive/openlibrary/assets/28732543/89e4552c-27cd-496d-9060-3db457a62428)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mheiman 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
