### PR TITLE
Fix: `Seed.from_db()` now handles `client.Thing` types

### DIFF
--- a/openlibrary/core/lists/model.py
+++ b/openlibrary/core/lists/model.py
@@ -399,7 +399,9 @@ class Seed:
     def from_db(list: List, seed: Thing | SeedSubjectString) -> 'Seed':
         if isinstance(seed, str):
             return Seed(list, seed)
-        elif isinstance(seed, Thing):
+        # If there is a cache miss, `seed` is a client.Thing.
+        # See https://github.com/internetarchive/openlibrary/issues/8882#issuecomment-1983844076
+        elif isinstance(seed, Thing | client.Thing):
             if seed.key is None:
                 return Seed(list, cast(AnnotatedSeed, seed._data))
             else:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8882 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix.

Thanks to @cdrini for very quickly figuring out the problem.

### Technical
<!-- What should be noted about the implementation? -->
When there is a cache miss with a list containing a redirect, `Seed.from_db()` is called with a `client.Thing` type, but the logic didn't handle this.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Create a list with a redirected item on it (e.g. by adding an item to the list and merging). Note: you cannot have the non-redirected version of the item on the same list or the error won't occur.

Try viewing the profile page of the account with the relevant list before and after applying the PR.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/9ea55258-78bb-4557-bdca-7684d07c8bf7)

After:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/098ac7d5-3fe5-4988-834d-328528a0e6d1)


### Stakeholders
<!-- @ tag stakeholders of this bug -->
@RayBB 
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
