### PR TITLE
Allow `limit` query param for `/admin/waitinglists` page

### DIFF
--- a/openlibrary/templates/admin/waitinglists.html
+++ b/openlibrary/templates/admin/waitinglists.html
@@ -10,9 +10,10 @@ $var title: Waiting Lists - Admin Center
     <h2>Recently available waiting loans</h2>
 
 $ page = safeint(query_param("page", 1), 1)
-$ offset = (page-1)*50
+$ limit = safeint(query_param("limit", 50), 50)
+$ offset = (page-1)*limit
 
-$ loans = wlstats.get_available_waiting_loans(limit=50, offset=offset)
+$ loans = wlstats.get_available_waiting_loans(limit=limit, offset=offset)
 $if not loans:
     <em>None found.</em>
 $else:
@@ -20,7 +21,7 @@ $else:
     <table>
         <thead>
             <tr>
-                <th class="titles" colspan="2">Showing ${offset+1}-${offset+min(50, len(loans))} of many</th>
+                <th class="titles" colspan="2">Showing ${offset+1}-${offset+min(limit, len(loans))} of many</th>
                 <th class="user">$_("Who")</th>
                 <th class="expires">$_("Expires")</th>
                 <th class="what">$_("Loan Status")</th>
@@ -88,9 +89,9 @@ $else:
     <div style="text-align: center; margin: 20px 0px;">
         $if page > 1:
             <a href="$changequery(page=page-1)">&larr; Newer</a>
-        $if page > 1 and len(loans) == 50:
+        $if page > 1 and len(loans) == limit:
             <span>|</span>
-        $if len(loans) == 50:
+        $if len(loans) == limit:
             <a href="$changequery(page=page+1)">Older &rarr;</a>
     </div>
 </div>


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Our `/admin/waitinglists` page is timing out.  As a quick fix, this branch allows one to override the default limit (`50`) by use of a `limit` query parameter.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
