### PR TITLE
Add fixed creation date to POT file

### DIFF
--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -5,6 +5,7 @@ import subprocess
 from collections.abc import Iterator
 from io import BytesIO
 from pathlib import Path
+from datetime import datetime
 
 import web
 
@@ -14,6 +15,7 @@ from babel.messages import Catalog, Message
 from babel.messages.pofile import read_po, write_po
 from babel.messages.mofile import write_mo
 from babel.messages.extract import extract_from_file, extract_from_dir, extract_python
+from babel.dates import get_timezone
 
 from .validators import validate
 
@@ -159,7 +161,16 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
 
 
 def extract_messages(dirs: list[str], verbose: bool, forced: bool):
-    catalog = Catalog(project='Open Library', copyright_holder='Internet Archive')
+    # The creation date is fixed to prevent merge conflicts on this line as a result of i18n auto-updates
+    # In the unlikely event we need to update the fixed creation date, you can change the hard-coded date below
+    fixed_creation_date = datetime(
+        2024, 5, 1, 18, 58, tzinfo=get_timezone('US/Eastern')
+    )
+    catalog = Catalog(
+        project='Open Library',
+        copyright_holder='Internet Archive',
+        creation_date=fixed_creation_date,
+    )
     METHODS = [("**.py", "python"), ("**.html", "openlibrary.i18n:extract_templetor")]
     COMMENT_TAGS = ["NOTE:"]
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9208.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Prevents unnecessary merge conflicts in auto-updated `messages.pot` file by setting `POT-Creation-Date` to a fixed date. 

### Technical
<!-- What should be noted about the implementation? -->
The date and timezone was selected to exactly match the creation date we have currently, so no date-based merge conflicts should occur, including with this PR.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Locally, with `pre-commit` installed, make a temporary change to the site text (i.e. adding or removing a word) and do a test commit
2. The `generate POT` method will auto-generate a new `messages.pot` file
3. Look at the `messages.pot` file diff and confirm that the only change in it is the text change (i.e. the creation date field remains the same)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
