### PR TITLE
My Books visual fixes

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -224,7 +224,7 @@ class lists(delegate.page):
             template = render_template(
                 "lists/lists.html", mb.user, mb.user.get_lists(), show_header=False
             )
-            return mb.render(template=template, header_title=_("Lists"), page=mb.user)
+            return mb.render(template=template, header_title=_("Lists"))
         else:
             doc = self.get_doc(path)
             if not doc:

--- a/openlibrary/templates/account/sidebar.html
+++ b/openlibrary/templates/account/sidebar.html
@@ -2,14 +2,14 @@ $def with (username, key=None, owners_page=False, public=False, counts=None, lis
 
   $ component_times['Sidebar'] = time()
   <div class="mybooks-menu">
-    <ul class="sidebar-section">
-      <li class="section-header">$username</li>
-      $if owners_page:
+    $if owners_page:
+      <ul class="sidebar-section">
+        <li class="section-header">$username</li>
         <li>
           <a class="li-title-desktop" href="/account/loans" data-ol-link-track="MyBooksSidebar|Loans" $('class=selected' if key == 'loans' else '')>$_('My Loans')</a>
         </li>
-        <li><a class="external-link" data-ol-link-track="MyBooksSidebar|LoanHistory" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a></li>
-    </ul>
+        <li><a class="li-title-desktop" data-ol-link-track="MyBooksSidebar|LoanHistory" href="https://archive.org/account/?tab=loans#loans-history">$_('Loan History')</a></li>
+      </ul>
     $if public or owners_page:
       <ul class="sidebar-section">
         <li class="section-header">$_('Reading Log')</li>

--- a/openlibrary/templates/account/view.html
+++ b/openlibrary/templates/account/view.html
@@ -19,7 +19,10 @@ $var title: $header_title
     <header>
       <div class="breadcrumb-wrapper">
         $# Only show breadcrumbs when we're not on mybooks
-        <img src="https://archive.org/services/img/$mb.user_itemname" class="account-avatar">
+	<div class="account-breadcrumb">
+          <a href="$mb.user.key"><img src="https://archive.org/services/img/$mb.user_itemname" class="account-avatar"></a>
+	  <h2 class="account-username"><a href="$mb.user.key">$mb.username</a> &rsaquo;</h2>
+	</div>
         $if mb.key == 'list':
           <h1 class="details-title">$header_title</h1>
         $else:

--- a/openlibrary/templates/books/breadcrumb_select.html
+++ b/openlibrary/templates/books/breadcrumb_select.html
@@ -14,7 +14,6 @@ $def with (mb, selected="books")
       $ options += [
       $   (_("Loans"), "/account/loans"),
       $   (_("Notes"), url_prefix + "/books/notes"),
-      $   (_("Notes"), url_prefix + "/books/notes"),
       $   (_("Reviews"), url_prefix + "/books/observations"),
       $   (_("Imports and Exports"), "/account/import")
       $ ]

--- a/static/css/components/mybooks-details.less
+++ b/static/css/components/mybooks-details.less
@@ -1,6 +1,6 @@
 .crumb {
   display: flex;
-  margin: 15px 0;
+  margin: 0;
   align-items: center;
   vertical-align: bottom;
 }
@@ -9,6 +9,7 @@
   display: grid;
   grid: [stack] var(--crumbicon-size) / [stack] var(--crumbicon-size);
   place-items: start;
+  width: min-content;
 }
 
 .crumbicon>* {
@@ -18,7 +19,8 @@
 
 .breadcrumb-wrapper {
   display: flex;
-  flex: 1;
+  flex-wrap: wrap;
+  white-space: nowrap;
 }
 
 .breadcrumb-title {

--- a/static/css/components/mybooks.less
+++ b/static/css/components/mybooks.less
@@ -28,10 +28,29 @@
   width: 18px;
 }
 
+.account-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 img.account-avatar {
   border-radius: 100px;
   width: 40px;
   height: 40px;
   margin-top: 10px;
   margin-right: 5px;
+}
+
+h2.account-username {
+  margin: 20px 10px 20px 5px;
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+@media only screen and (min-width: (@width-breakpoint-tablet + 1)) {
+  .crumb {
+    margin: 15px 0;
+  }
 }


### PR DESCRIPTION
- fixes Loan History class so it's not individually underlined
- adds username (links to profile) on my books page before nav dropper
- removed duplicated `notes` from nav dropper

<!-- What issue does this PR close? -->
Resolves outstanding issues from #8597

## Nav Dropper Updates
Make it clear what page you're on
<img width="290" alt="Screenshot 2023-12-14 at 10 13 08 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/8b2ab163-890a-4b8c-8046-b8d6f14d9e46">

EDIT: Mobile
<img width="334" alt="Screenshot 2023-12-14 at 10 39 36 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/6c9dda59-dafd-4268-92f7-090da41f5909">


Remove duplicate notes

<img width="235" alt="Screenshot 2023-12-14 at 10 17 12 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/c3a9c56f-39da-4ce9-afcc-4517d5fa8d9e">

## Fixed sidebar
No underlined link (Loan History took visual precedence over My Loans and the Section was empty for non-owners)

Before:
<img width="147" alt="Screenshot 2023-12-14 at 10 14 56 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/d5f3e315-534e-4e13-815b-8c6d707e89cb">

After:
<img width="148" alt="Screenshot 2023-12-14 at 10 14 03 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/b5dbd930-9687-4361-ac48-6460ccba15ad">

After (when not owner, hide initial section):
<img width="411" alt="Screenshot 2023-12-14 at 10 15 37 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/cc184cb8-b3e3-4517-9953-d565a953842c">

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
