### PR TITLE
Added:Bulk Tagger: Dry-run mode .

### DIFF
--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -1,6 +1,6 @@
 from infogami.utils import delegate
 
-from openlibrary.core import stats
+from openlibrary.core import stats  
 from openlibrary.utils import uniq
 from openlibrary.utils import get_original_subjects
 import web
@@ -8,98 +8,98 @@ import json
 
 
 class bulk_tag_works(delegate.page):
-   path = "/tags/bulk_tag_works"
+    path = "/tags/bulk_tag_works"
 
-   def POST(self):
-       i = web.input(work_ids='', tags_to_add='', tags_to_remove='')
+    def POST(self):
+        i = web.input(work_ids='', tags_to_add='', tags_to_remove='')
 
-       is_dry_run = i.dry_run == '1'
+        is_dry_run = i.dry_run == '1'
 
-       if is_dry_run:
-           original_subjects = get_original_subjects(works)
-           return delegate.RawText(render_template('diff.html',
-                               original=original_subjects,
-                               updated=docs_to_update))
-       else:
-           web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
+        if is_dry_run:
+            original_subjects = get_original_subjects(works)
+            return delegate.RawText(render_template('diff.html',
+                                original=original_subjects,
+                                updated=docs_to_update))
+        else:
+            web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
-           works = i.work_ids.split(',')
-           tags_to_add = json.loads(i.tags_to_add or '{}')
-           tags_to_remove = json.loads(i.tags_to_remove or '{}')
+            works = i.work_ids.split(',')
+            tags_to_add = json.loads(i.tags_to_add or '{}')
+            tags_to_remove = json.loads(i.tags_to_remove or '{}')
 
-           docs_to_update = []
-           # Number of tags added per work:
-           docs_adding = 0
-           # Number of tags removed per work:
-           docs_removing = 0
+            docs_to_update = []
+            # Number of tags added per work:
+            docs_adding = 0 
+            # Number of tags removed per work:
+            docs_removing = 0
 
-           for work in works:
-               w = web.ctx.site.get(f"/works/{work}")
+            for work in works:
+                w = web.ctx.site.get(f"/works/{work}")
 
-               current_subjects = {
-                   # XXX : Should an empty list be the default for these?
-                   'subjects': uniq(w.get('subjects', '')),
-                   'subject_people': uniq(w.get('subject_people', '')),
-                   'subject_places': uniq(w.get('subject_places', '')),
-                   'subject_times': uniq(w.get('subject_times', '')),
-               }
-               for subject_type, add_list in tags_to_add.items():
-                   if add_list:
-                       orig_len = len(current_subjects[subject_type])
-                       current_subjects[subject_type] = uniq(  # dedupe incoming subjects
-                           current_subjects[subject_type] + add_list
-                       )
-                       docs_adding += len(current_subjects[subject_type]) - orig_len
-                       w[subject_type] = current_subjects[subject_type]
+                current_subjects = {
+                    # XXX : Should an empty list be the default for these?
+                    'subjects': uniq(w.get('subjects', '')),
+                    'subject_people': uniq(w.get('subject_people', '')),
+                    'subject_places': uniq(w.get('subject_places', '')),
+                    'subject_times': uniq(w.get('subject_times', '')),
+                }
+                for subject_type, add_list in tags_to_add.items():
+                    if add_list:
+                        orig_len = len(current_subjects[subject_type])
+                        current_subjects[subject_type] = uniq(  # dedupe incoming subjects
+                            current_subjects[subject_type] + add_list
+                        )
+                        docs_adding += len(current_subjects[subject_type]) - orig_len
+                        w[subject_type] = current_subjects[subject_type]
 
-               for subject_type, remove_list in tags_to_remove.items():
-                   if remove_list:
-                       orig_len = len(current_subjects[subject_type])
-                       current_subjects[subject_type] = [
-                           item
-                           for item in current_subjects[subject_type]
-                           if item not in remove_list
-                       ]
-                       docs_removing += orig_len - len(current_subjects[subject_type])
-                       w[subject_type] = current_subjects[subject_type]
+                for subject_type, remove_list in tags_to_remove.items():
+                    if remove_list:
+                        orig_len = len(current_subjects[subject_type])
+                        current_subjects[subject_type] = [
+                            item
+                            for item in current_subjects[subject_type]
+                            if item not in remove_list
+                        ]
+                        docs_removing += orig_len - len(current_subjects[subject_type])
+                        w[subject_type] = current_subjects[subject_type]
 
-               docs_to_update.append(
-                   w.dict()
-               )  # need to convert class to raw dict in order for save_many to work
+                docs_to_update.append(
+                    w.dict()
+                )  # need to convert class to raw dict in order for save_many to work
 
