### PR TITLE
Added warning about OpenAPI definitions

### DIFF
--- a/static/openapi.json
+++ b/static/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Open Library API",
     "version": "0.1.0",
-    "description": "- These are still in development and may not be perfect\n- Contribute by proposing edits to [openapi.json](https://github.com/internetarchive/openlibrary/blob/master/static/openapi.json)\n- Please do not use our APIs for bulk downloads, see [dev center](https://openlibrary.org/developers/api)"
+    "description": "- These are still in development and may not be perfect\n- Contribute by proposing edits to [openapi.json](https://github.com/internetarchive/openlibrary/blob/master/static/openapi.json)\n- Please do not use our APIs for bulk downloads, see [dev center](https://openlibrary.org/developers/api)\n-As Swagger only contains a subset of the API, please see the API pages in the developer's docs for the full set."
   },
   "tags": [
     {

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Open Library API",
     "version": "0.1.0",
-    "description": "- These are still in development and may not be perfect\n- Contribute by proposing edits to [openapi.json](https://github.com/internetarchive/openlibrary/blob/master/static/openapi.json)\n- Please do not use our APIs for bulk downloads, see [dev center](https://openlibrary.org/developers/api)\n-As Swagger only contains a subset of the API, please see the API pages in the developer's docs for the full set."
+    "description": "- These are still in development and may not be perfect\n- Contribute by proposing edits to [openapi.json](https://github.com/internetarchive/openlibrary/blob/master/static/openapi.json)\n- Please do not use our APIs for bulk downloads, see [dev center](https://openlibrary.org/developers/api) \n- (Warning!) As Swagger only contains a subset of the API, please see the API pages in the developer's docs for the full set."
   },
   "tags": [
     {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8474

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add warning about OpenAPI definitions that swagger only includes subset of api and people should view developer's docs for the full set.

### Technical
<!-- What should be noted about the implementation? -->
Adds more to open library swagger docs page adding disclaimer that it is not all of the docs.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

   1.  docker compose up
    2. http://localhost:8080/
   3. Go to add swagger/docs#/ to url or http://localhost:8080/swagger/docs#/
   4. View changed swagger docs page

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before
![Screenshot from 2024-04-02 14-02-04](https://github.com/internetarchive/openlibrary/assets/56459277/af3f0e2f-d871-4bf4-803a-99bb54915303)
After
![Screenshot from 2024-04-02 14-05-30](https://github.com/internetarchive/openlibrary/assets/56459277/d55265da-90b2-4116-af8a-fee66bea881c)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
