### PR TITLE
Feature: add osp as import source

### DIFF
--- a/openlibrary/templates/history/sources.html
+++ b/openlibrary/templates/history/sources.html
@@ -42,7 +42,7 @@ $code:
         elif item.startswith("bwb:"):
             source_name = "Better World Books"
             source_url = "https://www.betterworldbooks.com/"
-        elif item.startswith("idb:"):
+        elif item.startswith("idb:") or item.startswith("osp:"):
             source_name = "ISBNdb"
             source_url = "https://isbndb.com/"
         else:


### PR DESCRIPTION
Partially closes #8589.

Include `osp:` as a source record and point to ISBNdb, as it is the source of data for OSP-sourced imports.

Pursuant to #8589 we want to import ISBNdb records, based on ISBNs from OSP that are not already in Open Library. We also want to track these records, so we settled on including `osp:<isbn_13>` in the `source_records` field. But if it's in the source records field, we should handle it 'properly' as a source record so it doesn't falsely display as a MARC record instead.

### Technical
Note, `osp:` will currently only show in an import record if (1) we 'fix' the import sources history so it doesn't always display the last source record, or (2) `osp:` isn't the last source record.

Currently OSP records have been imported with the `idb:` source record as last, so it displays.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Without this PR applied:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/f615e423-74e0-4a43-80df-f6ac218cd38a)

With the PR applied:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/443162ec-c590-40b2-931c-e2ff701d0538)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
