### PR TITLE
Sardinian added to language_list.html

### DIFF
--- a/openlibrary/templates/languages/language_list.html
+++ b/openlibrary/templates/languages/language_list.html
@@ -10,6 +10,7 @@ $def with (classes='')
   <li><a href="#" lang="it" data-lang-id="it" title="$_('Italian')">Italiano (it)</a></li>
   <li><a href="#" lang="pt" data-lang-id="pt" title="$_('Portuguese')">Português (pt)</a></li>
   <li><a href="#" lang="hi" data-lang-id="hi" title="$_('Hindi')">हिंदी (hi)</a></li>
+  <li><a href="#" lang="sc" data-lang-id="sc" title="$_('Sardinian')">Sardu (sc)</a></li>
   <li><a href="#" lang="te" data-lang-id="te" title="$_('Telugu')">తెలుగు (te)</a></li>
   <li><a href="#" lang="uk" data-lang-id="uk" title="$_('Ukrainian')">Українська (uk)</a></li>
   <li><a href="#" lang="zh" data-lang-id="zh" title="$_('Chinese')">中文 (zh)</a></li>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8857 Add Sardinian to list of languages

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
It adds Sardinian (sc) to the drop down menu of languages

### Technical
<!-- What should be noted about the implementation? -->
On my local deployed version, I can't see if the other languages worked (e.g. when I press German, it refreshes but still shows English). I'm not sure if this is normal or a bug on my side but it means I couldn't test if when clicking on Sardinian, whether the language changed or not. 

Also I noticed Hindi isn't sorted alphabetically, but not sure if there's a reason for this, so kept the order as is. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The change was made to file: openlibrary/templates/languages/language_list.html

In this file I added an extra <li> and <a> tag for Sardinian, with the same attributes as the other elements.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/139546996/ab2edbd9-c070-4323-8678-c7f003738c8d)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
