### PR TITLE
Redo password validation for registration form

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -883,8 +883,8 @@ msgstr ""
 msgid "The Open Library Team"
 msgstr ""
 
-#: account/create.html
-msgid "Password must be between 3 and 20 characters"
+#: account/create.html forms.py
+msgid "Must be between 3 and 20 characters"
 msgstr ""
 
 #: account/create.html
@@ -6523,10 +6523,6 @@ msgstr ""
 
 #: forms.py
 msgid "Must be between 3 and 20 letters and numbers"
-msgstr ""
-
-#: forms.py
-msgid "Must be between 3 and 20 characters"
 msgstr ""
 
 #: forms.py

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -884,6 +884,10 @@ msgid "The Open Library Team"
 msgstr ""
 
 #: account/create.html
+msgid "Password must be between 3 and 20 characters"
+msgstr ""
+
+#: account/create.html
 msgid "Sign Up to Open Library"
 msgstr ""
 

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -1,4 +1,6 @@
 export function initRealTimeValidation() {
+    const i18nStrings = JSON.parse(document.querySelector('form[name="signup"]').dataset.i18n);
+
     if (window.grecaptcha) {
         // Callback that is called when grecaptcha.execute() is successful
         function submitCreateAccountForm() {
@@ -80,32 +82,17 @@ export function initRealTimeValidation() {
         }
     }
 
-    function validatePasswords() {
-        // NOTE: Outdated two-password implementation to be replaced and helper functions to be added in issue #9165
-        var value = document.getElementById('password').value;
-        var value2 = document.getElementById('password2').value;
-        if (value && value2) {
-            if (value2 === value) {
-                $('#password2Message').removeClass().addClass('darkgreen').text('');
-                $('label[for="password2"]').removeClass();
-                $(document.getElementById('password2')).removeClass().addClass('required');
-            }
-            else {
-                $(document.getElementById('password2')).removeClass().addClass('required invalid');
-                $('label[for="password2"]').removeClass().addClass('invalid');
-                $('#password2Message').removeClass().addClass('invalid').text('Passwords didnt match');
-            }
+    function validatePassword() {
+        const value_password = $(this).val();
+        if (value_password !== '' && (value_password.length < 3 || value_password.length > 20)) {
+            renderError('#password', '#passwordMessage', i18nStrings['password_length_err']);
         }
-        else {
-            $('label[for="password2"]').removeClass();
-            $(document.getElementById('password2')).removeClass().addClass('required');
-            $('#password2Message').removeClass().text('');
-        }
+        else clearError('#password', '#passwordMessage');
     }
 
     $('#username').on('blur', validateUsername);
     $('#emailAddr').on('blur', validateEmail);
-    $('#password, #password2').on('blur', validatePasswords);
+    $('#password').on('blur', validatePassword);
 
     $('#signup').on('click', function(e) {
         e.preventDefault();

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -1,5 +1,9 @@
 $def with (form)
 
+$ i18n_strings = {
+    $ "password_length_err": _("Password must be between 3 and 20 characters")
+    $ }
+
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:
 
 $var title: $_("Sign Up to Open Library")
@@ -46,7 +50,7 @@ $if ctx.user:
     <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
     <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
 $else:
-    <form class="olform create validate" name="signup" method="post" action="">
+    <form class="olform create validate" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
         $if form.note:
             <div class="note">$form.note</div>
 

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -1,7 +1,7 @@
 $def with (form)
 
 $ i18n_strings = {
-    $ "password_length_err": _("Password must be between 3 and 20 characters")
+    $ "password_length_err": _("Must be between 3 and 20 characters")
     $ }
 
 $# :param openlibrary.plugins.upstream.forms.RegisterForm form:

--- a/tests/unit/js/realtime_account_validation.test.js
+++ b/tests/unit/js/realtime_account_validation.test.js
@@ -2,78 +2,81 @@ import { initRealTimeValidation } from '../../../openlibrary/plugins/openlibrary
 
 beforeEach(() => {
     document.body.innerHTML = `
-    <form id="signup">
+    <form id="signup" name="signup" data-i18n={}>
       <input type="text" id="username">
       <input type="text" id="emailAddr">
-      <input type="password" id="password">
-      <input type="password" id="password2">
-      <div id="password2Message"></div>
-      <label for="password2" class="default">Label for password2</label>
+      <div id="passwordMessage"></div>
+      <label for="password">Label for password</label>
+      <input type="password" class="required" id="password">
     </form>
   `;
 });
 
 describe('Password tests', () => {
-    let label, passwordField, passwordField2, passwordMessage2
+    let label, passwordField, passwordMessage
 
     beforeEach(() => {
         // call the function
         initRealTimeValidation();
 
         //declare the elements
-        label = document.querySelector('label[for="password2"]');
+        label = document.querySelector('label[for="password"]');
         passwordField = document.getElementById('password');
-        passwordField2 = document.getElementById('password2');
-        passwordMessage2 = document.getElementById('password2Message');
+        passwordMessage = document.getElementById('passwordMessage');
     })
 
     test('validatePassword should update elements correctly on success', () => {
-        // set the password values
+        // set the password value
         passwordField.value = 'password123';
-        passwordField2.value = 'password123';
 
-        // Trigger the blur event on the password fields
+        // Trigger the blur event on the password field
         passwordField.dispatchEvent(new Event('blur'));
-        passwordField2.dispatchEvent(new Event('blur'));
 
         // Assert that the elements have the expected classes
-        expect(passwordField2.classList.contains('required')).toBe(true);
-        expect(passwordField2.classList.contains('invalid')).toBe(false);
+        expect(passwordField.classList.contains('required')).toBe(true);
+        expect(passwordField.classList.contains('invalid')).toBe(false);
         expect(label.classList.length).toBe(0);
-        expect(passwordMessage2.classList.contains('darkgreen')).toBe(true);
     });
 
     test('validatePassword should update elements correctly for empty fields', () => {
-        // set the password values
+        // set the password value
         passwordField.value = '';
-        passwordField2.value = '';
 
-        // Trigger the blur event on the password fields
+        // Trigger the blur event on the password field
         passwordField.dispatchEvent(new Event('blur'));
-        passwordField2.dispatchEvent(new Event('blur'));
 
         // Assert that the elements have the expected classes
-        expect(passwordField2.classList.contains('required')).toBe(true);
-        expect(passwordField2.classList.contains('invalid')).toBe(false);
-        expect(label.classList.length).toBe(0);
-        expect(passwordMessage2.textContent).toBe('');
+        expect(passwordField.classList.contains('required')).toBe(true);
+        expect(passwordField.classList.contains('invalid')).toBe(false);
+        expect(label.classList.contains('invalid')).toBe(false);
+        expect(passwordMessage.textContent).toBe('');
     });
 
-    test('validatePassword should update elements correctly for passwords not matching', () => {
+    test('validatePassword should update elements correctly for passwords over 20 chars', () => {
         // set the password values
-        passwordField.value = 'password123';
-        passwordField2.value = 'password321';
+        passwordField.value = 'password1234567891011';
 
         // Trigger the blur event on the password fields
         passwordField.dispatchEvent(new Event('blur'));
-        passwordField2.dispatchEvent(new Event('blur'));
 
         // Assert that the elements have the expected classes
-        expect(passwordField2.classList.contains('required')).toBe(true);
-        expect(passwordField2.classList.contains('invalid')).toBe(true);
-        expect(label.classList.contains('default')).toBe(false);
+        expect(passwordField.classList.contains('required')).toBe(true);
+        expect(passwordField.classList.contains('invalid')).toBe(true);
         expect(label.classList.contains('invalid')).toBe(true);
-        expect(passwordMessage2.classList.contains('invalid')).toBe(true);
-        expect(passwordMessage2.textContent).toBe('Passwords didnt match');
+        expect(passwordMessage.classList.contains('invalid')).toBe(true);
+    });
+
+    test('validatePassword should update elements correctly for passwords under 3 chars', () => {
+        // set the password values
+        passwordField.value = 'pa';
+
+        // Trigger the blur event on the password fields
+        passwordField.dispatchEvent(new Event('blur'));
+
+        // Assert that the elements have the expected classes
+        expect(passwordField.classList.contains('required')).toBe(true);
+        expect(passwordField.classList.contains('invalid')).toBe(true);
+        expect(label.classList.contains('invalid')).toBe(true);
+        expect(passwordMessage.classList.contains('invalid')).toBe(true);
     });
 });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9165

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Addresses console errors re: non-existent `#password2` field, and updates real-time password validation to make the correct checks (determining whether password length is <3 or >20 rather than whether two passwords match).

Also involves re-writing the relevant unit tests.

### Technical
<!-- What should be noted about the implementation? -->
Fairly simple! 
- Added `i18n`-ized error message to `create.html` to pass to `realtime_account_validation.js`
- Rewrote `validatePasswords` function to check length instead of match

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log out (if logged in)
2. Go to the sign up page (/account/create)
3. Enter a password that is < 3 or > 20 characters
4. An error message should appear next to the field (on blur)
5. Enter a password that is the correct length
6. The error message should disappear (on blur)

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
