### PR TITLE
improve bulk resolve redirects performance

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -679,15 +679,17 @@ class Work(Thing):
     def get_redirects(cls, day, batch_size=1000, batch=0):
         tomorrow = day + timedelta(days=1)
 
-        work_redirect_ids = web.ctx.site.things({
-            "type": "/type/redirect",
-            "key~": "/works/*",
-            "limit": batch_size,
-            "offset": (batch * batch_size),
-            "sort": "-last_modified",
-            "last_modified>": day.strftime('%Y-%m-%d'),
-            "last_modified<": tomorrow.strftime('%Y-%m-%d'),
-        })
+        work_redirect_ids = web.ctx.site.things(
+            {
+                "type": "/type/redirect",
+                "key~": "/works/*",
+                "limit": batch_size,
+                "offset": (batch * batch_size),
+                "sort": "-last_modified",
+                "last_modified>": day.strftime('%Y-%m-%d'),
+                "last_modified<": tomorrow.strftime('%Y-%m-%d'),
+            }
+        )
         more = len(work_redirect_ids) == batch_size
         logger.info(
             f"[update-redirects] batch: {batch}, size {batch_size}, offset {batch * batch_size}, more {more}, len {len(work_redirect_ids)}"

--- a/scripts/update_stale_work_references.py
+++ b/scripts/update_stale_work_references.py
@@ -15,10 +15,7 @@ def main(ol_config: str, days=1, skip=7):
     load_config(ol_config)
     infogami._setup()
     Work.resolve_redirects_bulk(
-        batch_size=1000,
-        days=days,
-        grace_period_days=skip,
-        test=False
+        batch_size=1000, days=days, grace_period_days=skip, test=False
     )
 
 

--- a/scripts/update_stale_work_references.py
+++ b/scripts/update_stale_work_references.py
@@ -11,13 +11,14 @@ from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 import datetime
 
 
-def main(ol_config: str, start_offset=0, days=31):
+def main(ol_config: str, days=1, skip=7):
     load_config(ol_config)
     infogami._setup()
-    cutoff_date = datetime.datetime.today() - datetime.timedelta(days=days)
     Work.resolve_redirects_bulk(
-        start_offset=start_offset,
-        cutoff_date=cutoff_date,
+        batch_size=1000,
+        days=days,
+        grace_period_days=skip,
+        test=False
     )
 
 


### PR DESCRIPTION
Modified the resolve redirects query from doing batches across all time, to a query-per-day.

Modifying the grace period allows the developer to specify a start offset.


<!-- What issue does this PR close? -->
Closes #8778 and follows up on #6511 


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

This has been run on the last 2 years of redirects on ol-dev1 with e.g.:
```bash
PYTHONPATH=. python scripts/update_stale_work_references.py /olsystem/etc/openlibrary.yml --days=365 --skip=7
```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1139" alt="Screenshot 2024-02-28 at 5 23 11 AM" src="https://github.com/internetarchive/openlibrary/assets/978325/e9f7ea2b-f8d8-4bfa-89e4-ff135ea47a86">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mheiman @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
