### PR TITLE
Display the merge buttons only after the page has loaded

### DIFF
--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -1,6 +1,11 @@
 import { declineRequest } from './merge-request-table/MergeRequestService';
 
 export function initAuthorMergePage() {
+    const mergeButtons = $(".merge-feedback__buttons");
+    $(document).ready(function () {
+        mergeButtons.css("display", "");
+    });
+
     $('#save').on('click', function () {
         const n = $('#mergeForm input[type=radio]:checked').length;
         const confirmMergeButton = document.querySelector('#confirmMerge')

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -1,9 +1,9 @@
 import { declineRequest } from './merge-request-table/MergeRequestService';
 
 export function initAuthorMergePage() {
-    const mergeButtons = $(".merge-feedback__buttons");
-    $(document).ready(function () {
-        mergeButtons.css("display", "");
+    const mergeButtons = $('.merge-feedback__buttons');
+    $(function () {
+        mergeButtons.css('display', '');
     });
 
     $('#save').on('click', function () {

--- a/openlibrary/templates/merge/authors.html
+++ b/openlibrary/templates/merge/authors.html
@@ -102,7 +102,7 @@ $if can_merge:
 
     <div class="merge-feedback">
         <label for="merge-comment">$_('Comment:') <input type="text" id="author-merge-comment" name="comment" placeholder="$_('Comment...')"></label>
-        <div class="merge-feedback__buttons">
+        <div class="merge-feedback__buttons" style="display: none;">
             $if can_merge:
                 $ cta = _('Merge Authors')
             $else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8655

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Merge buttons now display only after the page has finished loading in order to avoid accidental misclicks and merges on slow networks

### Technical
<!-- What should be noted about the implementation? -->
The merge buttons have the display style set to "none" initially, which is removed on page load and then they go back to their default display styles.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
In order to emulate slow networks, Inspect Element > Network > Network Throttling > Slow 3G or similar

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2023-12-25 01-25-22](https://github.com/internetarchive/openlibrary/assets/73329256/debce77f-0909-40ec-a8ba-1a498372c1a6)
![Screenshot from 2023-12-25 01-25-39](https://github.com/internetarchive/openlibrary/assets/73329256/75e8e1a5-95a7-4d6c-8110-1bc2ca22134b)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@Eds-Dbug 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
