### PR TITLE
Show profile page history table conditionally

### DIFF
--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -70,7 +70,7 @@ $else:
             </div>
         </div>
         <div class="clearfix"></div>
-    
+
     $ is_admin = ctx.user and ctx.user.is_admin()
     $ is_librarian = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian())
 

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -70,14 +70,17 @@ $else:
             </div>
         </div>
         <div class="clearfix"></div>
+    
+    $ is_admin = ctx.user and ctx.user.is_admin()
 
-    $if "recentchanges_v2" in ctx.features:
-        $ changes = render_template("recentchanges/render", author=page.key, limit=25)
-        $if changes.length > 1:
-            <h2>$_('Recent Activity')</h2>
-            $:changes
+    $if owners_page or is_admin:
+        $if "recentchanges_v2" in ctx.features:
+            $ changes = render_template("recentchanges/render", author=page.key, limit=25)
+            $if changes.length > 1:
+                <h2>$_('Recent Activity')</h2>
+                $:changes
+            $else:
+                <p>$_("No edits. Yet.")</p>
         $else:
-            <p>$_("No edits. Yet.")</p>
-    $else:
-        $:macros.RecentChangesUsers(author=page, limit=25)
+            $:macros.RecentChangesUsers(author=page, limit=25)
 </div>

--- a/openlibrary/templates/type/user/view.html
+++ b/openlibrary/templates/type/user/view.html
@@ -72,8 +72,9 @@ $else:
         <div class="clearfix"></div>
     
     $ is_admin = ctx.user and ctx.user.is_admin()
+    $ is_librarian = ctx.user and (ctx.user.is_librarian() or ctx.user.is_super_librarian())
 
-    $if owners_page or is_admin:
+    $if owners_page or is_admin or is_librarian:
         $if "recentchanges_v2" in ctx.features:
             $ changes = render_template("recentchanges/render", author=page.key, limit=25)
             $if changes.length > 1:


### PR DESCRIPTION
Closes #8905

When viewing a profile page, the history table will now only be rendered page owners and members of any of the following usergroups:
`admin`
`librarians`
`super-librarians`

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
While logged out:
1. Visit as many profile pages as you like, ensuring that there is no history table at the bottom of the page.

While logged in with a non-admin account:
1. Visit your account's profile page.  Ensure that the history table **is** rendered.
2. Visit any number of other profile pages.  Ensure that the history table **is not** rendered.

While logged in with an admin or librarian account:
1. Visit your account's profile page.  Ensure that the history table **is** rendered.
2. Visit any number of other profile pages.  Ensure that the history table **is** rendered.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/28732543/70216c66-9425-4ced-90d5-b8c28495f13a)
_Desktop view when history table is not present_

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
