### PR TITLE
Drafts now skipped by PR assignment workflow

### DIFF
--- a/.github/workflows/new_pr_labeler.yml
+++ b/.github/workflows/new_pr_labeler.yml
@@ -5,8 +5,8 @@ on:
       - opened
 jobs:
   label_pr:
-    # Continue only if the PR was opened in the same repository that is running this action:
-    if: ${{ github.repository == github.event.repository.full_name }}
+    # Continue only if the PR is not a draft, and was opened in the same repository that is running this action:
+    if: ${{ github.repository == github.event.repository.full_name && !github.event.pull_request.draft}}
     permissions:
       contents: read
       issues: read


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9251

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Prevents running the `new_pr_labeler` workflow if the new PR is a draft.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
