### PR TITLE
update to python:3.11.7-slim

### DIFF
--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,4 +1,4 @@
-FROM python:3.11.1-slim
+FROM python:3.11.7-slim
 
 ENV LANG en_US.UTF-8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [project]
 name = "openlibrary"
 version = "1.0.0"
-requires-python = ">=3.11.1,<3.11.2"
+requires-python = ">=3.11.7,<3.11.8"
 
 [tool.black]
 skip-string-normalization = true

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     from openlibrary.data import dump
     from openlibrary.utils.sentry import Sentry
 
-    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.11.1
+    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.11.7
 
     ol_config = os.getenv("OL_CONFIG")
     if ol_config:


### PR DESCRIPTION
Can we please update to 3.11.7?

Why?
[Version 7.83](https://curl.se/changes.html#7_83_0), has a --no-clobber option that I'd like to use inside the docker image. For https://github.com/internetarchive/openlibrary/pull/8395/

python:3.11.1-slim has curl 7.74.0 

python:3.11.7-slim has curl 7.88.1

cc: @cdrini 

# Testing

I'm not quite sure how to test but since it is a minor version bump I think the CI and a small push to staging should be good.