### PR TITLE
Fix: add 1900-01-01 to AMZ/BWB suspect publish_date list

### DIFF
--- a/openlibrary/catalog/add_book/__init__.py
+++ b/openlibrary/catalog/add_book/__init__.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
 re_normalize = re.compile('[^[:alphanum:] ]', re.U)
 re_lang = re.compile('^/languages/([a-z]{3})$')
 ISBD_UNIT_PUNCT = ' : '  # ISBD cataloging title-unit separator punctuation
-SUSPECT_PUBLICATION_DATES: Final = ["1900", "January 1, 1900"]
+SUSPECT_PUBLICATION_DATES: Final = ["1900", "January 1, 1900", "1900-01-01"]
 SOURCE_RECORDS_REQUIRING_DATE_SCRUTINY: Final = ["amazon", "bwb", "promise"]
 
 


### PR DESCRIPTION
Closes #9137.

Addes `1900-01-01` to the list of dates that will be cleared for AMZ/BWB imports because this seems to be a date added when the true `publish_date` is unknown.

Other checked dates not included because they didn't seem to be a problem:
- https://openlibrary.org/query.json?type=/type/edition&publish_date~=1-1-1900 (none)
- https://openlibrary.org/query.json?type=/type/edition&publish_date~=01-01-1900 (none)
- https://openlibrary.org/query.json?type=/type/edition&publish_date~=01/01/1900 (none)
- https://openlibrary.org/query.json?type=/type/edition&publish_date~=1/1/1900 (one entry)
- https://openlibrary.org/query.json?type=/type/edition&publish_date~=1900-1-1 (none)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Import something with a `publish_date` of `1900-01-01` and that `publish_date` should be removed. I didn't update the unit tests for this function because it operates on a list of strings and I just added a new string.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 
@hornc 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
