### PR TITLE
Merge Queue tweaks

### DIFF
--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -5,6 +5,7 @@ import json
 import web
 
 from openlibrary import accounts
+from math import ceil
 from openlibrary.core.edits import CommunityEditsQueue, get_status_for_view
 from infogami.utils import delegate
 from infogami.utils.view import render_template
@@ -61,11 +62,12 @@ class community_edits_queue(delegate.page):
             "reviewers": CommunityEditsQueue.get_reviewers(),
         }
 
+
         librarians = {
             'submitters': CommunityEditsQueue.get_submitters(),
             'reviewers': CommunityEditsQueue.get_reviewers(),
         }
-
+        
         return render_template(
             'merge_request_table/merge_request_table',
             total_found,

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -62,12 +62,11 @@ class community_edits_queue(delegate.page):
             "reviewers": CommunityEditsQueue.get_reviewers(),
         }
 
-
         librarians = {
             'submitters': CommunityEditsQueue.get_submitters(),
             'reviewers': CommunityEditsQueue.get_reviewers(),
         }
-        
+
         return render_template(
             'merge_request_table/merge_request_table',
             total_found,

--- a/openlibrary/plugins/upstream/edits.py
+++ b/openlibrary/plugins/upstream/edits.py
@@ -5,7 +5,6 @@ import json
 import web
 
 from openlibrary import accounts
-from math import ceil
 from openlibrary.core.edits import CommunityEditsQueue, get_status_for_view
 from infogami.utils import delegate
 from infogami.utils.view import render_template

--- a/openlibrary/templates/merge_request_table/merge_request_table.html
+++ b/openlibrary/templates/merge_request_table/merge_request_table.html
@@ -41,9 +41,6 @@ $else:
   </div>
 
   $ page = int(input(page=1).page)
-  <div class="pager">
-    $:macros.Pager(page, total[mode], results_per_page=25)
-  </div>
   <div class="librarian-queue-wrapper" data-username="$username" data-i18n="$json_encode(i18n_strings)">
     $:render_template('merge_request_table/table_header', total, librarians, mode, username, submitter, reviewer, status)
     <table class="mr-table">
@@ -58,9 +55,7 @@ $else:
       </tbody>
     </table>
   </div>
-
-  <div class="paginate">
-    $:render_template("lib/pagination", total[mode]/25, page, "/merges?page=%(page)s")
+  <div class="pager">
+    $:macros.Pager(page, total[mode], results_per_page=25)
   </div>
-  
 </div>

--- a/openlibrary/templates/merge_request_table/merge_request_table.html
+++ b/openlibrary/templates/merge_request_table/merge_request_table.html
@@ -29,17 +29,6 @@ $else:
 <div class="librarian-queue-page">
   <h1>$_('Community Edit Requests')</h1>
 
-  <div class="description">
-    $if can_merge:
-      <span class="reviewer-filter">
-        $if reviewer:
-          $_("Showing requests reviewed by %(reviewer)s only.", reviewer=reviewer) <a href="$changequery(reviewer=None, page=None)">$_("Remove reviewer filter")</a>
-        $else:
-          <a href="$changequery(reviewer=username, page=None)">$_("Show requests that I've reviewed")</a>
-      </span>
-    <span>$desc <a href="$href">$link_text</a></span>
-  </div>
-
   $ page = int(input(page=1).page)
   <div class="librarian-queue-wrapper" data-username="$username" data-i18n="$json_encode(i18n_strings)">
     $:render_template('merge_request_table/table_header', total, librarians, mode, username, submitter, reviewer, status)

--- a/openlibrary/templates/merge_request_table/merge_request_table.html
+++ b/openlibrary/templates/merge_request_table/merge_request_table.html
@@ -58,7 +58,9 @@ $else:
       </tbody>
     </table>
   </div>
-  <div class="pager">
-    $:macros.Pager(page, total[mode], results_per_page=25)
+
+  <div class="paginate">
+    $:render_template("lib/pagination", total[mode]/25, page, "/merges?page=%(page)s")
   </div>
+  
 </div>

--- a/openlibrary/templates/merge_request_table/table_row.html
+++ b/openlibrary/templates/merge_request_table/table_row.html
@@ -26,7 +26,7 @@ $code:
         $# End : Status dot indicator
 
         <div class="mr-details">
-        $:_('<span class="mr-details__request-title"><a href="%(url)s" target="_blank">%(title)s</a></span>', title=request_title, url=request["url"])
+        <span class="mr-details__request-title">$request_title</span>
 
         $# Start : Most recent comment preview
         <div class="mr-details__comment-preview">

--- a/openlibrary/templates/merge_request_table/table_row.html
+++ b/openlibrary/templates/merge_request_table/table_row.html
@@ -26,7 +26,7 @@ $code:
         $# End : Status dot indicator
 
         <div class="mr-details">
-        $:_('<span class="mr-details__request-title">%(title)s</span>', title=request_title)
+        $:_('<span class="mr-details__request-title"><a href="%(url)s" target="_blank">%(title)s</a></span>', title=request_title, url=request["url"])
 
         $# Start : Most recent comment preview
         <div class="mr-details__comment-preview">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
a.) Removes top of page pagination.
b.) Removes the "Show requests that I've reviewed" and "Show my requests" at the top of the page.
c.) Makes the make the MR title a link to preview the merge without assigning.

### Technical
<!-- What should be noted about the implementation? -->

Changes in merge_request_table.html only

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Mostly visual. Will update next section with images.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

Will update

### Stakeholders
<!-- @ tag stakeholders of this bug -->

@mekarpeles @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
