### PR TITLE
Allow xxxx in date field when adding new edition

### DIFF
--- a/openlibrary/plugins/openlibrary/js/validate.js
+++ b/openlibrary/plugins/openlibrary/js/validate.js
@@ -20,11 +20,15 @@ export default function initValidate() {
     // validate publish-date to make sure the date is not in future
     // used in templates/books/add.html
     jQuery.validator.addMethod('publish-date', function(value) {
+
+        // we allow the year dates 'xxxx', '199x', '19xx' date variants: https://github.com/internetarchive/openlibrary/issues/5254
+        var token_xxxx = /(\b[1-9|x][1-9|x][1-9|x][1-9|x]\b)/.exec(value);
+
         // if it doesn't have even three digits then it can't be a future date
         var tokens = /(\d{3,})/.exec(value);
 
         var year = new Date().getFullYear();
-        return tokens && tokens[1] && parseInt(tokens[1]) <= year + 1; // allow one year in future.
+        return token_xxxx || (tokens && tokens[1] && parseInt(tokens[1]) <= year + 1); // allow one year in future.
     },
     'Are you sure that\'s the published date?'
     );


### PR DESCRIPTION
This adds an additional validation token for '199x' or 'xxxx' dates for template/books/add.html

<!-- What issue does this PR close? -->
Closes #5254 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix
This PR adds the support for 'xxxx' dates in the regex validation for the add books page.
It also explores the support for '199x', '19xx' type dates ([1-9 | x] regex) as suggested by [this comment](https://github.com/internetarchive/openlibrary/issues/5254#issuecomment-855928778)

**Important**: The reason this is a 'draft pull request' is that I need additional clarification on what the acceptable unknown dates should be. The current case allows the case of strange year dates such as 'xxx9' or 'x102'. I need clarification if the first character of 4 digit year must be a digit, and not an 'x', as these cases look strange to me.

### Technical
<!-- What should be noted about the implementation? -->
This implementation adds an additional regex token

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The following video showcases the usage by adding 'xxxx' type dates

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/internetarchive/openlibrary/assets/26779639/74d3c596-8aea-4541-8d89-186b9c56bc01



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
