### PR TITLE
Fix: show the first import source in the history comment

### DIFF
--- a/openlibrary/plugins/upstream/utils.py
+++ b/openlibrary/plugins/upstream/utils.py
@@ -528,7 +528,7 @@ def process_version(v: HasGetKeyRevision) -> HasGetKeyRevision:
             and v.revision == 1
             or (v.comment and v.comment.lower() in comments)  # type: ignore [attr-defined]
         ):
-            marc = thing.source_records[-1]
+            marc = thing.source_records[0]
             if marc.startswith('marc:'):
                 v.machine_comment = marc[len("marc:") :]  # type: ignore [attr-defined]
             else:


### PR DESCRIPTION
Closes #2643

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. This PR makes the import source listed in a history comment of an edition show the original import source, rather than the latest, which is what @cdrini effectively suggested here:
https://github.com/internetarchive/openlibrary/issues/6778#issuecomment-1194630309

### Technical
<!-- What should be noted about the implementation? -->
This does nothing to address the fact that subsequent import sources don't show up anywhere. I  looked at the `Changset` class in the hope there would be an easy way to see the changes in each revision without having to query the database to do a diff between each revision to see if `source_records` change, but if it is there I simply overlooked it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
With the code on the current `master` branch:
Create an item with a `source_records` field having some `ia:identifier`, such as `"source_records": ["ia:b33093337"]`.

Verify the history looks something like this:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/751707d2-afff-4db5-b621-8e31c225e77f)

Re-import the item with a new source record, say, `idb:1111111111`, and notice the revision 1 comment changes to say that the item was imported from `idb`:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/47b79159-e615-4799-8382-e650683ce472)

![image](https://github.com/internetarchive/openlibrary/assets/26524678/53b6dadd-1c3d-432d-aecf-9c537daf575d)

Now apply the PR and see that the original import source is listed under revision 1:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/76cc2ba2-3033-4fb2-9214-63520385088b)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@hornc 
@seabelis 
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
