### PR TITLE
improve language autocomplete speed

### DIFF
--- a/openlibrary/plugins/openlibrary/js/autocomplete.js
+++ b/openlibrary/plugins/openlibrary/js/autocomplete.js
@@ -124,8 +124,7 @@ export default function($) {
             const term = options.termPreprocessor(q.term);
             const params = {
                 q: term,
-                limit: options.max,
-                timestamp: new Date()
+                limit: options.max
             };
             if (location.search.indexOf('lang=') !== -1) {
                 params.lang = new URLSearchParams(location.search).get('lang');

--- a/openlibrary/plugins/worksearch/autocomplete.py
+++ b/openlibrary/plugins/worksearch/autocomplete.py
@@ -96,6 +96,7 @@ class languages_autocomplete(delegate.page):
     def GET(self):
         i = web.input(q="", limit=5)
         i.limit = safeint(i.limit, 5)
+        web.header("Cache-Control", "max-age=%d" % (24 * 3600))
         return to_json(
             list(itertools.islice(utils.autocomplete_languages(i.q), i.limit))
         )


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9111

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Removes `timestamp` because it is not used and would mess up caching.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Compare the speed of language on prod and testing for a work like 
- https://testing.openlibrary.org/books/OL24938286M/Pacific_Vortex!/edit

As far as I can tell, it is drastically faster. 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
