### PR TITLE
Fix: Can set the page count for a book negative (fixed)

### DIFF
--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -557,7 +557,7 @@ $ })
                 </div>
                 <div class="input">
                     <input name="edition--number_of_pages" type="number"
-                        step="1" id="edition--number_of_pages" value="$book.number_of_pages"/>
+                        step="1" min="0" id="edition--number_of_pages" value="$book.number_of_pages"/>
                 </div>
             </div>
             <div class="formElement">

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -557,7 +557,7 @@ $ })
                 </div>
                 <div class="input">
                     <input name="edition--number_of_pages" type="number"
-                        step="1" min="0" id="edition--number_of_pages" value="$book.number_of_pages"/>
+                        step="1" min="1" id="edition--number_of_pages" value="$book.number_of_pages"/>
                 </div>
             </div>
             <div class="formElement">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9169

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix client side bug

### Technical
<!-- What should be noted about the implementation? -->
As was proposed by @RayBB adding html attribute "min" prevents users to go below 0 (including typing)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![issue #9169](https://github.com/internetarchive/openlibrary/assets/104564914/f22f4cc8-96ec-4932-8150-17d4b5159e1d)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Same as screenshot

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@scottbarnes 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->