### PR TITLE
remove old gitpod prebuild config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,11 +29,3 @@ tasks:
   # init runs once for each commit to the default branch
   init: ./scripts/setup_gitpod.sh
   openMode: split-right
-
-github:
-  prebuilds:
-    # Disable all prebuilds ; it's not faster and often errors
-    master: false
-    pullRequests: false
-    branches: false
-    pullRequestsFromForks: false


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Noticed these prebuild settings are deprecated. Prebuilds must be manually turned on [here](https://gitpod.io/repositories/b5c70fe2-e964-42ca-9992-4789b4134624) by someone with webhook permissions. As such, we don't need this part of the config file anymore.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Changed in Oct 2023: https://www.gitpod.io/changelog/simplified-prebuilds-defaults

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I suppose you could open this PR in GitPod but really no testing needed.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
