### PR TITLE
Add title and author to star ratings CSV exports

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1076,12 +1076,22 @@ class export_books(delegate.page):
         return "\n".join(lists_as_csv(lists))
 
     def generate_star_ratings(self, username: str) -> str:
+        from openlibrary.plugins.upstream.models import Work
+
+        def escape_csv_field(raw_string: str) -> str:
+            escaped_string = raw_string.replace('"', '""')
+            return f'"{escaped_string}"'
+
         def format_rating(rating: Mapping) -> dict:
+            work_id = f"OL{rating['work_id']}W"
+            work: Work = web.ctx.site.get(work_id)
             if edition_id := rating.get("edition_id") or "":
                 edition_id = f"OL{edition_id}M"
             return {
-                "Work ID": f"OL{rating['work_id']}W",
+                "Work ID": work_id,
                 "Edition ID": edition_id,
+                "Title": escape_csv_field(work.title),
+                "Author(s)": escape_csv_field(" | ".join(work.get_author_names())),
                 "Rating": f"{rating['rating']}",
                 "Created On": rating['created'].strftime(self.date_format),
             }

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -922,18 +922,6 @@ def csv_string(source: Iterable[Mapping], row_formatter: Callable | None = None)
     return '\n'.join(csv_body())
 
 
-def escape_csv_field(raw_string: str) -> str:
-    """
-    Formats given CSV field string such that it conforms to definition outlined
-    in RFC #4180.
-
-    Note: We should probably use
-    https://docs.python.org/3/library/csv.html
-    """
-    escaped_string = raw_string.replace('"', '""')
-    return f'"{escaped_string}"'
-
-
 class export_books(delegate.page):
     path = "/account/export"
     date_format = '%Y-%m-%d %H:%M:%S'
@@ -969,6 +957,17 @@ class export_books(delegate.page):
         web.header('Content-disposition', f'attachment; filename={filename}')
         return delegate.RawText('' or data, content_type="text/csv")
 
+    def escape_csv_field(self, raw_string: str) -> str:
+        """
+        Formats given CSV field string such that it conforms to definition outlined
+        in RFC #4180.
+
+        Note: We should probably use
+        https://docs.python.org/3/library/csv.html
+        """
+        escaped_string = raw_string.replace('"', '""')
+        return f'"{escaped_string}"'
+
     def get_work_from_id(self, work_id: str) -> "Work":
         """
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
@@ -1002,8 +1001,8 @@ class export_books(delegate.page):
             ratings_average, ratings_count = ratings.values()
             return {
                 "work_id": work_id,
-                "title": escape_csv_field(work.title),
-                "authors": escape_csv_field(" | ".join(work.get_author_names())),
+                "title": self.escape_csv_field(work.title),
+                "authors": self.escape_csv_field(" | ".join(work.get_author_names())),
                 "first_publish_year": work.first_publish_year,
                 "edition_id": edition_id,
                 "edition_count": work.edition_count,
@@ -1012,16 +1011,16 @@ class export_books(delegate.page):
                 "ratings_average": ratings_average,
                 "ratings_count": ratings_count,
                 "has_ebook": work.has_ebook(),
-                "subjects": escape_csv_field(
+                "subjects": self.escape_csv_field(
                     get_subjects(work=work, subject_type="subject")
                 ),
-                "subject_people": escape_csv_field(
+                "subject_people": self.escape_csv_field(
                     get_subjects(work=work, subject_type="person")
                 ),
-                "subject_places": escape_csv_field(
+                "subject_places": self.escape_csv_field(
                     get_subjects(work=work, subject_type="place")
                 ),
-                "subject_times": escape_csv_field(
+                "subject_times": self.escape_csv_field(
                     get_subjects(work=work, subject_type="time")
                 ),
             }
@@ -1093,8 +1092,8 @@ class export_books(delegate.page):
             return {
                 "Work ID": work_id,
                 "Edition ID": edition_id,
-                "Title": escape_csv_field(work.title),
-                "Author(s)": escape_csv_field(" | ".join(work.get_author_names())),
+                "Title": self.escape_csv_field(work.title),
+                "Author(s)": self.escape_csv_field(" | ".join(work.get_author_names())),
                 "Rating": f"{rating['rating']}",
                 "Created On": rating['created'].strftime(self.date_format),
             }

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -969,12 +969,12 @@ class export_books(delegate.page):
         web.header('Content-disposition', f'attachment; filename={filename}')
         return delegate.RawText('' or data, content_type="text/csv")
 
-    def get_work_from_id(self, work_id: str) -> Work:
+    def get_work_from_id(self, work_id: str) -> "Work":
         """
         Gets work data for a given work ID (OLxxxxxW format), used to access work author, title, etc. for CSV generation.
         """
         work_key = f"/works/{work_id}"
-        work: Work = web.ctx.site.get(work_key)
+        work: "Work" = web.ctx.site.get(work_key)
         if not work:
             raise ValueError(f"No Work found for {work_key}.")
         if work.type.key == '/type/redirect':
@@ -986,7 +986,7 @@ class export_books(delegate.page):
     def generate_reading_log(self, username: str) -> str:
         bookshelf_map = {1: 'Want to Read', 2: 'Currently Reading', 3: 'Already Read'}
 
-        def get_subjects(work: Work, subject_type: str) -> str:
+        def get_subjects(work: "Work", subject_type: str) -> str:
             return " | ".join(s.title for s in work.get_subject_links(subject_type))
 
         def format_reading_log(book: dict) -> dict:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7985. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Adds "Title" and "Author(s)" fields to star rating CSV.

### Technical
<!-- What should be noted about the implementation? -->
**Note**: Switched to a draft while I fix a quick circular import issue. 

Reused logic from `generate_reading_log`, extracting two helper functions -- `escape_csv_field` and `get_work_from_id` -- to use in both places.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log in (if not logged in)
2. Give at least one book a star rating
3. Go to `/account/import`
4. Download star ratings in CSV format; the file should include work title and author info

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="535" alt="Sample_StarRating_CSV" src="https://github.com/internetarchive/openlibrary/assets/140550988/bef48c8b-8044-4f12-a1ba-bb92b39b7340">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
