### PR TITLE
Refactor manage-imports to use advancedsearch endpoint

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -136,8 +136,6 @@ services:
     networks:
       - webnet
       - dbnet
-    secrets:
-      - ia_db_pw_file
 
   infobase:
     profiles: ["ol-home0"]
@@ -301,12 +299,6 @@ services:
     networks:
       - webnet
       - dbnet
-
-# secrets mounted to /run/secrets/
-# e.g. /run/secrets/ia_db_pw_file
-secrets:
-    ia_db_pw_file:
-      file: /opt/.petabox/dbserver
 
 volumes:
     archive-webserver-logs-data:

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -1,8 +1,10 @@
 """Library for interacting with archive.org.
 """
 
+import datetime
 import logging
 import os
+from urllib.parse import urlencode
 import requests
 import web
 
@@ -10,7 +12,6 @@ from infogami import config
 from infogami.utils import stats
 
 from openlibrary.core import cache
-from openlibrary.utils.dateutil import date_n_days_ago
 
 logger = logging.getLogger('openlibrary.ia')
 
@@ -305,91 +306,64 @@ def get_ia_db(configfile=None):
     return _ia_db
 
 
-def get_candidate_ocaids(
-    since_days=None,
-    since_date=None,
-    scanned_within_days=60,
-    repub_states=None,
-    marcs=True,
-    custom=None,
-    lazy=False,
-    count=False,
-    db=None,
-):
-    """Returns a list of identifiers which match the specified criteria
-    and are candidates for ImportBot.
-
-    If since_days and since_date are None, no date restrictions are
-    applied besides `scanned_within_days` (which may also be None)
-
-    Args:
-        since_days (int) - number of days to look back for item updates
-        since_date (Datetime) - only completed after since_date
-                                (default: if None, since_days used)
-        scanned_within_days (int) - only consider items `scanned_within_days`
-                                    of `since_date` (default 60 days; 2 months)
-        marcs (bool) - require MARCs present?
-        lazy (bool) - if True, returns query as iterator, otherwise,
-                      returns identifiers list
-        count (bool) - if count, return (long) number of matching identifiers
-        db (web.db) - A web.py database object with an active
-                      connection (optional)
-
-    Usage:
-        >>> from openlibrary.core.ia import get_ia_db, get_candidate_ocaids
-        >>> candidates = get_candidate_ocaids(
-        ...    since_days=1, db=get_ia_db('openlibrary/config/openlibrary.yml'))
-
-    Returns:
-        A list of identifiers which are candidates for ImportBot, or
-        (if count=True) the number of candidates which would be returned.
-
-    """
-    db = db or get_ia_db()
-    date = since_date or date_n_days_ago(n=since_days)
-    min_scandate = date_n_days_ago(start=date, n=scanned_within_days)
-    repub_states = repub_states or VALID_READY_REPUB_STATES
-
-    qvars = {
-        'c1': '%opensource%',
-        'c2': '%additional_collections%',
-        'c3': '%litigationworks%',
+def get_candidates_url(
+    day: datetime.date,
+    marcs: bool = True,
+) -> str:
+    DAY = datetime.timedelta(days=1)
+    params = {
+        'q': ' AND '.join(
+            [
+                'mediatype:texts',
+                '(%s)'
+                % ' OR '.join(
+                    f'repub_state:{state}' for state in VALID_READY_REPUB_STATES
+                ),
+                'scanningcenter:*',
+                'scanner:*',
+                'scandate:*',
+                '!collection:opensource',
+                '!collection:additional_collections',
+                '!collection:litigationworks',
+                '!noindex:true',
+                '!is_dark:true',
+                'format:pdf',
+                f'indexdate:{day}*',
+                # Fetch back to items added before the day of interest, since items
+                # sometimes take a few days to process into the collection.
+                f'addeddate:[{day - 60 * DAY} TO {day + 1 * DAY}]',
+                # TODO: This seems to be getting more records than expected
+                *(['format:marc'] if marcs else []),
+            ]
+        ),
+        'fl': 'identifier,format',
+        'service': 'metadata__unlimited',
+        'rows': '100000',  # This is the max, I believe
+        'output': 'json',
     }
 
-    _valid_repub_states_sql = "(%s)" % (', '.join(str(i) for i in repub_states))
-    q = (
-        "SELECT "
-        + ("count(identifier)" if count else "identifier")
-        + " FROM metadata"
-        + " WHERE repub_state IN "
-        + _valid_repub_states_sql
-        + "   AND mediatype='texts'"
-        + "   AND (noindex IS NULL)"
-        + "   AND scancenter IS NOT NULL"
-        + "   AND scanner IS NOT NULL"
-        + "   AND collection NOT LIKE $c1"
-        + "   AND collection NOT LIKE $c2"
-        + "   AND collection NOT LIKE $c3"
-        + "   AND (curatestate IS NULL OR curatestate NOT IN ('freeze', 'dark'))"
-        + "   AND scandate is NOT NULL"
-        + "   AND lower(format) LIKE '%%pdf%%'"
-    )
+    return f'{IA_BASE_URL}/advancedsearch.php?' + urlencode(params)
 
-    if custom:
-        q += custom
 
-    if marcs:
-        q += " AND (lower(format) LIKE '%%marc;%%' OR lower(format) LIKE '%%marc')"
+def get_candidate_ocaids(
+    day: datetime.date,
+    marcs: bool = True,
+):
+    """
+    Returns a list of identifiers that were finalized on the provided
+    day, which may need to be imported into Open Library.
 
-    if min_scandate:
-        qvars['min_scandate'] = min_scandate.strftime("%Y%m%d")
-        q += " AND scandate > $min_scandate"
+    :param day: only find items modified on this given day
+    :param marcs: require MARCs present?
+    """
+    url = get_candidates_url(day, marcs=marcs)
+    results = requests.get(url).json()['response']['docs']
+    assert len(results) < 100_000, f'100,000 results returned for {day}'
 
-    if date:
-        qvars['date'] = date.isoformat()
-        q += " AND updated > $date AND updated < ($date::date + INTERVAL '1' DAY)"
-
-    results = db.query(q, vars=qvars)
-    if count:
-        return results if lazy else results.list()[0].count
-    return results if lazy else [row.identifier for row in results]
+    for row in results:
+        if marcs:
+            # Exclude MARC Source since this doesn't contain the actual MARC data
+            formats = {fmt.lower() for fmt in row.get('format', [])}
+            if not formats & {'marc', 'marc binary'}:
+                continue
+        yield row['identifier']

--- a/openlibrary/core/ia.py
+++ b/openlibrary/core/ia.py
@@ -3,7 +3,6 @@
 
 import datetime
 import logging
-import os
 from urllib.parse import urlencode
 import requests
 import web
@@ -277,33 +276,6 @@ class ItemEdition(dict):
             self["isbn_10"] = isbn_10
         if isbn_13:
             self["isbn_13"] = isbn_13
-
-
-_ia_db = None
-
-
-def get_ia_db(configfile=None):
-    """Metadata API is slow.
-
-    Talk to archive.org database directly if it is specified in the
-    global configuration or if a configfile is provided.
-    """
-    if configfile:
-        from openlibrary.config import load_config
-
-        load_config(configfile)
-
-    if not config.get("ia_db"):
-        return None
-    global _ia_db
-    if not _ia_db:
-        settings = config.ia_db
-        host = settings['host']
-        db = settings['db']
-        user = settings['user']
-        pw = os.popen(settings['pw_file']).read().strip()
-        _ia_db = web.database(dbn="postgres", host=host, db=db, user=user, pw=pw)
-    return _ia_db
 
 
 def get_candidates_url(

--- a/scripts/manage-imports.py
+++ b/scripts/manage-imports.py
@@ -122,7 +122,7 @@ def add_new_scans(args):
         # yesterday
         date = datetime.date.today() - datetime.timedelta(days=1)
 
-    items = get_candidate_ocaids(since_date=date)
+    items = list(get_candidate_ocaids(date))
     batch_name = f"new-scans-{date.year:04}{date.month:02}"
     batch = Batch.find(batch_name) or Batch.new(batch_name)
     batch.add_items(items)
@@ -176,24 +176,6 @@ def import_all(args, **kwargs):
             logger.info("starmap END")
 
 
-def retroactive_import(start=None, stop=None, servername=None):
-    """Retroactively searches and imports all previously missed books
-    (through all time) in the Archive.org database which were
-    created after scribe3 was released (when we switched repub states
-    from 4 to [19, 20, 22]).
-    """
-    scribe3_repub_states = [19, 20, 22]
-    items = get_candidate_ocaids(
-        scanned_within_days=None, repub_states=scribe3_repub_states
-    )[start:stop]
-    date = datetime.date.today()
-    batch_name = f"new-scans-{date.year:04}{date.month:02}"
-    batch = Batch.find(batch_name) or Batch.new(batch_name)
-    batch.add_items(items)
-    for item in batch.get_items():
-        do_import(item, servername=servername)
-
-
 def main():
     if "--config" in sys.argv:
         index = sys.argv.index("--config")
@@ -227,13 +209,6 @@ def main():
         else:
             args.append(i)
 
-    if cmd == "import-retro":
-        start, stop = (
-            (int(a) for a in args) if (args and len(args) == 2) else (None, None)
-        )
-        return retroactive_import(
-            start=start, stop=stop, servername=flags['servername']
-        )
     if cmd == "import-ocaids":
         return import_ocaids(*args, **flags)
     if cmd == "add-items":


### PR DESCRIPTION
Refactor. Switches to the archive.org search endpoint for better dev ex and simplicity.

- olsystem side: https://github.com/internetarchive/olsystem/pull/202

### Technical
- The original code is a bit confusing and littered with variables that do something else than what they say, or which aren't really used. The new code does what the old code did, even if the names now seem like they do something else (eg `since_date` is now just `day`, because the old code wasn't _Actually_ finding all items since that date, it was just finding items from that specific day! See the + 1 day interval chunk).
- I tested the query on past days, and it was usually spot on the exact same results as the previous db query, or more results were returned through the advanced search call. But these would be filtered out further down if they were already enqueued.
- Note I had to filter for `marc` after-the-fact, because in elastic search, `format:"MARC Source"` was interferring and not letting me search for just `format:/^MARC$/` or `format:"MARC Binary"`.

### Testing
- I tested by creating a helper to compare the two items.

```py
def add_new_scans_test(args):
    """Adds new scans from yesterday."""
    if args:
        datestr = args[0]
        yyyy, mm, dd = datestr.split("-")
        date = datetime.date(int(yyyy), int(mm), int(dd))
    else:
        # yesterday
        date = datetime.date.today() - datetime.timedelta(days=1)

    items_db = set(get_candidate_ocaids(since_date=date))
    items_es = set(get_candidate_ocaids2(date))
    print(f"DB: {len(items_db)}")
    print(f"ES: {len(items_es)}")
    print("MISSING:")
    missing = sorted(list(items_db - items_es))
    for identifier in missing:
        print(identifier)

    print("ADDED:")
    added = sorted(list(items_es - items_db))
    for identifier in added:
        print(identifier)
```

Where `get_candidate_ocaids2` is the new implementation that's defined in this PR.
And then I went back through the days. Here are some sample results:

```bash
$ su openlibrary -c "python /openlibrary/scripts/manage-imports.py --config /olsystem/etc/openlibrary.yml add-new-scans-test 2024-02-06"
[...]
DB: 5159
ES: 5191
MISSING:
ADDED:
abrahamdevriendg00ridd
attitudestowardo00flem
beliefsthatmatte00brow
biblehistorygene00blac
bookoftwelveprop01smit_2
childcenteredsch00rugg_0
[...]

$ su openlibrary -c "python /openlibrary/scripts/manage-imports.py --config /olsystem/etc/openlibrary.yml add-new-scans-test 2024-02-05"
[...]
DB: 19
ES: 19
MISSING:
ADDED:

$ su openlibrary -c "python /openlibrary/scripts/manage-imports.py --config /olsystem/etc/openlibrary.yml add-new-scans-test 2024-02-04"
[...]
DB: 77
ES: 77
MISSING:
ADDED:

$ su openlibrary -c "python /openlibrary/scripts/manage-imports.py --config /olsystem/etc/openlibrary.yml add-new-scans-test 2024-02-03"
[...]
DB: 84
ES: 84
MISSING:
ADDED:

$ su openlibrary -c "python /openlibrary/scripts/manage-imports.py --config /olsystem/etc/openlibrary.yml add-new-scans-test 2024-02-02"
[...]
DB: 174
ES: 344
MISSING:
ADDED:
0D-DHP-485
1000000evroility0000stog
10000dnifilmowej0000hali
1000artistsbooks0000sala
1000carsofnycsol0000kore
1000fontsillustr0000davi
[...]

$ su openlibrary -c "python /openlibrary/scripts/manage-imports.py --config /olsystem/etc/openlibrary.yml add-new-scans-test 2024-02-01"
[...]
DB: 77
ES: 78
MISSING:
ADDED:
irregularspartis00blac_0
```


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
