### PR TITLE
Improve Information Layout on Book Edit Page

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -89,6 +89,7 @@ $jsdef render_work_autocomplete_item(item):
                 <input type="text" name="edition--subtitle" id="edition-subtitle" value="$book.subtitle"/>
             </div>
         </div>
+    
         <fieldset class="major">
             <legend>$_("Publishing Info")</legend>
 
@@ -124,8 +125,6 @@ $jsdef render_work_autocomplete_item(item):
                 </div>
 
 
-
-
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-copyright_date">$_("What is the copyright date?")</label>
@@ -155,28 +154,142 @@ $jsdef render_work_autocomplete_item(item):
                         <input type="text" name="edition--series--0" id="edition-series" value="$(book.series and book.series[0] or '')"/>
                     </div>
                 </div>
+
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-description">$_("Description of this edition")</label>
+                        <span class="tip">$_("Only if it's different from the work's description")</span>
+                    </div>
+                    <div class="input">
+                        <textarea name="edition--description" id="edition-description" rows="3" cols="50">$book.description</textarea>
+                    </div>
+                </div>
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-toc">$_('Table of Contents')</label>
+                        <span class="tip">$:_('Use a "*" for an indent, a "|" to add a column, and line breaks for new lines. Like this:')</span><br/><br/>
+                <pre class="smaller gray"> * Part 1 | THIS WORLD | 1
+                ** Chapter 1 | Of the Nature of Flatland | 3
+                ** Chapter 2 | Of the Climate and Houses in Flatland | 5
+                * Part 2 | OTHER WORLDS | 42</pre>
+                <br/>
+                    </div>
+                    <div class="input">
+                        <textarea name="edition--table_of_contents" id="edition-toc" rows="5" cols="50">$book.get_toc_text()</textarea>
+                    </div>
+                </div>
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-notes">$_("Any notes about this specific edition?")</label>
+                    <span class="tip">$_("Anything about the book that may be of interest.") $_("For example:") <i>A Plume Book</i>.</span>
+                    </div>
+                    <div class="input">
+                        <textarea name="edition--notes" class="markdown" id="edition-notes" rows="3" cols="50">$book.notes</textarea>
+                    </div>
+                </div>
+        
+                <div class="formElement">
+                    <div class="label">
+                        <label for="edition-title_other">$_("Is it known by any other titles?")</label>
+                        <span class="tip">$_("Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here.")</span>
+                    </div>
+                    <div class="input">
+                        <input type="text" name="edition--other_titles--0" id="edition-title_other" value="$(book.other_titles and book.other_titles[0])"/>
+                        <div class="tip">$_("For example:") <i>Eaters of the Dead</i> $_("is an alternate title for") <i><a href="/books/OL24923038M">The 13th Warrior</a></i>.</div>
+                    </div>
+                    $if book.other_titles and len(book.other_titles) > 1:
+                        $for i, t in enumerate(book.other_titles):
+                            $if i > 0:
+                                <input type="hidden" name="edition--other_titles--$i" value="$book.other_titles[i]"/>
+                </div>
+        
+                <div class="formElement formBackLeft">
+                    <div class="label">
+                        <label for="edition--works--$0">$_("What work is this an edition of?")</label>
+                        <span class="tip">
+                            $_("Sometimes editions can be associated with the wrong work. You can correct that here.")
+                            $_("You can search by title or by Open Library ID (like")
+                            <a href="/works/OL262757W" target="_blank"><em>OL262757W</em></a>).
+                            <br/>
+                            $_("WARNING: Any edits made to the work from this page will be ignored.")
+                        </span>
+                    </div>
+                    $ config = {'addnew': is_privileged_user, 'new_name': _('-- Move to a new work')}
+                    <div class="multi-input-autocomplete--works" data-config="$dumps(config)">
+                        $if book.works:
+                            $for i, work in enumerate(book.works):
+                                $:render_work_field(i, work)
+                        $else:
+                            $:render_work_field(0, storage(title="", key=""))
+                    </div>
+                </div>        
         </fieldset>
 
