### PR TITLE
Add carousel analytics

### DIFF
--- a/openlibrary/book_providers.py
+++ b/openlibrary/book_providers.py
@@ -1,5 +1,5 @@
 from typing import TypedDict, Literal, cast, TypeVar, Generic
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import web
 from web import uniq
@@ -81,9 +81,13 @@ class AbstractBookProvider(Generic[TProviderMetadata]):
     def get_template_path(self, typ: Literal['read_button', 'download_options']) -> str:
         return f"book_providers/{self.short_name}_{typ}.html"
 
-    def render_read_button(self, ed_or_solr: Edition | dict):
+    def render_read_button(
+        self, ed_or_solr: Edition | dict, analytics_attr: Callable[[str], str]
+    ):
         return render_template(
-            self.get_template_path('read_button'), self.get_best_identifier(ed_or_solr)
+            self.get_template_path('read_button'),
+            self.get_best_identifier(ed_or_solr),
+            analytics_attr,
         )
 
     def render_download_options(self, edition: Edition, extra_args: list | None = None):

--- a/openlibrary/macros/BookPreview.html
+++ b/openlibrary/macros/BookPreview.html
@@ -1,11 +1,11 @@
-$def with (ocaid)
+$def with (ocaid, analytics_attr)
 $# :param str ocaid:
 
   <div class="cta-button-group">
     <a class="cta-btn cta-btn--preview"
       data-iframe-src="https://archive.org/details/$ocaid?view=theater&wrapper=false"
       data-iframe-link="https://archive.org/details/$ocaid"
-      data-ol-link-track="CTAClick|Preview" href="#bookPreview">$_('Preview') <span>$_('Only')</span></a>
+      $:analytics_attr('Preview') href="#bookPreview">$_('Preview') <span>$_('Only')</span></a>
   </div>
 
 $if render_once('book-preview-floater'):

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -46,18 +46,18 @@ $def analytics_attr(action):
     data-ol-link-track="CTAClick|$action"
 
 $if user_loan:
-  $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
+  $:macros.ReadButton(ocaid, analytics_attr, loan=user_loan, listen=listen)
   $if secondary_action:
     $:macros.ReturnForm(ocaid)
     $:macros.FormatExpiry(user_loan['expiry'])
 
 $elif book_provider and book_provider.short_name != 'ia':
   $# Partner Trusted Book Provider Read Buttons
-  $:book_provider.render_read_button(doc)
+  $:book_provider.render_read_button(doc, analytics_attr)
 
 $elif availability.get('is_readable') or availability.get('status') == 'open':
   $# Open / Publicly Readable (Unrestricted)
-  $:macros.ReadButton(ocaid, listen=listen)
+  $:macros.ReadButton(ocaid, analytics_attr, listen=listen)
   $if secondary_action:
     $:macros.BookSearchInside(ocaid)
 
@@ -66,14 +66,14 @@ $elif ocaid and ctx.user and ctx.user.is_printdisabled():
   $ pd_eligible = availability and availability.get('is_printdisabled')
   $ std_borrow = availability.get("available_to_borrow") or availability.get("available_to_browse")
   $if secondary_action and (availability.get('is_printdisabled') or availability.get('is_lendable')):
-    $:macros.BookPreview(ocaid)
-  $:macros.ReadButton(ocaid, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen)
+    $:macros.BookPreview(ocaid, analytics_attr)
+  $:macros.ReadButton(ocaid, analytics_attr, borrow=pd_eligible, printdisabled=not std_borrow, listen=listen)
 
 $elif availability.get('is_lendable'):
   $if secondary_action:
-    $:macros.BookPreview(ocaid)
+    $:macros.BookPreview(ocaid, analytics_attr)
   $if availability.get("available_to_borrow") or availability.get("available_to_browse"):
-    $:macros.ReadButton(ocaid, borrow=True, listen=listen)
+    $:macros.ReadButton(ocaid, analytics_attr, borrow=True, listen=listen)
   $elif availability.get('available_to_waitlist'):
     $if waiting_loan:
       $if secondary_action:
