### PR TITLE
Create template for search facets

### DIFF
--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -1,6 +1,7 @@
-$def with (facet_map, param, facet_counts)
+$def with (facet_map, param, facet_counts=None)
 
 $code:
+    async_load = facet_counts == None
     start_facet_count = 5
     facet_inc = 10
 
@@ -27,6 +28,50 @@ $code:
         }
         return "SearchFacet|" + facets[key]
 
+$def facet(header, label, counts):
+    <div class="facet $header">
+        $ magic_wand_markup = ''
+        $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
+            $ keys = '&'.join('key=%s' % k for k, display, count in counts)
+            $ magic_wand_markup = ' <span class="merge"><a href="/authors/merge?%s" title="%s">%s</a></span>' % (keys, _('Merge duplicate authors from this search'), _("Merge duplicates"))
+        <h4 class="facetHead">$(label)$:(magic_wand_markup)</h4>
+        $ num = 0
+        $for k, display, count in counts:
+            $ num = num + 1
+            $ hide_entry = num > start_facet_count
+            $ facet_url = None if async_load else add_facet_url(header, k)
+            $ num_found = 0 if async_load else commify(count)
+            $:facet_entry(display, num_found, facet_url, hide_entry=hide_entry)
+        $if len(counts) > start_facet_count:
+            <div class="facetMoreLess">
+                <span class="header_more small" data-header="$header">
+                    <a href="javascript:;" id="${header}_more" class="red">$_("more")</a>
+                </span>
+                <span id="${header}_bull" class="header_bull small gray">&bull;</span>
+                <span class="header_less small" data-header="$header">
+                    <a href="javascript:;" id="${header}_less" class="red ui-helper-hidden">$_("less")</a>
+                </span>
+            </div>
+    </div>
+
+$def facet_entry(display, count, facet_url, hide_entry=False):
+    $ facet_classes = 'facetEntry'
+    $if hide_entry:
+        $ facet_classes += ' ui-helper-hidden'
+    <div class="$facet_classes">
+        $if async_load:
+            <span class="small">$_('Loading...')</span>
+        $else:
+            $ link_title = _('Filter results for %(facet)s', facet=display)
+            $if header == 'has_fulltext':
+                $ link_title = _('Filter results for ebook availability')
+                $if display == 'yes':
+                    $ display = _('yes')
+                $else:
+                    $ display = _('no')
+            <span class="small"><a href="$facet_url" title="$link_title" data-ol-link-track="$add_track(header)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+    </div>
+
 <div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})">
     <h3 class="collapse">$_("Zoom In")</h3>
     <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
@@ -37,40 +82,8 @@ $code:
             $continue
         $if header=='public_scan_b':
             $continue
-        $ counts = [i for i in facet_counts[header] if i[0] not in param.get(header, [])]
-        $if not counts:
+        $ counts = [i for i in facet_counts[header] if i[0] not in param.get(header, [])] if not async_load else [(None, None, None)]
+        $if not counts and not async_load:
             $continue
