### PR TITLE
Add account look-up by IA ID

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -25,7 +25,7 @@ from openlibrary.catalog.add_book import (
 import openlibrary
 
 from openlibrary import accounts
-
+from openlibrary.accounts.model import OpenLibraryAccount
 from openlibrary.core import admin as admin_stats, helpers as h, imports, cache
 from openlibrary.core.waitinglist import Stats as WLStats
 from openlibrary.core.sponsorships import summary, sync_completed_sponsored_books
@@ -174,13 +174,16 @@ class any:
 
 class people:
     def GET(self):
-        i = web.input(email=None)
+        i = web.input(email=None, ia_id=None)
 
+        account = None
         if i.email:
             account = accounts.find(email=i.email)
-            if account:
-                raise web.seeother("/admin/people/" + account.username)
-        return render_template("admin/people/index", email=i.email)
+        if i.ia_id:
+            account = OpenLibraryAccount.get_by_link(i.ia_id)
+        if account:
+            raise web.seeother(f"/admin/people/{account.username}")
+        return render_template("admin/people/index", email=i.email, ia_id=i.ia_id)
 
 
 class add_work_to_staff_picks:

--- a/openlibrary/templates/admin/people/index.html
+++ b/openlibrary/templates/admin/people/index.html
@@ -1,4 +1,4 @@
-$def with (email=None)
+$def with (email=None, ia_id=None)
 
 $var title: [Admin Center] People
 
@@ -16,7 +16,8 @@ $var title: [Admin Center] People
 .user-search td {
     font-size: 1.0em !important;
 }
-input#email {
+input#email,
+input#ia-id {
     padding: 3px;
     width: 400px;
 }
@@ -33,6 +34,19 @@ input#email {
                 <span class="invalid" htmlfor="email" generated="true">
                     $if email:
                         No account found with this email.
+                </span>
+            </form>
+        </td>
+    </tr>
+    <tr>
+        <td>$_("IA ID:")</td>
+        <td>
+            <form method="GET" name="form-ia-id">
+                <input type="text" name="ia_id" id="ia-id" value="$ia_id">
+                <button type="submit">$_("Find")</button>
+                <span class="invalid">
+                    $if ia_id:
+                        $_("No account found with this ID.")
                 </span>
             </form>
         </td>

--- a/openlibrary/templates/admin/people/index.html
+++ b/openlibrary/templates/admin/people/index.html
@@ -42,7 +42,7 @@ input#ia-id {
         <td>$_("IA ID:")</td>
         <td>
             <form method="GET" name="form-ia-id">
-                <input type="text" name="ia_id" id="ia-id" value="$ia_id">
+                <input type="text" name="ia_id" id="ia-id" pattern="^@.*$" placeholder="e.g. @foobar">
                 <button type="submit">$_("Find")</button>
                 <span class="invalid">
                     $if ia_id:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8151

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds second account look-up option to `/admin/people` page.  New option allows one to look up accounts by IA identifier.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-11-20 16-42-40](https://github.com/internetarchive/openlibrary/assets/28732543/14a6dc80-a66f-4bc2-8390-2b97615e1d91)
_New input with error message.  Successful account look-ups redirect to the admin account page._

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
