### PR TITLE
Always use "My Books" droppers

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -142,10 +142,9 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
                 <div id="searchResults">
                     <ul class="list-books">
-                      $ use_my_books_droppers = 'my_books_dropper' in ctx.features
                       $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
                       $for doc in books.docs:
-                         $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras, include_dropper = use_my_books_droppers)
+                         $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras, include_dropper=True)
                     </ul>
                 </div>
 

--- a/openlibrary/templates/type/list/view_body.html
+++ b/openlibrary/templates/type/list/view_body.html
@@ -120,9 +120,8 @@ $def seed_attrs(seed):
                 $ cover_url = default_image
 
             $if seed.type in ['edition', 'work']:
-                $ use_my_books_droppers = 'my_books_dropper' in ctx.features
                 $ doc = solr_works.get(seed.key) or seed.document
-                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=availabilities.get(seed.key), decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=use_my_books_droppers, footer=seed.notes and sanitize(format(seed.notes)))
+                $:macros.SearchResultsWork(doc, attrs=seed_attrs(seed), availability=availabilities.get(seed.key), decorations=remove_item_link(), extra=seed_meta_line(seed), include_dropper=True, footer=seed.notes and sanitize(format(seed.notes)))
             $else:
                 <li class="searchResultItem sri--w-main" $:seed_attrs(seed)>
                     <div class="sri__main">


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The My Books dropper feature flag is being removed from the config, so we shouldn't use the flag to decide whether or not to use the refactored droppers.  The notion of a "My Books" feature flag was removed by #8539.

> [!WARNING]
> Merge the [config changes olsystem #195](https://github.com/internetarchive/olsystem/pull/195) before merging these changes. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
