### PR TITLE
Added markdown control buttons to edition description

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -323,7 +323,7 @@ $jsdef render_work_autocomplete_item(item):
                 <span class="tip">$_("Only if it's different from the work's description")</span>
             </div>
             <div class="input">
-                <textarea name="edition--description" id="edition-description" rows="3" cols="50">$book.description</textarea>
+                <textarea name="edition--description" class="markdown" id="edition-description" rows="3" cols="50">$book.description</textarea>
             </div>
         </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8825 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
feature of having **markdown controls on edition description** field on edit

### Technical
<!-- What should be noted about the implementation? -->
markdown class has been added to the textarea input of **edition description**, it enables JS to show controls above the input **edition description**

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
click on edit button of a book to reproduce, you can directly visit [Book URL](http://localhost:8080/books/OL7361700M/Three_Cups_of_Tea/edit?work_key=/works/OL5702375W) directly to open a book in edit mode.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2024-03-04 12-36-47](https://github.com/internetarchive/openlibrary/assets/98279986/e015a60e-ca0f-4208-a3e1-f13629ca5d6f)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@bitnapper

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
