### PR TITLE
Fix: stop isbns from being `<Nothing>` in `view.html`

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -181,8 +181,8 @@ $ component_times['affiliate_links component'] = time()
 $ prices = edition.key.startswith('/books/')
 
 $ oclc_numbers = (edition.oclc_numbers and edition.oclc_numbers[0]) or ""
-$ isbn_13 = edition.get_isbn13()
-$ isbn_10 = edition.get_isbn10()
+$ isbn_13 = edition.get_isbn13() or None
+$ isbn_10 = edition.get_isbn10() or None
 
 $ asin = None
 $if edition.get('identifiers'):


### PR DESCRIPTION
For some reason `edition.to_isbn10()` and `edition.to_isbn13` seem to be returning the good for nothing `<Nothing>` type in `view.html`.

This commit opts for `None` over other falsy values when setting `isbn_10` and `isbn_13`.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Try to load a work or edition:
* http://localhost:8080/books/OL20431791M
* https://staging.openlibrary.org/works/OL118388W/Flatland?edition=key%3A/books/OL37044775M.


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
