### PR TITLE
Use JSON endpoint for reading goal partials

### DIFF
--- a/openlibrary/plugins/openlibrary/js/check-ins/index.js
+++ b/openlibrary/plugins/openlibrary/js/check-ins/index.js
@@ -580,14 +580,15 @@ function updateProgressComponent(elem, goal) {
  * @param {string} goalYear Year that the goal is set for.
  */
 function fetchProgressAndUpdateView(yearlyGoalElem, goalYear) {
-    fetch(`/reading-goal/partials?year=${goalYear}`)
+    fetch(`/reading-goal/partials.json?year=${goalYear}`)
         .then((response) => {
             if (!response.ok) {
                 throw new Error('Failed to fetch progress element')
             }
-            return response.text()
+            return response.json()
         })
-        .then(function(html) {
+        .then(function(data) {
+            const html = data['partials']
             const progress = document.createElement('SPAN')
             progress.id = 'reading-goal-container'
             progress.innerHTML = html

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -274,9 +274,7 @@ class ui_partials(delegate.page):
         year = i.year or datetime.now().year
         goal = get_reading_goals(year=year)
         component = render_template('check_ins/reading_goal_progress', [goal])
-        partials = {
-            "partials": str(component)
-        }
+        partials = {"partials": str(component)}
         return delegate.RawText(json.dumps(partials))
 
 

--- a/openlibrary/plugins/upstream/checkins.py
+++ b/openlibrary/plugins/upstream/checkins.py
@@ -267,13 +267,17 @@ class YearlyGoal:
 
 class ui_partials(delegate.page):
     path = '/reading-goal/partials'
+    encoding = 'json'
 
     def GET(self):
         i = web.input(year=None)
         year = i.year or datetime.now().year
         goal = get_reading_goals(year=year)
         component = render_template('check_ins/reading_goal_progress', [goal])
-        return delegate.RawText(component)
+        partials = {
+            "partials": str(component)
+        }
+        return delegate.RawText(json.dumps(partials))
 
 
 def setup():


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7447

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes YRG partials endpoint to use JSON encoding.

This endpoint is called whenever a patron sets a yearly reading goal from their `/account/books` page.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
