### PR TITLE
Allow Docker to install `web.py` from git rather than latest release

### DIFF
--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -11,7 +11,7 @@ RUN python -m pip install -r requirements_test.txt \
 USER root
 RUN ln -s /home/openlibrary/.local/bin/pytest /usr/local/bin/pytest
 # For i18n scripts, which run as root (to modify the host filesystem) and need these packages.
-RUN pip install $(grep -E 'web\.py==|Babel==' requirements.txt)
+RUN pip install $(grep -E 'webpy\.git|web\.py==|Babel==' requirements.txt)
 USER openlibrary
 
 COPY --chown=openlibrary:openlibrary package*.json ./

--- a/docker/Dockerfile.oldev
+++ b/docker/Dockerfile.oldev
@@ -11,7 +11,7 @@ RUN python -m pip install -r requirements_test.txt \
 USER root
 RUN ln -s /home/openlibrary/.local/bin/pytest /usr/local/bin/pytest
 # For i18n scripts, which run as root (to modify the host filesystem) and need these packages.
-RUN pip install $(grep -E 'webpy\.git|web\.py==|Babel==' requirements.txt)
+RUN pip install $(grep -E 'webpy\.git|web\.py==|multipart==|Babel==' requirements.txt)
 USER openlibrary
 
 COPY --chown=openlibrary:openlibrary package*.json ./


### PR DESCRIPTION
<!-- What issue does this PR close? -->


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Fixes bug that was preventing successful runs of the `i18n` script to `extract` messages in Docker by ensuring Docker installs the `git`-installed version of `web.py` if that is what is in `requirements.txt`.

### Technical
<!-- What should be noted about the implementation? -->
Currently Docker runs of the script are causing `TokenError`s as a result of a mismatch between Python 3.12 and the `web.py` version, which was solved in a recent `web.py` git commit, but not in the latest release.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Start a Docker container
2. Run the following command: `docker compose run --rm -uroot home ./scripts/i18n-messages extract`
A new `messages.pot` file should be generated!

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
