### PR TITLE
fix #8785

### DIFF
--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -197,30 +197,17 @@ class ia_importapi(importapi):
         """
         from_marc_record = False
 
-        # Case 1 - Is this a valid Archive.org item?
+        # Check 1 - Is this a valid Archive.org item?
         metadata = ia.get_metadata(identifier)
         if not metadata:
             raise BookImportError('invalid-ia-identifier', '%s not found' % identifier)
 
-        # Case 2 - Does the item have an openlibrary field specified?
-        # The scan operators search OL before loading the book and add the
-        # OL key if a match is found. We can trust them and attach the item
-        # to that edition.
-        edition_olid = metadata.get('openlibrary_edition') or metadata.get(
-            'openlibrary'
-        )
-        if metadata.get('mediatype') == 'texts' and edition_olid:
-            edition_data = cls.get_ia_record(metadata)
-            edition_data['openlibrary'] = edition_olid
-            edition_data = cls.populate_edition_data(edition_data, identifier)
-            return cls.load_book(edition_data)
-
-        # Case 3 - Can the item be loaded into Open Library?
+        # Check 2 - Can the item be loaded into Open Library?
         status = ia.get_item_status(identifier, metadata)
         if status != 'ok' and not force_import:
             raise BookImportError(status, 'Prohibited Item %s' % identifier)
 
-        # Case 4 - Does this item have a marc record?
+        # Check 3 - Does this item have a marc record?
         marc_record = get_marc_record_from_ia(
             identifier=identifier, ia_metadata=metadata
         )

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -200,12 +200,12 @@ class ia_importapi(importapi):
         # Check 1 - Is this a valid Archive.org item?
         metadata = ia.get_metadata(identifier)
         if not metadata:
-            raise BookImportError('invalid-ia-identifier', '%s not found' % identifier)
+            raise BookImportError('invalid-ia-identifier', f'{identifier} not found')
 
         # Check 2 - Can the item be loaded into Open Library?
         status = ia.get_item_status(identifier, metadata)
         if status != 'ok' and not force_import:
-            raise BookImportError(status, 'Prohibited Item %s' % identifier)
+            raise BookImportError(status, f'Prohibited Item {identifier}')
 
         # Check 3 - Does this item have a MARC record?
         marc_record = get_marc_record_from_ia(
@@ -222,7 +222,7 @@ class ia_importapi(importapi):
                 edition_data = read_edition(marc_record)
             except MarcException as e:
                 logger.error(
-                    'failed to read from MARC record %s: %s', identifier, str(e)
+                    f'failed to read from MARC record {identifier}: {str(e)}'
                 )
                 raise BookImportError('invalid-marc-record')
         else:
@@ -267,8 +267,8 @@ class ia_importapi(importapi):
                 rec = MarcBinary(data)
                 edition = read_edition(rec)
             except MarcException as e:
-                details = f"{identifier}: {e}"
-                logger.error("failed to read from bulk MARC record %s", details)
+                details = f'{identifier}: {e}'
+                logger.error(f'failed to read from bulk MARC record {details}')
                 return self.error('invalid-marc-record', details, **next_data)
 
             actual_length = int(rec.leader()[:MARC_LENGTH_POS])

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -207,7 +207,7 @@ class ia_importapi(importapi):
         if status != 'ok' and not force_import:
             raise BookImportError(status, 'Prohibited Item %s' % identifier)
 
-        # Check 3 - Does this item have a marc record?
+        # Check 3 - Does this item have a MARC record?
         marc_record = get_marc_record_from_ia(
             identifier=identifier, ia_metadata=metadata
         )

--- a/openlibrary/plugins/importapi/code.py
+++ b/openlibrary/plugins/importapi/code.py
@@ -221,9 +221,7 @@ class ia_importapi(importapi):
             try:
                 edition_data = read_edition(marc_record)
             except MarcException as e:
-                logger.error(
-                    f'failed to read from MARC record {identifier}: {str(e)}'
-                )
+                logger.error(f'failed to read from MARC record {identifier}: {e}')
                 raise BookImportError('invalid-marc-record')
         else:
             try:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8785 

Previous behaviour was:

* If the archive.org item has an open library reference (`openlibrary`, or `openlibrary_edition`),
ignore the `require_marc` setting and any MARC record present and import the metadata from the archive.org item only.

This is the lesser quality import option, and is only used as a fallback in the normal case.

I don't see what the value of this "if we already know about it, use lesser quality metadata" case is.

This PR makes the /ia import consistent.

It's most likely that OL will already have the same MARC metadata (OL is probably where archive.org got its metadata from in the first place), but  re-importing the same MARC should not cause a double up, and it _will_ take advantage of any improvements to the import process, so it will be a proper re-import ***from the same source***.

This should fix #8785 where due to the different way archive.org combined fields into its `description`, OL was getting redundant fields.  Now the /ia import path will _always_ prefer the source MARC when it exists.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@seabelis 
@scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
