### PR TITLE
Handle "Add to staff picks" errors

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -209,7 +209,9 @@ class add_work_to_staff_picks:
                         ocaid, subjects=subjects
                     )
                 except ItemLocateError as err:
-                    results[work_id][ocaid] = f'Failed to add to staff picks. Error message: {err}'
+                    results[work_id][
+                        ocaid
+                    ] = f'Failed to add to staff picks. Error message: {err}'
 
         return delegate.RawText(json.dumps(results), content_type="application/json")
 

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -10,6 +10,8 @@ import traceback
 import logging
 import json
 
+from internetarchive.exceptions import ItemLocateError
+
 from infogami import config
 from infogami.utils import delegate
 from infogami.utils.view import render, public
@@ -206,7 +208,7 @@ class add_work_to_staff_picks:
                     results[work_id][ocaid] = create_ol_subjects_for_ocaid(
                         ocaid, subjects=subjects
                     )
-                except Exception as err:
+                except ItemLocateError as err:
                     results[work_id][ocaid] = f'Failed to add to staff picks. Error message: {err}'
 
         return delegate.RawText(json.dumps(results), content_type="application/json")

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -202,9 +202,12 @@ class add_work_to_staff_picks:
             ocaids = [edition.ocaid for edition in editions if edition.ocaid]
             results[work_id] = {}
             for ocaid in ocaids:
-                results[work_id][ocaid] = create_ol_subjects_for_ocaid(
-                    ocaid, subjects=subjects
-                )
+                try:
+                    results[work_id][ocaid] = create_ol_subjects_for_ocaid(
+                        ocaid, subjects=subjects
+                    )
+                except Exception as err:
+                    results[work_id][ocaid] = f'Failed to add to staff picks. Error message: {err}'
 
         return delegate.RawText(json.dumps(results), content_type="application/json")
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8473

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Wraps `create_ol_subjects_for_ocaid` call in a `try/except` block.  If any edition is not added to the staff picks, an error message for that edition will be included in the handler's `json` response.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