@@ -87,8 +87,13 @@ $elif availability.get('is_lendable'):
         </p>
       <form method="POST" action="$borrow_link" class="leave-waitlist waitinglist-form">
         <input type="hidden" name="action" value="leave-waitinglist"/>
-        <input type="submit" class="cta-btn" id="unwaitlist_ebook"
-               value="$_('Leave waiting list')"/>
+        <input
+          type="submit"
+          class="cta-btn"
+          id="unwaitlist_ebook"
+          value="$_('Leave waiting list')"
+          $:analytics_attr('LeaveWaitlist')
+        />
       </form>
     $else:
       $# "JOIN-WAITLIST" button
@@ -96,7 +101,13 @@ $elif availability.get('is_lendable'):
       <form method="POST" action="$borrow_link" class="join-waitlist waitinglist-form">
         <input type="hidden" name="action" value="join-waitinglist"/>
         <div class="cta-button-group">
-          <input type="submit" class="cta-btn cta-btn--unavailable" id="waitlist_ebook" value="$_('Join Waitlist')"/>
+          <input
+            type="submit"
+            class="cta-btn cta-btn--unavailable"
+            id="waitlist_ebook"
+            value="$_('Join Waitlist')"
+            $:analytics_attr('JoinWaitlist')
+          />
         </div>
       </form>
       $if secondary_action:
@@ -118,7 +129,7 @@ $elif availability.get('is_lendable'):
     </div>
 
 $elif ocaid and availability.get('is_previewable') and book_provider.short_name == 'ia':
-  $:macros.BookPreview(ocaid)
+  $:macros.BookPreview(ocaid, analytics_attr)
   $if secondary_action:
       $:macros.BookSearchInside(ocaid)
 
@@ -127,9 +138,9 @@ $else:
   $# secondary_action means we're on a book page and it's the button under the cover image.
   $ key = doc.key if is_edition else work_key
   $if (is_edition and is_book_page) or secondary_action:
-      $:macros.NotInLibrary(link=None, analytics_override=analytics_override)
+      $:macros.NotInLibrary(None, analytics_attr)
   $else:
-      $:macros.NotInLibrary(link=key, analytics_override=analytics_override)
+      $:macros.NotInLibrary(key, analytics_attr)
 
 $:post
 

--- a/openlibrary/macros/LoanStatus.html
+++ b/openlibrary/macros/LoanStatus.html
@@ -1,4 +1,4 @@
-$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False, check_loan_status=False, user_lists=None, post='', is_book_page=False)
+$def with (doc, work_key=None, listen=True, allow_expensive_availability_check=False, secondary_action=False, check_sponsorship=False, sponsorship_help=False, check_loan_status=False, user_lists=None, post='', is_book_page=False, analytics_override=None)
 $# Takes following parameters:
 $# * doc - Can be a Work, Edition, or solr dict.
 $# * listen - whether to display listen button
