### PR TITLE
Fix: add missing `int` conversion to notes page

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -100,7 +100,7 @@ class mybooks_notes(delegate.page):
         if mb.is_my_page:
             docs = PatronBooknotes(mb.user).get_notes(page=int(i.page))
             template = render['account/notes'](
-                docs, mb.user, mb.counts['notes'], page=i.page
+                docs, mb.user, mb.counts['notes'], page=int(i.page)
             )
             return mb.render(header_title=_("Notes"), template=template)
         raise web.seeother(mb.user.key)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8771

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
This employs the same strategy as #8772, but adds an `int()` conversion to a line that was missed.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Look at, for example, page 2 of notes, assuming 26+ notes: http://localhost:8080/people/openlibrary/books/notes?page=2.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/26524678/07101f4e-39d4-4da6-ae18-7a1a114545ed)



### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