-           web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
+            web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
-           def response(msg, status="success"):
-               return delegate.RawText(
-                   json.dumps({status: msg}), content_type="application/json"
-               )
+            def response(msg, status="success"):
+                return delegate.RawText(
+                    json.dumps({status: msg}), content_type="application/json"
+                )
 
-           # Number of times the handler was hit:
-           stats.increment('ol.tags.bulk_update')
-           stats.increment('ol.tags.bulk_update.add', n=docs_adding)
-           stats.increment('ol.tags.bulk_update.remove', n=docs_removing)
+            # Number of times the handler was hit:
+            stats.increment('ol.tags.bulk_update')
+            stats.increment('ol.tags.bulk_update.add', n=docs_adding)
+            stats.increment('ol.tags.bulk_update.remove', n=docs_removing)
 
-           return response('Tagged works successfully')
+            return response('Tagged works successfully')
 
-           def get_original_subjects(works):
+def get_original_subjects(works):
 
-             original = []
+    original = []
 
-             for work_id in works:
+    for work_id in works:
 
-              work = web.ctx.site.get("/works/" + work_id)
+      work = web.ctx.site.get("/works/" + work_id)
 
-              original_subjects = {
-                "subjects": work.get("subjects"),
-                "subject_people": work.get("subject_people"),
-                "subject_places": work.get("subject_places"),
-                "subject_times": work.get("subject_times")
-               }
+      original_subjects = {
+        "subjects": work.get("subjects"),
+        "subject_people": work.get("subject_people"),
+        "subject_places": work.get("subject_places"),
+        "subject_times": work.get("subject_times")
+      }
 
-               original.append(original_subjects)
+      original.append(original_subjects)
 
-             return original
+    return original
 
 
 def setup():
-   pass
+    pass

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -11,20 +11,19 @@ class bulk_tag_works(delegate.page):
 
     def POST(self):
         i = web.input(work_ids='', tags_to_add='', tags_to_remove='', dry_run=False)
-        
-        if i.dry_run:
-          original_works = []
-          updated_works = []
 
+        if i.dry_run:
+            original_works = []
+            updated_works = []
 
         works = i.work_ids.split(',')
         tags_to_add = json.loads(i.tags_to_add or '{}')
         tags_to_remove = json.loads(i.tags_to_remove or '{}')
-         
+
         docs_to_update = []
         docs_adding = 0
-        docs_removing = 0 
-        
+        docs_removing = 0
+
         for work in works:
             original_work = web.ctx.site.get(f"/works/{work}")
             original_works.append(original_work)
@@ -56,16 +55,14 @@ class bulk_tag_works(delegate.page):
                     ]
                     docs_removing += orig_len - len(current_subjects[subject_type])
                     w[subject_type] = current_subjects[subject_type]
-            
+
             updated_works.append(w)
 
             if i.dry_run:
-              return self.show_diff(original_works, updated_works)
+                return self.show_diff(original_works, updated_works)
 
             if not i.dry_run:
-                docs_to_update.append(
-                    w.dict()
-                )
+                docs_to_update.append(w.dict())
             if not i.dry_run:
                 web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
@@ -75,12 +72,16 @@ class bulk_tag_works(delegate.page):
             stats.increment('ol.tags.bulk_update.remove', n=docs_removing)
 
             return delegate.RawText(
-                json.dumps({'status': 'success', 'message': 'Tagged works successfully'}), 
-                content_type="application/json"        
+                json.dumps(
+                    {'status': 'success', 'message': 'Tagged works successfully'}
+                ),
+                content_type="application/json",
             )
-        
-def show_diff(self, original, updated):      
+
+
+def show_diff(self, original, updated):
     pass
+
 
 def setup():
     pass

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -1,6 +1,6 @@
 from infogami.utils import delegate
 
-from openlibrary.core import stats  
+from openlibrary.core import stats
 from openlibrary.utils import uniq
 from openlibrary.utils import get_original_subjects
 import web
@@ -17,9 +17,11 @@ class bulk_tag_works(delegate.page):
 
         if is_dry_run:
             original_subjects = get_original_subjects(works)
-            return delegate.RawText(render_template('diff.html',
-                                original=original_subjects,
-                                updated=docs_to_update))
+            return delegate.RawText(
+                render_template(
+                    'diff.html', original=original_subjects, updated=docs_to_update
+                )
+            )
         else:
             web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
@@ -29,7 +31,7 @@ class bulk_tag_works(delegate.page):
 
             docs_to_update = []
             # Number of tags added per work:
-            docs_adding = 0 
+            docs_adding = 0
             # Number of tags removed per work:
             docs_removing = 0
 
@@ -46,7 +48,9 @@ class bulk_tag_works(delegate.page):
                 for subject_type, add_list in tags_to_add.items():
                     if add_list:
                         orig_len = len(current_subjects[subject_type])
