### PR TITLE
Release Notes navigation to Help Center footer

### DIFF
--- a/openlibrary/templates/lib/nav_foot.html
+++ b/openlibrary/templates/lib/nav_foot.html
@@ -43,6 +43,7 @@ $def with (page)
           <li><a href="/contact?$urlencode(dict(path=request.fullpath))" title="$_('Problems')">$_('Report A Problem')</a></li>
           <li><a href="/help/faq/editing" title="$_('Suggest Edits')">$_('Suggesting Edits')</a></li>
           <li><a href="/books/add" title="$_('Add a new book to Open Library')">$_('Add a Book')</a></li>
+          <li><a href="https://github.com/internetarchive/openlibrary/releases" title="$_('Release Notes')">$_('Release Notes')</a></li>
         </ul>
         <aside id="footer-icons">
           <a class="footer-icons__twitter" href="https://twitter.com/OpenLibrary">twitter</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8552

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add Release Notes link to footer navigation, under help center

Navigation links to : https://github.com/internetarchive/openlibrary/releases


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2023-11-29 at 12 43 27 AM](https://github.com/internetarchive/openlibrary/assets/57823363/16a07b77-18b9-4fed-b392-a3c2cd2be51e)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
