### PR TITLE
Update pull_request_template.md to mention tagging lead

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Closes #
 <!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
 
 ### Stakeholders
-<!-- @ tag stakeholders of this bug -->
+<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
 
 
 <!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->


### PR DESCRIPTION
I think this improves the PR template just a bit for new contributors.
Posted about this in slack [here](https://internetarchive.slack.com/archives/C0ETZV72L/p1710932131829919).
