### PR TITLE
Lists in Solr

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import random
 import string
+from typing import TYPE_CHECKING
 import uuid
 import logging
 import requests
@@ -30,6 +31,9 @@ try:
     from simplejson.errors import JSONDecodeError
 except ImportError:
     from json.decoder import JSONDecodeError  # type: ignore[misc, assignment]
+
+if TYPE_CHECKING:
+    from openlibrary.plugins.upstream.models import User
 
 logger = logging.getLogger("openlibrary.account.model")
 
@@ -263,7 +267,7 @@ class Account(web.storage):
         t = self.get("last_login")
         return t and helpers.parse_datetime(t)
 
-    def get_user(self):
+    def get_user(self) -> 'User':
         """A user is where preferences are attached to an account. An
         "Account" is outside of infogami in a separate table and is
         used to store private user information.

--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -218,7 +218,7 @@ def truncate(text, limit):
     return text[:limit] + "..."
 
 
-def urlsafe(path):
+def urlsafe(path: str) -> str:
     """Replaces the unsafe chars from path with underscores."""
     return _get_safepath_re().sub('_', path).strip('_')[:100]
 

--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -1,6 +1,7 @@
 """Helper functions used by the List model.
 """
 from functools import cached_property
+from typing import TypedDict, cast
 
 import web
 import logging
@@ -11,8 +12,8 @@ from infogami.utils import stats
 
 from openlibrary.core import helpers as h
 from openlibrary.core import cache
-from openlibrary.core.models import Image, Thing
-from openlibrary.plugins.upstream.models import Changeset
+from openlibrary.core.models import Image, Subject, Thing, ThingKey
+from openlibrary.plugins.upstream.models import Author, Changeset, Edition, User, Work
 
 from openlibrary.plugins.worksearch.search import get_solr
 from openlibrary.plugins.worksearch.subjects import get_subject
@@ -21,17 +22,34 @@ import contextlib
 logger = logging.getLogger("openlibrary.lists.model")
 
 
+class SeedDict(TypedDict):
+    key: ThingKey
+
+
+SeedSubjectString = str
+"""
+When a subject is added to a list, it's added as a string like:
+- "subject:foo"
+- "person:floyd_heywood"
+"""
+
+
 class List(Thing):
     """Class to represent /type/list objects in OL.
 
-    List contains the following properties:
-
-        * name - name of the list
-        * description - detailed description of the list (markdown)
-        * members - members of the list. Either references or subject strings.
+    List contains the following properties, theoretically:
         * cover - id of the book cover. Picked from one of its editions.
         * tags - list of tags to describe this list.
     """
+
+    name: str | None
+    """Name of the list"""
+
+    description: str | None
+    """Detailed description of the list (markdown)"""
+
+    seeds: list[Thing | SeedSubjectString]
+    """Members of the list. Either references or subject strings."""
 
     def url(self, suffix="", **params):
         return self.get_url(suffix, **params)
@@ -39,10 +57,12 @@ class List(Thing):
     def get_url_suffix(self):
         return self.name or "unnamed"
 
-    def get_owner(self):
+    def get_owner(self) -> User | None:
         if match := web.re_compile(r"(/people/[^/]+)/lists/OL\d+L").match(self.key):
             key = match.group(1)
-            return self._site.get(key)
+            return cast(User, self._site.get(key))
+        else:
+            return None
 
     def get_cover(self):
         """Returns a cover object."""
@@ -55,39 +75,29 @@ class List(Thing):
         """
         return [web.storage(name=t, url=self.key + "/tags/" + t) for t in self.tags]
 
-    def _get_subjects(self):
-        """Returns list of subjects inferred from the seeds.
-        Each item in the list will be a storage object with title and url.
+    def add_seed(self, seed: Thing | SeedDict | SeedSubjectString):
         """
