### PR TITLE
Refactor: Dissolve ListMixin

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -15,19 +15,10 @@ from openlibrary.core.models import Image, Thing
 from openlibrary.plugins.upstream.models import Changeset
 
 from openlibrary.plugins.worksearch.search import get_solr
+from openlibrary.plugins.worksearch.subjects import get_subject
 import contextlib
 
 logger = logging.getLogger("openlibrary.lists.model")
-
-# this will be imported on demand to avoid circular dependency
-subjects = None
-
-
-def get_subject(key):
-    global subjects
-    if subjects is None:
-        from openlibrary.plugins.worksearch import subjects
-    return subjects.get_subject(key)
 
 
 class List(Thing):

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -70,6 +70,10 @@ from openlibrary.core import models
 models.register_models()
 models.register_types()
 
+import openlibrary.core.lists.model as list_models
+
+list_models.register_models()
+
 # Remove movefiles install hook. openlibrary manages its own files.
 infogami._install_hooks = [
     h for h in infogami._install_hooks if h.__name__ != 'movefiles'

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -13,7 +13,7 @@ from infogami.infobase import client, common
 
 from openlibrary.accounts import get_current_user
 from openlibrary.core import formats, cache
-from openlibrary.core.lists.model import ListMixin
+from openlibrary.core.lists.model import List
 import openlibrary.core.helpers as h
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.addbook import safe_seeother
@@ -720,7 +720,7 @@ class export(delegate.page):
         else:
             raise web.notfound()
 
-    def get_exports(self, lst: ListMixin, raw: bool = False) -> dict[str, list]:
+    def get_exports(self, lst: List, raw: bool = False) -> dict[str, list]:
         export_data = lst.get_export_list()
         if "editions" in export_data:
             export_data["editions"] = sorted(

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -994,27 +994,6 @@ class AddBookChangeset(Changeset):
                 return doc
 
 
-class ListChangeset(Changeset):
-    def get_added_seed(self):
-        added = self.data.get("add")
-        if added and len(added) == 1:
-            return self.get_seed(added[0])
-
-    def get_removed_seed(self):
-        removed = self.data.get("remove")
-        if removed and len(removed) == 1:
-            return self.get_seed(removed[0])
-
-    def get_list(self):
-        return self.get_changes()[0]
-
-    def get_seed(self, seed):
-        """Returns the seed object."""
-        if isinstance(seed, dict):
-            seed = self._site.get(seed['key'])
-        return models.Seed(self.get_list(), seed)
-
-
 class Tag(models.Tag):
     """Class to represent /type/tag objects in Open Library."""
 
@@ -1040,5 +1019,4 @@ def setup():
     client.register_changeset_class('undo', Undo)
 
     client.register_changeset_class('add-book', AddBookChangeset)
-    client.register_changeset_class('lists', ListChangeset)
     client.register_changeset_class('new-account', NewAccountChangeset)

--- a/openlibrary/plugins/upstream/tests/test_models.py
+++ b/openlibrary/plugins/upstream/tests/test_models.py
@@ -5,6 +5,7 @@ import web
 from infogami.infobase import client
 
 from openlibrary.mocks.mock_infobase import MockSite
+import openlibrary.core.lists.model as list_model
 from .. import models
 
 
@@ -21,13 +22,14 @@ class TestModels:
             '/type/place': models.SubjectPlace,
             '/type/person': models.SubjectPerson,
             '/type/user': models.User,
+            '/type/list': list_model.List,
         }
         expected_changesets = {
             None: models.Changeset,
             'merge-authors': models.MergeAuthors,
             'undo': models.Undo,
             'add-book': models.AddBookChangeset,
-            'lists': models.ListChangeset,
+            'lists': list_model.ListChangeset,
             'new-account': models.NewAccountChangeset,
         }
         models.setup()

--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -46,8 +46,6 @@ from web.template import TemplateResult
 
 if TYPE_CHECKING:
     from openlibrary.plugins.upstream.models import (
-        AddBookChangeset,
-        ListChangeset,
         Work,
         Author,
         Edition,
@@ -412,7 +410,7 @@ def _get_changes_v2_raw(
 
 def get_changes_v2(
     query: dict[str, str | int], revision: int | None = None
-) -> list["Changeset | AddBookChangeset | ListChangeset"]:
+) -> list[Changeset]:
     page = web.ctx.site.get(query['key'])
 
     def first(seq, default=None):
@@ -447,7 +445,7 @@ def get_changes_v2(
 
 def get_changes(
     query: dict[str, str | int], revision: int | None = None
-) -> list["Changeset | AddBookChangeset | ListChangeset"]:
+) -> list[Changeset]:
     return get_changes_v2(query, revision=revision)
 
 

--- a/openlibrary/tests/core/lists/test_model.py
+++ b/openlibrary/tests/core/lists/test_model.py
@@ -1,0 +1,29 @@
+from openlibrary.mocks.mock_infobase import MockSite
+import openlibrary.core.lists.model as list_model
+
+
+class TestList:
+    def test_owner(self):
+        list_model.register_models()
+        self._test_list_owner("/people/anand")
+        self._test_list_owner("/people/anand-test")
+        self._test_list_owner("/people/anand_test")
+
+    def _test_list_owner(self, user_key):
+        site = MockSite()
+        list_key = user_key + "/lists/OL1L"
+
+        self.save_doc(site, "/type/user", user_key)
+        self.save_doc(site, "/type/list", list_key)
+
+        list = site.get(list_key)
+        assert list is not None
+        assert isinstance(list, list_model.List)
+
+        assert list.get_owner() is not None
+        assert list.get_owner().key == user_key
+
+    def save_doc(self, site, type, key, **fields):
+        d = {"key": key, "type": {"key": type}}
+        d.update(fields)
+        site.save(d)

--- a/openlibrary/tests/core/test_models.py
+++ b/openlibrary/tests/core/test_models.py
@@ -83,35 +83,6 @@ class TestSubject:
         assert subject.url("/lists") == "/subjects/love/lists"
 
 
-class TestList:
-    def test_owner(self):
-        models.register_models()
-        self._test_list_owner("/people/anand")
-        self._test_list_owner("/people/anand-test")
-        self._test_list_owner("/people/anand_test")
-
-    def _test_list_owner(self, user_key):
-        from openlibrary.mocks.mock_infobase import MockSite
-
-        site = MockSite()
-        list_key = user_key + "/lists/OL1L"
-
-        self.save_doc(site, "/type/user", user_key)
-        self.save_doc(site, "/type/list", list_key)
-
-        list = site.get(list_key)
-        assert list is not None
-        assert isinstance(list, models.List)
-
-        assert list.get_owner() is not None
-        assert list.get_owner().key == user_key
-
-    def save_doc(self, site, type, key, **fields):
-        d = {"key": key, "type": {"key": type}}
-        d.update(fields)
-        site.save(d)
-
-
 class TestWork:
     def test_resolve_redirect_chain(self, monkeypatch):
         # e.g. https://openlibrary.org/works/OL2163721W.json


### PR DESCRIPTION
`ListMixin` is one of the pieces that makes the list code really annoying to work with. Dissolve that class and have just a single `List` class. This also makes a lot of the types now make sense / possible to add!


### Technical
- Centralize all the list models into a single file. This clears up a circular dependency -- which is a good sign :P

### Testing
- ✅ Lists display
- ✅ Can edit lists
- ✅ Can add to list from search page
- ✅ List history displays nice history messages

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
