### PR TITLE
Added 'Want to Read' Dropper to the Search Inside page #8650

### DIFF
--- a/openlibrary/macros/FulltextResults.html
+++ b/openlibrary/macros/FulltextResults.html
@@ -8,12 +8,11 @@ $def render_snippet(query, doc):
 $if results and results.get('hits'):
   $ hits = results['hits'].get('hits', [])
   $ num_found = results['hits'].get('total', 0)
-  $ use_my_books_droppers = 'my_books_dropper' in ctx.features
   <div id="searchResults">
     <ul class="list-books">
       $for doc in hits:
         $if doc.get('edition'):
-          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=render_snippet(query, doc), include_dropper = use_my_books_droppers)
+          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=render_snippet(query, doc), include_dropper=True)
     </ul>
     $:macros.Pager(page, num_found)
   </div>

--- a/openlibrary/macros/FulltextResults.html
+++ b/openlibrary/macros/FulltextResults.html
@@ -8,11 +8,12 @@ $def render_snippet(query, doc):
 $if results and results.get('hits'):
   $ hits = results['hits'].get('hits', [])
   $ num_found = results['hits'].get('total', 0)
+  $ use_my_books_droppers = 'my_books_dropper' in ctx.features
   <div id="searchResults">
     <ul class="list-books">
       $for doc in hits:
         $if doc.get('edition'):
-          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=render_snippet(query, doc))
+          $:macros.SearchResultsWork(doc['edition'], availability=doc['availability'], extra=render_snippet(query, doc), include_dropper = use_my_books_droppers)
     </ul>
     $:macros.Pager(page, num_found)
   </div>


### PR DESCRIPTION


<!-- What issue does this PR close? -->
Closes #8650

Added 'Want to Read' Dropper to the Search Inside page.


### Technical
Added 'Want to Read' Dropper to the Search Inside page by importing and adding the dropper component to the calling of the searchResultsWork macro in ```openlibrary/macros/FulltextResults.html``` file.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


