### PR TITLE
Address deprecation warnings during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openlibrary",
   "version": "1.0.0",
-  "repository": "github:internetarchive:openlibrary",
+  "repository": "github:internetarchive/openlibrary",
   "license": "AGPL-3.0",
   "watch": {
     "build-assets:css": {


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes `repository` in `package.json` to conform with the shortcut syntax found [here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository).

This was done to address these types of deprecation warnings, which are seen while building assets:
```
(node:5804) [DEP0170] DeprecationWarning: The URL github:internetarchive:openlibrary is invalid. Future versions of Node.js will throw an error.
```

Here's a [link to the deprecation](https://nodejs.org/api/deprecations.html#dep0170-invalid-port-when-using-urlparse).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
