### PR TITLE
Add support for authenticated requests to the comment digest script

### DIFF
--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -17,5 +17,6 @@ jobs:
       - run: pip install requests
       - run: scripts/gh_scripts/issue_comment_bot.py 24 "$SLACK_CHANNEL" "$SLACK_TOKEN"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS }}

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -7,6 +7,7 @@ Writes links to each issue to given Slack channel.
 """
 import argparse
 import errno
+import os
 import sys
 import time
 
@@ -34,6 +35,10 @@ username_to_slack_id = {
     'hornc': '<@U0EUS8DV0>',
 }
 
+github_headers = {
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Accept': 'application/vnd.github+json',
+}
 
 def fetch_issues(updated_since: str):
     """
@@ -55,6 +60,7 @@ def fetch_issues(updated_since: str):
     response = requests.get(
         'https://api.github.com/search/issues',
         params=p,
+        headers=github_headers
     )
     d = response.json()
     results = d['items']
@@ -62,7 +68,7 @@ def fetch_issues(updated_since: str):
     # Fetch additional updated issues, if any exist
     def get_next_page(url: str):
         """Returns list of issues and optional url for next page"""
-        resp = requests.get(url)
+        resp = requests.get(url, headers=github_headers)
         # Get issues
         d = resp.json()
         issues = d['items']
@@ -93,7 +99,7 @@ def filter_issues(issues: list, since: datetime):
     for i in issues:
         # Fetch comments using URL from previous GitHub search results
         comments_url = i.get('comments_url')
-        resp = requests.get(comments_url, params={'per_page': 100})
+        resp = requests.get(comments_url, params={'per_page': 100}, headers=github_headers)
 
         # Ensure that we have the last page of comments
         links = resp.links
@@ -101,7 +107,7 @@ def filter_issues(issues: list, since: datetime):
         last_url = last.get('url', '')
 
         if last_url:
-            resp = requests.get(last_url)
+            resp = requests.get(last_url, headers=github_headers)
 
         # Get last comment
         comments = resp.json()
@@ -287,4 +293,9 @@ if __name__ == '__main__':
     # Process command-line arguments and starts the notification job
     parser = _get_parser()
     args = parser.parse_args()
+
+    # If found, add token to GitHub request headers:
+    github_token = os.environ.get('GITHUB_TOKEN', '')
+    if github_token:
+        github_headers['Authorization'] = f'Bearer {github_token}'
     start_job(args)

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -40,6 +40,7 @@ github_headers = {
     'Accept': 'application/vnd.github+json',
 }
 
+
 def fetch_issues(updated_since: str):
     """
     Fetches all GitHub issues that have been updated since the given date string and have at least one comment.
@@ -58,9 +59,7 @@ def fetch_issues(updated_since: str):
         'per_page': 100,
     }
     response = requests.get(
-        'https://api.github.com/search/issues',
-        params=p,
-        headers=github_headers
+        'https://api.github.com/search/issues', params=p, headers=github_headers
     )
     d = response.json()
     results = d['items']
@@ -99,7 +98,9 @@ def filter_issues(issues: list, since: datetime):
     for i in issues:
         # Fetch comments using URL from previous GitHub search results
         comments_url = i.get('comments_url')
-        resp = requests.get(comments_url, params={'per_page': 100}, headers=github_headers)
+        resp = requests.get(
+            comments_url, params={'per_page': 100}, headers=github_headers
+        )
 
         # Ensure that we have the last page of comments
         links = resp.links


### PR DESCRIPTION
Adds authorization token to GitHub request headers, iff a token is found in the environment.  Also adds API version and Accept headers.

Without authentication, we can only make 60 calls to GitHub's REST API per hour, which sometimes isn't enough to successfully run the new comment digest script.  This script can still be executed without an auth token.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
