### PR TITLE
set All as default for search bar

### DIFF
--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -83,7 +83,7 @@ $ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergrou
       <div class="search-bar">
         <div class="search-facet">
           <label class="search-facet-selector">
-            <span aria-hidden="true" class="search-facet-value"></span>
+            <span aria-hidden="true" class="search-facet-value">$_("All")</span>
             <select aria-label="Search by">
               <option value='all'>$_("All")</option>
               <option value='title'>$_("Title")</option>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Ever notice how every time you go to a page on OL the search bar selector flickers a bit?

<details>
  <summary>Current issue</summary>
  
  ![flicker2](https://github.com/internetarchive/openlibrary/assets/921217/cf6feb67-861e-4f79-89dc-a88dd805e925)
  
</details> 


Well this will fix it. At least for all the users that keep it set to the default of All.

<details>
  <summary>After this PR</summary>
  
  ![after_flicker2](https://github.com/internetarchive/openlibrary/assets/921217/8ea61d2c-b9ea-4f32-b19d-c06db5bb185d)
  
</details> 



<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
