### PR TITLE
Cache collections with new `CacheablePathsProcessor`

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -47,6 +47,7 @@ delegate.app.add_processor(processors.ReadableUrlProcessor())
 delegate.app.add_processor(processors.ProfileProcessor())
 delegate.app.add_processor(processors.CORSProcessor(cors_prefixes={'/api/'}))
 delegate.app.add_processor(processors.PreferenceProcessor())
+delegate.app.add_processor(processors.CacheablePathsProcessor())
 
 try:
     from infogami.plugins.api import code as api

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -157,7 +157,7 @@ class CacheablePathsProcessor:
             """
             Returns a cache key for a cacheable path.
 
-            Function constructs a key based on the path and langauge
+            Function constructs a key based on the path and language
             code, like the following key for the Spanish collections page:
             /collections.es
 

--- a/openlibrary/plugins/openlibrary/processors.py
+++ b/openlibrary/plugins/openlibrary/processors.py
@@ -140,7 +140,12 @@ class CacheablePathsProcessor:
             Attempts to return a cached page, if one exists. The full
             path is used as the cache key for the page.
             """
-            mc = cache.memcache_memoize(get_page, path, self.paths_and_expiries[match], prethread=caching_prethread())
+            mc = cache.memcache_memoize(
+                get_page,
+                path,
+                self.paths_and_expiries[match],
+                prethread=caching_prethread(),
+            )
             _page = mc()
 
             if not _page:
@@ -157,7 +162,7 @@ class CacheablePathsProcessor:
             /collections.es
 
             Any entries in the given _modes list will be prepended
-            to the key.  The entries will be pipe-delimited, and 
+            to the key.  The entries will be pipe-delimited, and
             inside of square brackets.  For example:
 
             [pd|sfw]/collections.es


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9058

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Creates new `CacheablePathsProcessor` that can be used to cache Infogami pages without overriding the default Infogami handler for such pages.

This processor attempts to fetch pages from cache when the following are true:
1. The request is a `GET`
2. The request is not specially encoded data (`json`, `yml`, etc.)
3. The request's path matches one of the patterns in the `paths_and_expiries` dictionary
4. `debug` is not in the request's query string
5. The requested page's mode is `view`

The processor has been set up to cache`/collections` and `/collections/{collection_identifier}` pages.

### Technical
<!-- What should be noted about the implementation? -->
Cache keys will take the form:
`{web.ctx.path}.{web.ctx.lang}{query_string}`

...where `query_string` is either an empty string or an ordered query string (e.g. `?a=1&b=1&c=1`)

Adding a new path pattern and expiry time to `paths_and_expiries` will enable caching for pages matching to path pattern.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Deploy this branch to a testing environment
2. Navigate to the `/collections` page
3. On page load, refresh the page

The load time on refresh should be noticeably faster than the initial page load.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
