### PR TITLE
Fix share modal iframe url

### DIFF
--- a/openlibrary/macros/ShareModal.html
+++ b/openlibrary/macros/ShareModal.html
@@ -6,7 +6,7 @@ $# :param str classes: HTML classes for this component
 
 
 $def embed_iframe(page_url):
-  <iframe frameborder="0" width="165" height="400" src="$(page_url)/-/widget"></iframe>
+  <iframe frameborder="0" width="165" height="400" src="//$request.domain$page_url/widget"></iframe>
 
 <div class="$classes">
   $:link_markup


### PR DESCRIPTION
Previously share modals had the wrong url; eg

```html
<iframe frameborder="0" width="165" height="400" src="/works/OL82563W/Harry_Potter_and_the_Philosopher&#39;s_Stone/-/widget"></iframe>
```

1. Should have `openlibrary.org`, of course since this will be pasted in other people's sites
2. Should not have both the page slug _and_ the `/-/` placeholder


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Tested it creates the right url on testing.

### Screenshot
```html
<iframe frameborder="0" width="165" height="400" src="//testing.openlibrary.org/works/OL459469W/Madlenka/widget"></iframe>
```

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
