### PR TITLE
Fix: change `team.js` so the current year is not hard coded

### DIFF
--- a/openlibrary/plugins/openlibrary/js/team.js
+++ b/openlibrary/plugins/openlibrary/js/team.js
@@ -1,5 +1,6 @@
 import team from '../../../templates/about/team.json';
 export function initTeamFilter() {
+    const currentYear = new Date().getFullYear().toString();
     // Photos
     const default_profile_image =
     '../../../static/images/openlibrary-180x180.png';
@@ -46,10 +47,10 @@ export function initTeamFilter() {
       !matchSubstring(person.roles, 'staff')
     );
     const currentFellows = fellows.filter((person) =>
-        matchSubstring(person.roles, '2023')
+        matchSubstring(person.roles, currentYear)
     );
     const pastFellows = fellows.filter(
-        (person) => !matchSubstring(person.roles, '2023')
+        (person) => !matchSubstring(person.roles, currentYear)
     );
 
     // ********** VOLUNTEERS **********
@@ -219,10 +220,10 @@ export function initTeamFilter() {
           !matchSubstring(person.roles, 'staff')
             );
             const currentFellows = fellows.filter((person) =>
-                matchSubstring(person.roles, '2023')
+                matchSubstring(person.roles, currentYear)
             );
             const pastFellows = fellows.filter(
-                (person) => !matchSubstring(person.roles, '2023')
+                (person) => !matchSubstring(person.roles, currentYear)
             );
 
             const volunteers = filteredTeam.filter(


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Related: #9227

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix: stops the current year in `team.js` from being hard coded.

### Technical
<!-- What should be noted about the implementation? -->
Without this change or a similar one, #9227 will have unintended outcomes because the years won't be right.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
With #9227, the team page will look like:
![image](https://github.com/internetarchive/openlibrary/assets/26524678/8a2f39b5-183f-404d-88fa-289aaf809272)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@mekarpeles 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
