### PR TITLE
Load editions table client-side

### DIFF
--- a/openlibrary/macros/LoadingIndicator.html
+++ b/openlibrary/macros/LoadingIndicator.html
@@ -1,6 +1,10 @@
-$def with (caption, additional_classes='')
+$def with (caption, additional_classes='', data_attrs=None)
 
-<div class="hidden loadingIndicator $additional_classes">
+<div 
+  class="hidden loadingIndicator $additional_classes"
+  $if data_attrs:
+    data-additional-data="$json_encode(data_attrs)"
+  >
   <figure>
   <img src="/images/ajax-loader-bar.gif" alt="Loading indicator" loading="lazy">
   <figcaption style="

--- a/openlibrary/macros/LoadingIndicator.html
+++ b/openlibrary/macros/LoadingIndicator.html
@@ -1,6 +1,6 @@
 $def with (caption, additional_classes='', data_attrs=None)
 
-<div 
+<div
   class="hidden loadingIndicator $additional_classes"
   $if data_attrs:
     data-additional-data="$json_encode(data_attrs)"

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1020,10 +1020,8 @@ class Partials(delegate.page):
     encoding = 'json'
 
     def GET(self):
-        # `data` is meant to be a dict with two keys: `args` and `kwargs`.
-        # `data['args']` is meant to be a list of a template's positional arguments, in order.
-        # `data['kwargs']` is meant to be a dict containing a template's keyword arguments.
-        i = web.input(workid=None, _component=None, data=None)
+        # `data` is a string that can be deserialized by `json.loads`
+        i = web.input(workid=None, _component=None, data='{}')
         component = i.pop("_component")
         partial = {}
         if component == "RelatedWorkCarousel":
@@ -1036,6 +1034,9 @@ class Partials(delegate.page):
                 args[0], args[1]
             )
             partial = {"partials": str(macro)}
+        elif component == "EditionsTable":
+            data = json.loads(i.data)
+            partial = {"partials": "<span>Watch this space for the editions table</span>"}
 
         return delegate.RawText(json.dumps(partial))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1036,7 +1036,13 @@ class Partials(delegate.page):
             partial = {"partials": str(macro)}
         elif component == "EditionsTable":
             data = json.loads(i.data)
-            partial = {"partials": "<span>Watch this space for the editions table</span>"}
+            work_key = data.get('work_key', None)
+            edition_key = data.get('edition_key', None)
+
+            work = web.ctx.site.get(work_key)
+            edition = web.ctx.site.get(edition_key)
+            ed_table = render_template('type/work/editions_datatable', work, editions=work.get_sorted_editions(keys=[edition_key], limit=10), edition=edition)
+            partial = {"partials": str(ed_table)}
 
         return delegate.RawText(json.dumps(partial))
 

--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1041,7 +1041,12 @@ class Partials(delegate.page):
 
             work = web.ctx.site.get(work_key)
             edition = web.ctx.site.get(edition_key)
-            ed_table = render_template('type/work/editions_datatable', work, editions=work.get_sorted_editions(keys=[edition_key], limit=10), edition=edition)
+            ed_table = render_template(
+                'type/work/editions_datatable',
+                work,
+                editions=work.get_sorted_editions(keys=[edition_key], limit=10),
+                edition=edition,
+            )
             partial = {"partials": str(ed_table)}
 
         return delegate.RawText(json.dumps(partial))

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -69,3 +69,34 @@ export function initEditionsTable() {
         });
     }
 }
+
+/**
+ * Fetches rendered HTML for the editions table, attaches the table to the DOM, and
+ * hydrates the table.
+ *
+ * The given `loadingIndicator` will be replaced by the HTML returned by the server.
+ *
+ * @param {HTMLElement} loadingIndicator Reference to placeholder loading indicator
+ */
+export function fetchEditionsTable(loadingIndicator) {
+    // Fetch table partials
+    fetch('/partials.json?_component=EditionsTable')
+        .then((resp) => {
+            if (resp.status !== 200) {
+                throw new Error('Failed to fetch editions table')
+            }
+            return resp.json()
+        })
+        .then((data) => {
+            // Replace loading indicator with partially rendered table
+            const span = document.createElement('span')
+            span.innerHTML = data['partials']
+            loadingIndicator.replaceWith(span)
+
+            // Hydrate table
+            initEditionsTable()
+        })
+        .catch(() => {
+            // handler error cases
+        })
+}

