### PR TITLE
Fix: deduplicate subjects on works and list items on editions

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -22,6 +22,7 @@ A record is loaded by calling the load function.
     response = load(record)
 
 """
+import itertools
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -912,16 +913,13 @@ def update_work_with_rec_data(
     if 'subjects' in rec:
         work_subjects: list[str] = list(work.get('subjects', []))
         rec_subjects: list[str] = rec.get('subjects', [])
-        dedup_set = {subject.casefold() for subject in work_subjects}
+        deduped_subjects = uniq(
+            itertools.chain(work_subjects, rec_subjects), lambda item: item.casefold()
+        )
 
-        for rec_subject in rec_subjects:
-            if rec_subject.casefold() not in dedup_set:
-                work_subjects.append(rec_subject)
-                dedup_set.add(rec_subject.casefold())
-                need_work_save = True
-
-        if need_work_save and work_subjects:
-            work['subjects'] = work_subjects
+        if len(work_subjects) != len(deduped_subjects):
+            work['subjects'] = deduped_subjects
+            need_work_save = True
 
     # Add cover to work, if needed
     if not work.get('covers') and edition.get_covers():

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -917,7 +917,7 @@ def update_work_with_rec_data(
             itertools.chain(work_subjects, rec_subjects), lambda item: item.casefold()
         )
 
-        if len(work_subjects) != len(deduped_subjects):
+        if work_subjects != deduped_subjects:
             work['subjects'] = deduped_subjects
             need_work_save = True
 

--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -849,7 +849,7 @@ def update_edition_with_rec_data(
         edition['ocaid'] = rec['ocaid']
         need_edition_save = True
 
-    # Add list fields to edition as needed
+    # Fields which have their VALUES added if absent.
     edition_list_fields = [
         'local_id',
         'lccn',
@@ -863,14 +863,16 @@ def update_edition_with_rec_data(
         # ensure values is a list
         values = rec[f] if isinstance(rec[f], list) else [rec[f]]
         if f in edition:
-            # get values from rec that are not currently on the edition
-            to_add = [v for v in values if v not in edition[f]]
+            # get values from rec field that are not currently on the edition
+            case_folded_values = {v.casefold() for v in edition[f]}
+            to_add = [v for v in values if v.casefold() not in case_folded_values]
             edition[f] += to_add
         else:
             edition[f] = to_add = values
         if to_add:
             need_edition_save = True
 
+    # Fields that are added as a whole if absent. (Individual values are not added.)
     other_edition_fields = [
         'description',
         'number_of_pages',
@@ -908,11 +910,16 @@ def update_work_with_rec_data(
     """
     # Add subjects to work, if not already present
     if 'subjects' in rec:
-        work_subjects = list(work.get('subjects', []))
-        for s in rec['subjects']:
-            if s not in work_subjects:
-                work_subjects.append(s)
+        work_subjects: list[str] = list(work.get('subjects', []))
+        rec_subjects: list[str] = rec.get('subjects', [])
+        dedup_set = {subject.casefold() for subject in work_subjects}
+
+        for rec_subject in rec_subjects:
+            if rec_subject.casefold() not in dedup_set:
+                work_subjects.append(rec_subject)
+                dedup_set.add(rec_subject.casefold())
                 need_work_save = True
+
         if need_work_save and work_subjects:
             work['subjects'] = work_subjects
 

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1143,7 +1143,7 @@ def test_add_subjects_to_work_deduplicates(mock_site) -> None:
     existing_work = {
         'authors': [{'author': '/authors/OL1A', 'type': {'key': '/type/author_role'}}],
         'key': '/works/OL1W',
-        'subjects': ['granite', 'Straße', 'ΠΑΡΆΔΕΙΣΟΣ'],
+        'subjects': ['granite', 'GRANITE', 'Straße', 'ΠΑΡΆΔΕΙΣΟΣ'],
         'title': 'Some Title',
         'type': {'key': '/type/work'},
     }
