### PR TITLE
Update bot useragents + hide shuffle link for bots

### DIFF
--- a/openlibrary/plugins/openlibrary/code.py
+++ b/openlibrary/plugins/openlibrary/code.py
@@ -1090,6 +1090,16 @@ def is_bot():
         'bingbot',
         'mj12bot',
         'yoozbotadsbot',
+        'ahrefsbot',
+        'amazonbot',
+        'applebot',
+        'bingbot',
+        'brightbot',
+        'gptbot',
+        'petalbot',
+        'semanticscholarbot',
+        'yandex.com/bots',
+        'icc-crawler',
     ]
     if not web.ctx.env.get('HTTP_USER_AGENT'):
         return True

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -63,7 +63,7 @@ $code:
         </select>
       $if not loop.last:
         |
-    $if selected_sort and selected_sort.startswith('random'):
+    $if selected_sort and selected_sort.startswith('random') and not is_bot():
       (<a href="$changequery(page=None, sort='random_%s' % today().timestamp())"
          data-ol-link-track="SearchSort|RandomShuffle"
          rel="nofollow"


### PR DESCRIPTION
Closes #9186

Only shows the "Shuffle" sort option for non-bot user agents.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
