### PR TITLE
Disable cover upload `submit` button while uploading

### DIFF
--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -56,6 +56,13 @@ function add_iframe(selector, src) {
 // covers/manage.html and covers/add.html
 export function initCoversAddManage() {
     $('#addcover-form').on('submit', function (event) {
+        const addLoadingStyling = () => {
+          let btn = $("#imageUpload");
+          btn.prop("disabled", true).html(btn.data("loading-text"));
+        }
+  
+        addLoadingStyling();
+
         var file = val('#coverFile');
         var url = val('#imageUrl');
         var coverid = val('#coverid');

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -38,7 +38,12 @@ export function initCoversChange() {
 }
 
 function val(selector) {
-    return $(selector).val().trim();
+    const val = $(selector).val();
+    if (val) {
+        return val.trim();
+    } else {
+        return val;
+    }
 }
 
 function error(message, event) {
@@ -60,12 +65,12 @@ export function initCoversAddManage() {
         var url = val('#imageUrl');
         var coverid = val('#coverid');
 
-        if (file === '' && url === '' && coverid === '') {
+        if (!file && !url && !coverid) {
             return error('Please choose an image or provide a URL.', event);
         }
 
-        let btn = $("#imageUpload");
-        btn.prop("disabled", true).html(btn.data("loading-text"));
+        const btn = $('#imageUpload');
+        btn.prop('disabled', true).html(btn.data('loading-text'));
     });
 
     // Clicking a cover should set the form value to the data-id of that cover

--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -56,13 +56,6 @@ function add_iframe(selector, src) {
 // covers/manage.html and covers/add.html
 export function initCoversAddManage() {
     $('#addcover-form').on('submit', function (event) {
-        const addLoadingStyling = () => {
-          let btn = $("#imageUpload");
-          btn.prop("disabled", true).html(btn.data("loading-text"));
-        }
-  
-        addLoadingStyling();
-
         var file = val('#coverFile');
         var url = val('#imageUrl');
         var coverid = val('#coverid');
@@ -70,6 +63,9 @@ export function initCoversAddManage() {
         if (file === '' && url === '' && coverid === '') {
             return error('Please choose an image or provide a URL.', event);
         }
+
+        let btn = $("#imageUpload");
+        btn.prop("disabled", true).html(btn.data("loading-text"));
     });
 
     // Clicking a cover should set the form value to the data-id of that cover

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -68,7 +68,9 @@ $if status:
             </div>
 
             <div class="formElement" style="margin: $('15px 0px 0px 15px;' if doc.type.key == '/type/work' else '0px;')">
-                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest">$_("Submit")</button>
+                <button type="submit" name="upload" id="imageUpload" value="$_('Submit')" class="largest" data-loading-text='$_("Uploading...")'>
+                    $_("Submit")
+                </button>
                 <a class="dialog--close-parent red" href="javascript:;">$_("Cancel")</a>
             </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8749 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds a js function to disable `Submit` button and replace text with `Uploading...` when form is submitted.

### Technical
<!-- What should be noted about the implementation? -->
The `addLoadingStyling` function is currently defined locally within the on submit function for `#addcover-form`. Could be moved into the `initCoversAddManage` function or elsewhere in the case of re-use (i.e. for the `Save` button in the manage cover window).

Another note: there is no function to clear the styling because the template is re-rendered when the function returns; if re-used elsewhere, a simple cleanup function may be necessary.

With @cdrini's help, I settled on the `data-loading-text` attribute to store the "Uploading..." message for translation purposes. Any other implementation of the function would require the same attribute in the corresponding HTML. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in (if not logged in)
2. Go to a book page
3. Hover over the book and select `Manage Covers`
4. Hit the `Submit` button in the `Add` tab

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="512" alt="Submit Button Uploading" src="https://github.com/internetarchive/openlibrary/assets/140550988/773995ee-dbaf-4203-ac7b-2268eec8af6b">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
