### PR TITLE
Filter out PRs having specific labels

### DIFF
--- a/scripts/pr_slack_digest.py
+++ b/scripts/pr_slack_digest.py
@@ -34,12 +34,7 @@ if __name__ == "__main__":
         'Priority: 1': '❗️ ',
     }
 
-    INCLUDE_AUTHORS = [
-        'mekarpeles',
-        'cdrini',
-        'scottbarnes',
-        'jimchamp'
-    ]
+    INCLUDE_AUTHORS = ['mekarpeles', 'cdrini', 'scottbarnes', 'jimchamp']
     EXCLUDE_LABELS = [
         'Needs: Submitter Input',
         'State: Blocked',

--- a/scripts/pr_slack_digest.py
+++ b/scripts/pr_slack_digest.py
@@ -33,8 +33,23 @@ if __name__ == "__main__":
         'Priority: 0': '🚨 ',
         'Priority: 1': '❗️ ',
     }
+
+    INCLUDE_AUTHORS = [
+        'mekarpeles',
+        'cdrini',
+        'scottbarnes',
+        'jimchamp'
+    ]
+    EXCLUDE_LABELS = [
+        'Needs: Submitter Input',
+        'State: Blocked',
+    ]
+    query = 'repo:internetarchive/openlibrary is:open is:pr -is:draft'
     # apparently `author` acts like an OR in this API and only this API -_-
-    query = 'repo:internetarchive/openlibrary is:open is:pr author:cdrini author:jimchamp author:mekarpeles author:scottbarnes -is:draft -label:"State: Blocked" -label:"Needs: Submitter Input"'
+    included_authors = " ".join([f"author:{author}" for author in INCLUDE_AUTHORS])
+    excluded_labels = " ".join([f'-label:"{label}"' for label in EXCLUDE_LABELS])
+    query = f'{query} {included_authors} {excluded_labels}'
+
     prs = requests.get(
         "https://api.github.com/search/issues",
         params={

--- a/scripts/pr_slack_digest.py
+++ b/scripts/pr_slack_digest.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         'Priority: 1': '❗️ ',
     }
     # apparently `author` acts like an OR in this API and only this API -_-
-    query = "repo:internetarchive/openlibrary is:open is:pr author:cdrini author:jimchamp author:mekarpeles author:scottbarnes -is:draft"
+    query = 'repo:internetarchive/openlibrary is:open is:pr author:cdrini author:jimchamp author:mekarpeles author:scottbarnes -is:draft -label:"State: Blocked" -label:"Needs: Submitter Input"'
     prs = requests.get(
         "https://api.github.com/search/issues",
         params={


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9088

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates query to avoid fetching pull requests that have either https://github.com/internetarchive/openlibrary/labels/State%3A%20Blocked or https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Submitter%20Input labels.

Draft PRs are already ignored by this query.

> [!IMPORTANT]
> This script is executed by our `cron` job runner.  Code changes will have to be deployed after merging before we see changes in the staff PR Slack digest. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
I checked the results of the new query in my browser, and compared to the most recent staff PR Slack message:
https://api.github.com/search/issues?q=repo:internetarchive/openlibrary%20%20is:open%20is:pr%20author:cdrini%20author:jimchamp%20author:mekarpeles%20author:scottbarnes%20-is:draft%20-label:%22State:%20Blocked%22%20-label:%22Needs:%20Submitter%20Input%22

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
