### PR TITLE
Add cautionary message to our Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,7 @@ labels: "Type: Bug, Needs: Triage, Needs: Lead"
 assignees: ''
 ---
 
+<!-- IMPORTANT: Before posting, be sure to redact or remove sensitive data, such as passwords, secret keys, session cookies, etc. -->
 <!-- What problem are we solving? What does the experience look like today? What are the symptoms? -->
 
 ### Evidence / Screenshot (if possible)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: "Type: Feature Request, Needs: Triage, Needs: Lead"
 assignees: ''
 ---
 
+<!-- IMPORTANT: Before posting, be sure to redact or remove sensitive data, such as passwords, secret keys, session cookies, etc. -->
+
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ### Describe the problem that you'd like solved

--- a/.github/ISSUE_TEMPLATE/post_mortem.md
+++ b/.github/ISSUE_TEMPLATE/post_mortem.md
@@ -6,6 +6,8 @@ labels: "Type: Post-Mortem, Priority: 0, GJ: Triage Exception"
 assignees: ''
 ---
 
+<!-- IMPORTANT: Before posting, be sure to redact or remove sensitive data, such as passwords, secret keys, session cookies, etc. -->
+
 ### Summary
 
 - **What is wrong?**

--- a/.github/ISSUE_TEMPLATE/question_template.md
+++ b/.github/ISSUE_TEMPLATE/question_template.md
@@ -6,6 +6,8 @@ labels: "Type: Question, Needs: Triage, Needs: Lead, Needs: Community Discussion
 assignees: ''
 ---
 
+<!-- IMPORTANT: Before posting, be sure to redact or remove sensitive data, such as passwords, secret keys, session cookies, etc. -->
+
 ### Question
 <!-- What question needs to be answered to close this issue? This should be one sentence. -->
 


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds cautionary message to our GitHub issue templates.  People are urged to remove or redact any sensitive information before submitting a new issue.

Message was not added to the new design proposal template.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
