### PR TITLE
Add whitespace validation for book titles

### DIFF
--- a/openlibrary/plugins/openlibrary/js/validate.js
+++ b/openlibrary/plugins/openlibrary/js/validate.js
@@ -33,8 +33,7 @@ export default function initValidate() {
     // character (otherwise it will appear blank)
     // used in templates/books/add.html
     jQuery.validator.addMethod('title', function(value) {
-        var containsNonWhitespace = /.*\S+.*/.exec(value);
-        return containsNonWhitespace;
+        return /\S/.test(value);
     },
     '',
     );

--- a/openlibrary/plugins/openlibrary/js/validate.js
+++ b/openlibrary/plugins/openlibrary/js/validate.js
@@ -29,6 +29,16 @@ export default function initValidate() {
     'Are you sure that\'s the published date?'
     );
 
+    // validate title to make sure it contains at least one non-whitespace
+    // character (otherwise it will appear blank)
+    // used in templates/books/add.html
+    jQuery.validator.addMethod('title', function(value) {
+        var containsNonWhitespace = /.*\S+.*/.exec(value);
+        return containsNonWhitespace;
+    },
+    '',
+    );
+
     $.validator.messages.required = '';
     $.validator.messages.email = ugettext('Are you sure that\'s an email address?');
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9136 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes a bug where users were able to add books without titles by putting only whitespace characters into the required title field.

### Technical
<!-- What should be noted about the implementation? -->
Adds a regex check in `plugins/openlibrary/js/validate.js` to the `title` class used by `templates/books/add.html` that ensures the title input contains at least one non-whitespace character.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go to the 'Add Book' page
2. Attempt to add a book with a title containing only whitespace characters (i.e. matches `/\s+/`)
3. Observe that the action is not successful and the title input box is red

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/17033120/cd1afaf8-0a8a-4636-aee1-1ad4eaac71c9)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