@@ -38,6 +38,12 @@ $ user_loan = doc.get('loan') or (check_loan_status and ocaid and ctx.user and c
 $ get_loan_for_total_time = time() - get_loan_for_start_time
 
 $ is_edition = doc.key.split('/')[1] == 'books'
+
+$def analytics_attr(action):
+  $if analytics_override:
+    data-ol-link-track="$analytics_override"
+  $else:
+    data-ol-link-track="CTAClick|$action"
 
 $if user_loan:
   $:macros.ReadButton(ocaid, loan=user_loan, listen=listen)
@@ -103,8 +109,12 @@ $elif availability.get('is_lendable'):
   $else:
     $# Checked out: Show checkout out + preview if secondary, else just preview
     <div class="cta-button-group">
-      <a href="$work_key" class="cta-btn cta-btn--missing" title="$_('This book is currently checked out, please check back later.')"
-       data-ol-link-track="CTAClick|CheckedOut">$_("Checked Out")</a>
+      <a
+        href="$work_key"
+        class="cta-btn cta-btn--missing"
+        title="$_('This book is currently checked out, please check back later.')"
+        $:analytics_attr('CheckedOut')
+      >$_("Checked Out")</a>
     </div>
 
 $elif ocaid and availability.get('is_previewable') and book_provider.short_name == 'ia':
@@ -117,9 +127,9 @@ $else:
   $# secondary_action means we're on a book page and it's the button under the cover image.
   $ key = doc.key if is_edition else work_key
   $if (is_edition and is_book_page) or secondary_action:
-      $:macros.NotInLibrary(link=None)
+      $:macros.NotInLibrary(link=None, analytics_override=analytics_override)
   $else:
-      $:macros.NotInLibrary(link=key)
+      $:macros.NotInLibrary(link=key, analytics_override=analytics_override)
 
 $:post
 

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,11 +1,11 @@
-$def with(link)
+$def with(link, analytics_override=None)
 
 $if link:
   <div class="cta-button-group">
     <a
       class="cta-btn"
       href="$link"
-      data-ol-link-track="CTAClick|NotInLibrary"
+      data-ol-link-track="$(analytics_override or 'CTAClick|NotInLibrary')"
     >$_('Not in Library')</a>
   </div>
 $else:

--- a/openlibrary/macros/NotInLibrary.html
+++ b/openlibrary/macros/NotInLibrary.html
@@ -1,11 +1,11 @@
-$def with(link, analytics_override=None)
+$def with(link, analytics_attr)
 
 $if link:
   <div class="cta-button-group">
     <a
       class="cta-btn"
       href="$link"
-      data-ol-link-track="$(analytics_override or 'CTAClick|NotInLibrary')"
+      $:analytics_attr('NotInLibrary')
     >$_('Not in Library')</a>
   </div>
 $else:

--- a/openlibrary/macros/QueryCarousel.html
+++ b/openlibrary/macros/QueryCarousel.html
@@ -9,9 +9,6 @@ $# * limit (int) -- initial number of books to pull
 $# * search (bool) -- whether to include search within collection
 $# * layout (str) -- layout type, default 'carousel', currently also supports 'grid'
 
-$# Set default for key
-$ key = key or str(abs(hash(query)))
-
 $# Enable search within this query
 $if search:
   <form action="/search" class="olform pagesearchbox">

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,4 +1,4 @@
-$def with(ocaid, borrow=False, listen=False, loan=None, label='', printdisabled=False)
+$def with(ocaid, borrow=False, listen=False, loan=None, label='', printdisabled=False, analytics_override=None)
 
 $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
@@ -6,30 +6,34 @@ $if printdisabled:
   $ action = "read"
   $ label = _("Special Access")
   $ title = _("Special ebook access from the Internet Archive for patrons with qualifying print disabilities")
+  $ analytics_action = "PrintDisabled"
 $elif (borrow and not loan):
   $ action = "borrow"
   $ label = label or _("Borrow")
   $ title = _("Borrow ebook from Internet Archive")
+  $ analytics_action = "Borrow"
 $else:
   $ action = "read"
   $ label = _("Read")
   $ title = _("Read ebook from Internet Archive")
+  $ analytics_action = "Read"
+
+$def analytics_attr(action):
+  $if analytics_override:
+    data-ol-link-track="$analytics_override"
+  $else:
+    data-ol-link-track="CTAClick|$action"
 
 <div class="cta-button-group">
   <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"
-     $if loan:
-       data-userid="$(loan['userid'])"
-     $elif printdisabled:
-       data-ol-link-track="CTAClick|PrintDisabled"
-     $elif borrow:
-       data-ol-link-track="CTAClick|Borrow"
-     $else:
-       data-ol-link-track="CTAClick|Read"
-    >$label</a>
+      $:analytics_attr(analytics_action)
+      $if loan:
+        data-userid="$(loan['userid'])"
+      >$label</a>
   $if listen:
     <a href="$(stream_url)&_autoReadAloud=show"
        title="$title using Read Aloud"
-       data-ol-link-track="CTAClick|$(action.capitalize())Listen"
+       $:analytics_attr(action.capitalize() + 'Listen')
        class="cta-btn cta-btn--available cta-btn--w-icon">
       <span class="btn-icon read-aloud"></span>
       <span class="btn-label">$_("Listen")</span>

--- a/openlibrary/macros/ReadButton.html
+++ b/openlibrary/macros/ReadButton.html
@@ -1,4 +1,4 @@
-$def with(ocaid, borrow=False, listen=False, loan=None, label='', printdisabled=False, analytics_override=None)
+$def with(ocaid, analytics_attr, borrow=False, listen=False, loan=None, label='', printdisabled=False)
 
 $ stream_url = "/borrow/ia/%s?ref=ol" % ocaid
 
@@ -17,12 +17,6 @@ $else:
   $ label = _("Read")
   $ title = _("Read ebook from Internet Archive")
   $ analytics_action = "Read"
-
-$def analytics_attr(action):
-  $if analytics_override:
-    data-ol-link-track="$analytics_override"
-  $else:
-    data-ol-link-track="CTAClick|$action"
 
 <div class="cta-button-group">
   <a href="$(stream_url)" title="$title" class="cta-btn cta-btn--ia cta-btn--available cta-btn--$(action)"

--- a/openlibrary/plugins/openlibrary/js/ol.analytics.js
+++ b/openlibrary/plugins/openlibrary/js/ol.analytics.js
@@ -16,7 +16,7 @@ export default function initAnalytics() {
                 kind: 'event',
                 ec: values['category'],
                 ea: values['action'],
-                el: location.pathname,
+                el: values['label'] || location.pathname,
                 ev: 1,
                 loadtime: (endTime.getTime() - startTime.getTime()),
                 cache_bust: Math.random()
@@ -37,7 +37,11 @@ export default function initAnalytics() {
             var category_action = $(this).attr('data-ol-link-track').split('|');
             // for testing,
             // console.log(category_action[0], category_action[1]);
-            window.archive_analytics.ol_send_event_ping({category: category_action[0], action: category_action[1]});
+            window.archive_analytics.ol_send_event_ping({
+                category: category_action[0],
+                action: category_action[1],
+                label: category_action[2],
+            });
         });
     }
     window.vs = vs;

