### PR TITLE
Instrument registration flow

### DIFF
--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -676,7 +676,6 @@ class InternetArchiveAccount(web.storage):
                 raise OLAuthenticationError('undefined_error')
 
             elif attempt >= retries:
-                # error_key: max_retries_exceeded (?)
                 e = OLAuthenticationError('username_registered')
                 e.value = _screenname
                 raise e

--- a/openlibrary/accounts/model.py
+++ b/openlibrary/accounts/model.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger("openlibrary.account.model")
 
 
+class OLAuthenticationError(Exception):
+    pass
+
+
 def append_random_suffix(text, limit=9999):
     return f'{text}{random.randint(0, limit)}'
 
@@ -643,10 +647,10 @@ class InternetArchiveAccount(web.storage):
         notifications = notifications or []
 
         if cls.get(email=email):
-            raise ValueError('email_registered')
+            raise OLAuthenticationError('email_registered')
 
         if not screenname:
-            raise ValueError('screenname required')
+            raise OLAuthenticationError('missing_fields')
 
         _screenname = screenname
         attempt = 0
@@ -669,13 +673,13 @@ class InternetArchiveAccount(web.storage):
                 return ia_account
 
             elif 'screenname' not in response.get('values', {}):
-                errors = '_'.join(response.get('values', {}))
-                raise ValueError(errors)
+                raise OLAuthenticationError('undefined_error')
 
             elif attempt >= retries:
-                ve = ValueError('username_registered')
-                ve.value = _screenname
-                raise ve
+                # error_key: max_retries_exceeded (?)
+                e = OLAuthenticationError('username_registered')
+                e.value = _screenname
+                raise e
 
             _screenname = append_random_suffix(screenname)
             attempt += 1

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6427,6 +6427,10 @@ msgid "Login attempted with invalid Internet Archive s3 credentials."
 msgstr ""
 
 #: account.py
+msgid "A problem occurred and we were unable to log you in"
+msgstr ""
+
+#: account.py
 #, python-format
 msgid ""
 "We've sent the verification email to %(email)s. You'll need to read that "

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -31,6 +31,7 @@ from openlibrary.core.lending import (
 )
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
+from openlibrary.plugins.openlibrary.sentry import sentry
 from openlibrary.plugins.recaptcha import recaptcha
 from openlibrary.plugins.upstream.mybooks import MyBooksTemplate
 from openlibrary.plugins import openlibrary as olib
@@ -320,6 +321,8 @@ class account_create(delegate.page):
                 )
             except OLAuthenticationError as e:
                 f.note = get_login_error(e.__str__())
+                if sentry.enabled:
+                    sentry.capture_exception(e)
 
         return render['account/create'](f)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -41,6 +41,7 @@ from openlibrary.accounts import (
     InternetArchiveAccount,
     valid_email,
     clear_cookies,
+    OLAuthenticationError,
 )
 from openlibrary.plugins.upstream import borrow, forms, utils
 from openlibrary.utils.dateutil import elapsed_time
@@ -87,6 +88,7 @@ def get_login_error(error_key):
         "invalid_s3keys": _(
             'Login attempted with invalid Internet Archive s3 credentials.'
         ),
+        "undefined_error": _('A problem occurred and we were unable to log you in'),
     }
     return LOGIN_ERRORS[error_key]
 
@@ -316,8 +318,8 @@ class account_create(delegate.page):
                 return render['account/verify'](
                     username=f.username.value, email=f.email.value
                 )
-            except ValueError:
-                f.note = get_login_error('max_retries_exceeded')
+            except OLAuthenticationError as e:
+                f.note = get_login_error(e.__str__())
 
         return render['account/create'](f)
 

--- a/openlibrary/utils/sentry.py
+++ b/openlibrary/utils/sentry.py
@@ -83,6 +83,11 @@ class Sentry:
             scope.add_event_processor(add_web_ctx_to_event)
             sentry_sdk.capture_exception()
 
+    def capture_exception(self, ex):
+        with sentry_sdk.push_scope() as scope:
+            scope.add_event_processor(add_web_ctx_to_event)
+            sentry_sdk.capture_exception(ex)
+
 
 @dataclass
 class InfogamiRoute:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
In support of #8863

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
1. Update our `Sentry` objects to allow for capturing handled exceptions
2. Creates new `OLAuthenticationError`, which are now thrown on IA account creation failures
3. Publishes `/account/create` `POST` handler to Sentry

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Deploy this to `testing`
2. Trigger an error during account registration
3. Check Sentry for an `OLAuthenticationError`

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