+        <fieldset class="major">
+            <legend>$_("Languages")</legend>
+
+            <div class="formElement multi-input-autocomplete--language">
+                <div class="label">
+                    <label for="edition-language">$_("What language is this edition written in?")</label>
+                    <span class="tip"></span>
+                </div>
+                $if book.languages:
+                    $for i, lang in enumerate(book.languages):
+                        $:render_language_field(i, lang, get_language_name(lang))
+                $else:
+                    $:render_language_field(0, storage(name="", key=""), None)
+                <a href="javascript:;" class="mia__add small">$_('Add another language?')</a>
+            </div>
+
+            <div class="formElement" id="translated-from">
+                <div class="label">
+                    <label for="is-translation">$_("Is it a translation of another book?")</label>
+                    <span class="tip"></span>
+                </div>
+                $ translation = book.translation_of or book.translated_from
+                $ checked_yes = cond(translation, 'checked="checked"', '')
+                $ checked_no = cond(not translation, 'checked="checked"', '')
+                $if translation:
+                    $ style_hidden = ""
+                $else:
+                    $ style_hidden = "display: none;"
+
+                <div class="input">
+                    <br/>
+                    <input type="radio" name="edition--translation" id="is-translation" value="no" $checked_no  onclick="\$('.transYes').fadeOut();"/>
+                    <label for="is-translation">$_("No")</label>
+                </div>
+                <div class="input">
+                    <input type="radio" name="edition--translation" id="is-translation2" value="yes" $checked_yes onclick="\$('.transYes').fadeIn();"/>
+                    <label for="is-translation2">$_("Yes, it's a translation")</label>
+                </div>
+
+                <div class="transYes" style="$style_hidden">
+                    <div class="label">
+                        <span class="tip">$_("What's the original book?")</span>
+                    </div>
+                    <div class="input">
+                        <input name="edition--translation_of" type="text" id="translation-of" value="$book.translation_of"/>
+                    </div>
+                </div>
+
+                <div class="transYes multi-input-autocomplete--language" style="$style_hidden">
+                    <div class="label">
+                        <label for="edition-translated_from"><span class="tip">$_("What language was the original written in?")</span></label>
+                    </div>
+                    $if book.translated_from:
+                        $for i, lang in enumerate(book.translated_from):
+                            $:render_translated_from_language_field(i, lang, get_language_name(lang))
+                    $else:
+                        $:render_translated_from_language_field(0, storage(name="", key=""), None)
+                </div>
+            </div>
+        </fieldset>     
 
 
-
-
-    </div>
-
-    <div class="formBackRight">
-        <div class="illustration">
-            $:render_template("covers/book_cover", book)
-            $:render_template("covers/change", book)
-        </div>
-    </div>
-
-    <div class="clearfix"></div>
-
-
-
-        <div class="clearfix"></div>
-
-        <fieldset class="minor formBackLeft">
+        <fieldset class="major">
             <legend>$_("Contributors")</legend>
 
             <div class="formElement" id="roles" data-config="$dumps({'Please select a role.': _('Please select a role.'), 'You need to give this ROLE a name.': _('You need to give this ROLE a name.')})">
@@ -249,148 +362,110 @@ $jsdef render_work_autocomplete_item(item):
                 </div>
             </div>
         </fieldset>
+    </div>
 
