### PR TITLE
added Yearly Reading Goals to /stats page

### DIFF
--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 from enum import IntEnum
 
-from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 from . import db
 
 
@@ -18,20 +17,6 @@ class BookshelfEvent(IntEnum):
 class BookshelvesEvents(db.CommonExtras):
     TABLENAME = 'bookshelves_events'
     NULL_EDITION_ID = -1
-
-    @classmethod
-    def summary(cls):
-        return {
-            'total_yearly_reading_goals': {
-                'total': BookshelvesEvents.total_yearly_reading_goals(),
-                'month': BookshelvesEvents.total_yearly_reading_goals(
-                    since=DATE_ONE_MONTH_AGO
-                ),
-                'week': BookshelvesEvents.total_yearly_reading_goals(
-                    since=DATE_ONE_WEEK_AGO
-                ),
-            },
-        }
 
     # Create methods:
     @classmethod
@@ -139,23 +124,6 @@ class BookshelvesEvents(db.CommonExtras):
         )
 
         return list(oldb.query(query, vars=data))
-
-    @classmethod
-    def total_yearly_reading_goals(cls, since: date | None = None) -> int:
-        """Returns a Storage object of <Storage {'count': int}> where 'count' specifies the
-        number reading goals updated. `since` may be used
-        to limit the result to those reading goals updated since a specific
-        date. Any python datetime.date type should work.
-        :param since: returns all reading goals after date
-        """
-        oldb = db.get_db()
-
-        query = "SELECT count(*) from yearly_reading_goals"
-        if since:
-            query += " WHERE updated >= $since"
-        results = tuple(oldb.query(query, vars={'since': since}))
-        print('total_yearly_reading_goals', results)
-        return results[0]
 
     # Update methods:
     @classmethod

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -24,8 +24,12 @@ class BookshelvesEvents(db.CommonExtras):
         return {
             'total_yearly_reading_goals': {
                 'total': BookshelvesEvents.total_yearly_reading_goals(),
-                'month': BookshelvesEvents.total_yearly_reading_goals(since=DATE_ONE_MONTH_AGO),
-                'week': BookshelvesEvents.total_yearly_reading_goals(since=DATE_ONE_WEEK_AGO),
+                'month': BookshelvesEvents.total_yearly_reading_goals(
+                    since=DATE_ONE_MONTH_AGO
+                ),
+                'week': BookshelvesEvents.total_yearly_reading_goals(
+                    since=DATE_ONE_WEEK_AGO
+                ),
             },
         }
 
@@ -138,7 +142,7 @@ class BookshelvesEvents(db.CommonExtras):
 
     @classmethod
     def total_yearly_reading_goals(cls, since: date | None = None) -> int:
-        """Returns a Storage object of <Storage {'count': int}> where 'count' specifies the 
+        """Returns a Storage object of <Storage {'count': int}> where 'count' specifies the
         number reading goals updated. `since` may be used
         to limit the result to those reading goals updated since a specific
         date. Any python datetime.date type should work.

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,5 +1,7 @@
-from datetime import datetime
+from datetime import date, datetime
 from enum import IntEnum
+
+from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 from . import db
 
 
@@ -16,6 +18,16 @@ class BookshelfEvent(IntEnum):
 class BookshelvesEvents(db.CommonExtras):
     TABLENAME = 'bookshelves_events'
     NULL_EDITION_ID = -1
+
+    @classmethod
+    def summary(cls):
+        return {
+            'total_yearly_reading_goals': {
+                'total': BookshelvesEvents.total_yearly_reading_goals(),
+                'month': BookshelvesEvents.total_yearly_reading_goals(since=DATE_ONE_MONTH_AGO),
+                'week': BookshelvesEvents.total_yearly_reading_goals(since=DATE_ONE_WEEK_AGO),
+            },
+        }
 
     # Create methods:
     @classmethod
@@ -123,6 +135,23 @@ class BookshelvesEvents(db.CommonExtras):
         )
 
         return list(oldb.query(query, vars=data))
