### PR TITLE
Replace: Cleanup use of is_usergroup_member('/usergroup/librarians')

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -80,7 +80,7 @@ class admin(delegate.page):
         else:
             if (
                 context.user
-                and context.user.is_usergroup_member('/usergroup/librarians')
+                and context.user.is_librarian()
                 and web.ctx.path == '/admin/solr'
             ):
                 return m(*args)

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -288,9 +288,7 @@ class merge_authors(delegate.page):
         can_merge = user and (
             user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
         )
-        can_request_merge = not can_merge and (
-            user and user.is_usergroup_member('/usergroup/librarians')
-        )
+        can_request_merge = not can_merge and (user and user.is_librarian())
 
         # filter bad keys
         keys = self.filter_authors(keys)

--- a/openlibrary/templates/search/sort_options.html
+++ b/openlibrary/templates/search/sort_options.html
@@ -36,7 +36,7 @@ $code:
           },
          { 'sort': 'random', 'name': _("Random"), 'ga_key': 'Random', 'selected': selected_sort and selected_sort.startswith('random') },
        ]
-       if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians')):
+       if ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian()):
          sort_options.append({ 'sort': 'title', 'name': _("Work Title (beta: Librarian only)"), 'ga_key': 'Title' })
     $for sort_option in sort_options:
       $if exclude and sort_option['sort'] in exclude:

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -139,7 +139,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
                 <div id="searchResults">
                     <ul class="list-books">
-                      $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
+                      $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
                       $for doc in books.docs:
                          $:macros.SearchResultsWork(doc, show_librarian_extras=show_librarian_extras, include_dropper=True)
                     </ul>

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -173,7 +173,7 @@ $ )
             $ username = ctx.user and ctx.user.key.split('/')[-1]
             $if username:
                 $ works = add_read_statuses(username, works)
-            $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/librarians'))
+            $ show_librarian_extras = ctx.user and (ctx.user.is_admin() or ctx.user.is_librarian())
 
             $# Subject key list will only be included in each doc if the patron has a sfw cookie
             $ subject_keys = [d.get('subject', []) for d in search_response.docs]


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9087 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Replaces the existing ```is_usergroup_member('/usergroup/librarians')``` with ```is_librarian()```

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
- Given below are the affected paths, the testing has been done and all seems to work similarly
- /admin/*
- /search/?q=the&mode=everything (any search path /search/*)
- /authors/merge (test url: http://localhost:8080/authors/merge?key=OL21093A&key=OL161167A&key=OL19677A&key=OL24638A&key=OL114411A&key=OL20585A&key=OL50694A&key=OL47908A&key=OL29586A&key=OL2688089A&key=OL29388A)
- /authors/* (http://localhost:8080/authors/OL22098A/Lewis_Carroll)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
