### PR TITLE
Fix: ensure /api/books defaults to high_priority=False

### DIFF
--- a/openlibrary/plugins/books/code.py
+++ b/openlibrary/plugins/books/code.py
@@ -42,10 +42,10 @@ class books_json(delegate.page):
 
     @jsonapi
     def GET(self):
-        i = web.input(bibkeys='', callback=None, details="false", high_priority="false")
+        i = web.input(bibkeys='', callback=None, details="false", high_priority=False)
+        i.high_priority = i.get("high_priority") == "true"
         if web.ctx.path.endswith('.json'):
             i.format = 'json'
-            i.high_priority = i.get("high_priority") == "true"
         return dynlinks.dynlinks(bib_keys=i.bibkeys.split(","), options=i)
 
 


### PR DESCRIPTION
### Technical
<!-- What should be noted about the implementation? -->
This commit ensures `/api/books/` passes `high_priority=False`, even if the endpoint called is _not_ JSON. It appears that this API returns JSON even if one requests `/api/books` and not `/api/books.json`, and that conumers do so call the endpoint this way.

Previously, the endpoint only set `high_priority=False` as a default when accessed at `/api/books.json`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
For both `/api/books` and `/api/books.json`, visit the respective endpoints without specifying a priority, and observe `high_priority=False`, and then specify `high_priority=true` and observe that `high_priority=True`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@cdrini 
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