+
+    @classmethod
+    def total_yearly_reading_goals(cls, since: date | None = None) -> int:
+        """Returns a Storage object of <Storage {'count': int}> where 'count' specifies the 
+        number reading goals updated. `since` may be used
+        to limit the result to those reading goals updated since a specific
+        date. Any python datetime.date type should work.
+        :param since: returns all reading goals after date
+        """
+        oldb = db.get_db()
+
+        query = "SELECT count(*) from yearly_reading_goals"
+        if since:
+            query += " WHERE updated >= $since"
+        results = tuple(oldb.query(query, vars={'since': since}))
+        print('total_yearly_reading_goals', results)
+        return results[0]
 
     # Update methods:
     @classmethod

--- a/openlibrary/core/bookshelves_events.py
+++ b/openlibrary/core/bookshelves_events.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 from enum import IntEnum
 
 from . import db

--- a/openlibrary/core/yearly_reading_goals.py
+++ b/openlibrary/core/yearly_reading_goals.py
@@ -70,7 +70,7 @@ class YearlyReadingGoals:
 
     @classmethod
     def total_yearly_reading_goals(cls, since: date | None = None) -> int:
-        """Returns a Storage object of <Storage {'count': int}> where 'count' specifies the
+        """Returns the number reading goals that were set. `since` may be used
         number reading goals updated. `since` may be used
         to limit the result to those reading goals updated since a specific
         date. Any python datetime.date type should work.
@@ -81,8 +81,8 @@ class YearlyReadingGoals:
         query = f"SELECT count(*) from {cls.TABLENAME}"
         if since:
             query += " WHERE updated >= $since"
-        results = list(oldb.query(query, vars={'since': since}))
-        return results[0]
+        results = oldb.query(query, vars={'since': since})
+        return results[0]['count'] if results else 0
 
     # Update methods:
     @classmethod

--- a/openlibrary/core/yearly_reading_goals.py
+++ b/openlibrary/core/yearly_reading_goals.py
@@ -1,9 +1,25 @@
-from datetime import datetime
+from datetime import date, datetime
+
+from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 from . import db
 
 
 class YearlyReadingGoals:
     TABLENAME = 'yearly_reading_goals'
+
+    @classmethod
+    def summary(cls):
+        return {
+            'total_yearly_reading_goals': {
+                'total': YearlyReadingGoals.total_yearly_reading_goals(),
+                'month': YearlyReadingGoals.total_yearly_reading_goals(
+                    since=DATE_ONE_MONTH_AGO
+                ),
+                'week': YearlyReadingGoals.total_yearly_reading_goals(
+                    since=DATE_ONE_WEEK_AGO
+                ),
+            },
+        }
 
     # Create methods:
     @classmethod
@@ -51,6 +67,22 @@ class YearlyReadingGoals:
             return False
         else:
             return results[0]['current'] >= results[0]['target']
+
+    @classmethod
+    def total_yearly_reading_goals(cls, since: date | None = None) -> int:
+        """Returns a Storage object of <Storage {'count': int}> where 'count' specifies the
+        number reading goals updated. `since` may be used
+        to limit the result to those reading goals updated since a specific
+        date. Any python datetime.date type should work.
+        :param since: returns all reading goals after date
+        """
+        oldb = db.get_db()
+
+        query = f"SELECT count(*) from {cls.TABLENAME}"
+        if since:
+            query += " WHERE updated >= $since"
+        results = list(oldb.query(query, vars={'since': since}))
+        return results[0]
 
     # Update methods:
     @classmethod

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -1837,6 +1837,10 @@ msgid "Users Logging"
 msgstr ""
 
 #: admin/index.html
+msgid "Yearly Reading Goals"
+msgstr ""
+
+#: admin/index.html
 msgid "Books Review Tags"
 msgstr ""
 

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -172,10 +172,10 @@ $ stats = get_admin_stats()
     </tr>
     <tr class="major even">
         <td>$_("Yearly Reading Goals")</td>
-        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['week']['count'])</td>
-        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['month']['count'])</td>
+        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['week'])</td>
+        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['month'])</td>
         <td></td>
