### PR TITLE
Update `messages.pot` creation date timezone and add `--skip-untracked` option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
     - id: generate-pot
       name: Generate POT
       description: This hook generates the .pot file for internationalization.
-      entry: python ./scripts/i18n-messages extract
+      entry: python ./scripts/i18n-messages extract --skip-untracked
       types_or: [python, html]
       language: python
       pass_filenames: false

--- a/openlibrary/i18n/__init__.py
+++ b/openlibrary/i18n/__init__.py
@@ -15,7 +15,6 @@ from babel.messages import Catalog, Message
 from babel.messages.pofile import read_po, write_po
 from babel.messages.mofile import write_mo
 from babel.messages.extract import extract_from_file, extract_from_dir, extract_python
-from babel.dates import get_timezone
 
 from .validators import validate
 
@@ -160,12 +159,12 @@ def extract_templetor(fileobj, keywords, comment_tags, options):
     return extract_python(f, keywords, comment_tags, options)
 
 
-def extract_messages(dirs: list[str], verbose: bool, forced: bool):
+def extract_messages(
+    dirs: list[str], verbose: bool, forced: bool, skip_untracked: bool
+):
     # The creation date is fixed to prevent merge conflicts on this line as a result of i18n auto-updates
     # In the unlikely event we need to update the fixed creation date, you can change the hard-coded date below
-    fixed_creation_date = datetime(
-        2024, 5, 1, 18, 58, tzinfo=get_timezone('US/Eastern')
-    )
+    fixed_creation_date = datetime.fromisoformat('2024-05-01 18:58-0400')
     catalog = Catalog(
         project='Open Library',
         copyright_holder='Internet Archive',
@@ -174,10 +173,12 @@ def extract_messages(dirs: list[str], verbose: bool, forced: bool):
     METHODS = [("**.py", "python"), ("**.html", "openlibrary.i18n:extract_templetor")]
     COMMENT_TAGS = ["NOTE:"]
 
-    untracked_files = get_untracked_files(dirs, ('.py', '.html'))
     template = read_po((Path(root) / 'messages.pot').open('rb'))
     msg_set = {msg.id for msg in template if msg.id != ''}
     new_set = set()
+    skipped_files = set()
+    if skip_untracked:
+        skipped_files = get_untracked_files(dirs, ('.py', '.html'))
 
     for d in dirs:
         extracted = extract_from_dir(
@@ -187,7 +188,7 @@ def extract_messages(dirs: list[str], verbose: bool, forced: bool):
         counts: dict[str, int] = {}
         for filename, lineno, message, comments, context in extracted:
             file_path = Path(d) / filename
-            if file_path in untracked_files:
+            if file_path in skipped_files:
                 continue
             new_set.add(message)
             counts[filename] = counts.get(filename, 0) + 1

--- a/scripts/i18n-messages
+++ b/scripts/i18n-messages
@@ -33,7 +33,10 @@ def main(cmd, args):
             'openlibrary/plugins/upstream',
         ]
         i18n.extract_messages(
-            message_sources, verbose='--verbose' in args, forced='--force-write' in args
+            message_sources,
+            verbose='--verbose' in args,
+            forced='--force-write' in args,
+            skip_untracked='--skip-untracked' in args,
         )
     elif cmd == 'compile':
         i18n.compile_translations(args)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Addendum to #9208.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Fixes a bug with the timezone rendering of the new static date, and adds a `--skip-untracked-files` option to prevent bugs when running the `extract` script in Docker.

### Technical
<!-- What should be noted about the implementation? -->
Simple! Involved:
 a. Switching from `Babel.dates` for timezone to a built-in `datetime` method, which is cleaner anyway
 b. Adding a flag for `--skip-untracked-files` that works similarly to the `--verbose` and `--forced` flags and is now called in `pre-commit-config.yaml`

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Make a new `html` file in `templates` with internationalized text.
2. Do a test commit locally
3. Pre-commit should skip the untracked file when generating the `messages.pot` file
4. Undo the commit, and use the extract script directly in Docker
5. Docker should run the script without errors and include the untracked file

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
