### PR TITLE
 remove second notes option

### DIFF
--- a/openlibrary/templates/books/mybooks_breadcrumb_select.html
+++ b/openlibrary/templates/books/mybooks_breadcrumb_select.html
@@ -14,7 +14,6 @@ $if mb.is_my_page:
   $ options += [
   $   (_("Loans"), "/account/loans"),
   $   (_("Notes"), url_prefix + "/books/notes"),
-  $   (_("Notes"), url_prefix + "/books/notes"),
   $   (_("Reviews"), url_prefix + "/books/observations"),
   $   (_("Imports and Exports"), "/account/import")
   $ ]


### PR DESCRIPTION
Closes #8800 

Removes extra notes option on the drop down menu on My Books page.

See issue #8800 for before image.

After fixing the duplication:

![370BF557-C7DE-405A-99F3-E5CB989D02C6](https://github.com/internetarchive/openlibrary/assets/92345662/6dbf153e-3545-4af5-b882-49e53a9f2c2f)

Testing the link:

<img width="502" alt="Screenshot 2024-02-08 at 1 36 03 PM" src="https://github.com/internetarchive/openlibrary/assets/92345662/d209a60c-66fe-45ed-82ac-9cb817b8c384">

@RayBB @scottbarnes 