### PR TITLE
Fixed Changing sort order of works on author page should reset page to 1

### DIFF
--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -45,7 +45,7 @@ $code:
       $if is_selected:
           <a><strong>$sort_option['name']</strong></a>
       $else:
-          <a href="$changequery(sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
+          <a href="$changequery(page=None, sort=cond(sort_option['sort'] == default_sort, None, sort_option['sort']))"
              data-ol-link-track="SearchSort|$sort_option['ga_key']"
              rel="nofollow"
           >$sort_option['name']</a>
@@ -57,14 +57,14 @@ $code:
           $for sub_sort in sort_option['sub_sorts']:
             $ is_selected = sub_sort['sort'] == selected_sort
             <option
-              value="$changequery(sort=cond(sub_sort['sort'] == default_sort, None, sub_sort['sort']))"
+              value="$changequery(page=None, sort=cond(sub_sort['sort'] == default_sort, None, sub_sort['sort']))"
               $cond(is_selected, 'selected')
             >$sub_sort['name']</option>
         </select>
       $if not loop.last:
         |
     $if selected_sort and selected_sort.startswith('random'):
-      (<a href="$changequery(sort='random_%s' % today().timestamp())"
+      (<a href="$changequery(page=None, sort='random_%s' % today().timestamp())"
          data-ol-link-track="SearchSort|RandomShuffle"
          rel="nofollow"
       >$_('Shuffle')</a>)


### PR DESCRIPTION
Closes #8723

Fixed Changing sort order of works on author page should reset page to 1
by modifying ```openlibrary/templates/search/sort_options.html```
by setting ```page=None``` wherever it calls ```changequery```.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Page no - 2
<img width="826" alt="image" src="https://github.com/internetarchive/openlibrary/assets/117273351/75030217-5ce1-43fb-b879-a03e8b2fe1a7">

After sorting page no reset to page 1
<img width="829" alt="image" src="https://github.com/internetarchive/openlibrary/assets/117273351/205da351-140b-4295-bc0c-e8bc13d8feae">



### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
