### PR TITLE
Fix links on subjects page font size too large, TOC too small

### DIFF
--- a/openlibrary/templates/publishers/view.html
+++ b/openlibrary/templates/publishers/view.html
@@ -60,11 +60,9 @@ $ subject_list = [('subjects', 20), ('places', 20), ('people', 10), ('times', 10
 	        <span class="title"><em>$_("None found.")</em></span>
 
     $for s, limit in subject_list:
-        <div class="contentQuarter link-box">
+        <div class="contentQuarter link-box link-box--with-header">
             <h6>$s</h6>
-			<div class="subjects" id="subjects-$s">
-				$:renderSubjects(page[s][:limit])
-			</div>
+            $:renderSubjects(page[s][:limit])
         </div>
         $if s != 'times':
             <div class="contentSpacer"></div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -91,11 +91,9 @@ $ has_tag = 'tag' in page
             <span class="title"><em>$_("None found.")</em></span>
 
     $for category, label, limit in subject_list:
-        <div class="contentQuarter link-box">
+        <div class="contentQuarter link-box link-box--with-header">
           <h6 class="black collapse uppercase">$label</h6>
-          <div class="subjects" id="subjects-$category">
-            $:renderSubjects(page[category][:limit])
-          </div>
+          $:renderSubjects(page[category][:limit])
         </div>
 
     <div class="clearfix"></div>

--- a/openlibrary/templates/type/author/view.html
+++ b/openlibrary/templates/type/author/view.html
@@ -156,7 +156,7 @@ $set_share_links(url=request.canonical_url, title=title, view_context=ctx)
 
         $def render_subjects(label, subjects, prefix):
             $if subjects:
-                <div class="section">
+                <div class="section link-box link-box--with-header">
                     <h6 class="collapse black uppercase">$label</h6>
                     $for _, subject, count in subjects:
                         <a itemprop="knowsAbout" href="/subjects/$prefix$subject.lower().replace(' ', '_')">$subject</a>$cond(not loop.last, ",", "")

--- a/static/css/components/link-box.less
+++ b/static/css/components/link-box.less
@@ -7,24 +7,16 @@
 }
 
 .link-box {
+  font-size: @font-size-body-medium;
+  white-space: normal;
+  word-wrap: break-word;
+
   h6 {
     color: @grey;
     margin: 0;
     padding: 0;
     text-transform: uppercase;
     display: inline;
-  }
-  > div {
-    font-size: @font-size-headline-small;
-  }
-}
-
-// div.subjects can be removed in future when legacy.css has been removed
-.link-box,
-div.subjects {
-  > div {
-    white-space: normal;
-    word-break: normal;
-    word-wrap: break-word;
+    font-size: @font-size-label-medium;
   }
 }

--- a/static/css/components/link-box.less
+++ b/static/css/components/link-box.less
@@ -2,10 +2,6 @@
  * Link Box
  * https://github.com/internetarchive/openlibrary/wiki/Design-Pattern-Library#linkbox
  */
-.contentQuarter div, .link-box div {
-  padding-right: 19px;
-}
-
 .link-box {
   font-size: @font-size-body-medium;
   white-space: normal;
@@ -18,5 +14,9 @@
     text-transform: uppercase;
     display: inline;
     font-size: @font-size-label-medium;
+  }
+
+  &.link-box--with-header h6 {
+    display: block;
   }
 }

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -130,7 +130,7 @@ textarea[name="work--description"] + h3 + .wmd-preview,
   content: attr(data-before);
 }
 
-.section, .section h6 {
+.section h6 {
   font-size: @font-size-label-medium;
 }
 

--- a/static/css/layout/v2.less
+++ b/static/css/layout/v2.less
@@ -25,10 +25,9 @@ body.full-width #test-body-mobile {
 }
 
 @media all and ( min-width: @width-breakpoint-desktop ) {
-  .content {
-    &Quarter {
-      float: left;
-      width: 240px;
-    }
+  .contentQuarter {
+    float: left;
+    width: 25%;
+    padding-right: 19px;
   }
 }


### PR DESCRIPTION
Addendum to #8931 . A few of the classes sizes were being used on other pages, causing them to appear odd. Also the TOC was accidentally might smaller. Mostly removed CSS which no longer made sense, and DRY'd the way the link-boxes were rendered (although this could be DRY'd quite a bit more).

### Technical
The `link-box` is the css component name we give to the e.g. "SUBJECTS: Horror, Fantasy, ..." block. It appears on author pages, book pages, and on subjects/publisher pages.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
TOC before/after:

![image](https://github.com/internetarchive/openlibrary/assets/6251786/37e1cc1a-efc4-4adc-9155-b72d004a6c46)

link-box before/after

![image](https://github.com/internetarchive/openlibrary/assets/6251786/183a5e0a-adea-417b-9e84-3a5849d92d4a)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/b233778b-de25-4f6d-96cc-0d40d5d8ccc4)
![image](https://github.com/internetarchive/openlibrary/assets/6251786/8882680f-1fa8-4284-b156-d274eb5bd7df)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
