### PR TITLE
Standardize font sizes on works page

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -237,7 +237,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $else:
           $ overview_desc = work.description
         <div class="book-description read-more">
-            <div class="read-more__content" style="max-height:58px">
+            <div class="read-more__content" style="max-height:81px">
                 $:sanitize(format(overview_desc))
             </div>
             $:macros.ReadMore()
@@ -464,7 +464,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
             $if work.description and work.description != overview_desc:
               <h4>$_("Work Description")</h4>
               <div class="work-description read-more">
-                <div class="read-more__content" style="max-height:58px">
+                <div class="read-more__content" style="max-height:81px">
                   $:sanitize(format(work.description))
                 </div>
                 $:macros.ReadMore()

--- a/static/css/base/headings.less
+++ b/static/css/base/headings.less
@@ -22,7 +22,7 @@ h1 {
 }
 
 h2 {
-  font-size: 1.375em;
+  font-size: @font-size-title-large;
   &.author {
     color: @brown;
     font-size: 1.125em;
@@ -68,7 +68,7 @@ h2 {
 }
 
 h3 {
-  font-size: 1.0em;
+  font-size: @font-size-label-medium;
   &.Question {
     font-family: @georgia_serif-1;
     font-size: 1.2em;

--- a/static/css/components/carousel.less
+++ b/static/css/components/carousel.less
@@ -8,7 +8,7 @@
 
 // Badly named. Should be renamed "carousel-heading" or similar.
 .home-h2 {
-  font-size: 1.2em;
+  font-size: @font-size-title-medium;
   font-weight: normal;
   color: @link-blue;
   margin-bottom: .5em;

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -25,7 +25,7 @@ div#editInfo {
     font-family: @lucida_sans_serif-1;
   }
   .smallest {
-    padding-top: 0.3rem;
+    padding-top: .3rem;
   }
 }
 

--- a/static/css/components/edit-toolbar.less
+++ b/static/css/components/edit-toolbar.less
@@ -19,13 +19,13 @@ div#editInfo {
   white-space: normal;
   text-align: right;
   > div {
-    font-size: 11px;
+    font-size: @font-size-label-small;
     font-weight: normal;
     color: @brown !important;
     font-family: @lucida_sans_serif-1;
   }
   .smallest {
-    padding-top: .3rem;
+    padding-top: 0.3rem;
   }
 }
 

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -56,7 +56,7 @@ table#editions,
   }
 
   div.title {
-    font-size: 1.0em;
+    font-size: @font-size-title-small;
     padding: 10px 0;
     min-width: 1%;
     overflow-wrap: break-word;

--- a/static/css/components/editions.less
+++ b/static/css/components/editions.less
@@ -28,7 +28,7 @@ table#editions,
 
   th {
     font-family: @news_gothic_sans_serif-2;
-    font-size: 11px;
+    font-size: @font-size-label-small;
     font-weight: 600;
     text-transform: uppercase;
     line-height: normal;
@@ -63,7 +63,7 @@ table#editions,
   }
 
   div.links {
-    font-size: 12px;
+    font-size: @font-size-label-medium;
     color: @dark-grey;
     line-height: 1.5em;
   }

--- a/static/css/components/link-box.less
+++ b/static/css/components/link-box.less
@@ -15,7 +15,7 @@
     display: inline;
   }
   > div {
-    font-size: .75em;
+    font-size: @font-size-headline-small;
   }
 }
 

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -5,18 +5,17 @@
 
 .readers-stats {
   color: @grey;
-  font-size: .9em;
+  font-size: @font-size-label-large;
   margin-bottom: 20px;
   li {
     list-style-type: none;
     display: inline-block;
     padding-bottom: 10px;
 
-    &:not(:first-child,:last-child):after {
+    &:not(:first-child, :last-child):after {
       content: "·";
       margin: 0 4px;
     }
-
   }
   .dot {
     list-style-type: none;
@@ -28,7 +27,7 @@
     color: @gold;
     font-size: 1.5em;
   }
-  &__star--half{
+  &__star--half {
     margin: 0 0 0 -5px;
     font-size: 1.5em;
     background: linear-gradient(90deg, @gold 50%, @light-grey 50%);

--- a/static/css/components/readerStats.less
+++ b/static/css/components/readerStats.less
@@ -12,7 +12,7 @@
     display: inline-block;
     padding-bottom: 10px;
 
-    &:not(:first-child, :last-child):after {
+    &:not(:first-child,:last-child):after {
       content: "·";
       margin: 0 4px;
     }
@@ -27,7 +27,7 @@
     color: @gold;
     font-size: 1.5em;
   }
-  &__star--half {
+  &__star--half{
     margin: 0 0 0 -5px;
     font-size: 1.5em;
     background: linear-gradient(90deg, @gold 50%, @light-grey 50%);

--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -46,7 +46,7 @@
 
   .first-published-date {
     color: @grey;
-    font-size: .8em;
+    font-size: @font-size-label-medium;
   }
 }
 

--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -46,7 +46,7 @@
 
   .first-published-date {
     color: @grey;
-    font-size: 0.8em;
+    font-size: .8em;
   }
 }
 
@@ -54,9 +54,9 @@
 @media only screen and (min-width: @width-breakpoint-desktop) {
   .work-title-and-author {
     &.mobile {
-      display: none;
+      display: none
     }
-    &.desktop {
+    &.desktop{
       display: inline;
     }
 
@@ -85,10 +85,10 @@
     }
 
     h2.edition-byline {
-      font-size: 0.875em;
+      font-size: .875em;
       margin-bottom: 10px;
 
-      & > a {
+      &> a {
         text-decoration: none;
       }
     }
@@ -102,7 +102,7 @@
 
       .icon-link__text {
         color: @dark-grey;
-        font-size: 0.675em;
+        font-size: .675em;
       }
     }
 
@@ -126,7 +126,7 @@
 
       li.avg-ratings,
       li.readers-stats__review-count {
-        font-size: 0.85em;
+        font-size: .85em;
       }
 
       // On mobile only, the rating count text has parentheses around it

--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -15,7 +15,7 @@
       font-family: @georgia_serif-1;
       margin: 10px 0 0;
       color: @dark-grey;
-      font-size: 2em;
+      font-size: @font-size-headline-large;
       overflow-wrap: break-word;
     }
   }

--- a/static/css/components/work-title-and-author.less
+++ b/static/css/components/work-title-and-author.less
@@ -29,7 +29,7 @@
       font-style: italic;
     }
     &.edition-byline {
-      font-size: 1em;
+      font-size: @font-size-title-medium;
       font-weight: normal;
       color: @dark-grey;
       margin: 10px 0 20px;
@@ -46,7 +46,7 @@
 
   .first-published-date {
     color: @grey;
-    font-size: .8em;
+    font-size: 0.8em;
   }
 }
 
@@ -54,9 +54,9 @@
 @media only screen and (min-width: @width-breakpoint-desktop) {
   .work-title-and-author {
     &.mobile {
-      display: none
+      display: none;
     }
-    &.desktop{
+    &.desktop {
       display: inline;
     }
 
@@ -85,10 +85,10 @@
     }
 
     h2.edition-byline {
-      font-size: .875em;
+      font-size: 0.875em;
       margin-bottom: 10px;
 
-      &> a {
+      & > a {
         text-decoration: none;
       }
     }
@@ -102,7 +102,7 @@
 
       .icon-link__text {
         color: @dark-grey;
-        font-size: .675em;
+        font-size: 0.675em;
       }
     }
 
@@ -126,8 +126,7 @@
 
       li.avg-ratings,
       li.readers-stats__review-count {
-        font-size: .85em;
-
+        font-size: 0.85em;
       }
 
       // On mobile only, the rating count text has parentheses around it

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -255,14 +255,14 @@ div.editionTools {
     margin: 0 4px;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: @font-size-label-large;
+    font-size: @font-size-label-medium;
     word-break: break-word;
     text-align: center;
     min-width: 100px;
 
     div {
       margin-bottom: 4px;
-      font-size: @font-size-label-large;
+      font-size: @font-size-label-medium;
       color: @grey;
       word-wrap: break-word;
     }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -40,7 +40,7 @@ div.editionAbout {
 
   p {
     margin: 1em 0;
-    font-size: @font-size-body-medium;
+    font-size: @font-size-body-small;
   }
   p.book-description {
     margin: 0;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -133,7 +133,7 @@ textarea[name="work--description"] + h3 + .wmd-preview,
 
 .section,
 .section h6 {
-  font-size: 0.8em;
+  font-size: @font-size-label-medium;
 }
 
 h3.edition-header {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -40,7 +40,7 @@ div.editionAbout {
 
   p {
     margin: 1em 0;
-    font-size: @font-size-body-small;
+    font-size: @font-size-body-medium;
   }
   p.book-description {
     margin: 0;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -40,7 +40,7 @@ div.editionAbout {
 
   p {
     margin: 1em 0;
-    font-size: @font-size-body-large;
+    font-size: @font-size-body-medium;
   }
   p.book-description {
     margin: 0;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -262,7 +262,7 @@ div.editionTools {
 
     div {
       margin-bottom: 4px;
-      font-size: .9em;
+      font-size: @font-size-label-large;
       color: @grey;
       word-wrap: break-word;
     }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -135,7 +135,7 @@ textarea[name="work--description"] + h3 + .wmd-preview,
 }
 
 h3.edition-header {
-  font-size: 14px;
+  font-size: @font-size-label-large;
   margin: 0;
 }
 
@@ -174,7 +174,7 @@ a.section-anchor {
 }
 
 .meta dt, .meta dd {
-  font-size: 12px;
+  font-size: @font-size-label-medium;
 }
 
 .book-subtitle{

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -18,13 +18,13 @@
   min-height: 10px;
   padding-right: 0;
   .cover-animation {
-    transition: transform .8s, opacity .8s;
+    transition: transform 0.8s, opacity 0.8s;
     position: relative;
     z-index: @z-index-level-negative;
   }
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
-    opacity: .8;
+    opacity: 0.8;
   }
 }
 @import (less) "components/cover.less";
@@ -56,7 +56,7 @@ div.editionAbout {
   }
 }
 
-.work-description{
+.work-description {
   pre {
     overflow: auto;
   }
@@ -91,16 +91,17 @@ textarea[name="edition--notes"] + h3 + .wmd-preview,
 .edition-notes,
 textarea[name="work--description"] + h3 + .wmd-preview,
 .book-description {
-  font-size: .8rem;
+  font-size: @font-size-label-medium;
   margin-top: 5px;
   margin-bottom: 20px;
 
-  ul, ol {
+  ul,
+  ol {
     padding-left: 2rem;
 
     li {
       list-style-type: initial;
-      font-size: .8rem;
+      font-size: 0.8rem;
     }
   }
 }
@@ -130,8 +131,9 @@ textarea[name="work--description"] + h3 + .wmd-preview,
   content: attr(data-before);
 }
 
-.section, .section h6 {
-  font-size: .8em;
+.section,
+.section h6 {
+  font-size: 0.8em;
 }
 
 h3.edition-header {
@@ -173,11 +175,12 @@ a.section-anchor {
   }
 }
 
-.meta dt, .meta dd {
+.meta dt,
+.meta dd {
   font-size: 12px;
 }
 
-.book-subtitle{
+.book-subtitle {
   margin-bottom: 0;
 }
 
@@ -233,7 +236,8 @@ div.editionTools {
   }
 }
 
-.print-disabled-download, .patron-metadata {
+.print-disabled-download,
+.patron-metadata {
   text-align: center;
   padding: 7px 0 0;
 }
@@ -255,14 +259,14 @@ div.editionTools {
     margin: 0 4px;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: .8em;
+    font-size: 0.8em;
     word-break: break-word;
     text-align: center;
     min-width: 100px;
 
     div {
       margin-bottom: 4px;
-      font-size: .9em;
+      font-size: 0.9em;
       color: @grey;
       word-wrap: break-word;
     }
@@ -290,7 +294,6 @@ div.editionTools {
       flex-direction: column;
       justify-content: flex-start;
       align-items: center;
-
     }
   }
 }
@@ -303,7 +306,7 @@ div.editionTools {
 }
 
 .preview-languages {
-  font-size: .8em;
+  font-size: 0.8em;
   color: @grey;
 }
 
@@ -318,7 +321,7 @@ div.editionTools {
   font-weight: normal;
   color: @link-blue;
 }
-@media only screen and (max-width: @width-breakpoint-desktop){
+@media only screen and (max-width: @width-breakpoint-desktop) {
   div.editionAbout .book-description {
     padding-top: 1em;
   }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -40,7 +40,7 @@ div.editionAbout {
 
   p {
     margin: 1em 0;
-    font-size: 13px;
+    font-size: @font-size-body-large;
   }
   p.book-description {
     margin: 0;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -259,7 +259,7 @@ div.editionTools {
     margin: 0 4px;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: 0.8em;
+    font-size: @font-size-label-large;
     word-break: break-word;
     text-align: center;
     min-width: 100px;

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -18,13 +18,13 @@
   min-height: 10px;
   padding-right: 0;
   .cover-animation {
-    transition: transform 0.8s, opacity 0.8s;
+    transition: transform .8s, opacity .8s;
     position: relative;
     z-index: @z-index-level-negative;
   }
   .cover-animation:hover {
     transform: perspective(465px) rotateX(0deg) rotateY(-10deg);
-    opacity: 0.8;
+    opacity: .8;
   }
 }
 @import (less) "components/cover.less";
@@ -56,7 +56,7 @@ div.editionAbout {
   }
 }
 
-.work-description {
+.work-description{
   pre {
     overflow: auto;
   }
@@ -95,13 +95,12 @@ textarea[name="work--description"] + h3 + .wmd-preview,
   margin-top: 5px;
   margin-bottom: 20px;
 
-  ul,
-  ol {
+  ul, ol {
     padding-left: 2rem;
 
     li {
       list-style-type: initial;
-      font-size: 0.8rem;
+      font-size: .8rem;
     }
   }
 }
@@ -131,8 +130,7 @@ textarea[name="work--description"] + h3 + .wmd-preview,
   content: attr(data-before);
 }
 
-.section,
-.section h6 {
+.section, .section h6 {
   font-size: @font-size-label-medium;
 }
 
@@ -175,12 +173,11 @@ a.section-anchor {
   }
 }
 
-.meta dt,
-.meta dd {
+.meta dt, .meta dd {
   font-size: 12px;
 }
 
-.book-subtitle {
+.book-subtitle{
   margin-bottom: 0;
 }
 
@@ -236,8 +233,7 @@ div.editionTools {
   }
 }
 
-.print-disabled-download,
-.patron-metadata {
+.print-disabled-download, .patron-metadata {
   text-align: center;
   padding: 7px 0 0;
 }
@@ -266,7 +262,7 @@ div.editionTools {
 
     div {
       margin-bottom: 4px;
-      font-size: 0.9em;
+      font-size: .9em;
       color: @grey;
       word-wrap: break-word;
     }
@@ -294,6 +290,7 @@ div.editionTools {
       flex-direction: column;
       justify-content: flex-start;
       align-items: center;
+
     }
   }
 }
@@ -306,7 +303,7 @@ div.editionTools {
 }
 
 .preview-languages {
-  font-size: 0.8em;
+  font-size: .8em;
   color: @grey;
 }
 
@@ -321,7 +318,7 @@ div.editionTools {
   font-weight: normal;
   color: @link-blue;
 }
-@media only screen and (max-width: @width-breakpoint-desktop) {
+@media only screen and (max-width: @width-breakpoint-desktop){
   div.editionAbout .book-description {
     padding-top: 1em;
   }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -255,7 +255,7 @@ div.editionTools {
     margin: 0 4px;
     border: 1px solid @lighter-grey;
     border-radius: 5px;
-    font-size: @font-size-label-medium;
+    font-size: @font-size-body-medium;
     word-break: break-word;
     text-align: center;
     min-width: 100px;

--- a/static/css/less/font-families.less
+++ b/static/css/less/font-families.less
@@ -39,3 +39,4 @@
 
 @font-size-body-large: 16px;
 @font-size-body-medium: 14px;
+@font-size-body-small: 12px;

--- a/static/css/less/font-families.less
+++ b/static/css/less/font-families.less
@@ -39,4 +39,3 @@
 
 @font-size-body-large: 16px;
 @font-size-body-medium: 14px;
-@font-size-body-small: 12px;

--- a/static/css/less/font-families.less
+++ b/static/css/less/font-families.less
@@ -20,3 +20,24 @@
 @verdana: verdana, sans-serif;
 @ichonochive: "Iconochive-Regular", sans-serif;
 @bahnschrift: Bahnschrift, sans-serif;
+
+
+
+@font-size-display-large: 57px;
+@font-size-display-medium: 45px;
+@font-size-display-small: 36px;
+
+@font-size-headline-large: 32px;
+@font-size-headline-medium: 28px;
+@font-size-headline-small: 24px;
+
+@font-size-title-large: 22px;
+@font-size-title-medium: 16px;
+@font-size-title-small: 14px;
+
+@font-size-label-large: 14px;
+@font-size-label-medium: 12px;
+@font-size-label-small: 11px;
+
+@font-size-body-large: 16px;
+@font-size-body-medium: 14px;

--- a/static/css/less/font-families.less
+++ b/static/css/less/font-families.less
@@ -21,8 +21,6 @@
 @ichonochive: "Iconochive-Regular", sans-serif;
 @bahnschrift: Bahnschrift, sans-serif;
 
-
-
 @font-size-display-large: 57px;
 @font-size-display-medium: 45px;
 @font-size-display-small: 36px;


### PR DESCRIPTION
Work towards #8692.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
A uniform font size for the Open Library application.

### Technical
<!-- What should be noted about the implementation? -->
Initially, we are updating a portion of the app, the works page. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->


### Screenshot

| Before | After |
| -- | -- |
| ![Screenshot 2024-03-22 at 12-43-18 The Memoirs of Sherlock Holmes by Arthur Conan Doyle Open Library](https://github.com/internetarchive/openlibrary/assets/6251786/4bea5a6d-6642-417f-be5b-8af5c892d073) | ![Screenshot 2024-03-22 at 12-43-31 The Memoirs of Sherlock Holmes by Arthur Conan Doyle Open Library](https://github.com/internetarchive/openlibrary/assets/6251786/b7ea665c-bfc8-4310-ace1-797d26ff9782) |

crossed out in read are the updated classes using our new font size variables instead of static numbers
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![screencapture-localhost-8080-works-OL13101191W-Alice-s-Adventures-in-Wonderland-2024-03-18-13_09_03](https://github.com/internetarchive/openlibrary/assets/28990037/4a49c9f1-a85a-4bc7-840a-2351d9303e97)

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
