### PR TITLE
Only load recaptcha JS when needed + DRY recaptcha code

### DIFF
--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -66,6 +66,7 @@ $else:
                 $ callback = "data-callback=submitCreateAccountForm"
                 $ classes = 'g-recaptcha'
                 $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
+                $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
             <button type="submit" name="signup" id="signup" class="larger $classes" $sitekey $callback>$_("Sign Up")</button>
             <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
         </div>

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -87,10 +87,7 @@ $ i18n_strings = {
             </div>
 
         $if recaptcha and not ctx.user:
-            <div class="formElement">
-                <div class="label">$_("Since you are not logged in, please satisfy the reCAPTCHA below.")</div>
-                <div class="g-recaptcha" data-sitekey="$:recaptcha.public_key"></div>
-            </div>
+            $:render_template("recaptcha", recaptcha.public_key, error=None)
 
         <div class="formElement bottom">
             <br/>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -126,9 +126,7 @@ $:macros.HiddenSaveButton("addWork")
         </div>
 
         $if recaptcha:
-            <div class="formElement">
-                <div class="g-recaptcha" data-sitekey="$:recaptcha.public_key"></div>
-            </div>
+            $:render_template("recaptcha", recaptcha.public_key, error=None)
 
         $:macros.EditButtons(comment=work.comment_)
 

--- a/openlibrary/templates/recaptcha.html
+++ b/openlibrary/templates/recaptcha.html
@@ -1,0 +1,16 @@
+$def with(public_key, error, invisible=False)
+
+$if not invisible:
+    <div class="formElement">
+        <div class="label smaller lighter">
+            $_("Please satisfy the reCAPTCHA below. If you have security settings or privacy blockers installed, please disable them to see the reCAPTCHA.")
+        </div>
+        <div class="g-recaptcha" data-sitekey="$public_key"></div>
+        <div class="input">
+            $if error:
+                <span class="invalid clearfix">$_('Incorrect. Please try again.')</span>
+        </div>
+    </div>
+
+$if render_once('recaptcha'):
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/openlibrary/templates/site/footer.html
+++ b/openlibrary/templates/site/footer.html
@@ -43,11 +43,6 @@ $if show_ol_shell:
 <!-- Passes total_time for analytics to ol.analytics.js -->
 <div class="analytics-stats-time-calculator" data-time="$total_time"></div>
 
-$if any([path in request.canonical_url for path in ['/account/create', '/books/add', '/edit', '/books', '/contact']]):
-    <!-- Must be loaded in Sign Up and Add new Books page -->
-    <!-- Must be loaded for all edit pages having link /books/*/*/edit -->
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-
 <!-- clear the window.q and setup the jQuery plugins -->
 <script>
 \$( function () {

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -56,9 +56,7 @@ $var title: $_('How can we help?')
 <!-- </div> -->
 
  $if recaptcha:
-   <div class="formElement">
-     <div class="g-recaptcha" data-sitekey="$:recaptcha.public_key"></div>
-   </div>
+    $:render_template("recaptcha", recaptcha.public_key, error=None)
 
  <div class="formElement bottom">
  <div class="input">

--- a/openlibrary/templates/tag/add.html
+++ b/openlibrary/templates/tag/add.html
@@ -49,10 +49,7 @@ $var title: $_("Add a tag")
         </div>
 
         $if recaptcha and not ctx.user:
-            <div class="formElement">
-                <div class="label">$_("Since you are not logged in, please satisfy the reCAPTCHA below.")</div>
-                <div class="g-recaptcha" data-sitekey="$:recaptcha.public_key"></div>
-            </div>
+            $:render_template("recaptcha", recaptcha.public_key, error=None)
 
         <div class="formElement bottom">
             <br/>


### PR DESCRIPTION
- Previously we were loading the recaptcha JS from google on every /books page and every edit page. We only need it for logged out users, and not at all on the books page, so load it then.
- Also DRY up recaptcha rendering

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- ✅ Invisible recaptcha appears on registration form

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@jimchamp 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