-        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['total']['count'])</td>
+        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['total'])</td>
       </tr>
     <tr class="major even">
       <td>$_("Books Review Tags")</td>

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -171,6 +171,13 @@ $ stats = get_admin_stats()
       <td class="amount">$commify(counts.reading_log['total_users_logged']['total']['count'])</td>
     </tr>
     <tr class="major even">
+        <td>$_("Yearly Reading Goals")</td>
+        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['week']['count'])</td>
+        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['month']['count'])</td>
+        <td></td>
+        <td class="amount">$commify(counts.reading_log['total_yearly_reading_goals']['total']['count'])</td>
+      </tr>
+    <tr class="major even">
       <td>$_("Books Review Tags")</td>
       <td class="amount">$commify(counts.reading_log['total_reviews']['week'])</td>
       <td class="amount">$commify(counts.reading_log['total_reviews']['month'])</td>

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -486,18 +486,21 @@ class TestYearlyReadingGoals:
             'year': 2022,
             'target': 5,
             'current': 6,
+            'updated': "2022-08-04 00:00:00",
         },
         {
             'username': '@billy_pilgrim',
             'year': 2023,
             'target': 7,
             'current': 0,
+            'updated': "2023-01-01 00:00:00",
         },
         {
             'username': '@kilgore_trout',
             'year': 2022,
             'target': 4,
             'current': 4,
+            'updated': "2022-04-20 00:00:00",
         },
     ]
 
@@ -515,6 +518,11 @@ class TestYearlyReadingGoals:
 
     def teardown_method(self):
         self.db.query('delete from yearly_reading_goals')
+
+    def test_total_yearly_reading_goals(self):
+        assert BookshelvesEvents.total_yearly_reading_goals()['count(*)'] == 3
+        # Combination of issues
+        assert BookshelvesEvents.total_yearly_reading_goals(since="2022-12-25")['count(*)'] == 1
 
     def test_create(self):
         assert len(list(self.db.select(self.TABLENAME))) == 3

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -486,21 +486,18 @@ class TestYearlyReadingGoals:
             'year': 2022,
             'target': 5,
             'current': 6,
-            'updated': "2022-08-04 00:00:00",
         },
         {
             'username': '@billy_pilgrim',
             'year': 2023,
             'target': 7,
             'current': 0,
-            'updated': "2023-01-01 00:00:00",
         },
         {
             'username': '@kilgore_trout',
             'year': 2022,
             'target': 4,
             'current': 4,
-            'updated': "2022-04-20 00:00:00",
         },
     ]
 
@@ -518,16 +515,6 @@ class TestYearlyReadingGoals:
 
     def teardown_method(self):
         self.db.query('delete from yearly_reading_goals')
-
-    def test_total_yearly_reading_goals(self):
-        assert YearlyReadingGoals.total_yearly_reading_goals()['count(*)'] == 3
-        # Combination of issues
-        assert (
-            YearlyReadingGoals.total_yearly_reading_goals(since="2022-12-25")[
-                'count(*)'
-            ]
-            == 1
-        )
 
     def test_create(self):
         assert len(list(self.db.select(self.TABLENAME))) == 3

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -522,7 +522,10 @@ class TestYearlyReadingGoals:
     def test_total_yearly_reading_goals(self):
         assert BookshelvesEvents.total_yearly_reading_goals()['count(*)'] == 3
         # Combination of issues
-        assert BookshelvesEvents.total_yearly_reading_goals(since="2022-12-25")['count(*)'] == 1
+        assert (
+            BookshelvesEvents.total_yearly_reading_goals(since="2022-12-25")['count(*)']
+            == 1
+        )
 
     def test_create(self):
         assert len(list(self.db.select(self.TABLENAME))) == 3

--- a/openlibrary/tests/core/test_db.py
+++ b/openlibrary/tests/core/test_db.py
@@ -520,10 +520,12 @@ class TestYearlyReadingGoals:
         self.db.query('delete from yearly_reading_goals')
 
     def test_total_yearly_reading_goals(self):
