### PR TITLE
Refactor checking super librarian status with is_usergroup_member()

### DIFF
--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -85,9 +85,7 @@ class admin(delegate.page):
             ):
                 return m(*args)
             if self.is_admin() or (
-                librarians
-                and context.user
-                and context.user.is_super_librarian()
+                librarians and context.user and context.user.is_super_librarian()
             ):
                 return m(*args)
             else:

--- a/openlibrary/plugins/admin/code.py
+++ b/openlibrary/plugins/admin/code.py
@@ -87,7 +87,7 @@ class admin(delegate.page):
             if self.is_admin() or (
                 librarians
                 and context.user
-                and context.user.is_usergroup_member('/usergroup/super-librarians')
+                and context.user.is_super_librarian()
             ):
                 return m(*args)
             else:

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -558,10 +558,7 @@ class SaveBookHelper:
         user = accounts.get_current_user()
         delete = (
             user
-            and (
-                user.is_admin()
-                or user.is_super_librarian()
-            )
+            and (user.is_admin() or user.is_super_librarian())
             and formdata.pop('_delete', '')
         )
 

--- a/openlibrary/plugins/upstream/addbook.py
+++ b/openlibrary/plugins/upstream/addbook.py
@@ -560,7 +560,7 @@ class SaveBookHelper:
             user
             and (
                 user.is_admin()
-                or user.is_usergroup_member('/usergroup/super-librarians')
+                or user.is_super_librarian()
             )
             and formdata.pop('_delete', '')
         )
@@ -780,9 +780,7 @@ class SaveBookHelper:
     def _prevent_ocaid_deletion(self, edition) -> None:
         # Allow admins to modify ocaid
         user = accounts.get_current_user()
-        if user and (
-            user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
-        ):
+        if user and (user.is_admin() or user.is_super_librarian()):
             return
 
         # read ocaid from form data

