### PR TITLE
Lazy-load affiliate links

### DIFF
--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -12,9 +12,9 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         <span name="price">$price$price_note</span>
   </li>
 
-<span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)" data-async-load="$('true' if async_load else 'false')">
+<span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)">
   $if async_load:
-    $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading", render_hidden=False)
+    $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading")
   $else:
     $code:
       prices = opts.get('prices')

--- a/openlibrary/macros/AffiliateLinks.html
+++ b/openlibrary/macros/AffiliateLinks.html
@@ -1,46 +1,4 @@
-$def with (page, opts)
-
-$code:
-  prices = opts.get('prices')
-  isbn = opts.get('isbn', '')
-  asin = opts.get('asin', '')
-
-  bwb = {
-    'key': 'betterworldbooks',
-    'analytics_key': 'BetterWorldBooks',
-    'name': _('Better World Books'),
-    'link': 'https://www.betterworldbooks.com/%s' % (
-      ('product/detail/-%s' % isbn) if isbn else ('search/results?q=' + page.title.replace(' ','%20'))
-    ),
-    'price_note': _(' - includes shipping')
-  }
-
-  amazon = {
-    'key': 'amazon',
-    'analytics_key': 'Amazon',
-    'name': _('Amazon'),
-    'link': 'https://www.amazon.com/dp/%s/?tag=%s' % (asin or isbn, affiliate_id('amazon')),
-  } if (asin or isbn) else None
-
-  bookshop = {
-    'key': 'bookshop-org',
-    'analytics_key': 'BookshopOrg',
-    'name': _('Bookshop.org'),
-    'link': 'https://bookshop.org/a/%s/%s' % (affiliate_id('bookshop-org'), isbn),
-  } if isbn else None
-
-  # Fetch price data
-  if not is_bot() and prices and isbn:
-    bwb_metadata = get_betterworldbooks_metadata(isbn)
-    bwb['price'] = bwb_metadata and bwb_metadata.get('price')
-    if amazon:
-      amazon['price'] = bwb_metadata and bwb_metadata.get('market_price')
-    if amazon and not amazon['price']:
-      amz_metadata = get_amazon_metadata(isbn, resources='prices')
-      amazon['price'] = amz_metadata and amz_metadata.get('price')
-
-  primary_stores = [store for store in [bwb, amazon] if store]
-  more_stores = [store for store in [bookshop] if store]
+$def with (title, opts, async_load=False)
 
 $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
   <li class="prices-$key">
@@ -54,19 +12,65 @@ $def affiliate_link(key, analytics_key, name, link, price='', price_note=''):
         <span name="price">$price$price_note</span>
   </li>
 
-<ul class="buy-options-table">
-    $for store in primary_stores:
-      $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-    $if more_stores:
-      <li class="more">
-        <details>
-          <summary>$_('More')</summary>
-          <ul>
-            $for store in more_stores:
-              $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
-          </ul>
-        </details>
-      </li>
+<span class="affiliate-links-section" data-title="$title" data-opts="$json_encode(opts)" data-async-load="$('true' if async_load else 'false')">
+  $if async_load:
+    $:macros.LoadingIndicator(_("Fetching prices"), additional_classes="affiliate-links-loading", render_hidden=False)
+  $else:
+    $code:
+      prices = opts.get('prices')
+      isbn = opts.get('isbn', '')
+      asin = opts.get('asin', '')
 
