### PR TITLE
Make title sorting ignore diacriticals

### DIFF
--- a/conf/solr/conf/managed-schema.xml
+++ b/conf/solr/conf/managed-schema.xml
@@ -514,8 +514,8 @@
     <fieldType name="text_title_sort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
       <analyzer>
         <tokenizer name="keyword" />
-        <filter name="lowercase" />
         <filter name="trim" />
+        <filter name="icuFolding"/>
         <filter name="patternReplace"
                 pattern="^(an? |the |l[aeo]s? |l'|de la |el |il |un[ae]? |du |de[imrst]? |das |ein |eine[mnrs]? |bir )(.*)"
                 replacement="$2, $1"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8722 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Title sorting now ignores diacriticals.

### Technical
This solution replaces the lowercase filter on the text_title_sort SOLR type with the icuFolding filter, which not only lowercases, but also removes diacritical marks from the search tokens according to Unicode standards.

A SOLR reindex will be required for this change to take effect.

### Testing
The test case in the issue, https://openlibrary.org/authors/OL291650A/Max_Ernst?q=&sort=title should now colllate Dechets and Déchets together.

### Screenshot
I add some works in my development instance to test this behavior.

<img width="652" alt="Screenshot 2024-01-19 at 9 26 47 PM" src="https://github.com/internetarchive/openlibrary/assets/886889/4b317ec2-3168-4b1d-a836-cc59003e19ef">

Before this change, the "With Mark Twain" work sorted between "Wit" and "Wít".

### Stakeholders
@mheiman @tfmorris @cdrini 
