### PR TITLE
cache edit pages for librarians when on view page

### DIFF
--- a/openlibrary/macros/databarEdit.html
+++ b/openlibrary/macros/databarEdit.html
@@ -5,7 +5,7 @@ $def with (page)
     <div id="editHistory">
         <a class="linkButton larger" href="$page.key?m=history" title="$_('View the editing history of this page')">$_("History")</a>
     </div>
-    <div class="editButton">
+    <div>
         <a href="$page.key" title="$_('View this page (exit Edit mode)')" class="cancel">$_("Cancel")</a>
     </div>
 </div>

--- a/openlibrary/plugins/openlibrary/js/edit.js
+++ b/openlibrary/plugins/openlibrary/js/edit.js
@@ -505,3 +505,30 @@ function isValidURL(url) {
         return false;
     }
 }
+
+/**
+ * When visiting a page with an edit button, pre-fetch the page
+ * This works in conjunction with server-worker.js which keeps the page in cache
+ */
+export function initEditPrefetch(editButton) {
+    // Only works for librarians now, in the future I'd like it to work for anyone who visited any edit page today
+    if (!document.getElementsByClassName('show-librarian-tools').length) return;
+
+    const pagesToRunOn = ['/authors/', '/books/', '/works/'];
+    const url = editButton.querySelector('a').href;
+    // only run on authors, books, and works pages
+    if (!pagesToRunOn.some(word => url.includes(word))) return;
+
+    // Fetch on page load
+    fetch(url);
+    let lastExecutionTime = Date.now();
+
+    // Fetch on page focus if we have not fetched in the last 10 seconds
+    document.addEventListener('visibilitychange', () => {
+        const isTenSecondsOld = Date.now() - lastExecutionTime > 10000;
+        if (document.hasFocus() && isTenSecondsOld) {
+            fetch(url);
+            lastExecutionTime = Date.now();
+        }
+    });
+}

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -563,4 +563,11 @@ jQuery(function () {
         import(/* webpackChunkName: "affiliate-links" */ './affiliate-links')
             .then(module => module.initAffiliateLinks(affiliateLinksSection))
     }
+
+    // Prefetching edit pages
+    const editButton = document.querySelector('.editButton');
+    if (editButton) {
+        import(/* webpackChunkName: "user-website" */ './edit')
+            .then(module => module.initEditPrefetch(editButton))
+    }
 });

--- a/openlibrary/plugins/openlibrary/js/service-worker-matchers.js
+++ b/openlibrary/plugins/openlibrary/js/service-worker-matchers.js
@@ -40,3 +40,13 @@ export function matchArchiveOrgImage({ url }) {
     // also caches some covers
     return url.href.startsWith('https://archive.org/services/img/');
 }
+
+export function matchAuthorEditPage({url}){
+    const regex = /\/authors\/OL\d+A\/.*\/edit/
+    return regex.test(url.pathname);
+}
+
+export function matchEditionEditPage({url}){
+    const regex = /\/books\/OL\d+M\/.*\/edit/
+    return regex.test(url.pathname);
+}

--- a/tests/unit/js/service-worker-matchers.test.js
+++ b/tests/unit/js/service-worker-matchers.test.js
@@ -1,4 +1,7 @@
-import { matchMiscFiles, matchSmallMediumCovers, matchLargeCovers, matchStaticImages, matchStaticBuild, matchArchiveOrgImage } from '../../../openlibrary/plugins/openlibrary/js/service-worker-matchers';
+import {
+    matchMiscFiles, matchSmallMediumCovers, matchLargeCovers, matchStaticImages,
+    matchStaticBuild, matchArchiveOrgImage, matchAuthorEditPage, matchEditionEditPage
+} from '../../../openlibrary/plugins/openlibrary/js/service-worker-matchers';
 
 
 // Helper function to create a URL object
@@ -75,6 +78,28 @@ describe('URL Matchers', () => {
 
         test('does not match other URLs', () => {
             expect(matchArchiveOrgImage(_u('https://archive.org/services/'))).toBe(false);
+        });
+    });
+
+    describe('matchAuthorEditPage', () => {
+        test('matches author edit page', () => {
+            expect(matchAuthorEditPage(_u('https://openlibrary.org/authors/OL7115219A/Sarah_J._Maas/edit'))).toBe(true);
+            expect(matchAuthorEditPage(_u('http://localhost:8080/authors/OL20585A/Edwin_Abbott_Abbott/edit'))).toBe(true);
+        });
+
+        test('does not match other URLs', () => {
+            expect(matchAuthorEditPage(_u('https://archive.org/services/'))).toBe(false);
+        });
+    });
+
+
+    describe('matchEditionEditPage', () => {
+        test('matches edition edit page', () => {
+            expect(matchEditionEditPage(_u('https://openlibrary.org/books/OL30162974M/A_Court_of_Mist_and_Fury/edit?work_key=/works/OL17860744W'))).toBe(true);
+        });
+
+        test('does not match other URLs', () => {
+            expect(matchEditionEditPage(_u('https://archive.org/services/'))).toBe(false);
         });
     });
 });


### PR DESCRIPTION
With this PR we will prefetch (cache) the edit page of authors/works/editions so when you click the edit button it should load nearly instantly.

<!-- What issue does this PR close? -->
Contributes to #9121 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

How it works:
- Visit an author page
- In the background, the edit page is automatically loaded (on page load and then on subsequent page focuses)
- When you click the edit button it should load instantly from the cache.


### Technical
<!-- What should be noted about the implementation? -->
- We can't just load on focus because the focus event doesn't trigger if you just click a link normally

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

Side by side comparison of prod (no precache) vs testing (with precache). Button turns red when clicked.
Can you tell which is which?


https://github.com/internetarchive/openlibrary/assets/921217/bc425dc2-3526-464b-b722-aa5e3552bd59




<details>
  <summary>Longer video showing not whole process</summary>
  
  
    https://github.com/internetarchive/openlibrary/assets/921217/3a9125a6-ba6d-49fe-a2ea-50642e67d727
  
</details> 



Script used to click two buttons at once:
```
function executeAtTopOfMinute() {
  const now = new Date();
  // Calculate the time difference to the top of the minute
  const targetTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours(), now.getMinutes()+1, 0);
  const timeDifference = targetTime - now;
  // Execute the action after the calculated time difference
  setTimeout(() => {
                // turn button red and then click it
                document.querySelector('.editButton a').style = "background-color:red" 
		document.querySelector('.editButton a').click();
  }, timeDifference);
}

// Call the function to schedule the action
executeAtTopOfMinute();
```


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
No UI changes.

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
