### PR TITLE
Fixed Links and code section overflow in API Documentation pages

### DIFF
--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -15,6 +15,9 @@ div#contentBody {
   img {
     max-width: 100%;
   }
+  p {
+    word-wrap: break-word;
+  }
 }
 .section,
 section {

--- a/static/css/layout/index.less
+++ b/static/css/layout/index.less
@@ -15,7 +15,10 @@ div#contentBody {
   img {
     max-width: 100%;
   }
-  p {
+  pre {
+    overflow-x: auto;
+  }
+  p a {
     word-wrap: break-word;
   }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8839 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixed Links and code section overflow in API Documentation pages.


### Technical
<!-- What should be noted about the implementation? -->
Added ```word-wrap: break-word```  property to ```div#contentBody``` to solve the issue.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="50%" height="50%" src="https://github.com/internetarchive/openlibrary/assets/117273351/53ba667c-6c16-42c9-8952-468ab218f9e6">

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
