### PR TITLE
Block .rdf from Googlebot crawling in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -10,3 +10,5 @@ Sitemap: https://openlibrary.org/static/sitemaps/siteindex.xml.gz
 User-agent: Baiduspider
 Crawl-delay: 0.5
 
+User-agent: Googlebot
+Disallow: /*.rdf$


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8959 

I'm seeing these a lot in the nginx logs lately, and they waste our crawl budget (~24%!) as well as cause unnecessary traffic to the site. So let's block 'em!


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
