### PR TITLE
Always publish new comment digest

### DIFF
--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -245,16 +245,9 @@ def start_job(args: argparse.Namespace):
     since, date_string = time_since(args.hours)
     issues = fetch_issues(date_string)
 
-    # XXX : If we are only running this script daily, we can remove this condition to
-    # always post a message to Slack. If the digest is ever not published, we'll know
-    # that something is wrong with our script runner.
-    if filtered_issues := filter_issues(issues, since):
-        publish_digest(filtered_issues, args.channel, args.slack_token, args.hours)
-        # XXX : Log this
-        print('Digest posted to Slack.')
-    else:
-        # XXX : Log this
-        print('No issues needing attention found.')
+    filtered_issues = filter_issues(issues, since)
+    publish_digest(filtered_issues, args.channel, args.slack_token, args.hours)
+    print('Digest posted to Slack.')
 
 
 def _get_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Ensures that the new comment digest is always published to Slack, even if no new comments were found.  If we publish the digest daily, we'll know that something has gone wrong with the workflow if the digest is ever not published.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
