### PR TITLE
Fix `i18n` syntax in Donate Modal to include closing tags

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -6010,14 +6010,14 @@ msgstr ""
 #: DonateModal.html
 msgid ""
 "Beautiful <a target=\"_blank\" href=\"https://archive.org/scanning"
-"\">high-fidelity digitization"
+"\">high-fidelity digitization</a>"
 msgstr ""
 
 #: DonateModal.html
 msgid ""
 "Long-term <a href=\"https://blog.archive.org/2011/06/06/why-preserve-"
 "books-the-new-physical-archive-of-the-internet-archive/\">archival "
-"preservation"
+"preservation</a>"
 msgstr ""
 
 #: DonateModal.html

--- a/openlibrary/macros/DonateModal.html
+++ b/openlibrary/macros/DonateModal.html
@@ -34,8 +34,8 @@ San Francisco, CA 94118
       <div class="donation__info">
         <img src="$book.get_cover_url('M')" alt="$_('Donation info')">
         <ul class="donation__benefits">
-          <li>$:_('Beautiful <a target="_blank" href="https://archive.org/scanning">high-fidelity digitization')</a></li>
-          <li>$:_('Long-term <a href="https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/">archival preservation')</a></li>
+          <li>$:_('Beautiful <a target="_blank" href="https://archive.org/scanning">high-fidelity digitization</a>')</li>
+          <li>$:_('Long-term <a href="https://blog.archive.org/2011/06/06/why-preserve-books-the-new-physical-archive-of-the-internet-archive/">archival preservation</a>')</li>
           <li>$:_('Free <a href="https://controlleddigitallending.org/">controlled digital library access</a> by the <a href="https://en.wikipedia.org/wiki/Print_disability">print-disabled</a> public')<sup><a href="https://openlibrary.org/sponsorship#takedowns">†</a></sup></li>
         </ul>
       </div>


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9297.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Hotfix. Fixes the last two remaining un-closed tags in our `messages.pot` file, both of which are located in `DonateModal.html`.

### Technical
<!-- What should be noted about the implementation? -->
- Simply changed the placement of the closing quote and parentheses for the relevant strings
- Also searched the `messages.pot` file for various HTML opening tags (`<a`, `<i>`, `<em>`, `<strong>`) and confirmed that, aside from these two, each other opening tag was accompanied by a closing tag

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Go the Donate Modal section of the `messages.pot` file
2. Confirm all opening tags are now closed

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@dcapillae 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