-</ul>
-<p>When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.</p>
+      bwb = {
+        'key': 'betterworldbooks',
+        'analytics_key': 'BetterWorldBooks',
+        'name': _('Better World Books'),
+        'link': 'https://www.betterworldbooks.com/%s' % (
+          ('product/detail/-%s' % isbn) if isbn else ('search/results?q=' + title.replace(' ','%20'))
+        ),
+        'price_note': _(' - includes shipping')
+      }
+
+      amazon = {
+        'key': 'amazon',
+        'analytics_key': 'Amazon',
+        'name': _('Amazon'),
+        'link': 'https://www.amazon.com/dp/%s/?tag=%s' % (asin or isbn, affiliate_id('amazon')),
+      } if (asin or isbn) else None
+
+      bookshop = {
+        'key': 'bookshop-org',
+        'analytics_key': 'BookshopOrg',
+        'name': _('Bookshop.org'),
+        'link': 'https://bookshop.org/a/%s/%s' % (affiliate_id('bookshop-org'), isbn),
+      } if isbn else None
+
+      # Fetch price data
+      if not is_bot() and prices and isbn:
+        bwb_metadata = get_betterworldbooks_metadata(isbn)
+        bwb['price'] = bwb_metadata and bwb_metadata.get('price')
+        if amazon:
+          amazon['price'] = bwb_metadata and bwb_metadata.get('market_price')
+        if amazon and not amazon['price']:
+          amz_metadata = get_amazon_metadata(isbn, resources='prices')
+          amazon['price'] = amz_metadata and amz_metadata.get('price')
+
+      primary_stores = [store for store in [bwb, amazon] if store]
+      more_stores = [store for store in [bookshop] if store]
+
+    <ul class="buy-options-table">
+        $for store in primary_stores:
+          $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
+        $if more_stores:
+          <li class="more">
+            <details>
+              <summary>$_('More')</summary>
+              <ul>
+                $for store in more_stores:
+                  $:affiliate_link(store['key'], store['analytics_key'], store['name'], store['link'], store.get('price', ''), store.get('price_note', ''))
+              </ul>
+            </details>
+          </li>
+    </ul>
+    <p>When you buy books using these links the Internet Archive may earn a <a class="nostyle" href="/help/faq/about#selling">small commission</a>.</p>  
+</span>

--- a/openlibrary/macros/DonateModal.html
+++ b/openlibrary/macros/DonateModal.html
@@ -26,7 +26,7 @@ Open Library Book Donations
 300 Funston Avenue
 San Francisco, CA 94118
       </pre>
-      $:macros.AffiliateLinks(book, ids)
+      $:macros.AffiliateLinks(book.title, ids)
       </div>
 
       <h2>Benefits of donating</h2>

--- a/openlibrary/macros/LoadingIndicator.html
+++ b/openlibrary/macros/LoadingIndicator.html
@@ -1,11 +1,6 @@
-$def with (caption, additional_classes='', render_hidden=True)
+$def with (caption, additional_classes='')
 
-$# XXX : Remove the notion of rendering this w/o the 'hidden' class.
-$# An everlasting loading indicator is a bad experience for no-js folk.
-
-$ hidden = 'hidden' if render_hidden else ''
-
-<div class="$hidden loadingIndicator $additional_classes">
+<div class="hidden loadingIndicator $additional_classes">
   <figure>
   <img src="/images/ajax-loader-bar.gif" alt="Loading indicator" loading="lazy">
   <figcaption style="

--- a/openlibrary/macros/LoadingIndicator.html
+++ b/openlibrary/macros/LoadingIndicator.html
@@ -1,0 +1,16 @@
+$def with (caption, additional_classes='', render_hidden=True)
+
+$# XXX : Remove the notion of rendering this w/o the 'hidden' class.
+$# An everlasting loading indicator is a bad experience for no-js folk.
+
+$ hidden = 'hidden' if render_hidden else ''
+
+<div class="$hidden loadingIndicator $additional_classes">
+  <figure>
+  <img src="/images/ajax-loader-bar.gif" alt="Loading indicator" loading="lazy">
+  <figcaption style="
+      justify-content: center;
+      display: flex;
+  ">$caption</figcaption>
+  </figure>
+</div>

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1020,11 +1020,21 @@ class Partials(delegate.page):
     encoding = 'json'
 
     def GET(self):
-        i = web.input(workid=None, _component=None)
+        # `data` is meant to be a dict with two keys: `args` and `kwargs`.
+        # `data['args']` is meant to be a list of a template's positional arguments, in order.
+        # `data['kwargs']` is meant to be a dict containing a template's keyword arguments.
+        i = web.input(workid=None, _component=None, data=None)
         component = i.pop("_component")
         partial = {}
         if component == "RelatedWorkCarousel":
             partial = _get_relatedcarousels_component(i.workid)