-                        current_subjects[subject_type] = uniq(  # dedupe incoming subjects
+                        current_subjects[
+                            subject_type
+                        ] = uniq(  # dedupe incoming subjects
                             current_subjects[subject_type] + add_list
                         )
                         docs_adding += len(current_subjects[subject_type]) - orig_len
@@ -81,22 +85,21 @@ class bulk_tag_works(delegate.page):
 
             return response('Tagged works successfully')
 
-def get_original_subjects(works):
 
+def get_original_subjects(works):
     original = []
 
     for work_id in works:
+        work = web.ctx.site.get("/works/" + work_id)
 
-      work = web.ctx.site.get("/works/" + work_id)
+        original_subjects = {
+            "subjects": work.get("subjects"),
+            "subject_people": work.get("subject_people"),
+            "subject_places": work.get("subject_places"),
+            "subject_times": work.get("subject_times"),
+        }
 
-      original_subjects = {
-        "subjects": work.get("subjects"),
-        "subject_people": work.get("subject_people"),
-        "subject_places": work.get("subject_places"),
-        "subject_times": work.get("subject_times")
-      }
-
-      original.append(original_subjects)
+        original.append(original_subjects)
 
     return original
 

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -17,9 +17,9 @@ class bulk_tag_works(delegate.page):
 
       if is_dry_run:
          original_subjects = get_original_subjects(works)
-         return delegate.RawText(render_template('diff.html', 
+         return delegate.RawText(render_template('diff.html',
                                 original=original_subjects,
-                                updated=docs_to_update)) 
+                                updated=docs_to_update))
       else:
         web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
@@ -86,7 +86,7 @@ class bulk_tag_works(delegate.page):
           original = []
 
           for work_id in works:
-  
+
            work = web.ctx.site.get("/works/" + work_id)
 
            original_subjects = {
@@ -95,7 +95,7 @@ class bulk_tag_works(delegate.page):
              "subject_places": work.get("subject_places"),
              "subject_times": work.get("subject_times")
             }
-    
+
             original.append(original_subjects)
 
           return original

--- a/openlibrary/plugins/openlibrary/bulk_tag.py
+++ b/openlibrary/plugins/openlibrary/bulk_tag.py
@@ -8,98 +8,98 @@ import json
 
 
 class bulk_tag_works(delegate.page):
-    path = "/tags/bulk_tag_works"
+   path = "/tags/bulk_tag_works"
 
-    def POST(self):
-        i = web.input(work_ids='', tags_to_add='', tags_to_remove='')
+   def POST(self):
+       i = web.input(work_ids='', tags_to_add='', tags_to_remove='')
 
-         is_dry_run = i.dry_run == '1'
+       is_dry_run = i.dry_run == '1'
 
-      if is_dry_run:
-         original_subjects = get_original_subjects(works)
-         return delegate.RawText(render_template('diff.html',
-                                original=original_subjects,
-                                updated=docs_to_update))
-      else:
-        web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
+       if is_dry_run:
+           original_subjects = get_original_subjects(works)
+           return delegate.RawText(render_template('diff.html',
+                               original=original_subjects,
+                               updated=docs_to_update))
+       else:
+           web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
-        works = i.work_ids.split(',')
-        tags_to_add = json.loads(i.tags_to_add or '{}')
-        tags_to_remove = json.loads(i.tags_to_remove or '{}')
+           works = i.work_ids.split(',')
+           tags_to_add = json.loads(i.tags_to_add or '{}')
+           tags_to_remove = json.loads(i.tags_to_remove or '{}')
 
-        docs_to_update = []
-        # Number of tags added per work:
-        docs_adding = 0
-        # Number of tags removed per work:
-        docs_removing = 0
+           docs_to_update = []
+           # Number of tags added per work:
+           docs_adding = 0
+           # Number of tags removed per work:
+           docs_removing = 0
 
-        for work in works:
-            w = web.ctx.site.get(f"/works/{work}")
+           for work in works:
+               w = web.ctx.site.get(f"/works/{work}")
 
-            current_subjects = {
-                # XXX : Should an empty list be the default for these?
-                'subjects': uniq(w.get('subjects', '')),
-                'subject_people': uniq(w.get('subject_people', '')),
-                'subject_places': uniq(w.get('subject_places', '')),
-                'subject_times': uniq(w.get('subject_times', '')),
-            }
-            for subject_type, add_list in tags_to_add.items():
-                if add_list:
-                    orig_len = len(current_subjects[subject_type])
-                    current_subjects[subject_type] = uniq(  # dedupe incoming subjects
-                        current_subjects[subject_type] + add_list
-                    )
-                    docs_adding += len(current_subjects[subject_type]) - orig_len
-                    w[subject_type] = current_subjects[subject_type]
+               current_subjects = {
+                   # XXX : Should an empty list be the default for these?
+                   'subjects': uniq(w.get('subjects', '')),
+                   'subject_people': uniq(w.get('subject_people', '')),
+                   'subject_places': uniq(w.get('subject_places', '')),
+                   'subject_times': uniq(w.get('subject_times', '')),
+               }
+               for subject_type, add_list in tags_to_add.items():
+                   if add_list:
+                       orig_len = len(current_subjects[subject_type])
+                       current_subjects[subject_type] = uniq(  # dedupe incoming subjects
+                           current_subjects[subject_type] + add_list
+                       )
+                       docs_adding += len(current_subjects[subject_type]) - orig_len
+                       w[subject_type] = current_subjects[subject_type]
 
-            for subject_type, remove_list in tags_to_remove.items():
-                if remove_list:
-                    orig_len = len(current_subjects[subject_type])
-                    current_subjects[subject_type] = [
-                        item
-                        for item in current_subjects[subject_type]
-                        if item not in remove_list
-                    ]
-                    docs_removing += orig_len - len(current_subjects[subject_type])
-                    w[subject_type] = current_subjects[subject_type]
+               for subject_type, remove_list in tags_to_remove.items():
+                   if remove_list:
+                       orig_len = len(current_subjects[subject_type])
+                       current_subjects[subject_type] = [
+                           item
+                           for item in current_subjects[subject_type]
+                           if item not in remove_list
+                       ]
+                       docs_removing += orig_len - len(current_subjects[subject_type])
+                       w[subject_type] = current_subjects[subject_type]
 
-            docs_to_update.append(
-                w.dict()
-            )  # need to convert class to raw dict in order for save_many to work
+               docs_to_update.append(
+                   w.dict()
+               )  # need to convert class to raw dict in order for save_many to work
 
-        web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
+           web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")
 
-        def response(msg, status="success"):
-            return delegate.RawText(
-                json.dumps({status: msg}), content_type="application/json"
-            )
+           def response(msg, status="success"):
+               return delegate.RawText(
+                   json.dumps({status: msg}), content_type="application/json"
+               )
 
-        # Number of times the handler was hit:
-        stats.increment('ol.tags.bulk_update')
-        stats.increment('ol.tags.bulk_update.add', n=docs_adding)
-        stats.increment('ol.tags.bulk_update.remove', n=docs_removing)
+           # Number of times the handler was hit:
+           stats.increment('ol.tags.bulk_update')
+           stats.increment('ol.tags.bulk_update.add', n=docs_adding)
+           stats.increment('ol.tags.bulk_update.remove', n=docs_removing)
 
-        return response('Tagged works successfully')
+           return response('Tagged works successfully')
 
-        def get_original_subjects(works):
+           def get_original_subjects(works):
 
-          original = []
+             original = []
 
-          for work_id in works:
+             for work_id in works:
 
-           work = web.ctx.site.get("/works/" + work_id)
+              work = web.ctx.site.get("/works/" + work_id)
 
-           original_subjects = {
-             "subjects": work.get("subjects"),
-             "subject_people": work.get("subject_people"),
-             "subject_places": work.get("subject_places"),
-             "subject_times": work.get("subject_times")
-            }
+              original_subjects = {
+                "subjects": work.get("subjects"),
+                "subject_people": work.get("subject_people"),
+                "subject_places": work.get("subject_places"),
+                "subject_times": work.get("subject_times")
+               }
 
-            original.append(original_subjects)
+               original.append(original_subjects)
 
-          return original
+             return original
 
 
 def setup():
-    pass
+   pass

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/index.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/index.js
@@ -12,7 +12,7 @@ export function renderBulkTagger() {
         <div class="search-subject-container">
             <input type="text" class="subjects-search-input" placeholder='Filter subjects e.g. Epic'>
         </div>
-
+        <input type="hidden" name="dry_run" value="0">
         <input name="work_ids" value="" type="hidden">
         <input name="tags_to_add" value="" type="hidden">
         <input name="tags_to_remove" value="" type="hidden">


### PR DESCRIPTION
issue: #8657

<!-- What issue does this PR close? -->
Closes #8657 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] 
feature:Bulk Tagger: Dry-run mode .


### Technical
<!-- What should be noted about the implementation? -->
  is_dry_run = i.dry_run == '1'

      if is_dry_run:
         original_subjects = get_original_subjects(works)
         return delegate.RawText(render_template('diff.html', 
                                original=original_subjects,
                                updated=docs_to_update)) 
      else:
        web.ctx.site.save_many(docs_to_update, comment="Bulk tagging works")

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This pr adds  Dry-run mode  and function  def get_original_subjects(works):

### Stakeholders
@xonx4l 


