### PR TITLE
copy changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -13,11 +13,13 @@ body:
       label: Problem
       description: A short description of the issue you're facing.
       value: |
+        ### Problem
 
+        ### Related Issue(s)
 
         #### Evidence / Screenshot
 
-        #### Relevant URL
+        #### Relevant URL(s)
 
   - type: textarea
     attributes:
@@ -41,9 +43,9 @@ body:
         - Environment (prod, dev, local): prod
   - type: textarea
     attributes:
-      label: ⚠️ Experienced contributors only
+      label: Notes from this Issue's Lead
       description: |
-        Please leave these sections blank for maintainers if you are unsure what to enter!
+        Please leave these sections blank for maintainers if you are unsure what to enter
       value: |
         ### Proposal & constraints
         <!-- What is the proposed solution / implementation? Is there a precedent of this approach succeeding elsewhere? -->


### PR DESCRIPTION
The `Experienced contributors only` section -- when it has no content -- makes it seem as if it's a label and that the entire issue is for experienced contributors only (as opposed to being a content section for staff to fill in). This PR proposes alternate copy to address confusion.

![image](https://github.com/internetarchive/openlibrary/assets/978325/84a0433f-735f-4238-8a64-2fa4a5ecb013)


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