--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -1,4 +1,4 @@
-$def with(gutenberg_id)
+$def with(gutenberg_id, analytics_attr)
 
 <div class="cta-button-group">
   <a
@@ -6,8 +6,9 @@ $def with(gutenberg_id)
       title="$_('Read eBook from Project Gutenberg')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--gutenberg"
       target="_blank"
-       aria-haspopup="true"
-       aria-controls="gutenberg-toast"
+      $:analytics_attr('Read')
+      aria-haspopup="true"
+      aria-controls="gutenberg-toast"
   >$_('Read')</a>
 </div>
 

--- a/openlibrary/templates/book_providers/librivox_read_button.html
+++ b/openlibrary/templates/book_providers/librivox_read_button.html
@@ -1,9 +1,9 @@
-$def with(librivox_id)
+$def with(librivox_id, analytics_attr)
 
 <div class="cta-button-group">
 <a href="https://librivox.org/$librivox_id"
    title="$_('Listen to a reading from LibriVox')"
-   data-ol-link-track="CTAClick|Listen"
+   $:analytics_attr('Listen')
    class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external cta-btn--librivox"
    target="_blank"
    aria-haspopup="true"

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -1,4 +1,4 @@
-$def with(openstax_id)
+$def with(openstax_id, analytics_attr)
 
 <div class="cta-button-group">
   <a
@@ -6,8 +6,9 @@ $def with(openstax_id)
       title="$_('Read eBook from OpenStax')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--openstax"
       target="_blank"
