### PR TITLE
Revert blue "Check Options" but keep click behaviour

### DIFF
--- a/openlibrary/macros/CheckOptions.html
+++ b/openlibrary/macros/CheckOptions.html
@@ -1,6 +1,0 @@
-$def with(key)
-
-<div class="cta-button-group">
-    <a href="$key" class="cta-btn cta-btn--available"
-       data-ol-link-track="CTAClick|CheckOptions">$_('Check Options')</a>
-</div>

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -113,13 +113,13 @@ $elif ocaid and availability.get('is_previewable') and book_provider.short_name 
       $:macros.BookSearchInside(ocaid)
 
 $else:
-  $# Only render NotInLibrary on an edition's page, for that specific edition.
+  $# Only render clickable NotInLibrary when not on an edition's page, for that specific edition.
   $# secondary_action means we're on a book page and it's the button under the cover image.
   $ key = doc.key if is_edition else work_key
   $if (is_edition and is_book_page) or secondary_action:
-      $:macros.NotInLibrary()
+      $:macros.NotInLibrary(link=None)
   $else:
-      $:macros.CheckOptions(key)
+      $:macros.NotInLibrary(link=key)
 
 $:post
 

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,5 +1,14 @@
-$def with()
+$def with(link)
 
-<div class="cta-button-group">
-  <a class="cta-btn cta-btn--no-pointer">$_('Not in Library')</a>
-</div>
+$if link:
+  <div class="cta-button-group">
+    <a
+      class="cta-btn"
+      href="$link"
+      data-ol-link-track="CTAClick|NotInLibrary"
+    >$_('Not in Library')</a>
+  </div>
+$else:
+  <div class="cta-button-group">
+    <span class="cta-btn cta-btn--no-pointer">$_('Not in Library')</span>
+  </div>

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -46,7 +46,7 @@ a.cta-btn {
   }
 
   &--no-pointer {
-    cursor: not-allowed;
+    cursor: default;
   }
 
   &--available, &--preview, &--primary {


### PR DESCRIPTION
Addendum to #8524 . We had a miscommunication internally about what we wanted the design to look like!

### Technical
This basically has the exact same click behaviour as the previous PR (which we discussed during calls w @mekarpeles and @scottbarnes ), but no longer has the blue "check options" button.

### Testing
Try it here: https://testing.openlibrary.org/search?q=Teachers%2C+preachers%2C+non-believers&mode=everything

### Screenshot
![image](https://github.com/internetarchive/openlibrary/assets/6251786/3d34c063-79c2-4e6c-aab9-ed621673e149)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/efd5be4e-1859-4f53-b647-a9d4f460fed8)


### Stakeholders
@mekarpeles @scottbarnes 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
