### PR TITLE
Disable bulk tagger's "Submit" button after submission is made

### DIFF
--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -523,8 +523,6 @@ export class BulkTagger {
         })
             .then(response => {
                 if (!response.ok) {
-                // Error handling
-                    this.isSubmitting = false;
                     this.submitButton.disabled = false;
                     this.submitButton.textContent = 'Submit';
                     new FadingToast('Error submitting batch').show();

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -527,8 +527,6 @@ export class BulkTagger {
                     this.submitButton.textContent = 'Submit';
                     new FadingToast('Batch subject update failed. Please try again in a few minutes.').show();
                 } else {
-                // Success
-                    this.isSubmitting = false;
                     this.submitButton.textContent = 'Submitted!';
                     // Rest of success handling
                     this.hideTaggingMenu();

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -510,39 +510,39 @@ export class BulkTagger {
 
         // Adds state
         this.isSubmitting = true;
-      
+
         // Disable button
         this.submitButton.disabled = true;
-      
+
         // Show loading spinner
-        this.submitButton.textContent = "Submitting...";
-      
+        this.submitButton.textContent = 'Submitting...';
+
         const url = this.rootElement.action
         this.prepareFormForSubmission()
-      
+
         fetch(url, {
             method: 'post',
             body: new FormData(this.rootElement)
         })
-        .then(response => {
-            if (!response.ok) {
+            .then(response => {
+                if (!response.ok) {
                 // Error handling
-                this.isSubmitting = false;
-                this.submitButton.disabled = false;
-                this.submitButton.textContent = "Submit";
-                new FadingToast('Error submitting batch').show();
-            } else {
+                    this.isSubmitting = false;
+                    this.submitButton.disabled = false;
+                    this.submitButton.textContent = 'Submit';
+                    new FadingToast('Error submitting batch').show();
+                } else {
                 // Success
-                this.isSubmitting = false;
-                this.submitButton.textContent = "Submitted!";
-                // Rest of success handling
-                this.hideTaggingMenu();
-                new FadingToast('Success!').show();
-                this.updateFetchedSubjects(); 
-                this.resetTaggingMenu();
-            }
-        })
-     }
+                    this.isSubmitting = false;
+                    this.submitButton.textContent = 'Submitted!';
+                    // Rest of success handling
+                    this.hideTaggingMenu();
+                    new FadingToast('Success!').show();
+                    this.updateFetchedSubjects();
+                    this.resetTaggingMenu();
+                }
+            })
+    }
 
     /**
      * Populates the form's hidden inputs.

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -525,7 +525,7 @@ export class BulkTagger {
                 if (!response.ok) {
                     this.submitButton.disabled = false;
                     this.submitButton.textContent = 'Submit';
-                    new FadingToast('Error submitting batch').show();
+                    new FadingToast('Batch subject update failed. Please try again in a few minutes.').show();
                 } else {
                 // Success
                     this.isSubmitting = false;

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -508,8 +508,6 @@ export class BulkTagger {
      */
     submitBatch() {
 
-        // Adds state
-        this.isSubmitting = true;
 
         // Disable button
         this.submitButton.disabled = true;

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -507,26 +507,42 @@ export class BulkTagger {
      * Submits the bulk tagging form and updates the view.
      */
     submitBatch() {
+
+        // Adds state
+        this.isSubmitting = true;
+      
+        // Disable button
+        this.submitButton.disabled = true;
+      
+        // Show loading spinner
+        this.submitButton.textContent = "Submitting...";
+      
         const url = this.rootElement.action
         this.prepareFormForSubmission()
-
+      
         fetch(url, {
             method: 'post',
             body: new FormData(this.rootElement)
         })
-            .then(response => {
-                if (!response.ok) {
-                    new FadingToast('Batch subject update failed. Please try again in a few minutes.').show()
-                } else {
-                    this.hideTaggingMenu()
-                    new FadingToast('Subjects successfully updated.').show()
-
-                    // Update fetched subjects:
-                    this.updateFetchedSubjects()
-                    this.resetTaggingMenu()
-                }
-            })
-    }
+        .then(response => {
+            if (!response.ok) {
+                // Error handling
+                this.isSubmitting = false;
+                this.submitButton.disabled = false;
+                this.submitButton.textContent = "Submit";
+                new FadingToast('Error submitting batch').show();
+            } else {
+                // Success
+                this.isSubmitting = false;
+                this.submitButton.textContent = "Submitted!";
+                // Rest of success handling
+                this.hideTaggingMenu();
+                new FadingToast('Success!').show();
+                this.updateFetchedSubjects(); 
+                this.resetTaggingMenu();
+            }
+        })
+     }
 
     /**
      * Populates the form's hidden inputs.

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -512,7 +512,6 @@ export class BulkTagger {
         // Disable button
         this.submitButton.disabled = true;
 
-        // Show loading spinner
         this.submitButton.textContent = 'Submitting...';
 
         const url = this.rootElement.action

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -527,10 +527,9 @@ export class BulkTagger {
                     this.submitButton.textContent = 'Submit';
                     new FadingToast('Batch subject update failed. Please try again in a few minutes.').show();
                 } else {
-                    this.submitButton.textContent = 'Submitted!';
-                    // Rest of success handling
                     this.hideTaggingMenu();
-                    new FadingToast('Success!').show();
+                    new FadingToast('Subjects successfully updated.').show()
+                    this.submitButton.textContent = 'Submit';
                     this.updateFetchedSubjects();
                     this.resetTaggingMenu();
                 }


### PR DESCRIPTION
issue-:#8651

<!-- What issue does this PR close? -->
Closes #8651 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix:  Disable 'Submit" button after submission with a loading spinner .

### Technical
<!-- What should be noted about the implementation? -->

  // Adds state
        this.isSubmitting = true;

        // Disable button
        this.submitButton.disabled = true;

        // Show loading spinner
        this.submitButton.textContent = "Submitting...";
  
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
A loading spinner can be seen after submission is made 


### Stakeholders
<!-- @xonx4l  -->



