### PR TITLE
Limit cover image file type.

### DIFF
--- a/openlibrary/templates/covers/add.html
+++ b/openlibrary/templates/covers/add.html
@@ -54,7 +54,7 @@ $if status:
                     <label id="imageBrowse" for="coverFile">$_("Choose a JPG, GIF or PNG on your computer,")</label>
                 </div>
                 <div class="input">
-                    <input type="file" name="file" id="coverFile" value=""/>
+                    <input type="file" name="file" id="coverFile" value="" accept=".jpg, .jpeg, .gif, .png"/>
                 </div>
             </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8762.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature/refactor. Uses HTML `accept` attribute to specify acceptable cover image file types (jpg/png/gif) so that no other file types can be submitted.

### Technical
<!-- What should be noted about the implementation? -->
Super simple! Ended up just adding the single attribute to the HTML in `covers/add.html`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to a book page, select "Add Cover" or "Manage Covers"
2. Try to upload an incorrect file type (like a PDF) -- the file should be greyed out and not selectable.

### Screenshot
<img width="1002" alt="Image upload UI screenshot" src="https://github.com/internetarchive/openlibrary/assets/140550988/8cdb7e1f-e1c1-49bd-9d30-677c1c55a5ad">


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
