### PR TITLE
Add author date when showing author name, closes #7799, supersedes #8076

### DIFF
--- a/openlibrary/macros/BookByline.html
+++ b/openlibrary/macros/BookByline.html
@@ -1,8 +1,20 @@
-$def with(author_names_and_urls, limit=None, overflow_url=None, attrs='')
+$def with(author_data, limit=None, overflow_url=None, attrs='', show_years=False)
 
-$def render_author_link(name, url):
+$def render_author_link(author):
+  $ name = author.get("name")
+  $ url = author.get("url")
   $ rendered_name = cond(name, truncate(name, 40), _("Unknown author"))
-  $if url:
+  $if show_years and author.get("birth_date"):
+    $ birth_date_formatted = author.get("birth_date")[-4:]
+    $if author.get("death_date"):
+      $ death_date_formatted = author.get("death_date")[-4:]
+    $else:
+      $ death_date_formatted = ''
+  $if url and author.get("birth_date"):
+    <a href="$url" $:attrs>$rendered_name ($birth_date_formatted - $death_date_formatted)</a>
+  $elif author.get("birth_date"):
+    <span $:attrs>$rendered_name ($birth_date_formatted - $death_date_formatted)</span>
+  $elif url:
     <a href="$url" $:attrs>$rendered_name</a>
   $else:
     <span $:attrs>$rendered_name</span>
@@ -12,10 +24,10 @@ $def render_overflow_link(remaining_authors, overflow_url):
 
 $code:
   if limit is None:
-    limit = len(author_names_and_urls)
+    limit = len(author_data)
 
-  remaining_authors = max(0, len(author_names_and_urls) - limit)
-  render_items = [render_author_link(name, url) for name, url in author_names_and_urls][:limit]
+  remaining_authors = max(0, len(author_data) - limit)
+  render_items = [render_author_link(author) for author in author_data][:limit]
 
   if remaining_authors > 0:
     render_items.append(render_overflow_link(remaining_authors, overflow_url))

--- a/openlibrary/macros/SearchResultsWork.html
+++ b/openlibrary/macros/SearchResultsWork.html
@@ -73,14 +73,14 @@ $code:
             <em>$_('Unknown author')</em>
           $else:
             $code:
-              author_names_and_urls = [
-                (
-                  a.get('name') or a.get('author', {}).get('name'),
-                  a.get('url') or a.get('key') or a.get('author', {}).get('url') or a.get('author', {}).get('key')
-                )
+              author_data = [
+                {
+                  "name": a.get('name') or a.get('author', {}).get('name'),
+                  "url": a.get('url') or a.get('key') or a.get('author', {}).get('url') or a.get('author', {}).get('key')
+                }
                 for a in authors
               ]
-            $:macros.BookByline(author_names_and_urls, limit=max_rendered_authors, overflow_url=work_edition_url, attrs='class="results"')
+            $:macros.BookByline(author_data, limit=max_rendered_authors, overflow_url=work_edition_url, attrs='class="results"')
         </span>
         <span class="resultPublisher">
           $if doc.get('first_publish_year'):

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -78,7 +78,7 @@ $else:
                     </a>
                     </span>
                     <span class="author">
-                    $:macros.BookByline([(a.name, a.url()) for a in book.get_authors()])
+                    $:macros.BookByline([{"name": a.name, "url": a.url()} for a in book.get_authors()])
                     </span>
                     <div class="date">
                     Borrowed $datestr(datetime_from_utc_timestamp(loan['loaned_at']))
@@ -161,7 +161,7 @@ $else:
                               <a href="$book.key" class="borrowResults"><strong>$book.title</strong></a>
                           </span>
                           <span class="author">
-                              $:macros.BookByline([(a.name, a.url()) for a in book.get_authors()])
+                              $:macros.BookByline([{"name": a.name, "url": a.url()} for a in book.get_authors()])
                           </span>
                           <div class="date">
                               $ ndays = record.get_waiting_in_days()

--- a/openlibrary/templates/admin/loans_table.html
+++ b/openlibrary/templates/admin/loans_table.html
@@ -63,7 +63,7 @@ $else:
                     </span>
 
                     <span class="author">
-                    $# :macros.BookByline([(a.name, a.url()) for a in book.get_authors()])
+                    $# :macros.BookByline([{"name": a.name, "url": a.url()} for a in book.get_authors()])
                     </span>
                     <div class="date">
                     $if waiting_loan:

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -56,7 +56,7 @@ $:macros.HiddenSaveButton("addWork")
         <h1 class="editFormBookTitle">$this_title</h1>
         $if authors:
             <h3 class="editFormBookAuthors">
-                $:macros.BookByline([(author.name, author.url()) for author in authors])
+                $:macros.BookByline([{"name": a.name, "url": a.url()} for author in authors])
             </h3>
         <div id="tabsAddbook">
             <ul>

--- a/openlibrary/templates/type/edition/title_and_author.html
+++ b/openlibrary/templates/type/edition/title_and_author.html
@@ -37,11 +37,11 @@ $ view_type = 'desktop' if for_desktop else 'mobile'
     $ author_names = (work or edition).author_names
     $if authors:
       <h2 class="edition-byline">
-        $:macros.BookByline([(author.name, author.url()) for author in authors], attrs='itemprop="author"')
+        $:macros.BookByline([{"name": author.name, "url": author.url(), "birth_date": author.birth_date, "death_date": author.death_date} for author in authors], attrs='itemprop="author"', show_years=True)
       </h2>
     $elif author_names:
       <h2 class="edition-byline">
-        $:macros.BookByline([(name, None) for name in author_names], attrs='itemprop="author"')
+        $:macros.BookByline([{"name": name} for name in author_names], attrs='itemprop="author"')
       </h2>
     $:star_ratings_stats
   </span>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7799

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[feature]

### Technical
<!-- What should be noted about the implementation? -->
Updated version of #8076 as that PR is inactive. Started out by copying the original PR, addressing its comments, re-testing the solution and fixing an issue I found while testing.

Differences to #8076:
- Removed added integration test as integration tests have now been generally removed
- Don't show the ( - ) if no birth date is known. It should show when no death date is set, but not if there's no birth date either
- Addressed comments from @cdrini to use a dict for the data and only show the years on the book page specficially

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Navigate to a random book and check if the author is showing a birth and death year.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![example of the change](https://github.com/internetarchive/openlibrary/assets/12281102/64b6302b-114d-435b-a353-bd8a01cf4557)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
