### PR TITLE
Allow `issue_comment_bot.py` to run without updating issues or publishing Slack digest

### DIFF
--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install requests
-      - run: scripts/gh_scripts/issue_comment_bot.py 24 "$SLACK_CHANNEL" "$SLACK_TOKEN"
+      - run: scripts/gh_scripts/issue_comment_bot.py 24 -c "$SLACK_CHANNEL" -t "$SLACK_TOKEN"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -3,7 +3,9 @@
 Fetches Open Library GitHub issues that have been commented on
 within some amount of time, in hours.
 
-Writes links to each issue to given Slack channel.
+Publishes a digest of the issues that were identified to the 
+given Slack channel, and adds the "Needs: Response" label to the
+issues in Github.
 """
 import argparse
 import errno
@@ -264,7 +266,9 @@ def start_job(args: argparse.Namespace):
     issues = fetch_issues(date_string)
 
     filtered_issues = filter_issues(issues, since)
-    add_label_to_issues(filtered_issues)
+    if not args.no_labels:
+        add_label_to_issues(filtered_issues)
+        print('Issues labeled as "Needs: Response"')
     publish_digest(filtered_issues, args.channel, args.slack_token, args.hours)
     print('Digest posted to Slack.')
 
@@ -290,6 +294,11 @@ def _get_parser() -> argparse.ArgumentParser:
         metavar='slack-token',
         help='Slack auth token',
         type=str,
+    )
+    parser.add_argument(
+        '--no-labels',
+        help='Prevent the script from labeling the issues',
+        action='store_true',
     )
 
     return parser

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -3,9 +3,10 @@
 Fetches Open Library GitHub issues that have been commented on
 within some amount of time, in hours.
 
-Publishes a digest of the issues that were identified to the 
-given Slack channel, and adds the "Needs: Response" label to the
-issues in Github.
+If called with a Slack token and channel, publishes a digest of
+the issues that were identified to the given channel.
+
+Adds the "Needs: Response" label to the issues in Github.
 """
 import argparse
 import errno
@@ -269,8 +270,9 @@ def start_job(args: argparse.Namespace):
     if not args.no_labels:
         add_label_to_issues(filtered_issues)
         print('Issues labeled as "Needs: Response"')
-    publish_digest(filtered_issues, args.channel, args.slack_token, args.hours)
-    print('Digest posted to Slack.')
+    if args.slack_token and args.channel:
+        publish_digest(filtered_issues, args.channel, args.slack_token, args.hours)
+        print('Digest posted to Slack')
 
 
 def _get_parser() -> argparse.ArgumentParser:
@@ -285,13 +287,14 @@ def _get_parser() -> argparse.ArgumentParser:
         type=int,
     )
     parser.add_argument(
-        'channel',
+        '-c',
+        '--channel',
         help="Issues will be published to this Slack channel",
         type=str,
     )
     parser.add_argument(
-        'slack_token',
-        metavar='slack-token',
+        '-t',
+        '--slack-token',
         help='Slack auth token',
         type=str,
     )

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -259,6 +259,18 @@ def add_label_to_issues(issues):
         )
 
 
+def verbose_output(issues):
+    """
+    Prints detailed information about the given issues.
+    """
+    for issue in issues:
+        print(f'Issue #{issue["number"]}:')
+        print(f'\tTitle: {issue["issue_title"]}')
+        print(f'\t{issue["lead_label"]}')
+        print(f'\tCommenter: {issue["commenter"]}')
+        print(f'\tComment URL: {issue["comment_url"]}')
+
+
 def start_job(args: argparse.Namespace):
     """
     Starts the new comment digest job.
@@ -273,6 +285,8 @@ def start_job(args: argparse.Namespace):
     if args.slack_token and args.channel:
         publish_digest(filtered_issues, args.channel, args.slack_token, args.hours)
         print('Digest posted to Slack')
+    if args.verbose:
+        verbose_output(filtered_issues)
 
 
 def _get_parser() -> argparse.ArgumentParser:
@@ -301,6 +315,12 @@ def _get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '--no-labels',
         help='Prevent the script from labeling the issues',
+        action='store_true',
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        help='Print detailed information about the issues that were found',
         action='store_true',
     )
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9143

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds `--verbose` and `--no-labels` flags, and makes the Slack token and channel optional arguments. Digest will only be published to Slack of both the token and the channel are present when the script is called.  Our `new_comment_digest` action has been updated to accommodate these changes.
If the `--no-labels` flag is included, https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Response labels are not added to the issues.
Detailed information about each identified issue is printed to `stdout` whenever the `--verbose` flag is included.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
