### PR TITLE
Go to "My Books" page on Google sign-in

### DIFF
--- a/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
+++ b/openlibrary/plugins/openlibrary/js/ia_thirdparty_logins.js
@@ -24,7 +24,7 @@ export function initMessageEventListener(element) {
             })
                 .then((resp) => {
                     if (resp.ok) {
-                        window.location = new URLSearchParams(window.location.search).get('redirect') || '/account/loans';
+                        window.location = new URLSearchParams(window.location.search).get('redirect') || '/account/books';
                     }
                     return resp.json()
                 })


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9108

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Sets the default redirect value for Google sign-in to `/account/books`, the "My Books" page.

This conforms with our default redirect value for email and password authentication, set here:
https://github.com/internetarchive/openlibrary/blob/2ca79bd87b458c40f6ceb6746063aab45bf900e8/openlibrary/plugins/upstream/account.py#L455-L456

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Visit the log in page, and sign-in using your Google account.
2. Ensure that you're redirected to the "My Books" page.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
