### PR TITLE
Add permissions for labeling issues

### DIFF
--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  issues: write
 
 jobs:
   new_comment_digest:


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9113

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
I noticed that the `Needs: Response` label wasn't being added to issues with new comments.  Turns out that we were missing the correct permissions for adding labels.

See documentation for the [add label endpoint](https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue) for more details.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
