### PR TITLE
Add issue number to `filter_issues` results

### DIFF
--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -127,6 +127,7 @@ def filter_issues(issues: list, since: datetime):
                 lead_label = find_lead_label(i.get('labels', []))
                 results.append(
                     {
+                        'number': i['number'],
                         'comment_url': last_comment['html_url'],
                         'commenter': last_commenter,
                         'issue_title': i['title'],


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Closes #9113

Our recent changes to the `issue_comment_bot` script are [breaking](https://github.com/internetarchive/openlibrary/actions/runs/8750728637/job/24014837209), as the results of `filter_issues` do not have the issue number.  This PR adds the issue number to the results.

`filter_issues` is a poor name for the function, as it returns a list of newly created objects containing only the data that is needed for the Slack comment, not the whole `issue` object itself.  Is there a better name for `filter_issues`?

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
