### PR TITLE
made correction on reading logs page when no matches found

### DIFF
--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -71,7 +71,21 @@ $add_metatag(property="og:image", content=meta_photo_url)
       $:macros.Pager(int(current_page), doc_count, results_per_page=results_per_page)
   $else:
     <ul class="list-books">
-      $if checkin_year:
+      $if q:
+        <form method="GET" class="olform pagesearchbox">
+          <input type="text" minlength="3" placeholder="$_('Search your reading log')" name="q" value="$(query_param('q', ''))"/>
+          <input type="submit"/>
+        </form>
+        $ query = query_param('q') 
+        <center> 
+          <hr>
+          <div class="red">$_("No results found in %s" %key) </div> 
+          <hr> 
+          <div> 
+            <a href="/search/inside?$urlencode(dict(q=query))">$_('Search all of Open Library for "%s"?' % query)</a> 
+          </div> 
+        </center> 
+      $elif checkin_year:
         <p>$_("You haven't marked any books as read for this year.")</p>
       $else:
         <p>$_("You haven't added any books to this shelf yet.")</p>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8811

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Searches on the reading log with no matches incorrectly show the "No books on this shelf" screen, this PR fixes it by showing correct error messages and other changes mentioned in issue #8811.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->z
1. Go to one of your reading log shelves (eg https://openlibrary.org/people/ScarTissue/books/already-read )
2. Perform a search for something that won't match (eg "foo bar")
3. See the output and then check thr search facility by going to "Search all of Open Library for "{query}"?" button .

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2024-02-11 00-13-57](https://github.com/internetarchive/openlibrary/assets/59080746/9d4decb1-58fd-4e66-bd88-f76882d03e9b)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
