### PR TITLE
Move `sentry` import to function

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -326,6 +326,7 @@ class account_create(delegate.page):
             except OLAuthenticationError as e:
                 f.note = get_login_error(e.__str__())
                 from openlibrary.plugins.openlibrary.sentry import sentry
+
                 if sentry.enabled:
                     sentry.capture_exception(e)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -32,7 +32,6 @@ from openlibrary.core.lending import (
 )
 from openlibrary.core.observations import Observations
 from openlibrary.core.ratings import Ratings
-from openlibrary.plugins.openlibrary.sentry import sentry
 from openlibrary.core.follows import PubSub
 
 from openlibrary.plugins.recaptcha import recaptcha
@@ -326,6 +325,7 @@ class account_create(delegate.page):
                 )
             except OLAuthenticationError as e:
                 f.note = get_login_error(e.__str__())
+                from openlibrary.plugins.openlibrary.sentry import sentry
                 if sentry.enabled:
                     sentry.capture_exception(e)
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9292

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes issue where `sentry` is `None` if imported before `setup()` is called (as per [this comment](https://github.com/internetarchive/openlibrary/pull/4055/files#r527004362)).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
