### PR TITLE
Gather stats on bulk tagging operations

### DIFF
--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -26,7 +26,7 @@ class bulk_tag_works(delegate.page):
             w = web.ctx.site.get(f"/works/{work}")
 
             current_subjects = {
-                 # XXX : Should an empty list be the default for these?
+                # XXX : Should an empty list be the default for these?
                 'subjects': uniq(w.get('subjects', '')),
                 'subject_people': uniq(w.get('subject_people', '')),
                 'subject_places': uniq(w.get('subject_places', '')),


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Follow-up for: #8575 

Increments three new statsd counters whenever a bulk tagging operation occurs.

| Counter Name | Tracks |
|---|---|
| `ol.tags.bulk_update` |  Number of `POST` requests to the bulk tagging handler |
| `ol.tags.bulk_update.add` | Total tags added, per work |
| `ol.tags.bulk_update.remove` | Total tags removed, per work |

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
