### PR TITLE
Fixed the Reading log carousels overflow on tablets #8672

### DIFF
--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -125,7 +125,6 @@
   background: @book-cover-carousel-background;
   border-bottom: 1px solid @book-cover-carousel-border-bottom;
   border-top: 1px solid @book-cover-carousel-border-top;
-  margin-right: calc(35px - 30 * (100vw - 770px) / (1000 - 770));
 }
 
 // TODO: Document where this is used. This is unlikely to need to be so specific.

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -125,6 +125,7 @@
   background: @book-cover-carousel-background;
   border-bottom: 1px solid @book-cover-carousel-border-bottom;
   border-top: 1px solid @book-cover-carousel-border-top;
+  margin-right: calc(35px - 30 * (100vw - 770px) / (1000 - 770));
 }
 
 // TODO: Document where this is used. This is unlikely to need to be so specific.

--- a/static/css/components/mybooks-menu.less
+++ b/static/css/components/mybooks-menu.less
@@ -284,4 +284,13 @@
   .mybooks-menu-mobile {
     display: none;
   }
+  .mybooks-menu {
+    width: 200px;  // 250px width + 75% width in `.mybooks-details {}` causes overflow.
+  }
+}
+
+@media only screen and (min-width: @width-breakpoint-desktop + 1) {
+  .mybooks-menu {
+    width: 250px;  // Desktops are fine with the wider menu.
+  }
 }


### PR DESCRIPTION

<!-- What issue does this PR close? -->
Closes #8672 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes the carousel overflow in the my account page

### Technical
<!-- What should be noted about the implementation? -->
Fixed it by dynamically adjusting how the margin on the right behaves.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1693" alt="Screenshot 2023-12-31 at 4 30 25 PM" src="https://github.com/internetarchive/openlibrary/assets/112886451/ac8ef462-68dd-4663-9e85-203e521a9967">

### Stakeholders
<!-- @ tag stakeholders of this bug -->

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
