### PR TITLE
Fix: make `isbndb.py` handle literal `None` values for `subjects`

### DIFF
--- a/scripts/providers/isbndb.py
+++ b/scripts/providers/isbndb.py
@@ -71,7 +71,7 @@ class ISBNdb:
         self.languages = self._get_languages(data)
         self.source_records = [self.source_id]
         self.subjects = [
-            subject.capitalize() for subject in data.get('subjects', '') if subject
+            subject.capitalize() for subject in (data.get('subjects') or []) if subject
         ]
         self.binding = data.get('binding', '')
 


### PR DESCRIPTION
Closes #8830 

This PR ensures `[]` is returned if either:
1. the `subjects` key is absent; or
2. the `subjects` key has a literal `None` value.

Sometimes `subjects` in the ISBNdb dump have literal `None` values, which would cause an error even if doing something like `data.get('subjects', [])`, because it would return `None` instead of `[]`.

E.g., consider the following record:
```python
{
    'isbn': '0134878868',
    'msrp': '0.00',
    'title': 'Learn Adobe Premiere Pro Cc For Video Communication',
    'isbn13': '9780134878867',
    'authors': ['Dockery, Joe (author.)'],
    'binding': 'Electronic Resource',
    'language': 'en',
    'subjects': None,
}
```
This would crash with:
```
        ^^^^^^^^^^^^^^^^^^^
  File "/openlibrary/scripts/providers/isbndb.py", line 73, in __init__
    self.subjects = [
                    ^
TypeError: 'NoneType' object is not iterable
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This was tested by processing 11k ISBNdb records successfully, many of which had a literal `None` value for the `'subjects'` key.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
