### PR TITLE
Removed duplicate revert button

### DIFF
--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -9,7 +9,7 @@ $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergrou
                 <button type="submit">$_("Revert to this revision?")</button>
             </form>
         </div>
-        <div id="revertLink"><a rel="nofollow" href="$changequery(m='revert')">$_("Revert to this revision")</a>?</div>
+        <!-- <div id="revertLink"><a rel="nofollow" href="$changequery(m='revert')">$_("Revert to this revision")</a>?</div> -->
 
         $putctx("robots", "noindex,nofollow")
     $else:


### PR DESCRIPTION
Revert button styling on Edition pages shows link which should be hidden
Closes https://github.com/internetarchive/openlibrary/issues/2282
Fix

### Technical
Is a quick fix to the duplicate revert buttons bug where there was two revert buttons instead of one.

### Testing
   1. docker compose up
   2. http://localhost:8080/
   3. Go find a book
   4. Make Edit on book
   5. Click History
    6. Click previous version
    7. Look at side to see revert button

### Screenshot
![Before](https://github.com/internetarchive/openlibrary/assets/56459277/ed1661fa-ebab-4ce2-a571-138cae34632f)
![After Fix](https://github.com/internetarchive/openlibrary/assets/56459277/435dacc1-5ffe-498c-91df-e9248242e1c9)

### Stakeholders
@jdlrobson



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
