### PR TITLE
Create Sentry factory

### DIFF
--- a/conf/coverstore.yml
+++ b/conf/coverstore.yml
@@ -7,10 +7,3 @@ db_parameters:
 
 data_root: "/var/lib/coverstore"
 default_image: "static/images/empty.gif"
-
-sentry:
-    enabled: false
-    # Dummy endpoint; where sentry logs are sent to
-    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
-    traces_sample_rate: 1.0
-    environment: 'local'

--- a/conf/infobase.yml
+++ b/conf/infobase.yml
@@ -22,11 +22,3 @@ cache:
 
 errorlog: /var/log/openlibrary/infobase/errorlog
 writelog: /var/lib/openlibrary/infobase/writelog
-
-sentry:
-    enabled: false
-    # Dummy endpoint; where sentry logs are sent
-    # `dns` field is placeholder & needs to be changed to a real url
-    # when/if `enabled: true`
-    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
-    environment: 'local'

--- a/conf/openlibrary.yml
+++ b/conf/openlibrary.yml
@@ -178,18 +178,5 @@ ia_civicrm_api:
     site_key: XXX
     auth: XXX
 
-sentry:
-    enabled: false
-    # Dummy endpoint; where sentry logs are sent to
-    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
-    traces_sample_rate: 1.0
-    environment: 'local'
-
-sentry_cron_jobs:
-    enabled: false
-    # Dummy endpoint; where sentry logs are sent to
-    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
-    environment: 'local'
-
 # Observations cache settings:
 observation_cache_duration: 86400

--- a/conf/sentry.yml
+++ b/conf/sentry.yml
@@ -1,0 +1,26 @@
+# Open Library's Sentry configurations
+
+# Dummy endpoints used for `dns` fields as placeholders.  These must be
+# changed to a real URL when and if `enabled: true`
+
+ol_covers:
+    enabled: false
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    traces_sample_rate: 1.0
+    environment: 'local'
+
+ol_infobase:
+    enabled: false
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    environment: 'local'
+
+ol_web:
+    enabled: false
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    traces_sample_rate: 1.0
+    environment: 'local'
+
+ol_cron_jobs:
+    enabled: false
+    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
+    environment: 'local'

--- a/openlibrary/coverstore/server.py
+++ b/openlibrary/coverstore/server.py
@@ -7,7 +7,7 @@ import yaml
 import web
 
 from openlibrary.coverstore import config, code, archive
-from openlibrary.utils.sentry import Sentry
+from openlibrary.utils.sentry import sentry_factory
 
 
 def runfcgi(func, addr=('localhost', 8000)):
@@ -39,9 +39,8 @@ def load_config(configfile):
 def setup(configfile: str) -> None:
     load_config(configfile)
 
-    sentry = Sentry(getattr(config, 'sentry', {}))
+    sentry = sentry_factory.get_instance('ol_covers')
     if sentry.enabled:
-        sentry.init()
         sentry.bind_to_webpy_app(code.app)
 
 

--- a/openlibrary/plugins/openlibrary/sentry.py
+++ b/openlibrary/plugins/openlibrary/sentry.py
@@ -1,15 +1,13 @@
-import infogami
 from infogami.utils import delegate
-from openlibrary.utils.sentry import Sentry, InfogamiSentryProcessor
+from openlibrary.utils.sentry import Sentry, InfogamiSentryProcessor, sentry_factory
 
 sentry: Sentry | None = None
 
 
 def setup():
     global sentry
-    sentry = Sentry(getattr(infogami.config, 'sentry', {}))
+    sentry = sentry_factory.get_instance('ol_web')
 
     if sentry.enabled:
-        sentry.init()
         delegate.add_exception_hook(lambda: sentry.capture_exception_webpy())
         delegate.app.add_processor(InfogamiSentryProcessor(delegate.app))

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -90,6 +90,7 @@ class SentryFactory:
     Keeps reference to each `Sentry` object in use by Open Library,
     and provides an easy way to request a `Sentry` instance.
     """
+
     def __init__(self, config_path):
         """
         Creates new `SentryFactory` object.
@@ -126,6 +127,7 @@ class SentryFactory:
 
 
 sentry_factory = SentryFactory('conf/sentry.yml')
+
 
 @dataclass
 class InfogamiRoute:

--- a/scripts/infobase-server
+++ b/scripts/infobase-server
@@ -19,7 +19,7 @@ import sys
 import _init_path  # noqa: F401  Imported for its side effect of setting PYTHONPATH
 import web
 
-from openlibrary.utils.sentry import Sentry
+from openlibrary.utils.sentry import sentry_factory
 
 logger = logging.getLogger("openlibrary." + __file__)
 
@@ -45,9 +45,8 @@ def start(config_file, *args):
 
     server.load_config(config_file)
 
-    sentry = Sentry(getattr(server.config, 'sentry', {}))
+    sentry = sentry_factory.get_instance('ol_infobase')
     if sentry.enabled:
-        sentry.init()
         sentry.bind_to_webpy_app(server.app)
 
     # remove config from command line args

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -26,17 +26,9 @@ if __name__ == "__main__":
 
     log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.12.2
 
