### PR TITLE
Show error message on Google sign-in failure

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
+++ b/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
@@ -21,9 +21,20 @@ export function initMessageEventListener(element) {
                 method: 'POST',
                 credentials: 'include',
                 body: JSON.stringify(e.data.s3)
-            }).then(function() {
-                window.location = new URLSearchParams(window.location.search).get('redirect') || '/account/loans';
-            });
+            })
+                .then((resp) => {
+                    if (resp.ok) {
+                        window.location = new URLSearchParams(window.location.search).get('redirect') || '/account/loans';
+                    }
+                    return resp.json()
+                })
+                .then((error) => {
+                    const loginForm = document.querySelector('#register')
+                    const errorDiv = document.createElement('div')
+                    errorDiv.classList.add('note')
+                    errorDiv.textContent = error.errorDisplayString
+                    loginForm.insertAdjacentElement('afterbegin', errorDiv)
+                })
         }
     }
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -341,7 +341,11 @@ class account_login_json(delegate.page):
             )
             error = audit.get('error')
             if error:
-                raise olib.code.BadRequest(error)
+                resp = {
+                    'error': error,
+                    'errorDisplayString': LOGIN_ERRORS[error],
+                }
+                raise olib.code.BadRequest(json.dumps(resp))
             expires = 3600 * 24 * 365 if remember.lower() == 'true' else ""
             web.setcookie(config.login_cookie_name, web.ctx.conn.get_auth_token())
             if audit.get('ia_email'):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9019

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Shows error message on Google sign-in failures.

### Technical
<!-- What should be noted about the implementation? -->
If the response from the `/account/login.json` call is ok, we immediately redirect to the patron's account page (this is BAU).  Otherwise, we display the localized error message in a newly created `.note` `div`.

The `account/login.json` handler has been updated to return a JSON string containing the error short code and the localized error message when a `BadRequest` is raised.  Previously, only the error short code was returned in these cases (it wasn't even JSON encoded...).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Recommend testing this before #8980 is deployed and tested.

1. Delete an existing IA account that was created using Google sign-in.
2. Re-create the IA account using the same Google account.
3. Attempt to log into OL using Google sign-in.  If you see an error like the one in the screenshot, below, this code is working as expected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/28732543/40413b61-ed1f-4d53-a4ea-d767bb8d907f)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
