### PR TITLE
Add:ILE Increase visibility of selected works.

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -32,6 +32,7 @@ export class IntegratedLibrarianEnvironment {
         this.$actions = this.$toolbar.find('#ile-drag-actions');
         this.$hiddenForms = this.$toolbar.find('#ile-hidden-forms');
         this.bulkTagger = null
+        this.selectedItemsPreview = null;
     }
 
     init() {
@@ -44,10 +45,47 @@ export class IntegratedLibrarianEnvironment {
         this.selectionManager.init();
     }
 
+    toggleSelectedItemsPreview() {
+
+        if (this.selectedItemsPreview) {
+          this.selectedItemsPreview.hide();
+          this.selectedItemsPreview = null;
+          return;
+        }
+      
+        this.selectedItemsPreview = new SelectedItemsPreview(this.selectionManager.selectedItems);
+        this.$toolbar.append(this.selectedItemsPreview.$el);
+        this.selectedItemsPreview.show();
+      
+      }
+
+     class SelectedItemsPreview {
+
+        constructor(selectedItems) {
+          this.$el = $(/* html for component */); 
+          this.selectedItems = selectedItems;
+      
+          this.$el.on('click', '.preview-item', (e) => {
+          });
+      
+        }
+      
+        show() {
+          this.$el.show();
+        }
+      
+        hide() {
+          this.$el.hide();
+        }
+      
+      };  
+
     /** @param {string} text */
     setStatusText(text) {
         this.$statusText.text(text);
-        this.$toolbar.toggle(text.length > 0);
+        this.$toolbar.on('click', '#ile-selections', () => {
+            this.toggleSelectedItemsPreview(); 
+          });
     }
 
     /**

--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -52,39 +52,39 @@ export class IntegratedLibrarianEnvironment {
           this.selectedItemsPreview = null;
           return;
         }
-      
+
         this.selectedItemsPreview = new SelectedItemsPreview(this.selectionManager.selectedItems);
         this.$toolbar.append(this.selectedItemsPreview.$el);
         this.selectedItemsPreview.show();
-      
+
       }
 
      class SelectedItemsPreview {
 
         constructor(selectedItems) {
-          this.$el = $(/* html for component */); 
+          this.$el = $(/* html for component */);
           this.selectedItems = selectedItems;
-      
+
           this.$el.on('click', '.preview-item', (e) => {
           });
-      
+
         }
-      
+
         show() {
           this.$el.show();
         }
-      
+
         hide() {
           this.$el.hide();
         }
-      
-      };  
+
+      };
 
     /** @param {string} text */
     setStatusText(text) {
         this.$statusText.text(text);
         this.$toolbar.on('click', '#ile-selections', () => {
-            this.toggleSelectedItemsPreview(); 
+            this.toggleSelectedItemsPreview();
           });
     }
 


### PR DESCRIPTION
Proposal for:#8659

<!-- What issue does this PR close? -->
Closes #8659

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
 Increase visibility of selected works.

### Technical
<!-- What should be noted about the implementation? -->Created a new Vue component that renders the preview of selections. It takes a prop like selectedItems that contains the array of selected items.

Rendered this below the ILE toolbar, hidden by default.

When the "N items selected" text is clicked, toggle visibility of the preview component.

Linked the title in each preview item to the corresponding work/author page.

If there is no cover image, show a generic icon indicating if it is a work or author.

Styled it similar to the current selected items but more compact, with options to scroll through the preview.

When preview is closed, reset its state.

###Testing 
Add:SelectedItemsPreview for visibility of selected works.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@xonx4l 

