### PR TITLE
Documentation: add docker troubleshooting when unable to connect to solr

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -135,14 +135,14 @@ First, verify the `solr` container is running (e.g. `docker ps | grep solr`, and
 
 If the `solr` container is running and the error persists, one cause seems to be that the containers become disconnected from `openlibrary_webnet` (though conceivably this could happen with `openlibrary_dbnet` too). `openlibrary-web-1`/`web` should be connected to both `openlibrary_webnet` and `openlibrary_dbnet`, but instead only one is connected. E.g.:
 ```sh
-❯ docker container inspect --format '{{.NetworkSettings.Networks}}' openlibrary-web-1
-map[openlibrary_dbnet:0xc00037c1c0]
+docker container inspect --format '{{.NetworkSettings.Networks}}' openlibrary-web-1
+# output: map[openlibrary_dbnet:0xc00037c1c0]
 ```
 A fix seems to be:
 ```
-❯ docker network connect openlibrary_webnet openlibrary-web-1
-❯ docker container inspect --format '{{.NetworkSettings.Networks}}' openlibrary-web-1
-map[openlibrary_dbnet:0xc00016c460 openlibrary_webnet:0xc00016c540]
+docker network connect openlibrary_webnet openlibrary-web-1
+docker container inspect --format '{{.NetworkSettings.Networks}}' openlibrary-web-1
+# output: map[openlibrary_dbnet:0xc00016c460 openlibrary_webnet:0xc00016c540]
 ```
 No restart is required. If `webnet` no longer exists, recreating it _may_ fix things: `docker network create openlibrary_webnet`. This is, however, speculation.
 


### PR DESCRIPTION
Recently a few people have experienced an error similar to:
```
/openlibrary/openlibrary/templates/home/index.html: error in processing
 template: ConnectionError: HTTPConnectionPool(host='solr', port=8983):
Max retries exceeded with url: /solr/openlibrary/select (Caused by
NameResolutionError("<urllib3.connection.HTTPConnection object at
0x77a95c4e7f90>: Failed to resolve 'solr' ([Errno -2] Name or service
not known)")) (falling back to default template)
```

This commit details one way to address this, as well as providing some context.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 
@benbdeitch 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
