### PR TITLE
Added logic for page dump and commented out test line

### DIFF
--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -217,7 +217,7 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         "/type/author",
         "/type/work",
         "/type/redirect",
-        "/type/list"
+        "/type/list",
     )
     files = {}
     files['misc'] = xopen(format % 'misc', 'wt')

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -209,7 +209,7 @@ def generate_idump(day, **db_parameters):
 
 
 def split_dump(dump_file=None, format="oldump_%s.txt"):
-    """Split dump into authors, editions and works."""
+    """Split dump into authors, editions, works and misc to account for outliers."""
     log(f"split_dump({dump_file}, format={format})")
     start_time = datetime.now()
     types = (

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -217,6 +217,7 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         "/type/author",
         "/type/work",
         "/type/redirect",
+        "/type/delete",
         "/type/list",
     )
     files = {}

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -217,9 +217,11 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         "/type/author",
         "/type/work",
         "/type/redirect",
-        "/type/list",
+        "/type/list"
     )
     files = {}
+    files['misc'] = xopen(format % 'misc', 'wt')
+
     for t in types:
         tname = t.split("/")[-1] + "s"
         files[t] = xopen(format % tname, "wt")
@@ -231,6 +233,8 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         type, rest = line.split("\t", 1)
         if type in files:
             files[type].write(line)
+        else:
+            files['misc'].write(line)
 
     for f in files.values():
         f.close()

--- a/openlibrary/data/dump.py
+++ b/openlibrary/data/dump.py
@@ -209,7 +209,7 @@ def generate_idump(day, **db_parameters):
 
 
 def split_dump(dump_file=None, format="oldump_%s.txt"):
-    """Split dump into authors, editions, works and misc to account for outliers."""
+    """Split dump into authors, editions, works, redirects, and other."""
     log(f"split_dump({dump_file}, format={format})")
     start_time = datetime.now()
     types = (
@@ -220,7 +220,7 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         "/type/list",
     )
     files = {}
-    files['misc'] = xopen(format % 'misc', 'wt')
+    files['other'] = xopen(format % 'other', 'wt')
 
     for t in types:
         tname = t.split("/")[-1] + "s"
@@ -234,7 +234,7 @@ def split_dump(dump_file=None, format="oldump_%s.txt"):
         if type in files:
             files[type].write(line)
         else:
-            files['misc'].write(line)
+            files['other'].write(line)
 
     for f in files.values():
         f.close()

--- a/openlibrary/plugins/upstream/data.py
+++ b/openlibrary/plugins/upstream/data.py
@@ -31,11 +31,16 @@ def download_url(item, filename):
     return f"{IA_BASE_URL}/download/{item}/{filename}"
 
 
+# Should include openlibrary/data/dump.py split_dump's types at least
 DUMP_PREFIXES = (
     '',
     '_authors',
     '_editions',
     '_works',
+    '_redirects',
+    '_deletes',
+    '_lists',
+    '_other',
     '_deworks',
     '_ratings',
     '_reading-log',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8401 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This is a refactor that allows all dump file types that are NOT   
```
        "/type/edition",
        "/type/author",
        "/type/work",
        "/type/redirect",
        "/type/list"
```
to be sorted into a `misc` category. This category catches all `/type/page` dump files, in addition to all other types that are not in above list. 

This misc files should help provide a comprehensive inventory of pages in the dump that is used to generate the sitemap. 

### Technical
<!-- What should be noted about the implementation? -->
I only tested these changes with a subset of full data (commented in line 38 of /scripts/oldump.sh) . 
When line 38 was commented in, I also had to change the `-z` in line 133 of /scripts/oldump.sh to `-n` to avoid an error in /data/dump.py. 
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Ran `docker compose run --rm home make test`
![Screenshot 2024-04-19 at 4 13 46 PM](https://github.com/internetarchive/openlibrary/assets/79802377/711c5036-4b0c-4339-9ac2-057e9cb4eed7)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
