### PR TITLE
Add user info tooltip to account icon

### DIFF
--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -23,7 +23,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
     <details>
       <summary $:cond(props['name'] == 'hamburger', 'data-ol-link-track="HeaderBar|Hamburger"')>
         $if props['name'] == 'hamburger' and ctx.user:
-            <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')">
+            <img class="account__icon" src="https://archive.org/services/img/$(get_internet_archive_id(ctx.user.key))" alt="$('My account')" title="$(ctx.user.key.split('/')[-1])&#10;$_('Joined %(date)s', date=datestr(ctx.user.created))">
             $if is_privileged_user and cached_get_counts_by_mode(mode='open') > 0:
               <span class="mr-notifications">$(cached_get_counts_by_mode(mode='open'))</span>
             <img class="$(props['image-class']) logged" src="$(props['image'])" alt="$(props['label'])"/>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8708.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Uses an HTML `title` attribute to show the user's username and joined date when they hover over the account icon.

### Technical
<!-- What should be noted about the implementation? -->
Very simple! Used `ctx.user` to get the relevant data, and replicated the joined date syntax from the `view.html` page. There are definitely fancier ways of making the tooltip that would look more stylish, but for the purpose of simplicity and responsiveness -- and avoiding any awkward tooltip hanging around once the on-click menu is opened -- I figured the `title` attribute would be the best way to go.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Hover over the account icon from any page. After a second or so, a tooltip should appear with the accurate username and user created date.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="274" alt="Tooltip screenshot" src="https://github.com/internetarchive/openlibrary/assets/140550988/03b6ad88-d8cc-4a35-8c7c-32b9bb5ccbf1">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @Abhishektharu 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
