### PR TITLE
Feature: add OpenAlex as a source record

### DIFF
--- a/openlibrary/templates/history/comment.html
+++ b/openlibrary/templates/history/comment.html
@@ -12,9 +12,9 @@ $if record_id:
     $ record = get_source_record(record_id)
     $if v.revision == 1:
        $ record_type = ''
-       $if record.source_name not in ('amazon.com', 'Better World Books', 'Promise Item', 'ISBNdb'):
+       $if record.source_name not in ('amazon.com', 'Better World Books', 'Promise Item', 'ISBNdb', 'OpenAlex'):
             $ record_type = 'item' if record.source_name == 'Internet Archive' else 'MARC'
-       $if record.source_name in ('Promise Item', 'ISBNdb'):
+       $if record.source_name in ('Promise Item', 'ISBNdb', 'OpenAlex'):
             $:_('Imported from %(source)s', source=link(record.source_url, record.source_name))
        $else:
             $:_('Imported from %(source)s  <a href="%(url)s">%(type)s record</a>.', source=link(record.source_url, record.source_name), url=record.url, type=record_type)

--- a/openlibrary/templates/history/sources.html
+++ b/openlibrary/templates/history/sources.html
@@ -45,6 +45,9 @@ $code:
         elif item.startswith("idb:") or item.startswith("osp:"):
             source_name = "ISBNdb"
             source_url = "https://isbndb.com/"
+        elif item.startswith("openalex:"):
+            source_name = "OpenAlex"
+            source_url = "https://openalex.org/" + item[9:]
         else:
             source_name = names.get(item, item)
             source_url = "//archive.org/details/" + item


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Partially closes #8623.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Pursuant to #8623, we will be importing some items with metadata based on OpenAlex's dataset, so this commit adds an OpenAlex data source.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Look at an item imported with a `source_records` value including, e.g., `openalex:W12345689`. Clicking on the link in "Imported from OpenAlex" line should take you to the OpenAlex page for that identifier.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before this PR:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/f40003a0-9f44-4a23-8649-0cbb4145898a)

After this PR:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/74ddb64a-7256-43dd-88cb-d152864ede12)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
