### PR TITLE
Add per-key caching to get_availability

### DIFF
--- a/openlibrary/core/cache.py
+++ b/openlibrary/core/cache.py
@@ -5,7 +5,7 @@ import string
 import time
 import threading
 import functools
-from typing import Literal
+from typing import Any, Literal, cast
 from collections.abc import Callable
 
 import memcache
@@ -334,15 +334,32 @@ class MemcacheCache(Cache):
 
                 return MockMemcacheClient()
 
-    def get(self, key):
-        key = web.safestr(key)
+    def _encode_key(self, key: str) -> str:
+        return cast(str, web.safestr(key))
+
+    def get(self, key: str) -> Any:
+        key = self._encode_key(key)
         stats.begin("memcache.get", key=key)
         value = self.memcache.get(key)
         stats.end(hit=value is not None)
         return value and json.loads(value)
 
-    def set(self, key, value, expires=0):
-        key = web.safestr(key)
+    def get_multi(self, keys: list[str]) -> dict[str, Any]:
+        keys = [self._encode_key(k) for k in keys]
+        stats.begin("memcache.get_multi")
+        d = self.memcache.get_multi(keys)
+        stats.end(hit=bool(d))
+        return {k: json.loads(v) for k, v in d.items()}
+
+    def set_multi(self, mapping: dict[str, Any], expires=0):
+        mapping = {self._encode_key(k): json.dumps(v) for k, v in mapping.items()}
+        stats.begin("memcache.set_multi")
+        d = self.memcache.set_multi(mapping, expires)
+        stats.end()
+        return d
+
+    def set(self, key: str, value: Any, expires=0):
+        key = cast(str, web.safestr(key))
         value = json.dumps(value)
         stats.begin("memcache.set", key=key)
         value = self.memcache.set(key, value, expires)
@@ -394,7 +411,7 @@ request_cache = RequestCache()
 
 
 def get_memcache():
-    return memcache_cache.memcache
+    return memcache_cache
 
 
 def _get_cache(engine):
@@ -464,22 +481,18 @@ class memoize:
 
     def __init__(
         self,
-        engine: Literal["memory", "memcache", "request"] = "memory",
-        key=None,
+        engine: Literal["memory", "memcache", "request"],
+        key: str | Callable[..., str | tuple],
         expires: int = 0,
         background: bool = False,
         cacheable: Callable | None = None,
     ):
         self.cache = _get_cache(engine)
-        self.keyfunc = self._make_key_func(key)
+        self.keyfunc = (
+            key if callable(key) else functools.partial(build_memcache_key, key)
+        )
         self.cacheable = cacheable
         self.expires = expires
-
-    def _make_key_func(self, key):
-        if isinstance(key, str):
-            return PrefixKeyFunc(key)
-        else:
-            return key
 
     def __call__(self, f):
         """Returns the memoized version of f."""
@@ -544,33 +557,15 @@ class memoize:
             return self.cache.set(key, value, expires=self.expires)
 
 
-class PrefixKeyFunc:
-    """A function to generate cache keys using a prefix and arguments."""
+def build_memcache_key(prefix: str, *args, **kw) -> str:
+    key = prefix
 
-    def __init__(self, prefix):
-        self.prefix = prefix
+    if args:
+        key += "-" + json.dumps(args, separators=(",", ":"), sort_keys=True)[1:-1]
+    if kw:
+        key += "-" + json.dumps(kw, separators=(",", ":"), sort_keys=True)
 
-    def __call__(self, *a, **kw):
-        return self.prefix + "-" + self.encode_args(a, kw)
-
-    def encode_args(self, args, kw=None):
-        kw = kw or {}
-        """Encodes arguments to construct the memcache key.
-        """
-        # strip [ and ] from key
-        a = self.json_encode(list(args))[1:-1]
-
-        if kw:
-            return a + "-" + self.json_encode(kw)
-        else:
-            return a
-
-    def json_encode(self, value):
-        """json.dumps without extra spaces and consistent ordering of dictionary keys.
-
-        memcache doesn't like spaces in the key.
-        """
-        return json.dumps(value, separators=(",", ":"), sort_keys=True)
+    return key
 
 
 def method_memoize(f):

--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -1,6 +1,6 @@
 """Module for providing core functionality of lending on Open Library.
 """
-from typing import Literal
+from typing import Literal, TypedDict, cast
 
 import web
 import datetime
@@ -50,7 +50,7 @@ class PatronAccessException(Exception):
 
 config_ia_loan_api_url = None
 config_ia_xauth_api_url = None
