### PR TITLE
Edit button should be rel=nofollow

### DIFF
--- a/openlibrary/macros/databarHistory.html
+++ b/openlibrary/macros/databarHistory.html
@@ -19,7 +19,13 @@ $else:
     $if not page.is_fake_record():
         <div class="editButton">
             <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
-            <a class="linkButton larger" href="$edit_url" title="$_('Edit this template')"
-               data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
+            <a
+                class="linkButton larger"
+                href="$edit_url"
+                title="$_('Edit this template')"
+                data-ol-link-track="CTAClick|Edit"
+                accesskey="e"
+                rel="nofollow"
+            >$_("Edit")</a>
         </div>
 </div>

--- a/openlibrary/macros/databarTemplate.html
+++ b/openlibrary/macros/databarTemplate.html
@@ -5,7 +5,13 @@ $def with (page)
       <a class="linkButton larger" href="$changequery(m='history')" title="View this template's edit history" accesskey="h">$_("History")</a>
     </div>
     <div class="editButton">
-        <a class="linkButton larger" href="$changequery(m='edit')" title="Edit this template"
-           data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
+        <a
+          class="linkButton larger"
+          href="$changequery(m='edit')"
+          title="Edit this template"
+          data-ol-link-track="CTAClick|Edit"
+          accesskey="e"
+          rel="nofollow"
+        >$_("Edit")</a>
     </div>
 </div>

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -27,7 +27,13 @@ $else:
     $if edit and not page.is_fake_record():
         <div class="editButton">
           <!-- FIXME: accesskey / keyboard shortcut needs i18n -->
-          <a class="cta-btn cta-btn--vanilla" href="$edit_url" title="$_('Edit this template')"
-             data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
+          <a
+            class="cta-btn cta-btn--vanilla"
+            href="$edit_url"
+            title="$_('Edit this template')"
+            data-ol-link-track="CTAClick|Edit"
+            accesskey="e"
+            rel="nofollow"
+        >$_("Edit")</a>
         </div>
 </div>

--- a/openlibrary/macros/databarWork.html
+++ b/openlibrary/macros/databarWork.html
@@ -1,12 +1,5 @@
 $def with (page, worldcat_links, affiliate_links, editions_page=False, render_times={})
 
-$if page.type.key == '/type/work' and page.edition_count == 1:
-    $ edit_url = page.editions[0].key + '?m=edit'
-$elif page.type.key in ["/type/work", "/type/edition", "/type/author"]:
-    $ edit_url = page.url(suffix="/edit")
-$else:
-    $ edit_url = page.key + "?m=edit"
-
 $ viewbook = "//%s/stream/XXX?ref=ol" % bookreader_host()
 
 <div class="Tools">

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -17,8 +17,14 @@ $ has_tag = 'tag' in page
     $if can_add_tag:
       <div class="subjectTagEdit">
         $ edit_tag_url = page.tag.get('id') + '/edit' if 'tag' in page else '/tag/add'
-        <a class="editTagButton" href="$edit_tag_url" title="$_('Edit Subject Tag')"
-            data-ol-link-track="CTAClick|Edit" accesskey="e">$_("Edit")</a>
+        <a
+          class="editTagButton"
+          href="$edit_tag_url"
+          title="$_('Edit Subject Tag')"
+          data-ol-link-track="CTAClick|Edit"
+          accesskey="e"
+          rel="nofollow"
+        >$_("Edit")</a>
       </div>
     <h1 class="inline">
         $page.name

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -3,7 +3,12 @@ $def with (book_title, edit_url)
 <div class="compact-title hidden">
   <span class="compact-title__heading">$book_title</span>
   <div class="compact-title__edit-btn">
-    <a class="linkButton linkButton--large" href="$edit_url" title="$_('Edit this template')"
-      data-ol-link-track="CTAClick|StickyEdit">$_("Edit")</a>
+    <a
+      class="linkButton linkButton--large"
+      href="$edit_url"
+      title="$_('Edit this template')"
+      data-ol-link-track="CTAClick|StickyEdit"
+      rel="nofollow"
+    >$_("Edit")</a>
   </div>
 </div>


### PR DESCRIPTION
These pages should not be crawled by search engines. ~4.3k appear in the "Soft 404" error section of Google Search Console.

https://search.google.com/u/1/search-console/index/drilldown?resource_id=sc-domain%3Aarchive.org&item_key=CAMYDiAC


### Technical
<!-- What should be noted about the implementation? -->

### Testing
Should have no effect on behaviour

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
