### PR TITLE
Hotfix some bug in solr updater refactor

### DIFF
--- a/openlibrary/solr/updater/edition.py
+++ b/openlibrary/solr/updater/edition.py
@@ -30,7 +30,7 @@ class EditionSolrUpdater(AbstractSolrUpdater):
             if thing.get("works"):
                 new_keys.append(thing["works"][0]['key'])
                 # Make sure we remove any fake works created from orphaned editions
-                new_keys.append(thing['key'].replace('/books/', '/works/'))
+                update.deletes.append(thing['key'].replace('/books/', '/works/'))
             else:
                 # index the edition as it does not belong to any work
                 new_keys.append(thing['key'].replace('/books/', '/works/'))

--- a/openlibrary/solr/updater/work.py
+++ b/openlibrary/solr/updater/work.py
@@ -388,7 +388,19 @@ class WorkSolrBuilder(AbstractSolrBuilder):
 
     @property
     def contributor(self) -> set[str]:
-        return {v for e in self._editions for v in e.get('contributors', [])}
+        return {
+            v
+            for e in self._editions
+            for v in (
+                e.get('contributions', [])
+                # TODO: contributors wasn't included here in the past, but
+                # we likely want it to be edition-only if possible?
+                # Excluding for now to avoid a possible perf hit in the
+                # next full reindex which is already pretty loaded
+                # + [c.get('name') for c in e.get('contributors', [])]
+            )
+            if v
+        }
 
     @property
     def lcc(self) -> set[str]:

--- a/openlibrary/tests/solr/updater/test_edition.py
+++ b/openlibrary/tests/solr/updater/test_edition.py
@@ -1,0 +1,30 @@
+import pytest
+from openlibrary.solr.updater.edition import EditionSolrUpdater
+
+from openlibrary.tests.solr.test_update import FakeDataProvider
+
+
+class TestEditionSolrUpdater:
+    @pytest.mark.asyncio()
+    async def test_deletes_old_orphans(self):
+        req, new_keys = await EditionSolrUpdater(FakeDataProvider()).update_key(
+            {
+                'key': '/books/OL1M',
+                'type': {'key': '/type/edition'},
+                'works': [{'key': '/works/OL1W'}],
+            }
+        )
+
+        assert req.deletes == ['/works/OL1M']
+        assert req.adds == []
+        assert new_keys == ['/works/OL1W']
+
+    @pytest.mark.asyncio()
+    async def test_enqueues_orphans_as_works(self):
+        req, new_keys = await EditionSolrUpdater(FakeDataProvider()).update_key(
+            {'key': '/books/OL1M', 'type': {'key': '/type/edition'}}
+        )
+
+        assert req.deletes == []
+        assert req.adds == []
+        assert new_keys == ['/works/OL1M']

--- a/openlibrary/tests/solr/updater/test_work.py
+++ b/openlibrary/tests/solr/updater/test_work.py
@@ -444,6 +444,19 @@ class TestWorkSolrBuilder:
             assert d.ddc == set()
             assert d.ddc_sort is None
 
+    def test_contributor(self):
+        work = make_work()
+        d = WorkSolrBuilder(
+            work,
+            [make_edition(work, contributors=[{'role': 'Illustrator', 'name': 'Foo'}])],
+            [],
+            FakeDataProvider(),
+            {},
+        )
+
+        # For now it should ignore it and not error
+        assert d.contributor == set()
+
 
 class Test_number_of_pages_median:
     def test_no_editions(self):


### PR DESCRIPTION
Hotfix.

- [Fix presence of contributor causing index error](https://github.com/internetarchive/openlibrary/pull/8631/commits/ab9d65459de7ff888bc23713f1f0b9c813826fd9)
    - I checked the previous version and it was never using `contributor`! So just disabled it for now and switched it back to what it was doing before
- [Fix EditionSolrUpdate wrongly queueing old orphans](https://github.com/internetarchive/openlibrary/pull/8631/commits/6ccb2645f9a3c653e2a513e6a044a7b4399b18a6)
    - Typo on my end was causing it to create a fake work for every edition!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Added unit tests to prevent regression.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
