### PR TITLE
Boost search via reading log, phrase boosting

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/works.py
+++ b/openlibrary/plugins/worksearch/schemes/works.py
@@ -278,16 +278,19 @@ class WorkSearchScheme(SearchScheme):
         # query, but much more flexible. We wouldn't be able to do our
         # complicated parent/child queries with defType!
 
-        full_work_query = '({{!edismax q.op="AND" qf="{qf}" bf="{bf}" v={v}}})'.format(
+        full_work_query = '({{!edismax q.op="AND" qf="{qf}" pf="{pf}" bf="{bf}" v={v}}})'.format(
             # qf: the fields to query un-prefixed parts of the query.
             # e.g. 'harry potter' becomes
             # 'text:(harry potter) OR alternative_title:(harry potter)^20 OR ...'
-            qf='text alternative_title^20 author_name^20',
+            qf='text alternative_title^10 author_name^10',
+            # pf: phrase fields. This increases the score of documents that
+            # match the query terms in close proximity to each other.
+            pf='alternative_title^10 author_name^10',
             # bf (boost factor): boost results based on the value of this
             # field. I.e. results with more editions get boosted, upto a
             # max of 100, after which we don't see it as good signal of
             # quality.
-            bf='min(100,edition_count)',
+            bf='min(100,edition_count) min(100,def(readinglog_count,0))',
             # v: the query to process with the edismax query parser. Note
             # we are using a solr variable here; this reads the url parameter
             # arbitrarily called workQuery.


### PR DESCRIPTION
Improve search rankings by boosting results that have high reading log counts or have exact phrase matches to the user's query.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Has been up on testing.openlibrary.org over a week. Improvements to almost all our search metrics!

![image](https://github.com/internetarchive/openlibrary/assets/6251786/427ff01c-958c-4e46-b18c-5fc3abeff1d3)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/5d89c1cd-502a-4e0f-9ef3-8f1351f8fd34)

Percent high ranking (position <= 3)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/3ed24b14-1e64-4f24-8a48-35205256c2b9)


The only case I noticed some worsening is when searching for generic more subject-like terms such as "science textbook". For these searches, books like "Frankenstein" will pop to the surface because their popularity causes them to jump too high in the rankings. These searches are not measured by the spreadsheet.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