-config_ia_availability_api_v2_url = None
+config_ia_availability_api_v2_url = cast(str, None)
 config_ia_access_secret = None
 config_ia_domain = None
 config_ia_ol_shared_key = None
@@ -80,7 +80,9 @@ def setup(config):
     config_bookreader_host = config.get('bookreader_host', 'archive.org')
     config_ia_domain = config.get('ia_base_url', 'https://archive.org')
     config_ia_loan_api_url = config.get('ia_loan_api_url')
-    config_ia_availability_api_v2_url = config.get('ia_availability_api_v2_url')
+    config_ia_availability_api_v2_url = cast(
+        str, config.get('ia_availability_api_v2_url')
+    )
     config_ia_xauth_api_url = config.get('ia_xauth_api_url')
     config_ia_access_secret = config.get('ia_access_secret')
     config_ia_ol_shared_key = config.get('ia_ol_shared_key')
@@ -284,74 +286,148 @@ def get_available(
         return {'error': 'request_timeout'}
 
 
-def get_availability(key: str, ids: list[str]) -> dict:
+class AvailabilityStatus(TypedDict):
+    status: Literal["borrow_available", "borrow_unavailable", "open", "error"]
+    error_message: str | None
+    available_to_browse: bool | None
+    available_to_borrow: bool | None
+    available_to_waitlist: bool | None
+    is_printdisabled: bool | None
+    is_readable: bool | None
+    is_lendable: bool | None
+    is_previewable: bool
+
+    identifier: str | None
+    isbn: str | None
+    oclc: str | None
+    openlibrary_work: str | None
+    openlibrary_edition: str | None
+
+    last_loan_date: str | None
+    """e.g. 2020-07-31T19:07:55Z"""
+
+    num_waitlist: str | None
+    """A number represented inexplicably as a string"""
+
+    last_waitlist_date: str | None
+    """e.g. 2020-07-31T19:07:55Z"""
+
+
+class AvailabilityServiceResponse(TypedDict):
+    success: bool
+    responses: dict[str, AvailabilityStatus]
+
+
+class AvailabilityStatusV2(AvailabilityStatus):
+    is_restricted: bool
+    is_browseable: bool | None
+    __src__: str
+
+
+def update_availability_schema_to_v2(
+    v1_resp: AvailabilityStatus,
+    ocaid: str | None,
+) -> AvailabilityStatusV2:
     """
-    :param str key: the type of identifier
-    :param list of str ids:
+    This function attempts to take the output of e.g. Bulk Availability
+    API and add/infer attributes which are missing (but are present on
+    Ground Truth API)
     """
+    v2_resp = cast(AvailabilityStatusV2, v1_resp)
+    # TODO: Make less brittle; maybe add simplelists/copy counts to Bulk Availability
+    v2_resp['identifier'] = ocaid
+    v2_resp['is_restricted'] = v1_resp['status'] != 'open'
+    v2_resp['is_browseable'] = v1_resp.get('available_to_browse', False)
+    # For debugging
+    v2_resp['__src__'] = 'core.models.lending.get_availability'
+    return v2_resp
+
+
+def get_availability(
+    id_type: Literal['identifier', 'openlibrary_work', 'openlibrary_edition'],
+    ids: list[str],
+) -> dict[str, AvailabilityStatusV2]:
     ids = [id_ for id_ in ids if id_]  # remove infogami.infobase.client.Nothing
     if not ids:
         return {}
 
-    def update_availability_schema_to_v2(v1_resp, ocaid):
-        """This functionattempts to take the output of e.g. Bulk Availability
-        API and add/infer attributes which are missing (but are
-        present on Ground Truth API)
-        """
-        # TODO: Make less brittle; maybe add simplelists/copy counts to Bulk Availability
-        v1_resp['identifier'] = ocaid
-        v1_resp['is_restricted'] = v1_resp['status'] != 'open'
-        v1_resp['is_browseable'] = v1_resp.get('available_to_browse', False)
-        # For debugging
-        v1_resp['__src__'] = 'core.models.lending.get_availability'
-        return v1_resp
+    def key_func(_id: str) -> str:
+        return cache.build_memcache_key('lending.get_availability', id_type, _id)
 
-    url = '{}?{}={}'.format(config_ia_availability_api_v2_url, key, ','.join(ids))
+    mc = cache.get_memcache()
+
+    cached_values = cast(
+        dict[str, AvailabilityStatusV2], mc.get_multi([key_func(_id) for _id in ids])
+    )
+    availabilities = {
+        _id: cached_values[key]
+        for _id in ids
+        if (key := key_func(_id)) in cached_values
+    }
+    ids_to_fetch = set(ids) - set(availabilities)
+
+    if not ids_to_fetch:
+        return availabilities
+
     try:
-        client_ip = web.ctx.env.get('HTTP_X_FORWARDED_FOR', 'ol-internal')
-        params = {"scope": "printdisabled"}
         headers = {
-            "x-preferred-client-id": client_ip,
+            "x-preferred-client-id": web.ctx.env.get(
+                'HTTP_X_FORWARDED_FOR', 'ol-internal'
+            ),
             "x-application-id": "openlibrary",
         }
         if config_ia_ol_metadata_write_s3:
             headers["authorization"] = "LOW {s3_key}:{s3_secret}".format(
                 **config_ia_ol_metadata_write_s3
             )
-
-        # Make authenticated request to Bulk Availability API
-        response = requests.get(
-            url, params=params, headers=headers, timeout=config_http_request_timeout
+        response = cast(
+            AvailabilityServiceResponse,
+            requests.get(
+                config_ia_availability_api_v2_url,
+                params={
+                    id_type: ','.join(ids_to_fetch),
+                    "scope": "printdisabled",
+                },
+                headers=headers,
+                timeout=10,
+            ).json(),
         )
-
-        items = response.json().get('responses', {})
-        for pkey in items:
-            ocaid = pkey if key == 'identifier' else items[pkey].get('identifier')
-            items[pkey] = update_availability_schema_to_v2(items[pkey], ocaid)
-        return items
+        uncached_values = {
+            _id: update_availability_schema_to_v2(
+                availability,
+                ocaid=(
+                    _id if id_type == 'identifier' else availability.get('identifier')
+                ),
+            )
+            for _id, availability in response['responses'].items()
+        }
+        availabilities |= uncached_values
+        mc.set_multi(
+            {
+                key_func(_id): availability
+                for _id, availability in uncached_values.items()
+            },
+            expires=5 * dateutil.MINUTE_SECS,
+        )
+        return availabilities
     except Exception as e:  # TODO: Narrow exception scope
-        logger.exception("get_availability(%s)" % url)
-        items = {'error': 'request_timeout', 'details': str(e)}
-
-        for pkey in ids:
-            # key could be isbn, ocaid, or openlibrary_[work|edition]
-            ocaid = pkey if key == 'identifier' else None
-            items[pkey] = update_availability_schema_to_v2({'status': 'error'}, ocaid)
-        return items
-
-
-def get_edition_availability(ol_edition_id):
-    return get_availability_of_editions([ol_edition_id])
-
-
-def get_availability_of_editions(ol_edition_ids):
-    """Given a list of Open Library edition IDs, returns a list of
-    Availability v2 results.
-    """
-    return get_availability('openlibrary_edition', ol_edition_ids)
+        logger.exception("lending.get_availability", extra={'ids': ids})
+        availabilities.update(
+            {
+                _id: update_availability_schema_to_v2(
+                    cast(AvailabilityStatus, {'status': 'error'}),
+                    ocaid=_id if id_type == 'identifier' else None,
+                )
+                for _id in ids_to_fetch
+            }
+        )
+        return availabilities | {
+            'error': 'request_timeout',
+            'details': str(e),
+        }  # type:ignore
 
 
-def get_ocaid(item):
+def get_ocaid(item: dict) -> str | None:
     # Circular import otherwise
     from ..book_providers import is_non_ia_ocaid
 
@@ -415,7 +491,7 @@ def add_availability(
                 item['availability'] = availabilities.get(ocaid)
     elif mode == "openlibrary_work":
         _ids = [item['key'].split('/')[-1] for item in items]
-        availabilities = get_availability_of_works(_ids)
+        availabilities = get_availability('openlibrary_work', _ids)
         for item in items:
             olid = item['key'].split('/')[-1]
             if olid:
@@ -423,7 +499,6 @@ def add_availability(
     return items
 
 
-@public
 def get_availability_of_ocaid(ocaid):
     """Retrieves availability based on ocaid/archive.org identifier"""
     return get_availability('identifier', [ocaid])
@@ -434,15 +509,6 @@ def get_availability_of_ocaids(ocaids: list[str]) -> dict:
     Retrieves availability based on ocaids/archive.org identifiers
     """
     return get_availability('identifier', ocaids)
-
-
-@public
-def get_work_availability(ol_work_id):
-    return get_availability_of_works([ol_work_id])
-
-
-def get_availability_of_works(ol_work_ids):
-    return get_availability('openlibrary_work', ol_work_ids)
 
 
 def is_loaned_out(identifier):

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -785,7 +785,7 @@ class inspect:
         i = web.input(action="read")
         i.setdefault("keys", "")
 
-        mc = cache.get_memcache()
+        mc = cache.get_memcache().memcache
 
         keys = [k.strip() for k in i["keys"].split() if k.strip()]
         if i.action == "delete":

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -51,15 +51,10 @@ class book_availability(delegate.page):
         return delegate.RawText(json.dumps(result), content_type="application/json")
 
     def get_book_availability(self, id_type, ids):
-        return (
-            lending.get_availability_of_works(ids)
-            if id_type == "openlibrary_work"
-            else lending.get_availability_of_editions(ids)
-            if id_type == "openlibrary_edition"
-            else lending.get_availability_of_ocaids(ids)
-            if id_type == "identifier"
-            else []
-        )
+        if id_type in ["openlibrary_work", "openlibrary_edition", "identifier"]:
+            return lending.get_availability(id_type, ids)
+        else:
+            return []
 
 
 class trending_books_api(delegate.page):

--- a/openlibrary/plugins/upstream/models.py
+++ b/openlibrary/plugins/upstream/models.py
@@ -686,21 +686,6 @@ class Work(models.Work):
     def get_related_books_subjects(self, filter_unicode=True):
         return self.filter_problematic_subjects(self.get_subjects(), filter_unicode)
 
-    def get_representative_edition(self) -> str | None:
-        """When we have confidence we can direct patrons to the best edition
-        of a work (for them), return qualifying edition key. Attempts
-        to find best (most available) edition of work using
-        archive.org work availability API. May be extended to support language
-
-        :rtype str: infogami edition key or url which resolves to an edition or None
-        """
-        work_id = self.key.replace('/works/', '')
-        availability = lending.get_work_availability(work_id)
-        if ol_edition := availability.get(work_id, {}).get('openlibrary_edition'):
-            return f'/books/{ol_edition}'
-
-        return None
-
     def get_sorted_editions(
         self,
         ebooks_only: bool = False,

--- a/openlibrary/tests/core/test_lending.py
+++ b/openlibrary/tests/core/test_lending.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 from openlibrary.core import lending
 
 
@@ -40,3 +42,45 @@ class TestAddAvailability:
         r = f([{'ocaid': 'foo'}])
         print(r)
         assert r[0]['availability']['status'] == 'error'
+
+
+class TestGetAvailability:
+    def test_cache(self):
+        with patch("openlibrary.core.lending.requests.get") as mock_get:
+            mock_get.return_value = Mock()
+            mock_get.return_value.json.return_value = {
+                "responses": {"foo": {"status": "open"}}
+            }
+
+            foo_expected = {
+                "status": "open",
+                "identifier": "foo",
+                "is_restricted": False,
+                "is_browseable": False,
+                "__src__": 'core.models.lending.get_availability',
+            }
+            bar_expected = {
+                "status": "error",
+                "identifier": "bar",
+                "is_restricted": True,
+                "is_browseable": False,
+                "__src__": 'core.models.lending.get_availability',
+            }
+
+            r = lending.get_availability("identifier", ["foo"])
+            assert mock_get.call_count == 1
+            assert r == {"foo": foo_expected}
+
+            # Should not make a call to the API again
+            r2 = lending.get_availability("identifier", ["foo"])
+            assert mock_get.call_count == 1
+            assert r2 == {"foo": foo_expected}
+
+            # Now should make a call for just the new identifier
+            mock_get.return_value.json.return_value = {
+                "responses": {"bar": {"status": "error"}}
+            }
+            r3 = lending.get_availability("identifier", ["foo", "bar"])
+            assert mock_get.call_count == 2
+            assert mock_get.call_args[1]['params']['identifier'] == "bar"
+            assert r3 == {"foo": foo_expected, "bar": bar_expected}


### PR DESCRIPTION
We're having some performance issues associated with high traffic to the availability endpoint. Add caching to our /service/availability calls to avoid causing too much traffic.

### Technical
- DRY methods that call get_availability
- Add more types to availability data structures
- Add support for memcache's get/set_multi
- Decrease get_availability timeout to 10s instead of 30s

### Testing
- Loading a search result page twice results in no new call to availability endpoint
- Loading /widget endpoint works

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
