### PR TITLE
Fixed Unable to render this page Error when empty spaces passed to search/authors and search/subjects 

### DIFF
--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -1,6 +1,8 @@
 $def with (get_results)
 
 $ q = query_param('q', '')
+$if q:
+    $ q = q.strip()
 $ results_per_page = 100
 $ page = query_param('page')
 $if page:
@@ -26,7 +28,7 @@ $ sort = query_param('sort', None)
 </div>
 
 <div id="contentMeta">
-    $ results = get_results(q='', offset=offset, limit=results_per_page, sort=sort)
+    $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
 
     $if q and results.error:
         <strong>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -26,7 +26,7 @@ $ sort = query_param('sort', None)
 </div>
 
 <div id="contentMeta">
-    $ results = get_results(q, offset=offset, limit=results_per_page, sort=sort)
+    $ results = get_results(q='', offset=offset, limit=results_per_page, sort=sort)
 
     $if q and results.error:
         <strong>

--- a/openlibrary/templates/search/authors.html
+++ b/openlibrary/templates/search/authors.html
@@ -1,8 +1,6 @@
 $def with (get_results)
 
-$ q = query_param('q', '')
-$if q:
-    $ q = q.strip()
+$ q = query_param('q', '').strip()
 $ results_per_page = 100
 $ page = query_param('page')
 $if page:

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -26,7 +26,7 @@ $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
     </div>
 
 $if q:
-    $ response = get_results(q, offset=offset, limit=results_per_page)
+    $ response = get_results(q='', offset=offset, limit=results_per_page)
     $if not response.error:
         <p class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', response.num_found, count=commify(response.num_found))</p>
 

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -1,8 +1,6 @@
 $def with (get_results)
 
-$ q = query_param('q')
-$if q:
-    $ q = q.strip()
+$ q = query_param('q', '').strip()
 $ results_per_page = 100
 $ page = query_param('page')
 $if page:

--- a/openlibrary/templates/search/subjects.html
+++ b/openlibrary/templates/search/subjects.html
@@ -1,6 +1,8 @@
 $def with (get_results)
 
 $ q = query_param('q')
+$if q:
+    $ q = q.strip()
 $ results_per_page = 100
 $ page = query_param('page')
 $if page:
@@ -26,7 +28,7 @@ $ url_map = { 'person': 'person:', 'place': 'place:', 'time': 'time:' }
     </div>
 
 $if q:
-    $ response = get_results(q='', offset=offset, limit=results_per_page)
+    $ response = get_results(q, offset=offset, limit=results_per_page)
     $if not response.error:
         <p class="search-results-stats">$ungettext('%(count)s hit', '%(count)s hits', response.num_found, count=commify(response.num_found))</p>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8803

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixed Unable to render this page Error when empty spaces passed to search/authors and search/subjects.

### Technical
<!-- What should be noted about the implementation? -->
It is a simple fix by passing the default argument ```q=''``` to``` get_results``` function in ```search/authors.html``` and ```search/subjects.html```.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="757" alt="image" src="https://github.com/internetarchive/openlibrary/assets/117273351/b44e4321-44ca-469d-9f33-1c267f257839">
<img width="743" alt="image" src="https://github.com/internetarchive/openlibrary/assets/117273351/9dfc1af4-cbff-494f-94b7-2f2cc4485b5b">




### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
