### PR TITLE
Update Portuguese translation for 3 phrases.

### DIFF
--- a/openlibrary/i18n/pt/messages.po
+++ b/openlibrary/i18n/pt/messages.po
@@ -638,7 +638,7 @@ msgstr "Pedir emprestado \"%(title)s\""
 
 #: ReadButton.html:15 type/list/embed.html:79 widget.html:39
 msgid "Borrow"
-msgstr "Emprestar"
+msgstr "Empréstimo"
 
 #: widget.html:45
 #, python-format
@@ -3172,7 +3172,7 @@ msgstr "Explorar o Centro de Desenvolvimento da Open Library"
 
 #: lib/nav_foot.html:37 lib/nav_head.html:25
 msgid "Developer Center"
-msgstr "Centro de Desenvolvedor"
+msgstr "Central de desenvolvedor"
 
 #: lib/nav_foot.html:38
 msgid "Explore Open Library APIs"
@@ -3204,7 +3204,7 @@ msgstr "Adicionar um novo livro à Open Library"
 
 #: lib/nav_foot.html:47
 msgid "Help Center"
-msgstr "Centro de ajuda"
+msgstr "Central de ajuda"
 
 #: lib/nav_foot.html:48
 msgid "Problems"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8743

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Switches out 3 Portuguese phrases for more idiomatic versions.

### Technical
<!-- What should be noted about the implementation? -->
Very straightforward. All changes made in the [translation file](https://github.com/internetarchive/openlibrary/blob/136fc1ff4c86bbb3f81aee49224aa44c01297950/openlibrary/i18n/pt/messages.po). Note: Switched second word of both longer phrases ("ajuda", "desenvolvedor") to lowercase for consistency, but can switch both to uppercase if preferred. 

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
