### PR TITLE
Fixed inconsistent margin gap between search box and search button #8595

### DIFF
--- a/openlibrary/templates/lists/home.html
+++ b/openlibrary/templates/lists/home.html
@@ -15,7 +15,7 @@ $var title: $_('Lists')
       </p>
       <p>$:_('For the top 2000+ most requested eBooks in California for the print disabled <a href="%(url)s">click here</a>.', url="../people/sionnac/lists/OL25152L")</p>
 
-  <form class="siteSearch searchInsideForm" action="/search/lists">
+  <form class="siteSearch olform" action="/search/lists">
     <input type="text" class="larger" name="q" value=""
            placeholder="$_('Find a list by name')"/>
     <input type="submit" class="generic-button" value="$_('Search')">

--- a/openlibrary/templates/search/inside.html
+++ b/openlibrary/templates/search/inside.html
@@ -8,8 +8,8 @@ $var title: $_('Search Open Library for %s', q)
 
 <div id="contentBody">
   $:macros.SearchNavigation()
-  <form class="siteSearch searchInsideForm" action="/search/inside">
-    <input type="text" class="larger" name="q" value="$q"/>
+  <form class="siteSearch olform" action="/search/inside">
+    <input type="text" class="larger" name="q" size="100" value="$q"/>
     <input type="submit" class="larger" value="$_('Search')">
   </form>
     $ num_found = 0

--- a/openlibrary/templates/search/lists.html
+++ b/openlibrary/templates/search/lists.html
@@ -8,8 +8,8 @@ $var title: $_('Search results for Lists')
 
 <div id="contentBody">
   $:macros.SearchNavigation()
-  <form class="siteSearch searchInsideForm" action="/search/lists">
-    <input type="text" class="larger" name="q" value="$q"/>
+  <form class="siteSearch olform" action="/search/lists">
+    <input type="text" class="larger" name="q" size="100" value="$q"/>
     <input type="submit" class="larger" value="$_('Search')">
   </form>
 

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -1848,22 +1848,6 @@ div#subjectLists {
 }
 
 @import (less) "components/rating-form.less";
-
-// openlibrary/templates/lists/home.html
-// openlibrary/templates/search/lists.html
-// openlibrary/templates/search/inside.html
-.searchInsideForm {
-  input[type=text] {
-    margin: 0;
-    padding: 5px;
-    width: 100%;
-    max-width: 500px;
-    min-width: 100px;
-  }
-  input[type=submit] {
-    padding: 5px;
-  }
-}
 @import (less) "components/searchResultItemCta.less";
 
 @media only screen and (min-width: @width-breakpoint-tablet) {

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -14,10 +14,10 @@ class TestSearch:
 
     def test_search_inside(self, browser):
         browser.visit(self.host + '/search/inside')
-        browser.find_by_css(".searchInsideForm > input[name='q']").fill('black cat')
-        browser.find_by_css(".searchInsideForm > [type='submit']").click()
+        browser.find_by_css(".olform > input[name='q']").fill('black cat')
+        browser.find_by_css(".olform > [type='submit']").click()
         assert browser.is_text_present('Search Inside')
-        assert browser.is_element_present_by_css('.searchInsideForm')
+        assert browser.is_element_present_by_css('.olform')
 
     def test_search_inside_from_global_nav(self, browser):
         browser.visit(self.host)
@@ -25,7 +25,7 @@ class TestSearch:
         browser.find_by_css("#headerSearch input[name='search-fulltext']").check()
         browser.find_by_css("#headerSearch [type='submit']").click()
         assert browser.is_text_present('Search Inside')
-        assert browser.is_element_present_by_css('.searchInsideForm')
+        assert browser.is_element_present_by_css('.olform')
 
     def test_metadata_search(self, browser):
         browser.visit(self.host + '/search')


### PR DESCRIPTION
#8595 
1. deleted ```.searchInsideForm``` class from ```static/css/legacy.less``` as using ```.olform``` class can will maintain consistency and will allow us to remove code.
2. updated ```openlibrary/templates/lists/home.html``` , ```openlibrary/templates/search/inside.html ``` , ```openlibrary/templates/search/lists.html files``` . Changing ```.searchInsideForm``` class to ```.olform``` class which solves the issue and maintenaces consistency.
4. updated the references of ```.searchInsideForm``` to ``` .olform``` in ```tests/integration/test_search.py``` file.

### Screenshot( Before)
<img src="https://github.com/internetarchive/openlibrary/assets/117273351/f8f8fde3-4fd0-4f77-912b-35bdc4ea09b7" width ="50%" height = "50%">

### Screenshot(After)
<img src="https://github.com/internetarchive/openlibrary/assets/117273351/8fdd6a76-a230-43ac-a9e1-36d5c22cb6bb" width ="50%" height = "50%">

