### PR TITLE
Added: Highlighted staged changes in BulkTagger

### DIFF
--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -345,7 +345,7 @@ export class BulkTagger {
             break
         }
 
-        this.highlightMenuOption(menuOption);
+        menuOption.stage()
         this.updateSubmitButtonState()
     }
 
@@ -621,33 +621,5 @@ export class BulkTagger {
 
         this.tagsToAdd = []
         this.tagsToRemove = []
-    }
-
-    highlightMenuOption(menuOption) {
-        const menuOptionElement = menuOption.rootElement;
-
-        switch (menuOption.optionState) {
-        case MenuOptionState.NONE_TAGGED:
-            menuOptionElement.classList.remove(
-                'highlight-some-tagged',
-                'highlight-all-tagged'
-            );
-            menuOptionElement.classList.add('highlight-none-tagged');
-            break;
-        case MenuOptionState.SOME_TAGGED:
-            menuOptionElement.classList.remove(
-                'highlight-none-tagged',
-                'highlight-all-tagged'
-            );
-            menuOptionElement.classList.add('highlight-some-tagged');
-            break;
-        case MenuOptionState.ALL_TAGGED:
-            menuOptionElement.classList.remove(
-                'highlight-none-tagged',
-                'highlight-some-tagged'
-            );
-            menuOptionElement.classList.add('highlight-all-tagged');
-            break;
-        }
     }
 }

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -345,6 +345,7 @@ export class BulkTagger {
             break
         }
 
+        this.highlightMenuOption(menuOption);
         this.updateSubmitButtonState()
     }
 
@@ -620,5 +621,33 @@ export class BulkTagger {
 
         this.tagsToAdd = []
         this.tagsToRemove = []
+    }
+
+    highlightMenuOption(menuOption) {
+        const menuOptionElement = menuOption.rootElement;
+
+        switch (menuOption.optionState) {
+        case MenuOptionState.NONE_TAGGED:
+            menuOptionElement.classList.remove(
+                'highlight-some-tagged',
+                'highlight-all-tagged'
+            );
+            menuOptionElement.classList.add('highlight-none-tagged');
+            break;
+        case MenuOptionState.SOME_TAGGED:
+            menuOptionElement.classList.remove(
+                'highlight-none-tagged',
+                'highlight-all-tagged'
+            );
+            menuOptionElement.classList.add('highlight-some-tagged');
+            break;
+        case MenuOptionState.ALL_TAGGED:
+            menuOptionElement.classList.remove(
+                'highlight-none-tagged',
+                'highlight-some-tagged'
+            );
+            menuOptionElement.classList.add('highlight-all-tagged');
+            break;
+        }
     }
 }

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger/MenuOption.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger/MenuOption.js
@@ -175,4 +175,11 @@ export class MenuOption {
     show() {
         this.rootElement.classList.remove('hidden')
     }
+
+    /**
+     * Stages the selected menu option.
+     */
+    stage() {
+        this.rootElement.classList.add('selected-tag--staged');
+    }
 }

--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -246,15 +246,7 @@
     }
   }
 
-  &.highlight-none-tagged {
-    background-color: @light-grey;
-  }
-
-  &.highlight-some-tagged {
-    background-color: @light-yellow;
-  }
-
-  &.highlight-all-tagged {
+  &--staged {
     background-color: @light-yellow;
   }
 }

--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -245,6 +245,18 @@
       background-color: @primary-blue;
     }
   }
+
+  &.highlight-none-tagged {
+    background-color: @light-grey;
+  }
+
+  &.highlight-some-tagged {
+    background-color: @light-yellow;
+  }
+
+  &.highlight-all-tagged {
+    background-color: @light-yellow;
+  }
 }
 
 .loading-indicator {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8658 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR addresses the issue outlined in #8658 by enhancing the Bulk Tagger tool to provide visual indications of subjects staged for addition or removal. The proposed solution adds highlighting to the corresponding menu options when a subject is staged.

### Technical
<!-- What should be noted about the implementation? -->
The PR integrates the highlighting logic to the staged changes for addition or removal. The highlighting classes are applied based on the updated menu option state. I still have some queries regarding the staged changes as mentioned [**here**](https://github.com/internetarchive/openlibrary/issues/8658#issuecomment-1872234457)

### Testing
<!-- Steps for the reviewer to reproduce/verify what this PR does/fixes. -->
1. Open Manage Subjects Menu
![image](https://github.com/internetarchive/openlibrary/assets/85943021/c49564fd-470a-42e7-b46d-1f36884fda15)

2. Add / Remove subject to view highlighted staged changes
![image](https://github.com/internetarchive/openlibrary/assets/85943021/85733241-a867-4a1b-9b45-41b40ca8811e)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before Staging changes
![image](https://github.com/internetarchive/openlibrary/assets/85943021/a5493df3-e63b-4166-be02-d166a4d31199)

After Staging changes
![image](https://github.com/internetarchive/openlibrary/assets/85943021/4b85e3d4-c001-4284-98a2-c3663638e5a2)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
