### PR TITLE
Fix: add `.to_dict()` method to `PrioritizedISBN` for serialization

### DIFF
--- a/scripts/affiliate_server.py
+++ b/scripts/affiliate_server.py
@@ -272,7 +272,7 @@ class Status:
                     web.amazon_lookup_thread and web.amazon_lookup_thread.is_alive()
                 ),
                 "queue_size": web.amazon_queue.qsize(),
-                "queue": list(web.amazon_queue.queue),
+                "queue": [isbn.to_dict() for isbn in web.amazon_queue.queue],
             }
         )
 
@@ -327,6 +327,17 @@ class PrioritizedISBN:
     isbn: str = field(compare=False)
     priority: Priority = field(default=Priority.LOW)
     timestamp: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self):
+        """
+        Convert the PrioritizedISBN object to a dictionary representation suitable
+        for JSON serialization.
+        """
+        return {
+            "isbn": self.isbn,
+            "priority": self.priority.name,
+            "timestamp": self.timestamp.isoformat(),
+        }
 
 
 class Submit:

--- a/scripts/tests/test_affiliate_server.py
+++ b/scripts/tests/test_affiliate_server.py
@@ -4,6 +4,7 @@ for access to the mocker fixture.
 
 # docker compose run --rm home pytest scripts/tests/test_affiliate_server.py
 """
+import json
 import sys
 from unittest.mock import MagicMock
 
@@ -12,6 +13,8 @@ sys.modules['_init_path'] = MagicMock()
 
 from openlibrary.mocks.mock_infobase import mock_site  # noqa: F401
 from scripts.affiliate_server import (  # noqa: E402
+    PrioritizedISBN,
+    Priority,
     get_isbns_from_book,
     get_isbns_from_books,
     get_editions_for_books,
@@ -118,3 +121,16 @@ def test_get_isbns_from_books():
         '1234567890124',
         '1234567891',
     ]
+
+
+def test_prioritized_isbn_can_serialize_to_json() -> None:
+    """
+    `PrioritizedISBN` needs to be be serializable to JSON because it is sometimes
+    called in, e.g. `json.dumps()`.
+    """
+    p_isbn = PrioritizedISBN(isbn="1111111111", priority=Priority.HIGH)
+    dumped_isbn = json.dumps(p_isbn.to_dict())
+    dict_isbn = json.loads(dumped_isbn)
+
+    assert dict_isbn["priority"] == "HIGH"
+    assert isinstance(dict_isbn["timestamp"], str)


### PR DESCRIPTION
When checking `/status` on the affiliate-server, *if* there is an item in the queue, rather than display the count, the server would respond with a rather verbose error because to display items in the queue, they must be first serialized via `json.dumps`, but prior to this commit, the `PrioritizedISBN` class could not be serialized, and the queue contains only `PrioritizedISBN` items.

For reference, here is what would happen:
```
172.28.0.1:59064 - - [15/Mar/2024 22:20:29] "HTTP/1.1 GET /status" - 500 Internal Server Error
Traceback (most recent call last):
  File "/home/openlibrary/.local/lib/python3.12/site-packages/web/application.py", line 276, in process
    return self.handle()
           ^^^^^^^^^^^^^
  File "/home/openlibrary/.local/lib/python3.12/site-packages/web/application.py", line 267, in handle
    return self._delegate(fn, self.fvars, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/openlibrary/.local/lib/python3.12/site-packages/web/application.py", line 509, in _delegate
    return handle_class(cls)
           ^^^^^^^^^^^^^^^^^
  File "/home/openlibrary/.local/lib/python3.12/site-packages/web/application.py", line 487, in handle_class
    return tocall(*args)
           ^^^^^^^^^^^^^
  File "/openlibrary/./scripts/affiliate_server.py", line 305, in GET
    return json.dumps(
           ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type PrioritizedISBN is not JSON serializable
```

Now, as the accompany tests show, they can be serialized with the `to_dict()` method.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
It can be hard to 'catch' items in the queue, since it's processing up to 10 per second; to test this I made 30 concurrent requests to the local affiliate server and quickly checked the queue, catching 8 items in there:
```bash
curl localhost:31337/status; echo "";             
{"thread_is_alive": true, "queue_size": 8, "queue": [{"isbn": "816785146X", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.601706"}, {"isbn": "6755282065", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.605694"}, {"isbn": "4906172431", "priority": "LOW", "timestamp": "202
4-03-15T23:05:30.604042"}, {"isbn": "0170868575", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.605997"}, {"isbn": "0567433013", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.606594"}, {"isbn": "8803177922", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.605098"},
 {"isbn": "9945991396", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.605412"}, {"isbn": "7023385029", "priority": "LOW", "timestamp": "2024-03-15T23:05:30.796779"}]}
 ```

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
