### PR TITLE
Redirect immediately on unauthenticated note update request

### DIFF
--- a/openlibrary/plugins/openlibrary/api.py
+++ b/openlibrary/plugins/openlibrary/api.py
@@ -227,13 +227,13 @@ class booknotes(delegate.page):
         :return: the note
         """
         user = accounts.get_current_user()
+        if not user:
+            raise web.seeother('/account/login?redirect=/works/%s' % work_id)
+
         i = web.input(notes=None, edition_id=None, redir=None)
         edition_id = (
             int(extract_numeric_id_from_olid(i.edition_id)) if i.edition_id else -1
         )
-
-        if not user:
-            raise web.seeother('/account/login?redirect=/works/%s' % work_id)
 
         username = user.key.split('/')[2]
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9152

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Related to this Sentry [issue](https://sentry.archive.org/organizations/ia-ux/issues/274622/?query=is%3Aunresolved&referrer=issue-stream).

Immediately redirects to login page when an unauthenticated request to the notes update handler is made.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