-       aria-haspopup="true"
-       aria-controls="openstax-toast"
+      $:analytics_attr('Read')
+      aria-haspopup="true"
+      aria-controls="openstax-toast"
   >$_('Read')</a>
 </div>
 

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -1,4 +1,4 @@
-$def with(standard_ebooks_id)
+$def with(standard_ebooks_id, analytics_attr)
 
 <div class="cta-button-group">
   <a
@@ -6,6 +6,7 @@ $def with(standard_ebooks_id)
       title="$_('Read eBook from Standard eBooks')"
       class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--standard-ebooks"
       target="_blank"
+      $:analytics_attr('Read')
       aria-haspopup="true"
       aria-controls="standard-ebooks-toast"
   >$_('Read')</a>

--- a/openlibrary/templates/books/custom_carousel.html
+++ b/openlibrary/templates/books/custom_carousel.html
@@ -57,7 +57,7 @@ $def render_carousel_cover(book, lazy, layout):
 
   <div class="book carousel__item">
     <div class="book-cover">
-      <a href="$(url)">
+      <a href="$(url)" data-ol-link-track="BookCarousel|CoverClick|$key">
         $if cover_url:
           <img class="bookcover" loading="lazy"
             title="$('%s%s'%(title,byline))"
@@ -76,7 +76,7 @@ $def render_carousel_cover(book, lazy, layout):
       </a>
     </div>
     <div class="book-cta">
-      $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action)
+      $:macros.LoanStatus(book, work_key=work_key, listen=False, secondary_action=secondary_action, analytics_override="BookCarousel|CTAClick|%s" % key)
     </div>
   </div>
 
@@ -84,12 +84,16 @@ $if test or (books and len(books) >= min_books):
     <div class="carousel-section">
       $if title and url:
         <div class="carousel-section-header">
