### PR TITLE
Fix action button label changing behavior in MergeUI

### DIFF
--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -27,6 +27,8 @@ import { do_merge, update_merge_request, createMergeRequest, DEFAULT_EDITION_LIM
 
 const DO_MERGE = 'Do Merge'
 const REQUEST_MERGE = 'Request Merge'
+const LOADING = 'Loading...'
+const SAVING = 'Saving...'
 
 export default {
     name: 'app',
@@ -51,7 +53,7 @@ export default {
     data() {
         return {
             url: new URL(location.toString()),
-            mergeStatus: 'Loading...',
+            mergeStatus: LOADING,
             mergeOutput: null,
             show_diffs: false,
             comment: ''
@@ -79,7 +81,7 @@ export default {
         this.$watch(
             '$refs.mergeTable.merge',
             (new_value) => {
-                if (new_value !== undefined && this.mergeStatus !== 'Done') this.mergeStatus = readyCta;
+                if (new_value !== undefined && this.mergeStatus === LOADING) this.mergeStatus = readyCta;
             }
         );
     },
@@ -88,7 +90,7 @@ export default {
             if (!this.$refs.mergeTable.merge) return;
             const { record: master, dupes, editions_to_move, unmergeable_works } = this.$refs.mergeTable.merge;
 
-            this.mergeStatus = 'Saving...';
+            this.mergeStatus = SAVING;
             if (this.isSuperLibrarian) {
                 // Perform the merge and create new/update existing merge request
                 try {

--- a/openlibrary/components/MergeUI.vue
+++ b/openlibrary/components/MergeUI.vue
@@ -78,8 +78,8 @@ export default {
         const readyCta = this.isSuperLibrarian ? DO_MERGE : REQUEST_MERGE
         this.$watch(
             '$refs.mergeTable.merge',
-            (new_value, old_value) => {
-                if (new_value && new_value !== old_value) this.mergeStatus = readyCta;
+            (new_value) => {
+                if (new_value !== undefined && this.mergeStatus !== 'Done') this.mergeStatus = readyCta;
             }
         );
     },


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8655

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The MergeUI action button would confusingly change back to "Merge" from "Saving..." or "Done" in the midst of a merge. This PR fixes that behavior.

### Technical
The MergeUI interface is designed to change the action button to "Merge" (or "Request Merge") button as soon as enough data has loaded for the merge to complete successfully. This means that when the server is slow, the Merge button will be available before covers, list counts, reading log counts, etc. have loaded. That's the expected behavior.

A previous PR had added a watch function that set the button to "Merge" whenever the internal merge() function returned changed data. The merge() function returns values as soon as a merge is possible, but the returned values change as additional data comes in, so if the user pressed the "Merge" button before e.g. list counts had loaded, and the list counts loaded before the merge was complete, the button would switch from "Saving..." back to "Merge" briefly and then to "Done". 

If some of the nonessential data loaded after the merge was complete, the same check would change the button from "Done" back to "Merge".

This PR modifies the behavior of that watch function so that it only changes the button to "Merge" once — when the merge() function first returns data.

### Testing
This one is very tricky to test. I had to set up a network debugging tool that would delay lists.api requests by several seconds so that I could reproduce the problem consistently. I solemnly swear that it's fully tested and working. :)

### Stakeholders
@mheiman @jimchamp @cdrini @tfmorris @Eds-Dbug 
