### PR TITLE
ILE: Increasing the visibility of selected works

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -47,6 +47,10 @@ export class IntegratedLibrarianEnvironment {
             window.open(workLink, '_blank');
         });
 
+        this.$statusText.on('click', () => {
+            this.$statusImages.toggle();
+        });
+
         this.selectionManager.init();
     }
 

--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -41,6 +41,12 @@ export class IntegratedLibrarianEnvironment {
         // Ready bulk tagger:
         this.createBulkTagger()
 
+        this.$statusImages.on('click', 'img', (event) => {
+            const olid = $(event.currentTarget).attr('title');
+            const workLink = `/works/${olid}`;
+            window.open(workLink, '_blank');
+        });
+
         this.selectionManager.init();
     }
 

--- a/openlibrary/plugins/openlibrary/js/ile/index.js
+++ b/openlibrary/plugins/openlibrary/js/ile/index.js
@@ -41,16 +41,6 @@ export class IntegratedLibrarianEnvironment {
         // Ready bulk tagger:
         this.createBulkTagger()
 
-        this.$statusImages.on('click', 'img', (event) => {
-            const olid = $(event.currentTarget).attr('title');
-            const workLink = `/works/${olid}`;
-            window.open(workLink, '_blank');
-        });
-
-        this.$statusText.on('click', () => {
-            this.$statusImages.toggle();
-        });
-
         this.selectionManager.init();
     }
 

--- a/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.less
+++ b/openlibrary/plugins/openlibrary/js/ile/utils/SelectionManager/SelectionManager.less
@@ -58,7 +58,7 @@
 }
 #ile-drag-status .images {
   position: absolute;
-  top: calc(100% + 5px);
+  top: -90px;
   left: 8px;
 }
 #ile-drag-status ul {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
### Issue: #8659

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Proposed Solution
<!-- What should be noted about the implementation? -->
I think it would be better to stick with just sliding up the selection above the ILE blue bar on clicking  "```N``` works selected". It would allow the selected works to appear above the blue bar upon click and immediate visibility of the selected works. This implementation would not mess with the drag and drop functionality as mentioned here [https://github.com/internetarchive/openlibrary/issues/8659#issuecomment-1876019782](https://github.com/internetarchive/openlibrary/issues/8659#issuecomment-1876019782) by @cdrini.
Other than that we can also choose to go with an implementation of a drawer or a menu like bulktagger but I am not sure if that won't interfere with the drag and drop functionality. If @cdrini or someone can verify the working of ```setDragImage``` API in a drawer or menu, this can be a better solution :). As its been mentioned here [https://github.com/internetarchive/openlibrary/issues/8659#issuecomment-1876019782](https://github.com/internetarchive/openlibrary/issues/8659#issuecomment-1876019782) that 
![image](https://github.com/internetarchive/openlibrary/assets/85943021/c67ffdc8-6af1-480b-9290-58864f79f429)



### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