-        # sample subjects
-        return [
-            web.storage(title="Cheese", url="/subjects/cheese"),
-            web.storage(title="San Francisco", url="/subjects/place:san_francisco"),
-        ]
-
-    def add_seed(self, seed):
-        """Adds a new seed to this list.
+        Adds a new seed to this list.
 
         seed can be:
-            - author, edition or work object
-            - {"key": "..."} for author, edition or work objects
-            - subject strings.
+            - a `Thing`: author, edition or work object
+            - a key dict: {"key": "..."} for author, edition or work objects
+            - a string: for a subject
         """
-        if isinstance(seed, Thing):
-            seed = {"key": seed.key}
+        if isinstance(seed, dict):
+            seed = Thing(self._site, seed['key'], None)
 
-        index = self._index_of_seed(seed)
-        if index >= 0:
+        if self._index_of_seed(seed) >= 0:
             return False
         else:
             self.seeds = self.seeds or []
             self.seeds.append(seed)
             return True
 
-    def remove_seed(self, seed):
+    def remove_seed(self, seed: Thing | SeedDict | SeedSubjectString):
         """Removes a seed for the list."""
-        if isinstance(seed, Thing):
-            seed = {"key": seed.key}
+        if isinstance(seed, dict):
+            seed = Thing(self._site, seed['key'], None)
 
         if (index := self._index_of_seed(seed)) >= 0:
             self.seeds.pop(index)
@@ -95,10 +105,10 @@ class List(Thing):
         else:
             return False
 
-    def _index_of_seed(self, seed):
-        for i, s in enumerate(self.seeds):
-            if isinstance(s, Thing):
-                s = {"key": s.key}
+    def _index_of_seed(self, seed: Thing | SeedSubjectString) -> int:
+        if isinstance(seed, Thing):
+            seed = seed.key
+        for i, s in enumerate(self._get_seed_strings()):
             if s == seed:
                 return i
         return -1
@@ -106,14 +116,8 @@ class List(Thing):
     def __repr__(self):
         return f"<List: {self.key} ({self.name!r})>"
 
-    def _get_rawseeds(self):
-        def process(seed):
-            if isinstance(seed, str):
-                return seed
-            else:
-                return seed.key
-
-        return [process(seed) for seed in self.seeds]
+    def _get_seed_strings(self) -> list[SeedSubjectString | ThingKey]:
+        return [seed if isinstance(seed, str) else seed.key for seed in self.seeds]
 
     @cached_property
     def last_update(self):
@@ -215,7 +219,7 @@ class List(Thing):
             for k in doc['edition_key']:
                 yield "/books/" + k
 
-    def get_export_list(self) -> dict[str, list]:
+    def get_export_list(self) -> dict[str, list[dict]]:
         """Returns all the editions, works and authors of this list in arbitrary order.
 
         The return value is an iterator over all the entries. Each entry is a dictionary.
@@ -223,34 +227,24 @@ class List(Thing):
         This works even for lists with too many seeds as it doesn't try to
         return entries in the order of last-modified.
         """
-
-        # Separate by type each of the keys
-        edition_keys = {
-            seed.key for seed in self.seeds if seed and seed.type.key == '/type/edition'  # type: ignore[attr-defined]
-        }
-        work_keys = {
-            "/works/%s" % seed.key.split("/")[-1] for seed in self.seeds if seed and seed.type.key == '/type/work'  # type: ignore[attr-defined]
-        }
-        author_keys = {
-            "/authors/%s" % seed.key.split("/")[-1] for seed in self.seeds if seed and seed.type.key == '/type/author'  # type: ignore[attr-defined]
-        }
+        # Make one db call to fetch fully loaded Thing instances. By
+        # default they are 'shell' instances that dynamically get fetched
+        # as you access their attributes.
+        things = cast(
+            list[Thing],
+            web.ctx.site.get_many(
+                [seed.key for seed in self.seeds if isinstance(seed, Thing)]
+            ),
+        )
 
         # Create the return dictionary
