### PR TITLE
Fix incorrect `msgstr`

### DIFF
--- a/openlibrary/i18n/it/messages.po
+++ b/openlibrary/i18n/it/messages.po
@@ -1569,7 +1569,7 @@ msgstr "Email di verifica inviata"
 #: account/verify/success.html:10
 #, python-format
 msgid "Hi, %(user)s"
-msgstr "Ciao, %(users)s"
+msgstr "Ciao, %(user)s"
 
 #: account/email/forgot-ia.html:10 account/email/forgot.html:10
 msgid "Forgot Your Internet Archive Email?"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This is causing a `KeyError` on Italian `/account/create` pages (example Sentry event [here](https://sentry.archive.org/organizations/ia-ux/issues/363272/?query=is%3Aunresolved&referrer=issue-stream)).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
