### PR TITLE
Fix environment variables in compose file must not have quotes

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -82,8 +82,8 @@ services:
     user: root
     command: docker/ol-nginx-start.sh
     environment:
-      - CRONTAB_FILES="/etc/cron.d/archive-webserver-logs /etc/cron.d/certbot"
-      - NGINX_DOMAIN="covers.openlibrary.org"
+      - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs /etc/cron.d/certbot
+      - NGINX_DOMAIN=covers.openlibrary.org
     restart: unless-stopped
     hostname: "$HOSTNAME"
     depends_on:
@@ -173,8 +173,8 @@ services:
     user: root
     command: docker/ol-nginx-start.sh
     environment:
-      - CRONTAB_FILES="/etc/cron.d/archive-webserver-logs /etc/cron.d/pull-sitemaps-from-ol-home0 /etc/cron.d/certbot"
-      - NGINX_DOMAIN="openlibrary.org"
+      - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs /etc/cron.d/pull-sitemaps-from-ol-home0 /etc/cron.d/certbot
+      - NGINX_DOMAIN=openlibrary.org
     volumes:
       # letsencrypt
       - letsencrypt-data:/etc/letsencrypt
@@ -195,6 +195,8 @@ services:
       # Archive nginx logs regularly
       - ../olsystem/etc/cron.d/archive-webserver-logs:/etc/cron.d/archive-webserver-logs
       - archive-webserver-logs-data:/archive-webserver-logs-data
+      # Sitemaps
+      - ../olsystem/etc/cron.d/pull-sitemaps-from-ol-home0:/etc/cron.d/pull-sitemaps-from-ol-home0
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
Closes #8710
Causing expansion in CRONTAB_FILES to fail; it included the quote in the file path!

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
