### PR TITLE
Added Cancel button to book Edit Page and made layout of book edit pa…

### DIFF
--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -8,8 +8,6 @@ $putctx("robots", "noindex,nofollow")
 $:macros.HiddenSaveButton("addWork")
 
 <div id="contentHead">
-    <!-- removed class="editFormHead" -->
-    <!-- $:macros.databarEdit(work) -->
     $code:
         def find_mode():
             mode = query_param("mode")
@@ -37,13 +35,12 @@ $:macros.HiddenSaveButton("addWork")
             title = _("Editing...")
             note = ""
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+        $:macros.databarEdit(work)
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
                 <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>
             </form>
         </span>
-        $:macros.databarEdit(work)
-
 
     <h2 class="editFormTitle">$:title</h2>
     $if not ctx.user:

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -34,8 +34,8 @@ $:macros.HiddenSaveButton("addWork")
         else:
             title = _("Editing...")
             note = ""
+    $:macros.databarEdit(work)
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
-        $:macros.databarEdit(work)
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
                 <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -7,7 +7,9 @@ $putctx("robots", "noindex,nofollow")
 
 $:macros.HiddenSaveButton("addWork")
 
-<div id="contentHead" class="editFormHead">
+<div id="contentHead">
+    <!-- removed class="editFormHead" -->
+    <!-- $:macros.databarEdit(work) -->
     $code:
         def find_mode():
             mode = query_param("mode")
@@ -34,13 +36,16 @@ $:macros.HiddenSaveButton("addWork")
         else:
             title = _("Editing...")
             note = ""
-    <h2 class="editFormTitle">$:title</h2>
     $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
                 <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>
             </form>
         </span>
+        $:macros.databarEdit(work)
+
+
+    <h2 class="editFormTitle">$:title</h2>
     $if not ctx.user:
         $:render_template("lib/not_logged")
     $:note


### PR DESCRIPTION
Makes book edit page consistent with author edit page by changing layout and adding cancel button 

<!-- What issue does this PR close? -->
Closes #8883

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature: Adds Cancel button to author edit page

### Technical
Changes the html in order to reorder the book edit page to look consistent with author page
This implementation also adds cancel button to books that are recently added

### Testing
   1. docker compose up
  2. http://localhost:8080/
   3. Go find a book
   4. make Edit on book
    5. Look at side to see cancel button
    



### Screenshot
### New
![Screenshot from 2024-03-22 11-05-35](https://github.com/internetarchive/openlibrary/assets/56459277/2abe47c4-07b7-49ab-999b-695caafae3cb)
![Screenshot from 2024-03-22 11-08-03](https://github.com/internetarchive/openlibrary/assets/56459277/e8bd2b1d-8df6-4e06-aa01-1f5d58fbc9b7)
### Before
![Screenshot from 2024-03-22 11-08-57](https://github.com/internetarchive/openlibrary/assets/56459277/b0919226-5a9d-44aa-9c78-02e44cf406aa)


### Stakeholders
@RayBB

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
