### PR TITLE
Monitor HTTP status and top IPs of nginx servers

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -84,6 +84,7 @@ services:
     environment:
       - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs /etc/cron.d/certbot
       - NGINX_DOMAIN=covers.openlibrary.org
+      - NGINX_STATS_BUCKET=stats.ol-covers
     restart: unless-stopped
     hostname: "$HOSTNAME"
     depends_on:
@@ -175,6 +176,7 @@ services:
     environment:
       - CRONTAB_FILES=/etc/cron.d/archive-webserver-logs /etc/cron.d/pull-sitemaps-from-ol-home0 /etc/cron.d/certbot
       - NGINX_DOMAIN=openlibrary.org www.openlibrary.org
+      - NGINX_STATS_BUCKET=stats.ol
     volumes:
       # letsencrypt
       - letsencrypt-data:/etc/letsencrypt
@@ -212,6 +214,8 @@ services:
     image: "${OLIMAGE:-openlibrary/olbase:latest}"
     user: root
     command: docker/ol-nginx-start.sh
+    environment:
+      - NGINX_STATS_BUCKET=stats.ol-infobase
     restart: unless-stopped
     depends_on:
       - infobase

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -46,7 +46,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends nginx curl lets
     # log rotation service for ol-nginx
     logrotate \
     # rsync service for pulling monthly sitemaps from ol-home0 to ol-www0
-    rsync
+    rsync \
+    # Needed for monitoring scripts that send data to graphite
+    netcat
 COPY scripts/install_openresty.sh ./
 RUN ./install_openresty.sh && rm ./install_openresty.sh
 RUN rm /usr/sbin/nginx

--- a/docker/ol-nginx-start.sh
+++ b/docker/ol-nginx-start.sh
@@ -14,6 +14,11 @@ if [ "$RUN_CERTBOT" -eq 1 ]; then
   certbot certonly --webroot --webroot-path /openlibrary/static $CERTBOT_OPTIONS
 fi
 
+if [ -n "$NGINX_STATS_BUCKET" ]; then
+  watch -n 60 /openlibrary/scripts/nginx_http_status.sh "${NGINX_STATS_BUCKET}.http_status" &
+  watch -n 60 /openlibrary/scripts/nginx_top_ips.sh "${NGINX_STATS_BUCKET}.top_ips" &
+fi
+
 # Run crontab if there are files
 if [ -n "$CRONTAB_FILES" ] ; then
   cat $CRONTAB_FILES | crontab -

--- a/scripts/nginx_http_status.sh
+++ b/scripts/nginx_http_status.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Parses the last X lines of the nginx access log and logs the counts of
+# each HTTP status code to statsd
+
+STATSD_BUCKET=$1
+# Get top IP counts in the last 17500 requests
+# (As of 2024-01-08, that's about how many requests we have a minute)
+HTTP_STATUS_COUNTS=$(
+    tail -n 17500 /var/log/nginx/access.log | \
+    grep -oE '" [0-9]{3} ' | \
+    sort | uniq -c | sort -rn
+)
+# Output like this:
+#   60319 " 200
+#   55926 " 302
+#    9267 " 404
+#    8957 " 403
+#    7297 " 499
+#    7075 " 500
+#     640 " 429
+#     338 " 303
+#     100 " 304
+#      81 " 400
+
+# Iterate over, and log in grafana to bucket; eg `stats.ol-covers.http_status.http_{NUM}`
+while IFS= read -r line; do
+    count=$(echo $line | awk '{print $1}')
+    status=$(echo $line | awk '{print $3}')
+    graphite_event="$STATSD_BUCKET.http_$status $count $(date +%s)"
+    echo $graphite_event
+    echo $graphite_event | nc -q0 graphite.us.archive.org 2003
+done <<< "$HTTP_STATUS_COUNTS"

--- a/scripts/nginx_top_ips.sh
+++ b/scripts/nginx_top_ips.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Parses the last X lines of the nginx access log and logs the counts of
+# the top 25 IP addresses to statsd
+
+STATSD_BUCKET=$1
+# Get top IP counts in the last 17500 requests
+# (As of 2024-01-08, that's about how many requests we have a minute)
+TOP_IP_COUNTS=$(
+    tail -n 17500 /var/log/nginx/access.log | \
+    grep -oE '^[^ ]+' | \
+    sort | uniq -c | sort -rn | \
+    head -n 25 | \
+    awk '{print $1}'
+)
+# Output like this before the last awk:
+#  182089 0.125.240.191
+#  181874 0.36.168.144
+#  181779 0.198.202.145
+#  181093 0.233.200.251
+
+# Iterate over, and log in grafana to bucket `ol.stats.top_ip_1`, `ol.stats.top_ip_2`, etc.
+i=1
+for count in $TOP_IP_COUNTS; do
+    graphite_event="$STATSD_BUCKET.ip_$(printf "%02d" $i) $count $(date +%s)"
+    echo $graphite_event
+    echo $graphite_event | nc -q0 graphite.us.archive.org 2003
+    i=$((i+1))
+done


### PR DESCRIPTION
Feature. Cements the monitoring that has been running manually on our prod servers.

### Technical
* Special Deploy: Need to stop the existing scripts that are currently logging.

### Testing
- The scripts have been running in a tmux for a few weeks now
- I tested loading the http_status script on www nginx, and it worked like a charm!

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
