### PR TITLE
Update messages.po

### DIFF
--- a/openlibrary/i18n/es/messages.po
+++ b/openlibrary/i18n/es/messages.po
@@ -1517,6 +1517,10 @@ msgstr "Mis notas"
 msgid "My Reviews"
 msgstr "Mis reseñas"
 
+#: account/sidebar.html:47
+msgid "Create a list"
+msgstr "Crear una lista"
+
 #: account/sidebar.html:42
 msgid "Sponsoring"
 msgstr "Patrocinio"


### PR DESCRIPTION
In the "My books" section for the user, the button on the left column to "Create a list" is still in English, so I added Spanish translation on line 1520. This is my 1st time proposing any changes so please let me know if I did something wrong. I also noticed after proposing changes on my fork that "# account/sidebar.html:47" is already used for "Untitled list" but when I checked, it shows up on line 51 in the html file , so I have some confusion. In addition, in the same sidebar.html file, "My Reading Stats" shows up on line 32 but the messages.po file shows it as "# account/sidebar.html:33" for example. So this aspect is where I am confused.
<img width="242" alt="Screenshot 2024-03-04 at 8 43 49 PM" src="https://github.com/internetarchive/openlibrary/assets/154364021/b56130ce-8312-419d-a807-ff0603302872">


<!-- What issue does this PR close? -->
Closes # 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fill in Spanish translations where English text still appears

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
