### PR TITLE
Create action for assigning, labeling new PRs

### DIFF
--- a/.github/workflows/new_pr_labeler.yml
+++ b/.github/workflows/new_pr_labeler.yml
@@ -1,0 +1,24 @@
+name: new_pr_labeler
+on:
+  pull_request_target:
+    types:
+      - opened
+jobs:
+  label_pr:
+    # Continue only if the PR was opened in the same repository that is running this action:
+    if: ${{ github.repository == github.event.repository.full_name }}
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install @octokit/action
+      - run: node scripts/gh_scripts/new_pr_labeler.mjs ${{ github.repository }} ${{ github.event.pull_request.user.login }} ${{ github.event.pull_request.number }} "$PR_BODY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}

--- a/scripts/gh_scripts/new_pr_labeler.mjs
+++ b/scripts/gh_scripts/new_pr_labeler.mjs
@@ -1,0 +1,129 @@
+/**
+ * Script to automatically assign and label new GitHub pull requests.
+ *
+ * Usage:
+ * `node new_pr_labeler REPO_NAME PR_AUTHOR PR_NUMBER PR_BODY...`
+ *
+ * Where:
+ * `REPO_NAME` is the owner and repository (e.g. "internetarchive/openlibrary")
+ * `PR_AUTHOR` is the username of the PR's author
+ * `PR_NUMBER` is the newly created PR's number
+ * `PR_BODY`   is the body of the pull request
+ *
+ * Broadly, this script does the following:
+ * 1. Searches the given PR body for a "closes" statement
+ * 2. Fetches the issue referenced by the "closes" statement, storing references
+ *    to the first priority and lead label encountered
+ * 3. Updates PR, adding same priority label as issue, and assigning the lead (if
+ *    they are not also the author)
+ */
+import { Octokit } from "@octokit/action";
+
+console.log('Script starting....')
+const octokit = new Octokit()
+await main()
+console.log('Script terminated....')
+
+async function main() {
+    // Parse and assign all command-line variables
+    const {fullRepoName, prAuthor, prNumber, prBody} = parseArgs()
+
+    // Look for "Closes:" statement, storing the issue number (if present)
+    const issueNumber = findLinkedIssue(prBody)
+
+    if (!issueNumber) {
+        console.log('No linked issue found for this pull request.')
+        return
+    }
+
+    // Fetch the issue
+    const [repoOwner, repoName] = fullRepoName.split('/')
+    const linkedIssue = await octokit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+        owner: repoOwner,
+        repo: repoName,
+        issue_number: issueNumber,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28'
+        }
+      })
+    if (!linkedIssue) {
+        console.log(`An issue occurred while fetching issue #${issueNumber}`)
+        process.exit(1)
+    }
+
+    // Check the issue's labels for the priority and lead
+    let leadName
+    let priority
+    for (const label of linkedIssue.data.labels) {
+        if (!leadName && label.name.startsWith('Lead: @')) {
+            leadName = label.name.split('@')[1]
+        }
+        if (!priority && label.name.match(/Priority: \d/)) {
+            priority = label.name
+        }
+    }
+
+    // Don't assign lead to PR if PR author is the issue lead
+    const assignLead = leadName && !(leadName === prAuthor)
+
+    // Update PR, adding assignee and priority label
+    if (assignLead) {
+        await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+            owner: repoOwner,
+            repo: repoName,
+            issue_number: prNumber,
+            assignees: [leadName],
+            headers: {
+              'X-GitHub-Api-Version': '2022-11-28'
+            }
+          })
+    }
+
+    if (priority) {
+        await octokit.request('POST /repos/{owner}/{repo}/issues/{issue_number}/labels', {
+            owner: repoOwner,
+            repo: repoName,
+            issue_number: prNumber,
+            labels: [priority],
+            headers: {
+              'X-GitHub-Api-Version': '2022-11-28'
+            }
+          })
+    }
+}
+
+/**
+ * Returns an object containing the parsed command-line arguments.
+ * 
+ * Any newline characters in the PR's body are replaced by space characters.
+ *
+ * @returns {Record<string, string>}
+ */
+function parseArgs() {
+    if (process.argv.length < 6) {
+        console.log('Unexpected number of arguments.')
+        process.exit(1)
+    }
+    const prBody = process.argv.slice(5).join(' ')
+    return {
+        fullRepoName: process.argv[2],
+        prAuthor: process.argv[3],
+        prNumber: process.argv[4],
+        prBody: prBody
+    }
+}
+
+/**
+ * Finds first "Closes" statement in the given pull request body, then
+ * returns the number of the linked issue or an empty string, if none exists.
+ *
+ * @param {string} body The body of a GitHub pull request
+ * @returns {string} The number of the linked issue that will be closed 
+ *                   by this pull request, or an empty string if no 
+ *                   "Closes" statement is found.
+ */
+function findLinkedIssue(body) {
+    let lowerBody = body.toLowerCase()
+    const matches = lowerBody.match(/closes #(\d+)/)
+    return matches.length ? Number(matches[1]) : ''
+}

--- a/scripts/gh_scripts/new_pr_labeler.mjs
+++ b/scripts/gh_scripts/new_pr_labeler.mjs
@@ -94,7 +94,7 @@ async function main() {
 
 /**
  * Returns an object containing the parsed command-line arguments.
- * 
+ *
  * Any newline characters in the PR's body are replaced by space characters.
  *
  * @returns {Record<string, string>}
@@ -118,8 +118,8 @@ function parseArgs() {
  * returns the number of the linked issue or an empty string, if none exists.
  *
  * @param {string} body The body of a GitHub pull request
- * @returns {string} The number of the linked issue that will be closed 
- *                   by this pull request, or an empty string if no 
+ * @returns {string} The number of the linked issue that will be closed
+ *                   by this pull request, or an empty string if no
  *                   "Closes" statement is found.
  */
 function findLinkedIssue(body) {

--- a/scripts/gh_scripts/new_pr_labeler.mjs
+++ b/scripts/gh_scripts/new_pr_labeler.mjs
@@ -58,7 +58,7 @@ async function main() {
         if (!leadName && label.name.startsWith('Lead: @')) {
             leadName = label.name.split('@')[1]
         }
-        if (!priority && label.name.match(/Priority: \d/)) {
+        if (!priority && label.name.match(/Priority: [012]/)) {
             priority = label.name
         }
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9200

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Automatically labels and assigns newly created PRs, including drafts, via a new GitHub action.

When a new PR is created, the action passes the full repository name (e.g. `internetarchive/openlibrary`), the PR's author, the PR's number, and the PR's body to the `new_pr_labeler.mjs` script, which does the following:

1. Searches the PR body for a `closes #` statement.
2. Fetches the issue referenced by the `closes #` statement.
3. Checks the issue for the first `Priority` and `Lead:` labels.
4. If a level 0, 1, or 2 priority label is found, it is added to the new PR.
5. If a lead label is found, and the lead is not the PR's author, the issue's lead is assigned to the new PR.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
This can be tested by merging this branch into a forked Openlibrary repo by:
1. Merging into the fork's `master` branch
2. Opening and labeling some issues in the forked repo (you may have to create the labels)
3. Create a new PR that references one of your newly created issues

Note that, before somebody can be assigned to a PR, they must be a `collaborator` for your repo.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
