### PR TITLE
Fix thin scrollbar being applied to entire site

### DIFF
--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -52,24 +52,25 @@
 // Menu option containers:
 .selection-container {
   height: 266px;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   .subjects-search-results,
   .selected-tag-subjects {
     padding: 0 5px;
   }
-}
 
-::-webkit-scrollbar {
-  -webkit-appearance: none;
-  background-color: @lighter-grey;
-  width: 5px;
-}
-
-::-webkit-scrollbar-thumb {
-  border-radius: 4px;
-  background-color: @grey;
-  -webkit-box-shadow: 0 0 1px @grey;
+  scrollbar-width: thin;
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+    background-color: @lighter-grey;
+    width: 5px;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: @grey;
+    -webkit-box-shadow: 0 0 1px @grey;
+  }
 }
 
 .search-subject-row {

--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -65,7 +65,7 @@
     background-color: @lighter-grey;
     width: 5px;
   }
-  
+
   &::-webkit-scrollbar-thumb {
     border-radius: 4px;
     background-color: @grey;

--- a/static/css/components/tagging-menu.less
+++ b/static/css/components/tagging-menu.less
@@ -59,7 +59,6 @@
     padding: 0 5px;
   }
 
-  scrollbar-width: thin;
   &::-webkit-scrollbar {
     -webkit-appearance: none;
     background-color: @lighter-grey;


### PR DESCRIPTION
This css was leaking and applying to the entire site. We don't want thin scrollbars everywhere.


### Technical
- Also fix thin scrollbar only work on Chrome.
- Also fix thin scrollbar in tagging menu appearing when unnecessary.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
Before:
![image](https://github.com/internetarchive/openlibrary/assets/6251786/e0cf0908-48bd-4a17-906c-5e725d9380a6)
(note thin scrollbars in body, sidebar)

After:
![image](https://github.com/internetarchive/openlibrary/assets/6251786/0ff8f1cb-a3c4-4fae-953f-11c51fed76ca)
(normal sized scrollbars)



### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
