### PR TITLE
improve image height for mergeUI

### DIFF
--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -106,7 +106,7 @@ export default {
   font-size: 0.95em;
 
   img {
-    height: 60px;
+    height: 100%;
     width: 60px;
     background: #eee;
     object-fit: cover;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
A very tiny improvement to the MergeUI so the images don't have a white space under them.
| Before                                      | After                                      |
|---------------------------------------------|--------------------------------------------|
| ![image](https://github.com/internetarchive/openlibrary/assets/921217/29452704-ed1d-4dab-b42b-fe90666a3804) | ![image](https://github.com/internetarchive/openlibrary/assets/921217/07d30eb9-e51c-405d-9d69-6413d24d23ed) |

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

### Stakeholders
<!-- @ tag stakeholders of this bug -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
