### PR TITLE
allows librarians to view edition search

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -69,7 +69,7 @@ $ )
         <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
         <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
-      $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians') or ctx.user.is_usergroup_member('/usergroup/librarians')):
+      $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian() or ctx.user.is_librarian()):
         <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to super librarians.')">
             <label
             style="padding: 4px; display: inline-block;"

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -69,7 +69,7 @@ $ )
         <input type="radio" name="mode" value="printdisabled" id="mode-search-printdisabled" class="search-mode">
         <label for="mode-search-printdisabled">$_('Print Disabled')</label>
       </span>
-      $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+      $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians') or ctx.user.is_usergroup_member('/usergroup/librarians')):
         <div style="display: flex; justify-content: flex-end"  title="$_('This is only visible to super librarians.')">
             <label
             style="padding: 4px; display: inline-block;"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9054

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature

### Technical
<!-- What should be noted about the implementation? -->
Added another check for librarians when displaying the edition search checkbox

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Logged in as AccountBot and searching something, the "solr edition" checkbox should not be visible. After adding AccountBot as a librarian, the checkbox should be visible.


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before Adding AccountBot as librarian:
<img width="1096" alt="image" src="https://github.com/internetarchive/openlibrary/assets/91789460/2e551673-013e-4a89-92c1-35651a9da78a">

After Adding AccountBot as librarian:
<img width="1096" alt="image" src="https://github.com/internetarchive/openlibrary/assets/91789460/1ca2556a-f2e6-4fe5-b45a-1e969c78c0f5">


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 
@seabelis 



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
