### PR TITLE
Remove unused login errors

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -69,10 +69,8 @@ LOGIN_ERRORS = {
     "missing_fields": "Please fill out all fields and try again",
     "email_registered": "This email is already registered",
     "username_registered": "This username is already registered",
-    "ia_login_only": "Sorry, you must use your Internet Archive email and password to log in",
     "max_retries_exceeded": "A problem occurred and we were unable to log you in.",
     "invalid_s3keys": "Login attempted with invalid Internet Archive s3 credentials.",
-    "wrong_ia_account": "An Open Library account with this email is already linked to a different Internet Archive account. Please contact info@openlibrary.org.",
 }
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9068 
Follow-up to #8980


<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes unused `LOGIN_ERRORS` entries.  The last reference to `wrong_ia_account` was removed in #8980.  While removing this, I found that `ia_login_only` is also not referenced in the codebase, so it has also been removed.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