+        elif component == "AffiliateLinks":
+            data = json.loads(i.data)
+            args = data.get('args', [])
+            # XXX : Throw error if args length is less than 2
+            macro = web.template.Template.globals['macros'].AffiliateLinks(args[0], args[1])
+            partial = {"partials": str(macro)}
+            
         return delegate.RawText(json.dumps(partial))
 
 

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -1,0 +1,62 @@
+/**
+ * Replaces loading indicators with partially rendered affiliate links.
+ *
+ * Fetches and attaches partials to DOM iff any of the given affiliate link
+ * sections contain a loading indicator.
+ *
+ * @param {NodeList<HTMLElement>} affiliateLinksSections
+ */
+export function initAffiliateLinks(affiliateLinksSections) {
+    if (Array.from(affiliateLinksSections).some((section) => hasLoadingIndicator(section))) {
+        // Replace loading indicators with fetched partials
+
+        const title = affiliateLinksSections[0].dataset.title
+        const opts = JSON.parse(affiliateLinksSections[0].dataset.opts)
+        const args = [title, opts]
+        const d = {args: args}
+
+        getPartials(d)
+            .then((resp) => {
+                if (resp.status !== 200) {
+                    throw new Error(`Failed to fetch partials. Status code: ${resp.status}`)
+                }
+                return resp.json()
+            })
+            .then((data) => {
+                const span = document.createElement('span')
+                span.innerHTML = data['partials']
+                const links = span.firstElementChild
+                for (const section of affiliateLinksSections) {
+                    section.replaceWith(links.cloneNode(true))
+                }
+            })
+            .catch((error) => {
+                // XXX : Handle errors sensibly
+            })
+    }
+}
+
+/**
+ * Fetches rendered affiliate links template using the given arguments.
+ *
+ * @param {object} data Contains array of positional arguments for the template
+ * @returns {Promise<Response>}
+ */
+async function getPartials(data) {
+    const dataString = JSON.stringify(data)
+    const dataQueryParam = encodeURIComponent(dataString)
+
+    return fetch(`/partials.json?_component=AffiliateLinks&data=${dataQueryParam}`)
+}
+
+/**
+ * Returns `true` if the given element contains a loading indicator.
+ *
+ * If a loading indicator is present, `data-async-load` will equal `true`.
+ * @param {HTMLElement} affiliateLinkSection
+ * @returns {boolean} `true` if a loading indicator is present in the section
+ */
+function hasLoadingIndicator(affiliateLinkSection) {
+    const asyncLoad = affiliateLinkSection.dataset.asyncLoad
+    return asyncLoad === 'true'
+}

--- a/openlibrary/plugins/openlibrary/js/affiliate-links.js
+++ b/openlibrary/plugins/openlibrary/js/affiliate-links.js
@@ -7,7 +7,8 @@
  * @param {NodeList<HTMLElement>} affiliateLinksSections
  */
 export function initAffiliateLinks(affiliateLinksSections) {
-    if (Array.from(affiliateLinksSections).some((section) => hasLoadingIndicator(section))) {
+    const isLoading = showLoadingIndicators(affiliateLinksSections)
+    if (isLoading) {
         // Replace loading indicators with fetched partials
 
         const title = affiliateLinksSections[0].dataset.title
@@ -37,6 +38,25 @@ export function initAffiliateLinks(affiliateLinksSections) {
 }
 
 /**
+ * Removes `hidden` class from any loading indicators nested within the given
+ * elements.
+ *
+ * @param {NodeList<HTMLElement>} linkSections
+ * @returns {boolean} `true` if a loading indicator is displayed on the screen
+ */
+function showLoadingIndicators(linkSections) {
+    let isLoading = false
+    for (const section of linkSections) {
+        const loadingIndicator = section.querySelector('.loadingIndicator')
+        if (loadingIndicator) {
+            isLoading = true
+            loadingIndicator.classList.remove('hidden')
+        }
+    }
+    return isLoading
+}
+
+/**
  * Fetches rendered affiliate links template using the given arguments.
  *
  * @param {object} data Contains array of positional arguments for the template
@@ -47,16 +67,4 @@ async function getPartials(data) {
     const dataQueryParam = encodeURIComponent(dataString)
 
     return fetch(`/partials.json?_component=AffiliateLinks&data=${dataQueryParam}`)
-}
-
-/**
- * Returns `true` if the given element contains a loading indicator.
- *
- * If a loading indicator is present, `data-async-load` will equal `true`.
- * @param {HTMLElement} affiliateLinkSection
- * @returns {boolean} `true` if a loading indicator is present in the section
- */
-function hasLoadingIndicator(affiliateLinkSection) {
-    const asyncLoad = affiliateLinkSection.dataset.asyncLoad
-    return asyncLoad === 'true'
 }

--- a/openlibrary/plugins/openlibrary/js/carousels_partials.js
+++ b/openlibrary/plugins/openlibrary/js/carousels_partials.js
@@ -14,7 +14,7 @@ export function initCarouselsPartials() {
             },
             datatype: 'json',
             success: function (response) {
-                $('.loadingIndicator').addClass('hidden');
+                $('.loadingIndicator.carousel-loading').addClass('hidden');
                 if (response){
                     response = JSON.parse(response)
                     $('.RelatedWorksCarousel').append(response[0]);
@@ -32,7 +32,7 @@ export function initCarouselsPartials() {
         });
     };
 
-    $('.loadingIndicator').removeClass('hidden');
+    $('.loadingIndicator.carousel-loading').removeClass('hidden');
 
     fetchRelatedWorks();
 }

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -532,4 +532,11 @@ jQuery(function () {
         import(/* webpackChunkName: "password-visibility-toggle" */ './password-toggle')
             .then(module => module.initPasswordToggling(passwordVisibilityToggle))
     }
+
+    // Affiliate links:
+    const affiliateLinksSection = document.querySelectorAll('.affiliate-links-section')
+    if (affiliateLinksSection.length) {
+        import(/* webpackChunkName: "affiliate-links" */ './affiliate-links')
+            .then(module => module.initAffiliateLinks(affiliateLinksSection))
+    }
 });

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -192,7 +192,7 @@ $if edition.get('identifiers'):
 $if isbn_10 and not asin:
     $ asin = isbn_10
 
-$ affiliate_links = macros.AffiliateLinks(edition, {'isbn': isbn_13, 'asin': asin, 'prices': prices})
+$ affiliate_links = macros.AffiliateLinks(edition.title, {'isbn': isbn_13, 'asin': asin, 'prices': prices}, async_load=True)
 $ component_times['affiliate_links component'] = time() - component_times['affiliate_links component']
 
 $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=oclc_numbers, referer=page.url(relative=False))
