### PR TITLE
Remove `Needs: Submitter Input` label on push

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+# Configurations for the `labeler` GitHub action.
+# More details can be found here: https://github.com/actions/labeler?tab=readme-ov-file#usage
+"Needs: Submitter Input":
+  - changed-files:
+    # When the labeler action's `sync-labels` input it true,
+    # the `Needs: Submitter Input` label will be removed
+    # unless the update includes a change to any `dev/null/*` file
+    # (which should never happen).
+    - any-glob-to-any-file: dev/null/*

--- a/.github/workflows/pr_update_labeler.yml
+++ b/.github/workflows/pr_update_labeler.yml
@@ -1,0 +1,18 @@
+name: pr_update_labeler
+on:
+  pull_request_target:
+    types:
+      - synchronize
+    branches:
+      - master
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9199

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Removes any existing https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Submitter%20Input labels from PRs when the pull request's head branch is updated.

### Technical
<!-- What should be noted about the implementation? -->
The `pull_request_target` event was chosen over `pull_request` event, as the workflow will not run for `pull_request` events if there is a merge conflict (more details [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)).

Our labeler configuration is set to add a https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Submitter%20Input label if the PR includes changes to any file in the project's non-existent `dev/null` directory.  When coupled with a truthy `sync-labels` input, the label is removed every time there is no change to any `dev/null` file.  This isn't the most intuitive way to remove labels, but is recommended by the action's team ([here](https://github.com/actions/labeler/issues/78)).

`.github/labeler.yml` is the default path for the labeler's configuration file.  If we want to move this elsewhere, the path is configurable (not that I'm suggesting that we move the file --- just pointing out that we can).

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Merge this branch into the `master` branch of _your_ repo (not this one)
2. Open a PR in your repo that makes a small change (maybe a `README` update)
3. Label the new PR `Needs: Submitter Input`.  You'll likely have to create this label in your repo --- be sure to use the exact string when creating the label.
4. Update the PR.  The `Needs: Submitter Input` label should be removed after the action finishes.  Any other labels should be unaffected.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
