### PR TITLE
Add visual feedback when updating list via My Books Droppers

### DIFF
--- a/openlibrary/templates/lists/dropper_lists.html
+++ b/openlibrary/templates/lists/dropper_lists.html
@@ -3,6 +3,6 @@ $def with (lists)
 $for list in lists:
   $ list_active = "list--active" if list['active'] else ""
   <p class="list $list_active">
-    <span class="check">✔️</span>
+    <span class="list__status-indicator"></span>
     <a href="$list.key" class="modify-list" data-list-cover-url="$list.cover_url" data-list-key="$list.key" data-list-items="$(json_encode(list.list_items))">$list.name</a>
   </p>

--- a/static/css/components/mybooks-dropper.less
+++ b/static/css/components/mybooks-dropper.less
@@ -117,17 +117,42 @@
         display: flex;
         margin-top: 0;
 
-        .check {
+        .list__status-indicator {
           margin-right: 8px;
-          visibility: hidden;
+          min-width: 13px;
         }
       }
 
-      .list--active .check {
-        visibility: visible;
+      .list--active .list__status-indicator::after {
+        content: "✔️";
+      }
+      .list--pending .list__status-indicator {
+        display: inline-block;
+
+        &::after {
+          content: "";
+          display: block;
+          margin-top: 4px;
+          width: 1em;
+          height: 1em;
+          border-radius: 50%;
+          border: 1px solid @black;
+          border-color: @black transparent;
+          animation: spin 1.2s linear infinite;
+        }
       }
       /* stylelint-enable max-nesting-depth */
       /* stylelint-enable selector-max-specificity */
     }
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
   }
 }


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds some visual feedback whenever an item is added to or removed from a list via the My Books Dropper.

If the server responds with a `4XX` or `5XX` status when updating a list, a toast message is displayed and the list item's initial state (checked or unchecked) is restored.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![spinner](https://github.com/internetarchive/openlibrary/assets/28732543/00b0fb1d-3878-4772-8cc1-5809d6e872dd)
_Loading indicator beside a list named "137"_

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
