### PR TITLE
Standardized Fonts throughout the project

### DIFF
--- a/static/css/base/common.less
+++ b/static/css/base/common.less
@@ -39,7 +39,7 @@ body {
   font-size: 100%;
   line-height: normal;
   background-color: @beige;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
 }
 fieldset {
   width: 100%;
@@ -79,7 +79,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   color: @grey;
   font-weight: 600;
 }

--- a/static/css/base/headings.less
+++ b/static/css/base/headings.less
@@ -12,7 +12,7 @@ h1 {
   &.publisher {
     color: @brown;
     font-size: 1.375em;
-    font-family: @georgia_serif-1 !important;
+    font-family: @georgia_serif !important;
     font-weight: normal !important;
     margin: 0;
   }
@@ -41,7 +41,7 @@ h2 {
   &.edition-title {
     margin: 7px 0 0;
     color: @grey;
-    font-family: @georgia_serif-1;
+    font-family: @georgia_serif;
     font-weight: normal;
     font-size: 1.1em;
   }
@@ -59,7 +59,7 @@ h1,
 h2 {
   &.edition {
     color: @black;
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     font-size: 1.125em;
     margin: 0;
     padding: 0;
@@ -70,7 +70,7 @@ h2 {
 h3 {
   font-size: 1.0em;
   &.Question {
-    font-family: @georgia_serif-1;
+    font-family: @georgia_serif;
     font-size: 1.2em;
     font-weight: normal;
     color: @brown;
@@ -84,11 +84,11 @@ h4 {
   font-size: .8125em;
   &.publisher,
   &.observer-count {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-weight: normal;
   }
   &.facetHead {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .6875em;
     font-weight: 700;
     color: @black;
@@ -96,7 +96,7 @@ h4 {
     margin: 0 0 5px;
     padding: 0;
     span.merge {
-      font-family: @lucida_sans_serif-3;
+      font-family: @lucida_sans_serif;
       font-size: 11px;
       font-weight: normal !important;
       text-transform: none !important;
@@ -109,7 +109,7 @@ h4 {
 
 h5 {
   font-size: .875em;
-  font-family: @georgia_serif-1 !important;
+  font-family: @georgia_serif !important;
   font-weight: normal !important;
 }
 
@@ -149,14 +149,14 @@ span.title,
 h6.title {
   font-size: 12px;
   font-weight: normal !important;
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
   color: @grey;
   margin: 0;
   padding: 0;
 }
 
 .titleSmall {
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
   font-size: 11px;
   font-weight: 600;
 }

--- a/static/css/base/helpers-misc.less
+++ b/static/css/base/helpers-misc.less
@@ -194,7 +194,7 @@ button {
 
 .headline,
 .sansserif {
-  font-family: @lucida_sans_serif-1 !important;
+  font-family: @lucida_sans_serif !important;
 }
 
 .arial {

--- a/static/css/components/admin-table.less
+++ b/static/css/components/admin-table.less
@@ -10,7 +10,7 @@
   margin: 10px 0 30px;
   color: @dark-grey;
   th {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .6875em;
     text-align: right;
     vertical-align: bottom;
@@ -22,7 +22,7 @@
     vertical-align: bottom;
     font-size: .75em;
     &.type {
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       font-size: .6875em;
     }
   }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -16,7 +16,7 @@ a.cta-btn {
   margin-top: 5px;
   box-sizing: border-box;
   cursor: pointer;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   text-align: center;
   padding: 7px;
   white-space: nowrap;

--- a/static/css/components/buttonLink.less
+++ b/static/css/components/buttonLink.less
@@ -7,7 +7,7 @@
   background-color: @white;
   padding: 10px;
   display: inline-block;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   color: @grey;
   border: 1px solid @mid-grey;
   cursor: pointer;

--- a/static/css/components/buttonsAndLinks.less
+++ b/static/css/components/buttonsAndLinks.less
@@ -7,7 +7,7 @@ a {
     background-image: url(/images/icons/icon_cancel.png);
     background-repeat: no-repeat;
     background-position: 100% 0;
-    font-family: @lucida_sans_serif-4;
+    font-family: @lucida_sans_serif;
     font-size: 1em;
   }
   &.borrowResults {
@@ -79,7 +79,7 @@ a {
 button {
   &.plainText {
     border: none;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .75em;
     color: @red;
     background-color: @white;
@@ -90,7 +90,7 @@ button {
   }
   &.plain {
     border: none;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .75em;
     color: @black;
     background-color: transparent !important;

--- a/static/css/components/category-item.less
+++ b/static/css/components/category-item.less
@@ -44,6 +44,6 @@ p {
 .carousel {
   .category-item {
     padding: 2px;
-    font-family: @georgia_serif-1;
+    font-family: @georgia_serif;
   }
 }

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -116,7 +116,7 @@
 
 /* VIEW LARGER COVER POP-UP */
 div.coverFloat {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   background: @white;
   text-align: left;
   a.dialog--close {
@@ -141,7 +141,7 @@ div.coverFloat {
 /* ADD IMAGE/COVER POP-UP */
 div.floater {
   position: relative;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   min-height: 550px;
   background: @white;
   text-align: left;
@@ -172,12 +172,12 @@ div.floater {
 }
 
 .floatform {
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
 
   .label {
     label {
       font-size: 1.0em;
-      font-family: @lucida_sans_serif-5;
+      font-family: @lucida_sans_serif;
       font-weight: 700;
     }
     span {
@@ -196,7 +196,7 @@ div.floater {
   input[type=text],
   input[type=file] {
     font-size: 1.125em;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     padding: 3px;
   }
   input::file-selector-button{
@@ -228,7 +228,7 @@ div.imageIntro{
 /* ADD ROLES, ETC. */
 div.floaterAdd {
   position: relative;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   background: @white;
   text-align: left;
   .formElement {
@@ -243,7 +243,7 @@ div.floaterAdd {
       // stylelint-disable-next-line max-nesting-depth
       label {
         font-size: 1.0em;
-        font-family: @lucida_sans_serif-5;
+        font-family: @lucida_sans_serif;
         font-weight: 700;
       }
     }

--- a/static/css/components/chart.less
+++ b/static/css/components/chart.less
@@ -15,7 +15,7 @@
   padding: 0 8px @chart-bottom-padding 20px;
   margin-top: 0;
   font-size: .6875em;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   background-color: transparent;
   background-image: url(/images/ajax-loader-bar.gif);
   background-repeat: no-repeat;

--- a/static/css/components/compact-title.less
+++ b/static/css/components/compact-title.less
@@ -25,7 +25,7 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      font-family: @georgia_serif-1;
+      font-family: @georgia_serif;
       font-weight: 600;
     }
   }

--- a/static/css/components/diff.less
+++ b/static/css/components/diff.less
@@ -8,7 +8,7 @@
 #legend {
   float: left;
   font-size: 11px;
-  font-family: @lucida_sans_serif-6;
+  font-family: @lucida_sans_serif;
   line-height: 1em;
   margin-top: 20px;
 }
@@ -55,7 +55,7 @@ dd {
 
 .diff .revisions th {
   padding: 10px;
-  font-family: @news_gothic_sans_serif-2;
+  font-family: @news_gothic_sans_serif;
   font-size: 11px;
   font-weight: 700;
   color: @black;

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -22,7 +22,7 @@ div#editInfo {
     font-size: 11px;
     font-weight: normal;
     color: @brown !important;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
   }
   .smallest {
     padding-top: .3rem;

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -11,7 +11,7 @@ table#editions,
   margin-top: 15px;
   border-collapse: collapse;
   clear: both;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
 
   .cta-button-group {
     width: 185px;
@@ -27,7 +27,7 @@ table#editions,
   }
 
   th {
-    font-family: @news_gothic_sans_serif-2;
+    font-family: @news_gothic_sans_serif;
     font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
@@ -99,12 +99,12 @@ table#editions,
 .lists {
   table#editions {
     h3 {
-      font-family: @lucida_sans_serif-1 !important;
+      font-family: @lucida_sans_serif !important;
       font-size: .75em;
       display: inline;
     }
     th {
-      font-family: @lucida_sans_serif-1 !important;
+      font-family: @lucida_sans_serif !important;
       background-color: transparent;
       text-align: left;
       font-weight: normal;

--- a/static/css/components/flash-messages.less
+++ b/static/css/components/flash-messages.less
@@ -6,7 +6,7 @@
 
 .flash-messages {
   font-size: 1.0em;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   clear: both;
   span {
     display: block;
@@ -24,17 +24,17 @@
     span {
       background: @light-yellow url(/images/icons/icon_check.png) no-repeat 40px 40px;
       padding: 40px 40px 40px 80px;
-      font-family: @georgia_serif-2;
+      font-family: @georgia_serif;
       position: relative;
       // stylelint-disable-next-line max-nesting-depth
       span {
         display: inline;
         padding: 0;
-        font-family: @lucida_sans_serif-2;
+        font-family: @lucida_sans_serif;
       }
     }
     h3 {
-      font-family: @georgia_serif-2;
+      font-family: @georgia_serif;
       font-size: 1.5em;
       font-weight: normal;
       margin: 0;
@@ -54,7 +54,7 @@
       color: @dark-green;
     }
     .red {
-      font-family: @georgia_serif-2;
+      font-family: @georgia_serif;
     }
     .close {
       position: absolute;

--- a/static/css/components/footer.less
+++ b/static/css/components/footer.less
@@ -17,7 +17,7 @@ div#footer-links {
   div {
     flex: 1;
     flex-wrap: wrap;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     min-width: 150px;
   }
 }

--- a/static/css/components/form.olform.less
+++ b/static/css/components/form.olform.less
@@ -5,7 +5,7 @@
 @import (less) "less/font-families.less";
 
 .olform {
-  font-family: @lucida_sans_serif-4;
+  font-family: @lucida_sans_serif;
 
   .formBack {
     padding: 10px;
@@ -26,7 +26,7 @@
 
     label {
       font-size: 1.0em;
-      font-family: @lucida_sans_serif-5;
+      font-family: @lucida_sans_serif;
       font-weight: 700;
     }
 
@@ -95,7 +95,7 @@
   input[type=password],
   textarea {
     font-size: 1.0em;
-    font-family: @lucida_sans_serif-5;
+    font-family: @lucida_sans_serif;
     padding: 3px;
     max-width: 100%;
     resize: vertical;
@@ -113,7 +113,7 @@
   }
 
   select {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     padding: 3px;
   }
 
@@ -167,7 +167,7 @@
   .tip {
     font-size: 11px;
     color: @grey;
-    font-family: @lucida_sans_serif-1 !important;
+    font-family: @lucida_sans_serif !important;
   }
 }
 

--- a/static/css/components/home.less
+++ b/static/css/components/home.less
@@ -71,13 +71,13 @@ div.chartHome a:hover,
         }
         .ticks {
           margin-top: 2px;
-          font-family: @georgia_serif-2;
+          font-family: @georgia_serif;
           font-size: 1.125em;
           font-weight: 700;
           padding-top: 5px;
         }
         .label {
-          font-family: @lucida_sans_serif-3;
+          font-family: @lucida_sans_serif;
           font-size: .625em;
           text-transform: uppercase;
         }
@@ -101,14 +101,14 @@ div.chartHome a:hover,
     max-width: 439px;
     min-height: 100px;
     margin-bottom: 20px;
-    font-family: @georgia_serif-2;
+    font-family: @georgia_serif;
   }
   &-about-mission-tldr {
     padding: 0;
     margin: 0;
     font-size: 18px;
     line-height: 1.5em;
-    font-family: @georgia_serif-2;
+    font-family: @georgia_serif;
     color: @dark-grey;
     font-weight: normal;
   }

--- a/static/css/components/illustration.less
+++ b/static/css/components/illustration.less
@@ -75,7 +75,7 @@
   }
   .edition {
     font-size: .6875em;
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     margin: 10px auto;
   }
 }

--- a/static/css/components/jquery.autocomplete.less
+++ b/static/css/components/jquery.autocomplete.less
@@ -21,7 +21,7 @@
     margin: 0;
     padding: 5px;
     display: block;
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     font-size: 12px;
     cursor: pointer;
     color: @dark-grey;

--- a/static/css/components/list-entry.less
+++ b/static/css/components/list-entry.less
@@ -17,7 +17,7 @@
 
   .data {
     width: 100%;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
   }
 
   .name {

--- a/static/css/components/lists-page-cta.less
+++ b/static/css/components/lists-page-cta.less
@@ -10,7 +10,7 @@
   background-position: center 0;
   h2 {
     font-size: 1.5em;
-    font-family: @georgia_serif-2;
+    font-family: @georgia_serif;
     font-weight: normal;
     color: @dark-grey;
     margin: 0 0 10px;

--- a/static/css/components/merge-form.less
+++ b/static/css/components/merge-form.less
@@ -4,7 +4,7 @@
 // Consider using .merge-form OR #mergeForm for a common parent selector
 // openlibrary/templates/merge/authors.html
 div.merge {
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
   width: 100%;
   float: left;
   margin-bottom: 15px;

--- a/static/css/components/merge-request-table.less
+++ b/static/css/components/merge-request-table.less
@@ -96,7 +96,7 @@
       width: 13px;
       height: 17px;
       font-size: 28px;
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       cursor: pointer;
       background-color: transparent;
       border: 0;

--- a/static/css/components/mybooks-list.less
+++ b/static/css/components/mybooks-list.less
@@ -27,7 +27,7 @@
   }
 
   h4.work-subtitle {
-    font-family: @georgia_serif-1;
+    font-family: @georgia_serif;
     color: @grey;
     font-size: 1em;
     font-weight: normal;
@@ -55,7 +55,7 @@
   h3 {
     display: inline;
     padding-right: 10px;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: 1em;
     font-weight: normal;
     margin-bottom: 0;

--- a/static/css/components/navEdition.less
+++ b/static/css/components/navEdition.less
@@ -10,6 +10,6 @@ div.navEdition {
 
 span.booktitle {
   color: @dark-grey;
-  font-family: @georgia_serif-1;
+  font-family: @georgia_serif;
   font-weight: bold;
 }

--- a/static/css/components/page-banner.less
+++ b/static/css/components/page-banner.less
@@ -8,7 +8,7 @@
 .page-banner {
   display: block;
   color: @white;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   background: @dark-grey;
   padding: 15px;
   border-bottom: 1px solid @beige;
@@ -71,7 +71,7 @@
     justify-content: space-between;
     align-items: center;
     color: @white;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     background: @dark-grey;
     padding: 15px;
     border-bottom: 1px solid @beige;

--- a/static/css/components/page-heading-search-box.less
+++ b/static/css/components/page-heading-search-box.less
@@ -22,7 +22,7 @@
     background-color: @white;
     padding: 10px;
     display: inline-block;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @grey;
     border: 1px solid @mid-grey;
     cursor: pointer;

--- a/static/css/components/page-history.less
+++ b/static/css/components/page-history.less
@@ -39,7 +39,7 @@ table {
     }
     td {
       font-size: .6875em;
-      font-family: @lucida_sans_serif-6;
+      font-family: @lucida_sans_serif;
       color: @grey;
       border-bottom: 1px solid @grey-e7e7e7;
     }

--- a/static/css/components/search-result-item.less
+++ b/static/css/components/search-result-item.less
@@ -6,7 +6,7 @@
 @import "buttonCta.less";
 
 .bookauthor {
-  font-family: @lucida_sans_serif-6;
+  font-family: @lucida_sans_serif;
 }
 
 .searchResultItem {
@@ -35,7 +35,7 @@
     color: @dark-grey;
     font-size: 1.0em;
     font-weight: 700;
-    font-family: @lucida_sans_serif-6;
+    font-family: @lucida_sans_serif;
   }
   .details {
     overflow: auto;
@@ -47,13 +47,13 @@
   .resultTitle {
     overflow: auto;
     margin: 0 !important;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @grey;
   }
   span.resultPublisher {
     font-size: .75em;
     color: @grey;
-    font-family: @lucida_sans_serif-6;
+    font-family: @lucida_sans_serif;
     display: block;
   }
   span.resultType {

--- a/static/css/components/searchResultItemCta.less
+++ b/static/css/components/searchResultItemCta.less
@@ -13,7 +13,7 @@
     color: @white;
     cursor: pointer;
     text-align: center;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
   }
 }
 

--- a/static/css/components/ui-tabs.less
+++ b/static/css/components/ui-tabs.less
@@ -7,7 +7,7 @@
 .ui-tabs {
   &-nav,
   &-panel {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
   }
 
   &-nav {

--- a/static/css/components/wmd-prompt-dialog--js.less
+++ b/static/css/components/wmd-prompt-dialog--js.less
@@ -34,7 +34,7 @@
 
   >  div {
     font-size: 14px;
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     color: @darker-grey;
     padding: 20px !important;
     p {
@@ -52,7 +52,7 @@
       clear: both;
       width: 350px;
       font-size: 1.125em;
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       padding: 3px;
     }
     > input[type="button"] {

--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -12,7 +12,7 @@
   & h1 {
     line-height: normal;
     &.work-title {
-      font-family: @georgia_serif-1;
+      font-family: @georgia_serif;
       margin: 10px 0 0;
       color: @dark-grey;
       font-size: 2em;
@@ -21,7 +21,7 @@
   }
   & h2 {
     &.work-subtitle {
-      font-family: @georgia_serif-1;
+      font-family: @georgia_serif;
       margin: 0;
       color: @grey;
       font-size: 1.3em;

--- a/static/css/legacy-borrowTable-adminUser.less
+++ b/static/css/legacy-borrowTable-adminUser.less
@@ -10,12 +10,12 @@
   margin: 30px 0 25px;
   table {
     width: 100%;
-    font-family: @lucida_sans_serif-7;
+    font-family: @lucida_sans_serif;
     th {
       border-bottom: 1px solid @beige-three;
       vertical-align: bottom;
       padding-bottom: 10px;
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       color: @brown;
       font-weight: 600;
       font-size: .6875em;

--- a/static/css/legacy-datatables.less
+++ b/static/css/legacy-datatables.less
@@ -20,7 +20,7 @@
  */
 
 .dataTables_wrapper {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   position: relative;
   z-index: @z-index-level-1;
   clear: both;
@@ -257,7 +257,7 @@ div.dataTables_filter {
 
 .paging_full_numbers .paginate_button,
 .paging_full_numbers .paginate_active {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   font-size: 11px;
   border: 1px solid @lighter-grey;
   padding: 7px;

--- a/static/css/legacy-header.less
+++ b/static/css/legacy-header.less
@@ -27,7 +27,7 @@ div#header {
       top: 118px;
       width: 220px;
       text-align: center;
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       font-size: .6875em;
       color: @dark-grey;
       margin: 0;
@@ -68,7 +68,7 @@ div#header {
           width: 80px;
           height: 22px;
           padding: 10px 0 0 10px;
-          font-family: @lucida_sans_serif-1;
+          font-family: @lucida_sans_serif;
           font-size: .6875em;
           font-weight: 700;
           text-transform: uppercase;

--- a/static/css/legacy-tools.less
+++ b/static/css/legacy-tools.less
@@ -129,7 +129,7 @@
 
   li {
     font-size: .6875em;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     padding-left: 42px;
     margin-bottom: 5px;
   }
@@ -138,7 +138,7 @@
     width: 250px;
     td {
       font-size: .6875em;
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       &.price {
         padding: 3px 0 0;
       }
@@ -152,7 +152,7 @@
     font-size: 100%;
     min-height: 32px;
     width: 250px;
-    font-family: @lucida_sans_serif-1 !important;
+    font-family: @lucida_sans_serif !important;
     font-weight: normal;
     outline: 0;
     position: relative;
@@ -218,7 +218,7 @@
 
   h4 {
     font-size: 1em;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @teal;
     font-weight: 600;
     margin: 0 0 10px;
@@ -272,7 +272,7 @@
 
   p {
     font-size: .6875em;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     padding-left: 42px;
     margin-bottom: 5px;
   }

--- a/static/css/legacy-wmd.less
+++ b/static/css/legacy-wmd.less
@@ -33,7 +33,7 @@
 .wmd-preview {
   background-color: @white;
   border: 1px solid @lighter-grey;
-  font-family: @georgia_serif-1;
+  font-family: @georgia_serif;
   display: none;
   overflow-wrap: anywhere;
 }

--- a/static/css/legacy.less
+++ b/static/css/legacy.less
@@ -88,7 +88,7 @@ table {
   // openlibrary/templates/history.html
   &#pageHistory {
     width: 100%;
-    font-family: @lucida_sans_serif-6;
+    font-family: @lucida_sans_serif;
     margin: 10px 0 20px;
     td.number {
       text-align: right;
@@ -119,7 +119,7 @@ table {
   }
   &.changeHistory {
     width: 100%;
-    font-family: @lucida_sans_serif-6;
+    font-family: @lucida_sans_serif;
     margin: 0;
 
     td.time {
@@ -140,7 +140,7 @@ table {
     border-top: 1px solid @grey-e7e7e7;
     th {
       font-size: .75em;
-      font-family: @lucida_sans_serif-6;
+      font-family: @lucida_sans_serif;
       color: @grey;
       border-bottom: 1px solid @grey-e7e7e7;
       padding: 5px;
@@ -149,7 +149,7 @@ table {
     }
     td {
       font-size: .75em;
-      font-family: @lucida_sans_serif-6;
+      font-family: @lucida_sans_serif;
       color: @grey;
       border-bottom: 1px solid @grey-e7e7e7;
       padding: 5px;
@@ -351,7 +351,7 @@ q {
 // openlibrary/templates/showia.html
 // openlibrary/templates/showmarc.html
 .breadcrumbs {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   color: @brown;
   font-size: 11px;
   padding-bottom: 10px;
@@ -372,7 +372,7 @@ div.unordered {
 
 div.superNav {
   font-size: .6875em;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   color: @grey;
   margin-bottom: 5px;
 }
@@ -384,14 +384,14 @@ span {
     font-size: 12px;
     color: @darker-grey;
     font-weight: normal !important;
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     white-space: nowrap;
   }
   &.tools {
     font-size: 12px;
     color: @dark-grey;
     font-weight: normal !important;
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
 
     &.sorter {
       margin-right: 5px;
@@ -416,7 +416,7 @@ span {
   &.count {
     font-size: 12px !important;
     font-weight: normal !important;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @brown;
     padding: 5px 5px 0;
   }
@@ -425,18 +425,18 @@ span {
     padding: 2px 0;
   }
   &.resultTitle {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @grey;
     span.resultType {
       font-size: .75em;
-      font-family: @lucida_sans_serif-6;
+      font-family: @lucida_sans_serif;
       color: @brown;
     }
     .bookauthor,
     .resultPublisher {
       font-size: .75em;
       color: @grey;
-      font-family: @lucida_sans_serif-6;
+      font-family: @lucida_sans_serif;
       font-weight: normal;
     }
     span.details {
@@ -497,7 +497,7 @@ p {
 input[type=text],
 select,
 textarea {
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
   color: @darker-grey;
   font-size: .875em;
 }
@@ -624,7 +624,7 @@ div#content {
 // openlibrary/templates/merge/authors.html
 div.note {
   font-size: 1.0em;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   background-color: @light-yellow;
   margin: 0 auto;
   padding: 10px;
@@ -680,7 +680,7 @@ div.formElement {
     padding: 5px;
   }
   blockquote {
-    font-family: @georgia_serif-1;
+    font-family: @georgia_serif;
     font-size: .875em;
     margin: 1em 40px;
   }
@@ -697,13 +697,13 @@ fieldset {
   }
   &.major legend {
     padding: 5px 0;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @teal;
     font-weight: 600;
     font-size: 1.375em;
   }
   &.minor legend {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @teal;
     font-weight: 600;
     font-size: 1.125em;
@@ -737,7 +737,7 @@ div.invalid,
 div.valid {
   float: left;
   font-size: 1.0em !important;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   padding-top: 5px;
 }
 
@@ -799,14 +799,14 @@ input.query {
 // openlibrary/templates/search/subjects.html
 .siteSearch {
   .formElement {
-    font-family: @lucida_sans_serif-5;
+    font-family: @lucida_sans_serif;
     font-size: 1.1em;
   }
 }
 
 // openlibrary/templates/search/advancedsearch.html
 .searchPlus {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   font-size: .75em;
   color: @dark-grey;
   padding: 15px 0;
@@ -821,7 +821,7 @@ input.query {
 // openlibrary/macros/EditButtons.html
 // openlibrary/macros/EditButtonsMacros.html
 div.cclicense {
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
   font-size: .75em;
   min-height: 20px;
   padding: 3px 0 0 30px;
@@ -856,7 +856,7 @@ div#revertNotice {
 /* MESSAGING */
 div.alert,
 div.verify {
-  font: 1.25em @lucida_sans_serif-1;
+  font: 1.25em @lucida_sans_serif;
   span {
     margin: 0 auto;
     min-height: 25px;
@@ -880,7 +880,7 @@ div.verify {
 // openlibrary/templates/account/email/forgot-ia.html
 // openlibrary/templates/account/email/forgot.html
 .defaultstyling {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   .padtop {
     margin-top: 10px;
   }
@@ -901,7 +901,7 @@ hr.forgot-padding {
       margin-bottom: 10px;
     }
     label {
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       color: @dark-grey;
       font-weight: 600;
     }
@@ -1074,7 +1074,7 @@ div#searchResults {
 // openlibrary/templates/type/author/view.html
 .mode-options {
   font-size: .7em;
-  font-family: @lucida_sans_serif-6;
+  font-family: @lucida_sans_serif;
   input {
     margin-left: 15px;
     margin-right: 4px;
@@ -1088,7 +1088,7 @@ div#searchResults {
 
 // openlibrary/macros/AvailabilityButton.html
 .waitlist-msg {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   font-size: .7em;
   margin-bottom: -1.5em;
   color: @grey;
@@ -1135,14 +1135,14 @@ div#searchFacets {
 div.facet {
   margin-bottom: 20px;
   &Entry {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     margin-bottom: 5px;
     a {
       text-decoration: none !important;
     }
   }
   &MoreLess {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     margin-bottom: 5px;
     a {
       text-decoration: none !important;
@@ -1171,23 +1171,23 @@ div.list {
     width: 155px;
   }
   h5 {
-    font-family: @georgia_serif-1;
+    font-family: @georgia_serif;
     font-weight: normal;
     color: @dark-grey;
     margin-bottom: 5px;
     span {
-      font-family: @lucida_sans_serif-2;
+      font-family: @lucida_sans_serif;
       font-size: 80%;
     }
   }
   .tags {
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     font-size: .6875em;
     color: @grey;
     margin-bottom: 5px;
   }
   .owner {
-    font-family: @lucida_sans_serif-2;
+    font-family: @lucida_sans_serif;
     font-size: .6875em;
     color: @grey;
     text-align: right;
@@ -1201,10 +1201,10 @@ div.list {
 // openlibrary/templates/books/author-autocomplete.html
 // openlibrary/templates/type/work/view.html
 div.work {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   span.work,
   span.author {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @brown;
     font-size: 1.125em;
   }
@@ -1212,7 +1212,7 @@ div.work {
     font-weight: 700;
   }
   span.editions {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @brown;
     font-size: 1.125em;
   }
@@ -1331,7 +1331,7 @@ div.excerpt {
   }
   .attribution {
     padding-left: 15px;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .6875em;
   }
 }
@@ -1464,7 +1464,7 @@ span.actions {
     display: block;
     float: left;
     min-width: 35px;
-    font-family: @lucida_sans_serif-6;
+    font-family: @lucida_sans_serif;
     font-size: 10px;
     margin-left: 10px;
     font-weight: 700;
@@ -1551,7 +1551,7 @@ ul.list-books {
   .resultTitle {
     display: block;
     margin: 0 !important;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     color: @grey;
   }
 
@@ -1567,7 +1567,7 @@ ul.list-books {
   span.resultPublisher {
     font-size: .75em;
     color: @grey;
-    font-family: @lucida_sans_serif-6;
+    font-family: @lucida_sans_serif;
   }
   // openlibrary/templates/books/works-show.html
   // openlibrary/templates/books/show.html
@@ -1626,7 +1626,7 @@ div.pop {
     height: 200px;
     padding: 10px;
     margin: 10px;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .75em;
     overflow: auto;
     outline: none;
@@ -1637,7 +1637,7 @@ div.pop {
   p {
     margin: 10px 10px 0;
     padding: 0;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .75em;
   }
 }
@@ -1714,7 +1714,7 @@ div.postSubmit {
   ul {
     font-size: .75em;
     color: @grey;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     margin: 0 0 20px !important;
   }
   li {
@@ -1760,7 +1760,7 @@ div#subjectLists {
       display: block;
       float: left;
       width: 282px;
-      font-family: @lucida_sans_serif-1;
+      font-family: @lucida_sans_serif;
       padding-bottom: 10px;
       padding-top: 0;
       .display-flex();
@@ -1782,7 +1782,7 @@ div#subjectLists {
   }
   p {
     font-size: .6875em;
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     padding-left: 42px;
     margin-bottom: 5px !important;
   }

--- a/static/css/less/font-families.less
+++ b/static/css/less/font-families.less
@@ -1,21 +1,12 @@
-@arial_sans_serif: "Arial","Helvetica",sans-serif;
+@arial_sans_serif: "Arial", "Helvetica", sans-serif;
 
-@georgia_serif-1: Georgia, "Palatino Linotype", "Book Antiqua", Palatino, serif;
-@georgia_serif-2: "Georgia","Times New Roman",serif;
+@lucida_sans_serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 
-@news_gothic_sans_serif: "News Gothic MT","Arial Rounded MT",Geneva,Helvetica,sans-serif;
-@news_gothic_sans_serif-2: "News Gothic MT","Trebuchet MS",Geneva,Helvetica,sans-serif;
+@news_gothic_sans_serif: "News Gothic MT", "Arial Rounded MT", Geneva, Helvetica, sans-serif;
 
-@lucida_sans_serif-1: "Lucida Grande", Verdana, Geneva, Helvetica, Arial, sans-serif;
-@lucida_sans_serif-2: "Lucida Grande",Verdana,Geneva,Helvetica,sans-serif;
-@lucida_sans_serif-3: "Lucida Grande","Arial","Helvetica",sans-serif;
-@lucida_sans_serif-4: "Lucida Grande", "Trebuchet MS", Geneva, Helvetica, sans-serif;
-@lucida_sans_serif-5: "Lucida Grande", "Trebuchet MS", Geneva, Helvetica, Arial, sans-serif;
-@lucida_sans_serif-6: "Lucida Grande", Verdana, Geneva, Helvetica, sans-serif;
-@lucida_sans_serif-7: "Lucida Grande","Arial",sans-serif;
+@georgia_serif: Georgia, "Palatino Linotype", "Book Antiqua", Palatino, "Times New Roman", serif;
 
-@lucida_console_monospace: "Lucida Console","Courier New", monospace;
-
+@lucida_console_monospace: "Lucida Console", "Courier New", monospace;
 @monospace: monospace;
 @verdana: verdana, sans-serif;
 @ichonochive: "Iconochive-Regular", sans-serif;

--- a/static/css/page-admin.less
+++ b/static/css/page-admin.less
@@ -42,7 +42,7 @@ img {
 // openlibrary/templates/admin/services.html
 table.services {
   th {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: 11px;
     font-weight: bold;
     text-transform: uppercase;
@@ -62,7 +62,7 @@ table.services {
 // openlibrary/templates/admin/people/view.html
 #adminHistory {
   border-top: 1px solid @admin-table-border;
-  font-family: @lucida_sans_serif-6;
+  font-family: @lucida_sans_serif;
   margin: 0 0 20px;
   th {
     background-color: @lightest-grey;
@@ -92,7 +92,7 @@ table.services {
 // openlibrary/admin/templates/admin/index.html
 div#prolific {
   span {
-    font-family: @lucida_sans_serif-1;
+    font-family: @lucida_sans_serif;
     font-size: .6875em;
   }
 }
@@ -104,7 +104,7 @@ div#prolific {
   right: 0;
   bottom: 2px;
   font-size: .5625em;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   font-weight: normal;
   color: @grey;
   text-transform: uppercase;
@@ -135,7 +135,7 @@ div#background {
 /* stylelint-enable selector-max-specificity */
 /* stylelint-disable selector-max-specificity */
 div#content {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
 }
 /* stylelint-enable selector-max-specificity */
 /* stylelint-disable selector-max-specificity */

--- a/static/css/page-barcodescanner.less
+++ b/static/css/page-barcodescanner.less
@@ -66,7 +66,7 @@
 }
 
 .barcodescanner__toolbar {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   position: relative;
   background: @white;
 }

--- a/static/css/page-book-widget.less
+++ b/static/css/page-book-widget.less
@@ -23,7 +23,7 @@ body {
 }
 
 .cta {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   background: @primary-blue;
   border-radius: 3px;
   width: 130px;
@@ -65,7 +65,7 @@ img.bookcover {
 }
 
 .title {
-  font-family: @georgia_serif-1;
+  font-family: @georgia_serif;
   margin: 7px auto 0;
   color: @grey-555;
   font-size: .8em;
@@ -77,7 +77,7 @@ a.noshow {
 }
 
 .author {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   font-size: .7em;
   font-weight: normal;
   color: @grey;
@@ -86,7 +86,7 @@ a.noshow {
 }
 
 .service {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
   color: @light-grey;
   width: 130px;
   margin: 7px auto;

--- a/static/css/page-edit.less
+++ b/static/css/page-edit.less
@@ -32,7 +32,7 @@ div#content {
 
 /* stylelint-disable selector-max-specificity */
 div#content {
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
 }
 /* stylelint-enable selector-max-specificity */
 /* stylelint-disable selector-max-specificity */
@@ -47,23 +47,23 @@ div#revertLink {
   top: 60px;
   right: 20px;
   font-size: .75em;
-  font-family: @lucida_sans_serif-1;
+  font-family: @lucida_sans_serif;
 }
 /* stylelint-enable selector-max-specificity */
 .formElement {
-  font-family: @lucida_sans_serif-2;
+  font-family: @lucida_sans_serif;
   color: @darker-grey;
 }
 .label {
   padding: 10px 0 5px;
   label {
     font-size: 1.0em;
-    font-family: @lucida_sans_serif-5;
+    font-family: @lucida_sans_serif;
     font-weight: 700;
   }
   span {
     font-size: .75em;
-    font-family: @lucida_sans_serif-5;
+    font-family: @lucida_sans_serif;
   }
 }
 textarea {
@@ -75,7 +75,7 @@ textarea {
 .formElement input[type=text],
 .formElement select {
   font-size: 1em;
-  font-family: @lucida_sans_serif-4;
+  font-family: @lucida_sans_serif;
   color: @dark-grey;
   padding: 5px;
 }
@@ -111,7 +111,7 @@ div#databar {
   h2 {
     margin: 0 0 5px;
     a {
-      font-family: @lucida_sans_serif-4;
+      font-family: @lucida_sans_serif;
       color: @red;
       font-size: 14px;
       font-weight: normal;

--- a/static/css/page-plain.less
+++ b/static/css/page-plain.less
@@ -54,7 +54,7 @@ div.nav {
       padding-bottom: 10px;
 
       &.expires {
-        font-family: @lucida_sans_serif-1;
+        font-family: @lucida_sans_serif;
         color: @brown;
         font-weight: 600;
         font-size: .6875em;
@@ -63,7 +63,7 @@ div.nav {
       }
 
       &.titles {
-        font-family: @lucida_sans_serif-1;
+        font-family: @lucida_sans_serif;
         color: @teal;
         font-weight: 600;
         font-size: 1.125em;

--- a/static/css/page-user.less
+++ b/static/css/page-user.less
@@ -75,7 +75,7 @@ div.message {
   margin-bottom: 15px;
   background: @light-yellow;
   p {
-    font-family: @lucida_sans_serif-7;
+    font-family: @lucida_sans_serif;
   }
 }
 div.siteSearch {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8691 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Standardized the fonts on Open Library to use -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji" in the various/multiple cases where Lucida was being used + updated the css & html references. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
