### PR TITLE
Add pre-registration validation for IA email and username

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -5472,15 +5472,15 @@ msgid "Book Details"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
-msgid "Published in"
-msgstr ""
-
-#: type/edition/view.html type/work/view.html
 msgid "First Sentence"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
 msgid "Edition Notes"
+msgstr ""
+
+#: type/edition/view.html type/work/view.html
+msgid "Published in"
 msgstr ""
 
 #: type/edition/view.html type/work/view.html
@@ -6443,10 +6443,6 @@ msgstr ""
 
 #: account.py
 msgid "Username unavailable"
-msgstr ""
-
-#: account.py
-msgid "An Internet Archive account already exists with this username"
 msgstr ""
 
 #: account.py forms.py

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6445,12 +6445,20 @@ msgstr ""
 msgid "Username unavailable"
 msgstr ""
 
+#: account.py
+msgid "An Internet Archive account already exists with this username"
+msgstr ""
+
 #: account.py forms.py
 msgid "Must be a valid email address"
 msgstr ""
 
 #: account.py forms.py
 msgid "Email already registered"
+msgstr ""
+
+#: account.py
+msgid "An Internet Archive account already exists with this email"
 msgstr ""
 
 #: account.py

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -573,7 +573,7 @@ class account_validation(delegate.page):
 
         ia_account = account_validation.ia_username_exists(username)
         if ia_account:
-            return _("An Internet Archive account already exists with this username")
+            return _("Username unavailable")
 
     @staticmethod
     def validate_email(email):


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7080.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Adds checks for any existing Internet Archive account with the selected email or username before submission of registration form. This will notify users real time if the username they select is already taken, so that they can choose a new username rather than being auto-assigned one with random digits appended.

### Technical
<!-- What should be noted about the implementation? -->
Because of the scope of #2055 , I've limited this PR to only adding real-time validation for the fields, not preventing submission with a taken username. This means that if a user elects to ignore the "username taken" error message and submits anyway, the account creation will go through and random digits will be appended to their chosen username.

Submission prevention for this and other failing backend checks (i.e. taken OL email address) will be added as a part of  #9205.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log out (if logged in)
2. Hit "Sign Up" or go to `/account/create`
3. Enter an email address for which an IA account but no OL account exists (i.e. rebecca@rebeccashoptaw.dev)
4. An error message should appear (on tab out/de-select) with the warning "An Internet Archive account already exists with this email"
5. Enter a username for which an IA account but no OL account exists (i.e. rstesting)
6. An error message should appear (on tab out/de-select) with the warning "An Internet Archive account already exists with this username"

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
<img width="1033" alt="Realtime errors for IA checks" src="https://github.com/internetarchive/openlibrary/assets/140550988/3892659b-4e42-4771-96cc-3055f71ffd80">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles @seabelis @cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
