### PR TITLE
fix: fix overlap between button text and icon

### DIFF
--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -10,7 +10,7 @@ $def with(gutenberg_id)
        aria-controls="gutenberg-toast"
   >
     <span class="btn-label">$_('Read')</span>
-    <span class="btn-icon external-link-icon"></span>  
+    <span class="btn-icon external-link-icon"></span>
   </a>
 </div>
 

--- a/openlibrary/templates/book_providers/gutenberg_read_button.html
+++ b/openlibrary/templates/book_providers/gutenberg_read_button.html
@@ -4,11 +4,14 @@ $def with(gutenberg_id)
   <a
       href="https://www.gutenberg.org/ebooks/$gutenberg_id"
       title="$_('Read eBook from Project Gutenberg')"
-      class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--gutenberg"
+      class="cta-btn cta-btn--available cta-btn--read cta-btn--gutenberg"
       target="_blank"
        aria-haspopup="true"
        aria-controls="gutenberg-toast"
-  >$_('Read')</a>
+  >
+    <span class="btn-label">$_('Read')</span>
+    <span class="btn-icon external-link-icon"></span>  
+  </a>
 </div>
 
 $if render_once('gutenberg-toast'):

--- a/openlibrary/templates/book_providers/librivox_read_button.html
+++ b/openlibrary/templates/book_providers/librivox_read_button.html
@@ -4,13 +4,14 @@ $def with(librivox_id)
 <a href="https://librivox.org/$librivox_id"
    title="$_('Listen to a reading from LibriVox')"
    data-ol-link-track="CTAClick|Listen"
-   class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--external cta-btn--librivox"
+   class="cta-btn cta-btn--available cta-btn--w-icon cta-btn--librivox"
    target="_blank"
    aria-haspopup="true"
    aria-controls="librivox-toast"
 >
   <span class="btn-icon read-aloud"></span>
   <span class="btn-label">$_('Audiobook')</span>
+  <span class="btn-icon external-link-icon"></span>
 </a>
 </div>
 

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -4,11 +4,14 @@ $def with(openstax_id)
   <a
       href="https://openstax.org/details/books/$openstax_id"
       title="$_('Read eBook from OpenStax')"
-      class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--openstax"
+      class="cta-btn cta-btn--available cta-btn--read cta-btn--openstax"
       target="_blank"
        aria-haspopup="true"
        aria-controls="openstax-toast"
-  >$_('Read')</a>
+  >
+    <span class="btn-label">$_('Read')</span>
+    <span class="btn-icon external-link-icon"></span>  
+  </a>
 </div>
 
 $if render_once('openstax-toast'):

--- a/openlibrary/templates/book_providers/openstax_read_button.html
+++ b/openlibrary/templates/book_providers/openstax_read_button.html
@@ -10,7 +10,7 @@ $def with(openstax_id)
        aria-controls="openstax-toast"
   >
     <span class="btn-label">$_('Read')</span>
-    <span class="btn-icon external-link-icon"></span>  
+    <span class="btn-icon external-link-icon"></span>
   </a>
 </div>
 

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -4,11 +4,14 @@ $def with(standard_ebooks_id)
   <a
       href="https://standardebooks.org/ebooks/$standard_ebooks_id/text/single-page"
       title="$_('Read eBook from Standard eBooks')"
-      class="cta-btn cta-btn--available cta-btn--read cta-btn--external cta-btn--standard-ebooks"
+      class="cta-btn cta-btn--available cta-btn--read cta-btn--standard-ebooks"
       target="_blank"
       aria-haspopup="true"
       aria-controls="standard-ebooks-toast"
-  >$_('Read')</a>
+  >
+    <span class="btn-label">$_('Read')</span>
+    <span class="btn-icon external-link-icon"></span>  
+  </a>
 </div>
 
 $if render_once('standard-ebooks-toast'):

--- a/openlibrary/templates/book_providers/standard_ebooks_read_button.html
+++ b/openlibrary/templates/book_providers/standard_ebooks_read_button.html
@@ -10,7 +10,7 @@ $def with(standard_ebooks_id)
       aria-controls="standard-ebooks-toast"
   >
     <span class="btn-label">$_('Read')</span>
-    <span class="btn-icon external-link-icon"></span>  
+    <span class="btn-icon external-link-icon"></span>
   </a>
 </div>
 

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -43,6 +43,7 @@ a.cta-btn {
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
+    padding: 0 10px;
     margin-left: auto;
   }
 

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -37,6 +37,13 @@ a.cta-btn {
     background-size: contain;
     background-position: center;
   }
+  .btn-icon.external-link-icon {
+    background-image: url(/static/images/icons/octicon-link-external-24.svg);
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: center;
+    margin-left: auto;
+  }
 
   .btn-label { padding: 0 10px; }
 

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -37,6 +37,7 @@ a.cta-btn {
     background-size: contain;
     background-position: center;
   }
+  // stylelint-disable-next-line selector-max-specificity
   .btn-icon.external-link-icon {
     background-image: url(/static/images/icons/octicon-link-external-24.svg);
     background-repeat: no-repeat;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8899 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix

### Technical
<!-- What should be noted about the implementation? -->
- Issue: *gutenberg, librivox, openstax, standard_ebooks* read buttons were facing button text & icon "external link" overlap on mobile devices
- Cause: The class `cta-btn--external` was adding the external link as the background image of the `<a>` tag in these cases
Currently the icon was displayed as a background image of the `<a>` tag which allowed the text to appear in front of the icon.
- Fix: Added a new span with the icon as a sibling of the text in the `<a>` tag

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- You could witness the issue at places where Open Library displays *gutenberg, librivox, openstax, standard_ebooks* read buttons. (examples: [librivox](https://openlibrary.org/works/OL37473900W/Short_Story_Collection_102), [gutenberg](https://openlibrary.org/works/OL17732W/KJV_study_Bible_for_boys?edition=key%3A/books/OL26083434M#details), ...)
- If you want to test locally, you could run the setup from the contributing guidelines and load the books mentioned in examples (please note that you wouldn't be able to load all the books from the script as they're from the trusted book providers. book from librivox example loads fine)
- Use the *Responsive Design Mode* of your browsers developer tools and test the overlap of the buttons by reducing the width

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
**After fix** (Click the GIF to view clearly. Idk why some weird lines are appearing):
![fix-first-look](https://github.com/internetarchive/openlibrary/assets/67511891/c63106ad-5c63-4509-96d3-37914f3b9051)


### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
