### PR TITLE
Fix some i18n-related bugs

### DIFF
--- a/openlibrary/templates/account/reading_log.html
+++ b/openlibrary/templates/account/reading_log.html
@@ -4,7 +4,6 @@ $ username = user.key.split('/')[-1]
 $ meta_photo_url = "https://archive.org/services/img/%s" % get_internet_archive_id(user.key)
 $ userDisplayName = user.displayname or ctx.user.displayname
 $ readlog_keys = ['want-to-read', 'already-ready', 'current-reading']
-$ shelves = [_('want to read'), _('currently reading'), _('already read')]
 
 $if key == 'currently-reading':
   $ og_title = _("Books %(username)s is reading", username=userDisplayName)
@@ -68,6 +67,7 @@ $add_metatag(property="og:image", content=meta_photo_url)
       $if docs:
         $ bookshelf_id = {'want-to-read': 1, 'currently-reading': 2, 'already-read': 3}.get(key, None)
         $ doc_number = 1
+        $ shelves = ['want to read', 'currently reading', 'already read']
         $# enumerate because using zip() will result in empty iterator when no ratings are passed, and ratings are only used on already-read.
         $for idx, doc in enumerate(docs):
           $if doc.get('work', {}):

--- a/openlibrary/templates/lists/list_overview.html
+++ b/openlibrary/templates/lists/list_overview.html
@@ -23,6 +23,11 @@ $ data_list_key = 'data-list-key=%s' % list.key if is_owner else ''
                 <a href="$list.key" class="remove-from-list red smaller arial plain" data-list-key="$list.key" title="$_('Remove from your list?')">[X]</a>
         </span>
         $if has_owner:
-            <span class="owner">$:_('from <a href="%(link)s">You</a>', link=link)</span>
+            <span class="owner">
+                $if is_owner:
+                    $:_('from <a href="%(link)s">You</a>', link=list.owner.key)
+                $else:
+                    $:_('from <a href="%(link)s">%(name)s</a>', link=list.owner.key, name=websafe(list.owner.displayname))
+            </span>
     </span>
 </li>


### PR DESCRIPTION
Addendum to:
- #9025 - Displaying "from You" for all lists, not just own
- #8607 - This PR uses the readinglog_item strings in the URL, so will need those to be not internationalized: https://github.com/internetarchive/openlibrary/blob/d6dcacce55185a851c446173fb16bd9aee702dc3/openlibrary/macros/SearchResultsWork.html#L50

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
