### PR TITLE
Add ability to sort by different seeds of hourly/daily randoms

### DIFF
--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -51,7 +51,7 @@ class SearchScheme:
         'random_1_custom_seed asc'
         """
 
-        def process_individual_sort(sort: str):
+        def process_individual_sort(sort: str) -> str:
             if sort.startswith(('random_', 'random.hourly_', 'random.daily_')):
                 # Allow custom randoms; so anything random_* is allowed
                 # Also Allow custom time randoms to allow carousels with overlapping

--- a/openlibrary/plugins/worksearch/schemes/__init__.py
+++ b/openlibrary/plugins/worksearch/schemes/__init__.py
@@ -44,17 +44,27 @@ class SearchScheme:
         >>> scheme.process_user_sort('random')
         'random_1 asc'
         >>> scheme.process_user_sort('random_custom_seed')
-        'random_custom_seed asc'
+        'random_1_custom_seed asc'
         >>> scheme.process_user_sort('random_custom_seed desc')
-        'random_custom_seed desc'
+        'random_1_custom_seed desc'
         >>> scheme.process_user_sort('random_custom_seed asc')
-        'random_custom_seed asc'
+        'random_1_custom_seed asc'
         """
 
         def process_individual_sort(sort: str):
-            if sort.startswith('random_'):
+            if sort.startswith(('random_', 'random.hourly_', 'random.daily_')):
                 # Allow custom randoms; so anything random_* is allowed
-                return sort if ' ' in sort else f'{sort} asc'
+                # Also Allow custom time randoms to allow carousels with overlapping
+                # books to have a fresh ordering when on the same collection
+                sort_order: str | None = None
+                if ' ' in sort:
+                    sort, sort_order = sort.split(' ', 1)
+                random_type, random_seed = sort.split('_', 1)
+                solr_sort = self.sorts[random_type]
+                solr_sort_str = solr_sort() if callable(solr_sort) else solr_sort
+                solr_sort_field, solr_sort_order = solr_sort_str.split(' ', 1)
+                sort_order = sort_order or solr_sort_order
+                return f'{solr_sort_field}_{random_seed} {sort_order}'
             else:
                 solr_sort = self.sorts[sort]
                 return solr_sort() if callable(solr_sort) else solr_sort


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8965 .


### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Viewing https://testing.openlibrary.org/search?q=subject%3A("Reading+Level-Grade+11"+OR+"Reading+Level-Grade+12")+first_publish_year%3A[2000+TO+*]&sort=random.hourly returns the same results when refreshed or until the hour changes
- https://testing.openlibrary.org/search?q=subject%3A(%22Reading+Level-Grade+11%22+OR+%22Reading+Level-Grade+12%22)+first_publish_year%3A[2000+TO+*]&sort=random.hourly_1 has the same behaviour, but displays a different random than the above.

Note: Solr has a caveat that the order might change more frequently if the documents are edited.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
