### PR TITLE
Replace cover URL validation with HTML attributes

### DIFF
--- a/openlibrary/plugins/openlibrary/js/covers.js
+++ b/openlibrary/plugins/openlibrary/js/covers.js
@@ -60,19 +60,8 @@ export function initCoversAddManage() {
         var url = val('#imageUrl');
         var coverid = val('#coverid');
 
-        if (file === '' && (url === '' || url === 'http://') && coverid === '') {
+        if (file === '' && url === '' && coverid === '') {
             return error('Please choose an image or provide a URL.', event);
-        }
-
-        function test_url(url) {
-            var obj = {
-                optional: function () { return false; }
-            }
-            return window.$.validator.url.apply(obj, [url, null]);
-        }
-
-        if (url !== '' && url !== 'http://' && !test_url(url)) {
-            return error('Please provide a valid URL.');
         }
     });
 

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -63,7 +63,7 @@ $if status:
                     <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web.")</label>
                 </div>
                 <div class="input">
-                    <input type="url" name="url" id="imageUrl" value="" placeholder="https://..." />
+                    <input type="url" name="url" id="imageUrl" value="$data.get('url', '')" placeholder="https://..." />
                 </div>
             </div>
 

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -63,7 +63,7 @@ $if status:
                     <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web.")</label>
                 </div>
                 <div class="input">
-                    <input type="text" name="url" id="imageUrl" value="$data.get('url', 'https://')" onClick="if(!this._haschanged && this.value == 'https://'){this.value=''};this._haschanged=true;"/>
+                    <input type="url" name="url" id="imageUrl" value="" placeholder="https://" />
                 </div>
             </div>
 

--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -63,7 +63,7 @@ $if status:
                     <label id="imageWeb" for="imageUrl">$_("Or, paste in the image URL if it's on the web.")</label>
                 </div>
                 <div class="input">
-                    <input type="url" name="url" id="imageUrl" value="" placeholder="https://" />
+                    <input type="url" name="url" id="imageUrl" value="" placeholder="https://..." />
                 </div>
             </div>
 

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -194,6 +194,7 @@ div.floater {
     text-align: center;
   }
   input[type=text],
+  input[type=url],
   input[type=file] {
     font-size: 1.125em;
     font-family: @lucida_sans_serif-1;
@@ -273,6 +274,7 @@ div.floaterAdd {
     }
 
     input[type=text],
+    input[type=url],
     input[type=file] {
       width: 350px;
     }
@@ -289,6 +291,7 @@ div.floaterAdd {
     .input,
     .label,
     input[type=text],
+    input[type=url],
     textarea {
       width: 560px;
       resize: none;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8755 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactor. Removes unnecessary/outdated js by handling URL validation with the "url" HTML attribute.

### Technical
<!-- What should be noted about the implementation? -->
Very straightforward! Just a quick switch-out in the `add.html` file and removal of unnecessary url validation js from the `covers.js` file.

**One quick note:** This issue originally arose because I noticed that the `val` function was causing a type error (by trying to run `.trim()` on an empty string), which isn't directly fixed by this adjustment. Happy to add a quick fix for that -- confirming that `$(#selector).val()` is not an empty string before running `.trim()` on it -- to this PR or a separate one, but the fix may not be necessary.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to a book page (while logged in)
2. Select `Add a Cover`
3. Try typing an invalid URL and hitting `Submit`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="428" alt="Invalid URL screenshot" src="https://github.com/internetarchive/openlibrary/assets/140550988/420663ea-25e4-4232-a018-f9a739d0cb6d">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