-        <fieldset class="minor formBackRight">
-
-            <legend>$_('Languages')</legend>
-
-            <div class="formElement multi-input-autocomplete--language">
-                <div class="label">
-                    <label for="edition-language">$_("What language is this edition written in?")</label>
-                    <span class="tip"></span>
-                </div>
-                $if book.languages:
-                    $for i, lang in enumerate(book.languages):
-                        $:render_language_field(i, lang, get_language_name(lang))
-                $else:
-                    $:render_language_field(0, storage(name="", key=""), None)
-                <a href="javascript:;" class="mia__add small">$_('Add another language?')</a>
-            </div>
-
-            <div class="formElement" id="translated-from">
-                <div class="label">
-                    <label for="is-translation">$_("Is it a translation of another book?")</label>
-                    <span class="tip"></span>
-                </div>
-                $ translation = book.translation_of or book.translated_from
-                $ checked_yes = cond(translation, 'checked="checked"', '')
-                $ checked_no = cond(not translation, 'checked="checked"', '')
-                $if translation:
-                    $ style_hidden = ""
-                $else:
-                    $ style_hidden = "display: none;"
-
-                <div class="input">
-                    <br/>
-                    <input type="radio" name="edition--translation" id="is-translation" value="no" $checked_no  onclick="\$('.transYes').fadeOut();"/>
-                    <label for="is-translation">$_("No")</label>
-                </div>
-                <div class="input">
-                    <input type="radio" name="edition--translation" id="is-translation2" value="yes" $checked_yes onclick="\$('.transYes').fadeIn();"/>
-                    <label for="is-translation2">$_("Yes, it's a translation")</label>
-                </div>
-
-                <div class="transYes" style="$style_hidden">
-                    <div class="label">
-                        <span class="tip">$_("What's the original book?")</span>
-                    </div>
-                    <div class="input">
-                        <input name="edition--translation_of" type="text" id="translation-of" value="$book.translation_of"/>
-                    </div>
-                </div>
-
-                <div class="transYes multi-input-autocomplete--language" style="$style_hidden">
-                    <div class="label">
-                        <label for="edition-translated_from"><span class="tip">$_("What language was the original written in?")</span></label>
-                    </div>
-                    $if book.translated_from:
-                        $for i, lang in enumerate(book.translated_from):
-                            $:render_translated_from_language_field(i, lang, get_language_name(lang))
-                    $else:
-                        $:render_translated_from_language_field(0, storage(name="", key=""), None)
-                </div>
-
-            </div>
-
-
-        </fieldset>
-
-        <div class="clearfix"></div>
-
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-description">$_("Description of this edition")</label>
-                <span class="tip">$_("Only if it's different from the work's description")</span>
-            </div>
-            <div class="input">
-                <textarea name="edition--description" id="edition-description" rows="3" cols="50">$book.description</textarea>
-            </div>
+    <div class="formBackRight">
+        <div class="illustration">
+            $:render_template("covers/book_cover", book)
+            $:render_template("covers/change", book)
         </div>
+    </div>
 
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-toc">$_('Table of Contents')</label>
-                <span class="tip">$:_('Use a "*" for an indent, a "|" to add a column, and line breaks for new lines. Like this:')</span><br/><br/>
-        <pre class="smaller gray"> * Part 1 | THIS WORLD | 1
-        ** Chapter 1 | Of the Nature of Flatland | 3
-        ** Chapter 2 | Of the Climate and Houses in Flatland | 5
-        * Part 2 | OTHER WORLDS | 42</pre>
-        <br/>
-            </div>
-            <div class="input">
-                <textarea name="edition--table_of_contents" id="edition-toc" rows="5" cols="50">$book.get_toc_text()</textarea>
-            </div>
-        </div>
 
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-notes">$_("Any notes about this specific edition?")</label>
-            <span class="tip">$_("Anything about the book that may be of interest.") $_("For example:") <i>A Plume Book</i>.</span>
-            </div>
-            <div class="input">
-                <textarea name="edition--notes" class="markdown" id="edition-notes" rows="3" cols="50">$book.notes</textarea>
-            </div>
-        </div>
 
-        <div class="formElement">
-            <div class="label">
-                <label for="edition-title_other">$_("Is it known by any other titles?")</label>
-                <span class="tip">$_("Use this field if the title is different on the cover or spine. If the edition is a collection or anthology, you may also add the individual titles of each work here.")</span>
-            </div>
-            <div class="input">
-                <input type="text" name="edition--other_titles--0" id="edition-title_other" value="$(book.other_titles and book.other_titles[0])"/>
-                <div class="tip">$_("For example:") <i>Eaters of the Dead</i> $_("is an alternate title for") <i><a href="/books/OL24923038M">The 13th Warrior</a></i>.</div>
-            </div>
-            $if book.other_titles and len(book.other_titles) > 1:
-                $for i, t in enumerate(book.other_titles):
-                    $if i > 0:
-                        <input type="hidden" name="edition--other_titles--$i" value="$book.other_titles[i]"/>
-        </div>
-
-        <div class="formElement formBackLeft">
-            <div class="label">
-                <label for="edition--works--$0">$_("What work is this an edition of?")</label>
-                <span class="tip">
-                    $_("Sometimes editions can be associated with the wrong work. You can correct that here.")
-                    $_("You can search by title or by Open Library ID (like")
-                    <a href="/works/OL262757W" target="_blank"><em>OL262757W</em></a>).
-                    <br/>
-                    $_("WARNING: Any edits made to the work from this page will be ignored.")
-                </span>
-            </div>
-            $ config = {'addnew': is_privileged_user, 'new_name': _('-- Move to a new work')}
-            <div class="multi-input-autocomplete--works" data-config="$dumps(config)">
-                $if book.works:
-                    $for i, work in enumerate(book.works):
-                        $:render_work_field(i, work)
-                $else:
-                    $:render_work_field(0, storage(title="", key=""))
-            </div>
-        </div>
 
     </div>
 
 </fieldset>
