### PR TITLE
Relax yearly already-read page query

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -383,8 +383,7 @@ class Bookshelves(db.CommonExtras):
                 FROM bookshelves_books b
                 INNER JOIN bookshelves_events e
                 ON b.work_id = e.work_id AND b.username = e.username
-                WHERE b.bookshelf_id = $bookshelf_id
-                AND b.username = $username
+                WHERE b.username = $username
                 AND e.event_date LIKE $checkin_year || '%'
                 ORDER BY b.created DESC
                 """


### PR DESCRIPTION
Fixes yearly already-read reading log by showing books with checkins that have since been moved to other shelves, e.g. a book that was marked as read but then moved to e.g. "Already Read" or "Currently Reading"


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