-        assert BookshelvesEvents.total_yearly_reading_goals()['count(*)'] == 3
+        assert YearlyReadingGoals.total_yearly_reading_goals()['count(*)'] == 3
         # Combination of issues
         assert (
-            BookshelvesEvents.total_yearly_reading_goals(since="2022-12-25")['count(*)']
+            YearlyReadingGoals.total_yearly_reading_goals(since="2022-12-25")[
+                'count(*)'
+            ]
             == 1
         )
 

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -13,7 +13,7 @@ from ..core.observations import Observations
 from ..core.booknotes import Booknotes
 from ..core.follows import PubSub
 from ..core.bookshelves import Bookshelves
-from ..core.bookshelves_events import BookshelvesEvents
+from ..core.yearly_reading_goals import YearlyReadingGoals
 from ..core.ratings import Ratings
 from ..plugins.admin.code import get_counts
 from ..plugins.worksearch.code import get_solr_works
@@ -37,7 +37,7 @@ def reading_log_summary():
         delegate.fakeload()
 
     stats = Bookshelves.summary()
-    stats.update(BookshelvesEvents.summary())
+    stats.update(YearlyReadingGoals.summary())
     stats.update(Ratings.summary())
     stats.update(Observations.summary())
     stats.update(Booknotes.summary())

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -13,6 +13,7 @@ from ..core.observations import Observations
 from ..core.booknotes import Booknotes
 from ..core.follows import PubSub
 from ..core.bookshelves import Bookshelves
+from ..core.bookshelves_events import BookshelvesEvents
 from ..core.ratings import Ratings
 from ..plugins.admin.code import get_counts
 from ..plugins.worksearch.code import get_solr_works
@@ -36,6 +37,7 @@ def reading_log_summary():
         delegate.fakeload()
 
     stats = Bookshelves.summary()
+    stats.update(BookshelvesEvents.summary())
     stats.update(Ratings.summary())
     stats.update(Observations.summary())
     stats.update(Booknotes.summary())


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #7352

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Added `summary` and `total_yearly_reading_goals` functions to  `yearly_reading_goals.py`. Added unit test for `total_yearly_reading_goals` function. Added Yearly Reading Goals row in `openlibrary/templates/admin/index.html`.

Let me know if there are things we want to change!

### Technical
<!-- What should be noted about the implementation? -->
There are a few things to note:
1. First, during testing, I found that for some reason the key in the storage object (noted by @scottbarnes in https://github.com/internetarchive/openlibrary/pull/7560#discussion_r1153914826, Scott is also right that the other functions are documented incorrectly - they return Storage objects not ints) in the unit test is different from when the application is run (that is the reason in the HTML file the key is `'count'` while in the unit test it is `'count(*)'`)

Application log:
```
web-1           | total_yearly_reading_goals (<Storage {'count': 1}>,)
web-1           | total_yearly_reading_goals (<Storage {'count': 1}>,)
web-1           | total_yearly_reading_goals (<Storage {'count': 1}>,)
```
But when I use the key `'count'` in the unit tests:
```
====================================================================================== FAILURES ======================================================================================
_______________________________________________________________ TestYearlyReadingGoals.test_total_yearly_reading_goals _______________________________________________________________
self = <core.test_db.TestYearlyReadingGoals object at 0x7f8426bf9dc0>

    def test_total_yearly_reading_goals(self):
>       assert BookshelvesEvents.total_yearly_reading_goals()['count'] == 3
E       KeyError: 'count'

openlibrary/tests/core/test_db.py:523: KeyError
-------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------
total_yearly_reading_goals (<Storage {'count(*)': 3}>,)
```

2. The second is that I noticed the other stat functions (e.g., `total_books_logged` in `openlibrary/core/bookshelves.py`) don't have unit tests - is there a specific reason for that?

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
UI changes and `docker compose run --rm home make test`.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![1](https://github.com/internetarchive/openlibrary/assets/32963956/00c4596c-7846-4ba5-be76-fb8512deef27)


### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
