### PR TITLE
Reduce default limit of readinglog API to 100

### DIFF
--- a/openlibrary/core/bookshelves.py
+++ b/openlibrary/core/bookshelves.py
@@ -177,6 +177,24 @@ class Bookshelves(db.CommonExtras):
         )
 
     @classmethod
+    def count_user_books_on_shelf(
+        cls,
+        username: str,
+        bookshelf_id: int,
+    ) -> int:
+        result = db.get_db().query(
+            """
+            SELECT count(*) from bookshelves_books
+            WHERE bookshelf_id=$bookshelf_id AND username=$username
+            """,
+            vars={
+                'bookshelf_id': bookshelf_id,
+                'username': username,
+            },
+        )
+        return result[0].count if result else 0
+
+    @classmethod
     def count_total_books_logged_by_user_per_shelf(
         cls, username: str, bookshelf_ids: list[str] | None = None
     ) -> dict[int, int]:

--- a/openlibrary/plugins/upstream/mybooks.py
+++ b/openlibrary/plugins/upstream/mybooks.py
@@ -344,7 +344,7 @@ class public_my_books_json(delegate.page):
                 for w in books
             ]
 
-            if len(records_json) < limit:
+            if page == 1 and len(records_json) < limit:
                 num_found = len(records_json)
             else:
                 num_found = readlog.count_shelf(key)


### PR DESCRIPTION
Closes #8852 . The readinglog APIs were fetching with a default of 5000. That's too much for a default, so reduce that to 100. Also add a total `numFound` field to the response to make pagination easier.

Note this is a BREAKING CHANGE to a public API, but I think it's required for healthy site/solr performance. Also because of the bug in #8852 , it would error if you tried to get a lot of books in one go anyways.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
- Reading log loads only 100 items: https://testing.openlibrary.org/people/mheiman9541/books/already-read.json
- Pagination works https://testing.openlibrary.org/people/mheiman9541/books/already-read.json?page=5

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
@mheiman 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
