### PR TITLE
add gitpod port names

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,18 @@
 ports:
-- port: 8080
+- name: Web App
+  port: 8080
 # ignore these ports by default to avoid extra notifications
-- port: 8983
+- name: Solr
+  port: 8983
   onOpen: ignore
-- port: 7075
+- name: Covers
+  port: 7075
   onOpen: ignore
-- port: 7000
+- name: Infobase
+  port: 7000
   onOpen: ignore
-- port: 3000
+- name: Debugger
+  port: 3000
   onOpen: ignore
 tasks:
 - name: watch


### PR DESCRIPTION
<!-- What issue does this PR close? -->
A small improvement by adding names to ports for gitpod users :)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Docs: https://www.gitpod.io/docs/configure/workspaces/ports#specify-port-names--descriptions


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<details>
  <summary>Before</summary>
  
  
<img width="1512" alt="image" src="https://github.com/internetarchive/openlibrary/assets/921217/0b19bdaa-7dc9-451e-a846-09feefa2c7cd">

  
</details> 

<details>
  <summary>After</summary>
  
  
<img width="1512" alt="image" src="https://github.com/internetarchive/openlibrary/assets/921217/73313ae0-53f3-4b42-96c0-6a07bd6bcb6f">

  
</details> 

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
