### PR TITLE
Feature: remove suspect `publish_date` values from AMZ/BWB

### DIFF
--- a/openlibrary/catalog/add_book/tests/test_add_book.py
+++ b/openlibrary/catalog/add_book/tests/test_add_book.py
@@ -1617,3 +1617,131 @@ class TestNormalizeImportRecord:
     def test_dummy_data_to_satisfy_parse_data_is_removed(self, rec, expected):
         normalize_import_record(rec=rec)
         assert rec == expected
+
+    @pytest.mark.parametrize(
+        ["rec", "expected"],
+        [
+            (
+                # 1900 publication from non AMZ/BWB is okay.
+                {
+                    'title': 'a title',
+                    'source_records': ['ia:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': '1900',
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['ia:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': '1900',
+                },
+            ),
+            (
+                # 1900 publication from AMZ disappears.
+                {
+                    'title': 'a title',
+                    'source_records': ['amazon:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': '1900',
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['amazon:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                },
+            ),
+            (
+                # 1900 publication from bwb item disappears.
+                {
+                    'title': 'a title',
+                    'source_records': ['bwb:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': '1900',
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['bwb:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                },
+            ),
+            (
+                # 1900 publication from promise item disappears.
+                {
+                    'title': 'a title',
+                    'source_records': ['promise:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': 'January 1, 1900',
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['promise:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                },
+            ),
+            (
+                # An otherwise valid date from AMZ is okay.
+                {
+                    'title': 'a title',
+                    'source_records': ['amazon:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': 'January 2, 1900',
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['amazon:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': 'January 2, 1900',
+                },
+            ),
+            (
+                # An otherwise valid date from promise is okay.
+                {
+                    'title': 'a title',
+                    'source_records': ['promise:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': 'January 2, 1900',
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['promise:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                    'publish_date': 'January 2, 1900',
+                },
+            ),
+            (
+                # Handle records without publish_date.
+                {
+                    'title': 'a title',
+                    'source_records': ['promise:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                },
+                {
+                    'title': 'a title',
+                    'source_records': ['promise:someid'],
+                    'publishers': ['a publisher'],
+                    'authors': [{'name': 'an author'}],
+                },
+            ),
+        ],
+    )
+    def test_year_1900_removed_from_amz_and_bwb_promise_items(self, rec, expected):
+        """
+        A few import sources (e.g. promise items, BWB, and Amazon) have `publish_date`
+        values that are known to be inaccurate, so those `publish_date` values are
+        removed.
+        """
+        normalize_import_record(rec=rec)
+        assert rec == expected


### PR DESCRIPTION
Closes #8969

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Certain import sources, such as Amazon and BWB, have `publish_date` values that are known to be suspect, such as `1900` or `January 1, 1900`.

This commit removes the `publish_date` value from those import records prior to import.

Specifically, the `publish_date` value is removed in the following situations:
1. The import record has a `source_record` value starting with `amazon`, `bwb`, or `promise`; and
2. the `publish_date` is either `1900` or `January 1, 1900`.

### Questions
<!-- What should be noted about the implementation? -->
I want to verify the above above conditions for removal are correct.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See the unit tests.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 
@judec 
@hornc 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