@@ -1187,12 +1187,12 @@ def test_add_subjects_to_work_deduplicates(mock_site) -> None:
     assert reply['work']['key'] == '/works/OL1W'
     w = mock_site.get(reply['work']['key'])
 
-    def get_casefold_sort(item_list: list[str]):
-        return sorted([item.casefold() for item in item_list])
+    def get_casefold(item_list: list[str]):
+        return [item.casefold() for item in item_list]
 
     expected = ['granite', 'Straße', 'ΠΑΡΆΔΕΙΣΟΣ', 'sandstone']
     got = w.subjects
-    assert get_casefold_sort(got) == get_casefold_sort(expected)
+    assert get_casefold(got) == get_casefold(expected)
 
 
 def test_add_identifiers_to_edition(mock_site) -> None:

--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1129,6 +1129,72 @@ def test_add_description_to_work(mock_site) -> None:
     assert e.works[0]['description'] == 'An added description from an existing edition'
 
 
+def test_add_subjects_to_work_deduplicates(mock_site) -> None:
+    """
+    Ensure a rec's subjects, after a case insensitive check, are added to an
+    existing Work if not already present.
+    """
+    author = {
+        'type': {'key': '/type/author'},
+        'name': 'John Smith',
+        'key': '/authors/OL1A',
+    }
+
+    existing_work = {
+        'authors': [{'author': '/authors/OL1A', 'type': {'key': '/type/author_role'}}],
+        'key': '/works/OL1W',
+        'subjects': ['granite', 'Straße', 'ΠΑΡΆΔΕΙΣΟΣ'],
+        'title': 'Some Title',
+        'type': {'key': '/type/work'},
+    }
+
+    existing_edition = {
+        'key': '/books/OL1M',
+        'title': 'Some Title',
+        'publishers': ['Black Spot'],
+        'type': {'key': '/type/edition'},
+        'source_records': ['non-marc:test'],
+        'publish_date': 'Jan 09, 2011',
+        'isbn_10': ['1250144051'],
+        'works': [{'key': '/works/OL1W'}],
+    }
+
+    mock_site.save(author)
+    mock_site.save(existing_work)
+    mock_site.save(existing_edition)
+
+    rec = {
+        'authors': [{'name': 'John Smith'}],
+        'isbn_10': ['1250144051'],
+        'publish_date': 'Jan 09, 2011',
+        'publishers': ['Black Spot'],
+        'source_records': 'non-marc:test',
+        'subjects': [
+            'granite',
+            'Granite',
+            'SANDSTONE',
+            'sandstone',
+            'strasse',
+            'παράδεισος',
+        ],
+        'title': 'Some Title',
+    }
+
+    reply = load(rec)
+    assert reply['success'] is True
+    assert reply['edition']['status'] == 'matched'
+    assert reply['work']['status'] == 'modified'
+    assert reply['work']['key'] == '/works/OL1W'
+    w = mock_site.get(reply['work']['key'])
+
+    def get_casefold_sort(item_list: list[str]):
+        return sorted([item.casefold() for item in item_list])
+
+    expected = ['granite', 'Straße', 'ΠΑΡΆΔΕΙΣΟΣ', 'sandstone']
+    got = w.subjects
+    assert get_casefold_sort(got) == get_casefold_sort(expected)
+
+
 def test_add_identifiers_to_edition(mock_site) -> None:
     """
     Ensure a rec's identifiers that are not present in a matched edition are
@@ -1180,6 +1246,61 @@ def test_add_identifiers_to_edition(mock_site) -> None:
     e = mock_site.get(reply['edition']['key'])
     assert e.works[0]['key'] == '/works/OL19W'
     assert e.identifiers._data == {'goodreads': ['1234'], 'librarything': ['5678']}
+
+
+def test_adding_list_field_items_to_edition_deduplicates_input(mock_site) -> None:
+    """
+    Ensure a rec's edition_list_fields that are not present in a matched
+    edition are added to that matched edition.
+    """
+    author = {
+        'type': {'key': '/type/author'},
+        'name': 'John Smith',
+        'key': '/authors/OL1A',
+    }
+
+    existing_work = {
+        'authors': [{'author': '/authors/OL1A', 'type': {'key': '/type/author_role'}}],
+        'key': '/works/OL1W',
+        'title': 'Some Title',
+        'type': {'key': '/type/work'},
+    }
+
+    existing_edition = {
+        'isbn_10': ['1250144051'],
+        'key': '/books/OL1M',
+        'lccn': ['agr25000003'],
+        'publish_date': 'Jan 09, 2011',
+        'publishers': ['Black Spot'],
+        'source_records': ['non-marc:test'],
+        'title': 'Some Title',
+        'type': {'key': '/type/edition'},
+        'works': [{'key': '/works/OL1W'}],
+    }
+
+    mock_site.save(author)
+    mock_site.save(existing_work)
+    mock_site.save(existing_edition)
+
+    rec = {
+        'authors': [{'name': 'John Smith'}],
+        'isbn_10': ['1250144051'],
+        'lccn': ['AGR25000003', 'AGR25-3'],
+        'publish_date': 'Jan 09, 2011',
+        'publishers': ['Black Spot', 'Second Publisher'],
+        'source_records': ['NON-MARC:TEST', 'ia:someid'],
+        'title': 'Some Title',
+    }
+
+    reply = load(rec)
+    assert reply['success'] is True
+    assert reply['edition']['status'] == 'modified'
+    assert reply['work']['status'] == 'matched'
+    assert reply['work']['key'] == '/works/OL1W'
+    e = mock_site.get(reply['edition']['key'])
+    assert e.works[0]['key'] == '/works/OL1W'
+    assert e.lccn == ['agr25000003']
+    assert e.source_records == ['non-marc:test', 'ia:someid']
 
 
 @pytest.mark.parametrize(

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -753,9 +753,9 @@ class SaveBookHelper:
             f = io.StringIO(subjects.replace('\r\n', ''))
             dedup = set()
             for s in next(csv.reader(f, dialect='excel', skipinitialspace=True)):
-                if s.lower() not in dedup:
+                if s.casefold() not in dedup:
                     yield s
-                    dedup.add(s.lower())
+                    dedup.add(s.casefold())
 
         work.subjects = list(read_subject(work.get('subjects', '')))
         work.subject_places = list(read_subject(work.get('subject_places', '')))


### PR DESCRIPTION
Closes #8661. 

This PR de-duplicates, using `casefold()`, the `subjects` field on `Work` items, and field values of list items that are added to `Edition` items on re-import via `load()`.

This does not affect edits made via the UI as they go through `DocSaveHelper()` and `process_work()` from `openlibrary/plugins/upstream/addbook.py`, which de-duplicates via a slightly differest strategy. Rather than merging two lists (existing subjects on a matched item, and new ones from an import item), it takes form data with every subject as a CSV and dedupes that string.

Though I had hoped to unify the de-duping logic, I think that is beyond the scope of this particular issue.

### Technical
<!-- What should be noted about the implementation? -->
I added a slight bit of logic to the fields that looked as if they might possibly result in duplicates because of a lack of case-insensitive matching.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The unit tests should cover this, but the test is whether it's possible, via `load()`, to add a duplicated subject or value in a list field on reimport after accounting for Python's `string.casefold()` method. That is to say, for the purposes of this PR, if `"Straße"` exists as a subject on a `Work`, `"strasse"` should not be added via `load()`.

*NOTE*: Because the web UI (e.g. the `Work` and `Edition` edit pages) uses `process_work()`, which currently de-duplicates via `string.lower()`, this PR changes the behavior there to use `string.casefold()` so it matches the `load()` de-duping.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
