### PR TITLE
Updated regex 'path' of isbn and added canonical to have correct isbn

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -35,7 +35,7 @@ from infogami.core.db import ValidationException
 
 from openlibrary.core import cache
 from openlibrary.core.vendors import create_edition_from_amazon_metadata
-from openlibrary.utils.isbn import isbn_13_to_isbn_10, isbn_10_to_isbn_13
+from openlibrary.utils.isbn import isbn_13_to_isbn_10, isbn_10_to_isbn_13, canonical
 from openlibrary.core.models import Edition
 from openlibrary.core.lending import get_availability
 import openlibrary.core.stats
@@ -479,11 +479,11 @@ def remove_high_priority(query: str) -> str:
 
 
 class isbn_lookup(delegate.page):
-    path = r'/(?:isbn|ISBN)/([0-9xX-]+)'
+    path = r'/(?:isbn|ISBN)/(.{10,})'
 
     def GET(self, isbn):
         input = web.input(high_priority=False)
-
+        isbn = canonical(isbn)
         high_priority = input.get("high_priority") == "true"
         if "high_priority" in web.ctx.env.get('QUERY_STRING'):
             web.ctx.env['QUERY_STRING'] = remove_high_priority(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8964

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR aims to extract valid isbns from the ```/isbn/{isbn}``` path to avoid unnecessary manual stripping of unwanted characters in {isbn}

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- log the isbn in the isbn_lookup's GET method and notice the stripping of unwanted characters of from the isbn
- go to http://localhost:8080/isbn/_9781554042951_

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB @scottbarnes 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
