### PR TITLE
8042/hotfix/false success on author merge

### DIFF
--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -91,6 +91,11 @@ export function initAuthorView() {
         url: '/authors/merge.json',
         type: 'POST',
         data: JSON.stringify(data),
+        //jqXHR: JQueryXMLHttpRequest OBject, textStatus and errorThrown are both strings. 
+        error: function(jqXHR, textStatus, errorThrown) {
+            $('#preMerge').fadeOut();
+            $('#errorMerge').fadeIn();
+        },
         complete: function() {
             $('#preMerge').fadeOut();
             $('#postMerge').fadeIn();

--- a/openlibrary/plugins/openlibrary/js/merge.js
+++ b/openlibrary/plugins/openlibrary/js/merge.js
@@ -96,7 +96,7 @@ export function initAuthorView() {
             $('#preMerge').fadeOut();
             $('#errorMerge').fadeIn();
         },
-        complete: function() {
+        success: function(data,  textStatus, jqXHR) {
             $('#preMerge').fadeOut();
             $('#postMerge').fadeIn();
         }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8042 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix, so that unsuccessful merges don't display as successful.

### Technical
<!-- What should be noted about the implementation? -->
The Ajax request for merges was set to always load in the 'successful merge element' on completion, regardless of whether or not the merge was successful. It has been split into a 'success' function and an 'error' function respectively. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Simply attempt an impossible merge, and an error message should show up. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="806" alt="image" src="https://github.com/internetarchive/openlibrary/assets/131627264/db413d4f-d837-4a21-835a-a662a3a230aa">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
