### PR TITLE
Switch out personal URL for team page

### DIFF
--- a/openlibrary/templates/about/team.json
+++ b/openlibrary/templates/about/team.json
@@ -241,8 +241,8 @@
     "departments": ["engineering"],
     "projects": ["Registration", "i18n"],
     "photo_path": "https://github.com/internetarchive/openlibrary/assets/978325/c6eae0c8-0896-4fe6-a4e7-2972d18b8b8d",
-    "personal_url": "https://www.rebeccashoptaw.com/",
-    "favorite_book_url": "",
+    "personal_url": "https://www.rebeccashoptaw.dev/",
+    "favorite_book_url": "https://openlibrary.org/works/OL20867W/Middlemarch",
     "ol_key": ""
   },
   {


### PR DESCRIPTION
<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Switched out my personal URL on the team page so it points to the correct site.

### Technical
<!-- What should be noted about the implementation? -->
Quick adjustment to `team.json`, also added a favorite book url while I was at it.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