-    sentry_config = os.getenv('SENTRY_CONFIG')
-    if sentry_config:
-        logger.info(f"loading config from {sentry_config}")
-        # Squelch output from infobase (needed for sentry setup)
-        # So it doesn't end up in our data dumps body
-        with open(os.devnull, 'w') as devnull, redirect_stdout(devnull):
-            # XXX : Does this script require us to load the `OL_CONFIG` for anything other than Sentry?
-            # XXX : If the sentry config is loaded in `sentry.py`, does it need to be loaded here?
-            load_config(sentry_config)
-        sentry = sentry_factory.get_instance('ol_cron_jobs')
+    logger.info("Getting Sentry instance")
+    sentry = sentry_factory.get_instance('ol_cron_jobs')
 
-    log(f"sentry.enabled = {bool(sentry_config and sentry.enabled)}")
+    log(f"sentry.enabled = {bool(sentry and sentry.enabled)}")
 
     dump.main(sys.argv[1], sys.argv[2:])

--- a/scripts/oldump.py
+++ b/scripts/oldump.py
@@ -20,23 +20,23 @@ def log(*args) -> None:
 
 if __name__ == "__main__":
     from contextlib import redirect_stdout
-    from infogami import config
     from openlibrary.config import load_config
     from openlibrary.data import dump
-    from openlibrary.utils.sentry import Sentry
+    from openlibrary.utils.sentry import sentry_factory
 
     log("{} on Python {}.{}.{}".format(sys.argv, *sys.version_info))  # Python 3.12.2
 
-    ol_config = os.getenv("OL_CONFIG")
-    if ol_config:
-        logger.info(f"loading config from {ol_config}")
+    sentry_config = os.getenv('SENTRY_CONFIG')
+    if sentry_config:
+        logger.info(f"loading config from {sentry_config}")
         # Squelch output from infobase (needed for sentry setup)
         # So it doesn't end up in our data dumps body
         with open(os.devnull, 'w') as devnull, redirect_stdout(devnull):
-            load_config(ol_config)
-        sentry = Sentry(getattr(config, "sentry_cron_jobs", {}))
-        if sentry.enabled:
-            sentry.init()
-    log(f"sentry.enabled = {bool(ol_config and sentry.enabled)}")
+            # XXX : Does this script require us to load the `OL_CONFIG` for anything other than Sentry?
+            # XXX : If the sentry config is loaded in `sentry.py`, does it need to be loaded here?
+            load_config(sentry_config)
+        sentry = sentry_factory.get_instance('ol_cron_jobs')
+
+    log(f"sentry.enabled = {bool(sentry_config and sentry.enabled)}")
 
     dump.main(sys.argv[1], sys.argv[2:])

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -41,7 +41,6 @@ SCRIPTS=/openlibrary/scripts
 PSQL_PARAMS=${PSQL_PARAMS:-"-h db openlibrary"}
 TMPDIR=${TMPDIR:-/openlibrary}
 OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
-SENTRY_CONFIG=/openlibrary/conf/sentry.yml
 
 yyyymmdd=$1  # 2022-05-31
 yyyymm=${yyyymmdd:0:7}  # 2022-05-31 --> 2022-05

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -41,6 +41,7 @@ SCRIPTS=/openlibrary/scripts
 PSQL_PARAMS=${PSQL_PARAMS:-"-h db openlibrary"}
 TMPDIR=${TMPDIR:-/openlibrary}
 OL_CONFIG=${OL_CONFIG:-/openlibrary/conf/openlibrary.yml}
+SENTRY_CONFIG=/openlibrary/conf/sentry.yml
 
 yyyymmdd=$1  # 2022-05-31
 yyyymm=${yyyymmdd:0:7}  # 2022-05-31 --> 2022-05


### PR DESCRIPTION
Closes #9031
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Makes the following Sentry-related changes:
1. Consolidates all Sentry configurations in a single file
2. Creates `SentryFactory` object, which initializes and provides access to each `Sentry` instance

The hope is that this will make our code more readable, and allow us to obtain a reference to any `Sentry` instance, which may be needed to capture notable handled exceptions.

### Technical
<!-- What should be noted about the implementation? -->
A single `SentryFactory` instance is available for import from `/openlibrary/utils`.  The factory exposes `Sentry` instances via the `get_instance` method, which takes a string identifier named `key`.

When called, `get_instance()` checks its `_instances` dict for an instance that maps to the given `key`.  If none are found, `None` is returned.

Before calling `get_instance()`, the `Sentry` instance must have been created using the factory's `create_instance` method.  After the factory is created, an instance is created for each entry in the `sentry.yml` configuration file.

Usage:

```
from openlibrary.utils.sentry import sentry_factory  # imports the exposed `SentryFactory` instance

# Create "ol-web" `Sentry` instance
sentry_factory.create_instance('ol_web', {
    'enabled': True,
    'environment': 'local',
    'dsn': <dsn_url>,
    'traces_sample_rate': 0.01,
  })

# Get instance of Open Library's "ol-web" `Sentry` object
sentry = sentry_factory.get_instance('ol_web')
```

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
