### PR TITLE
Add comment to `helpers.py`

### DIFF
--- a/openlibrary/core/helpers.py
+++ b/openlibrary/core/helpers.py
@@ -31,6 +31,8 @@ from infogami.infobase.client import Nothing
 from infogami.infobase.utils import parse_datetime
 from infogami.utils.view import safeint
 
+# Helper functions that are added to `__all__` are exposed for use in templates
+# in /openlibrary/plugins/upstream/utils.py setup()
 __all__ = [
     "sanitize",
     "json_encode",


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds comment to notify developers that functions in `openlibrary.core.helpers` `__all__` are exposed to templates.

> [!IMPORTANT]
> Reviewer to confirm that comment is accurate.
>
> Functions found in `helpers` are exposed to templates [here](https://github.com/internetarchive/openlibrary/blob/4e47fb46e329fd8e55ff3b8b100692d69e9964b8/openlibrary/plugins/upstream/utils.py#L1700-L1702).
>
> `helpers` variable is set [here](https://github.com/internetarchive/openlibrary/blob/4e47fb46e329fd8e55ff3b8b100692d69e9964b8/openlibrary/core/helpers.py#L336-L342), using `__all__`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
