### PR TITLE
fix/Arrow missing from add to list dropdown on author pages #9065

### DIFF
--- a/openlibrary/templates/lib/dropper.html
+++ b/openlibrary/templates/lib/dropper.html
@@ -3,7 +3,7 @@ $def with(primary_button, dropdown_content, classes='')
 <div class="generic-dropper-wrapper $(classes)">
   <div class="generic-dropper">
     <div class="generic-dropper__actions">
-      <div class="generic-dropper__primary">
+      <div class="generic-dropper__primary old-style-lists">
         $:primary_button
       </div>
       <a class="generic-dropper__dropclick" href="javascript:;">

--- a/openlibrary/templates/my_books/dropper.html
+++ b/openlibrary/templates/my_books/dropper.html
@@ -19,7 +19,7 @@ $if seed_key.startswith('/works/') and edition_key:
 
 $ additional_classes = 'my-books-dropper'
 $if not work_key:
-  $ additional_classes += ' old-style-lists'
+  $ additional_classes += ''
 $if not ctx.user:
   $ additional_classes += ' generic-dropper--disabled'
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9065

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
[fix]: Arrow missing from add to list dropdown on author pages

### Technical
<!-- What should be noted about the implementation? -->


### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. first I figure out the issue and verify that respective page
2. locate the affected div
3. fix the issue 

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![before](https://github.com/internetarchive/openlibrary/assets/142248999/8a8b1b16-7479-4082-957e-5637a53678a5)

After:
![after](https://github.com/internetarchive/openlibrary/assets/142248999/34f4c81f-a32b-470c-ab1e-3b9237053c5f)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 
<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
