### PR TITLE
Update ia.py to fix the bug of undefined IA base url

### DIFF
--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -14,10 +14,14 @@ from openlibrary.utils.dateutil import date_n_days_ago
 
 logger = logging.getLogger('openlibrary.ia')
 
-# FIXME: We can't reference `config` in module scope like this; it will always be undefined!
-# See lending.py for an example of how to do it correctly.
-IA_BASE_URL = config.get('ia_base_url', 'https://archive.org')
+IA_BASE_URL = None
 VALID_READY_REPUB_STATES = ['4', '19', '20', '22']
+
+def setup(config):
+    """Initializes this module from openlibrary config."""
+    global IA_BASE_URL
+
+    IA_BASE_URL = config.get('ia_base_url', 'https://archive.org')
 
 
 def get_api_response(url: str, params: dict | None = None) -> dict:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #4437 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes IA_BASE_URL not being read from openlibrary.yml

Technical
<!-- What should be noted about the implementation? -->
This change modifies the implementation for referencing config to read the IA_BASE_URL by adding a setup method. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
