### PR TITLE
Set default author book count to zero

### DIFF
--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -26,7 +26,7 @@ $if books and books.docs:
     $ book_titles_excerpt = [work.title for work in books.docs[:8]]
     $ book_list_excerpt = ', '.join(book_titles_excerpt)
 
-$ num_found = books.num_found or 0
+$ books_count = books.num_found or 0
 
 $ description = _("Author of %(book_titles)s", book_titles=book_list_excerpt)
 $putctx("description", description)
@@ -111,11 +111,11 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
         <div class="clearfix"></div>
         <div id="works" class="section">
                 <h2 class="collapse">
-                    $ungettext("%(count)d work", "%(count)d works", num_found, count=num_found)
+                    $ungettext("%(count)d work", "%(count)d works", books_count, count=books_count)
                     <span class="count smaller"><a href="/books/add?author=$page.key">$_('Add another?')</a></span>
                 </h2>
                 <p id="books">
-                $if num_found > 1:
+                $if books_count > 1:
                     $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
 
                 <p>
@@ -135,7 +135,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                   <input type="submit"/>
                 </form>
 
-                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=num_found)
+                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books_count)
 
                 <div id="searchResults">
                     <ul class="list-books">
@@ -145,7 +145,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     </ul>
                 </div>
 
-                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=num_found)
+                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books_count)
         </div>
     </div>
     <div class="contentOnethird">
@@ -163,7 +163,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 </div>
 
         <!-- SUBJECTS DISPLAY -->
-        $if num_found > 0:
+        $if books_count > 0:
             $:render_subjects(_("Subjects"), books.facet_counts.get('subject_facet'), '')
             $:render_subjects(_("Places"), books.facet_counts.get('place_facet'), 'place:')
             $:render_subjects(_("People"), books.facet_counts.get('person_facet'), 'person:')

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -25,6 +25,9 @@ $ book_list_excerpt = ''
 $if books and books.docs:
     $ book_titles_excerpt = [work.title for work in books.docs[:8]]
     $ book_list_excerpt = ', '.join(book_titles_excerpt)
+
+$ num_found = books.num_found or 0
+
 $ description = _("Author of %(book_titles)s", book_titles=book_list_excerpt)
 $putctx("description", description)
 
@@ -108,11 +111,11 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
         <div class="clearfix"></div>
         <div id="works" class="section">
                 <h2 class="collapse">
-                    $ungettext("%(count)d work", "%(count)d works", books.num_found, count=books.num_found)
+                    $ungettext("%(count)d work", "%(count)d works", num_found, count=num_found)
                     <span class="count smaller"><a href="/books/add?author=$page.key">$_('Add another?')</a></span>
                 </h2>
                 <p id="books">
-                $if books.num_found > 1:
+                $if num_found > 1:
                     $:render_template("search/sort_options.html", books.sort, exclude='relevance', default_sort='editions')
 
                 <p>
@@ -132,7 +135,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                   <input type="submit"/>
                 </form>
 
-                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
+                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=num_found)
 
                 <div id="searchResults">
                     <ul class="list-books">
@@ -142,7 +145,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                     </ul>
                 </div>
 
-                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=books.num_found)
+                $:macros.Pager(page=safeint(query_param('page'), default=1), num_found=num_found)
         </div>
     </div>
     <div class="contentOnethird">
@@ -160,7 +163,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
                 </div>
 
         <!-- SUBJECTS DISPLAY -->
-        $if books.num_found > 0:
+        $if num_found > 0:
             $:render_subjects(_("Subjects"), books.facet_counts.get('subject_facet'), '')
             $:render_subjects(_("Places"), books.facet_counts.get('place_facet'), 'place:')
             $:render_subjects(_("People"), books.facet_counts.get('person_facet'), 'person:')


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Naive solution for these Sentry [events](https://sentry.archive.org/organizations/ia-ux/issues/469294/events/c61d5ccdbd4044f3ba471874a36da3f1/events/?project=7&referrer=events-table%2F%3Fenvironment%3Dproduction&statsPeriod=14d).

`books.num_found` can sometimes be `None`.  This change creates a new `num_found` variable that hold the immutable `books.num_found` value, or 0 if none exists.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This [page](https://openlibrary.org/authors/OL120205A/Marcel_Proust?has_fulltext=true&q=1%C0%A7%C0%A2%252527%252522%5C%27%5C%22&debug=true) fails to load in production, but works in testing with this branch deployed.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
