### PR TITLE
Re-enable Amazon imports from /isbn

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -432,10 +432,10 @@ class Edition(Thing):
             return edition
 
         # Finally, try to fetch the book data from Amazon + import, using
-        # priority=0 to put the request at the front of the queue.
+        # `?priority=true` to put the request at the front of the queue.
         try:
             r = requests.get(
-                f'http://{affiliate_server_url}/isbn/{isbn10 or isbn13}?priority=0'
+                f'http://{affiliate_server_url}/isbn/{isbn10 or isbn13}?priority=true'
             )
             r.raise_for_status()
             if data := r.json().get('hit'):

--- a/openlibrary/core/vendors.py
+++ b/openlibrary/core/vendors.py
@@ -322,8 +322,6 @@ def _get_amazon_metadata(
     :param float sleep_sec: Delay time.sleep(sleep_sec) seconds before each retry
     :return: A single book item's metadata, or None.
     """
-    # TMP: This is causing a bunch of duplicate imports
-    return None
     if not affiliate_server_url:
         return None
 

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -13,13 +13,37 @@ from openlibrary.plugins.books import dynlinks, readlinks
 
 
 class books_json(delegate.page):
+    """
+    Endpoint for mapping bib keys (e.g. ISBN, LCCN) to certain links associated
+    with Open Library editions, such as the thumbnail URL.
+
+    - `bibkeys` is expected a comma separated string of ISBNs, LCCNs, etc.
+    - `import_missing=1` will attempt to import an edition from a supplied ISBN
+      if no matching edition is found.
+
+    Example call:
+        http://localhost:8080/api/books.json?bibkeys=059035342X,0312368615&import_missing=1
+
+    Returns a JSONified dictionary of the form:
+        {"059035342X": {
+            "bib_key": "059035342X",
+            "info_url": "http://localhost:8080/books/OL43M/Harry_Potter_and_the_Sorcerer's_Stone",
+            "preview": "noview",
+            "preview_url": "https://archive.org/details/lccn_078073006991",
+            "thumbnail_url": "https://covers.openlibrary.org/b/id/21-S.jpg"
+            }
+        "0312368615": {...}
+        }
+    """
+
     path = "/api/books"
 
     @jsonapi
     def GET(self):
-        i = web.input(bibkeys='', callback=None, details="false")
+        i = web.input(bibkeys='', callback=None, details="false", import_missing=0)
         if web.ctx.path.endswith('.json'):
             i.format = 'json'
+            i.import_missing = int(i.import_missing)
         return dynlinks.dynlinks(i.bibkeys.split(","), i)
 
 

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -18,11 +18,13 @@ class books_json(delegate.page):
     with Open Library editions, such as the thumbnail URL.
 
     - `bibkeys` is expected a comma separated string of ISBNs, LCCNs, etc.
-    - `import_missing=1` will attempt to import an edition from a supplied ISBN
-      if no matching edition is found.
+    - `'high_priority=true'` will attempt to import an edition from a supplied ISBN
+      if no matching edition is found. If not `high_priority`, then missed bib_keys
+      are queued for lookup on the affiliate-server, and any responses are `staged`
+      in `import_item`.
 
     Example call:
-        http://localhost:8080/api/books.json?bibkeys=059035342X,0312368615&import_missing=1
+        http://localhost:8080/api/books.json?bibkeys=059035342X,0312368615&high_priority=true
 
     Returns a JSONified dictionary of the form:
         {"059035342X": {
@@ -40,13 +42,11 @@ class books_json(delegate.page):
 
     @jsonapi
     def GET(self):
-        i = web.input(
-            bibkeys='', callback=None, details="false", import_missing="false"
-        )
+        i = web.input(bibkeys='', callback=None, details="false", high_priority="false")
         if web.ctx.path.endswith('.json'):
             i.format = 'json'
-            i.import_missing = i.get("import_missing") == "true"
-        return dynlinks.dynlinks(i.bibkeys.split(","), i)
+            i.high_priority = i.get("high_priority") == "true"
+        return dynlinks.dynlinks(bib_keys=i.bibkeys.split(","), options=i)
 
 
 class read_singleget(delegate.page):

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -40,10 +40,14 @@ class books_json(delegate.page):
 
     @jsonapi
     def GET(self):
-        i = web.input(bibkeys='', callback=None, details="false", import_missing=0)
+        i = web.input(
+            bibkeys='', callback=None, details="false", import_missing="false"
+        )
         if web.ctx.path.endswith('.json'):
             i.format = 'json'
-            i.import_missing = int(i.import_missing)
+            i.import_missing = (
+                True if i.get("import_missing") == "true" else False  # noqa: SIM210
+            )
         return dynlinks.dynlinks(i.bibkeys.split(","), i)
 
 

--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -45,9 +45,7 @@ class books_json(delegate.page):
         )
         if web.ctx.path.endswith('.json'):
             i.format = 'json'
-            i.import_missing = (
-                True if i.get("import_missing") == "true" else False  # noqa: SIM210
-            )
+            i.import_missing = i.get("import_missing") == "true"
         return dynlinks.dynlinks(i.bibkeys.split(","), i)
 
 

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -427,7 +427,7 @@ def process_doc_for_viewapi(bib_key, page):
     return d
 
 
-def format_result(result, options):
+def format_result(result: dict, options: web.storage) -> str:
     """Format result as js or json.
 
     >>> format_result({'x': 1}, {})
@@ -448,7 +448,7 @@ def format_result(result, options):
             return "var _OLBookInfo = %s;" % json_data
 
 
-def dynlinks(bib_keys, options):
+def dynlinks(bib_keys: Iterable[str], options: web.storage) -> str:
     """
     Return a JSONified dictionary of bib_keys (e.g. ISBN, LCCN) and select URLs
     associated with the corresponding edition, if any.

--- a/openlibrary/plugins/books/dynlinks.py
+++ b/openlibrary/plugins/books/dynlinks.py
@@ -467,13 +467,18 @@ def get_missed_isbn_bib_keys(
     )
 
 
-def get_editions_from_isbns(isbns: Iterable) -> dict[str, Edition | None]:
+def get_editions_from_isbns(
+    isbns: Iterable, high_priority: bool = False
+) -> dict[str, Edition | None]:
     """
     Attempts to import items from their ISBN, returning a dict of possibly
     imported editions in the following form:
         {"123456789": edition | None, ...}}
     """
-    return {isbn: Edition.from_isbn(isbn) for isbn in isbns}
+    return {
+        isbn: Edition.from_isbn(isbn=isbn, high_priority=high_priority)
+        for isbn in isbns
+    }
 
 
 def get_editions_as_dicts(editions: dict[str, Edition | None]) -> dict[str, Any]:
@@ -489,7 +494,8 @@ def dynlinks(bib_keys: Iterable[str], options: web.storage) -> str:
     Return a JSONified dictionary of bib_keys (e.g. ISBN, LCCN) and select URLs
     associated with the corresponding edition, if any.
 
-    If a bib key is an ISBN and no edition is found, an imported is attempted.
+    If a bib key is an ISBN, options.import_missing=True, and no edition is found,
+    an import is attempted with high priority.
 
     Example return value for a bib key of the ISBN "1452303886":
         '{"1452303886": {"bib_key": "1452303886", "info_url": '
@@ -507,7 +513,7 @@ def dynlinks(bib_keys: Iterable[str], options: web.storage) -> str:
         if options.get("import_missing") and (
             missed_isbns := get_missed_isbn_bib_keys(bib_keys, edition_dicts)
         ):
-            editions = get_editions_from_isbns(missed_isbns)
+            editions = get_editions_from_isbns(missed_isbns, high_priority=True)
             edition_dicts.update(get_editions_as_dicts(editions))
         edition_dicts = process_result(edition_dicts, options.get('jscmd'))
     except:

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -940,6 +940,5 @@ def make_bookreader_auth_link(loan_key, item_id, book_path, ol_host, ia_userid=N
     return auth_link + urllib.parse.urlencode(params)
 
 
-models.setup(config)
 lending.setup(config)
 vendors.setup(config)

--- a/openlibrary/plugins/upstream/borrow.py
+++ b/openlibrary/plugins/upstream/borrow.py
@@ -17,6 +17,7 @@ from infogami.utils import delegate
 from infogami.utils.view import public, render_template, add_flash_message
 from infogami.infobase.utils import parse_datetime
 
+from openlibrary.core import models
 from openlibrary.core import stats
 from openlibrary.core import lending
 from openlibrary.core import vendors
@@ -939,5 +940,6 @@ def make_bookreader_auth_link(loan_key, item_id, book_path, ol_host, ia_userid=N
     return auth_link + urllib.parse.urlencode(params)
 
 
+models.setup(config)
 lending.setup(config)
 vendors.setup(config)

--- a/openlibrary/tests/core/test_vendors.py
+++ b/openlibrary/tests/core/test_vendors.py
@@ -216,7 +216,7 @@ def test_get_amazon_metadata() -> None:
     mock_response = {
         'status': 'success',
         'hit': {
-            'url': 'https://www.amazon.com/dp/059035342X/?tag=ia',
+            'url': 'https://www.amazon.com/dp/059035342X/?tag=internetarchi-20',
             'source_records': ['amazon:059035342X'],
             'isbn_10': ['059035342X'],
             'isbn_13': ['9780590353427'],
@@ -234,7 +234,7 @@ def test_get_amazon_metadata() -> None:
         },
     }
     expected = {
-        'url': 'https://www.amazon.com/dp/059035342X/?tag=ia',
+        'url': 'https://www.amazon.com/dp/059035342X/?tag=internetarchi-20',
         'source_records': ['amazon:059035342X'],
         'isbn_10': ['059035342X'],
         'isbn_13': ['9780590353427'],
@@ -254,5 +254,5 @@ def test_get_amazon_metadata() -> None:
     with patch("requests.get", return_value=MockRequests()), patch(
         "openlibrary.core.vendors.affiliate_server_url", new=True
     ):
-        got = get_amazon_metadata(id_=isbn, id_type="isbn", retries=1)
+        got = get_amazon_metadata(id_=isbn, id_type="isbn")
         assert got == expected

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -207,7 +207,10 @@ def process_amazon_batch(isbn_10s: list[str]) -> None:
             n=len(pending_books),
         )
         get_current_amazon_batch().add_items(
-            [{'ia_id': b['source_records'][0], 'data': b} for b in pending_books]
+            [
+                {'ia_id': b['source_records'][0], 'status': 'staged', 'data': b}
+                for b in pending_books
+            ]
         )
 
 

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -43,7 +43,7 @@ import threading
 import time
 
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import datetime
 from enum import Enum
 from typing import Final
 
@@ -96,16 +96,13 @@ web.amazon_lookup_thread = None
 
 def get_current_amazon_batch() -> Batch:
     """
