### PR TITLE
Fix private reading log errors

### DIFF
--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -402,7 +402,7 @@ class MyBooksTemplate:
         self.counts = (
             self.readlog.reading_log_counts
             if (self.is_my_page or self.is_public)
-            else []
+            else {}
         )
 
         self.reading_goals = []

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -232,18 +232,18 @@ class mybooks_readinglog(delegate.page):
 
     def GET(self, username, key='want-to-read'):
         mb = MyBooksTemplate(username, key)
-        KEYS_TITLES = {
-            'currently-reading': _(
-                "Currently Reading (%(count)d)", count=mb.counts['currently-reading']
-            ),
-            'want-to-read': _(
-                "Want to Read (%(count)d)", count=mb.counts['want-to-read']
-            ),
-            'already-read': _(
-                "Already Read (%(count)d)", count=mb.counts['already-read']
-            ),
-        }
         if mb.is_my_page or mb.is_public:
+            KEYS_TITLES = {
+                'currently-reading': _(
+                    "Currently Reading (%(count)d)", count=mb.counts['currently-reading']
+                ),
+                'want-to-read': _(
+                    "Want to Read (%(count)d)", count=mb.counts['want-to-read']
+                ),
+                'already-read': _(
+                    "Already Read (%(count)d)", count=mb.counts['already-read']
+                ),
+            }
             template = self.render_template(mb)
             return mb.render(header_title=KEYS_TITLES[key], template=template)
         raise web.seeother(mb.user.key)

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -235,7 +235,8 @@ class mybooks_readinglog(delegate.page):
         if mb.is_my_page or mb.is_public:
             KEYS_TITLES = {
                 'currently-reading': _(
-                    "Currently Reading (%(count)d)", count=mb.counts['currently-reading']
+                    "Currently Reading (%(count)d)",
+                    count=mb.counts['currently-reading'],
                 ),
                 'want-to-read': _(
                     "Want to Read (%(count)d)", count=mb.counts['want-to-read']


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8917

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Avoids error that occurs when a private reading log page is visited.

Also, sets default fall-back value of `MyBooksTemplate.counts` to an empty `dict`.  This doesn't fix anything, but should give developers an indication, with a cursory glance, that this property is meant to be a `dict`.

### Technical
<!-- What should be noted about the implementation? -->
Today, whenever a private reading log page is visited, the default `mb.counts` value is an empty list.  The reading log view handler attempts to set the values of `KEYS_TITLES` by accessing `mb.counts` with a key, which causes an error when `mb.counts` is a list.  The PR sets `KEYS_VALUES` inside of the conditional that checks if the page is viewable, avoiding the error altogether.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Open a private browser window, and navigate to a private reading log page.  Ensure that you are redirected to the expected profile page.
2. Navigate to a public reading log page.  Ensure that the expected reading log page is rendered without error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