+
+<fieldset class="major" style="padding:0;">
+    <legend>$_("The Physical Object")</legend>
+    <div class="formBack">
+
+        <fieldset class="minor formBackLeft">
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--physical_format">$_("What sort of book is it?")</label>
+                    <span class="tip">$_("Paperback; Hardcover, etc.")</span>
+                </div>
+                <div class="input">
+                    <input name="edition--physical_format" type="text" id="edition--physical_format" value="$book.physical_format"/>
+                </div>
+            </div>
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--number_of_pages">$_("How many pages?")</label>
+                    <span class="tip"></span>
+                </div>
+                <div class="input">
+                    <input name="edition--number_of_pages" type="number"
+                        step="1" id="edition--number_of_pages" value="$book.number_of_pages"/>
+                </div>
+            </div>
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--pagination">$_("Pagination?")</label>
+                    <span class="tip">$_("Note the highest number in each pagination pattern.") <a href="/help/faq/editing#physical-object" target="_blank">$_("Help")</a></span>
+                </div>
+                <div class="input">
+                    <input name="edition--pagination" type="text" id="edition--pagination" value="$book.pagination"/>
+                    <div class="tip">$_("For example:") <em>xii, 346p.</em></div>
+                </div>
+            </div>
+
+            <div class="formElement">
+                <div class="label">
+                    <label for="edition--weight--value">$_("How much does the book weigh?")</label>
+                    <span class="tip"></span>
+                </div>
+                <div class="input">
+                    $ weight = book.get_weight() or storage(value="", units="grams")
+                    <input name="edition--weight--value" type="number" step="any"
+                           id="edition--weight--value" size="6" value="$weight.value"/>
+                    <span class="tip">
+                        $:radiobuttons("edition--weight--units", ["grams", "kilos", "ounces", "pounds"], weight.units)
+                    </span>
+                </div>
+            </div>
+        </fieldset>
+
+            <fieldset class="minor formBackRight">
+                <legend>$_("Dimensions")</legend>
+                $ dimensions = book.get_physical_dimensions() or storage(height="", width="", depth="", units="inches")
+                  <span class="tip">
+                    $:radiobuttons("edition--physical_dimensions--units", ["centimeters", "inches"], dimensions.units)
+                  </span>
+
+                <div class="formElement">
+                    <div class="input">
+                        <table cellpadding="1">
+                        <tbody>
+                            <tr>
+                                <td rowspan="3"><img src="/images/dimensions.png" alt="dimensions" width="107" height="69" align="left"/></td>
+                                <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
+                                <td><input name="edition--physical_dimensions--height" type="number" step="any"
+                                           id="dimensions-height" size="6" value="$dimensions.height"/></td>
+                            </tr>
+                            <tr>
+                                <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
+                                <td><input name="edition--physical_dimensions--width" type="number" step="any"
+                                           id="dimensions-width" size="6" value="$dimensions.width"/></td>
+                            </tr>
+                            <tr>
+                                <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
+                                <td><input name="edition--physical_dimensions--depth" type="number" step="any"
+                                           id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
+                            </tr>
+                        </tbody>
+                        </table>
+                    </div>
+                </div>
+            </fieldset>
+    </div>
+
+</fieldset>
+
+
 $ config = ({
     $ 'Please select an identifier.': _('Please select an identifier.'),
     $ 'You need to give a value to ID.': _('You need to give a value to ID.'),
@@ -534,94 +609,6 @@ $ })
     </div>
 </fieldset>
 
