### PR TITLE
Remove unused `User` method

### DIFF
--- a/openlibrary/core/models.py
+++ b/openlibrary/core/models.py
@@ -856,9 +856,6 @@ class User(Thing):
     def is_beta_tester(self):
         return self.is_usergroup_member('/usergroup/beta-testers')
 
-    def has_librarian_tools(self):
-        return self.is_usergroup_member('/usergroup/librarian-tools')
-
     def is_read_only(self):
         return self.is_usergroup_member('/usergroup/read-only')
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes unused and obsolete method for determining if a patron has access to librarian tools.

> [!NOTE]
> After deployment, this [usergroup](https://openlibrary.org/usergroup/librarian-tools) can be removed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
