### PR TITLE
Persist Yearly Reading Goals banner preferences

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -15,7 +15,7 @@ smtp_server: localhost
 dummy_sendmail: True
 debug: True
 
-coverstore_url: covers.openlibrary.org
+coverstore_url: http://covers:7075
 # URL to use inside HTML files; must be publicly accessible from
 # a client's browser
 coverstore_public_url: http://localhost:7075

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -15,7 +15,7 @@ smtp_server: localhost
 dummy_sendmail: True
 debug: True
 
-coverstore_url: http://covers:7075
+coverstore_url: covers.openlibrary.org
 # URL to use inside HTML files; must be publicly accessible from
 # a client's browser
 coverstore_public_url: http://localhost:7075

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -652,11 +652,13 @@ class hide_banner(delegate.page):
     path = '/hide_banner'
 
     def POST(self):
+        user = accounts.get_current_user()
         data = json.loads(web.data())
 
         # Set truthy cookie that expires in 30 days:
         DAY_SECONDS = 60 * 60 * 24
         cookie_duration_days = int(data.get('cookie-duration-days', 30))
+        user.save_preferences({'yrg_banner_pref': data['cookie-name']})
         web.setcookie(
             data['cookie-name'], '1', expires=(cookie_duration_days * DAY_SECONDS)
         )

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -659,7 +659,7 @@ class hide_banner(delegate.page):
         DAY_SECONDS = 60 * 60 * 24
         cookie_duration_days = int(data.get('cookie-duration-days', 30))
 
-        if data['cookie-name'].startswith('yrg'):
+        if user and data['cookie-name'].startswith('yrg'):
             user.save_preferences({'yrg_banner_pref': data['cookie-name']})
 
         web.setcookie(

--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -658,7 +658,10 @@ class hide_banner(delegate.page):
         # Set truthy cookie that expires in 30 days:
         DAY_SECONDS = 60 * 60 * 24
         cookie_duration_days = int(data.get('cookie-duration-days', 30))
-        user.save_preferences({'yrg_banner_pref': data['cookie-name']})
+
+        if data['cookie-name'].startswith('yrg'):
+            user.save_preferences({'yrg_banner_pref': data['cookie-name']})
+
         web.setcookie(
             data['cookie-name'], '1', expires=(cookie_duration_days * DAY_SECONDS)
         )

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -414,6 +414,8 @@ class account_login(delegate.page):
         ol_account = OpenLibraryAccount.get(email=email)
         if ol_account and ol_account.get_user().get_safe_mode() == 'yes':
             web.setcookie('sfw', 'yes', expires=expires)
+        if ol_account and 'yrg_banner_pref' in ol_account.get_user().preferences():
+            web.setcookie('yrg24', '1', expires=(3600 * 24 * 30))
         blacklist = [
             "/account/login",
             "/account/create",

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -355,7 +355,7 @@ class account_login_json(delegate.page):
                     web.setcookie(
                         ol_account.get_user().preferences()['yrg_banner_pref'],
                         '1',
-                        expires=(3600 * 24 * 30),
+                        expires=(3600 * 24 * 365),
                     )
         # Fallback to infogami user/pass
         else:
@@ -427,7 +427,7 @@ class account_login(delegate.page):
             web.setcookie(
                 ol_account.get_user().preferences()['yrg_banner_pref'],
                 '1',
-                expires=(3600 * 24 * 30),
+                expires=(3600 * 24 * 365),
             )
         blacklist = [
             "/account/login",

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -348,6 +348,15 @@ class account_login_json(delegate.page):
                 ol_account = OpenLibraryAccount.get(email=audit['ia_email'])
                 if ol_account and ol_account.get_user().get_safe_mode() == 'yes':
                     web.setcookie('sfw', 'yes', expires=expires)
+                if (
+                    ol_account
+                    and 'yrg_banner_pref' in ol_account.get_user().preferences()
+                ):
+                    web.setcookie(
+                        ol_account.get_user().preferences()['yrg_banner_pref'],
+                        '1',
+                        expires=(3600 * 24 * 30),
+                    )
         # Fallback to infogami user/pass
         else:
             from infogami.plugins.api.code import login as infogami_login
@@ -415,7 +424,11 @@ class account_login(delegate.page):
         if ol_account and ol_account.get_user().get_safe_mode() == 'yes':
             web.setcookie('sfw', 'yes', expires=expires)
         if ol_account and 'yrg_banner_pref' in ol_account.get_user().preferences():
-            web.setcookie('yrg24', '1', expires=(3600 * 24 * 30))
+            web.setcookie(
+                ol_account.get_user().preferences()['yrg_banner_pref'],
+                '1',
+                expires=(3600 * 24 * 30),
+            )
         blacklist = [
             "/account/login",
             "/account/create",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8814 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
This PR addresses the issue where the Yearly Reading Goal banner reappears upon each login. The solution involves persisting the banner preference on the User, preventing the banner from displaying every time a user logs in.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Dismiss the "Your Reading Goal" banner 
- You can monitor browser storage for the respective cookie starting with "yrg" stored locally
- Remove the cookies or open another browser
- Log in and check the "yrg" cookies being stored as per the user preference leading to no display of the YRG banner

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
