### PR TITLE
Made styles of tabs on trending page same as search page.

### DIFF
--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -6,10 +6,14 @@ $ page = int(input(page=1).page)
   $ pages = {'now': _('Now'), 'daily': _('Today'), 'weekly': _('This Week'), 'monthly': _('This Month'), 'yearly': _('This Year'), 'forever': _('All Time')}
   <h1>$_('Trending Books'): $(pages[mode])</h1>
   <p>$_("See what readers from the community are adding to their bookshelves")</p>
-  <p>
-    $for p in pages:
-      <a style="$('font-weight: bold;' if p==mode else '')" href="/trending/$(p)">$pages[p]</a>
-  </p>
+  <ul class="nav-bar">
+    $for p in pages:  
+    <li class="$('selected' if p==mode else '')">
+      <a 
+         href="/trending/$(p)">$pages[p]
+      </a>
+    </li>
+  </ul>
 
   <div class="mybooks-list">
     <ul class="list-books">

--- a/openlibrary/templates/trending.html
+++ b/openlibrary/templates/trending.html
@@ -7,9 +7,9 @@ $ page = int(input(page=1).page)
   <h1>$_('Trending Books'): $(pages[mode])</h1>
   <p>$_("See what readers from the community are adding to their bookshelves")</p>
   <ul class="nav-bar">
-    $for p in pages:  
+    $for p in pages:
     <li class="$('selected' if p==mode else '')">
-      <a 
+      <a
          href="/trending/$(p)">$pages[p]
       </a>
     </li>


### PR DESCRIPTION
Added nav-bar class just like in the searching page to make the menu appear exactly as the searching page.Fixes #8702

<!-- What issue does this PR close? -->
Closes #8702 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes styles of tabs on the trending page to appear same as same as the search page. 

### Technical
<!-- What should be noted about the implementation? -->
nav-bar class is used just like in the searching page.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Visit http://localhost:8080/trending/now on local deployment to see the changes and test them out.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://github.com/internetarchive/openlibrary/assets/59080746/979206c3-5dcb-4ef5-acc2-1c043deba530)
After:
![image](https://github.com/internetarchive/openlibrary/assets/59080746/221c8c74-a074-4bd4-a8ab-1a25a732dc7e)
### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
