### PR TITLE
Check for work key before rendering list showcase

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -529,7 +529,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
           </div>
           <div class="user-book-options">
             <div class="Tools tools-override">
-              $if work:
+              $if work and work.key:
                 $ component_times['lists widget: WorkListTime'] = time()
                 $:render_template("lists/widget", work, include_header=False, include_widget=False)
                 $ component_times['lists widget: WorkListTime'] = time() - component_times['lists widget: WorkListTime']


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8983

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Checks for a work key before rendering the work list showcase on book pages.

### Technical
<!-- What should be noted about the implementation? -->
On orphaned edition book pages, an `IndexError` was being thrown by the `get_seed_info` call in `lists/widget.html`, [here](https://github.com/internetarchive/openlibrary/blob/7755d8cc3a392740cca35e8539eccc23749270fc/openlibrary/templates/lists/widget.html#L16).  In these cases, a dummy `Work` object, which has an empty string as its `key`, is passed to `get_seed_info`, which requires a `Thing` with a non-empty string to function correctly.

Since the dummy `work` object is truthy, we also have to check for a `work.key` before rendering the work list showcase.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit an orphaned edition's book page.  Ensure that there are no error messages rendered on the page ("Lists" section and flash message).
2. Visit a work's book page and a non-orphaned edition's book page.  Confirm that these are rendering without error.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
