### PR TITLE
Add free-form subject field to contact form

### DIFF
--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -32,11 +32,12 @@ class contact(delegate.page):
         patron_name = form.get("name", "")
         email = form.get("email", "")
         topic = form.get("topic", "")
+        subject_line = form.get('subject', '')
         description = form.get("question", "")
         url = form.get("url", "")
         user = accounts.get_current_user()
         useragent = web.ctx.env.get("HTTP_USER_AGENT", "")
-        if not all([email, topic, description]):
+        if not all([email, description]):
             return ""
 
         hashed_ip = hashlib.md5(web.ctx.ip.encode('utf-8')).hexdigest()
@@ -59,7 +60,7 @@ class contact(delegate.page):
         else:
             assignee = default_assignees.get("default", "openlibrary@archive.org")
         stats.increment("ol.support.all")
-        subject = "Support case *%s*" % topic
+        subject = "Support case *%s*" % self.prepare_subject_line(subject_line)
 
         url = web.ctx.home + url
         displayname = user and user.get_name() or ""
@@ -72,6 +73,14 @@ class contact(delegate.page):
             'contact-POST-%s' % hashed_ip, "true", expires=15 * MINUTE_SECS
         )
         return render_template("email/case_created", assignee)
+
+    def prepare_subject_line(self, subject, max_length=60):
+        if not subject:
+            return '[no subject]'
+        if len(subject) <= max_length:
+            return subject
+        
+        return subject[:max_length]
 
 
 def sendmail(from_address, to_address, subject, message):
@@ -95,7 +104,7 @@ Description:\n
 
 A new support case has been filed by %(displayname)s <%(email)s>.
 
-Topic: %(topic)s
+Subject: %(subject_line)s
 URL: %(url)s
 User-Agent: %(useragent)s
 OL-username: %(username)s

--- a/openlibrary/plugins/openlibrary/support.py
+++ b/openlibrary/plugins/openlibrary/support.py
@@ -79,7 +79,7 @@ class contact(delegate.page):
             return '[no subject]'
         if len(subject) <= max_length:
             return subject
-        
+
         return subject[:max_length]
 
 

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -26,19 +26,10 @@ $var title: $_('How can we help?')
  </div>
 
  <div class="formElement">
-   <div class="label"><label for="topic">$_("Topic")</label></div>
-   <div class="input">
-     <select class="required" name="topic" id="topic">
-       <option value="">$_('Select...')</option>
-       <option value="Borrowing Books">$_('Borrowing Help')</option>
-       <option value="Developer/Code">$_('Developer/Code Question')</option>
-       <option value="Editing Problem">$_('Editing Issue')</option>
-       <option value="Login Trouble">$_('Login Trouble')</option>
-       <option value="Spam Report">$_('Spam Report')</option>
-       <option value="Waiting List Issue">$_('Waiting List')</option>
-       <option value="Other">$_('Other Question')</option>
-     </select>
-   </div>
+  <div class="label"><label for="subject">$_("Subject")</label></div>
+  <div class="input">
+    <input type="text" name="subject">
+  </div>
  </div>
 
  <div class="formElement">

--- a/openlibrary/templates/support.html
+++ b/openlibrary/templates/support.html
@@ -41,10 +41,7 @@ $var title: $_('How can we help?')
    <p>$_('If you encounter an error message, please include it. For questions about our books, please provide the title/author or Open Library ID.')</p>
  </div>
 
- <!-- <div class="formElement"> -->
- <!-- <div class="label"><label for="url">$_("Which page were you looking at?")</label></div> -->
  <div class="input"><input type="hidden" name="url" id="url" value="$url"/></div>
-<!-- </div> -->
 
  $if recaptcha:
     $:render_template("recaptcha", recaptcha.public_key, error=None)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8890

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces "Topic" drop-down with a "Subject" input on our `/contact` page.

Subject lines for support emails will read:
`Support case *{subject}*`

... where `subject` is the given subject string, truncated to 60 characters, or `[no subject]` if the field was left blank by the submitter.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
The following cases have been tested:

1. Sending a support email with no subject
2. Sending a support email with a subject shorter than 60 characters
3. Sending an email with a subject longer than 60 characters

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