-          <h2 class="home-h2"><a name="$key" href="$url">$title</a></h2>
+          <h2 class="home-h2">
+            <a data-ol-link-track="BookCarousel|HeaderClick|$key" href="$url">$title</a>
+          </h2>
         </div>
       <div class="carousel-container carousel-container-decorated">
         $code:
           config = {
             'booksPerBreakpoint': [4, 4, 4, 3, 2, 1] if compact_mode else [6, 5, 4, 3, 2, 1],
+            'analyticsCategory': 'BookCarousel',
+            'carouselKey': key,
             'loadMore': {
               "url": load_more["url"].replace("&amp;", "&"),
               "pageMode": load_more.get("mode", "offset"),
@@ -99,7 +103,7 @@ $if test or (books and len(books) >= min_books):
         $ compact = "carousel--compact" if compact_mode else ""
         $ grid = "carousel--grid" if layout == 'grid' else ""
         $ loadjs = "carousel--progressively-enhanced" if layout == 'carousel' else ""
-        <div class="carousel $grid $compact carousel-$key $loadjs"
+        <div class="carousel $grid $compact $loadjs"
           data-config="$json_encode(config)">
           $for index, book in enumerate(books or []):
               $:render_carousel_cover(book, index > 5, layout)

--- a/openlibrary/templates/home/categories.html
+++ b/openlibrary/templates/home/categories.html
@@ -8,7 +8,7 @@ $if subjects:
     </div>
     <div class="carousel-container">
       <div class="carousel carousel--progressively-enhanced"
-        data-config="$json_encode({'booksPerBreakpoint': [6, 5, 4, 3, 2, 2]})">
+        data-config="$json_encode({'carouselKey': 'categories', 'booksPerBreakpoint': [6, 5, 4, 3, 2, 2]})">
         $for subject in subjects:
           $ presentable_subject_name = subject['presentable_name']
           $ icon = subject['key'].split('/')[-1]

--- a/openlibrary/templates/home/index.html
+++ b/openlibrary/templates/home/index.html
@@ -20,7 +20,7 @@ $add_metatag(name="twitter:card", content="homepage_summary")
   $:render_template("home/welcome", test=test)
 
   $if not test:
-    $:render_template("books/custom_carousel", books=get_trending_books(books_only=True, since_days=0, since_hours=24, minimum=3, sort_by_count=False), title=_('Trending Books'), url="/trending/daily", test=test, load_more={"url": "/trending/hours.json?hours=24&minimum=3&sort_by_count=false", "mode": "page", "limit": 18})
+    $:render_template("books/custom_carousel", key="trending", books=get_trending_books(books_only=True, since_days=0, since_hours=24, minimum=3, sort_by_count=False), title=_('Trending Books'), url="/trending/daily", test=test, load_more={"url": "/trending/hours.json?hours=24&minimum=3&sort_by_count=false", "mode": "page", "limit": 18})
 
     $:macros.QueryCarousel(query="ddc:8* first_publish_year:[* TO 1950] publish_year:[2000 TO *] NOT public_scan_b:false", title=_('Classic Books'), key="public_domain", url="/read", sort='random.hourly')
 

--- a/openlibrary/templates/home/onboarding_card.html
+++ b/openlibrary/templates/home/onboarding_card.html
@@ -11,7 +11,7 @@ $# attribution    : str : Attribution for the image used in the card
 
 $ data_ol_link_track = ''
 $if ol_link_track:
-  $ data_ol_link_track = 'data-ol-link-track=%s' % ol_link_track
+  $ data_ol_link_track = 'data-ol-link-track="%s"' % ol_link_track
 
 <div class="carousel__item tutorial__item">
   <a

--- a/openlibrary/templates/home/welcome.html
+++ b/openlibrary/templates/home/welcome.html
@@ -8,7 +8,7 @@ $def with (test=False)
   <div class="carousel-container">
     <div
       class="carousel carousel--progressively-enhanced"
-      data-config="$json_encode({'booksPerBreakpoint': [3, 2, 2, 1, 1]})"
+      data-config="$json_encode({'carouselKey': 'welcome', 'booksPerBreakpoint': [3, 2, 2, 1, 1]})"
     >
       $ read_online_card = {
       $    "card_title": _("Read Free Library Books Online"),

--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -21,7 +21,7 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 </div>
 
 <div class="contentBody">
-  $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more={"url": page.key + ".json", "limit": len(page.works)})
+  $:render_template("books/custom_carousel", books=page.works, load_more={"url": page.key + ".json", "limit": len(page.works)})
 
 	<div class="head">
 	    <h2>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -50,7 +50,7 @@ $ has_tag = 'tag' in page
 
 <div class="contentBody">
 
-  $:render_template("books/custom_carousel", books=page.works, key="subjects", load_more={"url": page.key + ".json", "limit": len(page.works)})
+  $:render_template("books/custom_carousel", books=page.works, load_more={"url": page.key + ".json", "limit": len(page.works)})
 
   <div class="head">
     <h2 class="inline">


### PR DESCRIPTION
Closes #7301 . ~Depends on #8782 . Closes #8615 .~

Adds analytics events of the nature:

- `BookCarousel|CTAClick|thrillers`
- `BookCarousel|Next|related-subjects-carousel`
- `Carousel|Next|welcome`
- `Carousel|Next|categories`
- and so on.

### Technical
- Modifies the way we use `label`, which have in the past set to be the URL, to contain actual data. Not sure if this will have side-effects!
- We will no longer fire a eg `CTAClick|Borrow` event from the cta buttons in a carousel; it will now be eg `BookCarousel|CTAClick|thrillers`. I believe this is more useful than knowing what type of cta button was there.

### Testing
Open the networks panel, filter by `0.gif` while performing various carousel-y actions on carousel.

- ✅ Confirmed analytics events firing on ✅ cover click, ✅ cta click, ✅ next button click
- ✅ Confirmed still working after loading a JS-rendered slide for ✅ cover click, ✅ cta click
- Tested on pages:
    - ✅ Subjects page
    - Publishers page
    - Collection page
    - Homepage

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
