### PR TITLE
Fix typo in trim() docstring

### DIFF
--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -350,7 +350,7 @@ class DataProcessor:
 
 
 def trim(d):
-    """Remote empty values from given dictionary.
+    """Remove empty values from given dictionary.
 
     >>> trim({"a": "x", "b": "", "c": [], "d": {}})
     {'a': 'x'}


### PR DESCRIPTION
This merely fixes a typo in `trim()`'s docstring in `openlibrary/plugins/books/dynlinks.py`.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
