### PR TITLE
Remove `bookshelves_votes` table from `schema.sql` and pg dumps

### DIFF
--- a/openlibrary/core/schema.sql
+++ b/openlibrary/core/schema.sql
@@ -41,14 +41,6 @@ CREATE TABLE bookshelves_books (
     primary key (username, work_id, bookshelf_id)
 );
 CREATE INDEX bookshelves_books_work_id_idx ON bookshelves_books (work_id);
--- bookshelves_votes currently unused
-CREATE TABLE bookshelves_votes (
-    username text NOT NULL,
-    bookshelf_id serial NOT NULL REFERENCES bookshelves(id) ON DELETE CASCADE ON UPDATE CASCADE,
-    updated timestamp without time zone default (current_timestamp at time zone 'utc'),
-    created timestamp without time zone default (current_timestamp at time zone 'utc'),
-    primary key (username, bookshelf_id)
-);
 
 INSERT INTO bookshelves (name, description) VALUES ('Want to Read', 'A list of books I want to read');
 INSERT INTO bookshelves (name, description) VALUES ('Currently Reading', 'A list of books I am currently reading');

--- a/scripts/dev-instance/dev_db.pg_dump
+++ b/scripts/dev-instance/dev_db.pg_dump
@@ -11,14 +11,14 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
@@ -53,7 +53,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: account; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: account; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.account (
@@ -69,7 +69,7 @@ CREATE TABLE public.account (
 ALTER TABLE public.account OWNER TO openlibrary;
 
 --
--- Name: author_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.author_boolean (
@@ -83,7 +83,7 @@ CREATE TABLE public.author_boolean (
 ALTER TABLE public.author_boolean OWNER TO openlibrary;
 
 --
--- Name: author_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.author_int (
@@ -97,7 +97,7 @@ CREATE TABLE public.author_int (
 ALTER TABLE public.author_int OWNER TO openlibrary;
 
 --
--- Name: author_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.author_ref (
@@ -111,7 +111,7 @@ CREATE TABLE public.author_ref (
 ALTER TABLE public.author_ref OWNER TO openlibrary;
 
 --
--- Name: author_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.author_str (
@@ -125,7 +125,7 @@ CREATE TABLE public.author_str (
 ALTER TABLE public.author_str OWNER TO openlibrary;
 
 --
--- Name: booknotes; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: booknotes; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.booknotes (
@@ -141,7 +141,7 @@ CREATE TABLE public.booknotes (
 ALTER TABLE public.booknotes OWNER TO postgres;
 
 --
--- Name: bookshelves; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.bookshelves (
@@ -157,7 +157,7 @@ CREATE TABLE public.bookshelves (
 ALTER TABLE public.bookshelves OWNER TO postgres;
 
 --
--- Name: bookshelves_books; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves_books; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.bookshelves_books (
@@ -174,7 +174,7 @@ CREATE TABLE public.bookshelves_books (
 ALTER TABLE public.bookshelves_books OWNER TO postgres;
 
 --
--- Name: bookshelves_events; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves_events; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.bookshelves_events (
@@ -235,42 +235,7 @@ ALTER SEQUENCE public.bookshelves_id_seq OWNED BY public.bookshelves.id;
 
 
 --
--- Name: bookshelves_votes; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
---
-
-CREATE TABLE public.bookshelves_votes (
-    username text NOT NULL,
-    bookshelf_id integer NOT NULL,
-    updated timestamp without time zone DEFAULT timezone('utc'::text, now()),
-    created timestamp without time zone DEFAULT timezone('utc'::text, now())
-);
-
-
-ALTER TABLE public.bookshelves_votes OWNER TO postgres;
-
---
--- Name: bookshelves_votes_bookshelf_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
---
-
-CREATE SEQUENCE public.bookshelves_votes_bookshelf_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
-ALTER TABLE public.bookshelves_votes_bookshelf_id_seq OWNER TO postgres;
-
---
--- Name: bookshelves_votes_bookshelf_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
---
-
-ALTER SEQUENCE public.bookshelves_votes_bookshelf_id_seq OWNED BY public.bookshelves_votes.bookshelf_id;
-
-
---
--- Name: community_edits_queue; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: community_edits_queue; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.community_edits_queue (
@@ -311,7 +276,7 @@ ALTER SEQUENCE public.community_edits_queue_id_seq OWNED BY public.community_edi
 
 
 --
--- Name: data; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: data; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.data (
@@ -324,7 +289,7 @@ CREATE TABLE public.data (
 ALTER TABLE public.data OWNER TO openlibrary;
 
 --
--- Name: datum_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.datum_int (
@@ -338,7 +303,7 @@ CREATE TABLE public.datum_int (
 ALTER TABLE public.datum_int OWNER TO openlibrary;
 
 --
--- Name: datum_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.datum_ref (
@@ -352,7 +317,7 @@ CREATE TABLE public.datum_ref (
 ALTER TABLE public.datum_ref OWNER TO openlibrary;
 
 --
--- Name: datum_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.datum_str (
@@ -366,7 +331,7 @@ CREATE TABLE public.datum_str (
 ALTER TABLE public.datum_str OWNER TO openlibrary;
 
 --
--- Name: edition_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.edition_boolean (
@@ -380,7 +345,7 @@ CREATE TABLE public.edition_boolean (
 ALTER TABLE public.edition_boolean OWNER TO openlibrary;
 
 --
--- Name: edition_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.edition_int (
@@ -394,7 +359,7 @@ CREATE TABLE public.edition_int (
 ALTER TABLE public.edition_int OWNER TO openlibrary;
 
 --
--- Name: edition_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.edition_ref (
@@ -408,7 +373,7 @@ CREATE TABLE public.edition_ref (
 ALTER TABLE public.edition_ref OWNER TO openlibrary;
 
 --
--- Name: edition_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.edition_str (
@@ -422,7 +387,7 @@ CREATE TABLE public.edition_str (
 ALTER TABLE public.edition_str OWNER TO openlibrary;
 
 --
--- Name: import_batch; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_batch; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.import_batch (
@@ -457,7 +422,7 @@ ALTER SEQUENCE public.import_batch_id_seq OWNED BY public.import_batch.id;
 
 
 --
--- Name: import_item; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.import_item (
@@ -498,7 +463,7 @@ ALTER SEQUENCE public.import_item_id_seq OWNED BY public.import_item.id;
 
 
 --
--- Name: meta; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: meta; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.meta (
@@ -509,7 +474,7 @@ CREATE TABLE public.meta (
 ALTER TABLE public.meta OWNER TO openlibrary;
 
 --
--- Name: observations; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: observations; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.observations (
@@ -525,7 +490,7 @@ CREATE TABLE public.observations (
 ALTER TABLE public.observations OWNER TO postgres;
 
 --
--- Name: property; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: property; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.property (
@@ -559,7 +524,7 @@ ALTER SEQUENCE public.property_id_seq OWNED BY public.property.id;
 
 
 --
--- Name: publisher_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.publisher_boolean (
@@ -573,7 +538,7 @@ CREATE TABLE public.publisher_boolean (
 ALTER TABLE public.publisher_boolean OWNER TO openlibrary;
 
 --
--- Name: publisher_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.publisher_int (
@@ -587,7 +552,7 @@ CREATE TABLE public.publisher_int (
 ALTER TABLE public.publisher_int OWNER TO openlibrary;
 
 --
--- Name: publisher_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.publisher_ref (
@@ -601,7 +566,7 @@ CREATE TABLE public.publisher_ref (
 ALTER TABLE public.publisher_ref OWNER TO openlibrary;
 
 --
--- Name: publisher_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.publisher_str (
@@ -615,7 +580,7 @@ CREATE TABLE public.publisher_str (
 ALTER TABLE public.publisher_str OWNER TO openlibrary;
 
 --
--- Name: ratings; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: ratings; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.ratings (
@@ -631,7 +596,7 @@ CREATE TABLE public.ratings (
 ALTER TABLE public.ratings OWNER TO postgres;
 
 --
--- Name: scan_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.scan_boolean (
@@ -645,7 +610,7 @@ CREATE TABLE public.scan_boolean (
 ALTER TABLE public.scan_boolean OWNER TO openlibrary;
 
 --
--- Name: scan_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.scan_int (
@@ -659,7 +624,7 @@ CREATE TABLE public.scan_int (
 ALTER TABLE public.scan_int OWNER TO openlibrary;
 
 --
--- Name: scan_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.scan_ref (
@@ -673,7 +638,7 @@ CREATE TABLE public.scan_ref (
 ALTER TABLE public.scan_ref OWNER TO openlibrary;
 
 --
--- Name: scan_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.scan_str (
@@ -687,7 +652,7 @@ CREATE TABLE public.scan_str (
 ALTER TABLE public.scan_str OWNER TO openlibrary;
 
 --
--- Name: seq; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: seq; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.seq (
@@ -721,7 +686,7 @@ ALTER SEQUENCE public.seq_id_seq OWNED BY public.seq.id;
 
 
 --
--- Name: store; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.store (
@@ -755,7 +720,7 @@ ALTER SEQUENCE public.store_id_seq OWNED BY public.store.id;
 
 
 --
--- Name: store_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.store_index (
@@ -791,7 +756,7 @@ ALTER SEQUENCE public.store_index_id_seq OWNED BY public.store_index.id;
 
 
 --
--- Name: subject_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.subject_boolean (
@@ -805,7 +770,7 @@ CREATE TABLE public.subject_boolean (
 ALTER TABLE public.subject_boolean OWNER TO openlibrary;
 
 --
--- Name: subject_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.subject_int (
@@ -819,7 +784,7 @@ CREATE TABLE public.subject_int (
 ALTER TABLE public.subject_int OWNER TO openlibrary;
 
 --
--- Name: subject_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.subject_ref (
@@ -833,7 +798,7 @@ CREATE TABLE public.subject_ref (
 ALTER TABLE public.subject_ref OWNER TO openlibrary;
 
 --
--- Name: subject_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.subject_str (
@@ -847,7 +812,7 @@ CREATE TABLE public.subject_str (
 ALTER TABLE public.subject_str OWNER TO openlibrary;
 
 --
--- Name: tag_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.tag_boolean (
@@ -861,7 +826,7 @@ CREATE TABLE public.tag_boolean (
 ALTER TABLE public.tag_boolean OWNER TO openlibrary;
 
 --
--- Name: tag_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.tag_int (
@@ -875,7 +840,7 @@ CREATE TABLE public.tag_int (
 ALTER TABLE public.tag_int OWNER TO openlibrary;
 
 --
--- Name: tag_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.tag_ref (
@@ -889,7 +854,7 @@ CREATE TABLE public.tag_ref (
 ALTER TABLE public.tag_ref OWNER TO openlibrary;
 
 --
--- Name: tag_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.tag_str (
@@ -903,7 +868,7 @@ CREATE TABLE public.tag_str (
 ALTER TABLE public.tag_str OWNER TO openlibrary;
 
 --
--- Name: thing; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.thing (
@@ -940,7 +905,7 @@ ALTER SEQUENCE public.thing_id_seq OWNED BY public.thing.id;
 
 
 --
--- Name: transaction; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.transaction (
@@ -980,7 +945,7 @@ ALTER SEQUENCE public.transaction_id_seq OWNED BY public.transaction.id;
 
 
 --
--- Name: transaction_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.transaction_index (
@@ -1021,7 +986,7 @@ CREATE SEQUENCE public.type_edition_seq
 ALTER TABLE public.type_edition_seq OWNER TO openlibrary;
 
 --
--- Name: type_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.type_int (
@@ -1049,7 +1014,7 @@ CREATE SEQUENCE public.type_publisher_seq
 ALTER TABLE public.type_publisher_seq OWNER TO openlibrary;
 
 --
--- Name: type_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.type_ref (
@@ -1063,7 +1028,7 @@ CREATE TABLE public.type_ref (
 ALTER TABLE public.type_ref OWNER TO openlibrary;
 
 --
--- Name: type_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.type_str (
@@ -1105,7 +1070,7 @@ CREATE SEQUENCE public.type_work_seq
 ALTER TABLE public.type_work_seq OWNER TO openlibrary;
 
 --
--- Name: user_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.user_int (
@@ -1119,7 +1084,7 @@ CREATE TABLE public.user_int (
 ALTER TABLE public.user_int OWNER TO openlibrary;
 
 --
--- Name: user_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.user_ref (
@@ -1133,7 +1098,7 @@ CREATE TABLE public.user_ref (
 ALTER TABLE public.user_ref OWNER TO openlibrary;
 
 --
--- Name: user_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.user_str (
@@ -1147,7 +1112,7 @@ CREATE TABLE public.user_str (
 ALTER TABLE public.user_str OWNER TO openlibrary;
 
 --
--- Name: version; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: version; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.version (
@@ -1182,7 +1147,7 @@ ALTER SEQUENCE public.version_id_seq OWNED BY public.version.id;
 
 
 --
--- Name: work_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.work_boolean (
@@ -1196,7 +1161,7 @@ CREATE TABLE public.work_boolean (
 ALTER TABLE public.work_boolean OWNER TO openlibrary;
 
 --
--- Name: work_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.work_int (
@@ -1210,7 +1175,7 @@ CREATE TABLE public.work_int (
 ALTER TABLE public.work_int OWNER TO openlibrary;
 
 --
--- Name: work_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.work_ref (
@@ -1224,7 +1189,7 @@ CREATE TABLE public.work_ref (
 ALTER TABLE public.work_ref OWNER TO openlibrary;
 
 --
--- Name: work_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE TABLE public.work_str (
@@ -1238,7 +1203,7 @@ CREATE TABLE public.work_str (
 ALTER TABLE public.work_str OWNER TO openlibrary;
 
 --
--- Name: yearly_reading_goals; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
+-- Name: yearly_reading_goals; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE TABLE public.yearly_reading_goals (
@@ -1264,13 +1229,6 @@ ALTER TABLE ONLY public.bookshelves ALTER COLUMN id SET DEFAULT nextval('public.
 --
 
 ALTER TABLE ONLY public.bookshelves_events ALTER COLUMN id SET DEFAULT nextval('public.bookshelves_events_id_seq'::regclass);
-
-
---
--- Name: bookshelf_id; Type: DEFAULT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.bookshelves_votes ALTER COLUMN bookshelf_id SET DEFAULT nextval('public.bookshelves_votes_bookshelf_id_seq'::regclass);
 
 
 --
@@ -1635,9 +1593,9 @@ COPY public.booknotes (username, work_id, edition_id, notes, updated, created) F
 --
 
 COPY public.bookshelves (id, name, description, archived, updated, created) FROM stdin;
-1	Want to Read	A list of books I want to read	f	2023-09-01 21:33:01.32118	2023-09-01 21:33:01.32118
-2	Currently Reading	A list of books I am currently reading	f	2023-09-01 21:33:01.3226	2023-09-01 21:33:01.3226
-3	Already Read	A list of books I have finished reading	f	2023-09-01 21:33:01.323726	2023-09-01 21:33:01.323726
+1	Want to Read	A list of books I want to read	f	2023-12-12 18:51:29.303055	2023-12-12 18:51:29.303055
+2	Currently Reading	A list of books I am currently reading	f	2023-12-12 18:51:29.304327	2023-12-12 18:51:29.304327
+3	Already Read	A list of books I have finished reading	f	2023-12-12 18:51:29.305437	2023-12-12 18:51:29.305437
 \.
 
 
@@ -1669,21 +1627,6 @@ SELECT pg_catalog.setval('public.bookshelves_events_id_seq', 1, false);
 --
 
 SELECT pg_catalog.setval('public.bookshelves_id_seq', 3, true);
-
-
---
--- Data for Name: bookshelves_votes; Type: TABLE DATA; Schema: public; Owner: postgres
---
-
-COPY public.bookshelves_votes (username, bookshelf_id, updated, created) FROM stdin;
-\.
-
-
---
--- Name: bookshelves_votes_bookshelf_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
---
-
-SELECT pg_catalog.setval('public.bookshelves_votes_bookshelf_id_seq', 1, false);
 
 
 --
@@ -8247,7 +8190,7 @@ COPY public.yearly_reading_goals (username, year, target, created, updated) FROM
 
 
 --
--- Name: account_email_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: account_email_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.account
@@ -8255,7 +8198,7 @@ ALTER TABLE ONLY public.account
 
 
 --
--- Name: booknotes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: booknotes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.booknotes
@@ -8263,7 +8206,7 @@ ALTER TABLE ONLY public.booknotes
 
 
 --
--- Name: bookshelves_books_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves_books_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.bookshelves_books
@@ -8271,7 +8214,7 @@ ALTER TABLE ONLY public.bookshelves_books
 
 
 --
--- Name: bookshelves_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.bookshelves_events
@@ -8279,7 +8222,7 @@ ALTER TABLE ONLY public.bookshelves_events
 
 
 --
--- Name: bookshelves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.bookshelves
@@ -8287,15 +8230,7 @@ ALTER TABLE ONLY public.bookshelves
 
 
 --
--- Name: bookshelves_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
---
-
-ALTER TABLE ONLY public.bookshelves_votes
-    ADD CONSTRAINT bookshelves_votes_pkey PRIMARY KEY (username, bookshelf_id);
-
-
---
--- Name: community_edits_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: community_edits_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.community_edits_queue
@@ -8303,7 +8238,7 @@ ALTER TABLE ONLY public.community_edits_queue
 
 
 --
--- Name: import_batch_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_batch_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.import_batch
@@ -8311,7 +8246,7 @@ ALTER TABLE ONLY public.import_batch
 
 
 --
--- Name: import_item_batch_id_ia_id_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item_batch_id_ia_id_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.import_item
@@ -8319,7 +8254,7 @@ ALTER TABLE ONLY public.import_item
 
 
 --
--- Name: import_item_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.import_item
@@ -8327,7 +8262,7 @@ ALTER TABLE ONLY public.import_item
 
 
 --
--- Name: observations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: observations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.observations
@@ -8335,7 +8270,7 @@ ALTER TABLE ONLY public.observations
 
 
 --
--- Name: property_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: property_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.property
@@ -8343,7 +8278,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: property_type_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: property_type_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.property
@@ -8351,7 +8286,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.ratings
@@ -8359,7 +8294,7 @@ ALTER TABLE ONLY public.ratings
 
 
 --
--- Name: seq_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: seq_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.seq
@@ -8367,7 +8302,7 @@ ALTER TABLE ONLY public.seq
 
 
 --
--- Name: seq_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: seq_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.seq
@@ -8375,7 +8310,7 @@ ALTER TABLE ONLY public.seq
 
 
 --
--- Name: store_index_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store_index_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.store_index
@@ -8383,7 +8318,7 @@ ALTER TABLE ONLY public.store_index
 
 
 --
--- Name: store_key_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store_key_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.store
@@ -8391,7 +8326,7 @@ ALTER TABLE ONLY public.store
 
 
 --
--- Name: store_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.store
@@ -8399,7 +8334,7 @@ ALTER TABLE ONLY public.store
 
 
 --
--- Name: thing_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.thing
@@ -8407,7 +8342,7 @@ ALTER TABLE ONLY public.thing
 
 
 --
--- Name: transaction_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.transaction
@@ -8415,7 +8350,7 @@ ALTER TABLE ONLY public.transaction
 
 
 --
--- Name: version_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: version_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.version
@@ -8423,7 +8358,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: version_thing_id_revision_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: version_thing_id_revision_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 ALTER TABLE ONLY public.version
@@ -8431,7 +8366,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: yearly_reading_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
+-- Name: yearly_reading_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
 --
 
 ALTER TABLE ONLY public.yearly_reading_goals
@@ -8439,721 +8374,721 @@ ALTER TABLE ONLY public.yearly_reading_goals
 
 
 --
--- Name: account_thing_active_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: account_thing_active_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX account_thing_active_idx ON public.account USING btree (active);
 
 
 --
--- Name: account_thing_bot_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: account_thing_bot_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX account_thing_bot_idx ON public.account USING btree (bot);
 
 
 --
--- Name: account_thing_email_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: account_thing_email_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX account_thing_email_idx ON public.account USING btree (active);
 
 
 --
--- Name: account_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: account_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX account_thing_id_idx ON public.account USING btree (thing_id);
 
 
 --
--- Name: author_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_boolean_idx ON public.author_boolean USING btree (key_id, value);
 
 
 --
--- Name: author_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_boolean_thing_id_idx ON public.author_boolean USING btree (thing_id);
 
 
 --
--- Name: author_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_int_idx ON public.author_int USING btree (key_id, value);
 
 
 --
--- Name: author_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_int_thing_id_idx ON public.author_int USING btree (thing_id);
 
 
 --
--- Name: author_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_ref_idx ON public.author_ref USING btree (key_id, value);
 
 
 --
--- Name: author_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_ref_thing_id_idx ON public.author_ref USING btree (thing_id);
 
 
 --
--- Name: author_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_str_idx ON public.author_str USING btree (key_id, value);
 
 
 --
--- Name: author_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: author_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX author_str_thing_id_idx ON public.author_str USING btree (thing_id);
 
 
 --
--- Name: booknotes_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
+-- Name: booknotes_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE INDEX booknotes_work_id_idx ON public.booknotes USING btree (work_id);
 
 
 --
--- Name: bookshelves_books_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
+-- Name: bookshelves_books_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE INDEX bookshelves_books_work_id_idx ON public.bookshelves_books USING btree (work_id);
 
 
 --
--- Name: data_thing_id_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: data_thing_id_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE UNIQUE INDEX data_thing_id_revision_idx ON public.data USING btree (thing_id, revision);
 
 
 --
--- Name: datum_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX datum_int_idx ON public.datum_int USING btree (key_id, value);
 
 
 --
--- Name: datum_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX datum_int_thing_id_idx ON public.datum_int USING btree (thing_id);
 
 
 --
--- Name: datum_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX datum_ref_idx ON public.datum_ref USING btree (key_id, value);
 
 
 --
--- Name: datum_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX datum_ref_thing_id_idx ON public.datum_ref USING btree (thing_id);
 
 
 --
--- Name: datum_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX datum_str_idx ON public.datum_str USING btree (key_id, value);
 
 
 --
--- Name: datum_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: datum_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX datum_str_thing_id_idx ON public.datum_str USING btree (thing_id);
 
 
 --
--- Name: edition_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_boolean_idx ON public.edition_boolean USING btree (key_id, value);
 
 
 --
--- Name: edition_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_boolean_thing_id_idx ON public.edition_boolean USING btree (thing_id);
 
 
 --
--- Name: edition_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_int_idx ON public.edition_int USING btree (key_id, value);
 
 
 --
--- Name: edition_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_int_thing_id_idx ON public.edition_int USING btree (thing_id);
 
 
 --
--- Name: edition_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_ref_idx ON public.edition_ref USING btree (key_id, value);
 
 
 --
--- Name: edition_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_ref_thing_id_idx ON public.edition_ref USING btree (thing_id);
 
 
 --
--- Name: edition_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_str_idx ON public.edition_str USING btree (key_id, value);
 
 
 --
--- Name: edition_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: edition_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX edition_str_thing_id_idx ON public.edition_str USING btree (thing_id);
 
 
 --
--- Name: import_batch_name; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_batch_name; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_batch_name ON public.import_batch USING btree (name);
 
 
 --
--- Name: import_batch_submit_time_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_batch_submit_time_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_batch_submit_time_idx ON public.import_batch USING btree (submit_time);
 
 
 --
--- Name: import_batch_submitter_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_batch_submitter_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_batch_submitter_idx ON public.import_batch USING btree (submitter);
 
 
 --
--- Name: import_item_batch_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item_batch_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_item_batch_id ON public.import_item USING btree (batch_id);
 
 
 --
--- Name: import_item_ia_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item_ia_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_item_ia_id ON public.import_item USING btree (ia_id);
 
 
 --
--- Name: import_item_import_time; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item_import_time; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_item_import_time ON public.import_item USING btree (import_time);
 
 
 --
--- Name: import_item_status; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: import_item_status; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX import_item_status ON public.import_item USING btree (status);
 
 
 --
--- Name: observations_username_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
+-- Name: observations_username_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE INDEX observations_username_idx ON public.observations USING btree (username);
 
 
 --
--- Name: publisher_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_boolean_idx ON public.publisher_boolean USING btree (key_id, value);
 
 
 --
--- Name: publisher_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_boolean_thing_id_idx ON public.publisher_boolean USING btree (thing_id);
 
 
 --
--- Name: publisher_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_int_idx ON public.publisher_int USING btree (key_id, value);
 
 
 --
--- Name: publisher_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_int_thing_id_idx ON public.publisher_int USING btree (thing_id);
 
 
 --
--- Name: publisher_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_ref_idx ON public.publisher_ref USING btree (key_id, value);
 
 
 --
--- Name: publisher_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_ref_thing_id_idx ON public.publisher_ref USING btree (thing_id);
 
 
 --
--- Name: publisher_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_str_idx ON public.publisher_str USING btree (key_id, value);
 
 
 --
--- Name: publisher_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: publisher_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX publisher_str_thing_id_idx ON public.publisher_str USING btree (thing_id);
 
 
 --
--- Name: ratings_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
+-- Name: ratings_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
 --
 
 CREATE INDEX ratings_work_id_idx ON public.ratings USING btree (work_id);
 
 
 --
--- Name: scan_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_boolean_idx ON public.scan_boolean USING btree (key_id, value);
 
 
 --
--- Name: scan_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_boolean_thing_id_idx ON public.scan_boolean USING btree (thing_id);
 
 
 --
--- Name: scan_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_int_idx ON public.scan_int USING btree (key_id, value);
 
 
 --
--- Name: scan_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_int_thing_id_idx ON public.scan_int USING btree (thing_id);
 
 
 --
--- Name: scan_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_ref_idx ON public.scan_ref USING btree (key_id, value);
 
 
 --
--- Name: scan_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_ref_thing_id_idx ON public.scan_ref USING btree (thing_id);
 
 
 --
--- Name: scan_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_str_idx ON public.scan_str USING btree (key_id, value);
 
 
 --
--- Name: scan_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: scan_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX scan_str_thing_id_idx ON public.scan_str USING btree (thing_id);
 
 
 --
--- Name: store_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX store_idx ON public.store_index USING btree (type, name, value);
 
 
 --
--- Name: store_index_store_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: store_index_store_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX store_index_store_id_idx ON public.store_index USING btree (store_id);
 
 
 --
--- Name: subject_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_boolean_idx ON public.subject_boolean USING btree (key_id, value);
 
 
 --
--- Name: subject_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_boolean_thing_id_idx ON public.subject_boolean USING btree (thing_id);
 
 
 --
--- Name: subject_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_int_idx ON public.subject_int USING btree (key_id, value);
 
 
 --
--- Name: subject_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_int_thing_id_idx ON public.subject_int USING btree (thing_id);
 
 
 --
--- Name: subject_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_ref_idx ON public.subject_ref USING btree (key_id, value);
 
 
 --
--- Name: subject_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_ref_thing_id_idx ON public.subject_ref USING btree (thing_id);
 
 
 --
--- Name: subject_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_str_idx ON public.subject_str USING btree (key_id, value);
 
 
 --
--- Name: subject_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: subject_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX subject_str_thing_id_idx ON public.subject_str USING btree (thing_id);
 
 
 --
--- Name: tag_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_boolean_idx ON public.tag_boolean USING btree (key_id, value);
 
 
 --
--- Name: tag_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_boolean_thing_id_idx ON public.tag_boolean USING btree (thing_id);
 
 
 --
--- Name: tag_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_int_idx ON public.tag_int USING btree (key_id, value);
 
 
 --
--- Name: tag_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_int_thing_id_idx ON public.tag_int USING btree (thing_id);
 
 
 --
--- Name: tag_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_ref_idx ON public.tag_ref USING btree (key_id, value);
 
 
 --
--- Name: tag_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_ref_thing_id_idx ON public.tag_ref USING btree (thing_id);
 
 
 --
--- Name: tag_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_str_idx ON public.tag_str USING btree (key_id, value);
 
 
 --
--- Name: tag_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: tag_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX tag_str_thing_id_idx ON public.tag_str USING btree (thing_id);
 
 
 --
--- Name: thing_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX thing_created_idx ON public.thing USING btree (created);
 
 
 --
--- Name: thing_key_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_key_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE UNIQUE INDEX thing_key_idx ON public.thing USING btree (key);
 
 
 --
--- Name: thing_last_modified_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_last_modified_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX thing_last_modified_idx ON public.thing USING btree (last_modified);
 
 
 --
--- Name: thing_latest_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_latest_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX thing_latest_revision_idx ON public.thing USING btree (latest_revision);
 
 
 --
--- Name: thing_olid_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_olid_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX thing_olid_idx ON public.thing USING btree (public.get_olid(key));
 
 
 --
--- Name: thing_type_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: thing_type_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX thing_type_idx ON public.thing USING btree (type);
 
 
 --
--- Name: transaction_author_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_author_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX transaction_author_id_idx ON public.transaction USING btree (author_id);
 
 
 --
--- Name: transaction_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX transaction_created_idx ON public.transaction USING btree (created);
 
 
 --
--- Name: transaction_index_key_value_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_index_key_value_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX transaction_index_key_value_idx ON public.transaction_index USING btree (key, value);
 
 
 --
--- Name: transaction_index_tx_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_index_tx_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX transaction_index_tx_id_idx ON public.transaction_index USING btree (tx_id);
 
 
 --
--- Name: transaction_ip_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: transaction_ip_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX transaction_ip_idx ON public.transaction USING btree (ip);
 
 
 --
--- Name: type_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX type_int_idx ON public.type_int USING btree (key_id, value);
 
 
 --
--- Name: type_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX type_int_thing_id_idx ON public.type_int USING btree (thing_id);
 
 
 --
--- Name: type_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX type_ref_idx ON public.type_ref USING btree (key_id, value);
 
 
 --
--- Name: type_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX type_ref_thing_id_idx ON public.type_ref USING btree (thing_id);
 
 
 --
--- Name: type_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX type_str_idx ON public.type_str USING btree (key_id, value);
 
 
 --
--- Name: type_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: type_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX type_str_thing_id_idx ON public.type_str USING btree (thing_id);
 
 
 --
--- Name: user_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX user_int_idx ON public.user_int USING btree (key_id, value);
 
 
 --
--- Name: user_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX user_int_thing_id_idx ON public.user_int USING btree (thing_id);
 
 
 --
--- Name: user_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX user_ref_idx ON public.user_ref USING btree (key_id, value);
 
 
 --
--- Name: user_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX user_ref_thing_id_idx ON public.user_ref USING btree (thing_id);
 
 
 --
--- Name: user_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX user_str_idx ON public.user_str USING btree (key_id, value);
 
 
 --
--- Name: user_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: user_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX user_str_thing_id_idx ON public.user_str USING btree (thing_id);
 
 
 --
--- Name: work_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_boolean_idx ON public.work_boolean USING btree (key_id, value);
 
 
 --
--- Name: work_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_boolean_thing_id_idx ON public.work_boolean USING btree (thing_id);
 
 
 --
--- Name: work_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_int_idx ON public.work_int USING btree (key_id, value);
 
 
 --
--- Name: work_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_int_thing_id_idx ON public.work_int USING btree (thing_id);
 
 
 --
--- Name: work_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_ref_idx ON public.work_ref USING btree (key_id, value);
 
 
 --
--- Name: work_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_ref_thing_id_idx ON public.work_ref USING btree (thing_id);
 
 
 --
--- Name: work_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_str_idx ON public.work_str USING btree (key_id, value);
 
 
 --
--- Name: work_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
+-- Name: work_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
 --
 
 CREATE INDEX work_str_thing_id_idx ON public.work_str USING btree (thing_id);
@@ -9245,14 +9180,6 @@ ALTER TABLE ONLY public.author_str
 
 ALTER TABLE ONLY public.bookshelves_books
     ADD CONSTRAINT bookshelves_books_bookshelf_id_fkey FOREIGN KEY (bookshelf_id) REFERENCES public.bookshelves(id) ON UPDATE CASCADE ON DELETE CASCADE;
-
-
---
--- Name: bookshelves_votes_bookshelf_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.bookshelves_votes
-    ADD CONSTRAINT bookshelves_votes_bookshelf_id_fkey FOREIGN KEY (bookshelf_id) REFERENCES public.bookshelves(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -10026,16 +9953,6 @@ REVOKE ALL ON TABLE public.bookshelves_events FROM PUBLIC;
 REVOKE ALL ON TABLE public.bookshelves_events FROM postgres;
 GRANT ALL ON TABLE public.bookshelves_events TO postgres;
 GRANT SELECT ON TABLE public.bookshelves_events TO readcreateaccess;
-
-
---
--- Name: TABLE bookshelves_votes; Type: ACL; Schema: public; Owner: postgres
---
-
-REVOKE ALL ON TABLE public.bookshelves_votes FROM PUBLIC;
-REVOKE ALL ON TABLE public.bookshelves_votes FROM postgres;
-GRANT ALL ON TABLE public.bookshelves_votes TO postgres;
-GRANT SELECT ON TABLE public.bookshelves_votes TO readcreateaccess;
 
 
 --

--- a/scripts/dev-instance/dev_db.pg_dump
+++ b/scripts/dev-instance/dev_db.pg_dump
@@ -11,14 +11,14 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner:
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner:
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
@@ -53,7 +53,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: account; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: account; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.account (
@@ -69,7 +69,7 @@ CREATE TABLE public.account (
 ALTER TABLE public.account OWNER TO openlibrary;
 
 --
--- Name: author_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_boolean (
@@ -83,7 +83,7 @@ CREATE TABLE public.author_boolean (
 ALTER TABLE public.author_boolean OWNER TO openlibrary;
 
 --
--- Name: author_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_int (
@@ -97,7 +97,7 @@ CREATE TABLE public.author_int (
 ALTER TABLE public.author_int OWNER TO openlibrary;
 
 --
--- Name: author_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_ref (
@@ -111,7 +111,7 @@ CREATE TABLE public.author_ref (
 ALTER TABLE public.author_ref OWNER TO openlibrary;
 
 --
--- Name: author_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.author_str (
@@ -125,7 +125,7 @@ CREATE TABLE public.author_str (
 ALTER TABLE public.author_str OWNER TO openlibrary;
 
 --
--- Name: booknotes; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: booknotes; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.booknotes (
@@ -141,7 +141,7 @@ CREATE TABLE public.booknotes (
 ALTER TABLE public.booknotes OWNER TO postgres;
 
 --
--- Name: bookshelves; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.bookshelves (
@@ -157,7 +157,7 @@ CREATE TABLE public.bookshelves (
 ALTER TABLE public.bookshelves OWNER TO postgres;
 
 --
--- Name: bookshelves_books; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves_books; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.bookshelves_books (
@@ -174,7 +174,7 @@ CREATE TABLE public.bookshelves_books (
 ALTER TABLE public.bookshelves_books OWNER TO postgres;
 
 --
--- Name: bookshelves_events; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves_events; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.bookshelves_events (
@@ -235,7 +235,7 @@ ALTER SEQUENCE public.bookshelves_id_seq OWNED BY public.bookshelves.id;
 
 
 --
--- Name: community_edits_queue; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: community_edits_queue; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.community_edits_queue (
@@ -276,7 +276,7 @@ ALTER SEQUENCE public.community_edits_queue_id_seq OWNED BY public.community_edi
 
 
 --
--- Name: data; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: data; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.data (
@@ -289,7 +289,7 @@ CREATE TABLE public.data (
 ALTER TABLE public.data OWNER TO openlibrary;
 
 --
--- Name: datum_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.datum_int (
@@ -303,7 +303,7 @@ CREATE TABLE public.datum_int (
 ALTER TABLE public.datum_int OWNER TO openlibrary;
 
 --
--- Name: datum_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.datum_ref (
@@ -317,7 +317,7 @@ CREATE TABLE public.datum_ref (
 ALTER TABLE public.datum_ref OWNER TO openlibrary;
 
 --
--- Name: datum_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.datum_str (
@@ -331,7 +331,7 @@ CREATE TABLE public.datum_str (
 ALTER TABLE public.datum_str OWNER TO openlibrary;
 
 --
--- Name: edition_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_boolean (
@@ -345,7 +345,7 @@ CREATE TABLE public.edition_boolean (
 ALTER TABLE public.edition_boolean OWNER TO openlibrary;
 
 --
--- Name: edition_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_int (
@@ -359,7 +359,7 @@ CREATE TABLE public.edition_int (
 ALTER TABLE public.edition_int OWNER TO openlibrary;
 
 --
--- Name: edition_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_ref (
@@ -373,7 +373,7 @@ CREATE TABLE public.edition_ref (
 ALTER TABLE public.edition_ref OWNER TO openlibrary;
 
 --
--- Name: edition_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.edition_str (
@@ -387,7 +387,7 @@ CREATE TABLE public.edition_str (
 ALTER TABLE public.edition_str OWNER TO openlibrary;
 
 --
--- Name: import_batch; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_batch; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.import_batch (
@@ -422,7 +422,7 @@ ALTER SEQUENCE public.import_batch_id_seq OWNED BY public.import_batch.id;
 
 
 --
--- Name: import_item; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.import_item (
@@ -463,7 +463,7 @@ ALTER SEQUENCE public.import_item_id_seq OWNED BY public.import_item.id;
 
 
 --
--- Name: meta; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: meta; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.meta (
@@ -474,7 +474,7 @@ CREATE TABLE public.meta (
 ALTER TABLE public.meta OWNER TO openlibrary;
 
 --
--- Name: observations; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: observations; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.observations (
@@ -490,7 +490,7 @@ CREATE TABLE public.observations (
 ALTER TABLE public.observations OWNER TO postgres;
 
 --
--- Name: property; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: property; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.property (
@@ -524,7 +524,7 @@ ALTER SEQUENCE public.property_id_seq OWNED BY public.property.id;
 
 
 --
--- Name: publisher_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_boolean (
@@ -538,7 +538,7 @@ CREATE TABLE public.publisher_boolean (
 ALTER TABLE public.publisher_boolean OWNER TO openlibrary;
 
 --
--- Name: publisher_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_int (
@@ -552,7 +552,7 @@ CREATE TABLE public.publisher_int (
 ALTER TABLE public.publisher_int OWNER TO openlibrary;
 
 --
--- Name: publisher_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_ref (
@@ -566,7 +566,7 @@ CREATE TABLE public.publisher_ref (
 ALTER TABLE public.publisher_ref OWNER TO openlibrary;
 
 --
--- Name: publisher_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.publisher_str (
@@ -580,7 +580,7 @@ CREATE TABLE public.publisher_str (
 ALTER TABLE public.publisher_str OWNER TO openlibrary;
 
 --
--- Name: ratings; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: ratings; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.ratings (
@@ -596,7 +596,7 @@ CREATE TABLE public.ratings (
 ALTER TABLE public.ratings OWNER TO postgres;
 
 --
--- Name: scan_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_boolean (
@@ -610,7 +610,7 @@ CREATE TABLE public.scan_boolean (
 ALTER TABLE public.scan_boolean OWNER TO openlibrary;
 
 --
--- Name: scan_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_int (
@@ -624,7 +624,7 @@ CREATE TABLE public.scan_int (
 ALTER TABLE public.scan_int OWNER TO openlibrary;
 
 --
--- Name: scan_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_ref (
@@ -638,7 +638,7 @@ CREATE TABLE public.scan_ref (
 ALTER TABLE public.scan_ref OWNER TO openlibrary;
 
 --
--- Name: scan_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.scan_str (
@@ -652,7 +652,7 @@ CREATE TABLE public.scan_str (
 ALTER TABLE public.scan_str OWNER TO openlibrary;
 
 --
--- Name: seq; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: seq; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.seq (
@@ -686,7 +686,7 @@ ALTER SEQUENCE public.seq_id_seq OWNED BY public.seq.id;
 
 
 --
--- Name: store; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.store (
@@ -720,7 +720,7 @@ ALTER SEQUENCE public.store_id_seq OWNED BY public.store.id;
 
 
 --
--- Name: store_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.store_index (
@@ -756,7 +756,7 @@ ALTER SEQUENCE public.store_index_id_seq OWNED BY public.store_index.id;
 
 
 --
--- Name: subject_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_boolean (
@@ -770,7 +770,7 @@ CREATE TABLE public.subject_boolean (
 ALTER TABLE public.subject_boolean OWNER TO openlibrary;
 
 --
--- Name: subject_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_int (
@@ -784,7 +784,7 @@ CREATE TABLE public.subject_int (
 ALTER TABLE public.subject_int OWNER TO openlibrary;
 
 --
--- Name: subject_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_ref (
@@ -798,7 +798,7 @@ CREATE TABLE public.subject_ref (
 ALTER TABLE public.subject_ref OWNER TO openlibrary;
 
 --
--- Name: subject_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.subject_str (
@@ -812,7 +812,7 @@ CREATE TABLE public.subject_str (
 ALTER TABLE public.subject_str OWNER TO openlibrary;
 
 --
--- Name: tag_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.tag_boolean (
@@ -826,7 +826,7 @@ CREATE TABLE public.tag_boolean (
 ALTER TABLE public.tag_boolean OWNER TO openlibrary;
 
 --
--- Name: tag_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.tag_int (
@@ -840,7 +840,7 @@ CREATE TABLE public.tag_int (
 ALTER TABLE public.tag_int OWNER TO openlibrary;
 
 --
--- Name: tag_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.tag_ref (
@@ -854,7 +854,7 @@ CREATE TABLE public.tag_ref (
 ALTER TABLE public.tag_ref OWNER TO openlibrary;
 
 --
--- Name: tag_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.tag_str (
@@ -868,7 +868,7 @@ CREATE TABLE public.tag_str (
 ALTER TABLE public.tag_str OWNER TO openlibrary;
 
 --
--- Name: thing; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.thing (
@@ -905,7 +905,7 @@ ALTER SEQUENCE public.thing_id_seq OWNED BY public.thing.id;
 
 
 --
--- Name: transaction; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.transaction (
@@ -945,7 +945,7 @@ ALTER SEQUENCE public.transaction_id_seq OWNED BY public.transaction.id;
 
 
 --
--- Name: transaction_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_index; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.transaction_index (
@@ -986,7 +986,7 @@ CREATE SEQUENCE public.type_edition_seq
 ALTER TABLE public.type_edition_seq OWNER TO openlibrary;
 
 --
--- Name: type_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.type_int (
@@ -1014,7 +1014,7 @@ CREATE SEQUENCE public.type_publisher_seq
 ALTER TABLE public.type_publisher_seq OWNER TO openlibrary;
 
 --
--- Name: type_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.type_ref (
@@ -1028,7 +1028,7 @@ CREATE TABLE public.type_ref (
 ALTER TABLE public.type_ref OWNER TO openlibrary;
 
 --
--- Name: type_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.type_str (
@@ -1070,7 +1070,7 @@ CREATE SEQUENCE public.type_work_seq
 ALTER TABLE public.type_work_seq OWNER TO openlibrary;
 
 --
--- Name: user_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.user_int (
@@ -1084,7 +1084,7 @@ CREATE TABLE public.user_int (
 ALTER TABLE public.user_int OWNER TO openlibrary;
 
 --
--- Name: user_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.user_ref (
@@ -1098,7 +1098,7 @@ CREATE TABLE public.user_ref (
 ALTER TABLE public.user_ref OWNER TO openlibrary;
 
 --
--- Name: user_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.user_str (
@@ -1112,7 +1112,7 @@ CREATE TABLE public.user_str (
 ALTER TABLE public.user_str OWNER TO openlibrary;
 
 --
--- Name: version; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: version; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.version (
@@ -1147,7 +1147,7 @@ ALTER SEQUENCE public.version_id_seq OWNED BY public.version.id;
 
 
 --
--- Name: work_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_boolean; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_boolean (
@@ -1161,7 +1161,7 @@ CREATE TABLE public.work_boolean (
 ALTER TABLE public.work_boolean OWNER TO openlibrary;
 
 --
--- Name: work_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_int; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_int (
@@ -1175,7 +1175,7 @@ CREATE TABLE public.work_int (
 ALTER TABLE public.work_int OWNER TO openlibrary;
 
 --
--- Name: work_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_ref; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_ref (
@@ -1189,7 +1189,7 @@ CREATE TABLE public.work_ref (
 ALTER TABLE public.work_ref OWNER TO openlibrary;
 
 --
--- Name: work_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_str; Type: TABLE; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE TABLE public.work_str (
@@ -1203,7 +1203,7 @@ CREATE TABLE public.work_str (
 ALTER TABLE public.work_str OWNER TO openlibrary;
 
 --
--- Name: yearly_reading_goals; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+-- Name: yearly_reading_goals; Type: TABLE; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE public.yearly_reading_goals (
@@ -8190,7 +8190,7 @@ COPY public.yearly_reading_goals (username, year, target, created, updated) FROM
 
 
 --
--- Name: account_email_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: account_email_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.account
@@ -8198,7 +8198,7 @@ ALTER TABLE ONLY public.account
 
 
 --
--- Name: booknotes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: booknotes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.booknotes
@@ -8206,7 +8206,7 @@ ALTER TABLE ONLY public.booknotes
 
 
 --
--- Name: bookshelves_books_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves_books_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.bookshelves_books
@@ -8214,7 +8214,7 @@ ALTER TABLE ONLY public.bookshelves_books
 
 
 --
--- Name: bookshelves_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.bookshelves_events
@@ -8222,7 +8222,7 @@ ALTER TABLE ONLY public.bookshelves_events
 
 
 --
--- Name: bookshelves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.bookshelves
@@ -8230,7 +8230,7 @@ ALTER TABLE ONLY public.bookshelves
 
 
 --
--- Name: community_edits_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: community_edits_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.community_edits_queue
@@ -8238,7 +8238,7 @@ ALTER TABLE ONLY public.community_edits_queue
 
 
 --
--- Name: import_batch_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_batch_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.import_batch
@@ -8246,7 +8246,7 @@ ALTER TABLE ONLY public.import_batch
 
 
 --
--- Name: import_item_batch_id_ia_id_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item_batch_id_ia_id_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.import_item
@@ -8254,7 +8254,7 @@ ALTER TABLE ONLY public.import_item
 
 
 --
--- Name: import_item_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.import_item
@@ -8262,7 +8262,7 @@ ALTER TABLE ONLY public.import_item
 
 
 --
--- Name: observations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: observations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.observations
@@ -8270,7 +8270,7 @@ ALTER TABLE ONLY public.observations
 
 
 --
--- Name: property_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: property_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.property
@@ -8278,7 +8278,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: property_type_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: property_type_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.property
@@ -8286,7 +8286,7 @@ ALTER TABLE ONLY public.property
 
 
 --
--- Name: ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.ratings
@@ -8294,7 +8294,7 @@ ALTER TABLE ONLY public.ratings
 
 
 --
--- Name: seq_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: seq_name_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.seq
@@ -8302,7 +8302,7 @@ ALTER TABLE ONLY public.seq
 
 
 --
--- Name: seq_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: seq_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.seq
@@ -8310,7 +8310,7 @@ ALTER TABLE ONLY public.seq
 
 
 --
--- Name: store_index_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store_index_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.store_index
@@ -8318,7 +8318,7 @@ ALTER TABLE ONLY public.store_index
 
 
 --
--- Name: store_key_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store_key_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.store
@@ -8326,7 +8326,7 @@ ALTER TABLE ONLY public.store
 
 
 --
--- Name: store_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.store
@@ -8334,7 +8334,7 @@ ALTER TABLE ONLY public.store
 
 
 --
--- Name: thing_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.thing
@@ -8342,7 +8342,7 @@ ALTER TABLE ONLY public.thing
 
 
 --
--- Name: transaction_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.transaction
@@ -8350,7 +8350,7 @@ ALTER TABLE ONLY public.transaction
 
 
 --
--- Name: version_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: version_pkey; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.version
@@ -8358,7 +8358,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: version_thing_id_revision_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: version_thing_id_revision_key; Type: CONSTRAINT; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 ALTER TABLE ONLY public.version
@@ -8366,7 +8366,7 @@ ALTER TABLE ONLY public.version
 
 
 --
--- Name: yearly_reading_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+-- Name: yearly_reading_goals_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY public.yearly_reading_goals
@@ -8374,721 +8374,721 @@ ALTER TABLE ONLY public.yearly_reading_goals
 
 
 --
--- Name: account_thing_active_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: account_thing_active_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_active_idx ON public.account USING btree (active);
 
 
 --
--- Name: account_thing_bot_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: account_thing_bot_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_bot_idx ON public.account USING btree (bot);
 
 
 --
--- Name: account_thing_email_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: account_thing_email_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_email_idx ON public.account USING btree (active);
 
 
 --
--- Name: account_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: account_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX account_thing_id_idx ON public.account USING btree (thing_id);
 
 
 --
--- Name: author_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_boolean_idx ON public.author_boolean USING btree (key_id, value);
 
 
 --
--- Name: author_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_boolean_thing_id_idx ON public.author_boolean USING btree (thing_id);
 
 
 --
--- Name: author_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_int_idx ON public.author_int USING btree (key_id, value);
 
 
 --
--- Name: author_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_int_thing_id_idx ON public.author_int USING btree (thing_id);
 
 
 --
--- Name: author_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_ref_idx ON public.author_ref USING btree (key_id, value);
 
 
 --
--- Name: author_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_ref_thing_id_idx ON public.author_ref USING btree (thing_id);
 
 
 --
--- Name: author_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_str_idx ON public.author_str USING btree (key_id, value);
 
 
 --
--- Name: author_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: author_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX author_str_thing_id_idx ON public.author_str USING btree (thing_id);
 
 
 --
--- Name: booknotes_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
+-- Name: booknotes_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE INDEX booknotes_work_id_idx ON public.booknotes USING btree (work_id);
 
 
 --
--- Name: bookshelves_books_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
+-- Name: bookshelves_books_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE INDEX bookshelves_books_work_id_idx ON public.bookshelves_books USING btree (work_id);
 
 
 --
--- Name: data_thing_id_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: data_thing_id_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE UNIQUE INDEX data_thing_id_revision_idx ON public.data USING btree (thing_id, revision);
 
 
 --
--- Name: datum_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_int_idx ON public.datum_int USING btree (key_id, value);
 
 
 --
--- Name: datum_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_int_thing_id_idx ON public.datum_int USING btree (thing_id);
 
 
 --
--- Name: datum_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_ref_idx ON public.datum_ref USING btree (key_id, value);
 
 
 --
--- Name: datum_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_ref_thing_id_idx ON public.datum_ref USING btree (thing_id);
 
 
 --
--- Name: datum_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_str_idx ON public.datum_str USING btree (key_id, value);
 
 
 --
--- Name: datum_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: datum_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX datum_str_thing_id_idx ON public.datum_str USING btree (thing_id);
 
 
 --
--- Name: edition_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_boolean_idx ON public.edition_boolean USING btree (key_id, value);
 
 
 --
--- Name: edition_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_boolean_thing_id_idx ON public.edition_boolean USING btree (thing_id);
 
 
 --
--- Name: edition_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_int_idx ON public.edition_int USING btree (key_id, value);
 
 
 --
--- Name: edition_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_int_thing_id_idx ON public.edition_int USING btree (thing_id);
 
 
 --
--- Name: edition_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_ref_idx ON public.edition_ref USING btree (key_id, value);
 
 
 --
--- Name: edition_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_ref_thing_id_idx ON public.edition_ref USING btree (thing_id);
 
 
 --
--- Name: edition_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_str_idx ON public.edition_str USING btree (key_id, value);
 
 
 --
--- Name: edition_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: edition_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX edition_str_thing_id_idx ON public.edition_str USING btree (thing_id);
 
 
 --
--- Name: import_batch_name; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_batch_name; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_batch_name ON public.import_batch USING btree (name);
 
 
 --
--- Name: import_batch_submit_time_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_batch_submit_time_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_batch_submit_time_idx ON public.import_batch USING btree (submit_time);
 
 
 --
--- Name: import_batch_submitter_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_batch_submitter_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_batch_submitter_idx ON public.import_batch USING btree (submitter);
 
 
 --
--- Name: import_item_batch_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item_batch_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_item_batch_id ON public.import_item USING btree (batch_id);
 
 
 --
--- Name: import_item_ia_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item_ia_id; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_item_ia_id ON public.import_item USING btree (ia_id);
 
 
 --
--- Name: import_item_import_time; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item_import_time; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_item_import_time ON public.import_item USING btree (import_time);
 
 
 --
--- Name: import_item_status; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: import_item_status; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX import_item_status ON public.import_item USING btree (status);
 
 
 --
--- Name: observations_username_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
+-- Name: observations_username_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE INDEX observations_username_idx ON public.observations USING btree (username);
 
 
 --
--- Name: publisher_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_boolean_idx ON public.publisher_boolean USING btree (key_id, value);
 
 
 --
--- Name: publisher_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_boolean_thing_id_idx ON public.publisher_boolean USING btree (thing_id);
 
 
 --
--- Name: publisher_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_int_idx ON public.publisher_int USING btree (key_id, value);
 
 
 --
--- Name: publisher_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_int_thing_id_idx ON public.publisher_int USING btree (thing_id);
 
 
 --
--- Name: publisher_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_ref_idx ON public.publisher_ref USING btree (key_id, value);
 
 
 --
--- Name: publisher_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_ref_thing_id_idx ON public.publisher_ref USING btree (thing_id);
 
 
 --
--- Name: publisher_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_str_idx ON public.publisher_str USING btree (key_id, value);
 
 
 --
--- Name: publisher_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: publisher_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX publisher_str_thing_id_idx ON public.publisher_str USING btree (thing_id);
 
 
 --
--- Name: ratings_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace: 
+-- Name: ratings_work_id_idx; Type: INDEX; Schema: public; Owner: postgres; Tablespace:
 --
 
 CREATE INDEX ratings_work_id_idx ON public.ratings USING btree (work_id);
 
 
 --
--- Name: scan_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_boolean_idx ON public.scan_boolean USING btree (key_id, value);
 
 
 --
--- Name: scan_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_boolean_thing_id_idx ON public.scan_boolean USING btree (thing_id);
 
 
 --
--- Name: scan_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_int_idx ON public.scan_int USING btree (key_id, value);
 
 
 --
--- Name: scan_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_int_thing_id_idx ON public.scan_int USING btree (thing_id);
 
 
 --
--- Name: scan_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_ref_idx ON public.scan_ref USING btree (key_id, value);
 
 
 --
--- Name: scan_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_ref_thing_id_idx ON public.scan_ref USING btree (thing_id);
 
 
 --
--- Name: scan_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_str_idx ON public.scan_str USING btree (key_id, value);
 
 
 --
--- Name: scan_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: scan_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX scan_str_thing_id_idx ON public.scan_str USING btree (thing_id);
 
 
 --
--- Name: store_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX store_idx ON public.store_index USING btree (type, name, value);
 
 
 --
--- Name: store_index_store_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: store_index_store_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX store_index_store_id_idx ON public.store_index USING btree (store_id);
 
 
 --
--- Name: subject_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_boolean_idx ON public.subject_boolean USING btree (key_id, value);
 
 
 --
--- Name: subject_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_boolean_thing_id_idx ON public.subject_boolean USING btree (thing_id);
 
 
 --
--- Name: subject_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_int_idx ON public.subject_int USING btree (key_id, value);
 
 
 --
--- Name: subject_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_int_thing_id_idx ON public.subject_int USING btree (thing_id);
 
 
 --
--- Name: subject_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_ref_idx ON public.subject_ref USING btree (key_id, value);
 
 
 --
--- Name: subject_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_ref_thing_id_idx ON public.subject_ref USING btree (thing_id);
 
 
 --
--- Name: subject_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_str_idx ON public.subject_str USING btree (key_id, value);
 
 
 --
--- Name: subject_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: subject_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX subject_str_thing_id_idx ON public.subject_str USING btree (thing_id);
 
 
 --
--- Name: tag_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_boolean_idx ON public.tag_boolean USING btree (key_id, value);
 
 
 --
--- Name: tag_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_boolean_thing_id_idx ON public.tag_boolean USING btree (thing_id);
 
 
 --
--- Name: tag_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_int_idx ON public.tag_int USING btree (key_id, value);
 
 
 --
--- Name: tag_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_int_thing_id_idx ON public.tag_int USING btree (thing_id);
 
 
 --
--- Name: tag_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_ref_idx ON public.tag_ref USING btree (key_id, value);
 
 
 --
--- Name: tag_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_ref_thing_id_idx ON public.tag_ref USING btree (thing_id);
 
 
 --
--- Name: tag_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_str_idx ON public.tag_str USING btree (key_id, value);
 
 
 --
--- Name: tag_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: tag_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX tag_str_thing_id_idx ON public.tag_str USING btree (thing_id);
 
 
 --
--- Name: thing_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_created_idx ON public.thing USING btree (created);
 
 
 --
--- Name: thing_key_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_key_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE UNIQUE INDEX thing_key_idx ON public.thing USING btree (key);
 
 
 --
--- Name: thing_last_modified_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_last_modified_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_last_modified_idx ON public.thing USING btree (last_modified);
 
 
 --
--- Name: thing_latest_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_latest_revision_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_latest_revision_idx ON public.thing USING btree (latest_revision);
 
 
 --
--- Name: thing_olid_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_olid_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_olid_idx ON public.thing USING btree (public.get_olid(key));
 
 
 --
--- Name: thing_type_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: thing_type_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX thing_type_idx ON public.thing USING btree (type);
 
 
 --
--- Name: transaction_author_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_author_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_author_id_idx ON public.transaction USING btree (author_id);
 
 
 --
--- Name: transaction_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_created_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_created_idx ON public.transaction USING btree (created);
 
 
 --
--- Name: transaction_index_key_value_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_index_key_value_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_index_key_value_idx ON public.transaction_index USING btree (key, value);
 
 
 --
--- Name: transaction_index_tx_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_index_tx_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_index_tx_id_idx ON public.transaction_index USING btree (tx_id);
 
 
 --
--- Name: transaction_ip_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: transaction_ip_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX transaction_ip_idx ON public.transaction USING btree (ip);
 
 
 --
--- Name: type_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_int_idx ON public.type_int USING btree (key_id, value);
 
 
 --
--- Name: type_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_int_thing_id_idx ON public.type_int USING btree (thing_id);
 
 
 --
--- Name: type_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_ref_idx ON public.type_ref USING btree (key_id, value);
 
 
 --
--- Name: type_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_ref_thing_id_idx ON public.type_ref USING btree (thing_id);
 
 
 --
--- Name: type_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_str_idx ON public.type_str USING btree (key_id, value);
 
 
 --
--- Name: type_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: type_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX type_str_thing_id_idx ON public.type_str USING btree (thing_id);
 
 
 --
--- Name: user_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_int_idx ON public.user_int USING btree (key_id, value);
 
 
 --
--- Name: user_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_int_thing_id_idx ON public.user_int USING btree (thing_id);
 
 
 --
--- Name: user_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_ref_idx ON public.user_ref USING btree (key_id, value);
 
 
 --
--- Name: user_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_ref_thing_id_idx ON public.user_ref USING btree (thing_id);
 
 
 --
--- Name: user_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_str_idx ON public.user_str USING btree (key_id, value);
 
 
 --
--- Name: user_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: user_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX user_str_thing_id_idx ON public.user_str USING btree (thing_id);
 
 
 --
--- Name: work_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_boolean_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_boolean_idx ON public.work_boolean USING btree (key_id, value);
 
 
 --
--- Name: work_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_boolean_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_boolean_thing_id_idx ON public.work_boolean USING btree (thing_id);
 
 
 --
--- Name: work_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_int_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_int_idx ON public.work_int USING btree (key_id, value);
 
 
 --
--- Name: work_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_int_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_int_thing_id_idx ON public.work_int USING btree (thing_id);
 
 
 --
--- Name: work_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_ref_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_ref_idx ON public.work_ref USING btree (key_id, value);
 
 
 --
--- Name: work_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_ref_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_ref_thing_id_idx ON public.work_ref USING btree (thing_id);
 
 
 --
--- Name: work_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_str_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_str_idx ON public.work_str USING btree (key_id, value);
 
 
 --
--- Name: work_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace: 
+-- Name: work_str_thing_id_idx; Type: INDEX; Schema: public; Owner: openlibrary; Tablespace:
 --
 
 CREATE INDEX work_str_thing_id_idx ON public.work_str USING btree (thing_id);


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes unused `bookshelves_votes` table.

### Technical
<!-- What should be noted about the implementation? -->
PG dump file was generated after dropping the `bookshelves_votes` table from a newly created Open Library instance.
Commands used:
```
docker compose exec -uroot db bash
./openlibrary/scripts/dev-instance/create-dev-db-pgdump.sh > /openlibrary/scripts/dev-instance/dev_db.pg_dump
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
