### PR TITLE
Bulk Tagger: Move "Create subject" affordance to bottom of menu options scroll container

### DIFF
--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -413,12 +413,12 @@ export class BulkTagger {
                             }
                         }
                     }
+
                     // Update and show create subject affordance
                     const selectionContainer = this.rootElement.querySelector('.selection-container')
                     selectionContainer.addEventListener('scroll', () => {
-                        const searchResultsContainer = this.rootElement.querySelector('.subjects-search-results');
-                        if (searchResultsContainer.style.display !== 'none') {
-                            const isBottom = selectionContainer.scrollHeight - selectionContainer.scrollTop === selectionContainer.clientHeight;
+                        if (this.rootElement.querySelector('.selected-tag').classList.contains('hidden')) {
+                            const isBottom = selectionContainer.scrollHeight - Math.ceil(selectionContainer.scrollTop) <= selectionContainer.clientHeight;
                             if (isBottom) {
                                 this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
                             }

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -416,14 +416,19 @@ export class BulkTagger {
 
                     // Update and show create subject affordance
                     const selectionContainer = this.rootElement.querySelector('.selection-container')
-                    selectionContainer.addEventListener('scroll', () => {
-                        if (this.rootElement.querySelector('.selected-tag').classList.contains('hidden')) {
-                            const isBottom = selectionContainer.scrollHeight - Math.ceil(selectionContainer.scrollTop) <= selectionContainer.clientHeight;
-                            if (isBottom) {
-                                this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
+                    if ((selectionContainer.scrollHeight >= selectionContainer.clientHeight) && data['docs'].length === 0){
+                        this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
+                    }
+                    else {
+                        this.createSubjectElem.classList.add('hidden');
+                        selectionContainer.addEventListener('scroll', () => {
+                            if (this.rootElement.querySelector('.selected-tag').classList.contains('hidden')) {
+                                const isBottom = selectionContainer.scrollHeight - selectionContainer.scrollTop <= selectionContainer.clientHeight;
+                                if (isBottom) {
+                                    this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
+                                }
                             }
-                        }
-                    });
+                        })}
                 });
         } else {
             // Hide create subject affordance

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -415,20 +415,7 @@ export class BulkTagger {
                     }
 
                     // Update and show create subject affordance
-                    const selectionContainer = this.rootElement.querySelector('.selection-container')
-                    if ((selectionContainer.scrollHeight >= selectionContainer.clientHeight) && data['docs'].length === 0){
-                        this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
-                    }
-                    else {
-                        this.createSubjectElem.classList.add('hidden');
-                        selectionContainer.addEventListener('scroll', () => {
-                            if (this.rootElement.querySelector('.selected-tag').classList.contains('hidden')) {
-                                const isBottom = selectionContainer.scrollHeight - selectionContainer.scrollTop <= selectionContainer.clientHeight;
-                                if (isBottom) {
-                                    this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
-                                }
-                            }
-                        })}
+                    this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
                 });
         } else {
             // Hide create subject affordance

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/BulkTagger.js
@@ -413,9 +413,17 @@ export class BulkTagger {
                             }
                         }
                     }
-
                     // Update and show create subject affordance
-                    this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
+                    const selectionContainer = this.rootElement.querySelector('.selection-container')
+                    selectionContainer.addEventListener('scroll', () => {
+                        const searchResultsContainer = this.rootElement.querySelector('.subjects-search-results');
+                        if (searchResultsContainer.style.display !== 'none') {
+                            const isBottom = selectionContainer.scrollHeight - selectionContainer.scrollTop === selectionContainer.clientHeight;
+                            if (isBottom) {
+                                this.updateAndShowNewSubjectAffordance(trimmedSearchTerm)
+                            }
+                        }
+                    });
                 });
         } else {
             // Hide create subject affordance

--- a/openlibrary/plugins/openlibrary/js/bulk-tagger/index.js
+++ b/openlibrary/plugins/openlibrary/js/bulk-tagger/index.js
@@ -20,8 +20,7 @@ export function renderBulkTagger() {
         <div class="selection-container hidden">
             <div class="selected-tag-subjects"></div>
             <div class="subjects-search-results"></div>
-        </div>
-        <div class="create-new-subject-tag">
+            <div class="create-new-subject-tag">
             <div class="search-subject-row-name search-subject-row-name-create hidden">
                 <div class="search-subject-row-name-create-p">Create new subject <strong class="subject-name"></strong> with type:</div>
                 <div class="search-subject-row-name-create-select">
@@ -31,6 +30,7 @@ export function renderBulkTagger() {
                     <div class="subject-type-option subject-type-option--time" data-tag-type="subject_times">time</div>
                 </div>
             </div>
+        </div>
         </div>
         <div class="submit-tags-section">
             <button type="submit" class="bulk-tagging-submit cta-btn cta-btn--primary" disabled>Submit</button>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8652 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Moved the "Create subject" affordance to the bottom of the scroll container for better visibility and prevention of duplicate subjects.

### Technical
<!-- What should be noted about the implementation? -->
- Moved the "Create subject" affordance to the bottom of the scroll container.
- The functionality of updating and displaying the affordance remains unchanged and doesn't get affected from the following changes in this PR.
- Ensured that the visibility rules remain unchanged: the affordance is hidden when the subject search input is empty.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Search for a subject in bulk tagger component of ILE
- The behavior of displaying create new subject affordance has been updated as per requested whilst ensuring the visibility rules

### Screenshot



https://github.com/internetarchive/openlibrary/assets/85943021/ffbed116-7583-4e26-b4fa-2c4b4722cd38




<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
