### PR TITLE
Fix broken template rendering on /search requests

### DIFF
--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -19,7 +19,6 @@ from infogami.utils.view import public, render, render_template, safeint
 from openlibrary.core import cache
 from openlibrary.core.lending import add_availability
 from openlibrary.core.models import Edition
-from openlibrary.plugins.inside.code import fulltext_search
 from openlibrary.plugins.openlibrary.processors import urlsafe
 from openlibrary.plugins.upstream.utils import (
     get_language_name,
@@ -491,10 +490,17 @@ class search(delegate.page):
         page = int(param.get('page', 1))
         sort = param.get('sort', None)
         rows = 20
-        search_response: SearchResponse | None = None
         if param:
             search_response = do_search(
                 param, sort, page, rows=rows, spellcheck_count=3
+            )
+        else:
+            search_response = SearchResponse(
+                facet_counts=None,
+                sort='',
+                docs=[],
+                num_found=0,
+                solr_select=''
             )
         return render.work_search(
             ' '.join(q_list),

--- a/openlibrary/plugins/worksearch/code.py
+++ b/openlibrary/plugins/worksearch/code.py
@@ -496,11 +496,7 @@ class search(delegate.page):
             )
         else:
             search_response = SearchResponse(
-                facet_counts=None,
-                sort='',
-                docs=[],
-                num_found=0,
-                solr_select=''
+                facet_counts=None, sort='', docs=[], num_found=0, solr_select=''
             )
         return render.work_search(
             ' '.join(q_list),


### PR DESCRIPTION
Work search template expects a SearchResponse object, but None was being sent if the request did not have any params. Updated request to always send a SearchResponse object.

Also, removed an unused import.

<!-- What issue does this PR close? -->
Closes #8730 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix the broken rendering issues on the '/search' page when there are no query params.

### Technical
<!-- What should be noted about the implementation? -->
There was existing logic to prevent the solr search query from being executed if the param dict was empty. I am assuming this was done to prevent a db hit. Executing the search query with the empty param was a solution that I tested and worked but I decided to send back an empty SearchResponse.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
These are the steps I took to test.

1. Visit the `/search` page. Search form should be rendered.
2. Go to `/advancedsearch` and submit and empty search. This will redirect to `/search` and the Search form should render.
3. In the top search box, select the `ALL` filter and submit an empty search. This will redirect to `/search` and the Search form should render.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