@@ -548,15 +548,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
   $ component_times['RelatedWorksCarousel'] = time()
   <div class="RelatedWorksCarousel" data-workid="$work.key.split('/')[-1]">
-    <div class="hidden loadingIndicator">
-        <figure>
-        <img src="/images/ajax-loader-bar.gif" alt="Loading indicator" loading="lazy">
-        <figcaption style="
-            justify-content: center;
-            display: flex;
-        ">Loading Related Books</figcaption>
-        </figure>
-    </div>
+    $:macros.LoadingIndicator(_("Loading Related Books"), "carousel-loading")
   </div>
   $ component_times['RelatedWorksCarousel'] = time() -component_times['RelatedWorksCarousel']
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8576

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Asynchronously loads affiliate links on the book page.  Now, on book page load, the prices have been replaced with the same type of loading indicator that is used for the related works carousel.  This loading indicator is now a macro, but this can be reverted if another loading indicator should be used (like a skeleton loader).

As of writing, error cases are not handled gracefully (if at all).  What should the behavior be if the call for partials fails?  Should we retry?  Should the loading indicator be replaced by some error message?

### Technical
<!-- What should be noted about the implementation? -->
Replaced parameter `page` with `title` in the `AffiliateLinks.html`, as only the title was being accessed on the `page` object.

In order to simplify updating the view, the content of the affiliate links macro is now nested within a `span`.  This entire span is replaced with the partially rendered HTML on fetch success.

Affiliate links in the `DonateModal` component are *not* asynchronously fetched.  I'm not sure if this template is actively used today, so maybe it should be removed altogether?

### Ready for review when:
- [ ] We've decided what the loading indicator should look like
- [ ] Errors are handled gracefully

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit a book page.
2. Quickly try to spot the loading indicator in the `databarWork` section.
3. Ensure that the loading indicator is replaced by prices.
4. Ensure that the same is true in mobile views.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2024-02-15 16-16-58](https://github.com/internetarchive/openlibrary/assets/28732543/8fdb47aa-bcef-4af4-bbe0-dd17eb03e7e0)
_Loading indicator in desktop view._

![Screenshot from 2024-02-15 16-17-28](https://github.com/internetarchive/openlibrary/assets/28732543/a5bd7708-b6c3-4140-ad40-b10b8f8e3053)
_Loading indicator in mobile view._

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
