### PR TITLE
Modified alt text from Template to Page

### DIFF
--- a/openlibrary/macros/databarHistory.html
+++ b/openlibrary/macros/databarHistory.html
@@ -22,7 +22,7 @@ $else:
             <a
                 class="linkButton larger"
                 href="$edit_url"
-                title="$_('Edit this template')"
+                title="$_('Edit this page')"
                 data-ol-link-track="CTAClick|Edit"
                 accesskey="e"
                 rel="nofollow"

--- a/openlibrary/macros/databarTemplate.html
+++ b/openlibrary/macros/databarTemplate.html
@@ -2,7 +2,7 @@ $def with (page)
 
 <div id="editTools" class="edit">
     <div id="editHistory">
-      <a class="linkButton larger" href="$changequery(m='history')" title="View this template's edit history" accesskey="h">$_("History")</a>
+      <a class="linkButton larger" href="$changequery(m='history')" title="View this page's edit history" accesskey="h">$_("History")</a>
     </div>
     <div class="editButton">
         <a

--- a/openlibrary/macros/databarTemplate.html
+++ b/openlibrary/macros/databarTemplate.html
@@ -8,7 +8,7 @@ $def with (page)
         <a
           class="linkButton larger"
           href="$changequery(m='edit')"
-          title="Edit this template"
+          title="Edit this page"
           data-ol-link-track="CTAClick|Edit"
           accesskey="e"
           rel="nofollow"

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -30,7 +30,7 @@ $else:
           <a
             class="cta-btn cta-btn--vanilla"
             href="$edit_url"
-            title="$_('Edit this template')"
+            title="$_('Edit this page')"
             data-ol-link-track="CTAClick|Edit"
             accesskey="e"
             rel="nofollow"

--- a/openlibrary/macros/databarView.html
+++ b/openlibrary/macros/databarView.html
@@ -20,9 +20,9 @@ $else:
         $else:
             <div class="brown smaller sansserif">$_("Last edited anonymously")</div>
         $if page.url:
-            <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$page.url(m='history')" rel="nofollow" title="View this template's edit history">$_('History')</a></div>
+            <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$page.url(m='history')" rel="nofollow" title="View this page's edit history">$_('History')</a></div>
         $else:
-            <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$changequery(m='history')" rel="nofollow" title="View this template's edit history">$_('History')</a></div>
+            <div class="smallest gray sansserif">$(page.last_modified and datestr(page.last_modified)) | <a href="$changequery(m='history')" rel="nofollow" title="View this page's edit history">$_('History')</a></div>
     </div>
     $if edit and not page.is_fake_record():
         <div class="editButton">

--- a/openlibrary/templates/admin/profile.html
+++ b/openlibrary/templates/admin/profile.html
@@ -1,3 +1,3 @@
 $def with (page)
 
-<button class="linkButton" url="/admin$page.key" title="Edit this template" accesskey="e">$_("Admin")</button>
+<button class="linkButton" url="/admin$page.key" title="Edit this page" accesskey="e">$_("Admin")</button>

--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -6,7 +6,7 @@ $def with (book_title, edit_url)
     <a
       class="linkButton linkButton--large"
       href="$edit_url"
-      title="$_('Edit this template')"
+      title="$_('Edit this page')"
       data-ol-link-track="CTAClick|StickyEdit"
       rel="nofollow"
     >$_("Edit")</a>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9012

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Modifies the Alt text for the History button from Template to Page.

### Stakeholders
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->