### PR TITLE
Adds work subtitles to reading stats

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -174,7 +174,7 @@ class readinglog_stats(delegate.page):
             {
                 # Fallback to key if it is a redirect
                 'title': w.get('title') or w.key,
-                'subtitle' : w.get('subtitle'),
+                'subtitle': w.get('subtitle'),
                 'key': w.get('key'),
                 'author_keys': ['/authors/' + key for key in w.get('author_key', [])],
                 'first_publish_year': w.get('first_publish_year') or None,

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -174,6 +174,7 @@ class readinglog_stats(delegate.page):
             {
                 # Fallback to key if it is a redirect
                 'title': w.get('title') or w.key,
+                'subtitle' : w.get('subtitle'),
                 'key': w.get('key'),
                 'author_keys': ['/authors/' + key for key in w.get('author_key', [])],
                 'first_publish_year': w.get('first_publish_year') or None,

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -13,7 +13,12 @@ $var title: $_('My %(shelf_name)s Stats', shelf_name=shelf_name)
 $jsdef render_works_list(works):
     <ul class="works-list">
     $for work in works:
-        <li><a href="$work.key" style="font-style:oblique">$work.title $work.subtitle</a>
+        $if work.subtitle:
+            $ divider = ':'
+        $else:
+            $ divider = ''
+        <li>
+            <a href="$work.key" style="font-style: oblique">$work.title $divider $work.subtitle</a>
             $ first_publish_year = work.first_publish_year or '????'
             <span title="First published in $first_publish_year">($first_publish_year)</span>
             by

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -13,12 +13,11 @@ $var title: $_('My %(shelf_name)s Stats', shelf_name=shelf_name)
 $jsdef render_works_list(works):
     <ul class="works-list">
     $for work in works:
+        $ full_title = work.title
         $if work.subtitle:
-            $ divider = ':'
-        $else:
-            $ divider = ''
+            $ full_title = work.title + ': ' + work.subtitle
         <li>
-            <a href="$work.key" style="font-style: oblique">$work.title $divider $work.subtitle</a>
+            <a href="$work.key" style="font-style: oblique">$full_title</a>
             $ first_publish_year = work.first_publish_year or '????'
             <span title="First published in $first_publish_year">($first_publish_year)</span>
             by

--- a/openlibrary/templates/account/readinglog_stats.html
+++ b/openlibrary/templates/account/readinglog_stats.html
@@ -13,7 +13,7 @@ $var title: $_('My %(shelf_name)s Stats', shelf_name=shelf_name)
 $jsdef render_works_list(works):
     <ul class="works-list">
     $for work in works:
-        <li><a href="$work.key" style="font-style:oblique">$work.title</a>
+        <li><a href="$work.key" style="font-style:oblique">$work.title $work.subtitle</a>
             $ first_publish_year = work.first_publish_year or '????'
             <span title="First published in $first_publish_year">($first_publish_year)</span>
             by


### PR DESCRIPTION
Closes #8585 . Adds subtitles along with titles of books in stats

### Technical
<!-- What should be noted about the implementation? -->
added subtitle attribute to work_json in mybooks.py and printed it in readinglog_stats.html

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Step 1 : Add a book that has subtitle to Already read
Step 2 : Go to mybook section and click on the My Reading Stats and click on any bar

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
