### PR TITLE
Add messages.pot update script to pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,4 +105,4 @@ repos:
       additional_dependencies:
         - Babel==2.12.1
         - multipart==0.2.4
-        - "git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382#egg=web-py"
+        - "git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,6 +101,7 @@ repos:
       types_or: [python, html]
       language: python
       pass_filenames: false
+      # Dependencies must be manually updated to match versions in requirements.txt
       additional_dependencies:
         - Babel==2.12.1
         - multipart==0.2.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,7 @@ repos:
       name: Generate POT
       description: This hook generates the .pot file for internationalization.
       entry: python ./scripts/i18n-messages extract
+      types_or: [python, html]
       language: python
       pass_filenames: false
       additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,3 +91,16 @@ repos:
         - stylelint-declaration-strict-value@1.9.2
         - postcss-less@3.1.4
       args: [--fix]
+
+  - repo: local
+    hooks:
+    - id: generate-pot
+      name: Generate POT
+      description: This hook generates the .pot file for internationalization.
+      entry: python ./scripts/i18n-messages extract
+      language: python
+      files: '\.(html|py)$'
+      additional_dependencies:
+        - Babel==2.12.1
+        - multipart==0.2.4
+        - "git+https://github.com/webpy/webpy.git@ed3e92cceb6ed870b224107ea653f48fa7fc2d0a#egg=web-py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,4 +103,4 @@ repos:
       additional_dependencies:
         - Babel==2.12.1
         - multipart==0.2.4
-        - "git+https://github.com/webpy/webpy.git@ed3e92cceb6ed870b224107ea653f48fa7fc2d0a#egg=web-py"
+        - "git+https://github.com/webpy/webpy.git@d3649322b85777b291ac2b7b3699fb6fc839e382#egg=web-py"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
       description: This hook generates the .pot file for internationalization.
       entry: python ./scripts/i18n-messages extract
       language: python
-      files: '\.(html|py)$'
+      pass_filenames: false
       additional_dependencies:
         - Babel==2.12.1
         - multipart==0.2.4

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -140,7 +140,7 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
     return extract_python(f, keywords, comment_tags, options)
 
 
-def extract_messages(dirs: list[str]):
+def extract_messages(dirs: list[str], verbose: bool, forced: bool):
     catalog = Catalog(project='Open Library', copyright_holder='Internet Archive')
     METHODS = [("**.py", "python"), ("**.html", "openlibrary.i18n:extract_templetor")]
     COMMENT_TAGS = ["NOTE:"]
@@ -160,11 +160,13 @@ def extract_messages(dirs: list[str]):
             counts[filename] = counts.get(filename, 0) + 1
             catalog.add(message, None, [(filename, lineno)], auto_comments=comments)
 
-        for filename, count in counts.items():
-            path = filename if d == filename else os.path.join(d, filename)
-            print(f"{count}\t{path}", file=sys.stderr)
+        if verbose:
+            for filename, count in counts.items():
+                path = filename if d == filename else os.path.join(d, filename)
+                print(f"{count}\t{path}", file=sys.stderr)
 
-    if msg_set != new_set:
+    has_changed = msg_set != new_set
+    if has_changed or forced:
         path = os.path.join(root, 'messages.pot')
         f = open(path, 'wb')
         write_po(f, catalog, include_lineno=False)

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -35,8 +35,8 @@ def warning_color_fn(text: str) -> str:
     return '\033[93m' + text + '\033[0m'
 
 
-def get_untracked_files(dirs: list[str]) -> set:
-    """Gets untracked Python/HTML files to exclude from template."""
+def get_untracked_files(dirs: list[str], extensions: tuple[str, str] | str) -> set:
+    """Returns a set of all currently untracked files with specified extension(s)."""
     untracked_files = {
         Path(line)
         for dir in dirs
@@ -46,7 +46,7 @@ def get_untracked_files(dirs: list[str]) -> set:
             text=True,
             check=True,
         ).stdout.split('\n')
-        if line.endswith(('.py', '.html'))
+        if line.endswith(extensions)
     }
 
     return untracked_files
@@ -163,7 +163,7 @@ def extract_messages(dirs: list[str], verbose: bool, forced: bool):
     METHODS = [("**.py", "python"), ("**.html", "openlibrary.i18n:extract_templetor")]
     COMMENT_TAGS = ["NOTE:"]
 
-    untracked_files = get_untracked_files(dirs)
+    untracked_files = get_untracked_files(dirs, ('.py', '.html'))
     template = read_po((Path(root) / 'messages.pot').open('rb'))
     msg_set = {msg.id for msg in template if msg.id != ''}
     new_set = set()

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -147,11 +147,11 @@ def extract_messages(dirs: list[str]):
     pot_path = os.path.join(root, 'messages.pot')
     template = read_po(open(pot_path, 'rb'))
     catalog_msgs = template.__iter__()
-    msg_set = set()
+    msg_set: set[str | tuple[str]] = set()
     for msg in catalog_msgs:
         if msg.id != '':
             msg_set.add(msg.id)
