### PR TITLE
Update: Sidebar height and top margin and remove bg mask gradient

### DIFF
--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -96,7 +96,7 @@
     max-width: 100vw;
     right: 0;
     top: 0;
-    height: 100%;
+    height: 100vh;
     z-index: @z-index-level-2;
     overflow-y: auto;
     overscroll-behavior: contain;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -91,12 +91,11 @@
   }
 
   .app-drawer {
-    @topHeight: 0px;
     position: fixed;
     width: 300px;
     max-width: 100vw;
     right: 0;
-    top: @topHeight;
+    top: 0;
     height: 100%;
     z-index: @z-index-level-2;
     overflow-y: auto;

--- a/static/css/components/header-bar.less
+++ b/static/css/components/header-bar.less
@@ -91,13 +91,13 @@
   }
 
   .app-drawer {
-    @topHeight: 50px;
+    @topHeight: 0px;
     position: fixed;
     width: 300px;
     max-width: 100vw;
     right: 0;
     top: @topHeight;
-    height: calc(100% - @topHeight - 25px);
+    height: 100%;
     z-index: @z-index-level-2;
     overflow-y: auto;
     overscroll-behavior: contain;
@@ -259,14 +259,14 @@
 
   .mask-menu {
     position: fixed;
-    top: 75px;
+    top: 0;
     // stylelint-disable declaration-block-no-redundant-longhand-properties
     left: 0;
     right: 0;
     opacity: 0;
     bottom: 0;
     // stylelint-enable declaration-block-no-redundant-longhand-properties
-    background: linear-gradient(to bottom, transparent 0, @black);
+    background: rgba(0, 0, 0, .5);
     z-index: @z-index-level-1;
     visibility: hidden;
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8943 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR makes the sidebar cover the entire height instead of leaving top and bottom space. It also removes the linear gradient of the bg mask and bring a solid black translucent mask covering the entire screen uniformly 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Switch to small screen display and click the hamburger icon
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/85943021/aea3a696-ad35-4b32-99e2-8aa1bfcd14b3)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
