### PR TITLE
Link new IA accounts to existing, previously linked OL account

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -826,7 +826,7 @@ def audit_accounts(
         link = ol_account.itemname if ol_account else None
 
         # The fact that there is no link implies either:
-        # 1. There was no Open Library account ever linked this IA account
+        # 1. There was no Open Library account ever linked to this IA account
         # 2. There is an OL account, and it was linked to this IA account at some point,
         #    but the linkage was broken at some point.
 

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -840,9 +840,9 @@ def audit_accounts(
             # Open Library account having the same email as our IA account must have
             # been linked to a different Internet Archive account.
             if ol_account and ol_account.itemname:
+                logger.error('IA <-> OL itemname mismatch', extra={'ol_itemname': ol_account.itemname, 'ia_itemname': ia_account.itemname})
                 ol_account.unlink()
                 ol_account.link(ia_account.itemname)
-                # return {'error': 'wrong_ia_account'}
 
         # At this point, it must either be the case that
         # (a) `ol_account` already links to our IA account (in which case `link` has a

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -825,14 +825,18 @@ def audit_accounts(
         ol_account = OpenLibraryAccount.get(link=ia_account.itemname, test=test)
         link = ol_account.itemname if ol_account else None
 
-        # The fact that there is no link implies no Open Library account exists
-        # containing a link to this Internet Archive account...
-        if not link:
-            # then check if there's an Open Library account which shares
-            # the same email as this IA account.
-            ol_account = OpenLibraryAccount.get(email=email, test=test)
+        # The fact that there is no link implies either:
+        # 1. There was no Open Library account ever linked this IA account
+        # 2. There is an OL account, and it was linked to this IA account at some point,
+        #    but the linkage was broken at some point.
 
-            # TODO: update comment:
+        # Today, it is possible for #2 to occur if a patron creates an IA account, deletes said
+        # account, then creates a new IA account using the same email that was used to create the
+        # original account.
+        if not link:
+            # If no account linkage is found, then check if there's an Open Library account
+            # which shares the same email as this IA account.
+            ol_account = OpenLibraryAccount.get(email=email, test=test)
 
             # If an Open Library account with a matching email account exists...
             # Check if it is linked already, i.e. has an itemname set. We already

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -832,13 +832,17 @@ def audit_accounts(
             # the same email as this IA account.
             ol_account = OpenLibraryAccount.get(email=email, test=test)
 
+            # TODO: update comment:
+
             # If an Open Library account with a matching email account exists...
             # Check if it is linked already, i.e. has an itemname set. We already
             # determined that no OL account is linked to our IA account. Therefore this
             # Open Library account having the same email as our IA account must have
             # been linked to a different Internet Archive account.
             if ol_account and ol_account.itemname:
-                return {'error': 'wrong_ia_account'}
+                ol_account.unlink()
+                ol_account.link(ia_account.itemname)
+                # return {'error': 'wrong_ia_account'}
 
         # At this point, it must either be the case that
         # (a) `ol_account` already links to our IA account (in which case `link` has a

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -844,7 +844,13 @@ def audit_accounts(
             # Open Library account having the same email as our IA account must have
             # been linked to a different Internet Archive account.
             if ol_account and ol_account.itemname:
-                logger.error('IA <-> OL itemname mismatch', extra={'ol_itemname': ol_account.itemname, 'ia_itemname': ia_account.itemname})
+                logger.error(
+                    'IA <-> OL itemname mismatch',
+                    extra={
+                        'ol_itemname': ol_account.itemname,
+                        'ia_itemname': ia_account.itemname,
+                    },
+                )
                 ol_account.unlink()
                 ol_account.link(ia_account.itemname)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8696

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Re-establishes linkage between existing Open Library account and an IA account that has been deleted but later recreated using the same email address.

Publishes an "IA <-> OL itemname mismatch" event to sentry, which includes the old and new `itemname`s in the "Additional Details" section (as `ol_itemname` and `ia_itemname`, respectively).

### Technical
<!-- What should be noted about the implementation? -->
`logger.error` calls automatically publish events to Sentry (details [here](https://docs.sentry.io/platforms/python/integrations/logging/#verify)).  Such event, however, do not contain the entire stacktrace.  Additional data that is included in the `extra` dict will appear in the event's "Additional Data" section.

> [!important]
> I've only included the old and new `itemname` in these Sentry events.  Will this be enough to determine if we're only entering the `if ol_account and ol_account.itemname` code block when 2 existing accounts become unlinked?

An "IA <-> OL itemname mismatch" Sentry event can be found [here](https://sentry.archive.org/organizations/ia-ux/issues/480372/events/969c127feee347a19d23d658b1aa711c/?project=7).
The extra data can be found in this [section](https://sentry.archive.org/organizations/ia-ux/issues/480372/events/969c127feee347a19d23d658b1aa711c/?project=7#extra).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I've tested this by doing the following:

1. Creating a new IA account with Google Sign-in.
2. Logging into OL using Google Sign-in.
3. Deleting the account on IA.
4. Creating a new IA account with Google Sign-in, using the same Google account that was used in step 1.
5. Logging into OL again using Google Sign-in.

On success, I was redirected to the My Books page.
When this fails, the login page is reloaded without an error message.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 
@seabelis 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