-        export_list = {}
-        if edition_keys:
-            export_list["editions"] = [
-                doc.dict() for doc in web.ctx.site.get_many(list(edition_keys))
-            ]
-        if work_keys:
-            export_list["works"] = [
-                doc.dict() for doc in web.ctx.site.get_many(list(work_keys))
-            ]
-        if author_keys:
-            export_list["authors"] = [
-                doc.dict() for doc in web.ctx.site.get_many(list(author_keys))
-            ]
-
-        return export_list
+        return {
+            "editions": [
+                thing.dict() for thing in things if isinstance(thing, Edition)
+            ],
+            "works": [thing.dict() for thing in things if isinstance(thing, Work)],
+            "authors": [thing.dict() for thing in things if isinstance(thing, Author)],
+        }
 
     def _preload(self, keys):
         keys = list(set(keys))
@@ -355,8 +349,8 @@ class List(Thing):
                 d[kind].append(s)
         return d
 
-    def get_seeds(self, sort=False, resolve_redirects=False):
-        seeds = []
+    def get_seeds(self, sort=False, resolve_redirects=False) -> list['Seed']:
+        seeds: list['Seed'] = []
         for s in self.seeds:
             seed = Seed(self, s)
             max_checks = 10
@@ -370,15 +364,10 @@ class List(Thing):
 
         return seeds
 
-    def get_seed(self, seed):
+    def has_seed(self, seed: SeedDict | SeedSubjectString) -> bool:
         if isinstance(seed, dict):
             seed = seed['key']