-    At startup or when the month changes, create a new openlibrary.core.imports.Batch()
+    At startup, get the Amazon openlibrary.core.imports.Batch() for global use.
     """
     global batch
     if not batch:
         batch = Batch.find("amz") or Batch.new("amz")
     assert batch
     return batch
-
-
-def is_amz_entry_staged() -> bool:
 
 
 def get_isbns_from_book(book: dict) -> list[str]:  # Singular: book
@@ -402,7 +399,9 @@ class Submit:
                 if product := cache.memcache_cache.get(f'amazon_product_{isbn13}'):
                     cleaned_metadata = clean_amazon_metadata_for_load(product)
                     source, pid = cleaned_metadata['source_records'][0].split(":")
-                    if ImportItem.find_staged_or_pending(identifiers=[pid], sources=[source]):
+                    if ImportItem.find_staged_or_pending(
+                        identifiers=[pid], sources=[source]
+                    ):
                         return json.dumps({"status": "success", "hit": product})
 
             stats.increment("ol.affiliate.amazon.total_items_not_found")

--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -86,7 +86,6 @@ AZ_OL_MAP = {
 }
 RETRIES: Final = 5
 
-batch_name = ""
 batch: Batch | None = None
 
 web.amazon_queue = (
@@ -99,10 +98,9 @@ def get_current_amazon_batch() -> Batch:
     """
     At startup or when the month changes, create a new openlibrary.core.imports.Batch()
     """
-    global batch_name, batch
-    if batch_name != (new_batch_name := f"amz-{date.today():%Y%m}"):
-        batch_name = new_batch_name
-        batch = Batch.find(batch_name) or Batch.new(batch_name)
+    global batch
+    if not batch:
+        batch = Batch.find("amz") or Batch.new("amz")
     assert batch
     return batch
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8541 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

This PR reenables AMZ imports from `/isbn`.

With this PR, the logic upon visiting `/isbn/[some isbn]` is:
- (existing functionality) attempt to fetch the book from the OL database;
- (existing functionality) attempt to fetch the book from the `import_item` table (likely ISBNdb);
- (new) attempt to fetch the metadata from the Amazon Products API, clean that metadata for import, add the record as a `staged` import in the `import_item` table, and then immediately import it `load()`, by way of `ImportItem.import_first_staged()`.

### Technical
<!-- What should be noted about the implementation? -->
This leverages the change in bec372cfdddefdef8b19c1304a5c051f399c05e5 (hopefully) prevent the race condition that seemed to cause multiple Amazon imports in #6405.

I also want to draw attention to the fact this does _not_ add the proposed `GET` param, as `_get_amazon_metadata()` already has what amounts to a `while` loop that retries. As it stands, this PR retries 3 times with a 1 second sleep. I know the issue I created mentioned 5 retries, but my notes said 3. I have no opinion on which is 'better'.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit `/isbn/[isbn here]` with an ISBN only in Amazon data (i.e. not in OL already, and not in ISBNdb data that has been staged for import).

I attempted to test the race condition using the same method of concurrent requests that formerly added 4-5 items. Now it imports only one.

However, I did notice there is a race condition in `affliate_server.get_current_amazon_batch()`, but fixing it is I think out of scope of this issue, especially as it probably requires a change to the `import_item` schema to add a `UNIQUE` constraint (if it is desired these row names always be unique).

Having said that, after 10 concurrent requests to the `/isbn` endpoint, here's the `import_item` table:
```
openlibrary=# SELECT * from import_item;
-[ RECORD 1 ]---------------------------
id          | 39
batch_id    | 12
added_time  | 2024-01-05 05:38:49.103233
import_time | 2024-01-05 05:38:49.76983
status      | created
error       | 
ia_id       | amazon:059035342X
data        | 
ol_key      | /books/OL29M
comments    | 
```

And here's `import_batch`, showing the potential for a race:
```
openlibrary=# SELECT * from import_batch;
 id |    name    | submitter |        submit_time         
----+------------+-----------+----------------------------
 12 | amz-202401 |           | 2024-01-05 05:38:49.101042
 13 | amz-202401 |           | 2024-01-05 05:38:49.101614
 14 | amz-202401 |           | 2024-01-05 05:38:49.101806
 15 | amz-202401 |           | 2024-01-05 05:38:49.102198
(4 rows)
```

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 
@tfmorris

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
