### PR TITLE
Add LibriVox and Project Gutenberg identifiers to add book page

### DIFF
--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -87,7 +87,7 @@ function parseAndValidateId(event) {
     else if (fieldName === 'lccn') {
         parseAndValidateLccn(event, idValue);
     }
-    else if (!isEmptyId(event, idValue)) {
+    else if (!fieldName || !isEmptyId(event, idValue)) {
         document.getElementById('id_value').value = idValue.trim();
     }
 }

--- a/openlibrary/plugins/openlibrary/js/add-book.js
+++ b/openlibrary/plugins/openlibrary/js/add-book.js
@@ -12,6 +12,7 @@ let invalidChecksum;
 let invalidIsbn10;
 let invalidIsbn13;
 let invalidLccn;
+let emptyId;
 
 export function initAddBookImport () {
     $('.list-books a').on('click', function() {
@@ -29,6 +30,7 @@ export function initAddBookImport () {
     invalidIsbn10 = i18nStrings.invalid_isbn10;
     invalidIsbn13 = i18nStrings.invalid_isbn13;
     invalidLccn = i18nStrings.invalid_lccn;
+    emptyId = i18nStrings.empty_id;
 
     $('#id_value').on('change',autoCompleteIdName);
     $('#addbook').on('submit', parseAndValidateId);
@@ -85,6 +87,20 @@ function parseAndValidateId(event) {
     else if (fieldName === 'lccn') {
         parseAndValidateLccn(event, idValue);
     }
+    else if (!isEmptyId(event, idValue)) {
+        document.getElementById('id_value').value = idValue.trim();
+    }
+}
+
+function isEmptyId(event, idValue) {
+    if (!idValue.trim()) {
+        const errorDiv = document.getElementById('id-errors');
+        errorDiv.classList.remove('hidden');
+        errorDiv.textContent = emptyId;
+        event.preventDefault();
+        return true;
+    }
+    return false;
 }
 
 function parseAndValidateIsbn10(event, idValue) {

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -6,7 +6,8 @@ $ i18n_strings = {
     $ "invalid_checksum": _("Invalid ISBN checksum digit"),
     $ "invalid_isbn10": _("ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or 0198534531"),
     $ "invalid_isbn13": _("ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or 9783161484100"),
-    $ "invalid_lccn": _("Invalid LC Control Number format")
+    $ "invalid_lccn": _("Invalid LC Control Number format"),
+    $ "empty_id": _("Please enter a value for the selected identifier")
     $ }
 
 <div id="contentHead">
@@ -70,6 +71,8 @@ $ i18n_strings = {
                 <option value="isbn_10">ISBN 10</option>
                 <option value="isbn_13">ISBN 13</option>
                 <option value="lccn">LCCN</option>
+                <option value="librivox">LibriVox</option>
+                <option value="project_gutenberg">Project Gutenberg</option>
                 </select>
                 &nbsp;
                 <input type="text" name="id_value" id="id_value" size="20" style="width:200px;"/>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8475 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
LibriVox and Project Gutenberg can now be selected as identifiers when adding a new work.

### Technical
<!-- What should be noted about the implementation? -->
Added a default empty check for all identifiers on the page that don't have specific validation.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

1. Go to /books/add
2. Attempt to select LibriVox or Project Gutenberg as the book's identifiers
3. Ensure that an empty value will not be accepted
4. Once submitted, ensure that the identifier is populated on the edition edit screen with the proper value

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
New identifiers on add book page
![image](https://github.com/internetarchive/openlibrary/assets/29631356/cbfbced7-646c-491e-9d58-461005096f1e)

Empty value error message
![image](https://github.com/internetarchive/openlibrary/assets/29631356/ba9b0b68-8eee-486e-8cf9-c3f6a4874aac)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini @seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
