### PR TITLE
remove inlinejs for waitlist

### DIFF
--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -526,10 +526,10 @@ jQuery(function () {
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
 
-    const leaveWaitlistLInks = document.querySelectorAll('a.leave');
-    if (leaveWaitlistLInks.length && document.getElementById('leave-waitinglist-dialog')) {
+    const leaveWaitlistLinks = document.querySelectorAll('a.leave');
+    if (leaveWaitlistLinks.length && document.getElementById('leave-waitinglist-dialog')) {
         import(/* webpackChunkName: "waitlist" */ './waitlist')
-            .then(module => module.initLeaveWaitlist(leaveWaitlistLInks));
+            .then(module => module.initLeaveWaitlist(leaveWaitlistLinks));
     }
 
     const thirdPartyLoginsIframe = document.getElementById('ia-third-party-logins');

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -526,10 +526,10 @@ jQuery(function () {
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
 
-    const waitlistLinks = document.querySelectorAll('a.leave');
-    if (waitlistLinks.length && document.getElementById('leave-waitinglist-dialog')) {
+    const leaveWaitlistLInks = document.querySelectorAll('a.leave');
+    if (leaveWaitlistLInks.length && document.getElementById('leave-waitinglist-dialog')) {
         import(/* webpackChunkName: "waitlist" */ './waitlist')
-            .then(module => module.initLeaveWaitlist(waitlistLinks));
+            .then(module => module.initLeaveWaitlist(leaveWaitlistLInks));
     }
 
     const thirdPartyLoginsIframe = document.getElementById('ia-third-party-logins');

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -526,6 +526,12 @@ jQuery(function () {
             .then(module => module.initBreadcrumbSelect(crumbs));
     }
 
+    const waitlistLinks = document.querySelectorAll('a.leave');
+    if (waitlistLinks.length && document.getElementById('leave-waitinglist-dialog')) {
+        import(/* webpackChunkName: "waitlist" */ './waitlist')
+            .then(module => module.initLeaveWaitlist(waitlistLinks));
+    }
+
     const thirdPartyLoginsIframe = document.getElementById('ia-third-party-logins');
     if (thirdPartyLoginsIframe) {
         import(/* webpackChunkName: "ia_thirdparty_logins" */ './ia_thirdparty_logins')

--- a/openlibrary/plugins/openlibrary/js/waitlist.js
+++ b/openlibrary/plugins/openlibrary/js/waitlist.js
@@ -1,0 +1,19 @@
+/**
+ * Initialize the leave waitlist link
+ *
+ * @param {NodeList<HTMLElement>} waitlistLinks - NodeList of leave waitlist links
+ */
+export function initLeaveWaitlist(waitlistLinks) {
+    if (true) {
+        return
+    }
+    Array.from(waitlistLinks).forEach(link=>{
+        $(link).on('click', function() {
+            const title = $(this).parents('tr').find('.book').text();
+            $('#leave-waitinglist-dialog strong').text(title);
+            $('#leave-waitinglist-dialog')
+                .data('origin', $(this))
+                .dialog('open');
+        });
+    })
+}

--- a/openlibrary/plugins/openlibrary/js/waitlist.js
+++ b/openlibrary/plugins/openlibrary/js/waitlist.js
@@ -4,16 +4,11 @@
  * @param {NodeList<HTMLElement>} waitlistLinks - NodeList of leave waitlist links
  */
 export function initLeaveWaitlist(waitlistLinks) {
-    if (true) {
-        return
-    }
-    Array.from(waitlistLinks).forEach(link=>{
-        $(link).on('click', function() {
-            const title = $(this).parents('tr').find('.book').text();
-            $('#leave-waitinglist-dialog strong').text(title);
-            $('#leave-waitinglist-dialog')
-                .data('origin', $(this))
-                .dialog('open');
-        });
-    })
+    $(waitlistLinks).on('click', function() {
+        const title = $(this).parents('tr').find('.book').text();
+        $('#leave-waitinglist-dialog strong').text(title);
+        $('#leave-waitinglist-dialog')
+            .data('origin', $(this))
+            .dialog('open');
+    });
 }

--- a/openlibrary/plugins/openlibrary/js/waitlist.js
+++ b/openlibrary/plugins/openlibrary/js/waitlist.js
@@ -1,10 +1,10 @@
 /**
  * Initialize the leave waitlist link
  *
- * @param {NodeList<HTMLElement>} waitlistLinks - NodeList of leave waitlist links
+ * @param {NodeList<HTMLElement>} leaveWaitlistLinks - NodeList of leave waitlist links
  */
-export function initLeaveWaitlist(waitlistLinks) {
-    $(waitlistLinks).on('click', function() {
+export function initLeaveWaitlist(leaveWaitlistLinks) {
+    $(leaveWaitlistLinks).on('click', () => {
         const title = $(this).parents('tr').find('.book').text();
         $('#leave-waitinglist-dialog strong').text(title);
         $('#leave-waitinglist-dialog')

--- a/openlibrary/plugins/openlibrary/js/waitlist.js
+++ b/openlibrary/plugins/openlibrary/js/waitlist.js
@@ -4,11 +4,14 @@
  * @param {NodeList<HTMLElement>} leaveWaitlistLinks - NodeList of leave waitlist links
  */
 export function initLeaveWaitlist(leaveWaitlistLinks) {
-    $(leaveWaitlistLinks).on('click', () => {
-        const title = $(this).parents('tr').find('.book').text();
-        $('#leave-waitinglist-dialog strong').text(title);
-        $('#leave-waitinglist-dialog')
-            .data('origin', $(this))
-            .dialog('open');
-    });
+    for (const link of leaveWaitlistLinks) {
+        link.addEventListener('click', () => {
+            const $link = $(link)
+            const title = $link.parents('tr').find('.book').text();
+            $('#leave-waitinglist-dialog strong').text(title);
+            $('#leave-waitinglist-dialog')
+                .data('origin', $link)
+                .dialog('open');
+        })
+    }
 }

--- a/openlibrary/plugins/openlibrary/js/waitlist.js
+++ b/openlibrary/plugins/openlibrary/js/waitlist.js
@@ -9,6 +9,8 @@ export function initLeaveWaitlist(leaveWaitlistLinks) {
             const $link = $(link)
             const title = $link.parents('tr').find('.book').text();
             $('#leave-waitinglist-dialog strong').text(title);
+            // We remove the hidden class here because otherwise it flashes for a moment on page load
+            $('#leave-waitinglist-dialog').removeClass('hidden');
             $('#leave-waitinglist-dialog')
                 .data('origin', $link)
                 .dialog('open');

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -122,7 +122,7 @@ $else:
     $if len(waitinglist) == 0:
         <div><em>$_('You are not waiting for any books at this moment.')</em></div>
     $else:
-        <div id="leave-waitinglist-dialog" class="hidden dialog"
+        <div id="leave-waitinglist-dialog" class="dialog"
              title="$_('Leave the Waiting List')">$:_('Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?')</div>
         <div class="borrow borrow-table collapse waitinglist">
           <table>

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -124,17 +124,6 @@ $else:
     $else:
         <div id="leave-waitinglist-dialog" class="hidden dialog"
              title="$_('Leave the Waiting List')">$:_('Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?')</div>
-        <script type="text/javascript">
-        window.q.push(function() {
-            \$("a.leave").on('click', function() {
-                var title = \$(this).parents("tr").find(".book").text();
-                \$("#leave-waitinglist-dialog strong").text(title);
-                \$("#leave-waitinglist-dialog")
-                    .data("origin", \$(this))
-                    .dialog("open");
-            });
-        });
-        </script>
         <div class="borrow borrow-table collapse waitinglist">
           <table>
               <thead>

--- a/openlibrary/templates/account/loans.html
+++ b/openlibrary/templates/account/loans.html
@@ -122,7 +122,7 @@ $else:
     $if len(waitinglist) == 0:
         <div><em>$_('You are not waiting for any books at this moment.')</em></div>
     $else:
-        <div id="leave-waitinglist-dialog" class="dialog"
+        <div id="leave-waitinglist-dialog" class="hidden dialog"
              title="$_('Leave the Waiting List')">$:_('Are you sure you want to leave the waiting list of<br/><strong>TITLE</strong>?')</div>
         <div class="borrow borrow-table collapse waitinglist">
           <table>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8378

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I don't know locate a book that is waitlistable to test better. However, I have a book on my waitlist from long ago. The testing plan is:

1. Demonstrate the functionality of the "Leave Waitlist" button on the Open Library testing platform, accessible at https://testing.openlibrary.org/account/loans.
1. Deploy a version of the application to the testing environment that temporarily removes this functionality. This step is crucial for observing the impact of the removal on the user experience.
1. Deploy a refactored version of the application to the testing environment. This deployment aims to reintroduce the "Leave Waitlist" functionality, ensuring that it operates as expected and maintains consistency with the previous version.

This plan will be shown via the screen recording

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

https://github.com/internetarchive/openlibrary/assets/921217/64944a45-80ed-436e-b1c0-b333d3c2a913



### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