--- a/openlibrary/plugins/openlibrary/js/editions-table/index.js
+++ b/openlibrary/plugins/openlibrary/js/editions-table/index.js
@@ -79,8 +79,13 @@ export function initEditionsTable() {
  * @param {HTMLElement} loadingIndicator Reference to placeholder loading indicator
  */
 export function fetchEditionsTable(loadingIndicator) {
+    // Show loading indicator:
+    loadingIndicator.classList.remove('hidden')
+
     // Fetch table partials
-    fetch('/partials.json?_component=EditionsTable')
+    const dataQueryParam = encodeURIComponent(loadingIndicator.dataset.additionalData)
+
+    fetch(`/partials.json?_component=EditionsTable&data=${dataQueryParam}`)
         .then((resp) => {
             if (resp.status !== 200) {
                 throw new Error('Failed to fetch editions table')

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -113,6 +113,13 @@ jQuery(function () {
     if (document.getElementsByClassName('editions-table--progressively-enhanced').length) {
         import(/* webpackChunkName: "editions-table" */ './editions-table')
             .then(module => module.initEditionsTable());
+    } else {
+        // Async editions table:
+        const editionsTableLoadingIndicator = document.querySelector('.editions-table-loading-indicator')
+        if (editionsTableLoadingIndicator) {
+            import(/*webpackChunkName: "editions-table" */ './editions-table')
+                .then((module) => module.fetchEditionsTable(editionsTableLoadingIndicator))
+        }
     }
 
     const edition = document.getElementById('tabsAddbook');

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -56,12 +56,16 @@ $# Tradeoff: limits our ability to select best edition
 $ editions_limit = None if query_param('mode') in ['all', 'ebooks'] else 10
 $# key ensures the current edition we're on or requested edition are fetched by get_sorted_editions
 $ keys = (edition and [edition.key]) or (provider and provider.get_olids(selected_id))
-$if ebooks_only:
-  $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=keys)
-$if not editions:
-  $# use ebooks_only to determine whether to lazyload editions table
-  $ ebooks_only = False
-  $ editions = work.get_sorted_editions(limit=editions_limit, keys=keys)
+
+$ block_for_table = True if query_param('et') == 'sync' else False
+
+$if block_for_table:
+  $if ebooks_only:
+    $ editions = work.get_sorted_editions(ebooks_only=ebooks_only, limit=editions_limit, keys=keys)
+  $if not editions:
+    $# use ebooks_only to determine whether to lazyload editions table
+    $ ebooks_only = False
+    $ editions = work.get_sorted_editions(limit=editions_limit, keys=keys)
 $ availabilities = {e.availability.get('identifier'): e.availability for e in editions}
 $ component_times['get_sorted_editions'] = time() - component_times['get_sorted_editions']
 
@@ -341,7 +345,11 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
       <a id="editions-list" name="editions-list" class="section-anchor"></a>
       <div class="tab-section">
         $ component_times['EditionsTable'] = time()
-        $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
+        
+        $if block_for_table:
+          $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
+        $else:
+          $:macros.LoadingIndicator(_('Fetching editions table'), additional_classes='editions-table-loading-indicator')
         $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
       </div>
 

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -345,7 +345,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
       <a id="editions-list" name="editions-list" class="section-anchor"></a>
       <div class="tab-section">
         $ component_times['EditionsTable'] = time()
-        
+
         $if block_for_table:
           $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
         $else:

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -349,6 +349,10 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $if block_for_table:
           $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
         $else:
+          $# Provide link to load editions table for no-js patrons
+          <noscript>
+            <span>Click <a href="$changequery(et='sync')">here</a> to load the editions table</span>
+          </noscript>
           $ data_attrs = {
           $ "edition_key": edition.key,
           $ "work_key": work.key

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -349,7 +349,11 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $if block_for_table:
           $:render_template("type/work/editions_datatable", work, editions=editions, edition=edition, editions_limit=editions_limit)
         $else:
-          $:macros.LoadingIndicator(_('Fetching editions table'), additional_classes='editions-table-loading-indicator')
+          $ data_attrs = {
+          $ "edition_key": edition.key,
+          $ "work_key": work.key
+          $ }
+          $:macros.LoadingIndicator(_('Fetching editions table'), additional_classes='editions-table-loading-indicator', data_attrs=data_attrs)
         $ component_times['EditionsTable'] = time() - component_times['EditionsTable']
       </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the book page to asynchronously load the editions table by default.  The table can still be loaded synchronously if query parameter `et=sync` is included in the URL (where `et` is short for "editions table").  Patrons who have disabled Javascript in their browser will see a link that will reload the page with the `et=sync` param.

### Technical
<!-- What should be noted about the implementation? -->
The `LoadingIndicator` macro has been updated to take an optional `data-attrs` parameter, which is expected to be a `dict`.  If present, `data-attrs` is JSON encoded and added to the root loading indicator element as `data-additional-data`.

This changes allows us to decorate the indicator with the book's work and edition keys, and the main `/partials` handler has been updated to handle requests for editions tables.  Using the keys, the handler gets a reference to the `Work` and `Edition`, and passes these to the editions table template.

#### Assumptions
- The `Work` and `Edition` are cached when the book page is first visited.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Ensure that the editions table loads with the correct entries after a book page loads.
- With JS disabled, verify that you can navigate to a page where the editions table is loaded synchronously.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2024-03-06 16-33-30](https://github.com/internetarchive/openlibrary/assets/28732543/b0cecade-5e06-43fe-b015-8428b46f5ab6)
_The loading indicator._

![Screenshot from 2024-03-06 16-18-51](https://github.com/internetarchive/openlibrary/assets/28732543/f05cd24b-ff85-40bf-88b6-5414e7736e8b)
_Link that "no-js" patrons will see in place of the editions table._
### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
