### PR TITLE
Adds follow (pubsub) feature

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -93,6 +93,20 @@ class Bookshelves(db.CommonExtras):
         return results[0]
 
     @classmethod
+    def patrons_who_also_read(cls, work_id: str, limit: int = 15):
+        oldb = db.get_db()
+        query = "select DISTINCT username from bookshelves_books where work_id=$work_id AND bookshelf_id=3 limit $limit"
+        results = oldb.query(query, vars={'work_id': work_id, 'limit': limit})
+        # get all patrons with public reading logs
+        return [
+            p
+            for p in web.ctx.site.get_many(
+                [f'/people/{r.username}/preferences' for r in results]
+            )
+            if p.dict().get('notifications', {}).get('public_readlog') == 'yes'
+        ]
+
+    @classmethod
     def most_logged_books(
         cls,
         shelf_id: str = '',

--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -41,7 +41,7 @@ class PubSub:
     def get_followers(cls, publisher):
         """Get publishers subscribers"""
         oldb = db.get_db()
-        where='publisher=$publisher'
+        where = 'publisher=$publisher'
         subscribers = oldb.select(
             cls.TABLENAME, where=where, vars={'publisher': publisher}
         )
@@ -50,7 +50,7 @@ class PubSub:
     @classmethod
     def get_following(cls, subscriber, exclude_disabled=False):
         """Get subscriber's subscriptions"""
-        oldb = db.get_db()        
+        oldb = db.get_db()
         where = 'subscriber=$subscriber'
         if exclude_disabled:
             where += " AND disabled=false"
@@ -80,7 +80,7 @@ class PubSub:
 
         # Extract usernames from subscriptions
         usernames = [sub['publisher'] for sub in subscriptions]
-        
+
         if not usernames:
             return []
 
@@ -93,11 +93,7 @@ class PubSub:
         recent_books = list(
             oldb.query(
                 query,
-                vars={
-                    'usernames': usernames,
-                    'limit': limit,
-                    'offset': offset
-                },
+                vars={'usernames': usernames, 'limit': limit, 'offset': offset},
             )
         )
 
@@ -107,10 +103,9 @@ class PubSub:
 
         return Bookshelves.fetch(recent_books)
 
-
     @classmethod
     def count_following(cls, subscriber):
-        oldb = db.get_db()        
+        oldb = db.get_db()
         count = oldb.select(
             cls.TABLENAME,
             what='count(*) as count',
@@ -121,7 +116,7 @@ class PubSub:
 
     @classmethod
     def count_followers(cls, publisher):
-        oldb = db.get_db()        
+        oldb = db.get_db()
         count = oldb.select(
             cls.TABLENAME,
             what='count(*) as count',

--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -1,0 +1,152 @@
+import logging
+import web
+from typing import cast, Any
+from openlibrary.core.bookshelves import Bookshelves
+
+from . import db
+
+logger = logging.getLogger(__name__)
+
+
+class PubSub:
+    TABLENAME = "follows"
+    PRIMARY_KEY = ["subscriber", "publisher"]
+
+    @classmethod
+    def subscribe(cls, subscriber, publisher):
+        oldb = db.get_db()
+        return oldb.insert(cls.TABLENAME, subscriber=subscriber, publisher=publisher)
+
+    @classmethod
+    def unsubscribe(cls, subscriber, publisher):
+        oldb = db.get_db()
+        return oldb.delete(
+            cls.TABLENAME,
+            where='subscriber=$subscriber AND publisher=$publisher',
+            vars={'subscriber': subscriber, 'publisher': publisher},
+        )
+
+    @classmethod
+    def is_subscribed(cls, subscriber, publisher):
+        oldb = db.get_db()
+        subscription = oldb.select(
+            cls.TABLENAME,
+            where='subscriber=$subscriber AND publisher=$publisher',
+            vars={'subscriber': subscriber, 'publisher': publisher},
+            limit=1,  # Limiting to 1 result to check if the subscription exists
+        )
+        return len(subscription)
+
+    @classmethod
+    def get_followers(cls, publisher):
+        """Get publishers subscribers"""
+        oldb = db.get_db()
+        where='publisher=$publisher'
+        subscribers = oldb.select(
+            cls.TABLENAME, where=where, vars={'publisher': publisher}
+        )
+        return subscribers
+
+    @classmethod
+    def get_following(cls, subscriber, exclude_disabled=False):
+        """Get subscriber's subscriptions"""
+        oldb = db.get_db()        
+        where = 'subscriber=$subscriber'
+        if exclude_disabled:
+            where += " AND disabled=false"
+        subscriptions = oldb.select(
+            cls.TABLENAME,
+            where=where,
+            vars={'subscriber': subscriber},
+        )
+        return [dict(s) for s in subscriptions]
+
+    @classmethod
+    def toggle_privacy(cls, publisher, private=True):
+        oldb = db.get_db()
+        return oldb.update(
+            cls.TABLENAME,
+            disabled=private,
+            where="publisher=$publisher",
+            vars={"publisher": publisher},
+        )
+
+    @classmethod
+    def get_feed(cls, subscriber, limit=25, offset=0):
+        oldb = db.get_db()
+
+        # Get subscriber's subscriptions
+        subscriptions = cls.get_following(subscriber, exclude_disabled=True)
+
+        # Extract usernames from subscriptions
+        usernames = [sub['publisher'] for sub in subscriptions]
+        
+        if not usernames:
+            return []
+
+        # Formulate the SQL query to get latest 25 entries for subscribed users
+        query = (
+            "SELECT * FROM bookshelves_books WHERE username IN $usernames"
+            " ORDER BY created DESC LIMIT $limit OFFSET $offset"
+        )
+        # Fetch the recent books for subscribed users
+        recent_books = list(
+            oldb.query(
+                query,
+                vars={
+                    'usernames': usernames,
+                    'limit': limit,
+                    'offset': offset
+                },
+            )
+        )
+
+        # Add keys
+        for i, rb in enumerate(recent_books):
+            recent_books[i].key = f'/works/OL{recent_books[i].work_id}W'
+
+        return Bookshelves.fetch(recent_books)
+
+
+    @classmethod
+    def count_following(cls, subscriber):
+        oldb = db.get_db()        
+        count = oldb.select(
+            cls.TABLENAME,
+            what='count(*) as count',
+            where='subscriber=$subscriber',
+            vars={'subscriber': subscriber},
+        )
+        return cast(tuple[int], count)[0].get('count', 0)
+
+    @classmethod
+    def count_followers(cls, publisher):
+        oldb = db.get_db()        
+        count = oldb.select(
+            cls.TABLENAME,
+            what='count(*) as count',
+            where='publisher=$publisher',
+            vars={'publisher': publisher},
+        )
+        return cast(tuple[int], count)[0].get('count', 0)
+
+    @classmethod
+    def count_total_subscribers(cls):
+        oldb = db.get_db()
+        count = oldb.query("SELECT COUNT(DISTINCT subscriber) AS count FROM follows")
+        return cast(tuple[int], count)[0].get('count', 0)
+
+    @classmethod
+    def count_total_publishers(cls):
+        oldb = db.get_db()
+        count = oldb.query("SELECT COUNT(DISTINCT publisher) AS count FROM follows")
+        return cast(tuple[int], count)[0].get('count', 0)
+
+    @classmethod
+    def most_followed(cls, limit=100):
+        oldb = db.get_db()
+        top_publishers = oldb.query(
+            "SELECT publisher, COUNT(*) AS count FROM follows WHERE disabled=false GROUP BY publisher ORDER BY count DESC LIMIT $limit",
+            vars={'limit': limit},
+        )
+        return top_publishers

--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -22,6 +22,7 @@ from openlibrary.core import lending
 from openlibrary.catalog import add_book
 from openlibrary.core.booknotes import Booknotes
 from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.core.follows import PubSub
 from openlibrary.core.helpers import private_collection_in
 from openlibrary.core.imports import ImportItem
 from openlibrary.core.observations import Observations
@@ -480,6 +481,10 @@ class Work(Thing):
         rating = Ratings.get_users_rating_for_work(username, work_id)
         return rating
 
+    def get_patrons_who_also_read(self):
+        key = self.key.split('/')[-1][2:-1]
+        return Bookshelves.patrons_who_also_read(key)
+
     def get_users_read_status(self, username):
         if not username:
             return None
@@ -877,6 +882,15 @@ class User(Thing):
         if sort:
             lists = safesort(lists, reverse=True, key=lambda list: list.last_modified)
         return lists
+
+    @classmethod
+    # @cache.memoize(engine="memcache", key="user-avatar")
+    def get_avatar_url(cls, username):
+        username = username.split('/people/')[-1]
+        user = web.ctx.site.get('/people/%s' % username)
+        itemname = user.get_account().get('internetarchive_itemname')
+
+        return f'https://archive.org/services/img/{itemname}'
 
     @cache.memoize(engine="memcache", key=lambda self: ("d" + self.key, "l"))
     def _get_lists_cached(self):

--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -10,6 +10,17 @@ CREATE TABLE ratings (
 );
 CREATE INDEX ratings_work_id_idx ON ratings (work_id);
 
+CREATE TABLE follows (
+    subscriber text NOT NULL,
+    publisher text NOT NULL,
+    disabled BOOLEAN DEFAULT FALSE,
+    updated timestamp without time zone default (current_timestamp at time zone 'utc'),
+    created timestamp without time zone default (current_timestamp at time zone 'utc'),
+    primary key (subscriber, publisher)
+);
+CREATE INDEX subscriber_idx ON follows (subscriber);
+CREATE INDEX publisher_idx ON follows (publisher);
+
 CREATE TABLE booknotes (
     username text NOT NULL,
     work_id integer NOT NULL,

--- a/openlibrary/macros/Follow.html
+++ b/openlibrary/macros/Follow.html
@@ -1,0 +1,18 @@
+$def with (publisher, fid='', following=False)
+
+$ subscriber = ctx.user and ctx.user.key
+
+
+<div>
+  $if ctx.user:
+    <form class="follow-form" id="follow_$fid" method="POST" action="$(subscriber)/follows.json"
+          property="follow" typeof="Follows" vocab="http://schema.org/">
+      <input type="hidden" value="$following" name="state"/>
+      <input type="hidden" value="$publisher" name="publisher"/>
+      <input type="hidden" value="$request.fullpath" name="redir_url"/>
+      $ css_treatment = 'delete' if following else 'primary'
+      <button type="submit" class="cta-btn cta-btn--$(css_treatment)">$_("Unfollow" if following else "Follow")</button>
+    </form>
+  $else:
+    <a class="cta-btn cta-btn--primary" href="/account/login?redir_url=$(ctx.path)">$_("Follow")</a>
+</div>

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -41,6 +41,14 @@ $code:
 
 <li class="searchResultItem sri--w-main" itemscope itemtype="https://schema.org/Book" $:attrs>
   $ blur_cover = "bookcover--blur" if blur else ""
+  $if 'log' in doc:
+    <div class="feed-item">
+      <a class="feed-item--patron" href="/people/$(doc['log']['username'])">
+        <img src="/people/$(doc['log']['username'])/avatar" class="account-avatar account-avatar--sm account-avatar-fix">
+        $doc['log']['username']
+      </a> $_("added to")
+      <a href="/people/$(doc['log']['username'])/books/$(doc['log']['shelf'].replace(' ', '-'))" class="feed-item--shelf">$doc['log']['shelf']</a> $datestr(doc['log']['updated'])
+    </div>
   <div class="sri__main">
     <span class="bookcover $blur_cover">
       $ cover = get_cover_url(selected_ed) or "/images/icons/avatar_book-sm.png"
@@ -57,7 +65,7 @@ $code:
           <h3 itemprop="name" class="booktitle">
             <a itemprop="url" href="$work_edition_url" class="results">$full_title</a>
           </h3>
-          </div>
+        </div>
         <span itemprop="author" itemscope itemtype="https://schema.org/Organization" class="bookauthor">
           $ authors = None
           $if doc_type == 'infogami_work':
@@ -114,7 +122,7 @@ $code:
           </div>
         $if extra:
           $:extra
-        </div>
+    </div>
 
     <div class="searchResultItemCTA">
         $if decorations:

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -25,11 +25,13 @@ from openlibrary.core.bookshelves_events import BookshelvesEvents
 from openlibrary.core.observations import Observations, get_observation_metrics
 from openlibrary.core.models import Booknotes, Work
 from openlibrary.core.sponsorships import qualifies_for_sponsorship
+from openlibrary.core.follows import PubSub
 from openlibrary.core.vendors import (
     create_edition_from_amazon_metadata,
     get_amazon_metadata,
     get_betterworldbooks_metadata,
 )
+from openlibrary.core.helpers import NothingEncoder
 
 
 class book_availability(delegate.page):
@@ -497,6 +499,34 @@ class price_api(delegate.page):
                     metadata['ocaid'] = ed.ocaid
 
         return json.dumps(metadata)
+
+
+class patrons_follows_json(delegate.page):
+    path = r"(/people/[^/]+)/follows"
+    encoding = "json"
+
+    def GET(self, key):
+        i = web.input(publisher='', redir_url='', state='')
+        user = accounts.get_current_user()
+        if not user or user.key != key:
+            raise web.seeother(f'/account/login?redir_url={i.redir_url}')
+
+        username = user.key.split('/')[2]
+        return delegate.RawText(
+            json.dumps(PubSub.get_subscriptions(username), cls=NothingEncoder),
+            content_type="application/json",
+        )
+
+    def POST(self, key):
+        i = web.input(publisher='', redir_url='', state='')
+        user = accounts.get_current_user()
+        if not user or user.key != key:
+            raise web.seeother(f'/account/login?redir_url={i.redir_url}')
+
+        username = user.key.split('/')[2]
+        action = PubSub.subscribe if i.state == '0' else PubSub.unsubscribe
+        action(username, i.publisher)
+        raise web.seeother(i.redir_url)
 
 
 class patrons_observations(delegate.page):

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -770,7 +770,7 @@ class account_privacy(delegate.page):
 
         user.save_preferences(i)
         username = user.key.split('/')[-1]
-        PubSub.toggle_privacy(username, private=i.public_readlog=='no')
+        PubSub.toggle_privacy(username, private=i.public_readlog == 'no')
         web.setcookie(
             'sfw', i.safe_mode, expires="" if i.safe_mode.lower() == 'yes' else -1
         )

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -1,0 +1,21 @@
+$def with (user, follows=None, manage=False)
+
+$if follows:
+  $ username = user.key.split('/')[-1]
+  $for follow in follows:
+    <ul>
+      <li class="follow-row">
+	<div class="follow-row--name">
+          $if follow['publisher'] == username:
+            <a href="/people/$follow['subscriber']/books" class="username-avatar"><img src="/people/$follow['subscriber']/avatar" class="account-avatar">$follow['subscriber']</a>
+          $else:
+            <a href="/people/$follow['publisher']/books" class="username-avatar"><img src="/people/$follow['publisher']/avatar" class="account-avatar">$follow['publisher']</a>
+	</div>
+	<div>
+          $if manage:
+            $:macros.Follow(follow['publisher'], following=1)
+	</div>
+      </li>
+    </ul>
+$else:
+  <p>$_("There is nothing to see here yet.")</p>

--- a/openlibrary/templates/account/privacy.html
+++ b/openlibrary/templates/account/privacy.html
@@ -23,7 +23,7 @@ $ safe_mode = d.get('safe_mode', 'no')
 
         <div class="formElement">
             <h3 class="collapse">$:_('Would you like to make your <a href="/account/books">Reading Log</a> public?')</h3>
-            <p>$_("This will enable others to see what books you want to read, are reading, or have already read.")</p>
+            <p>$_("This will enable others to see what books you want to read, are reading, or have already read. Public accounts can be seen and followed by others.")</p>
         </div>
         <br/>
         <div class="formElement">

--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -3,6 +3,8 @@ $def with (docs, key, shelf_count, doc_count, owners_page, current_page, sort_or
 $ username = user.key.split('/')[-1]
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
 $ userDisplayName = user.displayname or ctx.user.displayname
+$ readlog_keys = ['want-to-read', 'already-ready', 'current-reading']
+$ shelves = [_('want to read'), _('currently reading'), _('already read')]
 
 $if key == 'currently-reading':
   $ og_title = _("Books %(username)s is reading", username=userDisplayName)
@@ -17,6 +19,9 @@ $elif key == 'already-read':
   $else:
     $ og_title = _("Books %(username)s has read", username=userDisplayName)
     $ og_description = _("%(username)s has read %(total)d books. Join %(username)s on OpenLibrary.org and tell the world about the books that you care about.", username=userDisplayName, total=shelf_count)
+$elif key == 'feed':
+  $ og_title = _("Books in %(username)s feed", username=userDisplayName)
+  $ og_description = _("Books added by people %(username)s follows", username=userDisplayName)
 $elif key == 'sponsorships':
   $ og_title = _("Books %(userdisplayname)s is sponsoring", userdisplayname=userDisplayName)
   $ og_description = "{username} is sponsoring {total} books. Join {username} on OpenLibrary.org and share the books that you'll soon be reading!".format(username=userDisplayName, total=shelf_count)
@@ -30,18 +35,19 @@ $add_metatag(property="og:image", content=meta_photo_url)
 
 <div class="mybooks-list">
   $ yearly_goal = get_reading_goals(year=checkin_year)
-  $if yearly_goal and owners_page:
+  $if yearly_goal and owners_page and key in readlog_keys:
     <div class="yearly-goal-section">
       $:render_template('check_ins/reading_goal_progress', [yearly_goal])
     </div>
 
   $# The reading log search is only displayed on non-empty shelves because some patrons were confused and searching empty reading lists, perhaps thinking they could add books that way. See #7143.
-  $if q or len(docs) > 0:
-    <form method="GET" class="olform pagesearchbox">
-      <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
-      <input type="submit"/>
-    </form>
+
   $if len(docs) > 0:
+    $if key in readlog_keys:
+      <form method="GET" class="olform pagesearchbox">
+        <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
+        <input type="submit"/>
+      </form>
     $if q:
       <span class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', doc_count, count=commify(doc_count))</span>
     $else:
@@ -64,8 +70,14 @@ $add_metatag(property="og:image", content=meta_photo_url)
         $ doc_number = 1
         $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
         $for idx, doc in enumerate(docs):
-          $ star_rating = macros.StarRatings(doc, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
-          $:macros.SearchResultsWork(doc, availability=doc.get('availability'), rating=star_rating, include_dropper=(bookshelf_id and owners_page))
+          $if doc.get('work', {}):
+            $ work = doc.pop('work')
+            $ work['log'] = doc
+            $ work['log']['shelf'] = shelves[doc['bookshelf_id'] - 1]
+          $else:
+            $ work = doc
+          $ star_rating = macros.StarRatings(work, redir_url='/account/books/already-read', id=doc_number, rating=ratings[idx]) if include_ratings else None
+          $:macros.SearchResultsWork(work, availability=doc.get('availability'), rating=star_rating, include_dropper=(bookshelf_id and owners_page))
           $ doc_number = doc_number + 1
     </ul>
     $if not checkin_year:
@@ -84,8 +96,10 @@ $add_metatag(property="og:image", content=meta_photo_url)
         </div>
       $elif checkin_year:
         <p>$_("You haven't marked any books as read for this year.")</p>
-      $else:
+      $elif key in readlog_keys:
         <p>$_("You haven't added any books to this shelf yet.")</p>
         <p>$:_('<a href="/search">Search for a book</a> to add to your reading log. <a href="/help/faq/reading-log">Learn more</a> about the reading log.')</p>
+      $elif key == 'feed':
+	<p>$_("There are no recent books in your feed. When you follow public accounts, their book updates will appear here.")</p>
     </ul>
   </div>

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -11,6 +11,8 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
         <li>
           <a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="/account/loan-history">$_('Loan History')</a>
         </li>
+	<li><a data-ol-link-track="MyBooksSidebar|MyFeed" $('class=selected' if key=='feed' else '') href="/people/$username/books/feed">$_('My Feed')</a></li>
+      </ul>
     </ul>
     $if public or owners_page:
       <ul class="sidebar-section">
@@ -26,7 +28,7 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
         </li>
       $if owners_page:
         <hr>
-        <li><a data-ol-link-track="MyBooksSidebar|MyNotes" $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
+	<li><a data-ol-link-track="MyBooksSidebar|MyNotes" $('class=selected' if key=='notes' else '') href="/people/$username/books/notes"><span class="li-count">$counts['notes']</span>$_('My Notes')</a></li>
         <li><a data-ol-link-track="MyBooksSidebar|MyReviews" $('class=selected' if key=='observations' else '') href="/people/$username/books/observations"><span class="li-count">$counts['observations']</span>$_('My Reviews')</a></li>
         <hr>
         <li><a data-ol-link-track="MyBooksSidebar|ReadingStats" href="/account/books/already-read/stats">$_('My Reading Stats')</a></li>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -19,10 +19,10 @@ $var title: $header_title
     <header>
       <div class="breadcrumb-wrapper">
         $# Only show breadcrumbs when we're not on mybooks
-	<div class="account-breadcrumb">
-          <a href="$mb.user.key"><img src="https://archive.org/services/img/$mb.user_itemname" class="account-avatar"></a>
-	  <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
-	</div>
+        <div class="account-breadcrumb">
+          <a href="$mb.user.key" class="username-avatar"><img src="$(mb.user.key)/avatar" class="account-avatar"></a>
+          <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
+        </div>
         $if mb.key == 'list':
           <h1 class="details-title">$header_title</h1>
         $else:
@@ -36,17 +36,24 @@ $var title: $header_title
           </div>
       </div>
 
+      $if not mb.is_my_page and mb.is_subscribed != -1:
+        $:macros.Follow(mb.username, following=mb.is_subscribed)
+
+      $if 'followers' in mb.counts:
+        <div class="social-wrapper">
+          <a class="cta-btn cta-btn--unstyled" href="$(mb.user.key)/following"><strong>$mb.counts['following']</strong> $_("Following")</a>
+          <a class="cta-btn cta-btn--unstyled" href="$(mb.user.key)/followers"><strong>$mb.counts['followers']</strong> $_("Followers")</a>
+          $if mb.is_public and mb.key in mb.PUBLIC_KEYS:
+            $set_share_links(url=request.canonical_url, title=header_title, view_context=ctx)
+            $if ctx.get('share_links'):
+              $ share_str = _('Share')
+              $ share_content = '<a class="cta-btn cta-btn--unstyled share-modal-link icon-link" href="javascript:;" data-ol-link-track="MyBooksModalLinkClick|ShareIcon"><img class="icon-link__image" src="/static/images/icons/share.svg" width="20"> %s</a>' % share_str
+              $ page_url = request.home
+              $ share_links = ctx.get('share_links')
+              $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
+        </div>
       $if page:
         $:macros.databarView(page)
-
-      $if mb.is_public and mb.key in mb.PUBLIC_KEYS:
-        $set_share_links(url=request.canonical_url, title=header_title, view_context=ctx)
-        $if ctx.get('share_links'):
-          $ share_str = _('Share')
-          $ share_content = '<a class="cta-btn cta-btn--unstyled share-modal-link icon-link" href="javascript:;" data-ol-link-track="MyBooksModalLinkClick|ShareIcon"><img class="icon-link__image" src="/static/images/icons/share.svg" width="20"> %s</a>' % share_str
-          $ page_url = request.home
-          $ share_links = ctx.get('share_links')
-          $:macros.ShareModal(share_links, page_url, share_content, "share-modal-wrapper", show_embed=False)
     </header>
 
     $ mb.component_times['Details header'] = time() - mb.component_times['Details header']

--- a/openlibrary/templates/books/mybooks_breadcrumb_select.html
+++ b/openlibrary/templates/books/mybooks_breadcrumb_select.html
@@ -7,9 +7,14 @@ $if mb.is_my_page or mb.is_public:
   $ options += [
   $   (_("Want to Read (%(count)d)", count=mb.counts['want-to-read']), readlog_url % "want-to-read"),
   $   (_("Currently Reading (%(count)d)", count=mb.counts['currently-reading']), readlog_url % "currently-reading"),
-  $   (_("Already Read (%(count)d)", count=mb.counts['already-read']), readlog_url % "already-read")
-  $ ]
-$ options += [(_("Lists (%(count)d)", count=len(mb.lists)) , url_prefix + "/lists")]
+  $   (_("Already Read (%(count)d)", count=mb.counts['already-read']), readlog_url % "already-read"),
+  $   (_("My Feed"), readlog_url % "feed"),
+$ ]
+$ options += [
+  $   (_("Lists (%(count)d)", count=len(mb.lists)) , url_prefix + "/lists"),
+  $   (_("Followers"), url_prefix + "/followers"),
+  $   (_("Following"), url_prefix + "/following"),
+$ ]
 $if mb.is_my_page:
   $ options += [
   $   (_("Loans"), "/account/loans"),

--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -23,6 +23,18 @@
   white-space: nowrap;
 }
 
+.social-wrapper {
+  display: flex;
+}
+
+.follow-row {
+  display: flex;
+  align-items: center;
+  &--name {
+    flex: .5;
+  }
+}
+
 .breadcrumb-title {
   display: inline-block;
   margin: 0;

--- a/static/css/components/mybooks.less
+++ b/static/css/components/mybooks.less
@@ -37,8 +37,23 @@ img.account-avatar {
   border-radius: 100px;
   width: 40px;
   height: 40px;
-  margin-top: 10px;
   margin-right: 5px;
+}
+
+.account-avatar-fix {
+  position: relative;
+  top: 7px;
+  left: 5px;
+}
+
+img.account-avatar--sm {
+  width: 25px;
+  height: 25px;
+}
+
+.username-avatar {
+  display: flex;
+  align-items: center;
 }
 
 h2.account-username {

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1843,7 +1843,6 @@ div#subjectLists {
 // openlibrary/templates/account/privacy.html
 // openlibrary/templates/account.html
 .account-settings-menu {
-  margin-bottom: 15px;
   display: flex;
 }
 


### PR DESCRIPTION

<!-- What issue does this PR close? -->
* Followup to #8597, closes #1966 (previous PR) and implements #739

closes #739

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- database schema for follows
- adds core model for follows
- elementary mybooks /feed of followers
- ability to follow/unfollow
- json API to fetch patron's follows

### Screen shots

**My Feed** (private)
<img width="782" alt="Screenshot 2024-02-20 at 9 48 08 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/5b627cd5-5966-4877-89fe-9fe28988c52a">

**My Followers** (public)
<img width="771" alt="Screenshot 2024-02-20 at 9 48 31 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/73ddce0c-e32c-45b8-b602-3a68738a2c69">

**Following** (public)
<img width="778" alt="Screenshot 2024-02-20 at 9 48 59 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/1ccaec99-d233-49d8-9466-cf33bc3ef618">

### Technical
<!-- What should be noted about the implementation? -->

**Schema already on production db**

### Product Notes

- [ ] Add follows to /stats dashboard
- [x] Add Patrons I Follow page to my books.
  - There are still valuable pieces from #1966 which we should consider implementing, like the [people I'm following page](https://github.com/internetarchive/openlibrary/pull/1966/files#diff-640b35cc042bf968b008b029cc8c77593cb5b668d22fa787cef684d31b4937f9) even if this is private
- [ ] Leverage follows to integrate book recommendations into Books Page
using with the following code:

```
+++ b/openlibrary/templates/type/edition/view.html
@@ -338,6 +338,13 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
       </div>
     </div>
 
+    <div>
+      <ul>
+	$for p in page.get_patrons_who_also_read():
+	  <a href="/people/$(p.key.split('/')[2])/books/already-read">$p.key.split('/')[2]</a></li>
+      </ul>
+    </div>
```


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
