### PR TITLE
Fix: This change was requested in order to standardize Open Library's buttons, #9238

### DIFF
--- a/openlibrary/templates/type/edition/compact_title.html
+++ b/openlibrary/templates/type/edition/compact_title.html
@@ -4,7 +4,7 @@ $def with (book_title, edit_url)
   <span class="compact-title__heading">$book_title</span>
   <div class="compact-title__edit-btn">
     <a
-      class="linkButton linkButton--large"
+      class="cta-btn cta-btn--vanilla"
       href="$edit_url"
       title="$_('Edit this page')"
       data-ol-link-track="CTAClick|StickyEdit"


### PR DESCRIPTION
This commit address the issue by changing a button class to the requested one
This change affects the appearance of the button border line

<!-- What issue does this PR close? -->
Closes #9238

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix the UX bug

### Technical
<!-- What should be noted about the implementation? -->
Were changed the button class to meet the requirement style

### Screenshot
![9238](https://github.com/internetarchive/openlibrary/assets/104564914/07362850-be55-4f68-908e-a1602cb50450)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Same as screenshot

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
