### PR TITLE
Fix broken reading log pages

### DIFF
--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -56,7 +56,7 @@ $add_metatag(property="og:image", content=meta_photo_url)
       </span>
 
     $if not checkin_year:
-      $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
+      $:macros.Pager(int(current_page), doc_count, results_per_page=results_per_page)
     <ul class="list-books">
       $if docs:
         $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
@@ -68,7 +68,7 @@ $add_metatag(property="og:image", content=meta_photo_url)
           $ doc_number = doc_number + 1
     </ul>
     $if not checkin_year:
-      $:macros.Pager(current_page, doc_count, results_per_page=results_per_page)
+      $:macros.Pager(int(current_page), doc_count, results_per_page=results_per_page)
   $else:
     <ul class="list-books">
       $if checkin_year:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes bug which causes reading log pages greater than `1` to fail to render. Root cause of the issue was that `current_page` was passed to the `Pager` macro as a string.  Casting `current_page` to an integer in the `Pager` macro call squashes this bug.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Navigate to the second page of any public reading log.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @onnotasler 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