-    new_set = set()
+    new_set: set[str | tuple[str]] = set()
 
     for d in dirs:
         extracted = extract_from_dir(

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -210,6 +210,14 @@ msgid "View revision %s"
 msgstr ""
 
 #: history.html
+msgid "Compare this version..."
+msgstr ""
+
+#: history.html
+msgid "...to this version"
+msgstr ""
+
+#: books/daisy.html history.html
 msgid "Back"
 msgstr ""
 
@@ -320,6 +328,17 @@ msgstr ""
 
 #: messages.html
 msgid "Thank you very much for improving that record!"
+msgstr ""
+
+#: BookPreview.html CreateListModal.html NotesModal.html ObservationsModal.html
+#: ShareModal.html book_providers/gutenberg_read_button.html
+#: book_providers/librivox_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html covers/author_photo.html
+#: covers/book_cover.html covers/book_cover_single_edition.html
+#: covers/book_cover_work.html covers/change.html lib/history.html
+#: my_books/dropdown_content.html native_dialog.html
+msgid "Close"
 msgstr ""
 
 #: notfound.html
@@ -577,9 +596,9 @@ msgstr ""
 
 #: CreateListModal.html EditButtons.html EditButtonsMacros.html
 #: account/create.html account/notifications.html account/password/reset.html
-#: account/privacy.html admin/imports-add.html books/add.html covers/add.html
-#: covers/manage.html databarAuthor.html databarEdit.html merge/authors.html
-#: my_books/dropdown_content.html support.html tag/add.html
+#: account/privacy.html admin/imports-add.html admin/permissions.html
+#: books/add.html covers/add.html covers/manage.html databarEdit.html
+#: merge/authors.html my_books/dropdown_content.html support.html tag/add.html
 msgid "Cancel"
 msgstr ""
 
@@ -587,7 +606,7 @@ msgstr ""
 msgid "Now"
 msgstr ""
 
-#: admin/graphs.html check_ins/check_in_form.html
+#: admin/graphs.html admin/index.html check_ins/check_in_form.html
 #: check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr ""
@@ -604,7 +623,8 @@ msgstr ""
 msgid "This Year"
 msgstr ""
 
-#: account/view.html books/year_breadcrumb_select.html trending.html
+#: account/view.html admin/index.html books/year_breadcrumb_select.html
+#: trending.html
 msgid "All Time"
 msgstr ""
 
@@ -726,7 +746,7 @@ msgstr ""
 msgid "Keywords"
 msgstr ""
 
-#: recentchanges/index.html work_search.html
+#: RecentChanges.html recentchanges/index.html work_search.html
 msgid "Everything"
 msgstr ""
 
@@ -752,6 +772,10 @@ msgstr ""
 
 #: work_search.html
 msgid "Classic eBook"
+msgstr ""
+
+#: work_search.html
+msgid "Search facets"
 msgstr ""
 
 #: work_search.html
@@ -810,11 +834,11 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: work_search.html
-msgid "Zoom In"
+msgid "BARF! Search engine ERROR!"
 msgstr ""
 
 #: work_search.html
-msgid "Focus your results using these"
+msgid "Zoom In"
 msgstr ""
 
 #: work_search.html:200
@@ -1110,6 +1134,10 @@ msgid "Set %(year_span)s reading goal"
 msgstr ""
 
 #: account/mybooks.html
+msgid "Yearly Reading Goal"
+msgstr ""
+
+#: account/mybooks.html
 msgid "No books are on this shelf"
 msgstr ""
 
@@ -1133,6 +1161,10 @@ msgstr ""
 
 #: account/mybooks.html
 msgid "View All Lists"
+msgstr ""
+
+#: account/mybooks.html
+msgid "My Stats"
 msgstr ""
 
 #: account/mybooks.html account/sidebar.html account/topmenu.html
@@ -1165,8 +1197,28 @@ msgstr ""
 msgid "Oops!"
 msgstr ""
 
+#: account/not_verified.html
+msgid "The email address you signed up with needs to be verified."
+msgstr ""
+
+#: account/not_verified.html
+#, python-format
+msgid ""
+"When you created your account, we sent an email to %(email)s that "
+"contained a link for you to verify your email address. We need you to "
+"click that link, please."
+msgstr ""
+
+#: account/not_verified.html
+msgid "If you can't find the email, just hit this button to send a fresh one:"
+msgstr ""
+
 #: account/not_verified.html account/verify/failed.html
 msgid "Resend the verification email"
+msgstr ""
+
+#: account/not_verified.html account/verify/failed.html
+msgid "Thanks!"
 msgstr ""
 
 #: BookByline.html SearchResultsWork.html account/notes.html
@@ -1514,6 +1566,18 @@ msgstr ""
 msgid "Hi, %(user)s"
 msgstr ""
 
+#: account/verify.html
+#, python-format
+msgid ""
+"We’ve sent an email to %(email)s containing a link to verify your "
+"account. Click/tap on the link to finish creating your Internet Archive "
+"account."
+msgstr ""
+
+#: account/verify.html
+msgid "Then, come back to Open Library and find some great books!"
+msgstr ""
+
 #: account/view.html type/edition/modal_links.html
 #: type/edition/title_and_author.html
 msgid "Share"
@@ -1638,6 +1702,10 @@ msgid ""
 msgstr ""
 
 #: account/verify/failed.html
+msgid "Fill your email and hit this button to resend a fresh verification email:"
+msgstr ""
+
+#: account/verify/failed.html
 msgid "Enter your email address here"
 msgstr ""
 
@@ -1674,22 +1742,155 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: admin/imports-add.html:14
+#: admin/imports-add.html books/add.html books/edit/edition.html
+#: books/edit/excerpts.html covers/change.html tag/add.html
+msgid "Add"
+msgstr ""
+
+#: admin/imports-add.html
 msgid "Add new books to import queue"
 msgstr ""
 
-#: admin/imports-add.html:16
+#: admin/imports-add.html
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr ""
 
 #: admin/imports-add.html admin/ip/view.html admin/people/edits.html
-#: check_ins/check_in_form.html check_ins/reading_goal_form.html
-#: covers/add.html
+#: admin/permissions.html check_ins/check_in_form.html
+#: check_ins/reading_goal_form.html covers/add.html
 msgid "Submit"
 msgstr ""
 
 #: admin/index.html
 msgid "Stats"
+msgstr ""
+
+#: admin/index.html
+msgid "Edits Per Day"
+msgstr ""
+
+#: admin/index.html admin/people/index.html
+msgid "Edits"
+msgstr ""
+
+#: admin/index.html
+msgid "Yesterday"
+msgstr ""
+
+#: admin/index.html
+msgid "Last 7 days"
+msgstr ""
+
+#: admin/index.html
+msgid "Last 28 days"
+msgstr ""
+
+#: admin/index.html
+msgid "Human"
+msgstr ""
+
+#: admin/index.html admin/people/view.html
+msgid "Bot"
+msgstr ""
+
+#: admin/index.html
+msgid "Total"
+msgstr ""
+
+#: admin/index.html
+msgid "New Accounts Per Day"
+msgstr ""
+
+#: admin/index.html
+msgid "Members"
+msgstr ""
+
+#: admin/index.html
+msgid "Items Added"
+msgstr ""
+
+#: admin/index.html
+msgid "Trend"
+msgstr ""
+
+#: admin/index.html
+msgid "Works Added"
+msgstr ""
+
+#: admin/index.html
+msgid "Editions Added"
+msgstr ""
+
+#: admin/index.html
+msgid "Authors Added"
+msgstr ""
+
+#: admin/index.html recentchanges/index.html
+msgid "Covers Added"
+msgstr ""
+
+#: admin/index.html home/stats.html
+msgid "New Members"
+msgstr ""
+
+#: admin/index.html
+msgid "Lists Added"
+msgstr ""
+
+#: admin/index.html
+msgid "Books Logged"
+msgstr ""
+
+#: admin/index.html
+msgid "Users Logging"
+msgstr ""
+
+#: admin/index.html
+msgid "Books Review Tags"
+msgstr ""
+
+#: admin/index.html
+msgid "Books Reviewed"
+msgstr ""
+
+#: admin/index.html
+msgid "Users Reviewing"
+msgstr ""
+
+#: admin/index.html
+msgid "Notes Created"
+msgstr ""
+
+#: admin/index.html
+msgid "Patrons Creating Notes"
+msgstr ""
+
+#: admin/index.html
+msgid "Books Starred"
+msgstr ""
+
+#: admin/index.html
+msgid "Star Rating Patrons"
+msgstr ""
+
+#: admin/index.html home/stats.html
+msgid "Unique Visitors"
+msgstr ""
+
+#: admin/index.html
+msgid "Unique visitors IPs per day graph"
+msgstr ""
+
+#: admin/index.html
+msgid "Borrows"
+msgstr ""
+
+#: admin/index.html
+msgid "Borrows, last 3 months graph"
+msgstr ""
+
+#: admin/index.html
+msgid "Borrows, last 2 years graph"
 msgstr ""
 
 #: admin/loans_table.html
@@ -1840,11 +2041,43 @@ msgstr ""
 msgid "# of edits"
 msgstr ""
 
+#: admin/ip/view.html
+msgid "IP"
+msgstr ""
+
 #: admin/ip/view.html:11
 msgid "IP"
 msgstr ""
 
-#: EditButtons.html EditButtonsMacros.html admin/ip/view.html
+#: admin/ip/view.html
+#, python-format
+msgid "Block %(ip)s"
+msgstr ""
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Please select the changesets to revert."
+msgstr ""
+
+#: RecentChanges.html admin/ip/view.html admin/people/edits.html
+#: recentchanges/render.html
+msgid "When you see numbers here, that's the IP address of the anonymous editor"
+msgstr ""
+
+#: admin/ip/view.html admin/people/edits.html
+#, python-format
+msgid "Reverted by %(revert_author)s"
+msgstr ""
+
+#: EditButtons.html admin/ip/view.html admin/people/edits.html
+msgid ""
+"Please, leave a short note about what you changed: <span class=\"small "
+"gray\">(Optional, but very useful!)</span>"
+msgstr ""
+
+#: admin/ip/view.html admin/people/edits.html
+msgid "Reverted spam"
+msgstr ""
+
 #: admin/people/edits.html
 msgid "Please, leave a short note about what you changed:"
 msgstr ""
@@ -1928,24 +2161,12 @@ msgstr ""
 msgid "email"
 msgstr ""
 
-#: admin/people/index.html
-msgid "Edits"
-msgstr ""
-
 #: admin/people/index.html admin/people/view.html
 msgid "Edit History"
 msgstr ""
 
 #: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
 msgid "Name:"
-msgstr ""
-
-#: admin/people/view.html
-msgid "Admin"
-msgstr ""
-
-#: admin/people/view.html
-msgid "Bot"
 msgstr ""
 
 #: admin/people/view.html
@@ -2060,18 +2281,6 @@ msgstr ""
 #: book_providers/standard_ebooks_read_button.html
 #: check_ins/reading_goal_progress.html
 msgid "Learn more"
-msgstr ""
-
-#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
-#: ObservationsModal.html ShareModal.html
-#: book_providers/gutenberg_read_button.html
-#: book_providers/librivox_read_button.html
-#: book_providers/openstax_read_button.html
-#: book_providers/standard_ebooks_read_button.html covers/author_photo.html
-#: covers/book_cover.html covers/book_cover_single_edition.html
-#: covers/book_cover_work.html covers/change.html lib/markdown.html
-#: my_books/dropdown_content.html
-msgid "Close"
 msgstr ""
 
 #: book_providers/ia_download_options.html
@@ -2534,7 +2743,7 @@ msgid "Editing..."
 msgstr ""
 
 #: EditButtonsMacros.html books/edit.html type/author/edit.html
-#: type/template/edit.html
+#: type/macro/edit.html type/template/edit.html
 msgid "Delete Record"
 msgstr ""
 
@@ -2596,6 +2805,10 @@ msgstr ""
 
 #: books/edition-sort.html
 msgid "Libraries near you:"
+msgstr ""
+
+#: books/edition-sort.html
+msgid "Look for this edition at WorldCat"
 msgstr ""
 
 #: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
@@ -2993,6 +3206,10 @@ msgid "Dimensions"
 msgstr ""
 
 #: books/edit/edition.html
+msgid "dimensions"
+msgstr ""
+
+#: books/edit/edition.html
 msgid "Height:"
 msgstr ""
 
@@ -3323,6 +3540,24 @@ msgstr ""
 msgid "Uploading..."
 msgstr ""
 
+#: covers/author_photo.html
+msgid "Pull up a larger author photo"
+msgstr ""
+
+#: covers/author_photo.html search/authors.html
+#, python-format
+msgid "Photo of %(author)s"
+msgstr ""
+
+#: covers/author_photo.html
+msgid "Click to close"
+msgstr ""
+
+#: covers/author_photo.html
+#, python-format
+msgid "We need a photo of %(author)s"
+msgstr ""
+
 #: covers/book_cover.html
 msgid "Pull up a bigger book cover"
 msgstr ""
@@ -3380,6 +3615,10 @@ msgstr ""
 msgid ""
 "You can drag and drop thumbnails to reorder, or into the trash to delete "
 "them."
+msgstr ""
+
+#: covers/saved.html
+msgid "New book cover"
 msgstr ""
 
 #: covers/saved.html
@@ -3506,19 +3745,11 @@ msgid "Area graph of recent unique visitors"
 msgstr ""
 
 #: home/stats.html
-msgid "Unique Visitors"
-msgstr ""
-
-#: home/stats.html
 msgid "How many new Open Library members have we welcomed?"
 msgstr ""
 
 #: home/stats.html
 msgid "Area graph of new members"
-msgstr ""
-
-#: home/stats.html
-msgid "New Members"
 msgstr ""
 
 #: home/stats.html
@@ -3698,6 +3929,10 @@ msgstr ""
 msgid "This doc was last edited anonymously"
 msgstr ""
 
+#: lib/header_dropdown.html
+msgid "My account"
+msgstr ""
+
 #: lib/header_dropdown.html type/user/view.html
 #, python-format
 msgid "Joined %(date)s"
@@ -3762,24 +3997,59 @@ msgstr ""
 msgid "Edited by %(user)s"
 msgstr ""
 
-#: lib/markdown.html
-msgid ""
-"We use a system called Markdown to format the text in your edits on Open "
-"Library. Some HTML formatting is also accepted. Paragraphs are "
-"automatically generated from any hard-break returns (blank lines) within "
-"your text. You can preview your work in real time below the editing "
-"field."
+#: lib/message_addbook.html
+msgid "Super!"
 msgstr ""
 
-#: lib/markdown.html
-msgid "Formatting marks should envelope the effected text, for example:"
+#: lib/message_addbook.html
+msgid " Your new record is in the library. Thank you!"
 msgstr ""
 
-#: lib/markdown.html
+#: lib/message_addbook.html
 msgid ""
-"To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk "
-"rather than emphasizing text) place a backslash \\ prior to the "
-"character."
+"There are a few other simple things you can add while you're here to "
+"improve your new record quickly, and make it much easier for other people"
+" to find later."
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Upload a cover image"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Snap a quick photo of the cover to share?"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Add an ISBN"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Help the library connect with other systems, like Amazon."
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Add some subjects"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "They're just like tags."
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Describe what the book's about"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Just a sentence or two is good."
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "cancel icon"
+msgstr ""
+
+#: lib/message_addbook.html
+msgid "Close this"
 msgstr ""
 
 #: lib/nav_foot.html
@@ -3959,10 +4229,6 @@ msgid ""
 msgstr ""
 
 #: lib/nav_head.html
-msgid "My Books"
-msgstr ""
-
-#: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
 msgstr ""
 
@@ -4038,16 +4304,6 @@ msgstr ""
 msgid "Search by barcode"
 msgstr ""
 
-#: lib/not_logged.html
-msgid ""
-"<strong>You are not <a href=\"/account/login\" title=\"Log in "
-"now\">logged in</a>.</strong> Open Library will record your IP address "
-"and include it in this page's publicly accessible edit history. If you <a"
-" href=\"/account/create\" title=\"Create an Open Library account\">create"
-" an account</a>, your IP address is concealed and you can more easily "
-"keep track of all your edits and additions."
-msgstr ""
-
 #: Pager.html Pager_loanhistory.html lib/pagination.html
 msgid "Previous"
 msgstr ""
@@ -4106,10 +4362,6 @@ msgid ""
 "<strong>export</strong> all the editions in a list as HTML, BibTeX or "
 "JSON. See all your lists and any activity using the \"Lists\" link on "
 "your Account page."
-msgstr ""
-
-#: lists/home.html
-msgid "Enjoy!"
 msgstr ""
 
 #: lists/home.html
@@ -4202,6 +4454,10 @@ msgid "Remove this seed?"
 msgstr ""
 
 #: lists/lists.html
+msgid "Remove"
+msgstr ""
+
+#: lists/lists.html
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
 msgstr ""
@@ -4229,7 +4485,7 @@ msgid_plural "%(count)d Lists"
 msgstr[0] ""
 msgstr[1] ""
 
-#: databarAuthor.html lists/widget.html my_books/dropdown_content.html
+#: lists/widget.html my_books/dropdown_content.html
 msgid "from"
 msgstr ""
 
@@ -4291,6 +4547,10 @@ msgstr ""
 
 #: merge/authors.html
 msgid "Merge"
+msgstr ""
+
+#: merge/authors.html
+msgid "birth/death date"
 msgstr ""
 
 #: merge/authors.html
@@ -4485,11 +4745,12 @@ msgstr ""
 msgid "Use this Work"
 msgstr ""
 
-#: CreateListModal.html databarAuthor.html my_books/dropdown_content.html
+#: CreateListModal.html my_books/dropdown_content.html
 msgid "Create a new list"
 msgstr ""
 
 #: CreateListModal.html my_books/dropdown_content.html
+#: type/permission/edit.html type/usergroup/edit.html
 msgid "Description:"
 msgstr ""
 
@@ -4558,6 +4819,14 @@ msgstr ""
 msgid "published most by this publisher"
 msgstr ""
 
+#: publishers/view.html
+msgid "Publisher Search"
+msgstr ""
+
+#: publishers/view.html
+msgid "Try a keyword."
+msgstr ""
+
 #: recentchanges/header.html recentchanges/index.html
 msgid "Recent Changes"
 msgstr ""
@@ -4578,15 +4847,11 @@ msgstr ""
 msgid "Books Added"
 msgstr ""
 
-#: recentchanges/index.html
-msgid "Covers Added"
-msgstr ""
-
-#: recentchanges/index.html
+#: RecentChanges.html recentchanges/index.html
 msgid "By Humans"
 msgstr ""
 
-#: recentchanges/index.html
+#: RecentChanges.html recentchanges/index.html
 msgid "By Bots"
 msgstr ""
 
@@ -5499,8 +5764,28 @@ msgstr ""
 msgid "Example"
 msgstr ""
 
+#: type/macro/edit.html
+msgid "Plugin"
+msgstr ""
+
+#: type/macro/edit.html
+msgid "Macro"
+msgstr ""
+
+#: type/macro/edit.html
+msgid "Delete this macro?"
+msgstr ""
+
 #: type/page/edit.html
 msgid "Document Body:"
+msgstr ""
+
+#: type/permission/edit.html
+msgid "Readers:"
+msgstr ""
+
+#: type/permission/edit.html
+msgid "Writers:"
 msgstr ""
 
 #: type/permission/view.html
@@ -5594,6 +5879,10 @@ msgstr ""
 msgid "No edits. Yet."
 msgstr ""
 
+#: type/usergroup/edit.html
+msgid "Members:"
+msgstr ""
+
 #: SearchResultsWork.html type/work/editions.html
 #, python-format
 msgid "First published in %(year)s"
@@ -5663,6 +5952,12 @@ msgstr ""
 
 #: AffiliateLinks.html
 msgid "Bookshop.org"
+msgstr ""
+
+#: AffiliateLinks.html
+msgid ""
+"When you buy books using these links the Internet Archive may earn a <a "
+"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
 msgstr ""
 
 #: BookByline.html
@@ -5845,8 +6140,8 @@ msgstr ""
 msgid "edit"
 msgstr ""
 
-#: RecentChangesAdmin.html
-msgid "diff"
+#: RecentChangesUsers.html
+msgid "No edit history available."
 msgstr ""
 
 #: ReturnForm.html
@@ -5855,6 +6150,11 @@ msgstr ""
 
 #: ReturnForm.html
 msgid "Return book"
+msgstr ""
+
+#: SRPCoverImage.html
+#, python-format
+msgid "Go to the page for %(title)s"
 msgstr ""
 
 #: SearchResultsWork.html
@@ -5867,6 +6167,11 @@ msgstr[1] ""
 #: SearchResultsWork.html
 #, python-format
 msgid "%s previewable"
+msgstr ""
+
+#: SearchResultsWork.html
+#, python-format
+msgid "Cover of edition %(id)s"
 msgstr ""
 
 #: SearchResultsWork.html
@@ -5884,6 +6189,10 @@ msgstr ""
 
 #: ShareModal.html:49
 msgid "Embed this book in your website"
+msgstr ""
+
+#: ShareModal.html
+msgid "Embed icon"
 msgstr ""
 
 #: ShareModal.html
@@ -6016,16 +6325,16 @@ msgstr ""
 msgid "Check WorldCat for an edition near you"
 msgstr ""
 
-#: databarAuthor.html
-msgid "Add to list"
+#: databarDiff.html databarEdit.html
+msgid "View the editing history of this page"
 msgstr ""
 
-#: databarAuthor.html
-msgid "×"
+#: databarDiff.html
+msgid "View this page (exit Comparison view)"
 msgstr ""
 
-#: databarAuthor.html
-msgid "Add new list"
+#: databarEdit.html
+msgid "View this page (exit Edit mode)"
 msgstr ""
 
 #: databarHistory.html databarView.html
@@ -6035,6 +6344,10 @@ msgstr ""
 
 #: databarHistory.html databarView.html
 msgid "Last edited anonymously"
+msgstr ""
+
+#: databarTemplate.html databarView.html
+msgid "View this template's edit history"
 msgstr ""
 
 #: databarWork.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Library VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-17 18:20+0000\n"
+"POT-Creation-Date: 2024-04-30 10:08-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -241,72 +241,71 @@ msgstr ""
 msgid "Library Explorer"
 msgstr ""
 
-#: lib/header_dropdown.html:59 lib/nav_head.html:128 login.html:10
-#: login.html:75
+#: lib/header_dropdown.html lib/nav_head.html login.html
 msgid "Log In"
 msgstr ""
 
-#: account/create.html:19 login.html:16
+#: account/create.html login.html
 msgid "OR"
 msgstr ""
 
-#: login.html:18
+#: login.html
 msgid ""
 "Please enter your <a href=\"https://archive.org\">Internet Archive</a> "
 "email and password to access your Open Library account."
 msgstr ""
 
-#: account/create.html:57 login.html:21
+#: account/create.html login.html
 #, python-format
 msgid "You are already logged into Open Library as %(user)s."
 msgstr ""
 
-#: account/create.html:58 login.html:22
+#: account/create.html login.html
 msgid ""
 "If you'd like to create a new, different Open Library account, you'll "
 "need to <a href=\"javascript:;\" onclick=\"document.forms['hamburger-"
 "logout'].submit()\">log out</a> and start the signup process afresh."
 msgstr ""
 
-#: login.html:30
+#: login.html
 msgid ""
 "This is a development instance, the default credentials are automatically"
 " filled."
 msgstr ""
 
-#: login.html:32
+#: login.html
 msgid "email:"
 msgstr ""
 
-#: login.html:32
+#: login.html
 msgid "password:"
 msgstr ""
 
-#: login.html:42
+#: login.html
 msgid "Email"
 msgstr ""
 
-#: login.html:44
+#: login.html
 msgid "Forgot your Internet Archive email?"
 msgstr ""
 
-#: account/email/forgot-ia.html:33 forms.py:31 login.html:54
+#: account/email/forgot-ia.html forms.py login.html
 msgid "Password"
 msgstr ""
 
-#: login.html:64
+#: login.html
 msgid "Remember me"
 msgstr ""
 
-#: account/email/forgot.html:48 login.html:79
+#: account/email/forgot.html login.html
 msgid "Forgot your Password?"
 msgstr ""
 
-#: login.html:81
+#: login.html
 msgid "Not a member of Open Library? <a href=\"/account/create\">Sign up now</a>."
 msgstr ""
 
-#: messages.html:11
+#: messages.html
 msgid "Created new author record."
 msgstr ""
 
@@ -410,19 +409,19 @@ msgstr ""
 msgid "Server status"
 msgstr ""
 
-#: SearchNavigation.html:24 SubjectTags.html:23 lib/nav_foot.html:28
-#: lib/nav_head.html:28 subjects.html:9 subjects/notfound.html:11
-#: type/author/view.html:174 type/list/view_body.html:195 work_search.html:51
+#: SearchNavigation.html SubjectTags.html lib/nav_foot.html lib/nav_head.html
+#: subjects.html subjects/notfound.html type/author/view.html
+#: type/list/view_body.html work_search.html
 msgid "Subjects"
 msgstr ""
 
-#: SubjectTags.html:27 subjects.html:9 type/author/view.html:175
-#: type/list/view_body.html:197 work_search.html:55
+#: SubjectTags.html subjects.html type/author/view.html
+#: type/list/view_body.html work_search.html
 msgid "Places"
 msgstr ""
 
-#: SubjectTags.html:25 admin/menu.html:20 subjects.html:9
-#: type/author/view.html:176 type/list/view_body.html:196 work_search.html:54
+#: SubjectTags.html admin/menu.html subjects.html type/author/view.html
+#: type/list/view_body.html work_search.html
 msgid "People"
 msgstr ""
 
@@ -438,8 +437,7 @@ msgstr ""
 msgid "See all works"
 msgstr ""
 
-#: merge/authors.html:102 publishers/view.html:17 subjects.html:38
-#: type/author/view.html:118
+#: merge/authors.html publishers/view.html subjects.html type/author/view.html
 #, python-format
 msgid "%(count)d work"
 msgid_plural "%(count)d works"
@@ -507,9 +505,9 @@ msgstr ""
 msgid "See more books by, and learn about, this author"
 msgstr ""
 
-#: account/loans.html:136 authors/index.html:28 publishers/view.html:83
-#: search/authors.html:60 search/publishers.html:29 search/subjects.html:73
-#: subjects.html:112
+#: account/loans.html authors/index.html publishers/view.html
+#: search/authors.html search/publishers.html search/subjects.html
+#: subjects.html
 #, python-format
 msgid "%(count)d book"
 msgid_plural "%(count)d books"
@@ -528,8 +526,8 @@ msgstr ""
 msgid "Get more information about this publisher"
 msgstr ""
 
-#: SearchResultsWork.html:95 books/check.html:36 merge/authors.html:95
-#: publishers/view.html:106 subjects.html:135
+#: SearchResultsWork.html books/check.html merge/authors.html
+#: publishers/view.html subjects.html
 #, python-format
 msgid "%(count)s edition"
 msgid_plural "%(count)s editions"
@@ -636,6 +634,10 @@ msgstr ""
 msgid "See what readers from the community are adding to their bookshelves"
 msgstr ""
 
+#: trending.html
+msgid "Earliest trending data is from October 2017"
+msgstr ""
+
 #: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
 #: my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
@@ -647,12 +649,11 @@ msgstr ""
 msgid "Currently Reading"
 msgstr ""
 
-#: LoanReadForm.html:9 ReadButton.html:19
-#: book_providers/gutenberg_read_button.html:15
-#: book_providers/openstax_read_button.html:15
-#: book_providers/standard_ebooks_read_button.html:15
-#: books/custom_carousel.html:18 books/edit/edition.html:660 books/show.html:34
-#: trending.html:27 type/list/embed.html:70 widget.html:34
+#: LoanReadForm.html ReadButton.html book_providers/gutenberg_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html books/custom_carousel.html
+#: books/edit/edition.html books/show.html trending.html type/list/embed.html
+#: widget.html
 msgid "Read"
 msgstr ""
 
@@ -674,45 +675,45 @@ msgstr ""
 msgid "Revert to this revision"
 msgstr ""
 
-#: widget.html:34
+#: widget.html
 #, python-format
 msgid "Read \"%(title)s\""
 msgstr ""
 
-#: widget.html:39
+#: widget.html
 #, python-format
 msgid "Borrow \"%(title)s\""
 msgstr ""
 
-#: ReadButton.html:15 books/custom_carousel.html:19 books/edit/edition.html:663
-#: type/list/embed.html:81 widget.html:39
+#: ReadButton.html books/custom_carousel.html books/edit/edition.html
+#: type/list/embed.html widget.html
 msgid "Borrow"
 msgstr ""
 
-#: widget.html:45
+#: widget.html
 #, python-format
 msgid "Join waitlist for \"%(title)s\""
 msgstr ""
 
-#: LoanStatus.html:97 books/custom_carousel.html:20 widget.html:45
+#: LoanStatus.html books/custom_carousel.html widget.html
 msgid "Join Waitlist"
 msgstr ""
 
-#: widget.html:49
+#: widget.html
 #, python-format
 msgid "Learn more about \"%(title)s\" at OpenLibrary"
 msgstr ""
 
-#: widget.html:49
+#: widget.html
 msgid "Learn More"
 msgstr ""
 
-#: widget.html:51
+#: widget.html
 #, python-format
 msgid "on <a target=\"_blank\" href=\"%(link)s\">openlibrary.org</a>"
 msgstr ""
 
-#: work_search.html:44
+#: work_search.html
 msgid "Search Books"
 msgstr ""
 
@@ -825,8 +826,8 @@ msgstr ""
 msgid "Add a new book to Open Library?"
 msgstr ""
 
-#: account/reading_log.html:50 search/authors.html:45 search/subjects.html:35
-#: work_search.html:167
+#: account/reading_log.html search/authors.html search/subjects.html
+#: work_search.html
 #, python-format
 msgid "%(count)s hit"
 msgid_plural "%(count)s hits"
@@ -841,7 +842,7 @@ msgstr ""
 msgid "Zoom In"
 msgstr ""
 
-#: work_search.html:200
+#: work_search.html
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
 msgstr ""
 
@@ -890,7 +891,7 @@ msgstr ""
 msgid "Sign Up"
 msgstr ""
 
-#: account/create.html:21
+#: account/create.html
 msgid "Complete the form below to create a new Internet Archive account."
 msgstr ""
 
@@ -906,7 +907,7 @@ msgstr ""
 msgid "Hide password"
 msgstr ""
 
-#: account/create.html:67
+#: account/create.html
 msgid "Your URL"
 msgstr ""
 
@@ -927,6 +928,10 @@ msgstr ""
 
 #: account/delete.html
 msgid "Sorry, this functionality is not yet implemented."
+msgstr ""
+
+#: account/follows.html
+msgid "There is nothing to see here yet."
 msgstr ""
 
 #: account/import.html
@@ -998,7 +1003,7 @@ msgid "Export your star ratings"
 msgstr ""
 
 #: account/import.html
-msgid "Download a copy of your star ratings"
+msgid "Download a copy of your star ratings."
 msgstr ""
 
 #: account/import.html
@@ -1069,66 +1074,66 @@ msgid ""
 "of<br/><strong>TITLE</strong>?"
 msgstr ""
 
-#: account/loans.html:138 admin/loans_table.html:43 admin/menu.html:33
+#: account/loans.html admin/loans_table.html admin/menu.html
 msgid "Status"
 msgstr ""
 
-#: RecentChangesAdmin.html:23 account/loans.html:139 admin/loans_table.html:47
+#: RecentChangesAdmin.html account/loans.html admin/loans_table.html
 msgid "Actions"
 msgstr ""
 
-#: account/loans.html:161
+#: account/loans.html
 #, python-format
 msgid "Waiting for 1 day"
 msgid_plural "Waiting for %(count)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html:168
+#: account/loans.html
 msgid "You are the next person to receive this book."
 msgstr ""
 
-#: ManageWaitlistButton.html:21 account/loans.html:170
+#: ManageWaitlistButton.html account/loans.html
 #, python-format
 msgid "There is one person ahead of you in the waiting list."
 msgid_plural "There are %(count)d people ahead of you in the waiting list."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html:179
+#: account/loans.html
 msgid "You have less than an hour to borrow it."
 msgstr ""
 
-#: account/loans.html:181
+#: account/loans.html
 #, python-format
 msgid "You have one more hour to borrow it."
 msgid_plural "You have %(hours)d more hours to borrow it."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html:188
+#: account/loans.html
 msgid "Borrow Now"
 msgstr ""
 
-#: account/loans.html:193
+#: account/loans.html
 msgid "Leave the waiting list?"
 msgstr ""
 
-#: account/loans.html:206
+#: account/loans.html
 msgid ""
 "Looking for a book to borrow?  Check out our staff picks, or search for a"
 " book on a specific subject:"
 msgstr ""
 
-#: account/loans.html:207 home/index.html:31
+#: account/loans.html home/index.html
 msgid "Books We Love"
 msgstr ""
 
-#: account/loans.html:209
+#: account/loans.html
 msgid "Or, check out our <a href=\"/collections\">special collections</a>."
 msgstr ""
 
-#: account/mybooks.html:29
+#: account/mybooks.html
 #, python-format
 msgid "Set %(year_span)s reading goal"
 msgstr ""
@@ -1145,9 +1150,9 @@ msgstr ""
 msgid "My Loans"
 msgstr ""
 
-#: account/mybooks.html:71 account/readinglog_shelf_name.html:12
-#: account/sidebar.html:29 my_books/dropdown_content.html:48
-#: my_books/primary_action.html:12 mybooks.py:227 search/sort_options.html:38
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html mybooks.py
+#: search/sort_options.html
 msgid "Already Read"
 msgstr ""
 
@@ -1171,8 +1176,8 @@ msgstr ""
 msgid "My Reading Stats"
 msgstr ""
 
-#: account.py:1144 account/mybooks.html:184 account/sidebar.html:16
-#: books/mybooks_breadcrumb_select.html:20
+#: account.py account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html
 msgid "Loan History"
 msgstr ""
 
@@ -1326,7 +1331,7 @@ msgstr ""
 #: account/privacy.html
 msgid ""
 "This will enable others to see what books you want to read, are reading, "
-"or have already read."
+"or have already read. Public accounts can be seen and followed by others."
 msgstr ""
 
 #: account/privacy.html
@@ -1345,6 +1350,18 @@ msgstr ""
 msgid ""
 "Safe Mode blurs book covers that have been flagged as having sensitive "
 "imagery."
+msgstr ""
+
+#: account/reading_log.html
+msgid "want to read"
+msgstr ""
+
+#: account/reading_log.html
+msgid "currently reading"
+msgstr ""
+
+#: account/reading_log.html
+msgid "already read"
 msgstr ""
 
 #: account/reading_log.html
@@ -1397,6 +1414,16 @@ msgstr ""
 
 #: account/reading_log.html
 #, python-format
+msgid "Books in %(username)s feed"
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
+msgid "Books added by people %(username)s follows"
+msgstr ""
+
+#: account/reading_log.html
+#, python-format
 msgid "Books %(userdisplayname)s is sponsoring"
 msgstr ""
 
@@ -1439,6 +1466,12 @@ msgid ""
 "href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
 msgstr ""
 
+#: account/reading_log.html
+msgid ""
+"There are no recent books in your feed. When you follow public accounts, "
+"their book updates will appear here."
+msgstr ""
+
 #: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr ""
@@ -1448,12 +1481,11 @@ msgstr ""
 msgid "My %(shelf_name)s Stats"
 msgstr ""
 
-#: account/readinglog_stats.html:104 lib/nav_head.html:13 lib/nav_head.html:25
-#: lib/nav_head.html:77
+#: account/readinglog_stats.html lib/nav_head.html
 msgid "My Books"
 msgstr ""
 
-#: account/readinglog_stats.html:111
+#: account/readinglog_stats.html
 #, python-format
 msgid ""
 "Displaying stats about <strong>%(works_count)d</strong> books. Note all "
@@ -1518,6 +1550,10 @@ msgstr ""
 msgid "Click on a bar to see matching works"
 msgstr ""
 
+#: account/sidebar.html books/mybooks_breadcrumb_select.html mybooks.py
+msgid "My Feed"
+msgstr ""
+
 #: account/sidebar.html search/sort_options.html type/user/view.html
 msgid "Reading Log"
 msgstr ""
@@ -1559,9 +1595,8 @@ msgstr ""
 msgid "Verification email sent"
 msgstr ""
 
-#: account.py:477 account.py:531 account/password/reset_success.html:10
-#: account/verify.html:9 account/verify/activated.html:10
-#: account/verify/success.html:10
+#: account.py account/password/reset_success.html account/verify.html
+#: account/verify/activated.html account/verify/success.html
 #, python-format
 msgid "Hi, %(user)s"
 msgstr ""
@@ -1576,6 +1611,14 @@ msgstr ""
 
 #: account/verify.html
 msgid "Then, come back to Open Library and find some great books!"
+msgstr ""
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Following"
+msgstr ""
+
+#: account/view.html books/mybooks_breadcrumb_select.html
+msgid "Followers"
 msgstr ""
 
 #: account/view.html type/edition/modal_links.html
@@ -1622,7 +1665,7 @@ msgstr ""
 msgid "Open Library Email"
 msgstr ""
 
-#: account/email/forgot-ia.html:38
+#: account/email/forgot-ia.html
 msgid "Retrieve Archive.org Email"
 msgstr ""
 
@@ -1634,7 +1677,7 @@ msgstr ""
 msgid "Forgot Your Open Library Email?"
 msgstr ""
 
-#: account/password/forgot.html:7 account/password/sent.html:7
+#: account/password/forgot.html account/password/sent.html
 msgid "Username/Password Reminder"
 msgstr ""
 
@@ -1732,14 +1775,8 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: admin/imports-add.html:10 admin/menu.html:27
+#: admin/imports-add.html admin/menu.html
 msgid "Imports"
-msgstr ""
-
-#: admin/imports-add.html:10 books/add.html:105 books/edit/edition.html:213
-#: books/edit/edition.html:451 books/edit/edition.html:516
-#: books/edit/excerpts.html:55 covers/change.html:49 tag/add.html:64
-msgid "Add"
 msgstr ""
 
 #: admin/imports-add.html books/add.html books/edit/edition.html
@@ -1897,15 +1934,14 @@ msgstr ""
 msgid "BookReader"
 msgstr ""
 
-#: admin/loans_table.html:18 book_providers/ia_download_options.html:12
-#: book_providers/openstax_download_options.html:13 books/edit/edition.html:672
+#: admin/loans_table.html book_providers/ia_download_options.html
+#: book_providers/openstax_download_options.html books/edit/edition.html
 msgid "PDF"
 msgstr ""
 
-#: admin/loans_table.html:19 book_providers/gutenberg_download_options.html:17
-#: book_providers/ia_download_options.html:16
-#: book_providers/standard_ebooks_download_options.html:15
-#: books/edit/edition.html:671
+#: admin/loans_table.html book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/standard_ebooks_download_options.html books/edit/edition.html
 msgid "ePub"
 msgstr ""
 
@@ -1930,8 +1966,8 @@ msgstr ""
 msgid "Sponsorship"
 msgstr ""
 
-#: account.py:1111 admin/menu.html:22 admin/people/view.html:233
-#: books/mybooks_breadcrumb_select.html:19 type/user/view.html:29
+#: account.py admin/menu.html admin/people/view.html
+#: books/mybooks_breadcrumb_select.html type/user/view.html
 msgid "Loans"
 msgstr ""
 
@@ -1963,49 +1999,49 @@ msgstr ""
 msgid "Inspect memcache"
 msgstr ""
 
-#: admin/permissions.html:11
+#: admin/permissions.html
 msgid "Site Permissions"
 msgstr ""
 
-#: admin/permissions.html:17
+#: admin/permissions.html
 msgid "Change the policy of who can edit the site."
 msgstr ""
 
-#: admin/permissions.html:28
+#: admin/permissions.html
 msgid "Who can edit Open Library records?"
 msgstr ""
 
-#: admin/permissions.html:29
+#: admin/permissions.html
 msgid "This applies to /authors/*, /books/* and /works/* records."
 msgstr ""
 
-#: admin/permissions.html:38
+#: admin/permissions.html
 msgid "Who can edit Open Library pages?"
 msgstr ""
 
-#: admin/permissions.html:39
+#: admin/permissions.html
 msgid "This applies to /about/*, /help/*, /dev/*, /docs/* etc."
 msgstr ""
 
-#: admin/permissions.html:49
+#: admin/permissions.html
 msgid "Update permissions"
 msgstr ""
 
-#: admin/permissions.html:57
+#: admin/permissions.html
 msgid ""
 "This updates  and  fields of /, /works, /books and /authors records in "
 "the database."
 msgstr ""
 
-#: admin/profile.html:7 databarTemplate.html:15
+#: admin/profile.html databarTemplate.html
 msgid "Edit this template"
 msgstr ""
 
-#: admin/people/view.html:171 admin/profile.html:7
+#: admin/people/view.html admin/profile.html
 msgid "Admin"
 msgstr ""
 
-#: admin/solr.html:31
+#: admin/solr.html
 msgid "Enter the keys to reindex in Solr"
 msgstr ""
 
@@ -2045,8 +2081,9 @@ msgstr ""
 msgid "IP"
 msgstr ""
 
-#: admin/ip/view.html:11
-msgid "IP"
+#: admin/ip/view.html
+#, python-format
+msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
 msgstr ""
 
 #: admin/ip/view.html
@@ -2079,48 +2116,15 @@ msgid "Reverted spam"
 msgstr ""
 
 #: admin/people/edits.html
-msgid "Please, leave a short note about what you changed:"
-msgstr ""
-
-#: admin/ip/view.html:21
-#, python-format
-msgid "Block %(ip)s"
-msgstr ""
-
-#: admin/ip/view.html:25 admin/people/edits.html:24
-msgid "Please select the changesets to revert."
-msgstr ""
-
-#: RecentChanges.html:48 admin/ip/view.html:70 admin/people/edits.html:67
-#: recentchanges/render.html:51
-msgid "When you see numbers here, that's the IP address of the anonymous editor"
-msgstr ""
-
-#: admin/ip/view.html:76 admin/people/edits.html:73
-#, python-format
-msgid "Reverted by %(revert_author)s"
-msgstr ""
-
-#: EditButtons.html:9 admin/ip/view.html:86 admin/people/edits.html:83
-msgid ""
-"Please, leave a short note about what you changed: <span class=\"small "
-"gray\">(Optional, but very useful!)</span>"
-msgstr ""
-
-#: admin/ip/view.html:89 admin/people/edits.html:86
-msgid "Reverted spam"
-msgstr ""
-
-#: admin/people/edits.html:18
 msgid "people"
 msgstr ""
 
-#: admin/people/edits.html:18
+#: admin/people/edits.html
 msgid "edits"
 msgstr ""
 
-#: RecentChanges.html:61 RecentChangesAdmin.html:56 RecentChangesUsers.html:58
-#: admin/people/edits.html:100 recentchanges/render.html:67
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/people/edits.html recentchanges/render.html
 msgid "Older"
 msgstr ""
 
@@ -2232,8 +2236,8 @@ msgstr ""
 msgid "Download an HTML from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:15
-#: book_providers/standard_ebooks_download_options.html:14
+#: book_providers/gutenberg_download_options.html
+#: book_providers/standard_ebooks_download_options.html
 msgid "HTML"
 msgstr ""
 
@@ -2299,19 +2303,19 @@ msgstr ""
 msgid "Download a MOBI file from Internet Archive"
 msgstr ""
 
-#: book_providers/ia_download_options.html:18
+#: book_providers/ia_download_options.html
 msgid "MOBI"
 msgstr ""
 
-#: book_providers/ia_download_options.html:19
+#: book_providers/ia_download_options.html
 msgid "Download open DAISY from Internet Archive (print-disabled format)"
 msgstr ""
 
-#: book_providers/ia_download_options.html:19 type/list/embed.html:86
+#: book_providers/ia_download_options.html type/list/embed.html
 msgid "DAISY"
 msgstr ""
 
-#: book_providers/librivox_download_options.html:12
+#: book_providers/librivox_download_options.html
 msgid "Download a ZIP file of the whole book from Internet Archive"
 msgstr ""
 
@@ -2380,19 +2384,19 @@ msgstr ""
 msgid "Download a Kindle file from Standard Ebooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:16
+#: book_providers/standard_ebooks_download_options.html
 msgid "Kindle (azw3)"
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:17
+#: book_providers/standard_ebooks_download_options.html
 msgid "Download a Kobo file from Standard Ebooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:17
+#: book_providers/standard_ebooks_download_options.html
 msgid "Kobo (kepub)"
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:18
+#: book_providers/standard_ebooks_download_options.html
 msgid "View the source code for this Standard Ebook at GitHub"
 msgstr ""
 
@@ -2542,6 +2546,10 @@ msgid "Add this book now"
 msgstr ""
 
 #: books/author-autocomplete.html
+msgid "Add a new author"
+msgstr ""
+
+#: books/author-autocomplete.html
 msgid "Create a new record for"
 msgstr ""
 
@@ -2574,20 +2582,20 @@ msgstr ""
 msgid "Select this book"
 msgstr ""
 
-#: books/check.html:38
+#: books/check.html
 #, python-format
 msgid "First published in %(year)d"
 msgstr ""
 
-#: books/check.html:46
+#: books/check.html
 msgid "None of these match the book I want to add."
 msgstr ""
 
-#: books/check.html:46
+#: books/check.html
 msgid "Continue</a>."
 msgstr ""
 
-#: NotInLibrary.html:13 NotInLibrary.html:17 books/custom_carousel.html:21
+#: NotInLibrary.html books/custom_carousel.html
 msgid "Not in Library"
 msgstr ""
 
@@ -2600,43 +2608,43 @@ msgstr ""
 msgid " by %(name)s"
 msgstr ""
 
-#: books/daisy.html:19
+#: books/daisy.html
 msgid "Open Library Home"
 msgstr ""
 
-#: books/daisy.html:24
+#: books/daisy.html
 msgid "There isn't a DAISY file available for "
 msgstr ""
 
-#: books/daisy.html:28
+#: books/daisy.html
 msgid "This DAISY file is protected."
 msgstr ""
 
-#: books/daisy.html:29
+#: books/daisy.html
 msgid ""
 "It can only be opened on a specialized device with a key issued by the "
 "Library of Congress."
 msgstr ""
 
-#: books/daisy.html:32 books/daisy.html:36
+#: books/daisy.html
 #, python-format
 msgid ""
 "<strong>Download the DAISY.zip</strong></a> for <a "
 "href=\"%(url)s\">%(title)s</a>"
 msgstr ""
 
-#: books/daisy.html:40
+#: books/daisy.html
 msgid "Books for people who don't read print?"
 msgstr ""
 
-#: books/daisy.html:41
+#: books/daisy.html
 msgid ""
 "The <a href=\"//archive.org\">Internet Archive</a> is proud to be "
 "distributing over 1 million books free in a format called DAISY, designed"
 " for those of us who find it challenging to use regular printed media. "
 msgstr ""
 
-#: books/daisy.html:42
+#: books/daisy.html
 #, python-format
 msgid ""
 "There are two types of DAISYs on Open Library: <i>open</i> and "
@@ -2646,15 +2654,15 @@ msgid ""
 "Congress NLS program</a>."
 msgstr ""
 
-#: books/daisy.html:43 lists/home.html:18
+#: books/daisy.html lists/home.html
 msgid "Enjoy!"
 msgstr ""
 
-#: books/daisy.html:48
+#: books/daisy.html
 msgid "What is the DAISY format?"
 msgstr ""
 
-#: books/daisy.html:49
+#: books/daisy.html
 msgid ""
 "The DAISY digital format helps people who have challenges using regular "
 "printed media. DAISY digital <span class=\"highlight\">talking "
@@ -2662,15 +2670,15 @@ msgid ""
 "within the book, to chapters or specific pages."
 msgstr ""
 
-#: books/daisy.html:50
+#: books/daisy.html
 msgid "More information at daisy.org"
 msgstr ""
 
-#: books/daisy.html:54
+#: books/daisy.html
 msgid "What is the NLS?"
 msgstr ""
 
-#: books/daisy.html:55
+#: books/daisy.html
 msgid ""
 "The Library of Congress <a href=\"http://www.loc.gov/nls/\">National "
 "Library Service for the Blind and Physically Handicapped (NLS)</a> "
@@ -2679,15 +2687,15 @@ msgid ""
 "network of cooperating libraries."
 msgstr ""
 
-#: books/daisy.html:56
+#: books/daisy.html
 msgid "Are you eligible to register?"
 msgstr ""
 
-#: books/daisy.html:60
+#: books/daisy.html
 msgid "How do I find DAISYs on Open Library?"
 msgstr ""
 
-#: books/daisy.html:62
+#: books/daisy.html
 msgid ""
 "In addition to<a href=\"/subjects/accessible_book\" title=\"Subject: "
 "Accessible book\"> loads of open DAISYs</a>, the Open Library lists a "
@@ -2697,23 +2705,23 @@ msgid ""
 " you by the<a href=\"//archive.org/\"> Internet Archive</a>."
 msgstr ""
 
-#: books/daisy.html:63
+#: books/daisy.html
 msgid ""
 "Looking for a specific title? The best way to find it is to<a "
 "href=\"/search\"> search for it</a>."
 msgstr ""
 
-#: books/daisy.html:69 lib/history.html:62
+#: books/daisy.html lib/history.html
 msgid "Need help?"
 msgstr ""
 
-#: books/daisy.html:69
+#: books/daisy.html
 msgid ""
 " Please read our <a href=\"/help/faq\">FAQ on accessing books through "
 "Open Library</a>."
 msgstr ""
 
-#: books/edit.html:30 books/edit.html:33 books/edit.html:36
+#: books/edit.html
 msgid "Add a little more?"
 msgstr ""
 
@@ -2778,12 +2786,10 @@ msgstr ""
 msgid "Links"
 msgstr ""
 
-#: IABook.html:13 IABook.html:14 SearchResultsWork.html:54
-#: SearchResultsWork.html:55 books/edition-sort.html:39
-#: books/edition-sort.html:40 jsdef/LazyWorkPreview.html:13
-#: lists/list_overview.html:15 lists/preview.html:9 lists/snippet.html:9
-#: lists/widget.html:78 my_books/dropdown_content.html:126
-#: type/work/editions.html:27
+#: IABook.html SearchResultsWork.html books/edition-sort.html
+#: jsdef/LazyWorkPreview.html lists/list_overview.html lists/preview.html
+#: lists/snippet.html lists/widget.html my_books/dropdown_content.html
+#: type/work/editions.html
 #, python-format
 msgid "Cover of: %(title)s"
 msgstr ""
@@ -2841,7 +2847,7 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: account.py:867 books/mybooks_breadcrumb_select.html:23
+#: account.py books/mybooks_breadcrumb_select.html
 msgid "Imports and Exports"
 msgstr ""
 
@@ -2865,47 +2871,47 @@ msgstr ""
 msgid "Please separate with commas."
 msgstr ""
 
-#: books/edit/about.html:38
+#: books/edit/about.html
 msgid ""
 "For example: <i><a href=\"/subjects/cheese\">cheese</a>, <a "
 "href=\"/subjects/roman_empire\">Roman Empire</a>, <a "
-"href=\"/subjects/psychology\">psychology"
+"href=\"/subjects/psychology\">psychology</a>"
 msgstr ""
 
 #: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr ""
 
-#: books/edit/about.html:49
+#: books/edit/about.html
 msgid ""
 "For example: <i><a href=\"/subjects/person:Theodore_Roosevelt\">Theodore "
 "Roosevelt</a>, <a href=\"/subjects/person:Julian_of_Norwich\">Julian of "
-"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin"
+"Norwich</a>, <a href=\"/subjects/person:Tintin\">Tintin</a>"
 msgstr ""
 
-#: books/edit/about.html:59
+#: books/edit/about.html
 msgid "Note any places mentioned?"
 msgstr ""
 
-#: books/edit/about.html:60
+#: books/edit/about.html
 msgid ""
 "For example: <i><a href=\"/subjects/place:London\">London</a>, <a "
 "href=\"/subjects/place:Atlantis\">Atlantis</a>, <a "
-"href=\"/subjects/place:Omaha\">Omaha"
+"href=\"/subjects/place:Omaha\">Omaha</a>"
 msgstr ""
 
-#: books/edit/about.html:70
+#: books/edit/about.html
 msgid "When is it set or about?"
 msgstr ""
 
-#: books/edit/about.html:71
+#: books/edit/about.html
 msgid ""
 "For example: <i><a href=\"/subjects/time:1984\">1984</a>, <a "
 "href=\"/subjects/time:the_middle_ages\">The Middle Ages</a>, <a "
-"href=\"/subjects/time:1810-1890\">1810-1890"
+"href=\"/subjects/time:1810-1890\">1810-1890</a>"
 msgstr ""
 
-#: books/edit/edition.html:22
+#: books/edit/edition.html
 msgid "Select this language"
 msgstr ""
 
@@ -2937,15 +2943,12 @@ msgstr ""
 msgid "Usually distinguished by different or smaller type."
 msgstr ""
 
-#: books/edit/edition.html:93 books/edit/edition.html:116
-#: books/edit/edition.html:149 books/edit/edition.html:159
-#: books/edit/edition.html:252 books/edit/edition.html:355
-#: books/edit/edition.html:369 books/edit/edition.html:577
-#: books/edit/excerpts.html:24 books/edit/web.html:29 type/author/edit.html:113
+#: books/edit/edition.html books/edit/excerpts.html books/edit/web.html
+#: type/author/edit.html
 msgid "For example:"
 msgstr ""
 
-#: books/edit/edition.html:100
+#: books/edit/edition.html
 msgid "Publishing Info"
 msgstr ""
 
@@ -3124,8 +3127,8 @@ msgstr ""
 msgid "Invalid ID format"
 msgstr ""
 
-#: books/edit/edition.html:411 type/author/view.html:186
-#: type/edition/view.html:458 type/work/view.html:458
+#: books/edit/edition.html type/author/view.html type/edition/view.html
+#: type/work/view.html
 msgid "ID Numbers"
 msgstr ""
 
@@ -3141,7 +3144,7 @@ msgstr ""
 msgid "Select one of many..."
 msgstr ""
 
-#: books/edit/edition.html:488
+#: books/edit/edition.html
 msgid "Please select a classification."
 msgstr ""
 
@@ -3454,11 +3457,11 @@ msgstr ""
 msgid "Delete Event"
 msgstr ""
 
-#: check_ins/check_in_prompt.html:24
+#: check_ins/check_in_prompt.html
 msgid "Read:"
 msgstr ""
 
-#: check_ins/check_in_prompt.html:32
+#: check_ins/check_in_prompt.html
 msgid "When did you finish this book?"
 msgstr ""
 
@@ -3852,7 +3855,7 @@ msgstr ""
 msgid "Your feedback will help us improve these cards"
 msgstr ""
 
-#: languages/index.html:15
+#: languages/index.html
 #, python-format
 msgid "%s book"
 msgid_plural "%s books"
@@ -3942,7 +3945,7 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: lib/header_dropdown.html:75
+#: lib/header_dropdown.html
 msgid "New!"
 msgstr ""
 
@@ -3979,11 +3982,11 @@ msgstr ""
 msgid "Copy and paste this code into your Wikipedia page."
 msgstr ""
 
-#: lib/history.html:62
+#: lib/history.html
 msgid "Get instructions at Wikipedia in a new window"
 msgstr ""
 
-#: lib/history.html:81 lib/history.html:83
+#: lib/history.html
 msgid "an anonymous user"
 msgstr ""
 
@@ -4116,9 +4119,8 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
-#: SearchNavigation.html:32 lib/nav_foot.html:30 lib/nav_head.html:36
-#: search/advancedsearch.html:7 search/advancedsearch.html:14
-#: search/advancedsearch.html:18
+#: SearchNavigation.html lib/nav_foot.html lib/nav_head.html
+#: search/advancedsearch.html
 msgid "Advanced Search"
 msgstr ""
 
@@ -4194,15 +4196,15 @@ msgstr ""
 msgid "Release Notes"
 msgstr ""
 
-#: lib/nav_foot.html:53
+#: lib/nav_foot.html
 msgid "Twitter"
 msgstr ""
 
-#: lib/nav_foot.html:54
+#: lib/nav_foot.html
 msgid "GitHub"
 msgstr ""
 
-#: lib/nav_foot.html:58 site/alert.html:17
+#: lib/nav_foot.html site/alert.html
 msgid "Change Website Language"
 msgstr ""
 
@@ -4292,7 +4294,7 @@ msgstr ""
 msgid "The Internet Archive's Open Library: One page for every book"
 msgstr ""
 
-#: lib/nav_head.html:90 lib/nav_head.html:92
+#: lib/nav_head.html
 msgid "All"
 msgstr ""
 
@@ -4379,7 +4381,7 @@ msgstr ""
 msgid "Active Lists"
 msgstr ""
 
-#: lists/home.html:49
+#: lists/home.html
 #, python-format
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr ""
@@ -4409,19 +4411,17 @@ msgstr ""
 msgid "See all"
 msgstr ""
 
-#: lists/list_overview.html:19 lists/widget.html:79
-#: my_books/dropdown_content.html:127
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "See this list"
 msgstr ""
 
-#: lists/list_overview.html:29 lists/widget.html:80
-#: my_books/dropdown_content.html:128
+#: lists/list_overview.html lists/widget.html my_books/dropdown_content.html
 msgid "Remove from your list?"
 msgstr ""
 
-#: lists/list_overview.html:32
+#: lists/list_overview.html
 #, python-format
-msgid "from <a href=\"$list.owner.key\">%(owner)s"
+msgid "from <a href=\"%(link)s\">You</a>"
 msgstr ""
 
 #: lists/lists.html
@@ -4489,15 +4489,15 @@ msgstr[1] ""
 msgid "from"
 msgstr ""
 
-#: lists/widget.html:82 my_books/dropdown_content.html:130
+#: lists/widget.html my_books/dropdown_content.html
 msgid "You"
 msgstr ""
 
-#: lists/widget.html:96
-msgid "Loading<span class=\"loading-ellipsis\">..."
+#: lists/widget.html
+msgid "Loading<span class=\"loading-ellipsis\">...</span>"
 msgstr ""
 
-#: merge/authors.html:7 merge/authors.html:11 merge/authors.html:111
+#: merge/authors.html
 msgid "Merge Authors"
 msgstr ""
 
@@ -4729,11 +4729,11 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: merge_request_table/table_row.html:90
+#: merge_request_table/table_row.html
 msgid "comments"
 msgstr ""
 
-#: my_books/dropdown_content.html:24
+#: my_books/dropdown_content.html
 msgid "Remove From Shelf"
 msgstr ""
 
@@ -4855,30 +4855,29 @@ msgstr ""
 msgid "By Bots"
 msgstr ""
 
-#: recentchanges/updated_records.html:54
+#: recentchanges/updated_records.html
 msgid "Review what's changed in from the previous revision"
 msgstr ""
 
-#: RecentChanges.html:42 RecentChangesAdmin.html:43 RecentChangesUsers.html:43
-#: recentchanges/default/path.html:26 recentchanges/updated_records.html:54
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: recentchanges/default/path.html recentchanges/updated_records.html
 msgid "diff"
 msgstr ""
 
-#: recentchanges/default/message.html:29
-#: recentchanges/edit-book/message.html:29 site/around_the_library.html:45
+#: recentchanges/default/message.html recentchanges/edit-book/message.html
+#: site/around_the_library.html
 msgid "opened a new Open Library account!"
 msgstr ""
 
-#: recentchanges/default/path.html:10 recentchanges/default/path.html:29
+#: recentchanges/default/path.html
 msgid "expand"
 msgstr ""
 
-#: RecentChanges.html:42 RecentChangesUsers.html:43
-#: recentchanges/default/path.html:26
+#: RecentChanges.html RecentChangesUsers.html recentchanges/default/path.html
 msgid "Review what's changed from the previous revision"
 msgstr ""
 
-#: recentchanges/merge/comment.html:24
+#: recentchanges/merge/comment.html
 #, python-format
 msgid "Merged %(count)d duplicate %(type)s record into this primary."
 msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
@@ -4907,7 +4906,7 @@ msgstr ""
 msgid "Details here"
 msgstr ""
 
-#: recentchanges/merge/view.html:43 type/author/view.html:81
+#: recentchanges/merge/view.html type/author/view.html
 msgid "Duplicates"
 msgstr ""
 
@@ -4946,7 +4945,7 @@ msgstr ""
 msgid "Search Authors"
 msgstr ""
 
-#: search/authors.html:51
+#: search/authors.html
 msgid "Is the same author listed twice?"
 msgstr ""
 
@@ -5287,11 +5286,11 @@ msgstr ""
 msgid "Does this author go by any other names?"
 msgstr ""
 
-#: type/author/edit.html:119
+#: type/author/edit.html
 msgid "Identifiers"
 msgstr ""
 
-#: type/author/edit.html:119
+#: type/author/edit.html
 msgid "Author Identifiers Purpose"
 msgstr ""
 
@@ -5304,84 +5303,84 @@ msgstr ""
 msgid "%(page_title)s | Open Library"
 msgstr ""
 
-#: type/author/view.html:35
+#: type/author/view.html
 #, python-format
 msgid "Author of %(book_titles)s"
 msgstr ""
 
-#: type/author/view.html:79
+#: type/author/view.html
 msgid "Merging Authors..."
 msgstr ""
 
-#: type/author/view.html:80
+#: type/author/view.html
 msgid "In progress..."
 msgstr ""
 
-#: type/author/view.html:92
+#: type/author/view.html
 msgid "Refresh the page?"
 msgstr ""
 
-#: type/author/view.html:93
+#: type/author/view.html
 msgid "Success!"
 msgstr ""
 
-#: type/author/view.html:94
+#: type/author/view.html
 msgid ""
 "OK. The merge is in motion. <i>It will take <u>a few minutes to "
 "finish</u> the update.</i>"
 msgstr ""
 
-#: type/author/view.html:98
+#: type/author/view.html
 msgid "Argh!"
 msgstr ""
 
-#: type/author/view.html:99
+#: type/author/view.html
 msgid "That merge didn't work. It's our fault, and we've made a note of it."
 msgstr ""
 
-#: type/author/view.html:111
+#: type/author/view.html
 msgid "Location"
 msgstr ""
 
-#: type/author/view.html:119
+#: type/author/view.html
 msgid "Add another?"
 msgstr ""
 
-#: type/author/view.html:127
+#: type/author/view.html
 #, python-format
 msgid ""
 "Showing all works by author. Would you like to see <a "
 "href=\"%(url)s\">only ebooks</a>?"
 msgstr ""
 
-#: type/author/view.html:129
+#: type/author/view.html
 #, python-format
 msgid ""
 "Showing ebooks only. Would you like to see <a "
 "href=\"%(url)s\">everything</a> by this author?"
 msgstr ""
 
-#: type/author/view.html:177
+#: type/author/view.html
 msgid "Time"
 msgstr ""
 
-#: type/author/view.html:188
+#: type/author/view.html
 msgid "OLID"
 msgstr ""
 
-#: type/author/view.html:204
+#: type/author/view.html
 msgid "Links <span class=\"gray small sansserif\">(outside Open Library)"
 msgstr ""
 
-#: type/author/view.html:214
+#: type/author/view.html
 msgid "No links yet."
 msgstr ""
 
-#: type/author/view.html:214
+#: type/author/view.html
 msgid "Add one"
 msgstr ""
 
-#: type/author/view.html:221
+#: type/author/view.html
 msgid "Alternative names"
 msgstr ""
 
@@ -5425,12 +5424,11 @@ msgstr ""
 msgid "Orphaned Edition"
 msgstr ""
 
-#: databarHistory.html:29 databarView.html:37
-#: type/edition/compact_title.html:13
+#: databarHistory.html databarView.html type/edition/compact_title.html
 msgid "Edit this page"
 msgstr ""
 
-#: type/edition/title_and_author.html:25
+#: type/edition/title_and_author.html
 msgid "An edition of"
 msgstr ""
 
@@ -5648,7 +5646,7 @@ msgstr ""
 msgid "Protected DAISY"
 msgstr ""
 
-#: BookByline.html:34 type/list/embed.html:101
+#: BookByline.html type/list/embed.html
 #, python-format
 msgid "by %(name)s"
 msgstr ""
@@ -5979,23 +5977,23 @@ msgstr ""
 msgid "Preview Book"
 msgstr ""
 
-#: EditButtons.html EditButtonsMacros.html
-msgid "(Optional, but very useful!)"
+#: EditButtonsMacros.html
+msgid "Really delete this macro?"
 msgstr ""
 
-#: EditButtonsMacros.html:7
+#: EditButtonsMacros.html
 msgid "Are you sure you want to delete this?"
 msgstr ""
 
-#: EditButtonsMacros.html:11
+#: EditButtonsMacros.html
 msgid "Please, leave a short note about what you changed: "
 msgstr ""
 
-#: EditButtonsMacros.html:12
+#: EditButtonsMacros.html
 msgid "(Optional, but very useful!)"
 msgstr ""
 
-#: EditButtonsMacros.html:27
+#: EditButtonsMacros.html
 msgid "Delete this record"
 msgstr ""
 
@@ -6025,16 +6023,24 @@ msgstr[1] ""
 msgid "Related Books"
 msgstr ""
 
-#: IABook.html:22
+#: Follow.html
+msgid "UnfollowFollow"
+msgstr ""
+
+#: Follow.html
+msgid "Follow"
+msgstr ""
+
+#: IABook.html
 #, python-format
 msgid "Borrowed from Internet Archive: %(title)s"
 msgstr ""
 
-#: LoadingIndicator.html:9
+#: LoadingIndicator.html
 msgid "Loading indicator"
 msgstr ""
 
-#: LoanStatus.html:82
+#: LoanStatus.html
 msgid "You are <strong>next</strong> on the waiting list"
 msgstr ""
 
@@ -6158,6 +6164,10 @@ msgid "Go to the page for %(title)s"
 msgstr ""
 
 #: SearchResultsWork.html
+msgid "added to"
+msgstr ""
+
+#: SearchResultsWork.html
 #, python-format
 msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
 msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
@@ -6182,12 +6192,12 @@ msgstr ""
 msgid "Work Title"
 msgstr ""
 
-#: ShareModal.html:35
+#: ShareModal.html
 #, python-format
 msgid "Share on %(share_link)s"
 msgstr ""
 
-#: ShareModal.html:49
+#: ShareModal.html
 msgid "Embed this book in your website"
 msgstr ""
 
@@ -6211,11 +6221,11 @@ msgstr ""
 msgid "Copy URL"
 msgstr ""
 
-#: SponsorCarousel.html:6
+#: SponsorCarousel.html
 msgid "Books to Sponsor"
 msgstr ""
 
-#: StarRatings.html:53
+#: StarRatings.html
 msgid "Clear my rating"
 msgstr ""
 
@@ -6363,130 +6373,120 @@ msgstr ""
 msgid "Learn more about Book Sponsorship"
 msgstr ""
 
-#: account.py:65
+#: account.py
 msgid "The email address you entered is invalid"
 msgstr ""
 
-#: account.py:66
+#: account.py
 msgid "This account has been blocked"
 msgstr ""
 
-#: account.py:67
+#: account.py
 msgid "This account has been locked"
 msgstr ""
 
-#: account.py:68
+#: account.py
 msgid "No account was found with this email. Please try again"
 msgstr ""
 
-#: account.py:71
+#: account.py
 msgid "The password you entered is incorrect. Please try again"
 msgstr ""
 
-#: account.py:74
+#: account.py
 msgid "Wrong password. Please try again"
 msgstr ""
 
-#: account.py:75
+#: account.py
 msgid "Please verify your Open Library account before logging in"
 msgstr ""
 
-#: account.py:78
+#: account.py
 msgid "Please verify your Internet Archive account before logging in"
 msgstr ""
 
-#: account.py:81
+#: account.py
 msgid "Please fill out all fields and try again"
 msgstr ""
 
-#: account.py:82
+#: account.py
 msgid "This email is already registered"
 msgstr ""
 
-#: account.py:83
+#: account.py
 msgid "This username is already registered"
 msgstr ""
 
-#: account.py:84
-msgid "Sorry, you must use your Internet Archive email and password to log in"
-msgstr ""
-
-#: account.py:87
+#: account.py
 msgid "A problem occurred and we were unable to log you in."
 msgstr ""
 
-#: account.py:90
+#: account.py
 msgid "Login attempted with invalid Internet Archive s3 credentials."
 msgstr ""
 
-#: account.py:93
-msgid ""
-"An Open Library account with this email is already linked to a different "
-"Internet Archive account. Please contact info@openlibrary.org."
-msgstr ""
-
-#: account.py:478 account.py:532
+#: account.py
 #, python-format
 msgid ""
 "We've sent the verification email to %(email)s. You'll need to read that "
 "and click on the verification link to verify your email."
 msgstr ""
 
-#: account.py:560
+#: account.py
 msgid "Username must be between 3-20 characters"
 msgstr ""
 
-#: account.py:562
+#: account.py
 msgid "Username may only contain numbers and letters"
 msgstr ""
 
-#: account.py:565
+#: account.py
 msgid "Username unavailable"
 msgstr ""
 
-#: account.py:570 forms.py:60
+#: account.py forms.py
 msgid "Must be a valid email address"
 msgstr ""
 
-#: account.py:574 forms.py:41
+#: account.py forms.py
 msgid "Email already registered"
 msgstr ""
 
-#: account.py:600
+#: account.py
 msgid "Email address is already used."
 msgstr ""
 
-#: account.py:601
+#: account.py
 msgid ""
 "Your email address couldn't be updated. The specified email address is "
 "already used."
 msgstr ""
 
-#: account.py:607
+#: account.py
 msgid "Email verification successful."
 msgstr ""
 
-#: account.py:608
+#: account.py
 msgid ""
 "Your email address has been successfully verified and updated in your "
 "account."
 msgstr ""
 
-#: account.py:614
+#: account.py
 msgid "Email address couldn't be verified."
 msgstr ""
 
-#: account.py:615
+#: account.py
 msgid ""
 "Your email address couldn't be verified. The verification link seems "
 "invalid."
 msgstr ""
 
-#: account.py:718 account.py:728
+#: account.py
 msgid "Password reset failed."
 msgstr ""
 
-#: account.py:780 account.py:799
+#: account.py
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -18,226 +18,218 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.12.1\n"
 
-#: account.html:7 account.html:18 account/notifications.html:13
-#: account/privacy.html:13 lib/nav_head.html:15 type/user/view.html:27
+#: account.html account/notifications.html account/privacy.html
+#: lib/nav_head.html type/user/view.html
 msgid "Settings"
 msgstr ""
 
-#: account.html:23
+#: account.html
 msgid "Settings & Privacy"
 msgstr ""
 
-#: account.html:24 databarDiff.html:12
+#: account.html databarDiff.html
 msgid "View"
 msgstr ""
 
-#: account.html:24
+#: account.html
 msgid "or"
 msgstr ""
 
-#: account.html:24 check_ins/check_in_prompt.html:26
-#: check_ins/reading_goal_progress.html:27 databarHistory.html:33
-#: databarTemplate.html:19 databarView.html:41 subjects.html:31
-#: type/edition/compact_title.html:16 type/user/view.html:67
+#: account.html check_ins/check_in_prompt.html
+#: check_ins/reading_goal_progress.html databarHistory.html
+#: databarTemplate.html databarView.html subjects.html
+#: type/edition/compact_title.html type/user/view.html
 msgid "Edit"
 msgstr ""
 
-#: account.html:24
+#: account.html
 msgid "Your Profile Page"
 msgstr ""
 
-#: account.html:25
+#: account.html
 msgid "View or Edit your Reading Log"
 msgstr ""
 
-#: account.html:26
+#: account.html
 msgid "View or Edit your Lists"
 msgstr ""
 
-#: account.html:27
+#: account.html
 msgid "Import and Export Options"
 msgstr ""
 
-#: account.html:28
+#: account.html
 msgid "Manage Privacy & Content Moderation Settings"
 msgstr ""
 
-#: account.html:29
+#: account.html
 msgid "Manage Notifications Settings"
 msgstr ""
 
-#: account.html:30
+#: account.html
 msgid "Manage Mailing List Subscriptions"
 msgstr ""
 
-#: account.html:31
+#: account.html
 msgid "Change Password"
 msgstr ""
 
-#: account.html:32
+#: account.html
 msgid "Update Email Address"
 msgstr ""
 
-#: account.html:33
+#: account.html
 msgid "Deactivate Account"
 msgstr ""
 
-#: account.html:35
+#: account.html
 msgid "Please contact us if you need help with anything else."
 msgstr ""
 
-#: barcodescanner.html:7
+#: barcodescanner.html
 msgid "Barcode Scanner (Beta)"
 msgstr ""
 
-#: barcodescanner.html:20 lib/nav_head.html:98
+#: barcodescanner.html lib/nav_head.html
 msgid "Advanced"
 msgstr ""
 
-#: barcodescanner.html:24
+#: barcodescanner.html
 msgid "Read Text ISBN"
 msgstr ""
 
-#: barcodescanner.html:26
+#: barcodescanner.html
 msgid "For books that print the ISBN without a barcode"
 msgstr ""
 
-#: barcodescanner.html:31
+#: barcodescanner.html
 msgid "Point your camera at a barcode! 📷"
 msgstr ""
 
-#: diff.html:7
+#: diff.html
 #, python-format
 msgid "Diff on %s"
 msgstr ""
 
-#: diff.html:26
+#: diff.html
 msgid "Added"
 msgstr ""
 
-#: diff.html:27
+#: diff.html
 msgid "Modified"
 msgstr ""
 
-#: diff.html:28
+#: diff.html
 msgid "Removed"
 msgstr ""
 
-#: diff.html:29
+#: diff.html
 msgid "Not changed"
 msgstr ""
 
-#: diff.html:39
+#: diff.html
 #, python-format
 msgid "Revision %d"
 msgstr ""
 
-#: books/check.html:32 books/show.html:16 covers/book_cover.html:56
-#: covers/book_cover_single_edition.html:36 covers/book_cover_work.html:32
-#: diff.html:43 jsdef/LazyWorkPreview.html:25 lists/preview.html:21
+#: books/check.html books/show.html covers/book_cover.html
+#: covers/book_cover_single_edition.html covers/book_cover_work.html diff.html
+#: jsdef/LazyWorkPreview.html lists/preview.html
 msgid "by"
 msgstr ""
 
-#: diff.html:45 diff.html:47
+#: diff.html
 msgid "by Anonymous"
 msgstr ""
 
-#: diff.html:113
+#: diff.html
 msgid "Differences"
 msgstr ""
 
-#: diff.html:171
+#: diff.html
 msgid "Both the revisions are identical."
 msgstr ""
 
-#: edit_yaml.html:14 lib/edit_head.html:9
+#: edit_yaml.html lib/edit_head.html
 msgid "You're in edit mode."
 msgstr ""
 
-#: edit_yaml.html:15 lib/edit_head.html:10
+#: edit_yaml.html lib/edit_head.html
 msgid "Cancel, and go back."
 msgstr ""
 
-#: edit_yaml.html:22
+#: edit_yaml.html
 msgid "YAML Representation:"
 msgstr ""
 
-#: BookPreview.html:12 books/edit/edition.html:664 editpage.html:15
+#: BookPreview.html books/edit/edition.html editpage.html
 msgid "Preview"
 msgstr ""
 
-#: history.html:23
+#: history.html
 msgid "History of edits to"
 msgstr ""
 
-#: history.html:31
+#: history.html
 msgid "Revision"
 msgstr ""
 
-#: RecentChanges.html:17 RecentChangesAdmin.html:20 RecentChangesUsers.html:20
-#: admin/ip/view.html:44 admin/people/edits.html:41 history.html:32
-#: recentchanges/render.html:31 recentchanges/updated_records.html:32
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/ip/view.html admin/people/edits.html history.html
+#: recentchanges/render.html recentchanges/updated_records.html
 msgid "When"
 msgstr ""
 
-#: RecentChanges.html:19 admin/ip/view.html:46 admin/loans_table.html:46
-#: admin/people/edits.html:43 admin/waitinglists.html:28 history.html:33
-#: recentchanges/render.html:33
+#: RecentChanges.html admin/ip/view.html admin/loans_table.html
+#: admin/people/edits.html admin/waitinglists.html history.html
+#: recentchanges/render.html
 msgid "Who"
 msgstr ""
 
-#: RecentChanges.html:20 RecentChangesUsers.html:22 admin/ip/view.html:47
-#: admin/people/edits.html:44 history.html:34 recentchanges/render.html:34
-#: recentchanges/updated_records.html:34
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
+#: admin/people/edits.html history.html recentchanges/render.html
+#: recentchanges/updated_records.html
 msgid "Comment"
 msgstr ""
 
-#: history.html:35
+#: history.html
 msgid "Diff"
 msgstr ""
 
-#: history.html:42 history.html:73
+#: history.html
 msgid "Compare"
 msgstr ""
 
-#: history.html:42 history.html:73
+#: history.html
 msgid "See Diff"
 msgstr ""
 
-#: history.html:48 lib/history.html:76
+#: history.html lib/history.html
 #, python-format
 msgid "View revision %s"
 msgstr ""
 
-#: history.html:57
-msgid "Compare this version..."
-msgstr ""
-
-#: history.html:64
-msgid "...to this version"
-msgstr ""
-
-#: books/daisy.html:17 history.html:85
+#: history.html
 msgid "Back"
 msgstr ""
 
-#: Pager.html:38 Pager_loanhistory.html:12 history.html:87
-#: lib/pagination.html:37 showmarc.html:54
+#: Pager.html Pager_loanhistory.html history.html lib/pagination.html
+#: showmarc.html
 msgid "Next"
 msgstr ""
 
-#: internalerror.html:14
+#: internalerror.html
 msgid "Sorry. There seems to be a problem with what you were just looking at."
 msgstr ""
 
-#: internalerror.html:15
+#: internalerror.html
 #, python-format
 msgid ""
 "We've noted the error %s and will look into it as soon as possible. Head "
 "for <a href=\"/\">home</a>?"
 msgstr ""
 
-#: lib/nav_head.html:30 library_explorer.html:6
+#: lib/nav_head.html library_explorer.html
 msgid "Library Explorer"
 msgstr ""
 
@@ -310,105 +302,92 @@ msgstr ""
 msgid "Created new author record."
 msgstr ""
 
-#: messages.html:12
+#: messages.html
 msgid "Created new edition record."
 msgstr ""
 
-#: messages.html:13
+#: messages.html
 msgid "Created new work record."
 msgstr ""
 
-#: messages.html:14
+#: messages.html
 msgid "Added new book."
 msgstr ""
 
-#: messages.html:16
+#: messages.html
 msgid "Thank you very much for adding that new book!"
 msgstr ""
 
-#: messages.html:17 messages.html:18
+#: messages.html
 msgid "Thank you very much for improving that record!"
 msgstr ""
 
-#: BookPreview.html:21 CreateListModal.html:11 NotesModal.html:32
-#: ObservationsModal.html:32 ShareModal.html:25
-#: book_providers/gutenberg_read_button.html:24
-#: book_providers/librivox_read_button.html:27
-#: book_providers/openstax_read_button.html:24
-#: book_providers/standard_ebooks_read_button.html:24
-#: covers/author_photo.html:22 covers/book_cover.html:54
-#: covers/book_cover_single_edition.html:34 covers/book_cover_work.html:30
-#: covers/change.html:44 lib/history.html:60 my_books/dropdown_content.html:91
-#: native_dialog.html:15
-msgid "Close"
-msgstr ""
-
-#: notfound.html:7
+#: notfound.html
 #, python-format
 msgid "%(path)s is not found"
 msgstr ""
 
-#: languages/notfound.html:10 notfound.html:14
+#: languages/notfound.html notfound.html
 msgid "404 - Page Not Found"
 msgstr ""
 
-#: notfound.html:18
+#: notfound.html
 #, python-format
 msgid "%(path)s does not exist."
 msgstr ""
 
-#: notfound.html:22
+#: notfound.html
 msgid "Create it?"
 msgstr ""
 
-#: notfound.html:26
+#: notfound.html
 msgid "Looking for a template/macro?"
 msgstr ""
 
-#: permission.html:10
+#: permission.html
 msgid "Permission of"
 msgstr ""
 
-#: permission.html:18
+#: permission.html
 msgid "Permission"
 msgstr ""
 
-#: permission.html:28
+#: permission.html
 msgid "Child Permission"
 msgstr ""
 
-#: permission_denied.html:10
+#: permission_denied.html
 msgid "Permission denied."
 msgstr ""
 
-#: permission_denied.html:30
+#: permission_denied.html
 #, python-format
 msgid "You may <a href=\"%s\">log in</a> if you have the required permissions."
 msgstr ""
 
-#: recaptcha.html:10
+#: recaptcha.html
 msgid ""
 "Please satisfy the reCAPTCHA below. If you have security settings or "
 "privacy blockers installed, please disable them to see the reCAPTCHA."
 msgstr ""
 
-#: recaptcha.html:15
+#: recaptcha.html
 msgid "Incorrect. Please try again."
 msgstr ""
 
-#: showamazon.html:8 showamazon.html:11 showbwb.html:8 showbwb.html:11
+#: showamazon.html showbwb.html
 msgid "Record details of"
 msgstr ""
 
-#: showamazon.html:15 showbwb.html:15
+#: showamazon.html showbwb.html
 msgid "This record came from"
 msgstr ""
 
-#: showia.html:42 showmarc.html:48
+#: showia.html showmarc.html
 msgid "Invalid MARC record."
 msgstr ""
 
-#: status.html:30
+#: status.html
 msgid "Server status"
 msgstr ""
 
@@ -428,16 +407,15 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: SubjectTags.html:29 subjects.html:9 type/list/view_body.html:198
-#: work_search.html:56
+#: SubjectTags.html subjects.html type/list/view_body.html work_search.html
 msgid "Times"
 msgstr ""
 
-#: subjects.html:27
+#: subjects.html
 msgid "Edit Subject Tag"
 msgstr ""
 
-#: subjects.html:38
+#: subjects.html
 msgid "See all works"
 msgstr ""
 
@@ -449,25 +427,24 @@ msgid_plural "%(count)d works"
 msgstr[0] ""
 msgstr[1] ""
 
-#: subjects.html:45 subjects.html:49
+#: subjects.html
 #, python-format
 msgid "Search for books with subject %(name)s."
 msgstr ""
 
-#: authors/index.html:21 lib/nav_head.html:103 lists/home.html:25
-#: publishers/notfound.html:19 publishers/view.html:115
-#: search/advancedsearch.html:48 search/authors.html:28 search/inside.html:17
-#: search/lists.html:17 search/publishers.html:19 search/subjects.html:28
-#: subjects.html:51 subjects/notfound.html:19 type/local_id/view.html:42
-#: work_search.html:67
+#: authors/index.html lib/nav_head.html lists/home.html
+#: publishers/notfound.html publishers/view.html search/advancedsearch.html
+#: search/authors.html search/inside.html search/lists.html
+#: search/publishers.html search/subjects.html subjects.html
+#: subjects/notfound.html type/local_id/view.html work_search.html
 msgid "Search"
 msgstr ""
 
-#: publishers/view.html:32 subjects.html:61
+#: publishers/view.html subjects.html
 msgid "Publishing History"
 msgstr ""
 
-#: subjects.html:63
+#: subjects.html
 msgid ""
 "This is a chart to show the publishing history of editions of works about"
 " this subject. Along the X axis is time, and on the y axis is the count "
@@ -475,39 +452,39 @@ msgid ""
 " chart</a>."
 msgstr ""
 
-#: publishers/view.html:34 subjects.html:64
+#: publishers/view.html subjects.html
 msgid "Reset chart"
 msgstr ""
 
-#: publishers/view.html:34 subjects.html:64
+#: publishers/view.html subjects.html
 msgid "or continue zooming in."
 msgstr ""
 
-#: subjects.html:65
+#: subjects.html
 msgid "This graph charts editions published on this subject."
 msgstr ""
 
-#: publishers/view.html:42 subjects.html:71
+#: publishers/view.html subjects.html
 msgid "Editions Published"
 msgstr ""
 
-#: admin/imports.html:25 publishers/view.html:44 subjects.html:73
+#: admin/imports.html publishers/view.html subjects.html
 msgid "You need to have JavaScript turned on to see the nifty chart!"
 msgstr ""
 
-#: publishers/view.html:46 subjects.html:75
+#: publishers/view.html subjects.html
 msgid "Year of Publication"
 msgstr ""
 
-#: subjects.html:81
+#: subjects.html
 msgid "Related..."
 msgstr ""
 
-#: publishers/view.html:64 subjects.html:95
+#: publishers/view.html subjects.html
 msgid "None found."
 msgstr ""
 
-#: publishers/view.html:81 subjects.html:110
+#: publishers/view.html subjects.html
 msgid "See more books by, and learn about, this author"
 msgstr ""
 
@@ -520,15 +497,15 @@ msgid_plural "%(count)d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: subjects.html:116
+#: subjects.html
 msgid "Prolific Authors"
 msgstr ""
 
-#: subjects.html:117
+#: subjects.html
 msgid "who have written the most books on this subject"
 msgstr ""
 
-#: publishers/view.html:104 subjects.html:133
+#: publishers/view.html subjects.html
 msgid "Get more information about this publisher"
 msgstr ""
 
@@ -540,119 +517,113 @@ msgid_plural "%(count)s editions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: support.html:7 support.html:10
+#: support.html
 msgid "How can we help?"
 msgstr ""
 
-#: support.html:16
+#: support.html
 msgid ""
 "Your question has been sent to our support team. We'll get back to you "
 "shortly. You can also <a href=\"https://twitter.com/openlibrary\">contact"
 " us on Twitter</a>."
 msgstr ""
 
-#: support.html:19
+#: support.html
 msgid ""
 "Please check our <a href=\"/help/\">Help Pages</a> and <a "
 "href=\"/help/faq\">Frequently Asked Questions</a> (FAQ) to see if your "
 "question is answered there. Thank you."
 msgstr ""
 
-#: support.html:22
+#: support.html
 msgid "Your Name"
 msgstr ""
 
-#: support.html:27
+#: support.html
 msgid "Your Email Address"
 msgstr ""
 
-#: support.html:28
+#: support.html
 msgid "We'll need this if you want a reply"
 msgstr ""
 
-#: support.html:29
+#: support.html
 msgid ""
 "If you wish to be contacted by other means, please add your contact "
 "preference and details to your question."
 msgstr ""
 
-#: lib/nav_head.html:96 search/advancedsearch.html:32 support.html:33
+#: lib/nav_head.html search/advancedsearch.html support.html
 msgid "Subject"
 msgstr ""
 
-#: support.html:40
+#: support.html
 msgid "Your Question"
 msgstr ""
 
-#: support.html:41
+#: support.html
 msgid "Note: our staff will likely only be able respond in English."
 msgstr ""
 
-#: support.html:45
+#: support.html
 msgid ""
 "If you encounter an error message, please include it. For questions about"
 " our books, please provide the title/author or Open Library ID."
 msgstr ""
 
-#: support.html:55
+#: support.html
 msgid "Send"
 msgstr ""
 
-#: CreateListModal.html:34 EditButtons.html:23 EditButtonsMacros.html:26
-#: account/create.html:91 account/notifications.html:59
-#: account/password/reset.html:24 account/privacy.html:79
-#: admin/imports-add.html:28 admin/permissions.html:51 books/add.html:107
-#: covers/add.html:85 covers/manage.html:52 databarEdit.html:13
-#: merge/authors.html:118 my_books/dropdown_content.html:114 support.html:57
-#: tag/add.html:66
+#: CreateListModal.html EditButtons.html EditButtonsMacros.html
+#: account/create.html account/notifications.html account/password/reset.html
+#: account/privacy.html admin/imports-add.html books/add.html covers/add.html
+#: covers/manage.html databarAuthor.html databarEdit.html merge/authors.html
+#: my_books/dropdown_content.html support.html tag/add.html
 msgid "Cancel"
 msgstr ""
 
-#: trending.html:10
+#: trending.html
 msgid "Now"
 msgstr ""
 
-#: admin/graphs.html:47 admin/index.html:39 admin/index.html:87
-#: check_ins/check_in_form.html:71 check_ins/check_in_prompt.html:36
-#: trending.html:10
+#: admin/graphs.html check_ins/check_in_form.html
+#: check_ins/check_in_prompt.html trending.html
 msgid "Today"
 msgstr ""
 
-#: admin/graphs.html:48 trending.html:10
+#: admin/graphs.html trending.html
 msgid "This Week"
 msgstr ""
 
-#: stats/readinglog.html:20 stats/readinglog.html:37 stats/readinglog.html:54
-#: trending.html:10
+#: stats/readinglog.html trending.html
 msgid "This Month"
 msgstr ""
 
-#: trending.html:10
+#: trending.html
 msgid "This Year"
 msgstr ""
 
-#: account/view.html:37 admin/index.html:91 books/year_breadcrumb_select.html:2
-#: books/year_breadcrumb_select.html:11 trending.html:10
+#: account/view.html books/year_breadcrumb_select.html trending.html
 msgid "All Time"
 msgstr ""
 
-#: home/index.html:27 trending.html:11
+#: home/index.html trending.html
 msgid "Trending Books"
 msgstr ""
 
-#: trending.html:12
+#: trending.html
 msgid "See what readers from the community are adding to their bookshelves"
 msgstr ""
 
-#: account/mybooks.html:70 account/sidebar.html:26
-#: my_books/dropdown_content.html:32 my_books/primary_action.html:16
-#: search/sort_options.html:36 trending.html:27
+#: account/mybooks.html account/sidebar.html my_books/dropdown_content.html
+#: my_books/primary_action.html search/sort_options.html trending.html
 msgid "Want to Read"
 msgstr ""
 
-#: account/mybooks.html:69 account/readinglog_shelf_name.html:8
-#: account/sidebar.html:23 my_books/dropdown_content.html:40
-#: my_books/primary_action.html:14 search/sort_options.html:37 trending.html:27
+#: account/mybooks.html account/readinglog_shelf_name.html account/sidebar.html
+#: my_books/dropdown_content.html my_books/primary_action.html
+#: search/sort_options.html trending.html
 msgid "Currently Reading"
 msgstr ""
 
@@ -665,21 +636,21 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
-#: trending.html:28
+#: trending.html
 #, python-format
 msgid "Someone marked as %(shelf)s %(k_hours_ago)s"
 msgstr ""
 
-#: trending.html:30
+#: trending.html
 #, python-format
 msgid "Logged %(count)i times %(time_unit)s"
 msgstr ""
 
-#: viewpage.html:13
+#: viewpage.html
 msgid "Revert to this revision?"
 msgstr ""
 
-#: viewpage.html:16
+#: viewpage.html
 msgid "Revert to this revision"
 msgstr ""
 
@@ -725,114 +696,108 @@ msgstr ""
 msgid "Search Books"
 msgstr ""
 
-#: work_search.html:48
+#: work_search.html
 msgid "eBook?"
 msgstr ""
 
-#: type/edition/view.html:291 type/work/view.html:291 work_search.html:49
+#: type/edition/view.html type/work/view.html work_search.html
 msgid "Language"
 msgstr ""
 
-#: books/add.html:42 books/edit.html:96 books/edit/edition.html:231
-#: lib/nav_head.html:94 search/advancedsearch.html:24 work_search.html:50
-#: work_search.html:138
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html work_search.html
 msgid "Author"
 msgstr ""
 
-#: work_search.html:52
+#: work_search.html
 msgid "First published"
 msgstr ""
 
-#: search/advancedsearch.html:44 type/edition/view.html:276
-#: type/work/view.html:276 work_search.html:53
+#: search/advancedsearch.html type/edition/view.html type/work/view.html
+#: work_search.html
 msgid "Publisher"
 msgstr ""
 
-#: work_search.html:57
+#: work_search.html
 msgid "Classic eBooks"
 msgstr ""
 
-#: work_search.html:65
+#: work_search.html
 msgid "Keywords"
 msgstr ""
 
-#: RecentChanges.html:74 recentchanges/index.html:61 work_search.html:70
+#: recentchanges/index.html work_search.html
 msgid "Everything"
 msgstr ""
 
-#: work_search.html:72
+#: work_search.html
 msgid "Ebooks"
 msgstr ""
 
-#: work_search.html:74
+#: work_search.html
 msgid "Print Disabled"
 msgstr ""
 
-#: work_search.html:77
+#: work_search.html
 msgid "This is only visible to super librarians."
 msgstr ""
 
-#: work_search.html:83
+#: work_search.html
 msgid "Solr Editions"
 msgstr ""
 
-#: work_search.html:100
+#: work_search.html
 msgid "eBook"
 msgstr ""
 
-#: work_search.html:103
+#: work_search.html
 msgid "Classic eBook"
 msgstr ""
 
-#: work_search.html:106
-msgid "Search facets"
-msgstr ""
-
-#: work_search.html:120
+#: work_search.html
 msgid "Explore Classic eBooks"
 msgstr ""
 
-#: work_search.html:120
+#: work_search.html
 msgid "Only Classic eBooks"
 msgstr ""
 
-#: work_search.html:124 work_search.html:126 work_search.html:128
-#: work_search.html:130
+#: work_search.html
 #, python-format
 msgid "Explore books about %(subject)s"
 msgstr ""
 
-#: merge/authors.html:97 work_search.html:132
+#: merge/authors.html work_search.html
 msgid "First published in"
 msgstr ""
 
-#: work_search.html:134
+#: work_search.html
 msgid "Written in"
 msgstr ""
 
-#: work_search.html:136
+#: work_search.html
 msgid "Published by"
 msgstr ""
 
-#: work_search.html:139
+#: work_search.html
 msgid "Click to remove this facet"
 msgstr ""
 
-#: work_search.html:141
+#: work_search.html
 #, python-format
 msgid "%(title)s - search"
 msgstr ""
 
-#: search/lists.html:29 work_search.html:154
+#: search/lists.html work_search.html
 msgid "No results found."
 msgstr ""
 
-#: search/lists.html:30 work_search.html:157
+#: search/lists.html work_search.html
 #, python-format
 msgid "Search for books containing the phrase \"%s\"?"
 msgstr ""
 
-#: work_search.html:161
+#: work_search.html
 msgid "Add a new book to Open Library?"
 msgstr ""
 
@@ -844,61 +809,60 @@ msgid_plural "%(count)s hits"
 msgstr[0] ""
 msgstr[1] ""
 
-#: work_search.html:195
-msgid "BARF! Search engine ERROR!"
+#: work_search.html
+msgid "Zoom In"
 msgstr ""
 
-#: work_search.html:199
-msgid "Zoom In"
+#: work_search.html
+msgid "Focus your results using these"
 msgstr ""
 
 #: work_search.html:200
 msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
 msgstr ""
 
-#: work_search.html:212
+#: work_search.html
 msgid "Merge duplicate authors from this search"
 msgstr ""
 
-#: type/work/editions.html:17 work_search.html:212
+#: type/work/editions.html work_search.html
 msgid "Merge duplicates"
 msgstr ""
 
-#: work_search.html:224
+#: work_search.html
 msgid "yes"
 msgstr ""
 
-#: work_search.html:226
+#: work_search.html
 msgid "no"
 msgstr ""
 
-#: work_search.html:227
+#: work_search.html
 msgid "Filter results for ebook availability"
 msgstr ""
 
-#: work_search.html:229
+#: work_search.html
 #, python-format
 msgid "Filter results for %(facet)s"
 msgstr ""
 
-#: work_search.html:234
+#: work_search.html
 msgid "more"
 msgstr ""
 
-#: work_search.html:238
+#: work_search.html
 msgid "less"
 msgstr ""
 
-#: about/index.html:6
+#: about/index.html
 msgid "The Open Library Team"
 msgstr ""
 
-#: account/create.html:9
+#: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""
 
-#: account/create.html:12 account/create.html:90 lib/header_dropdown.html:60
-#: lib/nav_head.html:129
+#: account/create.html lib/header_dropdown.html lib/nav_head.html
 msgid "Sign Up"
 msgstr ""
 
@@ -906,15 +870,15 @@ msgstr ""
 msgid "Complete the form below to create a new Internet Archive account."
 msgstr ""
 
-#: account/create.html:22
+#: account/create.html
 msgid "Each field is required"
 msgstr ""
 
-#: account/create.html:40
+#: account/create.html
 msgid "Show password"
 msgstr ""
 
-#: account/create.html:41
+#: account/create.html
 msgid "Hide password"
 msgstr ""
 
@@ -922,161 +886,160 @@ msgstr ""
 msgid "Your URL"
 msgstr ""
 
-#: account/create.html:67
+#: account/create.html
 msgid "screenname"
 msgstr ""
 
-#: account/create.html:80
+#: account/create.html
 msgid ""
 "By signing up, you agree to the Internet Archive's <a "
 "href='//archive.org/about/terms.php' target='_blank'>Terms of "
 "Service</a>."
 msgstr ""
 
-#: account/delete.html:6 account/delete.html:10
+#: account/delete.html
 msgid "Delete Account"
 msgstr ""
 
-#: account/delete.html:15
+#: account/delete.html
 msgid "Sorry, this functionality is not yet implemented."
 msgstr ""
 
-#: account/import.html:12
+#: account/import.html
 msgid "Import from Goodreads"
 msgstr ""
 
-#: account/import.html:18
+#: account/import.html
 msgid "File size limit 10MB and .csv file type only"
 msgstr ""
 
-#: account/import.html:22
+#: account/import.html
 msgid "Load Books"
 msgstr ""
 
-#: account/import.html:27
+#: account/import.html
 msgid "Export your Reading Log"
 msgstr ""
 
-#: account/import.html:28
+#: account/import.html
 msgid "Download a copy of your reading log."
 msgstr ""
 
-#: account/import.html:28
+#: account/import.html
 msgid "What is this?"
 msgstr ""
 
-#: account/import.html:33 account/import.html:44 account/import.html:55
-#: account/import.html:66 account/import.html:77
+#: account/import.html
 msgid "Download (.csv format)"
 msgstr ""
 
-#: account/import.html:38
+#: account/import.html
 msgid "Export your book notes"
 msgstr ""
 
-#: account/import.html:39
+#: account/import.html
 msgid "Download a copy of your book notes."
 msgstr ""
 
-#: account/import.html:39
+#: account/import.html
 msgid "What are book notes?"
 msgstr ""
 
-#: account/import.html:49
+#: account/import.html
 msgid "Export your reviews"
 msgstr ""
 
-#: account/import.html:50
+#: account/import.html
 msgid "Download a copy of your review tags."
 msgstr ""
 
-#: account/import.html:50
+#: account/import.html
 msgid "What are review tags?"
 msgstr ""
 
-#: account/import.html:60
+#: account/import.html
 msgid "Export your list overview"
 msgstr ""
 
-#: account/import.html:61
+#: account/import.html
 msgid "Download a summary of your lists and their contents."
 msgstr ""
 
-#: account/import.html:61
+#: account/import.html
 msgid "What are lists?"
 msgstr ""
 
-#: account/import.html:71
+#: account/import.html
 msgid "Export your star ratings"
 msgstr ""
 
-#: account/import.html:72
+#: account/import.html
 msgid "Download a copy of your star ratings"
 msgstr ""
 
-#: account/import.html:72
+#: account/import.html
 msgid "What are star ratings?"
 msgstr ""
 
-#: account/loan_history.html:23
+#: account/loan_history.html
 msgid "No loans found in your borrow history."
 msgstr ""
 
-#: account/loan_history.html:24
+#: account/loan_history.html
 msgid "<a href=\"/search\">Search for a book</a> to borrow."
 msgstr ""
 
-#: account/loans.html:54
+#: account/loans.html
 msgid "You've not checked out any books at this moment."
 msgstr ""
 
-#: account/loans.html:63
+#: account/loans.html
 #, python-format
 msgid "%(count)d Current Loan"
 msgid_plural "%(count)d Current Loans"
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html:65 admin/loans_table.html:41
+#: account/loans.html admin/loans_table.html
 msgid "Loan Expires"
 msgstr ""
 
-#: account/loans.html:66
+#: account/loans.html
 msgid "Loan actions"
 msgstr ""
 
-#: account/loans.html:93
+#: account/loans.html
 #, python-format
 msgid "There is %(count)d person waiting for this book."
 msgid_plural "There are %(count)d people waiting for this book."
 msgstr[0] ""
 msgstr[1] ""
 
-#: account/loans.html:99
+#: account/loans.html
 msgid "Not yet downloaded."
 msgstr ""
 
-#: account/loans.html:100
+#: account/loans.html
 msgid "Download Now"
 msgstr ""
 
-#: account/loans.html:109
+#: account/loans.html
 msgid "Return via<br/>Adobe Digital Editions"
 msgstr ""
 
-#: account/loans.html:120
+#: account/loans.html
 msgid "Books You're Waiting For"
 msgstr ""
 
-#: account/loans.html:127
+#: account/loans.html
 msgid "You are not waiting for any books at this moment."
 msgstr ""
 
-#: account/loans.html:130
+#: account/loans.html
 msgid "Leave the Waiting List"
 msgstr ""
 
-#: account/loans.html:130
+#: account/loans.html
 msgid ""
 "Are you sure you want to leave the waiting list "
 "of<br/><strong>TITLE</strong>?"
@@ -1146,15 +1109,11 @@ msgstr ""
 msgid "Set %(year_span)s reading goal"
 msgstr ""
 
-#: account/mybooks.html:32
-msgid "Yearly Reading Goal"
-msgstr ""
-
-#: account/mybooks.html:63
+#: account/mybooks.html
 msgid "No books are on this shelf"
 msgstr ""
 
-#: account/mybooks.html:68 account/sidebar.html:13
+#: account/mybooks.html account/sidebar.html
 msgid "My Loans"
 msgstr ""
 
@@ -1164,23 +1123,19 @@ msgstr ""
 msgid "Already Read"
 msgstr ""
 
-#: account/mybooks.html:81 type/user/view.html:62
+#: account/mybooks.html type/user/view.html
 msgid "This reader has chosen to make their Reading Log private."
 msgstr ""
 
-#: account/mybooks.html:132 account/sidebar.html:55
+#: account/mybooks.html account/sidebar.html
 msgid "Untitled list"
 msgstr ""
 
-#: account/mybooks.html:161
+#: account/mybooks.html
 msgid "View All Lists"
 msgstr ""
 
-#: account/mybooks.html:170
-msgid "My Stats"
-msgstr ""
-
-#: account/mybooks.html:176 account/sidebar.html:36 account/topmenu.html:17
+#: account/mybooks.html account/sidebar.html account/topmenu.html
 msgid "My Reading Stats"
 msgstr ""
 
@@ -1189,275 +1144,254 @@ msgstr ""
 msgid "Loan History"
 msgstr ""
 
-#: account/mybooks.html:192 account/sidebar.html:33
+#: account/mybooks.html account/sidebar.html
 msgid "My Notes"
 msgstr ""
 
-#: account/mybooks.html:201 account/sidebar.html:34
+#: account/mybooks.html account/sidebar.html
 msgid "My Reviews"
 msgstr ""
 
-#: account/mybooks.html:210 account/sidebar.html:37
+#: account/mybooks.html account/sidebar.html
 msgid "Import & Export Options"
 msgstr ""
 
-#: account/mybooks.html:219 account/sidebar.html:41
-#: books/mybooks_breadcrumb_select.html:26 mybooks.py:161
+#: account/mybooks.html account/sidebar.html
+#: books/mybooks_breadcrumb_select.html mybooks.py
 msgid "Sponsorships"
 msgstr ""
 
-#: account/not_verified.html:7 account/not_verified.html:18
-#: account/verify/failed.html:10
+#: account/not_verified.html account/verify/failed.html
 msgid "Oops!"
 msgstr ""
 
-#: account/not_verified.html:23
-msgid "The email address you signed up with needs to be verified."
-msgstr ""
-
-#: account/not_verified.html:25
-#, python-format
-msgid ""
-"When you created your account, we sent an email to %(email)s that "
-"contained a link for you to verify your email address. We need you to "
-"click that link, please."
-msgstr ""
-
-#: account/not_verified.html:27
-msgid "If you can't find the email, just hit this button to send a fresh one:"
-msgstr ""
-
-#: account/not_verified.html:36 account/verify/failed.html:29
+#: account/not_verified.html account/verify/failed.html
 msgid "Resend the verification email"
 msgstr ""
 
-#: account/not_verified.html:40 account/verify/failed.html:33
-msgid "Thanks!"
-msgstr ""
-
-#: BookByline.html:10 SearchResultsWork.html:77 account/notes.html:25
-#: account/observations.html:26
+#: BookByline.html SearchResultsWork.html account/notes.html
+#: account/observations.html
 msgid "Unknown author"
 msgstr ""
 
-#: account/notes.html:35
+#: account/notes.html
 msgid "My notes for an edition of "
 msgstr ""
 
-#: account/notes.html:39
+#: account/notes.html
 msgid "Title Missing"
 msgstr ""
 
-#: account/notes.html:46 type/work/editions.html:36
+#: account/notes.html type/work/editions.html
 msgid "Publish date unknown"
 msgstr ""
 
-#: account/notes.html:48 books/edition-sort.html:63 books/works-show.html:30
-#: type/work/editions.html:38
+#: account/notes.html books/edition-sort.html books/works-show.html
+#: type/work/editions.html
 msgid "Publisher unknown"
 msgstr ""
 
-#: account/notes.html:53
+#: account/notes.html
 #, python-format
 msgid "in %(language)s"
 msgstr ""
 
-#: NotesModal.html:42 account/notes.html:66
+#: NotesModal.html account/notes.html
 msgid "Delete Note"
 msgstr ""
 
-#: NotesModal.html:43 account/notes.html:67
+#: NotesModal.html account/notes.html
 msgid "Save Note"
 msgstr ""
 
-#: account/notes.html:75
+#: account/notes.html
 msgid "No notes found."
 msgstr ""
 
-#: account/notifications.html:7 account/notifications.html:16
+#: account/notifications.html
 msgid "Notifications from Open Library"
 msgstr ""
 
-#: account/notifications.html:14
+#: account/notifications.html
 msgid "Notifications"
 msgstr ""
 
-#: account/notifications.html:31
+#: account/notifications.html
 msgid ""
 "Notifications are connected to Lists at the moment. If one of the books "
 "on your list gets edited, or a new book comes into the catalog, we'll let"
 " you know, if you want."
 msgstr ""
 
-#: account/notifications.html:35
+#: account/notifications.html
 msgid "Would you like to receive very occasional emails from Open Library?"
 msgstr ""
 
-#: account/notifications.html:42
+#: account/notifications.html
 msgid "No, thank you"
 msgstr ""
 
-#: account/notifications.html:49
+#: account/notifications.html
 msgid "Yes! Please!"
 msgstr ""
 
-#: EditButtons.html:21 EditButtonsMacros.html:24 account/notifications.html:57
-#: account/privacy.html:77 covers/manage.html:51
+#: EditButtons.html EditButtonsMacros.html account/notifications.html
+#: account/privacy.html covers/manage.html
 msgid "Save"
 msgstr ""
 
-#: EditionNavBar.html:28 account/observations.html:33
-#: books/mybooks_breadcrumb_select.html:22 mybooks.py:120
+#: EditionNavBar.html account/observations.html
+#: books/mybooks_breadcrumb_select.html mybooks.py
 msgid "Reviews"
 msgstr ""
 
-#: account/observations.html:43
+#: account/observations.html
 msgid "Delete"
 msgstr ""
 
-#: account/observations.html:44
+#: account/observations.html
 msgid "Update Reviews"
 msgstr ""
 
-#: account/observations.html:52
+#: account/observations.html
 msgid "No observations found."
 msgstr ""
 
-#: account/privacy.html:7
+#: account/privacy.html
 msgid "Your Privacy on Open Library"
 msgstr ""
 
-#: account/privacy.html:16
+#: account/privacy.html
 msgid "Privacy & Content Moderation Settings"
 msgstr ""
 
-#: account/privacy.html:33
+#: account/privacy.html
 msgid ""
 "Would you like to make your <a href=\"/account/books\">Reading Log</a> "
 "public?"
 msgstr ""
 
-#: account/privacy.html:34
+#: account/privacy.html
 msgid ""
 "This will enable others to see what books you want to read, are reading, "
 "or have already read."
 msgstr ""
 
-#: account/privacy.html:41 account/privacy.html:62
+#: account/privacy.html
 msgid "Yes"
 msgstr ""
 
-#: account/privacy.html:48 account/privacy.html:69 books/edit/edition.html:293
+#: account/privacy.html books/edit/edition.html
 msgid "No"
 msgstr ""
 
-#: account/privacy.html:54
+#: account/privacy.html
 msgid "Enable Safe Mode?"
 msgstr ""
 
-#: account/privacy.html:55
+#: account/privacy.html
 msgid ""
 "Safe Mode blurs book covers that have been flagged as having sensitive "
 "imagery."
 msgstr ""
 
-#: account/reading_log.html:12
+#: account/reading_log.html
 #, python-format
 msgid "Books %(username)s is reading"
 msgstr ""
 
-#: account/reading_log.html:13
+#: account/reading_log.html
 #, python-format
 msgid ""
 "%(username)s is reading %(total)d books. Join %(username)s on "
 "OpenLibrary.org and tell the world what you're reading."
 msgstr ""
 
-#: account/reading_log.html:15
+#: account/reading_log.html
 #, python-format
 msgid "Books %(username)s wants to read"
 msgstr ""
 
-#: account/reading_log.html:16
+#: account/reading_log.html
 #, python-format
 msgid ""
 "%(username)s wants to read %(total)d books. Join %(username)s on "
 "OpenLibrary.org and share the books that you'll soon be reading!"
 msgstr ""
 
-#: account/reading_log.html:19
+#: account/reading_log.html
 #, python-format
 msgid "Books %(username)s has read in %(year)d"
 msgstr ""
 
-#: account/reading_log.html:20
+#: account/reading_log.html
 #, python-format
 msgid ""
 "%(username)s has read %(total)d books in %(year)d. Join %(username)s on "
 "OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 
-#: account/reading_log.html:22
+#: account/reading_log.html
 #, python-format
 msgid "Books %(username)s has read"
 msgstr ""
 
-#: account/reading_log.html:23
+#: account/reading_log.html
 #, python-format
 msgid ""
 "%(username)s has read %(total)d books. Join %(username)s on "
 "OpenLibrary.org and tell the world about the books that you care about."
 msgstr ""
 
-#: account/reading_log.html:25
+#: account/reading_log.html
 #, python-format
 msgid "Books %(userdisplayname)s is sponsoring"
 msgstr ""
 
-#: account/reading_log.html:45
+#: account/reading_log.html
 msgid "Search your reading log"
 msgstr ""
 
-#: account/reading_log.html:52 search/sort_options.html:8
+#: account/reading_log.html search/sort_options.html
 msgid "Sorting by"
 msgstr ""
 
-#: account/reading_log.html:54 account/reading_log.html:58
+#: account/reading_log.html
 msgid "Date Added (newest)"
 msgstr ""
 
-#: account/reading_log.html:56 account/reading_log.html:60
+#: account/reading_log.html
 msgid "Date Added (oldest)"
 msgstr ""
 
-#: account/reading_log.html:83
+#: account/reading_log.html
 msgid "No results found in this shelf"
 msgstr ""
 
-#: account/reading_log.html:86
+#: account/reading_log.html
 #, python-format
 msgid "Search all of Open Library for \"%s\"?"
 msgstr ""
 
-#: account/reading_log.html:90
+#: account/reading_log.html
 msgid "You haven't marked any books as read for this year."
 msgstr ""
 
-#: account/reading_log.html:92
+#: account/reading_log.html
 msgid "You haven't added any books to this shelf yet."
 msgstr ""
 
-#: account/reading_log.html:93
+#: account/reading_log.html
 msgid ""
 "<a href=\"/search\">Search for a book</a> to add to your reading log. <a "
 "href=\"/help/faq/reading-log\">Learn more</a> about the reading log."
 msgstr ""
 
-#: account/readinglog_shelf_name.html:10
+#: account/readinglog_shelf_name.html
 msgid "Want To Read"
 msgstr ""
 
-#: account/readinglog_stats.html:15 account/readinglog_stats.html:109
+#: account/readinglog_stats.html
 #, python-format
 msgid "My %(shelf_name)s Stats"
 msgstr ""
@@ -1474,27 +1408,27 @@ msgid ""
 "charts show only the top 20 bars. Note reading log stats are private."
 msgstr ""
 
-#: account/readinglog_stats.html:116
+#: account/readinglog_stats.html
 msgid "Author Stats"
 msgstr ""
 
-#: account/readinglog_stats.html:121
+#: account/readinglog_stats.html
 msgid "Most Read Authors"
 msgstr ""
 
-#: account/readinglog_stats.html:122
+#: account/readinglog_stats.html
 msgid "Works by Author Sex"
 msgstr ""
 
-#: account/readinglog_stats.html:123
+#: account/readinglog_stats.html
 msgid "Works by Author Country of Citizenship"
 msgstr ""
 
-#: account/readinglog_stats.html:124
+#: account/readinglog_stats.html
 msgid "Works by Author Country of Birth"
 msgstr ""
 
-#: account/readinglog_stats.html:134
+#: account/readinglog_stats.html
 msgid ""
 "Demographic statistics powered by <a "
 "href=\"https://www.wikidata.org/\">Wikidata</a>. Here's a <a id=\"wd-"
@@ -1504,75 +1438,72 @@ msgid ""
 "purpose\"> these instructions</a>."
 msgstr ""
 
-#: account/readinglog_stats.html:136
+#: account/readinglog_stats.html
 msgid "Work Stats"
 msgstr ""
 
-#: account/readinglog_stats.html:142
+#: account/readinglog_stats.html
 msgid "Works by Subject"
 msgstr ""
 
-#: account/readinglog_stats.html:143
+#: account/readinglog_stats.html
 msgid "Works by People"
 msgstr ""
 
-#: account/readinglog_stats.html:144
+#: account/readinglog_stats.html
 msgid "Works by Places"
 msgstr ""
 
-#: account/readinglog_stats.html:145
+#: account/readinglog_stats.html
 msgid "Works by Time Period"
 msgstr ""
 
-#: account/readinglog_stats.html:157
+#: account/readinglog_stats.html
 msgid "Matching works"
 msgstr ""
 
-#: account/readinglog_stats.html:161
+#: account/readinglog_stats.html
 msgid "Click on a bar to see matching works"
 msgstr ""
 
-#: account/sidebar.html:21 search/sort_options.html:31 type/user/view.html:50
-#: type/user/view.html:55
+#: account/sidebar.html search/sort_options.html type/user/view.html
 msgid "Reading Log"
 msgstr ""
 
-#: account/sidebar.html:45
+#: account/sidebar.html
 msgid "Sponsoring"
 msgstr ""
 
-#: account/sidebar.html:48
+#: account/sidebar.html
 msgid "My lists"
 msgstr ""
 
-#: EditionNavBar.html:32 SearchNavigation.html:28 account/sidebar.html:48
-#: lib/nav_head.html:31 lib/nav_head.html:97 lists/home.html:7
-#: lists/home.html:10 lists/widget.html:62 recentchanges/index.html:42
-#: type/edition/view.html:540 type/list/embed.html:29
-#: type/list/view_body.html:50 type/user/view.html:35 type/user/view.html:66
-#: type/work/view.html:540
+#: EditionNavBar.html SearchNavigation.html account/sidebar.html
+#: lib/nav_head.html lists/home.html lists/widget.html recentchanges/index.html
+#: type/edition/view.html type/list/embed.html type/list/view_body.html
+#: type/user/view.html type/work/view.html
 msgid "Lists"
 msgstr ""
 
-#: account/sidebar.html:48 type/edition/view.html:545 type/user/view.html:67
-#: type/work/view.html:545
+#: account/sidebar.html type/edition/view.html type/user/view.html
+#: type/work/view.html
 msgid "See All"
 msgstr ""
 
-#: account/sidebar.html:51 type/list/edit.html:7 type/list/edit.html:17
+#: account/sidebar.html type/list/edit.html
 msgid "Create a list"
 msgstr ""
 
-#: account/topmenu.html:21
+#: account/topmenu.html
 msgid "Import & Export"
 msgstr ""
 
-#: account/topmenu.html:25
+#: account/topmenu.html
 #, python-format
 msgid "Privacy settings: %(public)s"
 msgstr ""
 
-#: account/verify.html:7
+#: account/verify.html
 msgid "Verification email sent"
 msgstr ""
 
@@ -1583,59 +1514,47 @@ msgstr ""
 msgid "Hi, %(user)s"
 msgstr ""
 
-#: account/verify.html:14
-#, python-format
-msgid ""
-"We’ve sent an email to %(email)s containing a link to verify your "
-"account. Click/tap on the link to finish creating your Internet Archive "
-"account."
-msgstr ""
-
-#: account/verify.html:18
-msgid "Then, come back to Open Library and find some great books!"
-msgstr ""
-
-#: account/view.html:49 type/edition/modal_links.html:34
-#: type/edition/title_and_author.html:58
+#: account/view.html type/edition/modal_links.html
+#: type/edition/title_and_author.html
 msgid "Share"
 msgstr ""
 
-#: account/view.html:65
+#: account/view.html
 msgid "Your book notes are private and cannot be viewed by other patrons."
 msgstr ""
 
-#: account/view.html:67
+#: account/view.html
 msgid "Your book reviews will be shared anonymously with other patrons."
 msgstr ""
 
-#: account/yrg_banner.html:11
+#: account/yrg_banner.html
 #, python-format
 msgid "Set your %(year)s Yearly Reading Goal:"
 msgstr ""
 
-#: account/yrg_banner.html:12
+#: account/yrg_banner.html
 msgid "Set my goal"
 msgstr ""
 
-#: account/email/forgot-ia.html:10 account/email/forgot.html:10
+#: account/email/forgot-ia.html account/email/forgot.html
 msgid "Forgot Your Internet Archive Email?"
 msgstr ""
 
-#: account/email/forgot-ia.html:12
+#: account/email/forgot-ia.html
 msgid ""
 "Please enter your Open Library email and password, and we’ll retrieve "
 "your Archive.org email."
 msgstr ""
 
-#: account/email/forgot-ia.html:17
+#: account/email/forgot-ia.html
 msgid "Your email is:"
 msgstr ""
 
-#: account/email/forgot-ia.html:18
+#: account/email/forgot-ia.html
 msgid "Return to Log In?"
 msgstr ""
 
-#: account/email/forgot-ia.html:27
+#: account/email/forgot-ia.html
 msgid "Open Library Email"
 msgstr ""
 
@@ -1643,12 +1562,11 @@ msgstr ""
 msgid "Retrieve Archive.org Email"
 msgstr ""
 
-#: account/email/forgot-ia.html:43 account/password/forgot.html:10
-#: account/password/forgot.html:11
+#: account/email/forgot-ia.html account/password/forgot.html
 msgid "Forgot your Archive.org Password?"
 msgstr ""
 
-#: account/email/forgot.html:15
+#: account/email/forgot.html
 msgid "Forgot Your Open Library Email?"
 msgstr ""
 
@@ -1656,42 +1574,41 @@ msgstr ""
 msgid "Username/Password Reminder"
 msgstr ""
 
-#: account/password/forgot.html:11
+#: account/password/forgot.html
 msgid "Click here."
 msgstr ""
 
-#: account/password/forgot.html:23
+#: account/password/forgot.html
 msgid "Send It"
 msgstr ""
 
-#: account/password/reset.html:7 account/password/reset.html:10
-#: admin/people/view.html:161
+#: account/password/reset.html admin/people/view.html
 msgid "Reset Password"
 msgstr ""
 
-#: account/password/reset.html:15
+#: account/password/reset.html
 msgid "Please enter a new password for your Open Library account."
 msgstr ""
 
-#: account/password/reset.html:23
+#: account/password/reset.html
 msgid "Reset"
 msgstr ""
 
-#: account/password/reset_success.html:7
+#: account/password/reset_success.html
 msgid "Password Reset Successful"
 msgstr ""
 
-#: account/password/reset_success.html:14
+#: account/password/reset_success.html
 msgid ""
 "Your password has been updated. Please <a "
 "href='/account/login?redirect=/'>log in to continue</a>."
 msgstr ""
 
-#: account/password/sent.html:10
+#: account/password/sent.html
 msgid "Done."
 msgstr ""
 
-#: account/password/sent.html:14
+#: account/password/sent.html
 #, python-format
 msgid ""
 "We've sent an email to %(email)s with a reminder of your username and "
@@ -1699,55 +1616,51 @@ msgid ""
 "your inbox for a note from us."
 msgstr ""
 
-#: account/verify/activated.html:7
+#: account/verify/activated.html
 msgid "Account already activated"
 msgstr ""
 
-#: account/verify/activated.html:15
+#: account/verify/activated.html
 #, python-format
 msgid ""
 "Your account has been activated already. Please <a href=\"%s\">log in to "
 "continue</a>."
 msgstr ""
 
-#: account/verify/failed.html:7
+#: account/verify/failed.html
 msgid "Email Verification Failed"
 msgstr ""
 
-#: account/verify/failed.html:14
+#: account/verify/failed.html
 msgid ""
 "Your email address couldn't be verified. Your verification link seems "
 "invalid or expired."
 msgstr ""
 
-#: account/verify/failed.html:16
-msgid "Fill your email and hit this button to resend a fresh verification email:"
-msgstr ""
-
-#: account/verify/failed.html:22
+#: account/verify/failed.html
 msgid "Enter your email address here"
 msgstr ""
 
-#: account/verify/failed.html:25
+#: account/verify/failed.html
 msgid "No user registered with this email address."
 msgstr ""
 
-#: account/verify/success.html:7
+#: account/verify/success.html
 msgid "Email Verification Successful"
 msgstr ""
 
-#: account/verify/success.html:15
+#: account/verify/success.html
 #, python-format
 msgid ""
 "Yay! Your email address has been verified. Please <a href='%s'>log in to "
 "continue</a>."
 msgstr ""
 
-#: admin/attach_debugger.html:22
+#: admin/attach_debugger.html
 msgid "Waiting for debugger to attach..."
 msgstr ""
 
-#: admin/attach_debugger.html:22
+#: admin/attach_debugger.html
 msgid "Start"
 msgstr ""
 
@@ -1769,145 +1682,17 @@ msgstr ""
 msgid "Please add IA identifiers to be imported, one per line."
 msgstr ""
 
-#: admin/imports-add.html:26 admin/ip/view.html:95 admin/people/edits.html:92
-#: admin/permissions.html:49 check_ins/check_in_form.html:77
-#: check_ins/reading_goal_form.html:16 covers/add.html:82 covers/add.html:83
+#: admin/imports-add.html admin/ip/view.html admin/people/edits.html
+#: check_ins/check_in_form.html check_ins/reading_goal_form.html
+#: covers/add.html
 msgid "Submit"
 msgstr ""
 
-#: admin/index.html:19
+#: admin/index.html
 msgid "Stats"
 msgstr ""
 
-#: admin/index.html:25
-msgid "Edits Per Day"
-msgstr ""
-
-#: admin/index.html:26 admin/people/index.html:74
-msgid "Edits"
-msgstr ""
-
-#: admin/index.html:40 admin/index.html:88
-msgid "Yesterday"
-msgstr ""
-
-#: admin/index.html:41 admin/index.html:89 admin/index.html:116
-msgid "Last 7 days"
-msgstr ""
-
-#: admin/index.html:42 admin/index.html:90 admin/index.html:117
-msgid "Last 28 days"
-msgstr ""
-
-#: admin/index.html:47
-msgid "Human"
-msgstr ""
-
-#: admin/index.html:54 admin/people/view.html:173
-msgid "Bot"
-msgstr ""
-
-#: admin/index.html:61 admin/index.html:119
-msgid "Total"
-msgstr ""
-
-#: admin/index.html:74
-msgid "New Accounts Per Day"
-msgstr ""
-
-#: admin/index.html:75
-msgid "Members"
-msgstr ""
-
-#: admin/index.html:115
-msgid "Items Added"
-msgstr ""
-
-#: admin/index.html:118
-msgid "Trend"
-msgstr ""
-
-#: admin/index.html:122
-msgid "Works Added"
-msgstr ""
-
-#: admin/index.html:129
-msgid "Editions Added"
-msgstr ""
-
-#: admin/index.html:136
-msgid "Authors Added"
-msgstr ""
-
-#: admin/index.html:143 recentchanges/index.html:38
-msgid "Covers Added"
-msgstr ""
-
-#: admin/index.html:150 home/stats.html:24
-msgid "New Members"
-msgstr ""
-
-#: admin/index.html:157
-msgid "Lists Added"
-msgstr ""
-
-#: admin/index.html:164
-msgid "Books Logged"
-msgstr ""
-
-#: admin/index.html:171
-msgid "Users Logging"
-msgstr ""
-
-#: admin/index.html:178
-msgid "Books Review Tags"
-msgstr ""
-
-#: admin/index.html:185
-msgid "Books Reviewed"
-msgstr ""
-
-#: admin/index.html:192
-msgid "Users Reviewing"
-msgstr ""
-
-#: admin/index.html:200
-msgid "Notes Created"
-msgstr ""
-
-#: admin/index.html:207
-msgid "Patrons Creating Notes"
-msgstr ""
-
-#: admin/index.html:215
-msgid "Books Starred"
-msgstr ""
-
-#: admin/index.html:222
-msgid "Star Rating Patrons"
-msgstr ""
-
-#: admin/index.html:232 home/stats.html:17
-msgid "Unique Visitors"
-msgstr ""
-
-#: admin/index.html:233
-msgid "Unique visitors IPs per day graph"
-msgstr ""
-
-#: admin/index.html:235
-msgid "Borrows"
-msgstr ""
-
-#: admin/index.html:236
-msgid "Borrows, last 3 months graph"
-msgstr ""
-
-#: admin/index.html:237
-msgid "Borrows, last 2 years graph"
-msgstr ""
-
-#: admin/loans_table.html:17
+#: admin/loans_table.html
 msgid "BookReader"
 msgstr ""
 
@@ -1923,24 +1708,24 @@ msgstr ""
 msgid "ePub"
 msgstr ""
 
-#: admin/loans_table.html:31
+#: admin/loans_table.html
 #, python-format
 msgid "%d Current Loan"
 msgid_plural "%d Current Loans"
 msgstr[0] ""
 msgstr[1] ""
 
-#: RecentChanges.html:18 RecentChangesUsers.html:21 admin/ip/view.html:45
-#: admin/loans_table.html:45 admin/people/edits.html:42
-#: recentchanges/render.html:32 recentchanges/updated_records.html:33
+#: RecentChanges.html RecentChangesUsers.html admin/ip/view.html
+#: admin/loans_table.html admin/people/edits.html recentchanges/render.html
+#: recentchanges/updated_records.html
 msgid "What"
 msgstr ""
 
-#: admin/menu.html:19
+#: admin/menu.html
 msgid "Admin Center"
 msgstr ""
 
-#: admin/menu.html:21
+#: admin/menu.html
 msgid "Sponsorship"
 msgstr ""
 
@@ -1949,31 +1734,31 @@ msgstr ""
 msgid "Loans"
 msgstr ""
 
-#: admin/menu.html:23
+#: admin/menu.html
 msgid "Waiting Lists"
 msgstr ""
 
-#: admin/menu.html:24
+#: admin/menu.html
 msgid "Block IPs"
 msgstr ""
 
-#: admin/menu.html:25
+#: admin/menu.html
 msgid "Spam Words"
 msgstr ""
 
-#: admin/menu.html:26
+#: admin/menu.html
 msgid "Solr"
 msgstr ""
 
-#: admin/menu.html:29
+#: admin/menu.html
 msgid "Graphs"
 msgstr ""
 
-#: admin/menu.html:30
+#: admin/menu.html
 msgid "Inspect store"
 msgstr ""
 
-#: admin/menu.html:31
+#: admin/menu.html
 msgid "Inspect memcache"
 msgstr ""
 
@@ -2023,35 +1808,35 @@ msgstr ""
 msgid "Enter the keys to reindex in Solr"
 msgstr ""
 
-#: admin/solr.html:32
+#: admin/solr.html
 msgid "Write one entry per line"
 msgstr ""
 
-#: admin/solr.html:41
+#: admin/solr.html
 msgid "Update"
 msgstr ""
 
-#: FormatExpiry.html:10 admin/waitinglists.html:29
+#: FormatExpiry.html admin/waitinglists.html
 msgid "Expires"
 msgstr ""
 
-#: admin/waitinglists.html:30
+#: admin/waitinglists.html
 msgid "Loan Status"
 msgstr ""
 
-#: admin/ip/index.html:18
+#: admin/ip/index.html
 msgid "List of Banned IPs"
 msgstr ""
 
-#: admin/ip/index.html:22 admin/people/index.html:71
+#: admin/ip/index.html admin/people/index.html
 msgid "Date/Time"
 msgstr ""
 
-#: admin/ip/index.html:23
+#: admin/ip/index.html
 msgid "IP address"
 msgstr ""
 
-#: admin/ip/index.html:26
+#: admin/ip/index.html
 msgid "# of edits"
 msgstr ""
 
@@ -2059,9 +1844,9 @@ msgstr ""
 msgid "IP"
 msgstr ""
 
-#: admin/ip/view.html:17
-#, python-format
-msgid "IP %(ip)s is <a href=\"/admin/block\">blocked</a>."
+#: EditButtons.html EditButtonsMacros.html admin/ip/view.html
+#: admin/people/edits.html
+msgid "Please, leave a short note about what you changed:"
 msgstr ""
 
 #: admin/ip/view.html:21
@@ -2106,114 +1891,123 @@ msgstr ""
 msgid "Older"
 msgstr ""
 
-#: RecentChanges.html:64 RecentChangesAdmin.html:58 RecentChangesAdmin.html:60
-#: RecentChangesUsers.html:61 admin/people/edits.html:103
-#: recentchanges/render.html:70
+#: RecentChanges.html RecentChangesAdmin.html RecentChangesUsers.html
+#: admin/people/edits.html recentchanges/render.html
 msgid "Newer"
 msgstr ""
 
-#: admin/people/index.html:16
+#: admin/people/index.html
 msgid "Find Account"
 msgstr ""
 
-#: admin/people/index.html:33 admin/people/view.html:151
+#: admin/people/index.html admin/people/view.html
 msgid "Email Address:"
 msgstr ""
 
-#: admin/people/index.html:46
+#: admin/people/index.html
 msgid "IA ID:"
 msgstr ""
 
-#: admin/people/index.html:50
+#: admin/people/index.html
 msgid "Find"
 msgstr ""
 
-#: admin/people/index.html:53
+#: admin/people/index.html
 msgid "No account found with this ID."
 msgstr ""
 
-#: admin/people/index.html:65
+#: admin/people/index.html
 msgid "Recent Accounts"
 msgstr ""
 
-#: admin/people/index.html:72 type/author/edit.html:32
-#: type/language/view.html:27
+#: admin/people/index.html type/author/edit.html type/language/view.html
 msgid "Name"
 msgstr ""
 
-#: admin/people/index.html:73
+#: admin/people/index.html
 msgid "email"
 msgstr ""
 
-#: admin/people/index.html:89 admin/people/view.html:247
+#: admin/people/index.html
+msgid "Edits"
+msgstr ""
+
+#: admin/people/index.html admin/people/view.html
 msgid "Edit History"
 msgstr ""
 
-#: CreateListModal.html:16 admin/people/view.html:147
-#: my_books/dropdown_content.html:96
+#: CreateListModal.html admin/people/view.html my_books/dropdown_content.html
 msgid "Name:"
 msgstr ""
 
-#: admin/people/view.html:191
+#: admin/people/view.html
+msgid "Admin"
+msgstr ""
+
+#: admin/people/view.html
+msgid "Bot"
+msgstr ""
+
+#: admin/people/view.html
 msgid "# Edits"
 msgstr ""
 
-#: admin/people/view.html:195
+#: admin/people/view.html
 msgid "Member Since:"
 msgstr ""
 
-#: admin/people/view.html:204
+#: admin/people/view.html
 msgid "Last Login:"
 msgstr ""
 
-#: admin/people/view.html:213
+#: admin/people/view.html
 msgid "Tags:"
 msgstr ""
 
-#: admin/people/view.html:221
+#: admin/people/view.html
 msgid "Anonymize Account:"
 msgstr ""
 
-#: admin/people/view.html:226
+#: admin/people/view.html
 msgid "Anonymize Account"
 msgstr ""
 
-#: admin/people/view.html:243
+#: admin/people/view.html
 msgid "Waiting Loans"
 msgstr ""
 
-#: admin/people/view.html:256
+#: admin/people/view.html
 msgid "Debug Info"
 msgstr ""
 
-#: SearchNavigation.html:16 authors/index.html:9 authors/index.html:12
-#: lib/nav_foot.html:27 merge/authors.html:57 publishers/view.html:87
+#: SearchNavigation.html authors/index.html lib/nav_foot.html
+#: merge/authors.html publishers/view.html
 msgid "Authors"
 msgstr ""
 
-#: authors/index.html:18
+#: authors/index.html
 msgid "Search for an Author"
 msgstr ""
 
-#: authors/index.html:39 search/authors.html:72
+#: authors/index.html search/authors.html
 #, python-format
 msgid "about %(subjects)s"
 msgstr ""
 
-#: authors/index.html:40 search/authors.html:73
+#: authors/index.html search/authors.html
 #, python-format
 msgid "including <i>%(topwork)s</i>"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:11
-#: book_providers/ia_download_options.html:9
-#: book_providers/librivox_download_options.html:9
-#: book_providers/openstax_download_options.html:11
-#: book_providers/standard_ebooks_download_options.html:12
+#: book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
+#: book_providers/librivox_download_options.html
+#: book_providers/openstax_download_options.html
+#: book_providers/standard_ebooks_download_options.html
 msgid "Download Options"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:15
+#: book_providers/gutenberg_download_options.html
 msgid "Download an HTML from Project Gutenberg"
 msgstr ""
 
@@ -2222,36 +2016,36 @@ msgstr ""
 msgid "HTML"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:16
+#: book_providers/gutenberg_download_options.html
 msgid "Download a text version from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:16
-#: book_providers/ia_download_options.html:14
+#: book_providers/gutenberg_download_options.html
+#: book_providers/ia_download_options.html
 msgid "Plain text"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:17
+#: book_providers/gutenberg_download_options.html
 msgid "Download an ePub from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:18
+#: book_providers/gutenberg_download_options.html
 msgid "Download a Kindle file from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:18
+#: book_providers/gutenberg_download_options.html
 msgid "Kindle"
 msgstr ""
 
-#: book_providers/gutenberg_download_options.html:19
+#: book_providers/gutenberg_download_options.html
 msgid "More at Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_read_button.html:10
+#: book_providers/gutenberg_read_button.html
 msgid "Read eBook from Project Gutenberg"
 msgstr ""
 
-#: book_providers/gutenberg_read_button.html:21
+#: book_providers/gutenberg_read_button.html
 msgid ""
 "This book is available from <a "
 "href=\"https://www.gutenberg.org/\">Project Gutenberg</a>. Project "
@@ -2260,27 +2054,39 @@ msgid ""
 "free eBooks."
 msgstr ""
 
-#: book_providers/gutenberg_read_button.html:22
-#: book_providers/librivox_read_button.html:25
-#: book_providers/openstax_read_button.html:22
-#: book_providers/standard_ebooks_read_button.html:22
-#: check_ins/reading_goal_progress.html:28
+#: book_providers/gutenberg_read_button.html
+#: book_providers/librivox_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html
+#: check_ins/reading_goal_progress.html
 msgid "Learn more"
 msgstr ""
 
-#: book_providers/ia_download_options.html:12
+#: BookPreview.html CreateListModal.html DonateModal.html NotesModal.html
+#: ObservationsModal.html ShareModal.html
+#: book_providers/gutenberg_read_button.html
+#: book_providers/librivox_read_button.html
+#: book_providers/openstax_read_button.html
+#: book_providers/standard_ebooks_read_button.html covers/author_photo.html
+#: covers/book_cover.html covers/book_cover_single_edition.html
+#: covers/book_cover_work.html covers/change.html lib/markdown.html
+#: my_books/dropdown_content.html
+msgid "Close"
+msgstr ""
+
+#: book_providers/ia_download_options.html
 msgid "Download a PDF from Internet Archive"
 msgstr ""
 
-#: book_providers/ia_download_options.html:14
+#: book_providers/ia_download_options.html
 msgid "Download a text version from Internet Archive"
 msgstr ""
 
-#: book_providers/ia_download_options.html:16
+#: book_providers/ia_download_options.html
 msgid "Download an ePub from Internet Archive"
 msgstr ""
 
-#: book_providers/ia_download_options.html:18
+#: book_providers/ia_download_options.html
 msgid "Download a MOBI file from Internet Archive"
 msgstr ""
 
@@ -2300,31 +2106,31 @@ msgstr ""
 msgid "Download a ZIP file of the whole book from Internet Archive"
 msgstr ""
 
-#: book_providers/librivox_download_options.html:12
+#: book_providers/librivox_download_options.html
 msgid "Whole Book MP3"
 msgstr ""
 
-#: book_providers/librivox_download_options.html:13
+#: book_providers/librivox_download_options.html
 msgid "Get the RSS Feed from LibriVox"
 msgstr ""
 
-#: book_providers/librivox_download_options.html:13
+#: book_providers/librivox_download_options.html
 msgid "RSS Feed"
 msgstr ""
 
-#: book_providers/librivox_download_options.html:14
+#: book_providers/librivox_download_options.html
 msgid "More at LibriVox"
 msgstr ""
 
-#: book_providers/librivox_read_button.html:9
+#: book_providers/librivox_read_button.html
 msgid "Listen to a reading from LibriVox"
 msgstr ""
 
-#: book_providers/librivox_read_button.html:17
+#: book_providers/librivox_read_button.html
 msgid "Audiobook"
 msgstr ""
 
-#: book_providers/librivox_read_button.html:24
+#: book_providers/librivox_read_button.html
 msgid ""
 "This book is available from <a "
 "href=\"https://librivox.org/\">LibriVox</a>. LibriVox is a trusted book "
@@ -2332,19 +2138,19 @@ msgid ""
 " for free on the internet."
 msgstr ""
 
-#: book_providers/openstax_download_options.html:13
+#: book_providers/openstax_download_options.html
 msgid "Download PDF from OpenStax"
 msgstr ""
 
-#: book_providers/openstax_download_options.html:14
+#: book_providers/openstax_download_options.html
 msgid "More at OpenStax"
 msgstr ""
 
-#: book_providers/openstax_read_button.html:10
+#: book_providers/openstax_read_button.html
 msgid "Read eBook from OpenStax"
 msgstr ""
 
-#: book_providers/openstax_read_button.html:21
+#: book_providers/openstax_read_button.html
 msgid ""
 "This book is available from <a "
 "href=\"https://www.openstax.org/\">OpenStax</a>. OpenStax is a trusted "
@@ -2353,15 +2159,15 @@ msgid ""
 "online."
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:14
+#: book_providers/standard_ebooks_download_options.html
 msgid "Download an HTML from Standard Ebooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:15
+#: book_providers/standard_ebooks_download_options.html
 msgid "Download an ePub from Standard Ebook."
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:16
+#: book_providers/standard_ebooks_download_options.html
 msgid "Download a Kindle file from Standard Ebooks"
 msgstr ""
 
@@ -2381,20 +2187,19 @@ msgstr ""
 msgid "View the source code for this Standard Ebook at GitHub"
 msgstr ""
 
-#: Subnavigation.html:13
-#: book_providers/standard_ebooks_download_options.html:18
+#: Subnavigation.html book_providers/standard_ebooks_download_options.html
 msgid "Source Code"
 msgstr ""
 
-#: book_providers/standard_ebooks_download_options.html:19
+#: book_providers/standard_ebooks_download_options.html
 msgid "More at Standard Ebooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_read_button.html:10
+#: book_providers/standard_ebooks_read_button.html
 msgid "Read eBook from Standard eBooks"
 msgstr ""
 
-#: book_providers/standard_ebooks_read_button.html:21
+#: book_providers/standard_ebooks_read_button.html
 msgid ""
 "This book is available from <a "
 "href=\"https://standardebooks.org/\">Standard Ebooks</a>. Standard Ebooks"
@@ -2403,119 +2208,118 @@ msgid ""
 "source, free of copyright restrictions, and free of cost."
 msgstr ""
 
-#: books/RelatedWorksCarousel.html:19
+#: books/RelatedWorksCarousel.html
 msgid "You might also like"
 msgstr ""
 
-#: books/RelatedWorksCarousel.html:25
+#: books/RelatedWorksCarousel.html
 msgid "More by this author"
 msgid_plural "More by these authors"
 msgstr[0] ""
 msgstr[1] ""
 
-#: books/add.html:7 books/check.html:10
+#: books/add.html books/check.html
 msgid "Add a book"
 msgstr ""
 
-#: books/add.html:10
+#: books/add.html
 msgid "Invalid ISBN checksum digit"
 msgstr ""
 
-#: books/add.html:11
+#: books/add.html
 msgid ""
 "ID must be exactly 10 characters [0-9 or X]. For example 0-19-853453-1 or"
 " 0198534531"
 msgstr ""
 
-#: books/add.html:12
+#: books/add.html
 msgid ""
 "ID must be exactly 13 characters [0-9]. For example 978-3-16-148410-0 or "
 "9783161484100"
 msgstr ""
 
-#: books/add.html:13
+#: books/add.html
 msgid "Invalid LC Control Number format"
 msgstr ""
 
-#: books/add.html:14
+#: books/add.html
 msgid "Please enter a value for the selected identifier"
 msgstr ""
 
-#: books/add.html:19
+#: books/add.html
 msgid "Add a book to Open Library"
 msgstr ""
 
-#: books/add.html:21 tag/add.html:13
+#: books/add.html tag/add.html
 msgid ""
 "We require a minimum set of fields to create a new record. These are "
 "those fields."
 msgstr ""
 
-#: books/add.html:31 books/edit.html:90 books/edit/edition.html:75
-#: lib/nav_head.html:93 search/advancedsearch.html:20 type/about/edit.html:19
-#: type/page/edit.html:20 type/rawtext/edit.html:18 type/template/edit.html:18
+#: books/add.html books/edit.html books/edit/edition.html lib/nav_head.html
+#: search/advancedsearch.html type/about/edit.html type/page/edit.html
+#: type/rawtext/edit.html type/template/edit.html
 msgid "Title"
 msgstr ""
 
-#: books/add.html:31 books/edit.html:90
+#: books/add.html books/edit.html
 msgid "Use <b><i>Title: Subtitle</i></b> to add a subtitle."
 msgstr ""
 
-#: books/add.html:31 books/add.html:48 books/add.html:57 books/edit.html:90
-#: tag/add.html:24 type/author/edit.html:35 type/tag/edit.html:23
+#: books/add.html books/edit.html tag/add.html type/author/edit.html
+#: type/tag/edit.html
 msgid "Required field"
 msgstr ""
 
-#: books/add.html:42
+#: books/add.html
 msgid ""
 "Like, \"Agatha Christie\" or \"Jean-Paul Sartre.\" We'll also do a live "
 "check to see if we already know the author."
 msgstr ""
 
-#: books/add.html:48 books/edit/edition.html:105
+#: books/add.html books/edit/edition.html
 msgid "Who is the publisher?"
 msgstr ""
 
-#: books/add.html:48 books/edit/edition.html:106
+#: books/add.html books/edit/edition.html
 msgid "For example"
 msgstr ""
 
-#: books/add.html:57 books/edit/edition.html:125
+#: books/add.html books/edit/edition.html
 msgid "When was it published?"
 msgstr ""
 
-#: books/add.html:57 books/edit/edition.html:126
+#: books/add.html books/edit/edition.html
 msgid "You should be able to find this in the first few pages of the book."
 msgstr ""
 
-#: books/add.html:66
+#: books/add.html
 msgid ""
 "And optionally, an ID number &#151; like an ISBN &#151; would be "
 "helpful..."
 msgstr ""
 
-#: books/add.html:67
+#: books/add.html
 msgid "ID Type"
 msgstr ""
 
-#: books/add.html:69
+#: books/add.html
 msgid "ISBN may be invalid. Click \"Add\" again to submit."
 msgstr ""
 
-#: books/add.html:72 tag/add.html:47
+#: books/add.html tag/add.html
 msgid "Select"
 msgstr ""
 
-#: books/add.html:89 books/edit/edition.html:647
+#: books/add.html books/edit/edition.html
 msgid "Book URL"
 msgstr ""
 
-#: books/add.html:89
+#: books/add.html
 msgid "Only fill this out if this is a web book"
 msgstr ""
 
-#: EditButtons.html:17 EditButtonsMacros.html:20 books/add.html:102
-#: tag/add.html:61
+#: EditButtons.html EditButtonsMacros.html books/add.html tag/add.html
 msgid ""
 "By saving a change to this wiki, you agree that your contribution is "
 "given freely to the world under <a "
@@ -2524,44 +2328,40 @@ msgid ""
 "new window\">CC0</a>. Yippee!"
 msgstr ""
 
-#: books/add.html:105
+#: books/add.html
 msgid "Add this book now"
 msgstr ""
 
-#: books/author-autocomplete.html:15
-msgid "Add a new author"
-msgstr ""
-
-#: books/author-autocomplete.html:16
+#: books/author-autocomplete.html
 msgid "Create a new record for"
 msgstr ""
 
-#: books/author-autocomplete.html:27
+#: books/author-autocomplete.html
 msgid "Remove this author"
 msgstr ""
 
-#: books/author-autocomplete.html:34
+#: books/author-autocomplete.html
 msgid "Add another author?"
 msgstr ""
 
-#: books/check.html:13 lib/nav_foot.html:49 lib/nav_head.html:39
+#: books/check.html lib/nav_foot.html lib/nav_head.html
 msgid "Add a Book"
 msgstr ""
 
-#: books/check.html:15
+#: books/check.html
 #, python-format
 msgid ""
 "One moment... It looks like we already have <em>some potential "
 "matches</em> for <b>%(title)s</b> by <b>%(author)s</b>."
 msgstr ""
 
-#: books/check.html:17
+#: books/check.html
 msgid ""
 "Rather than creating a duplicate record, please click through the result "
 "you think best matches your book."
 msgstr ""
 
-#: books/check.html:27 books/check.html:31
+#: books/check.html
 msgid "Select this book"
 msgstr ""
 
@@ -2582,11 +2382,11 @@ msgstr ""
 msgid "Not in Library"
 msgstr ""
 
-#: books/custom_carousel.html:22
+#: books/custom_carousel.html
 msgid "Loading..."
 msgstr ""
 
-#: books/custom_carousel.html:60 books/mobile_carousel.html:41
+#: books/custom_carousel.html books/mobile_carousel.html
 #, python-format
 msgid " by %(name)s"
 msgstr ""
@@ -2708,13 +2508,13 @@ msgstr ""
 msgid "Add a little more?"
 msgstr ""
 
-#: books/edit.html:31
+#: books/edit.html
 msgid ""
 "Thank you for adding that book! Any more information you could provide "
 "would be wonderful!"
 msgstr ""
 
-#: books/edit.html:34
+#: books/edit.html
 #, python-format
 msgid ""
 "We already know about <b>%(work_title)s</b>, but not the <b>%(year)s "
@@ -2722,50 +2522,50 @@ msgid ""
 "edition?"
 msgstr ""
 
-#: books/edit.html:37
+#: books/edit.html
 #, python-format
 msgid ""
 "We already know about the <b>%(year)s %(publisher)s edition</b> of "
 "<b>%(work_title)s</b>, but please, tell us more!"
 msgstr ""
 
-#: books/edit.html:39
+#: books/edit.html
 msgid "Editing..."
 msgstr ""
 
-#: EditButtonsMacros.html:27 books/edit.html:45 type/author/edit.html:17
-#: type/macro/edit.html:51 type/template/edit.html:51
+#: EditButtonsMacros.html books/edit.html type/author/edit.html
+#: type/template/edit.html
 msgid "Delete Record"
 msgstr ""
 
-#: books/edit.html:69
+#: books/edit.html
 msgid "Work Details"
 msgstr ""
 
-#: books/edit.html:74
+#: books/edit.html
 msgid "Unknown publisher edition"
 msgstr ""
 
-#: books/edit.html:84
+#: books/edit.html
 msgid "This Work"
 msgstr ""
 
-#: books/edit.html:97
+#: books/edit.html
 msgid ""
 "You can search by author name (like <em>j k rowling</em>) or by Open "
 "Library ID (like <a href=\"/authors/OL23919A\" "
 "target=\"_blank\"><em>OL23919A</em></a>)."
 msgstr ""
 
-#: books/edit.html:102
+#: books/edit.html
 msgid "Author editing requires javascript"
 msgstr ""
 
-#: books/edit.html:115
+#: books/edit.html
 msgid "Add Excerpts"
 msgstr ""
 
-#: books/edit.html:121 type/about/edit.html:39 type/author/edit.html:50
+#: books/edit.html type/about/edit.html type/author/edit.html
 msgid "Links"
 msgstr ""
 
@@ -2779,56 +2579,52 @@ msgstr ""
 msgid "Cover of: %(title)s"
 msgstr ""
 
-#: books/edition-sort.html:49
+#: books/edition-sort.html
 #, python-format
 msgid "%(title)s: %(subtitle)s"
 msgstr ""
 
-#: books/edition-sort.html:61
+#: books/edition-sort.html
 #, python-format
 msgid "Publish date unknown, %(publisher)s"
 msgstr ""
 
-#: books/edition-sort.html:71 type/work/editions.html:47
+#: books/edition-sort.html type/work/editions.html
 #, python-format
 msgid "in %(languagelist)s"
 msgstr ""
 
-#: books/edition-sort.html:100
+#: books/edition-sort.html
 msgid "Libraries near you:"
 msgstr ""
 
-#: books/edition-sort.html:102
-msgid "Look for this edition at WorldCat"
-msgstr ""
-
-#: SearchNavigation.html:12 books/mybooks_breadcrumb_select.html:9
-#: lib/nav_foot.html:26 mybooks.py:44
+#: SearchNavigation.html books/mybooks_breadcrumb_select.html lib/nav_foot.html
+#: mybooks.py
 msgid "Books"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html:12 mybooks.py:241
+#: books/mybooks_breadcrumb_select.html mybooks.py
 #, python-format
 msgid "Want to Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html:13 mybooks.py:237
+#: books/mybooks_breadcrumb_select.html mybooks.py
 #, python-format
 msgid "Currently Reading (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html:14 mybooks.py:244
+#: books/mybooks_breadcrumb_select.html mybooks.py
 #, python-format
 msgid "Already Read (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html:16
+#: books/mybooks_breadcrumb_select.html
 #, python-format
 msgid "Lists (%(count)d)"
 msgstr ""
 
-#: books/mybooks_breadcrumb_select.html:21 mybooks.py:105
-#: type/edition/modal_links.html:30
+#: books/mybooks_breadcrumb_select.html mybooks.py
+#: type/edition/modal_links.html
 msgid "Notes"
 msgstr ""
 
@@ -2836,23 +2632,23 @@ msgstr ""
 msgid "Imports and Exports"
 msgstr ""
 
-#: books/edit/about.html:20
+#: books/edit/about.html
 msgid "Select this subject"
 msgstr ""
 
-#: books/edit/about.html:27
+#: books/edit/about.html
 msgid "How would you describe this book?"
 msgstr ""
 
-#: books/edit/about.html:28 tag/add.html:35
+#: books/edit/about.html tag/add.html
 msgid "There's no wrong answer here."
 msgstr ""
 
-#: books/edit/about.html:37
+#: books/edit/about.html
 msgid "Subject keywords?"
 msgstr ""
 
-#: books/edit/about.html:38
+#: books/edit/about.html
 msgid "Please separate with commas."
 msgstr ""
 
@@ -2863,7 +2659,7 @@ msgid ""
 "href=\"/subjects/psychology\">psychology"
 msgstr ""
 
-#: books/edit/about.html:48
+#: books/edit/about.html
 msgid "A person? Or, people?"
 msgstr ""
 
@@ -2900,31 +2696,31 @@ msgstr ""
 msgid "Select this language"
 msgstr ""
 
-#: books/edit/edition.html:33
+#: books/edit/edition.html
 msgid "Remove this language"
 msgstr ""
 
-#: books/edit/edition.html:50
+#: books/edit/edition.html
 msgid "Remove this work"
 msgstr ""
 
-#: books/edit/edition.html:59 books/edit/edition.html:388
+#: books/edit/edition.html
 msgid "-- Move to a new work"
 msgstr ""
 
-#: books/edit/edition.html:66
+#: books/edit/edition.html
 msgid "This Edition"
 msgstr ""
 
-#: books/edit/edition.html:76
+#: books/edit/edition.html
 msgid "Enter the title of this specific edition."
 msgstr ""
 
-#: books/edit/edition.html:92
+#: books/edit/edition.html
 msgid "Subtitle"
 msgstr ""
 
-#: books/edit/edition.html:93
+#: books/edit/edition.html
 msgid "Usually distinguished by different or smaller type."
 msgstr ""
 
@@ -2940,180 +2736,178 @@ msgstr ""
 msgid "Publishing Info"
 msgstr ""
 
-#: books/edit/edition.html:115
+#: books/edit/edition.html
 msgid "Where was the book published?"
 msgstr ""
 
-#: books/edit/edition.html:116
+#: books/edit/edition.html
 msgid "City, Country please."
 msgstr ""
 
-#: books/edit/edition.html:138
+#: books/edit/edition.html
 msgid "What is the copyright date?"
 msgstr ""
 
-#: books/edit/edition.html:139
+#: books/edit/edition.html
 msgid "The year following the copyright statement."
 msgstr ""
 
-#: books/edit/edition.html:148
+#: books/edit/edition.html
 msgid "Edition Name (if applicable):"
 msgstr ""
 
-#: books/edit/edition.html:158
+#: books/edit/edition.html
 msgid "Series Name (if applicable)"
 msgstr ""
 
-#: books/edit/edition.html:159
+#: books/edit/edition.html
 msgid "The name of the publisher's series."
 msgstr ""
 
-#: books/edit/edition.html:187 type/edition/view.html:437
-#: type/work/view.html:437
+#: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Contributors"
 msgstr ""
 
-#: books/edit/edition.html:189
+#: books/edit/edition.html
 msgid "Please select a role."
 msgstr ""
 
-#: books/edit/edition.html:189
+#: books/edit/edition.html
 msgid "You need to give this ROLE a name."
 msgstr ""
 
-#: books/edit/edition.html:191
+#: books/edit/edition.html
 msgid "List the people involved"
 msgstr ""
 
-#: books/edit/edition.html:201
+#: books/edit/edition.html
 msgid "Select role"
 msgstr ""
 
-#: books/edit/edition.html:206
+#: books/edit/edition.html
 msgid "Add a new role"
 msgstr ""
 
-#: books/edit/edition.html:226 books/edit/edition.html:242
+#: books/edit/edition.html
 msgid "Remove this contributor"
 msgstr ""
 
-#: books/edit/edition.html:251
+#: books/edit/edition.html
 msgid "By Statement:"
 msgstr ""
 
-#: books/edit/edition.html:262
+#: books/edit/edition.html
 msgid "Languages"
 msgstr ""
 
-#: books/edit/edition.html:266
+#: books/edit/edition.html
 msgid "What language is this edition written in?"
 msgstr ""
 
-#: books/edit/edition.html:274
+#: books/edit/edition.html
 msgid "Add another language?"
 msgstr ""
 
-#: books/edit/edition.html:279
+#: books/edit/edition.html
 msgid "Is it a translation of another book?"
 msgstr ""
 
-#: books/edit/edition.html:297
+#: books/edit/edition.html
 msgid "Yes, it's a translation"
 msgstr ""
 
-#: books/edit/edition.html:302
+#: books/edit/edition.html
 msgid "What's the original book?"
 msgstr ""
 
-#: books/edit/edition.html:311
+#: books/edit/edition.html
 msgid "What language was the original written in?"
 msgstr ""
 
-#: books/edit/edition.html:329
+#: books/edit/edition.html
 msgid "Description of this edition"
 msgstr ""
 
-#: books/edit/edition.html:330
+#: books/edit/edition.html
 msgid "Only if it's different from the work's description"
 msgstr ""
 
-#: books/edit/edition.html:339 type/edition/view.html:383
-#: type/work/view.html:383
+#: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Table of Contents"
 msgstr ""
 
-#: books/edit/edition.html:340
+#: books/edit/edition.html
 msgid ""
 "Use a \"*\" for an indent, a \"|\" to add a column, and line breaks for "
 "new lines. Like this:"
 msgstr ""
 
-#: books/edit/edition.html:354
+#: books/edit/edition.html
 msgid "Any notes about this specific edition?"
 msgstr ""
 
-#: books/edit/edition.html:355
+#: books/edit/edition.html
 msgid "Anything about the book that may be of interest."
 msgstr ""
 
-#: books/edit/edition.html:364
+#: books/edit/edition.html
 msgid "Is it known by any other titles?"
 msgstr ""
 
-#: books/edit/edition.html:365
+#: books/edit/edition.html
 msgid ""
 "Use this field if the title is different on the cover or spine. If the "
 "edition is a collection or anthology, you may also add the individual "
 "titles of each work here."
 msgstr ""
 
-#: books/edit/edition.html:369
+#: books/edit/edition.html
 msgid "is an alternate title for"
 msgstr ""
 
-#: books/edit/edition.html:379
+#: books/edit/edition.html
 msgid "What work is this an edition of?"
 msgstr ""
 
-#: books/edit/edition.html:381
+#: books/edit/edition.html
 msgid ""
 "Sometimes editions can be associated with the wrong work. You can correct"
 " that here."
 msgstr ""
 
-#: books/edit/edition.html:382
+#: books/edit/edition.html
 msgid "You can search by title or by Open Library ID (like"
 msgstr ""
 
-#: books/edit/edition.html:385
+#: books/edit/edition.html
 msgid "WARNING: Any edits made to the work from this page will be ignored."
 msgstr ""
 
-#: books/edit/edition.html:402
+#: books/edit/edition.html
 msgid "Please select an identifier."
 msgstr ""
 
-#: books/edit/edition.html:403
+#: books/edit/edition.html
 msgid "You need to give a value to ID."
 msgstr ""
 
-#: books/edit/edition.html:404
+#: books/edit/edition.html
 msgid "ID ids cannot contain whitespace."
 msgstr ""
 
-#: books/edit/edition.html:405
+#: books/edit/edition.html
 msgid "ID must be exactly 10 characters [0-9] or X."
 msgstr ""
 
-#: books/edit/edition.html:406
+#: books/edit/edition.html
 msgid "That ID already exists for this edition."
 msgstr ""
 
-#: books/edit/edition.html:407
+#: books/edit/edition.html
 msgid "ID must be exactly 13 digits [0-9]. For example: 978-1-56619-909-4"
 msgstr ""
 
-#: books/edit/edition.html:408
+#: books/edit/edition.html
 msgid "Invalid ID format"
 msgstr ""
 
@@ -3122,15 +2916,15 @@ msgstr ""
 msgid "ID Numbers"
 msgstr ""
 
-#: books/edit/edition.html:417
+#: books/edit/edition.html
 msgid "Do you know any identifiers for this edition?"
 msgstr ""
 
-#: books/edit/edition.html:418
+#: books/edit/edition.html
 msgid "Like, ISBN?"
 msgstr ""
 
-#: books/edit/edition.html:436 books/edit/edition.html:504
+#: books/edit/edition.html
 msgid "Select one of many..."
 msgstr ""
 
@@ -3138,315 +2932,308 @@ msgstr ""
 msgid "Please select a classification."
 msgstr ""
 
-#: books/edit/edition.html:488
+#: books/edit/edition.html
 msgid "You need to give a value to CLASS."
 msgstr ""
 
-#: books/edit/edition.html:489 type/edition/view.html:412
-#: type/work/view.html:412
+#: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Classifications"
 msgstr ""
 
-#: books/edit/edition.html:495
+#: books/edit/edition.html
 msgid "Do you know any classifications of this edition?"
 msgstr ""
 
-#: books/edit/edition.html:496
+#: books/edit/edition.html
 msgid "Like, Dewey Decimal?"
 msgstr ""
 
-#: books/edit/edition.html:509
+#: books/edit/edition.html
 msgid "Add a new classification type"
 msgstr ""
 
-#: books/edit/edition.html:526 books/edit/edition.html:535
+#: books/edit/edition.html
 msgid "Remove this classification"
 msgstr ""
 
-#: books/edit/edition.html:547 type/edition/view.html:446
-#: type/work/view.html:446
+#: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "The Physical Object"
 msgstr ""
 
-#: books/edit/edition.html:553
+#: books/edit/edition.html
 msgid "What sort of book is it?"
 msgstr ""
 
-#: books/edit/edition.html:554
+#: books/edit/edition.html
 msgid "Paperback; Hardcover, etc."
 msgstr ""
 
-#: books/edit/edition.html:562
+#: books/edit/edition.html
 msgid "How many pages?"
 msgstr ""
 
-#: books/edit/edition.html:572
+#: books/edit/edition.html
 msgid "Pagination?"
 msgstr ""
 
-#: books/edit/edition.html:573
+#: books/edit/edition.html
 msgid "Note the highest number in each pagination pattern."
 msgstr ""
 
-#: books/edit/edition.html:573 lib/nav_foot.html:44
+#: books/edit/edition.html lib/nav_foot.html
 msgid "Help"
 msgstr ""
 
-#: books/edit/edition.html:583
+#: books/edit/edition.html
 msgid "How much does the book weigh?"
 msgstr ""
 
-#: books/edit/edition.html:598 type/edition/view.html:451
-#: type/work/view.html:451
+#: books/edit/edition.html type/edition/view.html type/work/view.html
 msgid "Dimensions"
 msgstr ""
 
-#: books/edit/edition.html:609
-msgid "dimensions"
-msgstr ""
-
-#: books/edit/edition.html:610
+#: books/edit/edition.html
 msgid "Height:"
 msgstr ""
 
-#: books/edit/edition.html:615
+#: books/edit/edition.html
 msgid "Width:"
 msgstr ""
 
-#: books/edit/edition.html:620
+#: books/edit/edition.html
 msgid "Depth:"
 msgstr ""
 
-#: books/edit/edition.html:643
+#: books/edit/edition.html
 msgid "Web Book Providers"
 msgstr ""
 
-#: books/edit/edition.html:648
+#: books/edit/edition.html
 msgid "Access Type"
 msgstr ""
 
-#: books/edit/edition.html:649
+#: books/edit/edition.html
 msgid "File Format"
 msgstr ""
 
-#: books/edit/edition.html:650
+#: books/edit/edition.html
 msgid "Provider Name"
 msgstr ""
 
-#: ReadButton.html:39 books/edit/edition.html:661
+#: ReadButton.html books/edit/edition.html
 msgid "Listen"
 msgstr ""
 
-#: books/edit/edition.html:662
+#: books/edit/edition.html
 msgid "Buy"
 msgstr ""
 
-#: books/edit/edition.html:670
+#: books/edit/edition.html
 msgid "Web"
 msgstr ""
 
-#: books/edit/edition.html:680
+#: books/edit/edition.html
 msgid "Add a provider"
 msgstr ""
 
-#: books/edit/edition.html:687
+#: books/edit/edition.html
 msgid "First sentence"
 msgstr ""
 
-#: books/edit/edition.html:688
+#: books/edit/edition.html
 msgid "The opening line that starts the lead paragraph"
 msgstr ""
 
-#: books/edit/edition.html:698
+#: books/edit/edition.html
 msgid "Admin Only"
 msgstr ""
 
-#: books/edit/edition.html:701
+#: books/edit/edition.html
 msgid "Additional Metadata"
 msgstr ""
 
-#: books/edit/edition.html:702
+#: books/edit/edition.html
 msgid "This field can accept arbitrary key:value pairs"
 msgstr ""
 
-#: books/edit/excerpts.html:8
+#: books/edit/excerpts.html
 msgid "Please provide an excerpt."
 msgstr ""
 
-#: books/edit/excerpts.html:9
+#: books/edit/excerpts.html
 msgid "That excerpt is too long."
 msgstr ""
 
-#: books/edit/excerpts.html:18
+#: books/edit/excerpts.html
 msgid ""
 "If there are particular (short) passages you feel represent the book "
 "well, please feel free to transcribe them here."
 msgstr ""
 
-#: books/edit/excerpts.html:23
+#: books/edit/excerpts.html
 msgid "Page number?"
 msgstr ""
 
-#: books/edit/excerpts.html:28
+#: books/edit/excerpts.html
 msgid "This excerpt is the first sentence of the book."
 msgstr ""
 
-#: books/edit/excerpts.html:35
+#: books/edit/excerpts.html
 msgid "Transcribe the excerpt"
 msgstr ""
 
-#: books/edit/excerpts.html:36
+#: books/edit/excerpts.html
 msgid "Maximum length is 2000 characters. No HTML allowed."
 msgstr ""
 
-#: books/edit/excerpts.html:46
+#: books/edit/excerpts.html
 msgid "Why did you choose this excerpt?"
 msgstr ""
 
-#: books/edit/excerpts.html:47
+#: books/edit/excerpts.html
 msgid "Add an optional note."
 msgstr ""
 
-#: books/edit/excerpts.html:61
+#: books/edit/excerpts.html
 msgid "Excerpts so far..."
 msgstr ""
 
-#: books/edit/excerpts.html:75 books/edit/excerpts.html:97
+#: books/edit/excerpts.html
 msgid "noted:"
 msgstr ""
 
-#: books/edit/excerpts.html:77 books/edit/excerpts.html:99
+#: books/edit/excerpts.html
 msgid "An anonymous note:"
 msgstr ""
 
-#: books/edit/excerpts.html:95
+#: books/edit/excerpts.html
 msgid "From page"
 msgstr ""
 
-#: books/edit/web.html:8
+#: books/edit/web.html
 msgid "Please provide a label."
 msgstr ""
 
-#: books/edit/web.html:9
+#: books/edit/web.html
 msgid "Please provide a URL."
 msgstr ""
 
-#: books/edit/web.html:10
+#: books/edit/web.html
 msgid "Please enter a valid URL."
 msgstr ""
 
-#: books/edit/web.html:19
+#: books/edit/web.html
 msgid ""
 "Please connect Open Library records to <u>good</u><span "
 "class=\"orange\">*</span> online resources."
 msgstr ""
 
-#: books/edit/web.html:25
+#: books/edit/web.html
 msgid "Give your link a label"
 msgstr ""
 
-#: books/edit/web.html:34
+#: books/edit/web.html
 msgid "URL"
 msgstr ""
 
-#: books/edit/web.html:41
+#: books/edit/web.html
 msgid "Add Link"
 msgstr ""
 
-#: books/edit/web.html:49 books/edit/web.html:58
+#: books/edit/web.html
 msgid "Remove this link"
 msgstr ""
 
-#: books/edit/web.html:70
+#: books/edit/web.html
 msgid ""
 "\"Good\" means no spammy links, please. Keep them relevant to the book. "
 "Irrelevant sites may be removed. Blatant spam will be deleted without "
 "remorse."
 msgstr ""
 
-#: check_ins/check_in_form.html:10
+#: check_ins/check_in_form.html
 msgid "January"
 msgstr ""
 
-#: check_ins/check_in_form.html:11
+#: check_ins/check_in_form.html
 msgid "February"
 msgstr ""
 
-#: check_ins/check_in_form.html:12
+#: check_ins/check_in_form.html
 msgid "March"
 msgstr ""
 
-#: check_ins/check_in_form.html:13
+#: check_ins/check_in_form.html
 msgid "April"
 msgstr ""
 
-#: check_ins/check_in_form.html:14
+#: check_ins/check_in_form.html
 msgid "May"
 msgstr ""
 
-#: check_ins/check_in_form.html:15
+#: check_ins/check_in_form.html
 msgid "June"
 msgstr ""
 
-#: check_ins/check_in_form.html:16
+#: check_ins/check_in_form.html
 msgid "July"
 msgstr ""
 
-#: check_ins/check_in_form.html:17
+#: check_ins/check_in_form.html
 msgid "August"
 msgstr ""
 
-#: check_ins/check_in_form.html:18
+#: check_ins/check_in_form.html
 msgid "September"
 msgstr ""
 
-#: check_ins/check_in_form.html:19
+#: check_ins/check_in_form.html
 msgid "October"
 msgstr ""
 
-#: check_ins/check_in_form.html:20
+#: check_ins/check_in_form.html
 msgid "November"
 msgstr ""
 
-#: check_ins/check_in_form.html:21
+#: check_ins/check_in_form.html
 msgid "December"
 msgstr ""
 
-#: check_ins/check_in_form.html:38
+#: check_ins/check_in_form.html
 msgid ""
 "Add an optional check-in date.  Check-in dates are used to track yearly "
 "reading goals."
 msgstr ""
 
-#: check_ins/check_in_form.html:41
+#: check_ins/check_in_form.html
 msgid "End Date:"
 msgstr ""
 
-#: check_ins/check_in_form.html:43
+#: check_ins/check_in_form.html
 msgid "Year:"
 msgstr ""
 
-#: check_ins/check_in_form.html:45
+#: check_ins/check_in_form.html
 msgid "Year"
 msgstr ""
 
-#: check_ins/check_in_form.html:53
+#: check_ins/check_in_form.html
 msgid "Month:"
 msgstr ""
 
-#: check_ins/check_in_form.html:55
+#: check_ins/check_in_form.html
 msgid "Month"
 msgstr ""
 
-#: check_ins/check_in_form.html:62
+#: check_ins/check_in_form.html
 msgid "Day:"
 msgstr ""
 
-#: check_ins/check_in_form.html:64
+#: check_ins/check_in_form.html
 msgid "Day"
 msgstr ""
 
-#: check_ins/check_in_form.html:76
+#: check_ins/check_in_form.html
 msgid "Delete Event"
 msgstr ""
 
@@ -3458,28 +3245,28 @@ msgstr ""
 msgid "When did you finish this book?"
 msgstr ""
 
-#: check_ins/check_in_prompt.html:37
+#: check_ins/check_in_prompt.html
 msgid "Other"
 msgstr ""
 
-#: check_ins/check_in_prompt.html:42
+#: check_ins/check_in_prompt.html
 msgid "Check-In"
 msgstr ""
 
-#: check_ins/reading_goal_form.html:12
+#: check_ins/reading_goal_form.html
 msgid "How many books would you like to read this year?"
 msgstr ""
 
-#: check_ins/reading_goal_form.html:18
+#: check_ins/reading_goal_form.html
 msgid "Enter \"0\" to unset your reading goal. Your check-ins will be preserved."
 msgstr ""
 
-#: check_ins/reading_goal_progress.html:18
+#: check_ins/reading_goal_progress.html
 #, python-format
 msgid "%(year)d Reading Goal:"
 msgstr ""
 
-#: check_ins/reading_goal_progress.html:25
+#: check_ins/reading_goal_progress.html
 #, python-format
 msgid ""
 "<span class=\"reading-goal-progress__books-"
@@ -3487,188 +3274,164 @@ msgid ""
 "progress__goal\">%(goal)d</span> books"
 msgstr ""
 
-#: check_ins/reading_goal_progress.html:33
+#: check_ins/reading_goal_progress.html
 #, python-format
 msgid "Edit %(year)d Reading Goal"
 msgstr ""
 
-#: covers/add.html:8
+#: covers/add.html
 msgid "Please choose an image or provide a URL."
 msgstr ""
 
-#: covers/add.html:16
+#: covers/add.html
 msgid "There are two ways to put an author's image on Open Library"
 msgstr ""
 
-#: covers/add.html:18
+#: covers/add.html
 msgid "Image Guidelines"
 msgstr ""
 
-#: covers/add.html:20
+#: covers/add.html
 msgid "There are two ways to put a cover image on Open Library"
 msgstr ""
 
-#: covers/add.html:22
+#: covers/add.html
 msgid "Cover Guidelines"
 msgstr ""
 
-#: covers/add.html:27 covers/add.html:31
+#: covers/add.html
 msgid "Please provide a valid image."
 msgstr ""
 
-#: covers/add.html:29
+#: covers/add.html
 msgid "Please provide an image URL."
 msgstr ""
 
-#: covers/add.html:44
+#: covers/add.html
 msgid "<strong>Pick one</strong> from the existing covers,"
 msgstr ""
 
-#: covers/add.html:65
+#: covers/add.html
 msgid "Choose a JPG, GIF or PNG on your computer,"
 msgstr ""
 
-#: covers/add.html:74
+#: covers/add.html
 msgid "Or, paste in the image URL if it's on the web."
 msgstr ""
 
-#: covers/add.html:82
+#: covers/add.html
 msgid "Uploading..."
 msgstr ""
 
-#: covers/author_photo.html:13
-msgid "Pull up a larger author photo"
-msgstr ""
-
-#: covers/author_photo.html:14 covers/author_photo.html:25
-#: search/authors.html:67
-#, python-format
-msgid "Photo of %(author)s"
-msgstr ""
-
-#: covers/author_photo.html:24
-msgid "Click to close"
-msgstr ""
-
-#: covers/author_photo.html:32
-#, python-format
-msgid "We need a photo of %(author)s"
-msgstr ""
-
-#: covers/book_cover.html:29
+#: covers/book_cover.html
 msgid "Pull up a bigger book cover"
 msgstr ""
 
-#: covers/book_cover.html:37 covers/book_cover_single_edition.html:18
-#: covers/book_cover_small.html:18 covers/book_cover_work.html:18
+#: covers/book_cover.html covers/book_cover_single_edition.html
+#: covers/book_cover_small.html covers/book_cover_work.html
 #, python-format
 msgid "Cover of: %(title)s by %(authors)s"
 msgstr ""
 
-#: covers/book_cover_single_edition.html:18 covers/book_cover_work.html:18
+#: covers/book_cover_single_edition.html covers/book_cover_work.html
 msgid "View a larger book cover"
 msgstr ""
 
-#: covers/book_cover_single_edition.html:29 covers/book_cover_small.html:21
-#: covers/book_cover_work.html:21 covers/book_cover_work.html:25
+#: covers/book_cover_single_edition.html covers/book_cover_small.html
+#: covers/book_cover_work.html
 #, python-format
 msgid "We need a book cover for: %(title)s"
 msgstr ""
 
-#: covers/book_cover_small.html:18 covers/book_cover_small.html:21
-#: covers/book_cover_small.html:25
+#: covers/book_cover_small.html
 #, python-format
 msgid "Go to the main page for %(title)s"
 msgstr ""
 
-#: covers/change.html:15
+#: covers/change.html
 msgid "Author Photos"
 msgstr ""
 
-#: covers/change.html:17
+#: covers/change.html
 msgid "Manage Author Photos"
 msgstr ""
 
-#: covers/change.html:20
+#: covers/change.html
 msgid "Add Author Photo"
 msgstr ""
 
-#: covers/change.html:25
+#: covers/change.html
 msgid "Book Covers"
 msgstr ""
 
-#: covers/change.html:28
+#: covers/change.html
 msgid "Manage Covers"
 msgstr ""
 
-#: covers/change.html:31
+#: covers/change.html
 msgid "Add Cover Image"
 msgstr ""
 
-#: covers/change.html:50
+#: covers/change.html
 msgid "Manage"
 msgstr ""
 
-#: covers/manage.html:12
+#: covers/manage.html
 msgid ""
 "You can drag and drop thumbnails to reorder, or into the trash to delete "
 "them."
 msgstr ""
 
-#: covers/saved.html:13
-msgid "New book cover"
-msgstr ""
-
-#: covers/saved.html:17
+#: covers/saved.html
 msgid "Saved!"
 msgstr ""
 
-#: covers/saved.html:20
+#: covers/saved.html
 msgid "Notes:"
 msgstr ""
 
-#: covers/saved.html:30
+#: covers/saved.html
 msgid "Add another image"
 msgstr ""
 
-#: covers/saved.html:36
+#: covers/saved.html
 msgid "Finished"
 msgstr ""
 
-#: history/comment.html:27
+#: history/comment.html
 #, python-format
 msgid "Imported from %(source)s"
 msgstr ""
 
-#: history/comment.html:29
+#: history/comment.html
 #, python-format
 msgid "Imported from %(source)s  <a href=\"%(url)s\">%(type)s record</a>."
 msgstr ""
 
-#: history/comment.html:31
+#: history/comment.html
 #, python-format
 msgid "Found a <a href=\"%(url)s\">matching record</a> from %(source)s."
 msgstr ""
 
-#: history/comment.html:39
+#: history/comment.html
 msgid "Edited without comment."
 msgstr ""
 
-#: home/about.html:9
+#: home/about.html
 msgid "About the Project"
 msgstr ""
 
-#: home/about.html:15
+#: home/about.html
 msgid ""
 "Open Library is an open, editable library catalog, building towards a web"
 " page for every book ever published."
 msgstr ""
 
-#: AffiliateLinks.html:74 home/about.html:16
+#: AffiliateLinks.html home/about.html
 msgid "More"
 msgstr ""
 
-#: home/about.html:19
+#: home/about.html
 msgid ""
 "Just like Wikipedia, you can contribute new information or corrections to"
 " the catalog. You can browse by <a href=\"/subjects\">subjects</a>, <a "
@@ -3676,177 +3439,185 @@ msgid ""
 "have created. If you love books, why not help build a library?"
 msgstr ""
 
-#: home/about.html:23
+#: home/about.html
 msgid "Latest Blog Posts"
 msgstr ""
 
-#: home/categories.html:11
+#: home/categories.html
 msgid "Browse by Subject"
 msgstr ""
 
-#: home/categories.html:26
+#: home/categories.html
 #, python-format
 msgid "browse %(subject)s books"
 msgstr ""
 
-#: home/categories.html:31
+#: home/categories.html
 #, python-format
 msgid "%(count)s Book"
 msgid_plural "%(count)s Books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: home/index.html:8 home/welcome.html:9
+#: home/index.html home/welcome.html
 msgid "Welcome to Open Library"
 msgstr ""
 
-#: home/index.html:29
+#: home/index.html
 msgid "Classic Books"
 msgstr ""
 
-#: home/index.html:33
+#: home/index.html
 msgid "Recently Returned"
 msgstr ""
 
-#: home/index.html:35
+#: home/index.html
 msgid "Romance"
 msgstr ""
 
-#: home/index.html:37
+#: home/index.html
 msgid "Kids"
 msgstr ""
 
-#: home/index.html:39
+#: home/index.html
 msgid "Thrillers"
 msgstr ""
 
-#: home/index.html:41
+#: home/index.html
 msgid "Textbooks"
 msgstr ""
 
-#: home/stats.html:9 site/around_the_library.html:52
+#: home/stats.html site/around_the_library.html
 msgid "Around the Library"
 msgstr ""
 
-#: home/stats.html:10
+#: home/stats.html
 msgid ""
 "Here's what's happened over the last 28 days. More <a "
 "href=\"/recentchanges\">recent changes</a>"
 msgstr ""
 
-#: home/stats.html:15 home/stats.html:17
+#: home/stats.html
 msgid "See all visitors to OpenLibrary.org"
 msgstr ""
 
-#: home/stats.html:16
+#: home/stats.html
 msgid "Area graph of recent unique visitors"
 msgstr ""
 
-#: home/stats.html:22 home/stats.html:24
+#: home/stats.html
+msgid "Unique Visitors"
+msgstr ""
+
+#: home/stats.html
 msgid "How many new Open Library members have we welcomed?"
 msgstr ""
 
-#: home/stats.html:23
+#: home/stats.html
 msgid "Area graph of new members"
 msgstr ""
 
-#: home/stats.html:28 home/stats.html:30
+#: home/stats.html
+msgid "New Members"
+msgstr ""
+
+#: home/stats.html
 msgid "People are constantly updating the catalog"
 msgstr ""
 
-#: home/stats.html:29
+#: home/stats.html
 msgid "Area graph of recent catalog edits"
 msgstr ""
 
-#: home/stats.html:30
+#: home/stats.html
 msgid "Catalog Edits"
 msgstr ""
 
-#: home/stats.html:35 home/stats.html:37
+#: home/stats.html
 msgid "Members can create Lists"
 msgstr ""
 
-#: home/stats.html:36
+#: home/stats.html
 msgid "Area graph of lists created recently"
 msgstr ""
 
-#: home/stats.html:37
+#: home/stats.html
 msgid "Lists Created"
 msgstr ""
 
-#: home/stats.html:42 home/stats.html:44
+#: home/stats.html
 msgid "We're a library, so we lend books, too"
 msgstr ""
 
-#: home/stats.html:43
+#: home/stats.html
 msgid "Area graph of ebooks borrowed recently"
 msgstr ""
 
-#: home/stats.html:44
+#: home/stats.html
 msgid "eBooks Borrowed"
 msgstr ""
 
-#: home/welcome.html:18
+#: home/welcome.html
 msgid "Read Free Library Books Online"
 msgstr ""
 
-#: home/welcome.html:19
+#: home/welcome.html
 msgid "Millions of books available through Controlled Digital Lending"
 msgstr ""
 
-#: home/welcome.html:27
+#: home/welcome.html
 msgid "Set a Yearly Reading Goal"
 msgstr ""
 
-#: home/welcome.html:28
+#: home/welcome.html
 msgid "Learn how to set a yearly reading goal and track what you read"
 msgstr ""
 
-#: home/welcome.html:37
+#: home/welcome.html
 msgid "Keep Track of your Favorite Books"
 msgstr ""
 
-#: home/welcome.html:38
+#: home/welcome.html
 msgid "Organize your Books using Lists & the Reading Log"
 msgstr ""
 
-#: home/welcome.html:46
+#: home/welcome.html
 msgid "Try the virtual Library Explorer"
 msgstr ""
 
-#: home/welcome.html:47
+#: home/welcome.html
 msgid "Digital shelves organized like a physical library"
 msgstr ""
 
-#: home/welcome.html:55
+#: home/welcome.html
 msgid "Try Fulltext Search"
 msgstr ""
 
-#: home/welcome.html:56
+#: home/welcome.html
 msgid "Find matching results within the text of millions of books"
 msgstr ""
 
-#: home/welcome.html:64
+#: home/welcome.html
 msgid "Be an Open Librarian"
 msgstr ""
 
-#: home/welcome.html:65
+#: home/welcome.html
 msgid "Dozens of ways you can help improve the library"
 msgstr ""
 
-#: home/welcome.html:73
+#: home/welcome.html
 msgid "Volunteer at Open Library"
 msgstr ""
 
-#: home/welcome.html:74
+#: home/welcome.html
 msgid "Discover opportunities to improve the library"
 msgstr ""
 
-#: home/welcome.html:83
+#: home/welcome.html
 msgid "Send us feedback"
 msgstr ""
 
-#: home/welcome.html:84
+#: home/welcome.html
 msgid "Your feedback will help us improve these cards"
 msgstr ""
 
@@ -3857,86 +3628,82 @@ msgid_plural "%s books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: languages/language_list.html:8
+#: languages/language_list.html
 msgid "Czech"
 msgstr ""
 
-#: languages/language_list.html:9
+#: languages/language_list.html
 msgid "German"
 msgstr ""
 
-#: languages/language_list.html:10
+#: languages/language_list.html
 msgid "English"
 msgstr ""
 
-#: languages/language_list.html:11
+#: languages/language_list.html
 msgid "Spanish"
 msgstr ""
 
-#: languages/language_list.html:12
+#: languages/language_list.html
 msgid "French"
 msgstr ""
 
-#: languages/language_list.html:13
+#: languages/language_list.html
 msgid "Croatian"
 msgstr ""
 
-#: languages/language_list.html:14
+#: languages/language_list.html
 msgid "Italian"
 msgstr ""
 
-#: languages/language_list.html:15
+#: languages/language_list.html
 msgid "Portuguese"
 msgstr ""
 
-#: languages/language_list.html:16
+#: languages/language_list.html
 msgid "Hindi"
 msgstr ""
 
-#: languages/language_list.html:17
+#: languages/language_list.html
 msgid "Sardinian"
 msgstr ""
 
-#: languages/language_list.html:18
+#: languages/language_list.html
 msgid "Telugu"
 msgstr ""
 
-#: languages/language_list.html:19
+#: languages/language_list.html
 msgid "Ukrainian"
 msgstr ""
 
-#: languages/language_list.html:20
+#: languages/language_list.html
 msgid "Chinese"
 msgstr ""
 
-#: languages/notfound.html:7
+#: languages/notfound.html
 #, python-format
 msgid "%s is not found"
 msgstr ""
 
-#: languages/notfound.html:14
+#: languages/notfound.html
 #, python-format
 msgid "%s does not exist."
 msgstr ""
 
-#: lib/edit_head.html:14 lib/view_head.html:14
+#: lib/edit_head.html lib/view_head.html
 msgid "This doc was last edited by"
 msgstr ""
 
-#: lib/edit_head.html:16 lib/view_head.html:16
+#: lib/edit_head.html lib/view_head.html
 msgid "This doc was last edited anonymously"
 msgstr ""
 
-#: lib/header_dropdown.html:30
-msgid "My account"
-msgstr ""
-
-#: lib/header_dropdown.html:30 type/user/view.html:24
+#: lib/header_dropdown.html type/user/view.html
 #, python-format
 msgid "Joined %(date)s"
 msgstr ""
 
-#: lib/header_dropdown.html:38
+#: lib/header_dropdown.html
 msgid "Menu"
 msgstr ""
 
@@ -3944,36 +3711,36 @@ msgstr ""
 msgid "New!"
 msgstr ""
 
-#: databarDiff.html:9 databarEdit.html:10 databarTemplate.html:9
-#: databarView.html:27 databarView.html:29 lib/history.html:21
+#: databarDiff.html databarEdit.html databarTemplate.html databarView.html
+#: lib/history.html
 msgid "History"
 msgstr ""
 
-#: lib/history.html:25
+#: lib/history.html
 #, python-format
 msgid "Created %(date)s"
 msgstr ""
 
-#: lib/history.html:32
+#: lib/history.html
 #, python-format
 msgid "%(count)d revision"
 msgid_plural "%(count)d revisions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/history.html:44
+#: lib/history.html
 msgid "Download catalog record:"
 msgstr ""
 
-#: lib/history.html:52
+#: lib/history.html
 msgid "Cite this on Wikipedia"
 msgstr ""
 
-#: lib/history.html:52 lib/history.html:59
+#: lib/history.html
 msgid "Wikipedia citation"
 msgstr ""
 
-#: lib/history.html:62
+#: lib/history.html
 msgid "Copy and paste this code into your Wikipedia page."
 msgstr ""
 
@@ -3985,132 +3752,97 @@ msgstr ""
 msgid "an anonymous user"
 msgstr ""
 
-#: lib/history.html:85
+#: lib/history.html
 #, python-format
 msgid "Created by %(user)s"
 msgstr ""
 
-#: lib/history.html:87
+#: lib/history.html
 #, python-format
 msgid "Edited by %(user)s"
 msgstr ""
 
-#: lib/message_addbook.html:14
-msgid "Super!"
-msgstr ""
-
-#: lib/message_addbook.html:14
-msgid " Your new record is in the library. Thank you!"
-msgstr ""
-
-#: lib/message_addbook.html:15
+#: lib/markdown.html
 msgid ""
-"There are a few other simple things you can add while you're here to "
-"improve your new record quickly, and make it much easier for other people"
-" to find later."
+"We use a system called Markdown to format the text in your edits on Open "
+"Library. Some HTML formatting is also accepted. Paragraphs are "
+"automatically generated from any hard-break returns (blank lines) within "
+"your text. You can preview your work in real time below the editing "
+"field."
 msgstr ""
 
-#: lib/message_addbook.html:16
-msgid "Upload a cover image"
+#: lib/markdown.html
+msgid "Formatting marks should envelope the effected text, for example:"
 msgstr ""
 
-#: lib/message_addbook.html:16
-msgid "Snap a quick photo of the cover to share?"
+#: lib/markdown.html
+msgid ""
+"To \"escape\" any Markdown tags (i.e. use an asterisk as an asterisk "
+"rather than emphasizing text) place a backslash \\ prior to the "
+"character."
 msgstr ""
 
-#: lib/message_addbook.html:17
-msgid "Add an ISBN"
-msgstr ""
-
-#: lib/message_addbook.html:17
-msgid "Help the library connect with other systems, like Amazon."
-msgstr ""
-
-#: lib/message_addbook.html:18
-msgid "Add some subjects"
-msgstr ""
-
-#: lib/message_addbook.html:18
-msgid "They're just like tags."
-msgstr ""
-
-#: lib/message_addbook.html:19
-msgid "Describe what the book's about"
-msgstr ""
-
-#: lib/message_addbook.html:19
-msgid "Just a sentence or two is good."
-msgstr ""
-
-#: lib/message_addbook.html:20
-msgid "cancel icon"
-msgstr ""
-
-#: lib/message_addbook.html:20
-msgid "Close this"
-msgstr ""
-
-#: lib/nav_foot.html:13
+#: lib/nav_foot.html
 msgid "Vision"
 msgstr ""
 
-#: lib/nav_foot.html:14
+#: lib/nav_foot.html
 msgid "Volunteer"
 msgstr ""
 
-#: lib/nav_foot.html:15
+#: lib/nav_foot.html
 msgid "Partner With Us"
 msgstr ""
 
-#: lib/nav_foot.html:16
+#: lib/nav_foot.html
 msgid "Jobs"
 msgstr ""
 
-#: lib/nav_foot.html:16
+#: lib/nav_foot.html
 msgid "Careers"
 msgstr ""
 
-#: lib/nav_foot.html:17
+#: lib/nav_foot.html
 msgid "Blog"
 msgstr ""
 
-#: lib/nav_foot.html:18
+#: lib/nav_foot.html
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/nav_foot.html:19 site/alert.html:13
+#: lib/nav_foot.html site/alert.html
 msgid "Donate"
 msgstr ""
 
-#: lib/nav_foot.html:23
+#: lib/nav_foot.html
 msgid "Discover"
 msgstr ""
 
-#: lib/nav_foot.html:25
+#: lib/nav_foot.html
 msgid "Go home"
 msgstr ""
 
-#: lib/nav_foot.html:25
+#: lib/nav_foot.html
 msgid "Home"
 msgstr ""
 
-#: lib/nav_foot.html:26
+#: lib/nav_foot.html
 msgid "Explore Books"
 msgstr ""
 
-#: lib/nav_foot.html:27
+#: lib/nav_foot.html
 msgid "Explore authors"
 msgstr ""
 
-#: lib/nav_foot.html:28
+#: lib/nav_foot.html
 msgid "Explore subjects"
 msgstr ""
 
-#: lib/nav_foot.html:29
+#: lib/nav_foot.html
 msgid "Explore collections"
 msgstr ""
 
-#: lib/nav_foot.html:29 lib/nav_head.html:32
+#: lib/nav_foot.html lib/nav_head.html
 msgid "Collections"
 msgstr ""
 
@@ -4120,75 +3852,75 @@ msgstr ""
 msgid "Advanced Search"
 msgstr ""
 
-#: lib/nav_foot.html:31
+#: lib/nav_foot.html
 msgid "Navigate to top of this page"
 msgstr ""
 
-#: lib/nav_foot.html:31
+#: lib/nav_foot.html
 msgid "Return to Top"
 msgstr ""
 
-#: lib/nav_foot.html:35
+#: lib/nav_foot.html
 msgid "Develop"
 msgstr ""
 
-#: lib/nav_foot.html:37
+#: lib/nav_foot.html
 msgid "Explore Open Library Developer Center"
 msgstr ""
 
-#: lib/nav_foot.html:37 lib/nav_head.html:44
+#: lib/nav_foot.html lib/nav_head.html
 msgid "Developer Center"
 msgstr ""
 
-#: lib/nav_foot.html:38
+#: lib/nav_foot.html
 msgid "Explore Open Library APIs"
 msgstr ""
 
-#: lib/nav_foot.html:38
+#: lib/nav_foot.html
 msgid "API Documentation"
 msgstr ""
 
-#: lib/nav_foot.html:39
+#: lib/nav_foot.html
 msgid "Bulk Open Library data"
 msgstr ""
 
-#: lib/nav_foot.html:39
+#: lib/nav_foot.html
 msgid "Bulk Data Dumps"
 msgstr ""
 
-#: lib/nav_foot.html:40
+#: lib/nav_foot.html
 msgid "Write a bot"
 msgstr ""
 
-#: lib/nav_foot.html:40
+#: lib/nav_foot.html
 msgid "Writing Bots"
 msgstr ""
 
-#: lib/nav_foot.html:46
+#: lib/nav_foot.html
 msgid "Help Center"
 msgstr ""
 
-#: lib/nav_foot.html:47
+#: lib/nav_foot.html
 msgid "Problems"
 msgstr ""
 
-#: lib/nav_foot.html:47
+#: lib/nav_foot.html
 msgid "Report A Problem"
 msgstr ""
 
-#: lib/nav_foot.html:48
+#: lib/nav_foot.html
 msgid "Suggest Edits"
 msgstr ""
 
-#: lib/nav_foot.html:48
+#: lib/nav_foot.html
 msgid "Suggesting Edits"
 msgstr ""
 
-#: lib/nav_foot.html:49
+#: lib/nav_foot.html
 msgid "Add a new book to Open Library"
 msgstr ""
 
-#: lib/nav_foot.html:50
+#: lib/nav_foot.html
 msgid "Release Notes"
 msgstr ""
 
@@ -4204,11 +3936,11 @@ msgstr ""
 msgid "Change Website Language"
 msgstr ""
 
-#: lib/nav_foot.html:64 lib/nav_head.html:64 type/list/embed.html:23
+#: lib/nav_foot.html lib/nav_head.html type/list/embed.html
 msgid "Open Library logo"
 msgstr ""
 
-#: lib/nav_foot.html:66
+#: lib/nav_foot.html
 msgid ""
 "Open Library is an initiative of the <a href=\"//archive.org/\">Internet "
 "Archive</a>, a 501(c)(3) non-profit, building a digital library of "
@@ -4219,74 +3951,78 @@ msgid ""
 "\">archive-it.org</a>"
 msgstr ""
 
-#: lib/nav_foot.html:71
+#: lib/nav_foot.html
 #, python-format
 msgid ""
 "version <a "
 "href=\"https://github.com/internetarchive/openlibrary/commit/%s\">%s</a>"
 msgstr ""
 
-#: lib/nav_head.html:13
+#: lib/nav_head.html
+msgid "My Books"
+msgstr ""
+
+#: lib/nav_head.html
 msgid "Loans, Reading Log, Lists, Stats"
 msgstr ""
 
-#: lib/nav_head.html:14
+#: lib/nav_head.html
 msgid "My Profile"
 msgstr ""
 
-#: lib/nav_head.html:16
+#: lib/nav_head.html
 msgid "Log out"
 msgstr ""
 
-#: lib/nav_head.html:19
+#: lib/nav_head.html
 msgid "Pending Merge Requests"
 msgstr ""
 
-#: lib/nav_head.html:29
+#: lib/nav_head.html
 msgid "Trending"
 msgstr ""
 
-#: lib/nav_head.html:33
+#: lib/nav_head.html
 msgid "K-12 Student Library"
 msgstr ""
 
-#: lib/nav_head.html:34
+#: lib/nav_head.html
 msgid "Book Talks"
 msgstr ""
 
-#: lib/nav_head.html:35
+#: lib/nav_head.html
 msgid "Random Book"
 msgstr ""
 
-#: lib/nav_head.html:40
+#: lib/nav_head.html
 msgid "Recent Community Edits"
 msgstr ""
 
-#: lib/nav_head.html:43
+#: lib/nav_head.html
 msgid "Help & Support"
 msgstr ""
 
-#: lib/nav_head.html:45
+#: lib/nav_head.html
 msgid "Librarians Portal"
 msgstr ""
 
-#: lib/nav_head.html:49
+#: lib/nav_head.html
 msgid "My Open Library"
 msgstr ""
 
-#: lib/nav_head.html:50 lib/nav_head.html:71
+#: lib/nav_head.html
 msgid "Browse"
 msgstr ""
 
-#: lib/nav_head.html:51
+#: lib/nav_head.html
 msgid "Contribute"
 msgstr ""
 
-#: lib/nav_head.html:52
+#: lib/nav_head.html
 msgid "Resources"
 msgstr ""
 
-#: lib/nav_head.html:60
+#: lib/nav_head.html
 msgid "The Internet Archive's Open Library: One page for every book"
 msgstr ""
 
@@ -4294,68 +4030,77 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/nav_head.html:95
+#: lib/nav_head.html
 msgid "Text"
 msgstr ""
 
-#: lib/nav_head.html:110 lib/nav_head.html:111
+#: lib/nav_head.html
 msgid "Search by barcode"
 msgstr ""
 
-#: Pager.html:27 Pager_loanhistory.html:10 lib/pagination.html:22
+#: lib/not_logged.html
+msgid ""
+"<strong>You are not <a href=\"/account/login\" title=\"Log in "
+"now\">logged in</a>.</strong> Open Library will record your IP address "
+"and include it in this page's publicly accessible edit history. If you <a"
+" href=\"/account/create\" title=\"Create an Open Library account\">create"
+" an account</a>, your IP address is concealed and you can more easily "
+"keep track of all your edits and additions."
+msgstr ""
+
+#: Pager.html Pager_loanhistory.html lib/pagination.html
 msgid "Previous"
 msgstr ""
 
-#: lists/header.html:11 lists/header.html:24 lists/header.html:38
-#: lists/header.html:47 lists/header.html:56
+#: lists/header.html
 #, python-format
 msgid "<a href=\"%(href)s\">%(name)s</a> / Lists"
 msgstr ""
 
-#: lists/header.html:16
+#: lists/header.html
 #, python-format
 msgid "This author is on <strong>1 list</strong>."
 msgid_plural "This author is on <strong>%(count)s lists</strong>."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/header.html:31
+#: lists/header.html
 #, python-format
 msgid "This is edition is on <strong>1 list</strong>."
 msgid_plural "This edition is on <strong>%(count)s lists</strong>."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/header.html:40
+#: lists/header.html
 #, python-format
 msgid "This work is on <strong>1 list</strong>."
 msgid_plural "This work is on <strong>%(count)s lists</strong>."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/header.html:49
+#: lists/header.html
 #, python-format
 msgid "%(name)s has 1 list."
 msgid_plural "%(name)s has %(count)s lists."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/header.html:59
+#: lists/header.html
 #, python-format
 msgid "This subject is on <strong>1 list</strong>."
 msgid_plural "This subject is on <strong>%(count)s lists</strong>."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/header.html:88
+#: lists/header.html
 msgid "Hm. Can't find it."
 msgstr ""
 
-#: lists/home.html:16
+#: lists/home.html
 msgid "Create a list of any Subjects, Authors, Works or specific Editions."
 msgstr ""
 
-#: lists/home.html:17
+#: lists/home.html
 msgid ""
 "Once you've made a list, you can <strong>watch for updates</strong> or "
 "<strong>export</strong> all the editions in a list as HTML, BibTeX or "
@@ -4363,18 +4108,22 @@ msgid ""
 "your Account page."
 msgstr ""
 
-#: lists/home.html:20
+#: lists/home.html
+msgid "Enjoy!"
+msgstr ""
+
+#: lists/home.html
 #, python-format
 msgid ""
 "For the top 2000+ most requested eBooks in California for the print "
 "disabled <a href=\"%(url)s\">click here</a>."
 msgstr ""
 
-#: lists/home.html:24
+#: lists/home.html
 msgid "Find a list by name"
 msgstr ""
 
-#: lists/home.html:31
+#: lists/home.html
 msgid "Active Lists"
 msgstr ""
 
@@ -4383,28 +4132,28 @@ msgstr ""
 msgid "from <a href=\"%(key)s\">%(owner)s</a>"
 msgstr ""
 
-#: lists/home.html:52 lists/preview.html:24 lists/snippet.html:18
-#: type/list/embed.html:18 type/list/view_body.html:40
+#: lists/home.html lists/preview.html lists/snippet.html type/list/embed.html
+#: type/list/view_body.html
 #, python-format
 msgid "%(count)d item"
 msgid_plural "%(count)d items"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/home.html:54 lists/preview.html:27 lists/snippet.html:20
+#: lists/home.html lists/preview.html lists/snippet.html
 #, python-format
 msgid "Last modified %(date)s"
 msgstr ""
 
-#: lists/home.html:60 lists/snippet.html:26
+#: lists/home.html lists/snippet.html
 msgid "No description."
 msgstr ""
 
-#: lists/home.html:66 lists/lists.html:67 type/user/view.html:85
+#: lists/home.html lists/lists.html type/user/view.html
 msgid "Recent Activity"
 msgstr ""
 
-#: lists/home.html:67
+#: lists/home.html
 msgid "See all"
 msgstr ""
 
@@ -4423,68 +4172,64 @@ msgstr ""
 msgid "from <a href=\"$list.owner.key\">%(owner)s"
 msgstr ""
 
-#: lists/lists.html:12
+#: lists/lists.html
 #, python-format
 msgid "%(owner)s / Lists"
 msgstr ""
 
-#: lists/lists.html:31 lists/lists.html:38 type/list/view_body.html:66
+#: lists/lists.html type/list/view_body.html
 msgid "Yes, I'm sure"
 msgstr ""
 
-#: lists/lists.html:31 lists/lists.html:38 type/list/view_body.html:66
+#: lists/lists.html type/list/view_body.html
 msgid "No, cancel"
 msgstr ""
 
-#: lists/lists.html:31
+#: lists/lists.html
 msgid "Delete this list"
 msgstr ""
 
-#: lists/lists.html:33
+#: lists/lists.html
 msgid "Delete list"
 msgstr ""
 
-#: lists/lists.html:33
+#: lists/lists.html
 msgid "Are you sure you want to delete this list?"
 msgstr ""
 
-#: lists/lists.html:38
+#: lists/lists.html
 msgid "Remove this seed?"
 msgstr ""
 
-#: lists/lists.html:40
-msgid "Remove"
-msgstr ""
-
-#: lists/lists.html:40
+#: lists/lists.html
 #, python-format
 msgid "Are you sure you want to remove <strong>%(title)s</strong> from this list?"
 msgstr ""
 
-#: lists/lists.html:58
+#: lists/lists.html
 msgid "This reader hasn't created any lists yet."
 msgstr ""
 
-#: lists/lists.html:60
+#: lists/lists.html
 msgid "You haven't created any lists yet."
 msgstr ""
 
-#: lists/lists.html:63
+#: lists/lists.html
 msgid "Learn how to create your first list."
 msgstr ""
 
-#: lists/preview.html:18
+#: lists/preview.html
 msgid "by <a href=\"$owner.key\">You</a>"
 msgstr ""
 
-#: lists/widget.html:59
+#: lists/widget.html
 #, python-format
 msgid "%(count)d List"
 msgid_plural "%(count)d Lists"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lists/widget.html:81 my_books/dropdown_content.html:129
+#: databarAuthor.html lists/widget.html my_books/dropdown_content.html
 msgid "from"
 msgstr ""
 
@@ -4500,231 +4245,227 @@ msgstr ""
 msgid "Merge Authors"
 msgstr ""
 
-#: merge/authors.html:18
+#: merge/authors.html
 msgid "No authors selected."
 msgstr ""
 
-#: merge/authors.html:22
+#: merge/authors.html
 msgid "Please select a primary author record."
 msgstr ""
 
-#: merge/authors.html:24
+#: merge/authors.html
 msgid "Please select some authors to merge."
 msgstr ""
 
-#: merge/authors.html:27
+#: merge/authors.html
 msgid "Select the oldest profile as primary -"
 msgstr ""
 
-#: merge/authors.html:30
+#: merge/authors.html
 msgid "Select author records which should be merged with the primary"
 msgstr ""
 
-#: merge/authors.html:34
+#: merge/authors.html
 msgid "Press MERGE AUTHORS."
 msgstr ""
 
-#: merge/authors.html:38
+#: merge/authors.html
 msgid "No primary record"
 msgstr ""
 
-#: merge/authors.html:39
+#: merge/authors.html
 msgid "You must select a primary record to point the duplicates toward."
 msgstr ""
 
-#: merge/authors.html:43
+#: merge/authors.html
 msgid "Please Be Careful..."
 msgstr ""
 
-#: merge/authors.html:44
+#: merge/authors.html
 msgid "<b>Are you sure</b> you want to merge these records?"
 msgstr ""
 
-#: merge/authors.html:55 recentchanges/merge/view.html:23
+#: merge/authors.html recentchanges/merge/view.html
 msgid "Primary"
 msgstr ""
 
-#: merge/authors.html:56
+#: merge/authors.html
 msgid "Merge"
 msgstr ""
 
-#: merge/authors.html:81
-msgid "birth/death date"
-msgstr ""
-
-#: merge/authors.html:95
+#: merge/authors.html
 msgid "Open in a new window"
 msgstr ""
 
-#: merge/authors.html:102
+#: merge/authors.html
 msgid "Visit this author's page in a new window"
 msgstr ""
 
-#: merge/authors.html:108
+#: merge/authors.html
 msgid "Comment:"
 msgstr ""
 
-#: merge/authors.html:108
+#: merge/authors.html
 msgid "Comment..."
 msgstr ""
 
-#: merge/authors.html:113
+#: merge/authors.html
 msgid "Request Merge"
 msgstr ""
 
-#: merge/authors.html:116
+#: merge/authors.html
 msgid "Reject Merge"
 msgstr ""
 
-#: merge/works.html:9
+#: merge/works.html
 msgid "Merge Works"
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:12
+#: merge_request_table/merge_request_table.html
 msgid "Failed to submit comment. Please try again in a few moments."
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:13
+#: merge_request_table/merge_request_table.html
 msgid "(Optional) Why are you closing this request?"
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:25
+#: merge_request_table/merge_request_table.html
 #, python-format
 msgid "Showing %(username)s's requests only."
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:26
+#: merge_request_table/merge_request_table.html
 msgid "Show all requests"
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:29
+#: merge_request_table/merge_request_table.html
 msgid "Showing all requests."
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:30
+#: merge_request_table/merge_request_table.html
 msgid "Show my requests"
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:34
+#: merge_request_table/merge_request_table.html
 msgid "Community Edit Requests"
 msgstr ""
 
-#: merge_request_table/merge_request_table.html:43
+#: merge_request_table/merge_request_table.html
 msgid "No entries here!"
 msgstr ""
 
-#: merge_request_table/table_header.html:17
+#: merge_request_table/table_header.html
 msgid "Open"
 msgstr ""
 
-#: merge_request_table/table_header.html:18
+#: merge_request_table/table_header.html
 msgid "Closed"
 msgstr ""
 
-#: merge_request_table/table_header.html:22
+#: merge_request_table/table_header.html
 msgid "Status ▾"
 msgstr ""
 
-#: merge_request_table/table_header.html:25
+#: merge_request_table/table_header.html
 msgid "Request Status"
 msgstr ""
 
-#: merge_request_table/table_header.html:31
+#: merge_request_table/table_header.html
 msgid "Merged"
 msgstr ""
 
-#: merge_request_table/table_header.html:36
+#: merge_request_table/table_header.html
 msgid "Declined"
 msgstr ""
 
-#: merge_request_table/table_header.html:40
+#: merge_request_table/table_header.html
 msgid "Submitter ▾"
 msgstr ""
 
-#: merge_request_table/table_header.html:43
+#: merge_request_table/table_header.html
 msgid "Submitter"
 msgstr ""
 
-#: merge_request_table/table_header.html:46
+#: merge_request_table/table_header.html
 msgid "Filter submitters"
 msgstr ""
 
-#: merge_request_table/table_header.html:50
+#: merge_request_table/table_header.html
 msgid "Submitted by me"
 msgstr ""
 
-#: merge_request_table/table_header.html:61
+#: merge_request_table/table_header.html
 msgid "Reviewer ▾"
 msgstr ""
 
-#: merge_request_table/table_header.html:64
+#: merge_request_table/table_header.html
 msgid "Reviewer"
 msgstr ""
 
-#: merge_request_table/table_header.html:67
+#: merge_request_table/table_header.html
 msgid "Filter reviewers"
 msgstr ""
 
-#: merge_request_table/table_header.html:72
+#: merge_request_table/table_header.html
 msgid "Assigned to nobody"
 msgstr ""
 
-#: merge_request_table/table_header.html:84
+#: merge_request_table/table_header.html
 msgid "Sort ▾"
 msgstr ""
 
-#: merge_request_table/table_header.html:87
+#: merge_request_table/table_header.html
 msgid "Sort"
 msgstr ""
 
-#: merge_request_table/table_header.html:93
+#: merge_request_table/table_header.html
 msgid "Newest"
 msgstr ""
 
-#: merge_request_table/table_header.html:98
+#: merge_request_table/table_header.html
 msgid "Oldest"
 msgstr ""
 
-#: merge_request_table/table_row.html:10
+#: merge_request_table/table_row.html
 msgid "An untitled work"
 msgstr ""
 
-#: merge_request_table/table_row.html:10
+#: merge_request_table/table_row.html
 msgid "An unnamed author"
 msgstr ""
 
-#: merge_request_table/table_row.html:28
+#: merge_request_table/table_row.html
 msgid "Open request"
 msgstr ""
 
-#: merge_request_table/table_row.html:28
+#: merge_request_table/table_row.html
 msgid "Closed request"
 msgstr ""
 
-#: merge_request_table/table_row.html:37
+#: merge_request_table/table_row.html
 msgid "No comments yet."
 msgstr ""
 
-#: merge_request_table/table_row.html:52
+#: merge_request_table/table_row.html
 msgid "Add a comment..."
 msgstr ""
 
-#: merge_request_table/table_row.html:53
+#: merge_request_table/table_row.html
 msgid "Reply"
 msgstr ""
 
-#: merge_request_table/table_row.html:60
+#: merge_request_table/table_row.html
 #, python-format
 msgid ""
 "MR #%(id)s opened %(date)s by <a href=\"/people/%(submitter)s\" "
 "class=\"commenter\">@%(submitter)s</a>"
 msgstr ""
 
-#: merge_request_table/table_row.html:62
+#: merge_request_table/table_row.html
 msgid "Click to close this Merge Request"
 msgstr ""
 
-#: merge_request_table/table_row.html:85 type/edition/modal_links.html:25
+#: merge_request_table/table_row.html type/edition/modal_links.html
 msgid "Review"
 msgstr ""
 
@@ -4736,124 +4477,116 @@ msgstr ""
 msgid "Remove From Shelf"
 msgstr ""
 
-#: my_books/dropdown_content.html:60
+#: my_books/dropdown_content.html
 msgid "My Reading Lists:"
 msgstr ""
 
-#: my_books/dropdown_content.html:75
+#: my_books/dropdown_content.html
 msgid "Use this Work"
 msgstr ""
 
-#: CreateListModal.html:10 my_books/dropdown_content.html:79
-#: my_books/dropdown_content.html:90
+#: CreateListModal.html databarAuthor.html my_books/dropdown_content.html
 msgid "Create a new list"
 msgstr ""
 
-#: CreateListModal.html:24 my_books/dropdown_content.html:104
-#: type/permission/edit.html:22 type/usergroup/edit.html:22
+#: CreateListModal.html my_books/dropdown_content.html
 msgid "Description:"
 msgstr ""
 
-#: CreateListModal.html:32 my_books/dropdown_content.html:112
-#: type/list/edit.html:146
+#: CreateListModal.html my_books/dropdown_content.html type/list/edit.html
 msgid "Create new list"
 msgstr ""
 
-#: my_books/primary_action.html:42 my_books/primary_action.html:46
+#: my_books/primary_action.html
 msgid "Add to List"
 msgstr ""
 
-#: observations/review_component.html:16
+#: observations/review_component.html
 msgid "Community Reviews"
 msgstr ""
 
-#: observations/review_component.html:39
+#: observations/review_component.html
 msgid "No community reviews have been submitted for this work."
 msgstr ""
 
-#: observations/review_component.html:42
+#: observations/review_component.html
 msgid "+ Add your community review"
 msgstr ""
 
-#: observations/review_component.html:46
+#: observations/review_component.html
 msgid "+ Log in to add your community review"
 msgstr ""
 
-#: publishers/notfound.html:10
+#: publishers/notfound.html
 msgid "Publishers"
 msgstr ""
 
-#: publishers/notfound.html:13
+#: publishers/notfound.html
 #, python-format
 msgid "We couldn't find any books published by %(publisher)s."
 msgstr ""
 
-#: publishers/notfound.html:15 subjects/notfound.html:15
+#: publishers/notfound.html subjects/notfound.html
 msgid "Try something else?"
 msgstr ""
 
-#: publishers/view.html:19
+#: publishers/view.html
 #, python-format
 msgid "%(count)s ebook"
 msgid_plural "%(count)s ebooks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: publishers/view.html:33
+#: publishers/view.html
 msgid ""
 "This is a chart to show the when this publisher published books. Along "
 "the X axis is time, and on the y axis is the count of editions published."
 " <a href=\"#subjectRelated\">Click here to skip the chart</a>."
 msgstr ""
 
-#: publishers/view.html:35
+#: publishers/view.html
 msgid ""
 "This graph charts editions from this publisher over time. Click to view a"
 " single year, or drag across a range."
 msgstr ""
 
-#: publishers/view.html:52
+#: publishers/view.html
 msgid "Common Subjects"
 msgstr ""
 
-#: publishers/view.html:88
+#: publishers/view.html
 msgid "published most by this publisher"
 msgstr ""
 
-#: publishers/view.html:112
-msgid "Publisher Search"
-msgstr ""
-
-#: publishers/view.html:112
-msgid "Try a keyword."
-msgstr ""
-
-#: recentchanges/header.html:31 recentchanges/index.html:7
-#: recentchanges/index.html:13
+#: recentchanges/header.html recentchanges/index.html
 msgid "Recent Changes"
 msgstr ""
 
-#: recentchanges/index.html:34
+#: recentchanges/index.html
 msgid "Books Edited"
 msgstr ""
 
-#: recentchanges/index.html:35
+#: recentchanges/index.html
 msgid "Author Merges"
 msgstr ""
 
-#: recentchanges/index.html:36
+#: recentchanges/index.html
 msgid "Work Merges"
 msgstr ""
 
-#: recentchanges/index.html:37
+#: recentchanges/index.html
 msgid "Books Added"
 msgstr ""
 
-#: RecentChanges.html:72 recentchanges/index.html:59
+#: recentchanges/index.html
+msgid "Covers Added"
+msgstr ""
+
+#: recentchanges/index.html
 msgid "By Humans"
 msgstr ""
 
-#: RecentChanges.html:73 recentchanges/index.html:60
+#: recentchanges/index.html
 msgid "By Bots"
 msgstr ""
 
@@ -4887,25 +4620,25 @@ msgid_plural "Merged %(count)d duplicate %(type)s records into this primary."
 msgstr[0] ""
 msgstr[1] ""
 
-#: recentchanges/merge/message.html:13
+#: recentchanges/merge/message.html
 #, python-format
 msgid "%(who)s merged one duplicate of %(master)s"
 msgid_plural "%(who)s merged %(count)d duplicates of %(master)s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: recentchanges/merge/message.html:20
+#: recentchanges/merge/message.html
 #, python-format
 msgid "one duplicate of %(master)s was merged anonymously"
 msgid_plural "%(count)d duplicates of %(master)s were merged anonymously"
 msgstr[0] ""
 msgstr[1] ""
 
-#: recentchanges/merge/view.html:18
+#: recentchanges/merge/view.html
 msgid "This merge has been undone."
 msgstr ""
 
-#: recentchanges/merge/view.html:19
+#: recentchanges/merge/view.html
 msgid "Details here"
 msgstr ""
 
@@ -4913,38 +4646,38 @@ msgstr ""
 msgid "Duplicates"
 msgstr ""
 
-#: recentchanges/merge/view.html:55
+#: recentchanges/merge/view.html
 #, python-format
 msgid "%(count)d record modified."
 msgid_plural "%(count)d records modified."
 msgstr[0] ""
 msgstr[1] ""
 
-#: recentchanges/merge/view.html:59
+#: recentchanges/merge/view.html
 msgid "Updated Records"
 msgstr ""
 
-#: search/advancedsearch.html:28
+#: search/advancedsearch.html
 msgid "ISBN"
 msgstr ""
 
-#: search/advancedsearch.html:36
+#: search/advancedsearch.html
 msgid "Place"
 msgstr ""
 
-#: search/advancedsearch.html:40
+#: search/advancedsearch.html
 msgid "Person"
 msgstr ""
 
-#: search/advancedsearch.html:50
+#: search/advancedsearch.html
 msgid "How to search?"
 msgstr ""
 
-#: search/advancedsearch.html:51
+#: search/advancedsearch.html
 msgid "Full Text Search?"
 msgstr ""
 
-#: search/authors.html:20
+#: search/authors.html
 msgid "Search Authors"
 msgstr ""
 
@@ -4952,342 +4685,340 @@ msgstr ""
 msgid "Is the same author listed twice?"
 msgstr ""
 
-#: search/authors.html:51
+#: search/authors.html
 msgid "Merge authors"
 msgstr ""
 
-#: search/authors.html:54
+#: search/authors.html
 msgid "No hits"
 msgstr ""
 
-#: search/inside.html:7
+#: search/inside.html
 #, python-format
 msgid "Search Open Library for %s"
 msgstr ""
 
-#: BookSearchInside.html:9 SearchNavigation.html:20 search/inside.html:10
+#: BookSearchInside.html SearchNavigation.html search/inside.html
 msgid "Search Inside"
 msgstr ""
 
-#: search/inside.html:34
+#: search/inside.html
 #, python-format
 msgid "No hits for: %(query)s"
 msgstr ""
 
-#: search/inside.html:37
+#: search/inside.html
 #, python-format
 msgid "About %(count)s result found"
 msgid_plural "About %(count)s results found"
 msgstr[0] ""
 msgstr[1] ""
 
-#: search/inside.html:37
+#: search/inside.html
 #, python-format
 msgid "in %(seconds)s second"
 msgid_plural "in %(seconds)s seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: search/lists.html:7
+#: search/lists.html
 msgid "Search results for Lists"
 msgstr ""
 
-#: search/lists.html:10
+#: search/lists.html
 msgid "Search Lists"
 msgstr ""
 
-#: search/publishers.html:9
+#: search/publishers.html
 msgid "Publishers Search"
 msgstr ""
 
-#: search/sort_options.html:9
+#: search/sort_options.html
 msgid "Sorted by"
 msgstr ""
 
-#: search/sort_options.html:13 search/sort_options.html:24
+#: search/sort_options.html
 msgid "Relevance"
 msgstr ""
 
-#: search/sort_options.html:14
+#: search/sort_options.html
 msgid "Work Count"
 msgstr ""
 
-#: search/sort_options.html:15 search/sort_options.html:41
+#: search/sort_options.html
 msgid "Random"
 msgstr ""
 
-#: search/sort_options.html:19
+#: search/sort_options.html
 msgid "List Order"
 msgstr ""
 
-#: search/sort_options.html:20
+#: search/sort_options.html
 msgid "Last Modified"
 msgstr ""
 
-#: search/sort_options.html:25
+#: search/sort_options.html
 msgid "Most Editions"
 msgstr ""
 
-#: search/sort_options.html:26
+#: search/sort_options.html
 msgid "First Published"
 msgstr ""
 
-#: search/sort_options.html:27
+#: search/sort_options.html
 msgid "Most Recent"
 msgstr ""
 
-#: search/sort_options.html:28
+#: search/sort_options.html
 msgid "Top Rated"
 msgstr ""
 
-#: search/sort_options.html:35
+#: search/sort_options.html
 msgid "Any"
 msgstr ""
 
-#: search/sort_options.html:44
+#: search/sort_options.html
 msgid "Work Title (beta: Librarian only)"
 msgstr ""
 
-#: search/sort_options.html:74
+#: search/sort_options.html
 msgid "Shuffle"
 msgstr ""
 
-#: search/subjects.html:19
+#: search/subjects.html
 msgid "Search Subjects"
 msgstr ""
 
-#: search/subjects.html:57
+#: search/subjects.html
 msgid "time"
 msgstr ""
 
-#: search/subjects.html:59
+#: search/subjects.html
 msgid "subject"
 msgstr ""
 
-#: search/subjects.html:61
+#: search/subjects.html
 msgid "place"
 msgstr ""
 
-#: search/subjects.html:63
+#: search/subjects.html
 msgid "org"
 msgstr ""
 
-#: search/subjects.html:65
+#: search/subjects.html
 msgid "event"
 msgstr ""
 
-#: search/subjects.html:67
+#: search/subjects.html
 msgid "person"
 msgstr ""
 
-#: search/subjects.html:69
+#: search/subjects.html
 msgid "work"
 msgstr ""
 
-#: site/around_the_library.html:52
+#: site/around_the_library.html
 msgid "View all recent changes"
 msgstr ""
 
-#: site/body.html:22
+#: site/body.html
 msgid "It looks like you're offline."
 msgstr ""
 
-#: site/neck.html:15
+#: site/neck.html
 msgid ""
 "Open Library is an open, editable library catalog, building towards a web"
 " page for every book ever published. Read, borrow, and discover more than"
 " 3M books for free."
 msgstr ""
 
-#: site/neck.html:17
+#: site/neck.html
 msgid "Open Library"
 msgstr ""
 
-#: stats/readinglog.html:8
+#: stats/readinglog.html
 msgid "Reading Log Stats"
 msgstr ""
 
-#: stats/readinglog.html:11
+#: stats/readinglog.html
 msgid "# Books Logged"
 msgstr ""
 
-#: stats/readinglog.html:12
+#: stats/readinglog.html
 msgid "The total number of books logged using the Reading Log feature"
 msgstr ""
 
-#: stats/readinglog.html:16 stats/readinglog.html:33 stats/readinglog.html:50
+#: stats/readinglog.html
 msgid "All time"
 msgstr ""
 
-#: stats/readinglog.html:28
+#: stats/readinglog.html
 msgid "# Unique Users Logging Books"
 msgstr ""
 
-#: stats/readinglog.html:29
+#: stats/readinglog.html
 msgid ""
 "The total number of unique users who have logged at least one book using "
 "the Reading Log feature"
 msgstr ""
 
-#: stats/readinglog.html:45
+#: stats/readinglog.html
 msgid "# Books Starred"
 msgstr ""
 
-#: stats/readinglog.html:46
+#: stats/readinglog.html
 msgid "The total number of books which have been starred"
 msgstr ""
 
-#: stats/readinglog.html:58
+#: stats/readinglog.html
 msgid "Total # Unique Raters (all time)"
 msgstr ""
 
-#: stats/readinglog.html:67
+#: stats/readinglog.html
 msgid "Most Wanted Books (This Month)"
 msgstr ""
 
-#: stats/readinglog.html:71 stats/readinglog.html:79 stats/readinglog.html:88
-#: stats/readinglog.html:97
+#: stats/readinglog.html
 #, python-format
 msgid "Added %(count)d time"
 msgid_plural "Added %(count)d times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: stats/readinglog.html:75
+#: stats/readinglog.html
 msgid "Most Wanted Books (All Time)"
 msgstr ""
 
-#: stats/readinglog.html:83
+#: stats/readinglog.html
 msgid "Most Logged Books"
 msgstr ""
 
-#: stats/readinglog.html:84
+#: stats/readinglog.html
 msgid "Most Read Books (All Time)"
 msgstr ""
 
-#: stats/readinglog.html:92
+#: stats/readinglog.html
 msgid "Most Rated Books"
 msgstr ""
 
-#: stats/readinglog.html:93
+#: stats/readinglog.html
 msgid "Most Rated Books (All Time)"
 msgstr ""
 
-#: subjects/notfound.html:13
+#: subjects/notfound.html
 msgid "We couldn't find any books about"
 msgstr ""
 
-#: swagger/swaggerui.html:9
+#: swagger/swaggerui.html
 msgid "OpenAPI"
 msgstr ""
 
-#: tag/add.html:7
+#: tag/add.html
 msgid "Add a tag"
 msgstr ""
 
-#: tag/add.html:11
+#: tag/add.html
 msgid "Add a tag to Open Library"
 msgstr ""
 
-#: tag/add.html:24
+#: tag/add.html
 msgid "Name of Tag"
 msgstr ""
 
-#: tag/add.html:34
+#: tag/add.html
 msgid "How would you describe this tag?"
 msgstr ""
 
-#: tag/add.html:44 type/tag/edit.html:40
+#: tag/add.html type/tag/edit.html
 msgid "Tag type"
 msgstr ""
 
-#: tag/add.html:64
+#: tag/add.html
 msgid "Add this tag now"
 msgstr ""
 
-#: type/about/edit.html:9 type/page/edit.html:9 type/permission/edit.html:9
-#: type/rawtext/edit.html:9 type/template/edit.html:9
-#: type/usergroup/edit.html:9
+#: type/about/edit.html type/page/edit.html type/permission/edit.html
+#: type/rawtext/edit.html type/template/edit.html type/usergroup/edit.html
 #, python-format
 msgid "Edit %(title)s"
 msgstr ""
 
-#: type/about/edit.html:20
+#: type/about/edit.html
 msgid ""
 "This only appears in the document head, and gets attached to bookmark "
 "labels"
 msgstr ""
 
-#: type/about/edit.html:29
+#: type/about/edit.html
 msgid "Intro"
 msgstr ""
 
-#: type/about/edit.html:30
+#: type/about/edit.html
 msgid "This appears in first column."
 msgstr ""
 
-#: type/about/edit.html:40
+#: type/about/edit.html
 msgid "This appears in the second column, at top."
 msgstr ""
 
-#: type/about/edit.html:49
+#: type/about/edit.html
 msgid "Mailing List"
 msgstr ""
 
-#: type/about/edit.html:50
+#: type/about/edit.html
 msgid "This appears below the links list."
 msgstr ""
 
-#: type/author/edit.html:19
+#: type/author/edit.html
 msgid "Edit Author"
 msgstr ""
 
-#: type/author/edit.html:34
+#: type/author/edit.html
 msgid ""
 "Please use natural order. For example: <strong>Leo Tolstoy</strong> not "
 "<strong>Tolstoy, Leo</strong>."
 msgstr ""
 
-#: type/author/edit.html:49
+#: type/author/edit.html
 msgid "About"
 msgstr ""
 
-#: type/author/edit.html:59
+#: type/author/edit.html
 msgid "A short bio?"
 msgstr ""
 
-#: type/author/edit.html:60
+#: type/author/edit.html
 msgid ""
 "If you \"borrow\" information from somewhere, please make sure to cite "
 "the source."
 msgstr ""
 
-#: type/author/edit.html:71
+#: type/author/edit.html
 msgid "Date of birth"
 msgstr ""
 
-#: type/author/edit.html:80
+#: type/author/edit.html
 msgid "Date of death"
 msgstr ""
 
-#: type/author/edit.html:89
+#: type/author/edit.html
 msgid ""
 "We're not storing structured dates (yet) so a date like \"21 May 2000\" "
 "is recommended."
 msgstr ""
 
-#: type/author/edit.html:98
+#: type/author/edit.html
 msgid "Date"
 msgstr ""
 
-#: type/author/edit.html:105
+#: type/author/edit.html
 msgid ""
 "This is a deprecated field. You can help improve this record by removing "
 "this date and populating the \"Date of birth\" and \"Date of death\" "
 "fields. Thanks!"
 msgstr ""
 
-#: type/author/edit.html:112
+#: type/author/edit.html
 msgid "Does this author go by any other names?"
 msgstr ""
 
@@ -5299,11 +5030,11 @@ msgstr ""
 msgid "Author Identifiers Purpose"
 msgstr ""
 
-#: type/author/view.html:18
+#: type/author/view.html
 msgid "name missing"
 msgstr ""
 
-#: type/author/view.html:19 type/edition/view.html:98 type/work/view.html:98
+#: type/author/view.html type/edition/view.html type/work/view.html
 #, python-format
 msgid "%(page_title)s | Open Library"
 msgstr ""
@@ -5389,43 +5120,43 @@ msgstr ""
 msgid "Alternative names"
 msgstr ""
 
-#: type/delete/view.html:11
+#: type/delete/view.html
 msgid "This page has been deleted"
 msgstr ""
 
-#: type/delete/view.html:16
+#: type/delete/view.html
 msgid "What would you like to do?"
 msgstr ""
 
-#: type/delete/view.html:19
+#: type/delete/view.html
 msgid "Go back where I came from"
 msgstr ""
 
-#: type/delete/view.html:21
+#: type/delete/view.html
 msgid "View the previous version"
 msgstr ""
 
-#: type/delete/view.html:22
+#: type/delete/view.html
 msgid "Recreate it"
 msgstr ""
 
-#: type/delete/view.html:23
+#: type/delete/view.html
 msgid "See the page's history"
 msgstr ""
 
-#: type/edition/admin_bar.html:17
+#: type/edition/admin_bar.html
 msgid "Add to Staff Picks"
 msgstr ""
 
-#: type/edition/admin_bar.html:22
+#: type/edition/admin_bar.html
 msgid "Sync Archive.org ID"
 msgstr ""
 
-#: type/edition/admin_bar.html:25
+#: type/edition/admin_bar.html
 msgid "View Book on Archive.org"
 msgstr ""
 
-#: SearchResultsWork.html:117 type/edition/admin_bar.html:28
+#: SearchResultsWork.html type/edition/admin_bar.html
 msgid "Orphaned Edition"
 msgstr ""
 
@@ -5438,219 +5169,217 @@ msgstr ""
 msgid "An edition of"
 msgstr ""
 
-#: type/edition/title_and_author.html:27
+#: type/edition/title_and_author.html
 #, python-format
 msgid "First published in %s"
 msgstr ""
 
-#: type/edition/view.html:262 type/work/view.html:262
+#: type/edition/view.html type/work/view.html
 #, python-format
 msgid ""
 "This edition doesn't have a description yet. Can you <b><a "
 "href='%(url)s'>add one</a></b>?"
 msgstr ""
 
-#: type/edition/view.html:271 type/work/view.html:271
+#: type/edition/view.html type/work/view.html
 msgid "Publish Date"
 msgstr ""
 
-#: type/edition/view.html:281 type/work/view.html:281
+#: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Show other books from %(publisher)s"
 msgstr ""
 
-#: type/edition/view.html:285 type/work/view.html:285
+#: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Search for other books from %(publisher)s"
 msgstr ""
 
-#: type/edition/view.html:296 type/work/view.html:296
+#: type/edition/view.html type/work/view.html
 msgid "Pages"
 msgstr ""
 
-#: databarWork.html:77 type/edition/view.html:329 type/work/view.html:329
+#: databarWork.html type/edition/view.html type/work/view.html
 msgid "Buy this book"
 msgstr ""
 
-#: type/edition/view.html:364 type/work/view.html:364
+#: type/edition/view.html type/work/view.html
 msgid "Book Details"
 msgstr ""
 
-#: type/edition/view.html:368 type/work/view.html:368
+#: type/edition/view.html type/work/view.html
 msgid "Published in"
 msgstr ""
 
-#: type/edition/view.html:376 type/edition/view.html:474
-#: type/edition/view.html:475 type/work/view.html:376 type/work/view.html:474
-#: type/work/view.html:475
+#: type/edition/view.html type/work/view.html
 msgid "First Sentence"
 msgstr ""
 
-#: type/edition/view.html:392 type/work/view.html:392
+#: type/edition/view.html type/work/view.html
 msgid "Edition Notes"
 msgstr ""
 
-#: type/edition/view.html:399 type/work/view.html:399
+#: type/edition/view.html type/work/view.html
 msgid "Series"
 msgstr ""
 
-#: type/edition/view.html:400 type/work/view.html:400
+#: type/edition/view.html type/work/view.html
 msgid "Volume"
 msgstr ""
 
-#: type/edition/view.html:401 type/work/view.html:401
+#: type/edition/view.html type/work/view.html
 msgid "Genre"
 msgstr ""
 
-#: type/edition/view.html:402 type/work/view.html:402
+#: type/edition/view.html type/work/view.html
 msgid "Other Titles"
 msgstr ""
 
-#: type/edition/view.html:403 type/work/view.html:403
+#: type/edition/view.html type/work/view.html
 msgid "Copyright Date"
 msgstr ""
 
-#: type/edition/view.html:404 type/work/view.html:404
+#: type/edition/view.html type/work/view.html
 msgid "Translation Of"
 msgstr ""
 
-#: type/edition/view.html:405 type/work/view.html:405
+#: type/edition/view.html type/work/view.html
 msgid "Translated From"
 msgstr ""
 
-#: type/edition/view.html:424 type/work/view.html:424
+#: type/edition/view.html type/work/view.html
 msgid "External Links"
 msgstr ""
 
-#: type/edition/view.html:448 type/work/view.html:448
+#: type/edition/view.html type/work/view.html
 msgid "Format"
 msgstr ""
 
-#: type/edition/view.html:449 type/work/view.html:449
+#: type/edition/view.html type/work/view.html
 msgid "Pagination"
 msgstr ""
 
-#: type/edition/view.html:450 type/work/view.html:450
+#: type/edition/view.html type/work/view.html
 msgid "Number of pages"
 msgstr ""
 
-#: type/edition/view.html:452 type/work/view.html:452
+#: type/edition/view.html type/work/view.html
 msgid "Weight"
 msgstr ""
 
-#: type/edition/view.html:478 type/work/view.html:478
+#: type/edition/view.html type/work/view.html
 msgid "Work Description"
 msgstr ""
 
-#: type/edition/view.html:487 type/work/view.html:487
+#: type/edition/view.html type/work/view.html
 msgid "Original languages"
 msgstr ""
 
-#: type/edition/view.html:492 type/work/view.html:492
+#: type/edition/view.html type/work/view.html
 msgid "Excerpts"
 msgstr ""
 
-#: type/edition/view.html:502 type/work/view.html:502
+#: type/edition/view.html type/work/view.html
 #, python-format
 msgid "Page %(page)s"
 msgstr ""
 
-#: type/edition/view.html:509 type/work/view.html:509
+#: type/edition/view.html type/work/view.html
 #, python-format
 msgid "added by %(authorlink)s."
 msgstr ""
 
-#: type/edition/view.html:511 type/work/view.html:511
+#: type/edition/view.html type/work/view.html
 msgid "added anonymously."
 msgstr ""
 
-#: type/edition/view.html:519 type/work/view.html:519
+#: type/edition/view.html type/work/view.html
 msgid "Links <span class=\"gray small sansserif\">outside Open Library</span>"
 msgstr ""
 
-#: type/edition/view.html:523 type/work/view.html:523
+#: type/edition/view.html type/work/view.html
 msgid "Wikipedia"
 msgstr ""
 
-#: type/edition/view.html:558 type/work/view.html:558
+#: type/edition/view.html type/work/view.html
 msgid "This work does not appear on any lists."
 msgstr ""
 
-#: type/edition/view.html:568 type/work/view.html:568
+#: type/edition/view.html type/work/view.html
 msgid "Loading Related Books"
 msgstr ""
 
-#: type/language/view.html:22
+#: type/language/view.html
 msgid "Code"
 msgstr ""
 
-#: type/language/view.html:31
+#: type/language/view.html
 #, python-format
 msgid "Try a <a href=\"%(href)s\">search for readable books in %(language)s</a>?"
 msgstr ""
 
-#: type/list/edit.html:7
+#: type/list/edit.html
 #, python-format
 msgid "Editing list: %(list_name)s"
 msgstr ""
 
-#: type/list/edit.html:17
+#: type/list/edit.html
 msgid "Edit List"
 msgstr ""
 
-#: type/list/edit.html:21
+#: type/list/edit.html
 msgid ""
 "⚠️ Saving global lists is admin-only while the feature is under "
 "development."
 msgstr ""
 
-#: type/list/edit.html:47
+#: type/list/edit.html
 msgid "Search for a book"
 msgstr ""
 
-#: type/list/edit.html:66
+#: type/list/edit.html
 msgid "Notes (optional)"
 msgstr ""
 
-#: type/list/edit.html:115
+#: type/list/edit.html
 msgid "List Name"
 msgstr ""
 
-#: type/list/edit.html:122
+#: type/list/edit.html
 msgid "Description (optional)"
 msgstr ""
 
-#: type/list/edit.html:139
+#: type/list/edit.html
 msgid "Add another book"
 msgstr ""
 
-#: type/list/embed.html:23
+#: type/list/embed.html
 msgid "Visit Open Library"
 msgstr ""
 
-#: type/list/embed.html:43 type/list/view_body.html:101
+#: type/list/embed.html type/list/view_body.html
 msgid "Unknown authors"
 msgstr ""
 
-#: type/list/embed.html:68
+#: type/list/embed.html
 msgid ""
 "Open in online Book Reader. Downloads available in ePub, DAISY, PDF, TXT "
 "formats from main book page"
 msgstr ""
 
-#: type/list/embed.html:74
+#: type/list/embed.html
 msgid "This book is checked out"
 msgstr ""
 
-#: type/list/embed.html:76
+#: type/list/embed.html
 msgid "Checked out"
 msgstr ""
 
-#: type/list/embed.html:79
+#: type/list/embed.html
 msgid "Borrow book"
 msgstr ""
 
-#: type/list/embed.html:84
+#: type/list/embed.html
 msgid "Protected DAISY"
 msgstr ""
 
@@ -5659,195 +5388,175 @@ msgstr ""
 msgid "by %(name)s"
 msgstr ""
 
-#: type/list/exports.html:30
+#: type/list/exports.html
 msgid "Export"
 msgstr ""
 
-#: type/list/exports.html:31
+#: type/list/exports.html
 #, python-format
 msgid "as %(json_link)s, %(html_link)s, or %(bibtex_link)s"
 msgstr ""
 
-#: type/list/exports.html:35 type/list/exports.html:55
+#: type/list/exports.html
 msgid "Subscribe"
 msgstr ""
 
-#: type/list/exports.html:36 type/list/exports.html:56
+#: type/list/exports.html
 #, python-format
 msgid "Watch activity via <a rel=\"nofollow\" href=\"%s\">Atom feed</a>"
 msgstr ""
 
-#: type/list/exports.html:43
+#: type/list/exports.html
 msgid "Export Not Available"
 msgstr ""
 
-#: type/list/exports.html:48
+#: type/list/exports.html
 #, python-format
 msgid ""
 "Only lists with up to %(max)s editions can be exported. This one has "
 "%(count)s."
 msgstr ""
 
-#: type/list/exports.html:50
+#: type/list/exports.html
 #, python-format
 msgid ""
 "Try removing some seeds for more focus, or look at <a href=\"%s\">bulk "
 "download</a> of the catalog."
 msgstr ""
 
-#: type/list/view_body.html:8
+#: type/list/view_body.html
 #, python-format
 msgid "%(name)s | Lists | Open Library"
 msgstr ""
 
-#: type/list/view_body.html:17
+#: type/list/view_body.html
 #, python-format
 msgid "%(title)s: %(description)s"
 msgstr ""
 
-#: type/list/view_body.html:26
+#: type/list/view_body.html
 msgid "View the list on Open Library."
 msgstr ""
 
-#: type/list/view_body.html:66
+#: type/list/view_body.html
 msgid "Remove this item?"
 msgstr ""
 
-#: type/list/view_body.html:80
+#: type/list/view_body.html
 #, python-format
 msgid "Last modified <span>%(date)s</span>"
 msgstr ""
 
-#: type/list/view_body.html:92
+#: type/list/view_body.html
 msgid "Remove seed"
 msgstr ""
 
-#: type/list/view_body.html:92
+#: type/list/view_body.html
 msgid "Are you sure you want to remove this item from the list?"
 msgstr ""
 
-#: type/list/view_body.html:93
+#: type/list/view_body.html
 msgid "Remove Seed"
 msgstr ""
 
-#: type/list/view_body.html:94
+#: type/list/view_body.html
 msgid ""
 "You are about to remove the last item in the list. That will delete the "
 "whole list. Are you sure you want to continue?"
 msgstr ""
 
-#: type/list/view_body.html:122
+#: type/list/view_body.html
 msgid "There are no items on this list."
 msgstr ""
 
-#: type/list/view_body.html:124
+#: type/list/view_body.html
 msgid ""
 "<a href=\"/search\" target=\"_blank\">Search for book, subjects, or "
 "authors</a> to add to your list."
 msgstr ""
 
-#: type/list/view_body.html:125
+#: type/list/view_body.html
 msgid "Learn more."
 msgstr ""
 
-#: type/list/view_body.html:176
+#: type/list/view_body.html
 msgid "List Metadata"
 msgstr ""
 
-#: type/list/view_body.html:177
+#: type/list/view_body.html
 msgid "Derived from seed metadata"
 msgstr ""
 
-#: type/local_id/view.html:22
+#: type/local_id/view.html
 msgid "Source Item"
 msgstr ""
 
-#: type/local_id/view.html:34
+#: type/local_id/view.html
 msgid "prefix"
 msgstr ""
 
-#: type/local_id/view.html:38
+#: type/local_id/view.html
 msgid "Example"
 msgstr ""
 
-#: type/macro/edit.html:32
-msgid "Plugin"
-msgstr ""
-
-#: type/macro/edit.html:42
-msgid "Macro"
-msgstr ""
-
-#: type/macro/edit.html:51
-msgid "Delete this macro?"
-msgstr ""
-
-#: type/page/edit.html:31
+#: type/page/edit.html
 msgid "Document Body:"
 msgstr ""
 
-#: type/permission/edit.html:29
-msgid "Readers:"
-msgstr ""
-
-#: type/permission/edit.html:40
-msgid "Writers:"
-msgstr ""
-
-#: type/permission/view.html:17
+#: type/permission/view.html
 msgid "Readers"
 msgstr ""
 
-#: type/permission/view.html:23
+#: type/permission/view.html
 msgid "Writers"
 msgstr ""
 
-#: type/rawtext/edit.html:31 type/template/edit.html:41
+#: type/rawtext/edit.html type/template/edit.html
 msgid "Document Body"
 msgstr ""
 
-#: type/tag/edit.html:14
+#: type/tag/edit.html
 msgid "Edit Tag"
 msgstr ""
 
-#: type/tag/edit.html:23
+#: type/tag/edit.html
 msgid "Label"
 msgstr ""
 
-#: type/tag/edit.html:32 type/user/edit.html:39
+#: type/tag/edit.html type/user/edit.html
 msgid "Description"
 msgstr ""
 
-#: type/tag/view.html:22
+#: type/tag/view.html
 #, python-format
 msgid "View subject page for %(name)s."
 msgstr ""
 
-#: type/template/edit.html:51
+#: type/template/edit.html
 msgid "Delete this template?"
 msgstr ""
 
-#: type/type/view.html:19
+#: type/type/view.html
 msgid "Kind"
 msgstr ""
 
-#: type/type/view.html:31
+#: type/type/view.html
 msgid "Backreferences"
 msgstr ""
 
-#: type/user/edit.html:13
+#: type/user/edit.html
 msgid "Currently Editing:"
 msgstr ""
 
-#: type/user/edit.html:25
+#: type/user/edit.html
 msgid "Display Name"
 msgstr ""
 
-#: type/user/view.html:32
+#: type/user/view.html
 msgid "admin page"
 msgstr ""
 
-#: type/user/view.html:53
+#: type/user/view.html
 #, python-format
 msgid ""
 "You are publicly sharing the books you are <a href=\"%(username)s/books"
@@ -5856,19 +5565,19 @@ msgid ""
 "/want-to-read\">want to read</a>."
 msgstr ""
 
-#: type/user/view.html:55
+#: type/user/view.html
 msgid "You have chosen to make your"
 msgstr ""
 
-#: type/user/view.html:55
+#: type/user/view.html
 msgid "private"
 msgstr ""
 
-#: type/user/view.html:57
+#: type/user/view.html
 msgid "Manage your privacy settings"
 msgstr ""
 
-#: type/user/view.html:60
+#: type/user/view.html
 #, python-format
 msgid ""
 "Here are the books %(user)s is <a href=\"%(username)s/books/currently-"
@@ -5877,116 +5586,106 @@ msgid ""
 "read\">want to read</a>!"
 msgstr ""
 
-#: type/user/view.html:66
+#: type/user/view.html
 msgid "My Lists"
 msgstr ""
 
-#: RecentChangesUsers.html:64 type/user/view.html:88
+#: RecentChangesUsers.html type/user/view.html
 msgid "No edits. Yet."
 msgstr ""
 
-#: type/usergroup/edit.html:29
-msgid "Members:"
-msgstr ""
-
-#: SearchResultsWork.html:92 type/work/editions.html:11
+#: SearchResultsWork.html type/work/editions.html
 #, python-format
 msgid "First published in %(year)s"
 msgstr ""
 
-#: type/work/editions.html:14 type/work/editions_datatable.html:47
+#: type/work/editions.html type/work/editions_datatable.html
 #, python-format
 msgid "Add another edition of %(work)s"
 msgstr ""
 
-#: UserEditRow.html:25 type/work/editions.html:14
+#: UserEditRow.html type/work/editions.html
 msgid "Add another"
 msgstr ""
 
-#: type/work/editions.html:43
+#: type/work/editions.html
 msgid "Title missing"
 msgstr ""
 
-#: type/work/editions_datatable.html:13
+#: type/work/editions_datatable.html
 #, python-format
 msgid "Showing %(count)d featured edition."
 msgid_plural "Showing %(count)d featured editions."
 msgstr[0] ""
 msgstr[1] ""
 
-#: type/work/editions_datatable.html:14
+#: type/work/editions_datatable.html
 #, python-format
 msgid "View all %(count)d editions?"
 msgstr ""
 
-#: type/work/editions_datatable.html:20
+#: type/work/editions_datatable.html
 msgid "Edition"
 msgstr ""
 
-#: type/work/editions_datatable.html:21
+#: type/work/editions_datatable.html
 msgid "Availability"
 msgstr ""
 
-#: type/work/editions_datatable.html:42
+#: type/work/editions_datatable.html
 msgid "No editions available"
 msgstr ""
 
-#: type/work/editions_datatable.html:47
+#: type/work/editions_datatable.html
 msgid "Add another edition?"
 msgstr ""
 
-#: AffiliateLinks.html:12
+#: AffiliateLinks.html
 #, python-format
 msgid "Look for this edition for sale at %(store)s"
 msgstr ""
 
-#: AffiliateLinks.html:24
+#: AffiliateLinks.html
 msgid "Fetching prices"
 msgstr ""
 
-#: AffiliateLinks.html:34
+#: AffiliateLinks.html
 msgid "Better World Books"
 msgstr ""
 
-#: AffiliateLinks.html:38
+#: AffiliateLinks.html
 msgid " - includes shipping"
 msgstr ""
 
-#: AffiliateLinks.html:44
+#: AffiliateLinks.html
 msgid "Amazon"
 msgstr ""
 
-#: AffiliateLinks.html:51
+#: AffiliateLinks.html
 msgid "Bookshop.org"
 msgstr ""
 
-#: AffiliateLinks.html:82
-msgid ""
-"When you buy books using these links the Internet Archive may earn a <a "
-"class=\"nostyle\" href=\"/help/faq/about#selling\">small commission</a>."
-msgstr ""
-
-#: BookByline.html:20
+#: BookByline.html
 #, python-format
 msgid "%(n)s other"
 msgid_plural "%(n)s others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: BookByline.html:36
+#: BookByline.html
 msgid "by an <em>unknown author</em>"
 msgstr ""
 
-#: BookPreview.html:12
+#: BookPreview.html
 msgid "Only"
 msgstr ""
 
-#: BookPreview.html:20
+#: BookPreview.html
 msgid "Preview Book"
 msgstr ""
 
-#: EditButtonsMacros.html:7
-msgid "Really delete this macro?"
+#: EditButtons.html EditButtonsMacros.html
+msgid "(Optional, but very useful!)"
 msgstr ""
 
 #: EditButtonsMacros.html:7
@@ -6005,29 +5704,29 @@ msgstr ""
 msgid "Delete this record"
 msgstr ""
 
-#: EditionNavBar.html:13
+#: EditionNavBar.html
 msgid "Overview"
 msgstr ""
 
-#: EditionNavBar.html:17
+#: EditionNavBar.html
 #, python-format
 msgid "View %(count)s Edition"
 msgid_plural "View %(count)s Editions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: EditionNavBar.html:21
+#: EditionNavBar.html
 msgid "Details"
 msgstr ""
 
-#: EditionNavBar.html:26
+#: EditionNavBar.html
 #, python-format
 msgid "%(reviews)s Review"
 msgid_plural "%(reviews)s Reviews"
 msgstr[0] ""
 msgstr[1] ""
 
-#: EditionNavBar.html:35
+#: EditionNavBar.html
 msgid "Related Books"
 msgstr ""
 
@@ -6044,147 +5743,137 @@ msgstr ""
 msgid "You are <strong>next</strong> on the waiting list"
 msgstr ""
 
-#: LoanStatus.html:84
+#: LoanStatus.html
 #, python-format
 msgid "You are <strong>#%(spot)d</strong> of %(wlsize)d on the waiting list."
 msgstr ""
 
-#: LoanStatus.html:89
+#: LoanStatus.html
 msgid "Leave waiting list"
 msgstr ""
 
-#: LoanStatus.html:103
+#: LoanStatus.html
 #, python-format
 msgid "Readers in line: %(count)s"
 msgstr ""
 
-#: LoanStatus.html:105
+#: LoanStatus.html
 msgid "You'll be next in line."
 msgstr ""
 
-#: LoanStatus.html:110
+#: LoanStatus.html
 msgid "This book is currently checked out, please check back later."
 msgstr ""
 
-#: LoanStatus.html:111
+#: LoanStatus.html
 msgid "Checked Out"
 msgstr ""
 
-#: ManageLoansButtons.html:13
+#: ManageLoansButtons.html
 #, python-format
 msgid "There is one person waiting for this book."
 msgid_plural "There are %(n)s people waiting for this book."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ManageWaitlistButton.html:11
+#: ManageWaitlistButton.html
 #, python-format
 msgid "Waiting for %d day"
 msgid_plural "Waiting for %d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: NotesModal.html:31
+#: NotesModal.html
 msgid "My Book Notes"
 msgstr ""
 
-#: NotesModal.html:35
+#: NotesModal.html
 msgid "My private notes about this edition:"
 msgstr ""
 
-#: ObservationsModal.html:31
+#: ObservationsModal.html
 msgid "My Book Review"
 msgstr ""
 
-#: Pager.html:26 Pager_loanhistory.html:9
+#: Pager.html Pager_loanhistory.html
 msgid "First"
 msgstr ""
 
-#: ReadButton.html:11
+#: ReadButton.html
 msgid "Special Access"
 msgstr ""
 
-#: ReadButton.html:12
+#: ReadButton.html
 msgid ""
 "Special ebook access from the Internet Archive for patrons with "
 "qualifying print disabilities"
 msgstr ""
 
-#: ReadButton.html:16
+#: ReadButton.html
 msgid "Borrow ebook from Internet Archive"
 msgstr ""
 
-#: ReadButton.html:20
+#: ReadButton.html
 msgid "Read ebook from Internet Archive"
 msgstr ""
 
-#: ReadMore.html:6
+#: ReadMore.html
 msgid "Read more"
 msgstr ""
 
-#: ReadMore.html:7
+#: ReadMore.html
 msgid "Read less"
 msgstr ""
 
-#: RecentChanges.html:54
+#: RecentChanges.html
 msgid "View MARC"
 msgstr ""
 
-#: RecentChangesAdmin.html:21
+#: RecentChangesAdmin.html
 msgid "Path"
 msgstr ""
 
-#: RecentChangesAdmin.html:22
+#: RecentChangesAdmin.html
 msgid "Comments"
 msgstr ""
 
-#: RecentChangesAdmin.html:41
+#: RecentChangesAdmin.html
 msgid "view"
 msgstr ""
 
-#: RecentChangesAdmin.html:42
+#: RecentChangesAdmin.html
 msgid "edit"
 msgstr ""
 
-#: RecentChangesUsers.html:50
-msgid "No edit history available."
+#: RecentChangesAdmin.html
+msgid "diff"
 msgstr ""
 
-#: ReturnForm.html:8
+#: ReturnForm.html
 msgid "Really return this book?"
 msgstr ""
 
-#: ReturnForm.html:17
+#: ReturnForm.html
 msgid "Return book"
 msgstr ""
 
-#: SRPCoverImage.html:24
-#, python-format
-msgid "Go to the page for %(title)s"
-msgstr ""
-
-#: SearchResultsWork.html:98
+#: SearchResultsWork.html
 #, python-format
 msgid "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d language</a>"
 msgid_plural "in <a class=\"hoverlink\" title=\"%(langs)s\">%(count)d languages</a>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: SearchResultsWork.html:101
+#: SearchResultsWork.html
 #, python-format
 msgid "%s previewable"
 msgstr ""
 
-#: SearchResultsWork.html:107
-#, python-format
-msgid "Cover of edition %(id)s"
-msgstr ""
-
-#: SearchResultsWork.html:112
+#: SearchResultsWork.html
 msgid "This is only visible to librarians."
 msgstr ""
 
-#: SearchResultsWork.html:114
+#: SearchResultsWork.html
 msgid "Work Title"
 msgstr ""
 
@@ -6197,23 +5886,19 @@ msgstr ""
 msgid "Embed this book in your website"
 msgstr ""
 
-#: ShareModal.html:52
-msgid "Embed icon"
-msgstr ""
-
-#: ShareModal.html:58
+#: ShareModal.html
 msgid "Embed"
 msgstr ""
 
-#: ShareModal.html:62
+#: ShareModal.html
 msgid "Copy url to clipboard"
 msgstr ""
 
-#: ShareModal.html:64
+#: ShareModal.html
 msgid "Copy URL icon"
 msgstr ""
 
-#: ShareModal.html:70
+#: ShareModal.html
 msgid "Copy URL"
 msgstr ""
 
@@ -6225,86 +5910,86 @@ msgstr ""
 msgid "Clear my rating"
 msgstr ""
 
-#: StarRatingsStats.html:25
+#: StarRatingsStats.html
 msgid "Rating"
 msgid_plural "Ratings"
 msgstr[0] ""
 msgstr[1] ""
 
-#: StarRatingsStats.html:27
+#: StarRatingsStats.html
 msgid "Want to read"
 msgstr ""
 
-#: StarRatingsStats.html:28
+#: StarRatingsStats.html
 msgid "Currently reading"
 msgstr ""
 
-#: StarRatingsStats.html:29
+#: StarRatingsStats.html
 msgid "Have read"
 msgstr ""
 
-#: Subnavigation.html:9
+#: Subnavigation.html
 msgid "Developer Center (Home)"
 msgstr ""
 
-#: Subnavigation.html:10
+#: Subnavigation.html
 msgid "Web API"
 msgstr ""
 
-#: Subnavigation.html:11
+#: Subnavigation.html
 msgid "Client Library"
 msgstr ""
 
-#: Subnavigation.html:12
+#: Subnavigation.html
 msgid "Data Dumps"
 msgstr ""
 
-#: Subnavigation.html:14
+#: Subnavigation.html
 msgid "Report an Issue"
 msgstr ""
 
-#: Subnavigation.html:15
+#: Subnavigation.html
 msgid "Licensing"
 msgstr ""
 
-#: Subnavigation.html:19
+#: Subnavigation.html
 msgid "Welcome"
 msgstr ""
 
-#: Subnavigation.html:20
+#: Subnavigation.html
 msgid "Searching Open Library"
 msgstr ""
 
-#: Subnavigation.html:21
+#: Subnavigation.html
 msgid "Reading Books"
 msgstr ""
 
-#: Subnavigation.html:22
+#: Subnavigation.html
 msgid "Adding & Editing Books"
 msgstr ""
 
-#: Subnavigation.html:23
+#: Subnavigation.html
 msgid "Using Subjects"
 msgstr ""
 
-#: Subnavigation.html:24
+#: Subnavigation.html
 msgid "Open Library F.A.Q."
 msgstr ""
 
-#: TableOfContents.html:34
+#: TableOfContents.html
 #, python-format
 msgid "Page %s"
 msgstr ""
 
-#: TypeChanger.html:11
+#: TypeChanger.html
 msgid "Page Type"
 msgstr ""
 
-#: TypeChanger.html:13
+#: TypeChanger.html
 msgid "Huh?"
 msgstr ""
 
-#: TypeChanger.html:16
+#: TypeChanger.html
 msgid ""
 "Every piece of Open Library is defined by the type of content it "
 "displays, usually by content definition (e.g. Authors, Editions, Works) "
@@ -6313,59 +5998,55 @@ msgid ""
 " available for editing its content."
 msgstr ""
 
-#: TypeChanger.html:16
+#: TypeChanger.html
 msgid "Please use caution changing Page Type!"
 msgstr ""
 
-#: TypeChanger.html:16
+#: TypeChanger.html
 msgid ""
 "(Simplest solution: If you aren't sure whether this should be changed, "
 "don't change it.)"
 msgstr ""
 
-#: WorldcatLink.html:9
+#: WorldcatLink.html
 msgid "Check nearby libraries"
 msgstr ""
 
-#: WorldcatLink.html:13
+#: WorldcatLink.html
 msgid "Check WorldCat for an edition near you"
 msgstr ""
 
-#: databarDiff.html:9 databarEdit.html:10
-msgid "View the editing history of this page"
+#: databarAuthor.html
+msgid "Add to list"
 msgstr ""
 
-#: databarDiff.html:12
-msgid "View this page (exit Comparison view)"
+#: databarAuthor.html
+msgid "×"
 msgstr ""
 
-#: databarEdit.html:13
-msgid "View this page (exit Edit mode)"
+#: databarAuthor.html
+msgid "Add new list"
 msgstr ""
 
-#: databarHistory.html:16 databarView.html:23
+#: databarHistory.html databarView.html
 #, python-format
 msgid "Last edited by %(author_link)s"
 msgstr ""
 
-#: databarHistory.html:18 databarView.html:25
+#: databarHistory.html databarView.html
 msgid "Last edited anonymously"
 msgstr ""
 
-#: databarTemplate.html:9 databarView.html:27 databarView.html:29
-msgid "View this template's edit history"
-msgstr ""
-
-#: databarWork.html:89
+#: databarWork.html
 #, python-format
 msgid "This book was generously donated by %(donor)s"
 msgstr ""
 
-#: databarWork.html:91
+#: databarWork.html
 msgid "This book was generously donated anonymously"
 msgstr ""
 
-#: databarWork.html:96
+#: databarWork.html
 msgid "Learn more about Book Sponsorship"
 msgstr ""
 
@@ -6496,64 +6177,64 @@ msgstr ""
 msgid "Notification preferences have been updated successfully."
 msgstr ""
 
-#: borrow.py:205
+#: borrow.py
 msgid ""
 "Your account has hit a lending limit. Please try again later or contact "
 "info@archive.org."
 msgstr ""
 
-#: forms.py:30
+#: forms.py
 msgid "Username"
 msgstr ""
 
-#: forms.py:37
+#: forms.py
 msgid "No user registered with this email address"
 msgstr ""
 
-#: forms.py:44
+#: forms.py
 msgid "Disposable email not permitted"
 msgstr ""
 
-#: forms.py:48
+#: forms.py
 msgid "Your email provider is not recognized."
 msgstr ""
 
-#: forms.py:52
+#: forms.py
 msgid "Username already used"
 msgstr ""
 
-#: forms.py:57
+#: forms.py
 msgid "Must be between 3 and 20 letters and numbers"
 msgstr ""
 
-#: forms.py:59
+#: forms.py
 msgid "Must be between 3 and 20 characters"
 msgstr ""
 
-#: forms.py:78 forms.py:150
+#: forms.py
 msgid "Your email address"
 msgstr ""
 
-#: forms.py:90
+#: forms.py
 msgid "Choose a screen name. Screen names are public and cannot be changed later."
 msgstr ""
 
-#: forms.py:95
+#: forms.py
 msgid "Letters and numbers only please, and at least 3 characters."
 msgstr ""
 
-#: forms.py:101 forms.py:156
+#: forms.py
 msgid "Choose a password"
 msgstr ""
 
-#: forms.py:107
+#: forms.py
 msgid ""
 "I want to receive news, announcements, and resources from the <a "
 "href=\"https://archive.org/\">Internet Archive</a>, the non-profit that "
 "runs Open Library."
 msgstr ""
 
-#: forms.py:145
+#: forms.py
 msgid "Invalid password"
 msgstr ""
 

--- a/openlibrary/macros/ManageWaitlistButton.html
+++ b/openlibrary/macros/ManageWaitlistButton.html
@@ -14,7 +14,7 @@ $if status == "waiting":
   $if pos == 1:
     You are the next person to receive this book.
   $else:
-    $ungettext("There is one person ahead of you in the waiting list.", "There are %(count)s people ahead of you in the waiting list.", pos-1, count=pos-1)
+    $ungettext("There is one person ahead of you in the waiting list.", "There are %(count)d people ahead of you in the waiting list.", pos-1, count=pos-1)
 </div>
 
 <div class="status">

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -32,7 +32,9 @@ def main(cmd, args):
             # TODO: We should check all python files somehow, but too slow
             'openlibrary/plugins/upstream',
         ]
