### PR TITLE
Removed Author.website UI elements from Author.edit/view templates

### DIFF
--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -118,18 +118,6 @@ $:macros.HiddenSaveButton("addAuthor")
                             $:render_component('AuthorIdentifiers', attrs=dict(assigned_ids_string=dict(page.remote_ids),output_selector='#hiddenIdentifierInputs',author_config_string=dict(get_author_config())))
                         </div>
 
-                        $if page.website:
-                            $if ctx.user and ctx.user.is_admin():
-                                <div class="formElement adminOnly">
-                                    <div class="label">
-                                        <label for="uris">$_("Websites")</label>
-                                        <span class="tip">$_("Deprecated")</span>
-                                    </div>
-                                    <div class="input">
-                                        <input type="text" name="author--website" id="website" value="$page.website"/>
-                                    </div>
-                                </div>
-
 
                 </div>
 <!-- /ABOUT -->

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -99,12 +99,6 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
             $:format(page.get('bio', ''))
         </div>
 
-        $if page.website:
-            <div class="section">
-                <h6 class="collapse black uppercase">$_("Website")</h6>
-                <a href="$page.website" class="datalink">$page.website</a>
-            </div>
-
         $if page.location:
             <div class="section hidden">
                 <h6 class="collapse black uppercase">$_("Location")</h6>


### PR DESCRIPTION
… removed as Author.website is now deprecated and will be replaced with the links tab. Fix will remove Author.website UI elements during editing and viewing windows as they are no longer needed

<!-- What issue does this PR close? -->
Addresses #8293 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fix

### Technical
<!-- What should be noted about the implementation? -->
Author.website property has UI elements being built within author/edit.html and author/view.html, these references have been removed so that Author.website elements are no longer built.
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
View author previously containing a website link on their author page, website link should no longer be visible and when editing author, there should no longer be a website identifier.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/36286398/da731c6c-4134-47b1-8d3b-620b94085a02)
![image](https://github.com/internetarchive/openlibrary/assets/36286398/8c83cd9f-2d7b-488b-a101-d95e2c6e586a)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@hornc  @jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
