### PR TITLE
Added: Drop shadow to cover modal

### DIFF
--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -27,6 +27,9 @@
   img,
   iframe {
     width: 100%;
+  }
+
+  img.cover {
     border-radius: 5px;
     box-shadow: 1px 1px 2px 0 @book-cover-shadow-color;
   }

--- a/static/css/components/cbox.less
+++ b/static/css/components/cbox.less
@@ -27,6 +27,8 @@
   img,
   iframe {
     width: 100%;
+    border-radius: 5px;
+    box-shadow: 1px 1px 2px 0 @book-cover-shadow-color;
   }
 }
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8868 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR aims to add the drop shadow to the covers modal

### Technical
<!-- What should be noted about the implementation? -->
I just copied the previously applied css on the covers here
https://github.com/internetarchive/openlibrary/blob/21b78ad55cbb89a8260d1d4ebe0b1c5daac1c0e8/static/css/components/illustration.less#L14-L15

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Click on any book cover
- Notice the box shadow

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before
![image](https://github.com/internetarchive/openlibrary/assets/85943021/c796b29a-28f6-4b27-b6f3-91b69aee201e)

After
![image](https://github.com/internetarchive/openlibrary/assets/85943021/2b662dcb-3ab2-4470-87c2-80dcc8f5c035)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
