### PR TITLE
5151/fix/slick accessibility update

### DIFF
--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -220,4 +220,33 @@ export class Carousel {
     removeLoadingSlide() {
         this.slick.removeSlide(this.slick.$slides.length - 1);
     }
+
+    customaccessibilitySetup() {
+        // inital setup
+        this.ariasetup()
+        $(`${selector} [aria-live]`).removeAttr('aria-live');
+        $(`${selector} .slick-track`).attr('role','list').attr('aria-label',title);
+        setA11yAttributes();
+
+        // after prev or next button click it sets focus to other button didn't exist by default
+        $(`${selector} button.slick-prev`).on('click', function () {
+            $(`${selector} button.slick-next`).focus();
+        });
+        $(`${selector} button.slick-next`).on('click', function () {
+            $(`${selector} button.slick-prev`).focus();
+        });
+        
+        // changes aria properties after slide changes
+        $(selector).on('afterChange', setA11yAttributes);
+    }
+    ariasetup() {
+        // sets aria setup for accessibility
+        //Ensuring offscreen elements do not receive focus
+        $(`${selector} [aria-hidden="true"] a[href]`).attr('tabindex', -1);
+        $(`${selector} [aria-hidden="false"] a[href]`).removeAttr('tabindex');
+
+        //Ensuring any disabled button elements do not receive focus
+        $(`${selector} button[aria-disabled="true"]`).attr('tabindex', -1);
+        $(`${selector} button[aria-disabled="false"]`).removeAttr('tabindex');
+    }
 }

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -62,6 +62,7 @@ export class Carousel {
 
     init() {
         this.$container.slick({
+            accessibility: false,
             infinite: false,
             speed: 300,
             slidesToShow: this.config.booksPerBreakpoint[0],
@@ -174,10 +175,11 @@ export class Carousel {
                 </div>
             </div>`);
         $el.find('.bookcover').attr('title', work.title);
+        // $el.find('.slick-prev slick-arrow').attr('aria-hidden', false)
         $el.find('.cta-btn')
             .attr('title', `${cta}: ${work.title}`)
             .attr('data-ocaid', ocaid)
-            .attr('href', url);
+            .attr('href', url)
         return $el;
     }
 

--- a/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
+++ b/openlibrary/plugins/openlibrary/js/carousel/Carousel.js
@@ -230,12 +230,12 @@ export class Carousel {
 
         // after prev or next button click it sets focus to other button didn't exist by default
         $(`${selector} button.slick-prev`).on('click', function () {
-            $(`${selector} button.slick-next`).focus();
+            $(`${selector} button.slick-next`).trigger('focus');
         });
         $(`${selector} button.slick-next`).on('click', function () {
-            $(`${selector} button.slick-prev`).focus();
+            $(`${selector} button.slick-prev`).trigger('focus');
         });
-        
+
         // changes aria properties after slide changes
         $(selector).on('afterChange', setA11yAttributes);
     }

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -180,4 +180,3 @@ a.cta-btn {
 //     text-align: start;
 //   }
 // }
-

--- a/static/css/components/buttonCta.less
+++ b/static/css/components/buttonCta.less
@@ -144,7 +144,7 @@ a.cta-btn {
 
 .cta-button-group {
   display: flex;
-  align-items: center;
+  align-items: start;
   position: relative;
 
   .cta-btn--w-icon {
@@ -174,3 +174,10 @@ a.cta-btn {
     &:not(:first-child):hover { width: 100%; }
   }
 }
+// @media  (max-width: 750px) {
+//     .cta-btn,
+//   a.cta-btn {
+//     text-align: start;
+//   }
+// }
+


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #5151
Continues previous incomplete pull request https://github.com/internetarchive/openlibrary/pull/5151

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR provides an approach to increase the accessibility of our slick slider carousels. This allows for easy keyboard navigation of the slick carousel.


### Technical
<!-- What should be noted about the implementation? -->
Disables default aria for slick attributes
Adds event listener to slick that is not made by default which is focus allowing the user to be able to continue to next book in carousel instead of exiting carousel when interacting with slick button.
Default accessibility event listeners do not work with OL carousel
### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
![Screenshot from 2024-05-04 12-04-10](https://github.com/internetarchive/openlibrary/assets/56459277/5462ec49-7827-4c52-be5f-34877583c143)
1. Docker compose up (Run image)
2.  docker compose run --rm home npm run build-assets (update js)
3. http://localhost:8080/works/OL36891834W/Short_Mystery_Suspense_Collection_014 (Go to collection)
4. press tab until you reach carasol
5. observe how after passing next button keyboard navigation goes to next book in carousel index. 
6. Do the reverse with shift tab to test if prev button works


### Screenshot
Previous exits carousel after going past slick arrow
[Screencast from 05-02-2024 09:33:52 AM.webm](https://github.com/internetarchive/openlibrary/assets/56459277/c6b1fc91-0c5a-4e41-bfc3-ef1e433847df)
Works properly goes to next book in index after prev or next arrow
[Uploading Screencast from 05-04-2024 12:15:33 PM.webm…]()


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
