### PR TITLE
Show error messages without clearing inputs in edition edit page

### DIFF
--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -79,6 +79,7 @@ export function initRoleValidation() {
                 return error('#role-errors', '#role-name', dataConfig['You need to give this ROLE a name.'].replace(/ROLE/, data.role));
             }
             $('#role-errors').hide();
+            $('#select-role, #role-name').val('');
             return true;
         }
     });
@@ -97,7 +98,10 @@ export function isbnConfirmAdd(data) {
 
     const yesButtonSelector = '#yes-add-isbn'
     const noButtonSelector = '#do-not-add-isbn'
-    const onYes = () => {$('#id-errors').hide()};
+    const onYes = () => {
+        $('#id-errors').hide();
+        $('#select-id, #id-value').val('');
+    };
     const onNo = () => {
         $('#id-errors').hide();
         isbnOverride.clear();
@@ -122,8 +126,8 @@ export function isbnConfirmAdd(data) {
 function validateIsbn10(data, dataConfig, label) {
     data.value = parseIsbn(data.value);
 
-    if (isFormatValidIsbn10(data.value) === false) {
-        return error('#id-errors', 'id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
+    if (!isFormatValidIsbn10(data.value)) {
+        return error('#id-errors', '#id-value', dataConfig['ID must be exactly 10 characters [0-9] or X.'].replace(/ID/, label));
     }
     // Here the ISBN has a valid format, but also has an invalid checksum. Give the user a chance to verify
     // the ISBN, as books sometimes issue with invalid ISBNs and we want to be able to add them.
@@ -147,7 +151,7 @@ function validateIsbn13(data, dataConfig, label) {
     data.value = parseIsbn(data.value);
 
     if (isFormatValidIsbn13(data.value) === false) {
-        return error('#id-errors', 'id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
+        return error('#id-errors', '#id-value', dataConfig['ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4'].replace(/ID/, label));
     }
     // Here the ISBN has a valid format, but also has an invalid checksum. Give the user a chance to verify
     // the ISBN, as books sometimes issue with invalid ISBNs and we want to be able to add them.
@@ -171,7 +175,7 @@ function validateLccn(data, dataConfig, label) {
     data.value = parseLccn(data.value);
 
     if (isValidLccn(data.value) === false) {
-        return error('#id-errors', 'id-value', dataConfig['Invalid ID format'].replace(/ID/, label));
+        return error('#id-errors', '#id-value', dataConfig['Invalid ID format'].replace(/ID/, label));
     }
     return true;
 }
@@ -187,14 +191,14 @@ export function validateIdentifiers(data) {
     const dataConfig = JSON.parse(document.querySelector('#identifiers').dataset.config);
 
     if (data.name === '' || data.name === '---') {
-        return error('#id-errors', 'select-id', dataConfig['Please select an identifier.'])
+        return error('#id-errors', '#select-id', dataConfig['Please select an identifier.'])
     }
     const label = $('#select-id').find(`option[value='${data.name}']`).html();
     if (data.value === '') {
-        return error('#id-errors', 'id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
+        return error('#id-errors', '#id-value', dataConfig['You need to give a value to ID.'].replace(/ID/, label));
     }
     if (['ocaid'].includes(data.name) && /\s/g.test(data.value)) {
-        return error('#id-errors', 'id-value', dataConfig['ID ids cannot contain whitespace.'].replace(/ID/, label));
+        return error('#id-errors', '#id-value', dataConfig['ID ids cannot contain whitespace.'].replace(/ID/, label));
     }
 
     let validId = true;
@@ -214,12 +218,13 @@ export function validateIdentifiers(data) {
     if (isIdDupe(entries, data.value) === true) {
         // isbnOverride being set will override the dupe checker, so clear isbnOverride if there's a dupe.
         if (isbnOverride.get()) {isbnOverride.clear()}
-        return error('#id-errors', 'id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
+        return error('#id-errors', '#id-value', dataConfig['That ID already exists for this edition.'].replace(/ID/, label));
     }
 
     if (validId === false) return false;
 
     $('#id-errors').hide();
+    $('#select-id, #id-value').val('');
     return true;
 }
 
@@ -243,6 +248,7 @@ export function initClassificationValidation() {
                 return error('#classification-errors', '#classification-value', dataConfig['You need to give a value to CLASS.'].replace(/CLASS/, label));
             }
             $('#classification-errors').hide();
+            $('#select-classification, #classification-value').val('');
             return true;
         }
     });
@@ -394,6 +400,7 @@ export function initEditExcerpts() {
                 return error('#excerpts-errors', '#excerpts-excerpt', 'That excerpt is too long.')
             }
             $('#excerpts-errors').hide();
+            $('#excerpts-excerpt').val('');
             return true;
         }
     });
@@ -443,6 +450,7 @@ export function initEditLinks() {
                 return false;
             }
             $('#link-errors').addClass('hidden');
+            $('#link-label, #link-url').val('');
             return true;
         }
     });

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -100,7 +100,6 @@ export function isbnConfirmAdd(data) {
     const noButtonSelector = '#do-not-add-isbn'
     const onYes = () => {
         $('#id-errors').hide();
-        $('#select-id, #id-value').val('');
     };
     const onNo = () => {
         $('#id-errors').hide();
@@ -175,6 +174,7 @@ function validateLccn(data, dataConfig, label) {
     data.value = parseLccn(data.value);
 
     if (isValidLccn(data.value) === false) {
+        $('#id-value').val(data.value);
         return error('#id-errors', '#id-value', dataConfig['Invalid ID format'].replace(/ID/, label));
     }
     return true;
@@ -191,6 +191,7 @@ export function validateIdentifiers(data) {
     const dataConfig = JSON.parse(document.querySelector('#identifiers').dataset.config);
 
     if (data.name === '' || data.name === '---') {
+        $('#id-value').val(data.value);
         return error('#id-errors', '#select-id', dataConfig['Please select an identifier.'])
     }
     const label = $('#select-id').find(`option[value='${data.name}']`).html();
@@ -222,9 +223,7 @@ export function validateIdentifiers(data) {
     }
 
     if (validId === false) return false;
-
     $('#id-errors').hide();
-    $('#select-id, #id-value').val('');
     return true;
 }
 

--- a/openlibrary/plugins/openlibrary/js/jquery.repeat.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.repeat.js
@@ -39,25 +39,19 @@ export default function($){
         /**
          * Search elems.form for input fields and create an
          * object representing.
-         * This function has side effects and will reset any
-         * input[type=text] fields it has found in the process
          * @return {object} data mapping names to values
          */
         function formdata() {
             var data = {};
             $(':input', elems.form).each(function() {
                 var $e = $(this),
-                    type = $e.attr('type'),
                     name = $e.attr('name');
 
                 data[name] = $e.val().trim();
-                // reset the values we are copying across
-                if (type === 'text') {
-                    $e.val('');
-                }
             });
             return data;
         }
+
         /**
          * triggered when "add link" button is clicked on author edit field.
          * Creates a removable `repeat-item`.

--- a/openlibrary/plugins/openlibrary/js/jquery.repeat.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.repeat.js
@@ -47,11 +47,11 @@ export default function($){
                 var $e = $(this),
                     name = $e.attr('name'),
                     type = $e.attr('type'),
-                    id = $e.attr('id');
+                    _id = $e.attr('id');
 
                 data[name] = $e.val().trim();
 
-                if (type === 'text' && id === 'id-value') {
+                if (type === 'text' && _id === 'id-value') {
                     $e.val('');
                 }
             });

--- a/openlibrary/plugins/openlibrary/js/jquery.repeat.js
+++ b/openlibrary/plugins/openlibrary/js/jquery.repeat.js
@@ -45,9 +45,15 @@ export default function($){
             var data = {};
             $(':input', elems.form).each(function() {
                 var $e = $(this),
-                    name = $e.attr('name');
+                    name = $e.attr('name'),
+                    type = $e.attr('type'),
+                    id = $e.attr('id');
 
                 data[name] = $e.val().trim();
+
+                if (type === 'text' && id === 'id-value') {
+                    $e.val('');
+                }
             });
             return data;
         }

--- a/openlibrary/templates/books/edit/excerpts.html
+++ b/openlibrary/templates/books/edit/excerpts.html
@@ -1,6 +1,6 @@
 $def with (work)
 
-<div id="excerpts-errors" class="note hidden">
+<div id="excerpts-errors" class="note" style="display: none">
 </div>
 
 <fieldset class="major" id="addexcerpts">

--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -24,7 +24,7 @@ $def with (work, prefix="")
                     <label for="link-url">URL</label>
                 </div>
                 <div class="input">
-                    <input type="text" name="url" id="link-url" class="addweb" value="" placeholder="https://..."/>
+                    <input type="text" name="url" id="link-url" class="addweb" value="https://" />
                     <input type="button" id="repeat-add" class="repeat-add" value="Add Link"/>
                 </div>
             </div>

--- a/openlibrary/templates/books/edit/web.html
+++ b/openlibrary/templates/books/edit/web.html
@@ -24,7 +24,7 @@ $def with (work, prefix="")
                     <label for="link-url">URL</label>
                 </div>
                 <div class="input">
-                    <input type="text" name="url" id="link-url" class="addweb" value="https://"/>
+                    <input type="text" name="url" id="link-url" class="addweb" value="" placeholder="https://..."/>
                     <input type="button" id="repeat-add" class="repeat-add" value="Add Link"/>
                 </div>
             </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8423 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Makes the inputs for adding contributors, classifications, identifiers, excerpts and links (on the `Edit` page and the `Work Details` page) only clear once the input is accepted -- to make it easier for users to fix typos/etc. if rejected instead of having to re-type their entry.

### Technical
<!-- What should be noted about the implementation? -->
This ended up being a little more involved than expected. Since the values were automatically clearing (to be saved separately in a `data` variable) before the error checks ran, I initially implemented a workaround solution that used the `data` values to manually re-set the input fields to their lost values after the error checks.

After this, I discovered that the root of the problem was actually in the `jquery.repeat.js` file, where all text inputs were being cleared as a side effect of storing the values in `data`. 

So I removed that line from the function, and added value clearing to each relevant function to run only after the error checks pass. I.e. ` $('#select-role, #role-name').val('');`

This all worked great, and made the UI behave as desired -- and had the added benefit of clearing the role/identifier type as well when the entry is accepted.

**Edit:** Got the tests passing by adjusting the process for identifier validation specifically -- `formdata` now *does* clear the inputs, but just for identifier entries. The inputs are re-entered via `$('#id-value).val(data.value)` in a couple places so that the input remains in the case of errors like `no identifier type selected`.

#### Other Technical Notes
This also involved some cleanup along the way, specifically fixing some typos in the calls to the `error()` function to make sure the error message displayed and the correct input was focused on, and two quick HTML rewrites to improve the URL validation in `web.html` and make the excerpt error show/hide properly in `excerpts.html`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. While logged in, go to an edition edit page.
2. Enter a contributor without selecting a role (or vice versa) -- error message should appear without input fields clearing
3. Fix the problem and submit -- error message should disappear and input fields should clear.
4. Can follow the same process for classification/identifier/link/excerpt errors

### Screenshot
<img width="477" alt="Contributor Validation" src="https://github.com/internetarchive/openlibrary/assets/140550988/6e6f9d69-4203-4001-8573-5cc739a39bf2">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
