### PR TITLE
remove setup_jquery_urls

### DIFF
--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -78,7 +78,6 @@ upstream_to_www_migration: true
 default_template_root: /upstream
 css_root: /upstream/css
 js_root: /upstream/js
-use_google_cdn: false
 logging_config_file: conf/logging.ini
 email_config_file: conf/email.ini
 

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -277,21 +277,6 @@ def reload():
     all_js().reload()
 
 
-def setup_jquery_urls():
-    if config.get('use_google_cdn', True):
-        jquery_url = "http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"
-        jqueryui_url = (
-            "http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/jquery-ui.min.js"
-        )
-    else:
-        jquery_url = "/static/upstream/js/jquery-1.3.2.min.js"
-        jqueryui_url = "/static/upstream/js/jquery-ui-1.7.2.min.js"
-
-    web.template.Template.globals['jquery_url'] = jquery_url
-    web.template.Template.globals['jqueryui_url'] = jqueryui_url
-    web.template.Template.globals['use_google_cdn'] = config.get('use_google_cdn', True)
-
-
 def user_can_revert_records():
     user = web.ctx.site.get_user()
     return user and (
@@ -417,8 +402,6 @@ def setup():
     )
 
     web.template.STATEMENT_NODES["jsdef"] = jsdef.JSDefNode
-
-    setup_jquery_urls()
 
 
 setup()


### PR DESCRIPTION
I was poking around looking at https://github.com/internetarchive/openlibrary/issues/2340 and found this code for getting the jquery urls. I'm pretty sure this is long dead. I couldn't find a single reference to any of these variables or urls and I doubt if we've loaded from a CDN for a long time.