### PR TITLE
Fixes translated languages not being localized on edition edit page

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -21,15 +21,16 @@ $jsdef render_language_field(i, language, i18n_name):
     $ lang_name = i18n_name or language.name
     <div class="input ac-input mia__input">
       <div class="mia__reorder">≡</div>
-      <input class="ac-input__visible" name="languages--$i" type="text" value="$_(lang_name)"/>
+      <input class="ac-input__visible" name="languages--$i" type="text" value="$lang_name"/>
       <input class="ac-input__value" name="edition--languages--$i--key" type="hidden" value="$language.key" />
       <a class="mia__remove" href="javascript:;" title="$_('Remove this language')">[x]</a>
     </div>
 
 $# Render the ith translated_from language input field
-$jsdef render_translated_from_language_field(i, language):
+$jsdef render_translated_from_language_field(i, language, i18n_name):
+    $ lang_name = i18n_name or language.name
     <div class="input ac-input">
-      <input class="ac-input__visible" type="text" name="translated_from--$i" value="$_(language.name)"/>
+      <input class="ac-input__visible" type="text" name="translated_from--$i" value="$lang_name"/>
       <input class="ac-input__value" type="hidden" name="edition--translated_from--$i--key" value="$language.key" />
     </div>
 
@@ -304,9 +305,9 @@ $jsdef render_work_autocomplete_item(item):
                     </div>
                     $if book.translated_from:
                         $for i, lang in enumerate(book.translated_from):
-                            $:render_translated_from_language_field(i, lang)
+                            $:render_translated_from_language_field(i, lang, get_language_name(lang))
                     $else:
-                        $:render_translated_from_language_field(0, storage(name="", key=""))
+                        $:render_translated_from_language_field(0, storage(name="", key=""), None)
                 </div>
 
             </div>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -21,7 +21,7 @@ $jsdef render_language_field(i, language, i18n_name):
     $ lang_name = i18n_name or language.name
     <div class="input ac-input mia__input">
       <div class="mia__reorder">≡</div>
-      <input class="ac-input__visible" name="languages--$i" type="text" value="$lang_name"/>
+      <input class="ac-input__visible" name="languages--$i" type="text" value="$_(lang_name)"/>
       <input class="ac-input__value" name="edition--languages--$i--key" type="hidden" value="$language.key" />
       <a class="mia__remove" href="javascript:;" title="$_('Remove this language')">[x]</a>
     </div>
@@ -29,7 +29,7 @@ $jsdef render_language_field(i, language, i18n_name):
 $# Render the ith translated_from language input field
 $jsdef render_translated_from_language_field(i, language):
     <div class="input ac-input">
-      <input class="ac-input__visible" type="text" name="translated_from--$i" value="$language.name"/>
+      <input class="ac-input__visible" type="text" name="translated_from--$i" value="$_(language.name)"/>
       <input class="ac-input__value" type="hidden" name="edition--translated_from--$i--key" value="$language.key" />
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8174 

Hi, I'm a new contributor, I'm working with @karlitto01 to try to learn more about the codebase and find ways to contribute to OpenLibrary :)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
In the issue above, the language an edition was originally translated from did not appear in the localized language on the edition edit page, this is a small fix for that issue.

### Technical
<!-- What should be noted about the implementation? -->
I simply wrapped the initial value of the the language field in a '$_()' call. I believe this should correctly translate the text to the localized version.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Steps I took to test this:
- Setup dev environment
- Built the translation files
- Imported the work mentioned in the issue above (OL16656007W) to the dev environment.
- On the site, changed the language to Deutsch (but could use French like in the original issue)
- Going to the French edition of that work, and clicking "Edit"
Both the original language from which the work was translated and the language of the current edition should be localized.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Here's the screenshot of the same work as in the original issue, with the page in English, and Deutsch respectively:
**English**
![image](https://github.com/internetarchive/openlibrary/assets/48458243/be4fdc13-ea10-4e74-bec6-5378dd9a3ab6)
**Deutsch**
![image](https://github.com/internetarchive/openlibrary/assets/48458243/eabe94b1-d3ab-48eb-b9d9-f39aeafae228)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