-        return Seed(self, seed)
-
-    def has_seed(self, seed):
-        if isinstance(seed, dict):
-            seed = seed['key']
-        return seed in self._get_rawseeds()
+        return seed in self._get_seed_strings()
 
     # cache the default_cover_id for 60 seconds
     @cache.memoize(
@@ -409,7 +398,11 @@ class Seed:
         * cover
     """
 
-    def __init__(self, list, value: web.storage | str):
+    key: ThingKey | SeedSubjectString
+
+    value: Thing | SeedSubjectString
+
+    def __init__(self, list: List, value: Thing | SeedSubjectString):
         self._list = list
         self._type = None
 
@@ -421,7 +414,7 @@ class Seed:
             self.key = value.key
 
     @cached_property
-    def document(self):
+    def document(self) -> Subject | Thing:
         if isinstance(self.value, str):
             return get_subject(self.get_subject_url(self.value))
         else:
@@ -458,7 +451,7 @@ class Seed:
         return "unknown"
 
     @property
-    def title(self):
+    def title(self) -> str:
         if self.type in ("work", "edition"):
             return self.document.title or self.key
         elif self.type == "author":
@@ -478,7 +471,7 @@ class Seed:
             else:
                 return "/subjects/" + self.key
 
-    def get_subject_url(self, subject):
+    def get_subject_url(self, subject: SeedSubjectString) -> str:
         if subject.startswith("subject:"):
             return "/subjects/" + web.lstrips(subject, "subject:")
         else:

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 import json
 from urllib.parse import parse_qs
 import random
-from typing import TypedDict
+from typing import cast
 import web
 
 from infogami.utils import delegate
@@ -13,7 +13,8 @@ from infogami.infobase import client, common
 
 from openlibrary.accounts import get_current_user
 from openlibrary.core import formats, cache
-from openlibrary.core.lists.model import List
+from openlibrary.core.models import ThingKey
+from openlibrary.core.lists.model import List, SeedDict, SeedSubjectString
 import openlibrary.core.helpers as h
 from openlibrary.i18n import gettext as _
 from openlibrary.plugins.upstream.addbook import safe_seeother
@@ -24,8 +25,17 @@ from openlibrary.plugins.worksearch import subjects
 from openlibrary.coverstore.code import render_list_preview_image
 
 
-class SeedDict(TypedDict):
-    key: str
+def subject_key_to_seed(key: subjects.SubjectPseudoKey) -> SeedSubjectString:
+    name_part = key.split("/")[-1].replace(",", "_").replace("__", "_")
+    if name_part.split(":")[0] in ("place", "person", "time"):
+        return name_part
+    else:
+        return "subject:" + name_part
+
+
+def is_seed_subject_string(seed: str) -> bool:
+    subject_type = seed.split(":")[0]
+    return subject_type in ("subject", "place", "person", "time")
 
 
 @dataclass
@@ -33,18 +43,24 @@ class ListRecord:
     key: str | None = None
     name: str = ''
     description: str = ''
-    seeds: list[SeedDict | str] = field(default_factory=list)
+    seeds: list[SeedDict | SeedSubjectString] = field(default_factory=list)
 
     @staticmethod
-    def normalize_input_seed(seed: SeedDict | str) -> SeedDict | str:
+    def normalize_input_seed(
+        seed: SeedDict | subjects.SubjectPseudoKey,
+    ) -> SeedDict | SeedSubjectString:
         if isinstance(seed, str):
             if seed.startswith('/subjects/'):
+                return subject_key_to_seed(seed)
+            elif seed.startswith('/'):
+                return {'key': seed}
+            elif is_seed_subject_string(seed):
                 return seed
             else:
-                return {'key': seed if seed.startswith('/') else olid_to_key(seed)}
+                return {'key': olid_to_key(seed)}
         else:
             if seed['key'].startswith('/subjects/'):
-                return seed['key'].split('/', 2)[-1]
+                return subject_key_to_seed(seed['key'])
             else:
                 return seed
 
@@ -112,10 +128,7 @@ class lists_home(delegate.page):
 def get_seed_info(doc):
     """Takes a thing, determines what type it is, and returns a seed summary"""
     if doc.key.startswith("/subjects/"):
-        seed = doc.key.split("/")[-1]
-        if seed.split(":")[0] not in ("place", "person", "time"):
-            seed = f"subject:{seed}"
-        seed = seed.replace(",", "_").replace("__", "_")
+        seed = subject_key_to_seed(doc.key)
         seed_type = "subject"
         title = doc.name
     else:
@@ -259,7 +272,7 @@ class lists_edit(delegate.page):
                 f"Permission denied to edit {key}.",
             )
 
-        lst = web.ctx.site.get(key)
+        lst = cast(List | None, web.ctx.site.get(key))
         if lst is None:
             raise web.notfound()
         return render_template("type/list/edit", lst, new=False)
@@ -433,20 +446,10 @@ class lists_json(delegate.page):
         web.header("Content-Type", self.get_content_type())
         return delegate.RawText(self.dumps(result))
 
-    def process_seeds(self, seeds):
-        def f(seed):
-            if isinstance(seed, dict):
-                return seed
-            elif seed.startswith("/subjects/"):
-                seed = seed.split("/")[-1]
-                if seed.split(":")[0] not in ["place", "person", "time"]:
-                    seed = "subject:" + seed
-                seed = seed.replace(",", "_").replace("__", "_")
-            elif seed.startswith("/"):
-                seed = {"key": seed}
-            return seed
-
-        return [f(seed) for seed in seeds]
+    def process_seeds(
+        self, seeds: SeedDict | subjects.SubjectPseudoKey | ThingKey
+    ) -> list[SeedDict | SeedSubjectString]:
+        return [ListRecord.normalize_input_seed(seed) for seed in seeds]
 
     def get_content_type(self):
         return self.content_type
@@ -535,7 +538,7 @@ class list_seeds(delegate.page):
     def POST(self, key):
         site = web.ctx.site
 
-        lst = site.get(key)
+        lst = cast(List | None, site.get(key))
         if not lst:
             raise web.notfound()
 
@@ -566,8 +569,8 @@ class list_seeds(delegate.page):
         changeset_data = {
             "list": {"key": key},
             "seeds": seeds,
-            "add": data.get("add", []),
-            "remove": data.get("remove", []),
+            "add": data["add"],
+            "remove": data["remove"],
         }
 
         d = lst._save(comment="Updated list.", action="lists", data=changeset_data)
@@ -650,7 +653,7 @@ class list_subjects_json(delegate.page):
     content_type = "application/json"
 
     def GET(self, key):
-        lst = web.ctx.site.get(key)
+        lst = cast(List | None, web.ctx.site.get(key))
         if not lst:
             raise web.notfound()
 
@@ -697,7 +700,7 @@ class export(delegate.page):
     path = r"((?:/people/[^/]+)?/lists/OL\d+L)/export"
 
     def GET(self, key):
-        lst = web.ctx.site.get(key)
+        lst = cast(List | None, web.ctx.site.get(key))
         if not lst:
             raise web.notfound()
 
@@ -799,7 +802,7 @@ class feeds(delegate.page):
     path = r"((?:/people/[^/]+)?/lists/OL\d+L)/feeds/(updates).(atom)"
 
     def GET(self, key, name, fmt):
-        lst = web.ctx.site.get(key)
+        lst = cast(List | None, web.ctx.site.get(key))
         if lst is None:
             raise web.notfound()
         text = getattr(self, 'GET_' + name + '_' + fmt)(lst)
@@ -865,14 +868,6 @@ def _preload_lists(lists):
                 keys.add(seed['key'])
 
     web.ctx.site.get_many(list(keys))
-
-
-def get_randomized_list_seeds(lst_key):
-    """Fetches all the seeds of a list and shuffles them"""
-    lst = web.ctx.site.get(lst_key)
-    seeds = lst.seeds if lst else []
-    random.shuffle(seeds)
-    return seeds
 
 
 def _get_active_lists_in_random(limit=20, preload=True):

--- a/openlibrary/plugins/openlibrary/tests/test_lists.py
+++ b/openlibrary/plugins/openlibrary/tests/test_lists.py
@@ -3,20 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from openlibrary.plugins.openlibrary import lists
 from openlibrary.plugins.openlibrary.lists import ListRecord
-
-
-def test_process_seeds():
-    process_seeds = lists.lists_json().process_seeds
-
-    def f(s):
-        return process_seeds([s])[0]
-
-    assert f("/books/OL1M") == {"key": "/books/OL1M"}
-    assert f({"key": "/books/OL1M"}) == {"key": "/books/OL1M"}
-    assert f("/subjects/love") == "subject:love"
-    assert f("subject:love") == "subject:love"
 
 
 class TestListRecord:
@@ -111,3 +98,11 @@ class TestListRecord:
                 description='bar',
                 seeds=expected,
             )
+
+    def test_normalize_input_seed(self):
+        f = ListRecord.normalize_input_seed
+
+        assert f("/books/OL1M") == {"key": "/books/OL1M"}
+        assert f({"key": "/books/OL1M"}) == {"key": "/books/OL1M"}
+        assert f("/subjects/love") == "subject:love"
+        assert f("subject:love") == "subject:love"

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -712,7 +712,7 @@ class Work(models.Work):
         :param list[str] keys: ensure keys included in fetched editions
         """
         db_query = {"type": "/type/edition", "works": self.key}
-        db_query['limit'] = limit or 10000
+        db_query['limit'] = limit or 10000  # type: ignore[assignment]
 
         edition_keys = []
         if ebooks_only:
@@ -800,6 +800,8 @@ class SubjectPerson(Subject):
 
 
 class User(models.User):
+    displayname: str | None
+
     def get_name(self):
         return self.displayname or self.key.split('/')[-1]
 

--- a/openlibrary/plugins/worksearch/subjects.py
+++ b/openlibrary/plugins/worksearch/subjects.py
@@ -1,6 +1,7 @@
 """Subject pages.
 """
 from dataclasses import dataclass
+from typing import Literal
 import web
 import json
 import datetime
@@ -121,6 +122,8 @@ class subjects_json(delegate.page):
     def process_key(self, key):
         return key
 
+
+SubjectType = Literal["subject", "place", "person", "time"]
 
 SubjectPseudoKey = str
 """

--- a/openlibrary/solr/data_provider.py
+++ b/openlibrary/solr/data_provider.py
@@ -415,13 +415,7 @@ class BetterDataProvider(LegacyDataProvider):
         return self.cache.get(key) or {"key": key, "type": {"key": "/type/delete"}}
 
     async def preload_documents(self, keys: Iterable[str]):
-        identifiers = [
-            k.replace("/books/ia:", "") for k in keys if k.startswith("/books/ia:")
-        ]
-        # self.preload_ia_items(identifiers)
-        re_key = web.re_compile(r"/(books|works|authors)/OL\d+[MWA]")
-
-        keys2 = {k for k in keys if re_key.match(k)}
+        keys2 = set(keys)
         # keys2.update(k for k in self.ia_redirect_cache.values() if k is not None)
         self.preload_documents0(keys2)
         self._preload_works()

--- a/openlibrary/solr/update.py
+++ b/openlibrary/solr/update.py
@@ -15,6 +15,7 @@ from openlibrary.solr.data_provider import (
 from openlibrary.solr.updater.abstract import AbstractSolrUpdater
 from openlibrary.solr.updater.author import AuthorSolrUpdater
 from openlibrary.solr.updater.edition import EditionSolrUpdater
+from openlibrary.solr.updater.list import ListSolrUpdater
 from openlibrary.solr.updater.work import WorkSolrUpdater
 from openlibrary.solr.utils import (
     SolrUpdateRequest,
@@ -71,6 +72,7 @@ async def update_keys(
         EditionSolrUpdater(data_provider),
         WorkSolrUpdater(data_provider),
         AuthorSolrUpdater(data_provider),
+        ListSolrUpdater(data_provider),
     ]
 
     for updater in solr_updaters:

--- a/openlibrary/solr/updater/list.py
+++ b/openlibrary/solr/updater/list.py
@@ -1,0 +1,113 @@
+from collections import defaultdict
+import re
+from typing import cast
+
+import httpx
+from openlibrary.plugins.openlibrary.lists import (
+    SeedType,
+    seed_key_to_seed_type,
+)
+from openlibrary.plugins.worksearch.subjects import SubjectType
+from openlibrary.solr.solr_types import SolrDocument
+from openlibrary.solr.updater.abstract import AbstractSolrBuilder, AbstractSolrUpdater
+from openlibrary.solr.utils import SolrUpdateRequest, get_solr_base_url, str_to_key
+
+
+class ListSolrUpdater(AbstractSolrUpdater):
+    key_prefix = '/lists/'
+    thing_type = '/type/list'
+
+    def key_test(self, key: str) -> bool:
+        return bool(re.match(r'^(/people/[^/]+)?/lists/[^/]+$', key))
+
+    async def update_key(self, list: dict) -> tuple[SolrUpdateRequest, list[str]]:
+        lst = ListSolrBuilder(list)
+        seeds = lst.seed
+        lst = ListSolrBuilder(list, await fetch_seeds_facets(seeds))
+        doc = lst.build()
+        return SolrUpdateRequest(adds=[doc]), []
+
+
+async def fetch_seeds_facets(seeds: list[str]):
+    base_url = get_solr_base_url() + '/select'
+    facet_fields: list[SubjectType] = ['subject', 'time', 'person', 'place']
+
+    seeds_by_type: defaultdict[SeedType, list] = defaultdict(list)
+    for seed in seeds:
+        seeds_by_type[seed_key_to_seed_type(seed)].append(seed)
+
+    query: list[str] = []
+    for seed_type, seeds in seeds_by_type.items():
+        match seed_type:
+            case 'edition' | 'author':
+                edition_olids = " OR ".join(key.split('/')[-1] for key in seeds)
+                query.append(f'edition_key:( {edition_olids} )')
+            case 'work':
+                seed_keys = " OR ".join(f'"{key}"' for key in seeds)
+                query.append(f'key:( {seed_keys} )')
+            case 'subject':
+                pass
+            case _:
+                raise NotImplementedError(f'Unknown seed type {seed_type}')
+
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            base_url,
+            params=[  # type: ignore
+                ('wt', 'json'),
+                ('json.nl', 'arrarr'),
+                ('q', ' OR '.join(query)),
+                ('fq', 'type: work'),
+                ('rows', '0'),
+                ('facet', 'true'),
+                ('facet.mincount', '1'),
+                ('facet.limit', '50'),
+            ]
+            + [('facet.field', f"{field}_facet") for field in facet_fields],
+        )
+        return response.json()
+
+
+class ListSolrBuilder(AbstractSolrBuilder):
+    def __init__(self, list: dict, solr_reply: dict = None):
+        self._list = list
+        self._solr_reply = solr_reply
+
+    def build(self) -> SolrDocument:
+        doc = cast(dict, super().build())
+        doc |= self.build_subjects()
+        return cast(SolrDocument, doc)
+
+    def build_subjects(self) -> dict:
+        if not self._solr_reply:
+            return {}
+
+        doc = {}
+        for facet, counts in self._solr_reply['facet_counts']['facet_fields'].items():
+            subject_type = cast(SubjectType, facet.split('_')[0])
+            subjects = [s for s, count in counts]
+            doc |= {
+                subject_type: subjects,
+                f'{subject_type}_facet': subjects,
+                f'{subject_type}_key': [str_to_key(s) for s in subjects],
+            }
+        return doc
+
+    @property
+    def key(self) -> str:
+        return self._list['key']
+
+    @property
+    def type(self) -> str:
+        return 'list'
+
+    @property
+    def name(self) -> str | None:
+        return self._list.get('name')
+
+    @property
+    def seed(self) -> list[str]:
+        return [
+            seed['key'] if isinstance(seed, dict) else seed
+            for seed in self._list.get('seeds', [])
+        ]

--- a/openlibrary/solr/updater/list.py
+++ b/openlibrary/solr/updater/list.py
@@ -69,7 +69,7 @@ async def fetch_seeds_facets(seeds: list[str]):
 
 
 class ListSolrBuilder(AbstractSolrBuilder):
-    def __init__(self, list: dict, solr_reply: dict = None):
+    def __init__(self, list: dict, solr_reply: dict | None = None):
         self._list = list
         self._solr_reply = solr_reply
 
@@ -82,7 +82,7 @@ class ListSolrBuilder(AbstractSolrBuilder):
         if not self._solr_reply:
             return {}
 
-        doc = {}
+        doc: dict = {}
         for facet, counts in self._solr_reply['facet_counts']['facet_fields'].items():
             subject_type = cast(SubjectType, facet.split('_')[0])
             subjects = [s for s, count in counts]

--- a/scripts/solr_builder/Jenkinsfile
+++ b/scripts/solr_builder/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
     booleanParam(name: 'INDEX_ORPHANS', defaultValue: true, description: 'If true, reindexes orphans into solr')
     booleanParam(name: 'INDEX_SUBJECTS', defaultValue: true, description: 'If true, reindexes subjects into solr')
     booleanParam(name: 'INDEX_AUTHORS', defaultValue: true, description: 'If true, reindexes authors into solr')
+    booleanParam(name: 'INDEX_LISTS', defaultValue: true, description: 'If true, reindexes lists into solr')
     string(name: 'MAX_CORES', defaultValue: '18', description: 'Max number of simultaneous cores')
   }
   environment {
@@ -262,6 +263,27 @@ pipeline {
                         // Save Log Files
                         sh '''cat $(ls -tr logs/authors/*) | gzip > logs/authors-indexing.log.gz'''
                         archiveArtifacts artifacts: "logs/authors-indexing.log.gz"
+                      }
+                    }
+                  }
+                }
+                stage('Insert lists') {
+                  when { expression { return params.INDEX_LISTS } }
+                  steps {
+                    dir(env.HOST_SOLR_BUILDER_DIR) {
+                      sh "docker compose run --name ol_run_lists --rm -T ol ./index-type.sh list ${params.MAX_CORES} lists"
+                      solr_commit()
+                    }
+                  }
+                  post {
+                    always {
+                      dir(env.HOST_SOLR_BUILDER_DIR) {
+                        // Save Progress Files
+                        sh '''tail --quiet -n1 $(ls -tr progress/lists/*) | gzip > progress/lists-progress.txt.gz'''
+                        archiveArtifacts artifacts: "progress/lists-progress.txt.gz"
+                        // Save Log Files
+                        sh '''cat $(ls -tr logs/lists/*) | gzip > logs/lists-indexing.log.gz'''
+                        archiveArtifacts artifacts: "logs/lists-indexing.log.gz"
                       }
                     }
                   }

--- a/scripts/solr_builder/index-type.sh
+++ b/scripts/solr_builder/index-type.sh
@@ -7,7 +7,7 @@ source aliases.sh
 # Display each line before running it
 set -o xtrace
 
-# One of 'work' or 'author'
+# One of 'work' or 'author' or 'list'
 TYPE="$1"
 INSTANCES="$2"
 LOG_DIR="$3"

--- a/scripts/solr_builder/solr_builder/solr_builder.py
+++ b/scripts/solr_builder/solr_builder/solr_builder.py
@@ -327,7 +327,7 @@ async def simple_timeit_async(awaitable: Awaitable):
 
 
 def build_job_query(
-    job: Literal['works', 'orphans', 'authors'],
+    job: Literal['works', 'orphans', 'authors', 'lists'],
     start_at: str | None = None,
     offset: int = 0,
     last_modified: str | None = None,
@@ -340,7 +340,12 @@ def build_job_query(
     :param offset: Use `start_at` if possible.
     :param last_modified: Only import docs modified after this date.
     """
-    type = {"works": "work", "orphans": "edition", "authors": "author"}[job]
+    type = {
+        "works": "work",
+        "orphans": "edition",
+        "authors": "author",
+        "lists": "list",
+    }[job]
 
     q_select = """SELECT "Key", "JSON" FROM test"""
     q_where = """WHERE "Type" = '/type/%s'""" % type
@@ -370,7 +375,7 @@ def build_job_query(
 
 async def main(
     cmd: Literal['index', 'fetch-end'],
-    job: Literal['works', 'orphans', 'authors'],
+    job: Literal['works', 'orphans', 'authors', 'lists'],
     postgres="postgres.ini",
     ol="http://ol/",
     ol_config="../../conf/openlibrary.yml",
@@ -603,6 +608,10 @@ async def main(
                         q_auth=plog.last_entry.q_auth + authors_time,
                         cached=len(db.cache) + len(db2.cache),
                     )
+                elif job == 'lists':
+                    # Nothing to cache ; just need the lists themselves and
+                    # they are already cached
+                    pass
                 elif job == "authors":
                     # Nothing to cache; update.py queries solr directly for each
                     # other, and provides no way to cache.


### PR DESCRIPTION
Closes #7815. Feature. Stores lists in solr. Includes both global lists (series) and user lists. This will eventually be used to replace the current lists search implementation which uses postgres.

~Depends on #8618~

### Technical
Stores the names and a number of the aggregated book subjects.
Also some small refactors, including more list types.

### Testing
Did a full reindex, and they all correctly appear in solr search results.

### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/6251786/433506cd-a166-41e9-8af6-5a34811189ac)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