--- a/openlibrary/plugins/upstream/addtag.py
+++ b/openlibrary/plugins/upstream/addtag.py
@@ -44,7 +44,7 @@ class addtag(delegate.page):
         Can a tag be added?
         """
         user = web.ctx.site.get_user()
-        return user and (user.is_usergroup_member('/usergroup/super-librarians'))
+        return user and (user.is_super_librarian())
 
     def POST(self):
         i = web.input(

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -132,15 +132,13 @@ class merge_work(delegate.page):
         user = web.ctx.site.get_user()
         has_access = user and (
             (user.is_admin() or user.is_librarian())
-            or user.is_usergroup_member('/usergroup/super-librarians')
+            or user.is_super_librarian()
         )
         if not has_access:
             raise web.HTTPError('403 Forbidden')
 
         optional_kwargs = {}
-        if not (
-            user.is_usergroup_member('/usergroup/super-librarians') or user.is_admin()
-        ):
+        if not (user.is_admin() or user.is_super_librarian()):
             optional_kwargs['can_merge'] = 'false'
 
         return render_template(
@@ -279,9 +277,7 @@ def reload():
 
 def user_can_revert_records():
     user = web.ctx.site.get_user()
-    return user and (
-        user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
-    )
+    return user and (user.is_admin() or user.is_super_librarian())
 
 
 @public

--- a/openlibrary/plugins/upstream/code.py
+++ b/openlibrary/plugins/upstream/code.py
@@ -131,8 +131,7 @@ class merge_work(delegate.page):
         i = web.input(records='', mrid=None, primary=None)
         user = web.ctx.site.get_user()
         has_access = user and (
-            (user.is_admin() or user.is_librarian())
-            or user.is_super_librarian()
+            (user.is_admin() or user.is_librarian()) or user.is_super_librarian()
         )
         if not has_access:
             raise web.HTTPError('403 Forbidden')

--- a/openlibrary/plugins/upstream/merge_authors.py
+++ b/openlibrary/plugins/upstream/merge_authors.py
@@ -268,9 +268,7 @@ class merge_authors(delegate.page):
         keys = sorted(keys, key=lambda key: int(key[2:-1]))
 
         user = get_current_user()
-        can_merge = user and (
-            user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
-        )
+        can_merge = user and (user.is_admin() or user.is_super_librarian())
         return render_template(
             'merge/authors',
             keys,
@@ -285,9 +283,7 @@ class merge_authors(delegate.page):
         selected = uniq(i.merge_key)
 
         user = get_current_user()
-        can_merge = user and (
-            user.is_admin() or user.is_usergroup_member('/usergroup/super-librarians')
-        )
+        can_merge = user and (user.is_admin() or user.is_super_librarian())
         can_request_merge = not can_merge and (user and user.is_librarian())
 
         # filter bad keys

--- a/openlibrary/plugins/upstream/tests/test_addbook.py
+++ b/openlibrary/plugins/upstream/tests/test_addbook.py
@@ -16,6 +16,7 @@ def mock_user():
         (object,),
         {
             'is_admin': lambda slf: False,
+            'is_super_librarian': lambda slf: False,
             'is_librarian': lambda slf: False,
             'is_usergroup_member': lambda slf, grp: False,
         },

--- a/openlibrary/templates/books/add.html
+++ b/openlibrary/templates/books/add.html
@@ -57,7 +57,7 @@ $ i18n_strings = {
             </div>
         </div>
 
-        $ admin_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+        $ admin_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
         <div class="formElement">
             <div class="label"><label for="id_value">$:_("And optionally, an ID number &#151; like an ISBN &#151; would be helpful...")</label></div>
                 <label for="id_name" class="hidden">$_("ID Type")</label>

--- a/openlibrary/templates/books/edit.html
+++ b/openlibrary/templates/books/edit.html
@@ -35,7 +35,7 @@ $:macros.HiddenSaveButton("addWork")
             title = _("Editing...")
             note = ""
     $:macros.databarEdit(edition if edition is not None else work)
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
         <span class="adminOnly right">
             <form method="post" id="delete-record" name="delete">
                 <button type="submit" name="_delete" value="true" id="delete-btn">$_("Delete Record")</button>

--- a/openlibrary/templates/books/edit/edition.html
+++ b/openlibrary/templates/books/edit/edition.html
@@ -1,7 +1,7 @@
 $def with (work, book)
 
 $ edition_config = get_edition_config()
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
 
 $def radiobuttons(name, options, value):
     $for v in options:

--- a/openlibrary/templates/lib/header_dropdown.html
+++ b/openlibrary/templates/lib/header_dropdown.html
@@ -12,7 +12,7 @@ $# @param {string} props.label for menu, also used as alt text for dropdown icon
 $# @param {string|null} props.image URL for image (optional)
 $# @param {DropdownLink[]} props.links
 $ singleton = len(props.get('links', [])) == 1
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
 
 <div class="$(props['name'])-component header-dropdown">
   $if singleton:

--- a/openlibrary/templates/lib/nav_head.html
+++ b/openlibrary/templates/lib/nav_head.html
@@ -1,5 +1,5 @@
 $def with (page)
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
 
 <header id="header-bar" class="header-bar">
 

--- a/openlibrary/templates/merge_request_table/merge_request_table.html
+++ b/openlibrary/templates/merge_request_table/merge_request_table.html
@@ -10,7 +10,7 @@ $ i18n_strings = {
   $ }
 
 $ username = ctx.user and ctx.user.key.split('/')[-1]
-$ can_merge = ctx.user and (ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$ can_merge = ctx.user and (ctx.user.is_super_librarian())
 
 $ reviewer = query_param('reviewer', None)
 $ submitter = query_param('submitter', None)

--- a/openlibrary/templates/showmarc.html
+++ b/openlibrary/templates/showmarc.html
@@ -45,7 +45,7 @@ $var title: $title
     $else:
         <p><b>LEADER:</b> <code>$record.leader</code><br>
         $:record.html()</p>
-   $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+   $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
        <div>
           <a href="$next_url" class="slick-next adminOnly right">$_("Next")</a>
        </div>

--- a/openlibrary/templates/subjects.html
+++ b/openlibrary/templates/subjects.html
@@ -3,7 +3,7 @@ $def with (page)
 $var title: $page.name
 
 $ subject_list = [('subjects', _('Subjects'), 20), ('places', _('Places'), 20), ('people', _('People'), 10), ('times', _('Times'), 10)]
-$ can_add_tag = ctx.user and (ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$ can_add_tag = ctx.user and (ctx.user.is_super_librarian())
 $ has_tag = 'tag' in page
 
 

--- a/openlibrary/templates/type/author/edit.html
+++ b/openlibrary/templates/type/author/edit.html
@@ -8,7 +8,7 @@ $:macros.HiddenSaveButton("addAuthor")
 
 <div id="contentHead">
     $:macros.databarEdit(page)
-    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+    $if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
         <span class="adminOnly right">
             <button type="submit" value="$_('Delete Record')" name="_delete" title="$_('Delete Record')" id="delete" form="addAuthor">$_("Delete Record")</button>
         </span>

--- a/openlibrary/templates/type/edition/view.html
+++ b/openlibrary/templates/type/edition/view.html
@@ -1,6 +1,6 @@
 $def with (page, edition=None)
 
-$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians'))
+$ is_privileged_user = ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian())
 $ is_librarian = ctx.user and ctx.user.is_librarian()
 
 $ component_times = {}

--- a/openlibrary/templates/viewpage.html
+++ b/openlibrary/templates/viewpage.html
@@ -2,7 +2,7 @@ $def with (page)
 
 $ v = query_param("v", None)
 
-$if ctx.user and (ctx.user.is_admin() or ctx.user.is_usergroup_member('/usergroup/super-librarians')):
+$if ctx.user and (ctx.user.is_admin() or ctx.user.is_super_librarian()):
     $if v and not page.key.startswith("/books/ia:"):
         <div id="revertNotice">
             <form name="revert" method="POST" action="$changequery(m='revert')">


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9266

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Refactors uses of `self.is_usergroup_member('/usergroup/super-librarians')` to `is_super_librarian()`

### Technical
<!-- What should be noted about the implementation? -->
Simple find and replace (except the definition of course)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
