### PR TITLE
Change header titles for lists, shelves

### DIFF
--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -224,7 +224,7 @@ class lists(delegate.page):
             template = render_template(
                 "lists/lists.html", mb.user, mb.user.get_lists(), show_header=False
             )
-            return mb.render(template=template, header_title=_("Lists"))
+            return mb.render(template=template, header_title=_("Lists (%(count)d)", count=len(mb.lists)))
         else:
             doc = self.get_doc(path)
             if not doc:

--- a/openlibrary/plugins/openlibrary/lists.py
+++ b/openlibrary/plugins/openlibrary/lists.py
@@ -224,7 +224,10 @@ class lists(delegate.page):
             template = render_template(
                 "lists/lists.html", mb.user, mb.user.get_lists(), show_header=False
             )
-            return mb.render(template=template, header_title=_("Lists (%(count)d)", count=len(mb.lists)))
+            return mb.render(
+                template=template,
+                header_title=_("Lists (%(count)d)", count=len(mb.lists)),
+            )
         else:
             doc = self.get_doc(path)
             if not doc:

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -225,9 +225,15 @@ class mybooks_readinglog(delegate.page):
     def GET(self, username, key='want-to-read'):
         mb = MyBooksTemplate(username, key)
         KEYS_TITLES = {
-            'currently-reading': _("Want to Read (%(count)d)", count=mb.counts['want-to-read']),
-            'want-to-read': _("Currently Reading (%(count)d)", count=mb.counts['currently-reading']),
-            'already-read': _("Already Read (%(count)d)", count=mb.counts['already-read']),
+            'currently-reading': _(
+                "Want to Read (%(count)d)", count=mb.counts['want-to-read']
+            ),
+            'want-to-read': _(
+                "Currently Reading (%(count)d)", count=mb.counts['currently-reading']
+            ),
+            'already-read': _(
+                "Already Read (%(count)d)", count=mb.counts['already-read']
+            ),
         }
         if mb.is_my_page or mb.is_public:
             template = self.render_template(mb)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -223,12 +223,12 @@ class mybooks_readinglog(delegate.page):
     path = r'/people/([^/]+)/books/(want-to-read|currently-reading|already-read)'
 
     def GET(self, username, key='want-to-read'):
-        KEYS_TITLES = {
-            'currently-reading': _("Currently Reading"),
-            'want-to-read': _("Want to Read"),
-            'already-read': _("Already Read"),
-        }
         mb = MyBooksTemplate(username, key)
+        KEYS_TITLES = {
+            'currently-reading': _("Want to Read (%(count)d)", count=mb.counts['want-to-read']),
+            'want-to-read': _("Currently Reading (%(count)d)", count=mb.counts['currently-reading']),
+            'already-read': _("Already Read (%(count)d)", count=mb.counts['already-read']),
+        }
         if mb.is_my_page or mb.is_public:
             template = self.render_template(mb)
             return mb.render(header_title=KEYS_TITLES[key], template=template)


### PR DESCRIPTION
Closes #8665

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Breadcrumb selector now shows the fallback English text if no translations are available for the titles of the reading log and list overview pages.

### Technical
<!-- What should be noted about the implementation? -->
`breadcrumb_title` was not being set [here](https://github.com/internetarchive/openlibrary/blob/5c72f357664f04faafa0b0c3f4d7d6de099fd164/openlibrary/templates/books/breadcrumb_select.html#L41-L46), due to the `selected` string not matching any of the `options` that include a count.  `selected` is the `header_title` that is passed to `MyBooksTemplate.render`.  Modifying the `header_title`s to include the counts corrected this issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Repeat the repro steps found in #8665

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/28732543/94b394e5-52ed-41b0-9edb-702ee66eb733)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