-        i18n.extract_messages(message_sources)
+        i18n.extract_messages(
+            message_sources, verbose='--verbose' in args, forced='--force-write' in args
+        )
     elif cmd == 'compile':
         i18n.compile_translations(args)
     elif cmd == 'update':


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8818.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Automates generation of new `messages.pot` file for translation whenever Python or HTML files that affect `i18n` strings are changed.

### Technical
<!-- What should be noted about the implementation? -->
The implementation is in two parts and mainly confined to two files:
1. `pre-commit-config.yaml` -- Added a new `pre-commit` local hook that runs the `./scripts/i18n-messages extract` script to generate a new `messages.pot` file and is activated by changes to Python or HTML files.

**Note:** This hook has a few dependencies will need to be updated to match the current version when we update `Babel`, `multipart`, and/or `web.py`.

2. `__init__.py` in `openlibrary/i18n` -- Wrote new logic into the message extraction function, using a straightforward `symmetric_difference` compare between the old and new `i18n` messages to make sure that `messages.pot` only gets updated when `i18n` strings have been added/modified/deleted. 

**Note:** This was done to prevent an infinite loop of failure within the pre-commit hook, as the hook will otherwise update the template time field in `messages.pot` on every run, and report a failed run as a result of the file modification, which prevents CI autofixing.

This extra logic also had the nice side effect of ensuring that there will be no `messages.pot` updates for totally unrelated files, as only actual relevant string changes will trigger the re-generation.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Make a change to a Python or HTML file that adds, removes or modifies `i18n`-formatted text
4. Install `pre-commit` if not installed
5. Commit the change; `pre-commit` should automatically generate a new `messages.pot` file

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
