### PR TITLE
Update containers to Python 3.12.2 + Bookworm

### DIFF
--- a/.github/workflows/codegen_api_docs.yml
+++ b/.github/workflows/codegen_api_docs.yml
@@ -12,7 +12,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 # Learn more about this config here: https://pre-commit.com/
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 ci:
   submodules: true

--- a/docker/Dockerfile.olbase
+++ b/docker/Dockerfile.olbase
@@ -1,4 +1,4 @@
-FROM python:3.11.1-slim
+FROM python:3.12.2-slim-bookworm
 
 ENV LANG en_US.UTF-8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [project]
 name = "openlibrary"
 version = "1.0.0"
-requires-python = ">=3.11.1,<3.11.2"
+requires-python = ">=3.12.2,<3.12.3"
 
 [tool.black]
 skip-string-normalization = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ eventer==0.1.1
 feedparser==6.0.10
 flup-py3==1.0.3
 Genshi==0.7.7
+git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382
 gunicorn==20.1.0
 httpx==0.24.1
 ijson==3.2.3
@@ -28,4 +29,3 @@ sentry-sdk==1.28.1
 simplejson==3.19.1
 statsd==4.0.1
 validate_email==1.3
-git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ sentry-sdk==1.28.1
 simplejson==3.19.1
 statsd==4.0.1
 validate_email==1.3
-git+https://github.com/webpy/webpy.git@ed3e92cceb6ed870b224107ea653f48fa7fc2d0a#egg=web-py
+git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     from openlibrary.data import dump
     from openlibrary.utils.sentry import Sentry
 
-    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.11.1
+    log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.12.2
 
     ol_config = os.getenv("OL_CONFIG")
     if ol_config:

--- a/scripts/setup_gitpod.sh
+++ b/scripts/setup_gitpod.sh
@@ -2,7 +2,7 @@
 # This script does the setup needed for Gitpod
 
 # Setup pre-commit hooks
-pyenv install 3.11 --skip-existing # must match python version in .pre-commit-config.yaml
-pyenv global 3.11
+pyenv install 3.12 --skip-existing # must match python version in .pre-commit-config.yaml
+pyenv global 3.12
 sudo python3 -m pip install pre-commit
 pre-commit install --install-hooks


### PR DESCRIPTION
Update the Docker containers to Debian Bookworm and Python 3.12.

### Technical
<!-- What should be noted about the implementation? -->
This update is tied to a specific `webpy` commit because although the commit has been merged to master, there is not yet a release. Hence using the git hash in `requirements.txt`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Because of the webpy changes, the major Python version changes, and changes to the underlying Debian distribution, it would be good to test out as many tasks as possible.

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
