### PR TITLE
DRY design/code of "Book Details" section

### DIFF
--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -352,7 +352,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
           <hr>
           $if edition.first_sentence:
             <div>
-              <h3 class="list-header">$_("First Sentence")</h3>
+              <h3>$_("First Sentence")</h3>
               <p>"$(edition.first_sentence)"</p>
             </div>
 
@@ -368,7 +368,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
           $if edition.notes or edition.publish_places or edition.series or edition.volume or edition.genres or edition.other_titles or edition.copyright_date or edition.translation_of or edition.translated_from:
             <div class="section">
-                <h3 class="list-header">$_("Edition Notes")</h3>
+                <h3>$_("Edition Notes")</h3>
                 $if edition.notes:
                     <div class="edition-notes">
                     $:format(edition.notes)
@@ -388,7 +388,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
           $ classifications = edition.get_classifications().multi_items()
           $if classifications:
             <div class="section">
-                <h3 class="list-header collapse">$_("Classifications")</h3>
+                <h3>$_("Classifications")</h3>
                 <dl class="meta">
                     $for name, values in classifications:
                         $:display_identifiers(values[0].label, values)
@@ -413,7 +413,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
           $ contributors = edition.get('contributors', [])
           $if contributors:
             <div class="section">
-              <h3 class="list-header">$_("Contributors")</h3>
+              <h3>$_("Contributors")</h3>
               <dl class="meta">
               $for c in contributors:
                     $:display_value(c.role, c.name)
@@ -422,7 +422,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
           $if has_any("physical_format", "pagination", "physical_dimensions", "weight"):
             <div class="section">
-                <h3 class="list-header collapse">$_("The Physical Object")</h3>
+                <h3>$_("The Physical Object")</h3>
                 <dl class="meta">
                     $:display_value(_("Format"), edition.physical_format)
                     $:display_value(_("Pagination"), edition.pagination)
@@ -434,7 +434,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
 
 
           <div class="section">
-            <h3 class="list-header collapse">$_("ID Numbers")</h3>
+            <h3>$_("ID Numbers")</h3>
             <dl class="meta">
                 $:display_identifiers("Open Library", [storage(url=None, value=edition.key.split("/")[-1])])
                 $ no_index = edition.get_ia_meta_fields().get('noindex', False)

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -350,18 +350,10 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
         $if edition:
           <h2 class="details-title" itemprop="name">$_("Book Details")</h2>
           <hr>
-          $if edition.publish_places:
-            <div class="section">
-              <h3 class="edition-header">$_('Published in')</h3>
-              <p>
-              $for p in edition.publish_places:
-                $(p)$cond(loop.last, "", ", ")
-              </p>
-            </div>
           $if edition.first_sentence:
             <div>
-            <h3 class="edition-header">$_("First Sentence")</h3>
-            <p>"$(edition.first_sentence)"</p>
+              <h3 class="list-header">$_("First Sentence")</h3>
+              <p>"$(edition.first_sentence)"</p>
             </div>
 
           $ table_of_contents = edition.get_table_of_contents()
@@ -374,15 +366,15 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
               $:macros.ReadMore()
             </div>
 
-          $if edition.notes or edition.series or edition.volume or edition.genres or edition.other_titles or edition.copyright_date or edition.translation_of or edition.translated_from:
+          $if edition.notes or edition.publish_places or edition.series or edition.volume or edition.genres or edition.other_titles or edition.copyright_date or edition.translation_of or edition.translated_from:
             <div class="section">
-                <h3 class="edition-header">$_("Edition Notes")
-                </h3>
+                <h3 class="list-header">$_("Edition Notes")</h3>
                 $if edition.notes:
                     <div class="edition-notes">
                     $:format(edition.notes)
                     </div>
                 <dl class="meta">
+                    $:display_value(_("Published in"), edition.publish_places)
                     $:display_value(_("Series"), edition.series)
                     $:display_value(_("Volume"), edition.volume)
                     $:display_value(_("Genre"), edition.genres)
@@ -421,7 +413,7 @@ $ worldcat_links = macros.WorldcatLink(isbn=isbn_13 or isbn_10, oclc_numbers=ocl
           $ contributors = edition.get('contributors', [])
           $if contributors:
             <div class="section">
-              <h3 class="edition-header">$_("Contributors")</h3>
+              <h3 class="list-header">$_("Contributors")</h3>
               <dl class="meta">
               $for c in contributors:
                     $:display_value(c.role, c.name)

--- a/static/css/base/dl.less
+++ b/static/css/base/dl.less
@@ -9,10 +9,6 @@ dt,
 .list-header {
   clear: both;
 }
-.list-header {
-  float: left;
-  margin-bottom: 10px;
-}
 dl {
   margin: 10px 0;
   &:after {

--- a/static/css/base/dl.less
+++ b/static/css/base/dl.less
@@ -5,8 +5,7 @@ dd,
 dt {
   float: left;
 }
-dt,
-.list-header {
+dt {
   clear: both;
 }
 dl {

--- a/static/css/components/work.less
+++ b/static/css/components/work.less
@@ -134,11 +134,6 @@ textarea[name="work--description"] + h3 + .wmd-preview,
   font-size: @font-size-label-medium;
 }
 
-h3.edition-header {
-  font-size: @font-size-label-large;
-  margin: 0;
-}
-
 .edition-overview {
   background: @light-grey;
   padding: 10px;


### PR DESCRIPTION
Saw some simple opportunities while working on #9175 to DRY up some of the pieces of this section. Namely:

- Make all the heading here the same size
- Make `Published in` appear like `Other Titles`/other metadata instead of own section since it's very short.

### Technical
- Removed a number of classes that no longer really made sense:
    - `edition-header`: was only used here, and made the headings look meaninglessly inconsistent
    - `list-header`: The class didn't really make any style changes? And the `clear-both` was no longer needed after I changed this to not `float: left`. Floating was a residue of a former time when these mini table things were in a grid via float.
    - `list-header.collapse`: No longer necessary; residue when `.collapse` was used to remove the margins from something. The margins of the `h3` are already tiny.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
Before:
![image](https://github.com/internetarchive/openlibrary/assets/6251786/bd38c728-2037-4eba-8764-8398d331e482)

After:
![image](https://github.com/internetarchive/openlibrary/assets/6251786/58b6cc93-7317-4f1b-9734-73ed9523b378)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
