### PR TITLE
Fix work's `add-cover` carousel

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -42,14 +42,18 @@ export class Carousel {
         this.$container = $container;
 
         //This loads in i18n strings from a hidden input element, generated in the books/custom_carousel.html template.
-        this.i18n = JSON.parse($('input[name="carousel-i18n-strings"]').attr('value'));
-        this.availabilityStatuses = {
-            open: {cls: 'cta-btn--available', cta: this.i18n['open']},
-            borrow_available: {cls: 'cta-btn--available', cta: this.i18n['borrow_available']},
-            borrow_unavailable: {cls: 'cta-btn--unavailable', cta: this.i18n['borrow_unavailable']},
-            error: {cls: 'cta-btn--missing', cta: this.i18n['error']},
-            // private: {cls: 'cta-btn--available', cta: 'Preview'}
-        };
+        const i18nInput = document.querySelector('input[name="carousel-i18n-strings"]')
+        if (i18nInput) {
+            this.i18n = JSON.parse(i18nInput.value);
+
+            this.availabilityStatuses = {
+                open: {cls: 'cta-btn--available', cta: this.i18n['open']},
+                borrow_available: {cls: 'cta-btn--available', cta: this.i18n['borrow_available']},
+                borrow_unavailable: {cls: 'cta-btn--unavailable', cta: this.i18n['borrow_unavailable']},
+                error: {cls: 'cta-btn--missing', cta: this.i18n['error']},
+                // private: {cls: 'cta-btn--available', cta: 'Preview'}
+            };
+        }
     }
 
     get slick() {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8906

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Restores "next" and "previous" page buttons to the work `add-cover` carousel.

### Technical
<!-- What should be noted about the implementation? -->
An input with name `carousel-i18n-strings` does not exist on the work's add-cover page.  This caused an error during instantiation when i18n strings were parsed, preventing the `Carousel` from being created.

Now, we check for the `carousel-i18n-strings` input before attempting to parse its value.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/28732543/db60f78a-a804-441c-b0b0-747fb1225924)

### Stakeholders
<!-- @ tag stakeholders of this bug -->
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
