### PR TITLE
Add autofill for title form on add new book page

### DIFF
--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -1,8 +1,6 @@
-$def with (work=None, authors=None, recaptcha=None, book=None)
-$var title: $_("Add a book")
+$def with (work=None, authors=None, recaptcha=None)
 
-$ edition_config = get_edition_config()
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$var title: $_("Add a book")
 
 $ i18n_strings = {
     $ "invalid_checksum": _("Invalid ISBN checksum digit"),
@@ -11,25 +9,6 @@ $ i18n_strings = {
     $ "invalid_lccn": _("Invalid LC Control Number format")
     $ }
 
-$# Render the ith work input field
-$jsdef render_work_field(i, work):
-    <div class="input ac-input">
-        <input class="ac-input__visible" name="works--$i" type="text" value="$work.key.split('/')[-1]"/>
-        <input class="ac-input__value" name="edition--works--$i--key" type="hidden" value="$work.key" />
-        <a class="mia__remove hidden" href="javascript:;" title="$_('Remove this work')">[x]</a>
-    </div>
-
-$# Import the side-effect of the jsdef function
-$:render_template('jsdef/LazyWorkPreview', None)
-
-$jsdef render_work_autocomplete_item(item):
-    $if item.key == "__new__":
-        <div class="ac_work ac_addnew">
-            <span class="action">$_('-- Move to a new work')</span>
-        </div>
-    $else:
-        $:render_lazy_work_preview(item)
-    
 <div id="contentHead">
     <div class="head">
         <h1>$_("Add a book to Open Library")</h1>
@@ -46,9 +25,12 @@ $jsdef render_work_autocomplete_item(item):
             <div class="label">
                 <label for="title">$_("Title")</label> <span class="tip">$:_("Use <b><i>Title: Subtitle</i></b> to add a subtitle.")</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
             </div>
-            $ config = {'addnew': is_privileged_user, 'new_name': _('-- Move to a new work')}
-            <div class="multi-input-autocomplete--works" id="title" data-config="$dumps(config)">
-                    $:render_work_field(0, storage(title="", key=""))
+            <div class="input">
+                $if work:
+                    <input type="text" id="title" disabled="disabled" value="$work.title"/>
+                    <input type="hidden" name="title" value="$work.title"/>
+                $else:
+                    <input type="text" name="title" id="title" class="required title" style="width:630px;" value="$(work and work.title)" $cond(work, 'readonly="readonly"')/>
             </div>
         </div>
         <div class="formElement">
@@ -121,7 +103,6 @@ $jsdef render_work_autocomplete_item(item):
                 <a href="javascript:history.go(-1);" class="attn">$_('Cancel')</a>
             </div>
         </div>
-
     </form>
 </div>
 

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -1,6 +1,8 @@
-$def with (work=None, authors=None, recaptcha=None)
-
+$def with (work=None, authors=None, recaptcha=None, book=None)
 $var title: $_("Add a book")
+
+$ edition_config = get_edition_config()
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
 
 $ i18n_strings = {
     $ "invalid_checksum": _("Invalid ISBN checksum digit"),
@@ -9,6 +11,25 @@ $ i18n_strings = {
     $ "invalid_lccn": _("Invalid LC Control Number format")
     $ }
 
+$# Render the ith work input field
+$jsdef render_work_field(i, work):
+    <div class="input ac-input">
+        <input class="ac-input__visible" name="works--$i" type="text" value="$work.key.split('/')[-1]"/>
+        <input class="ac-input__value" name="edition--works--$i--key" type="hidden" value="$work.key" />
+        <a class="mia__remove hidden" href="javascript:;" title="$_('Remove this work')">[x]</a>
+    </div>
+
+$# Import the side-effect of the jsdef function
+$:render_template('jsdef/LazyWorkPreview', None)
+
+$jsdef render_work_autocomplete_item(item):
+    $if item.key == "__new__":
+        <div class="ac_work ac_addnew">
+            <span class="action">$_('-- Move to a new work')</span>
+        </div>
+    $else:
+        $:render_lazy_work_preview(item)
+    
 <div id="contentHead">
     <div class="head">
         <h1>$_("Add a book to Open Library")</h1>
@@ -25,12 +46,9 @@ $ i18n_strings = {
             <div class="label">
                 <label for="title">$_("Title")</label> <span class="tip">$:_("Use <b><i>Title: Subtitle</i></b> to add a subtitle.")</span> <span class="red">*<span class="tip">$_("Required field")</span></span>
             </div>
-            <div class="input">
-                $if work:
-                    <input type="text" id="title" disabled="disabled" value="$work.title"/>
-                    <input type="hidden" name="title" value="$work.title"/>
-                $else:
-                    <input type="text" name="title" id="title" class="required title" style="width:630px;" value="$(work and work.title)" $cond(work, 'readonly="readonly"')/>
+            $ config = {'addnew': is_privileged_user, 'new_name': _('-- Move to a new work')}
+            <div class="multi-input-autocomplete--works" id="title" data-config="$dumps(config)">
+                    $:render_work_field(0, storage(title="", key=""))
             </div>
         </div>
         <div class="formElement">
@@ -103,6 +121,7 @@ $ i18n_strings = {
                 <a href="javascript:history.go(-1);" class="attn">$_('Cancel')</a>
             </div>
         </div>
+
     </form>
 </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8598

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds back the autofill feature on the "Title" form of [https://openlibrary.org/books/add](https://openlibrary.org/books/add)

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
No unit tests were added but this can be verified by going to the Add a Book page and typing in half a word to see suggestion titles.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/mansip2002/openlibrary/assets/70120613/c1802924-4bc7-4c15-bb7c-93ca6fb87f9f)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
