### PR TITLE
Make MergeUI edition covers link to enlarged covers

### DIFF
--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -3,9 +3,9 @@
     <img
       loading="lazy"
       :src="cover_url"
-      @click="openEnlargedCover"
       tabindex="0"
       aria-label="Click to enlarge cover image"
+      @click="openEnlargedCover"
     >
     <div class="links">
       <a

--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -4,6 +4,8 @@
       loading="lazy"
       :src="cover_url"
       @click="openEnlargedCover"
+      tabindex="0"
+      aria-label="Click to enlarge cover image"
     >
     <div class="links">
       <a
@@ -87,11 +89,7 @@ export default {
         },
 
         cover_id() {
-            if (this.edition.covers && this.edition.covers[0] && this.edition.covers[0] > 0) {
-                return this.edition.covers[0]
-            } else {
-                return null;
-            }
+            return this.edition.covers?.[0] ?? null;
         },
 
         cover_url() {
@@ -124,7 +122,7 @@ export default {
             let url = '';
             if (this.cover_id) {
                 url = `https://covers.openlibrary.org/b/id/${this.cover_id}.jpg`;
-            } else {
+            } else if (this.edition.ocaid) {
                 const ocaid = this.edition.ocaid;
                 url = `https://archive.org/download/${ocaid}/page/cover_w600_h600.jpg`;
             }

--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -3,6 +3,7 @@
     <img
       loading="lazy"
       :src="cover_url"
+      @click="openEnlargedCover"
     >
     <div class="links">
       <a
@@ -85,18 +86,22 @@ export default {
             return title;
         },
 
+        cover_id() {
+            if (this.edition.covers && this.edition.covers[0] && this.edition.covers[0] > 0) {
+                return this.edition.covers[0]
+            } else {
+                return null;
+            }
+        },
+
         cover_url() {
-            const id =
-        this.edition.covers && this.edition.covers[0]
-            ? this.edition.covers[0]
-            : null;
-            if (id) return `https://covers.openlibrary.org/b/id/${id}-M.jpg`;
+            if (this.cover_id) return `https://covers.openlibrary.org/b/id/${this.cover_id}-M.jpg`;
 
             const ocaid = this.edition.ocaid;
             if (ocaid)
                 return `https://archive.org/download/${ocaid}/page/cover_w180_h360.jpg`;
 
-            return 'https://covers.openlibrary.org/b/id/-1-M.jpg';
+            return '';
         },
 
         languages() {
@@ -111,6 +116,22 @@ export default {
                 this.edition.isbn_10 && ISBN.asIsbn10(this.edition.isbn_10),
                 this.edition.isbn_13 && ISBN.asIsbn10(this.edition.isbn_13),
             ].filter(x => x));
+        }
+    },
+
+    methods: {
+        openEnlargedCover() {
+            let url = '';
+            if (this.cover_id) {
+                url = `https://covers.openlibrary.org/b/id/${this.cover_id}.jpg`;
+            } else {
+                const ocaid = this.edition.ocaid;
+                url = `https://archive.org/download/${ocaid}/page/cover_w600_h600.jpg`;
+            }
+
+            if (!url) return;
+
+            window.open(url, undefined, 'width=600,height=600');
         }
     }
 };
@@ -135,6 +156,9 @@ export default {
     margin-right: 7px;
     // Min Height added for lazy loading so that the lazy loaded images are not 1 pixel and start having many books start loading
     min-height: 80px;
+    &:not([src=""]) {
+      cursor: zoom-in;
+    }
     &:hover {
       object-fit: contain;
     }


### PR DESCRIPTION
Small fix to make clicking on edition covers in the merge UI open the cover in a new window.


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
