### PR TITLE
Prepares cover archival to be run as cron #8278

### DIFF
--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -512,11 +512,13 @@ class ZipManager:
             if file_list:
                 return max(file_list)
 
+
 def main(openlibrary_yml: str, coverstore_yml: str, dry_run: bool = False):
     load_config(openlibrary_yml)
     load_config(coverstore_yml)
     archive.archive()
     archive.Batch.process_pending(upload=True, finalize=True, test=not dry_run)
+
 
 if __name__ == '__main__':
     FnToCLI(main).run()

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -514,6 +514,7 @@ class ZipManager:
 
 def main(openlibrary_yml: str, coverstore_yml: str, dry_run: bool = False):
     from openlibrary.coverstore.server import load_config
+
     load_config(openlibrary_yml)
     load_config(coverstore_yml)
     archive()

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -518,7 +518,7 @@ def main(openlibrary_yml: str, coverstore_yml: str, dry_run: bool = False):
     load_config(openlibrary_yml)
     load_config(coverstore_yml)
     archive()
-    Batch.process_pending(upload=True, finalize=True, test=not dry_run)
+    Batch.process_pending(upload=True, finalize=True, test=dry_run)
 
 
 if __name__ == '__main__':

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -14,7 +14,6 @@ from infogami.infobase import utils
 
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import find_image_path
-from openlibrary.coverstore.server import load_config
 from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 
@@ -514,10 +513,11 @@ class ZipManager:
 
 
 def main(openlibrary_yml: str, coverstore_yml: str, dry_run: bool = False):
+    from openlibrary.coverstore.server import load_config
     load_config(openlibrary_yml)
     load_config(coverstore_yml)
-    archive.archive()
-    archive.Batch.process_pending(upload=True, finalize=True, test=not dry_run)
+    archive()
+    Batch.process_pending(upload=True, finalize=True, test=not dry_run)
 
 
 if __name__ == '__main__':

--- a/openlibrary/coverstore/archive.py
+++ b/openlibrary/coverstore/archive.py
@@ -14,6 +14,8 @@ from infogami.infobase import utils
 
 from openlibrary.coverstore import config, db
 from openlibrary.coverstore.coverlib import find_image_path
+from openlibrary.coverstore.server import load_config
+from scripts.solr_builder.solr_builder.fn_to_cli import FnToCLI
 
 
 ITEM_SIZE = 1_000_000
@@ -509,3 +511,12 @@ class ZipManager:
             file_list = zip_file.namelist()
             if file_list:
                 return max(file_list)
+
+def main(openlibrary_yml: str, coverstore_yml: str, dry_run: bool = False):
+    load_config(openlibrary_yml)
+    load_config(coverstore_yml)
+    archive.archive()
+    archive.Batch.process_pending(upload=True, finalize=True, test=not dry_run)
+
+if __name__ == '__main__':
+    FnToCLI(main).run()


### PR DESCRIPTION
Closes #8278

To be run with:
```
PYTHONPATH=. python /openlibrary/openlibrary/coverstore/archive.py /olsystem/etc/openlibrary.yml /olsystem/etc/coverstore.yml
```

Tested by running the following on `ol-home0`:
```
docker cp openlibrary/coverstore/archive.py openlibrary-cron-jobs-1:/openlibrary/openlibrary/coverstore/archive.py
docker exec -uroot -it openlibrary-cron-jobs-1 bash
su openlibrary -c "PYTHONPATH=. python /openlibrary/openlibrary/coverstore/archive.py /olsystem/etc/openlibrary.yml /olsystem/etc/coverstore.yml"
```

Depends also on https://github.com/internetarchive/olsystem/pull/210, which should be reviewed/merged **after** this PR.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
