### PR TITLE
Fixed overlap between button text and icon

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -66,7 +66,7 @@ export class Carousel {
             speed: 300,
             slidesToShow: this.config.booksPerBreakpoint[0],
             slidesToScroll: this.config.booksPerBreakpoint[0],
-            responsive: [1200, 1024, 600, 480, 360]
+            responsive: [1200, 1024, 740, 580, 360]
                 .map((breakpoint, i) => ({
                     breakpoint: breakpoint,
                     settings: {

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -157,8 +157,13 @@ a.cta-btn {
 
     &:first-child {
       flex: 1;
-      padding: 8px;
+      padding: 8px 0;
       overflow: hidden;
+      padding-right: 25px;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-size: 14px;
+      text-align: center;
     }
 
     &:not(:first-child) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8899

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes overlap between button text and icon

### Technical
<!-- What should be noted about the implementation? -->

- Issue: Audio book read buttons had button text & icon "external link" overlap on smaller screen sizes
- Cause: Responsive booksPerBreakpoints were not accurate with when less pages should be shown on the page

- Fix: Changing responsive booksPerBreakpoints was not css like issue had stated

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. docker compose up
// For running site
2. docker compose exec -e PYTHONPATH=. web bash -c "./scripts/copydocs.py --search 'author_key:OL9411725A' --search-limit 100"
// Adding data
3. http://localhost:8080/works/OL36891831W/
4. Start changing screen width

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
[Screencast from 04-10-2024 01:54:07 PM.webm](https://github.com/internetarchive/openlibrary/assets/56459277/823fe90a-010f-47ff-9da5-183c9692d1b4)
Will be screencast to demonstrate that text never overlaps with icon

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini @RayBB


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
