### PR TITLE
Fix: option forceclose removed in latest haproxy

### DIFF
--- a/conf/solr/haproxy.cfg
+++ b/conf/solr/haproxy.cfg
@@ -26,7 +26,6 @@ defaults
     # these are added so the client ip comes through
     option httpclose
     option forwardfor
-    option forceclose
 
 
 listen solr


### PR DESCRIPTION
It's an alias for `option httpclose`, which we specify a few lines up.

See https://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4.2-option%20forceclose

### Technical
<!-- What should be noted about the implementation? -->

### Testing
Patch deployed to fix haproxy not starting up due to the now invalid option.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