-
-
-<fieldset class="major" style="padding:0;">
-    <legend>$_("The Physical Object")</legend>
-    <div class="formBack">
-
-        <fieldset class="minor formBackLeft">
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--physical_format">$_("What sort of book is it?")</label>
-                    <span class="tip">$_("Paperback; Hardcover, etc.")</span>
-                </div>
-                <div class="input">
-                    <input name="edition--physical_format" type="text" id="edition--physical_format" value="$book.physical_format"/>
-                </div>
-            </div>
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--number_of_pages">$_("How many pages?")</label>
-                    <span class="tip"></span>
-                </div>
-                <div class="input">
-                    <input name="edition--number_of_pages" type="number"
-                        step="1" id="edition--number_of_pages" value="$book.number_of_pages"/>
-                </div>
-            </div>
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--pagination">$_("Pagination?")</label>
-                    <span class="tip">$_("Note the highest number in each pagination pattern.") <a href="/help/faq/editing#physical-object" target="_blank">$_("Help")</a></span>
-                </div>
-                <div class="input">
-                    <input name="edition--pagination" type="text" id="edition--pagination" value="$book.pagination"/>
-                    <div class="tip">$_("For example:") <em>xii, 346p.</em></div>
-                </div>
-            </div>
-
-            <div class="formElement">
-                <div class="label">
-                    <label for="edition--weight--value">$_("How much does the book weigh?")</label>
-                    <span class="tip"></span>
-                </div>
-                <div class="input">
-                    $ weight = book.get_weight() or storage(value="", units="grams")
-                    <input name="edition--weight--value" type="number" step="any"
-                           id="edition--weight--value" size="6" value="$weight.value"/>
-                    <span class="tip">
-                        $:radiobuttons("edition--weight--units", ["grams", "kilos", "ounces", "pounds"], weight.units)
-                    </span>
-                </div>
-            </div>
-        </fieldset>
-
-            <fieldset class="minor formBackRight">
-                <legend>$_("Dimensions")</legend>
-                $ dimensions = book.get_physical_dimensions() or storage(height="", width="", depth="", units="inches")
-                  <span class="tip">
-                    $:radiobuttons("edition--physical_dimensions--units", ["centimeters", "inches"], dimensions.units)
-                  </span>
-
-                <div class="formElement">
-                    <div class="input">
-                        <table cellpadding="1">
-                        <tbody>
-                            <tr>
-                                <td rowspan="3"><img src="/images/dimensions.png" alt="dimensions" width="107" height="69" align="left"/></td>
-                                <td><span class="tip"><label for="dimensions-height">$_("Height:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--height" type="number" step="any"
-                                           id="dimensions-height" size="6" value="$dimensions.height"/></td>
-                            </tr>
-                            <tr>
-                                <td><span class="tip"><label for="dimensions-width">$_("Width:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--width" type="number" step="any"
-                                           id="dimensions-width" size="6" value="$dimensions.width"/></td>
-                            </tr>
-                            <tr>
-                                <td><span class="tip"><label for="dimensions-depth">$_("Depth:")</label> </span></td>
-                                <td><input name="edition--physical_dimensions--depth" type="number" step="any"
-                                           id="dimensions-depth" size="6" value="$dimensions.depth"/></td>
-                            </tr>
-                        </tbody>
-                        </table>
-                    </div>
-                </div>
-            </fieldset>
-    </div>
-
-</fieldset>
 
 $code:
     def is_selected(actual, selected):

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -89,7 +89,7 @@ $jsdef render_work_autocomplete_item(item):
                 <input type="text" name="edition--subtitle" id="edition-subtitle" value="$book.subtitle"/>
             </div>
         </div>
-    
+
         <fieldset class="major">
             <legend>$_("Publishing Info")</legend>
 
@@ -164,7 +164,7 @@ $jsdef render_work_autocomplete_item(item):
                         <textarea name="edition--description" id="edition-description" rows="3" cols="50">$book.description</textarea>
                     </div>
                 </div>
-        
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-toc">$_('Table of Contents')</label>
@@ -179,7 +179,7 @@ $jsdef render_work_autocomplete_item(item):
                         <textarea name="edition--table_of_contents" id="edition-toc" rows="5" cols="50">$book.get_toc_text()</textarea>
                     </div>
                 </div>
-        
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-notes">$_("Any notes about this specific edition?")</label>
@@ -189,7 +189,7 @@ $jsdef render_work_autocomplete_item(item):
                         <textarea name="edition--notes" class="markdown" id="edition-notes" rows="3" cols="50">$book.notes</textarea>
                     </div>
                 </div>
-        
+
                 <div class="formElement">
                     <div class="label">
                         <label for="edition-title_other">$_("Is it known by any other titles?")</label>
@@ -204,7 +204,7 @@ $jsdef render_work_autocomplete_item(item):
                             $if i > 0:
                                 <input type="hidden" name="edition--other_titles--$i" value="$book.other_titles[i]"/>
                 </div>
-        
+
                 <div class="formElement formBackLeft">
                     <div class="label">
                         <label for="edition--works--$0">$_("What work is this an edition of?")</label>
@@ -224,7 +224,7 @@ $jsdef render_work_autocomplete_item(item):
                         $else:
                             $:render_work_field(0, storage(title="", key=""))
                     </div>
-                </div>        
+                </div>
         </fieldset>
 
         <fieldset class="major">
@@ -286,7 +286,7 @@ $jsdef render_work_autocomplete_item(item):
                         $:render_translated_from_language_field(0, storage(name="", key=""), None)
                 </div>
             </div>
-        </fieldset>     
+        </fieldset>
 
 
         <fieldset class="major">


### PR DESCRIPTION
This change will make the inforamtion on the edit page more readable and organized. This commit did several things. I changed Languages and Contributors fields to major fields so they are more readable. I removed several clearfix divs to make the page more cohesive. I reordered these two sections to be below some of the Publishing Info fields that they were previously interrupting. I moved the Physical Object section two sections higher. These changes addressed the issue in several ways. One complaint was that the page was too long. My changes to Contributors and Languages fixed this by taking them out-of-line. While this may have seemed like the right decision it actually made the web page longer and less readable when there was more than 1 or 2 items added in these fields. I also helped to make the page more cohesive my keeping the Publish Info fields in one consecutive seciton. Finally, a complaint was that the Physical Object section was too hard to reach so I moved it up higher. Going forward, it would be nice to figure out how to remove the awkward white space that is before both the Language and Contributions section, but I couldn't figure that out. Also, it would be nice to center the work picture so it looks more in place.

<!-- What issue does this PR close? -->
Closes #7314 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Just UI changes. No backend changes.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Validation tests were passed on local fork before PR.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
See attached screenshots 1-5 of the before state and the after state (my changes)
![Before 1](https://github.com/internetarchive/openlibrary/assets/116681221/ef077236-2055-4181-879a-32b2f2f59ccf)
![Before 2](https://github.com/internetarchive/openlibrary/assets/116681221/1284ac1f-5b75-40dc-bf32-ab79a21f5587)
![Before 3](https://github.com/internetarchive/openlibrary/assets/116681221/117085aa-59d7-4811-b4a9-294c25f5e827)
![Before 4](https://github.com/internetarchive/openlibrary/assets/116681221/922942ae-f9db-4a91-a7c2-5378d690b5f8)
![Before 5](https://github.com/internetarchive/openlibrary/assets/116681221/2f0c539c-3c89-4314-999f-0a7a6eb0d742)
![After 1](https://github.com/internetarchive/openlibrary/assets/116681221/6eb4ed82-14dd-44be-9a4c-2f7bcf91f0a6)
![After 2](https://github.com/internetarchive/openlibrary/assets/116681221/454c3af3-3c9a-45c2-86cb-82263c26113d)
![After 3](https://github.com/internetarchive/openlibrary/assets/116681221/60047ee5-313d-470e-b6ff-71a6955a1ed5)
![After 4](https://github.com/internetarchive/openlibrary/assets/116681221/f938d8bf-b65c-4da6-8ab9-e125c1287f1e)
![After 5](https://github.com/internetarchive/openlibrary/assets/116681221/9bced9af-f08b-4093-abc9-7223bb88efa1)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles @scottbarnes @onnotasler were crucial in helping me with this bug.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. --> Yes I affirm.
