### PR TITLE
Switch to urllib for parsing query string in changequery

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -852,7 +852,7 @@ api and api.add_hook('new', new)
 @public
 def changequery(query=None, **kw):
     if query is None:
-        query = web.input(_method='get', _unicode=False)
+        query = parse_qs(web.ctx.env.get("QUERY_STRING", ""))
     for k, v in kw.items():
         if v is None:
             query.pop(k, None)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8994 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes an issue where when multiple filters from the same category are added and then a filter from a different category is added using the side menu, only one of the multiple filters from the same category remain. 

### Technical
<!-- What should be noted about the implementation? -->
This bug occurred because we used `web.input` to generate our query dict, but doing so keeps only the last parameter if there are multiple that share the same key value. This pull request instead gets the query string from `web.ctx.env` and uses urllib to parse it. This keeps all parameters in the query intact. 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. On the book search page, apply multiple filters from the same category (subjects would be the easiest)
2. Apply a filter from a different category (e.g. language)
3. All filters should remain

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
If I have the following subject filters selected:
![image](https://github.com/internetarchive/openlibrary/assets/19312856/96bd17f6-6d47-48f8-8650-f534c3c086fe)

Adding a filter from a different category will not cause any of the previous filters to disappear:
![image](https://github.com/internetarchive/openlibrary/assets/19312856/b8cb33c0-eb3e-457b-86dd-4a17bf0b90da)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
