### PR TITLE
Fixed i18n syntax errors by removing \$_("") in 2 files

### DIFF
--- a/static/offline.html
+++ b/static/offline.html
@@ -13,10 +13,10 @@
         </style>
     </head>
     <body>
-    <div id="logo"><img src="/static/images/logo_OL-err.png" alt="$_('The Open Library is closed!')" width="219"/></div>
-    <p><strong>$_("Looks like you lost your connection. Please check it and try again.")</strong></p>
-    <a class="goback" href="javascript:history.back()">$_("Go Back")</a>
-    <a href="javascript:location.reload()">$_("Retry")</a>
+    <div id="logo"><img src="static/images/logo_OL-err.png" alt="The Open Library is closed!" width="219"/></div>
+    <p><strong>Looks like you lost your connection. Please check it and try again.</strong></p>
+    <a class="goback" href="javascript:history.back()">Go Back</a>
+    <a href="javascript:location.reload()">Retry</a>
 
     </body>
 </html>

--- a/static/status-500.html
+++ b/static/status-500.html
@@ -2,7 +2,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <html>
     <head>
-        <title>$_("Hmm...")</title>
+        <title>Hmm...</title>
         <style type="text/css">
         body{text-align:center; background: #E2DCC5;}
         #logo{margin:45px auto 75px;}
@@ -10,7 +10,7 @@
         </style>
     </head>
     <body>
-    <div id="logo"><img src="/images/logo_OL-err.png" alt="$_('The Open Library is closed!')" width="219" height="131"/></div>
-    <p><strong>$_("Open Library is temporarily offline.")</strong><br/>$:_('Please <a href="https://blog.openlibrary.org/">visit our blog</a> for updates about site status.')</p>
+    <div id="logo"><img src="/images/logo_OL-err.png" alt="The Open Library is closed!" width="219" height="131"/></div>
+    <p><strong>Open Library is temporarily offline.</strong><br/>Please <a href="https://blog.openlibrary.org/">visit our blog</a> for updates about site status.</p>
     </body>
 </html>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9097

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
fixed a syntax bug 

### Technical
<!-- What should be noted about the implementation? -->
removing the $(" ") and $(' ') from the necessary lines (the page is static HTML, and does not have access to the Python gettext function that the $_(" ") is supposed to call, so there is no need to use the syntax)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1.Go to any page on the Open Library site 
2.Turn off your wifi
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/117903616/371b455e-ad06-406a-ad91-b705bcfdc1b1)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@rebecca-shoptaw 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