-        <div class="facet $header">
-            $ magic_wand_markup = ''
-            $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
-                $ keys = '&'.join('key=%s' % k for k, display, count in counts)
-                $ magic_wand_markup = ' <span class="merge"><a href="/authors/merge?%s" title="%s">%s</a></span>' % (keys, _('Merge duplicate authors from this search'), _("Merge duplicates"))
-            <h4 class="facetHead">$(label)$:(magic_wand_markup)</h4>
-            $ num = 0
-            $for k, display, count in counts:
-                $ num = num + 1
-                $ facet_classes = 'facetEntry'
-                $if num > start_facet_count:
-                    $ facet_classes += ' ui-helper-hidden'
-                <div class="$facet_classes">
-                    $ link_title = _('Filter results for %(facet)s', facet=display)
-                    $if header == 'has_fulltext':
-                        $ link_title = _('Filter results for ebook availability')
-                        $if display == 'yes':
-                            $ display = _('yes')
-                        $else:
-                            $ display = _('no')
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$link_title" data-ol-link-track="$add_track(header)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
-                </div>
-            $if len(counts) > start_facet_count:
-                <div class="facetMoreLess">
-                    <span class="header_more small" data-header="$header">
-                        <a href="javascript:;" id="${header}_more" class="red">$_("more")</a>
-                    </span>
-                    <span id="${header}_bull" class="header_bull small gray">&bull;</span>
-                    <span class="header_less small" data-header="$header">
-                        <a href="javascript:;" id="${header}_less" class="red ui-helper-hidden">$_("less")</a>
-                    </span>
-                </div>
-        </div>
+        $:facet(header, label, counts)
 </div>

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -1,0 +1,76 @@
+$def with (facet_map, param, facet_counts)
+
+$code:
+    start_facet_count = 5
+    facet_inc = 10
+
+    def add_facet_url(k, v):
+        if k != 'has_fulltext':
+            return changequery(page=None,**{k:param.get(k, []) + [v]})
+        else:
+            return changequery(page=None,**{k:v})
+
+    def add_track(key: str) -> str:
+        """
+        KeyError will be raised if key is not in the following dict.
+        """
+        facets = {
+            "has_fulltext": "Ebook",
+            "author_key": "Author",
+            "subject_facet": "Subjects",
+            "person_facet": "People",
+            "place_facet": "Places",
+            "time_facet": "Times",
+            "first_publish_year": "FirstPublished",
+            "publisher_facet": "Publisher",
+            "language": "Language",
+        }
+        return "SearchFacet|" + facets[key]
+
+<div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})">
+    <h3 class="collapse">$_("Zoom In")</h3>
+    <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">
+        $:_('Focus your results using these <a href="/search/howto">filters</a>')
+    </div>
+    $for header, label in facet_map:
+        $if header=='has_fulltext' and 'has_fulltext' in param:
+            $continue
+        $if header=='public_scan_b':
+            $continue
+        $ counts = [i for i in facet_counts[header] if i[0] not in param.get(header, [])]
+        $if not counts:
+            $continue
+        <div class="facet $header">
+            $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
+                $ keys = '&'.join('key=%s' % k for k, display, count in counts)
+                <h4 class="facetHead">$label <span class="merge"><a href="/authors/merge?$keys" title="$_('Merge duplicate authors from this search')">$_("Merge duplicates")</a></span></h4>
+            $else:
+                <h4 class="facetHead">$label</h4>
+            $ num = 0
+            $for k, display, count in counts:
+                $ num = num + 1
+                $if num <= start_facet_count:
+                    <div class="facetEntry">
+                $else:
+                    <div class="facetEntry ui-helper-hidden">
+                $if header == 'has_fulltext':
+                    $if display == 'yes':
+                        $ display = _('yes')
+                    $else:
+                        $ display = _('no')
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')" data-ol-link-track="$add_track(header)" >$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                $else:
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)" data-ol-link-track="$add_track(header)">$display </a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                </div>
+            $if len(counts) > start_facet_count:
+                <div class="facetMoreLess">
+                    <span class="header_more small" data-header="$header">
+                        <a href="javascript:;" id="${header}_more" class="red">$_("more")</a>
+                    </span>
+                    <span id="${header}_bull" class="header_bull small gray">&bull;</span>
+                    <span class="header_less small" data-header="$header">
+                        <a href="javascript:;" id="${header}_less" class="red ui-helper-hidden">$_("less")</a>
+                    </span>
+                </div>
+        </div>
+</div>

--- a/openlibrary/templates/search/work_search_facets.html
+++ b/openlibrary/templates/search/work_search_facets.html
@@ -41,26 +41,26 @@ $code:
         $if not counts:
             $continue
         <div class="facet $header">
+            $ magic_wand_markup = ''
             $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
                 $ keys = '&'.join('key=%s' % k for k, display, count in counts)
-                <h4 class="facetHead">$label <span class="merge"><a href="/authors/merge?$keys" title="$_('Merge duplicate authors from this search')">$_("Merge duplicates")</a></span></h4>
-            $else:
-                <h4 class="facetHead">$label</h4>
+                $ magic_wand_markup = ' <span class="merge"><a href="/authors/merge?%s" title="%s">%s</a></span>' % (keys, _('Merge duplicate authors from this search'), _("Merge duplicates"))
+            <h4 class="facetHead">$(label)$:(magic_wand_markup)</h4>
             $ num = 0
             $for k, display, count in counts:
                 $ num = num + 1
-                $if num <= start_facet_count:
-                    <div class="facetEntry">
-                $else:
-                    <div class="facetEntry ui-helper-hidden">
-                $if header == 'has_fulltext':
-                    $if display == 'yes':
-                        $ display = _('yes')
-                    $else:
-                        $ display = _('no')
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')" data-ol-link-track="$add_track(header)" >$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
-                $else:
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)" data-ol-link-track="$add_track(header)">$display </a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                $ facet_classes = 'facetEntry'
+                $if num > start_facet_count:
+                    $ facet_classes += ' ui-helper-hidden'
+                <div class="$facet_classes">
+                    $ link_title = _('Filter results for %(facet)s', facet=display)
+                    $if header == 'has_fulltext':
+                        $ link_title = _('Filter results for ebook availability')
+                        $if display == 'yes':
+                            $ display = _('yes')
+                        $else:
+                            $ display = _('no')
+                    <span class="small"><a href="$add_facet_url(header, k)" title="$link_title" data-ol-link-track="$add_track(header)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
                 <div class="facetMoreLess">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -3,37 +3,11 @@ $def with (q_param, search_response, get_doc, param, page, rows)
 $ fulltext_names = {'true': 'Ebooks', 'false': 'Exclude ebooks'}
 
 $code:
-    def add_facet_url(k, v):
-        if k != 'has_fulltext':
-            return changequery(page=None,**{k:param.get(k, []) + [v]})
-        else:
-            return changequery(page=None,**{k:v})
-
     def del_facet_url(k, v):
         if k != 'has_fulltext':
             return changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
         else:
             return changequery(page=None,**{k:None})
-
-    def add_track(key: str) -> str:
-        """
-        KeyError will be raised if key is not in the following dict.
-        """
-        facets = {
-            "has_fulltext": "Ebook",
-            "author_key": "Author",
-            "subject_facet": "Subjects",
-            "person_facet": "People",
-            "place_facet": "Places",
-            "time_facet": "Times",
-            "first_publish_year": "FirstPublished",
-            "publisher_facet": "Publisher",
-            "language": "Language",
-        }
-        return "SearchFacet|" + facets[key]
-
-$ start_facet_count = 5
-$ facet_inc = 10
 
 <div>
     <div id="contentHead">
@@ -191,51 +165,7 @@ $if search_response.error:
     <h3>$_("BARF! Search engine ERROR!")</h3>
     <pre>$search_response.error.decode('utf-8', 'ignore')</pre>
 $elif param and len(search_response.docs):
-    <div id="searchFacets" data-config="$dumps({'start_facet_count': start_facet_count, 'facet_inc': facet_inc})">
-        <h3 class="collapse">$_("Zoom In")</h3>
-        <div class="smallest lightgreen sansserif" style="margin-bottom:20px;">$:_('Focus your results using these <a href="/search/howto">filters</a>')</div>
-        $for header, label in facet_map:
-            $if header=='has_fulltext' and 'has_fulltext' in param:
-                $continue
-            $if header=='public_scan_b':
-                $continue
-            $ counts = [i for i in search_response.facet_counts[header] if i[0] not in param.get(header, [])]
-            $if not counts:
-                $continue
-            <div class="facet $header">
-            $if header == 'author_key' and len(counts) > 1 and ctx.user and ("merge-authors" in ctx.features or ctx.user.is_admin()):
-                $ keys = '&'.join('key=%s' % k for k, display, count in counts)
-                <h4 class="facetHead">$label <span class="merge"><a href="/authors/merge?$keys" title="$_('Merge duplicate authors from this search')">$_("Merge duplicates")</a></span></h4>
-            $else:
-                <h4 class="facetHead">$label</h4>
-            $ num = 0
-            $for k, display, count in counts:
-                $ num = num + 1
-                $if num <= start_facet_count:
-                    <div class="facetEntry">
-                $else:
-                    <div class="facetEntry ui-helper-hidden">
-                $if header == 'has_fulltext':
-                    $if display == 'yes':
-                       $ display = _('yes')
-                    $else:
-                       $ display = _('no')
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')" data-ol-link-track="$add_track(header)" >$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
-                $else:
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)" data-ol-link-track="$add_track(header)">$display </a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
-                </div>
-            $if len(counts) > start_facet_count:
-                <div class="facetMoreLess">
-                    <span class="header_more small" data-header="$header">
-                        <a href="javascript:;" id="${header}_more" class="red">$_("more")</a>
-                    </span>
-                    <span id="${header}_bull" class="header_bull small gray">&bull;</span>
-                    <span class="header_less small" data-header="$header">
-                        <a href="javascript:;" id="${header}_less" class="red ui-helper-hidden">$_("less")</a>
-                    </span>
-                </div>
-            </div>
-        </div>
+    $:render_template('search/work_search_facets', facet_map, param, search_response.facet_counts)
 <!-- /facets -->
     </div>
 

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -165,7 +165,7 @@ $if search_response.error:
     <h3>$_("BARF! Search engine ERROR!")</h3>
     <pre>$search_response.error.decode('utf-8', 'ignore')</pre>
 $elif param and len(search_response.docs):
-    $:render_template('search/work_search_facets', facet_map, param, search_response.facet_counts)
+    $:render_template('search/work_search_facets', facet_map, param, facet_counts=search_response.facet_counts)
 <!-- /facets -->
     </div>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Supports #7271 
 
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Moves search facets sidebar into its own template.  The new `work_search_facets` template supports asynchronous loading, and will display `Loading...` indicators when `facet_counts` is `None`.

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
As of now, there is no way to trigger `async_load` mode via the UI.  However, you can make the following change to `work_search.html` to view the loading indicators:
https://github.com/internetarchive/openlibrary/pull/9276/files#r1602125790

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![image](https://github.com/internetarchive/openlibrary/assets/28732543/43631f2d-e64f-4062-984e-5ea2208a06f8)
_Facet sidebar when `facet_counts` is `None`._
### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
