### PR TITLE
Added lazy loading to merge books

### DIFF
--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="edition-snippet">
-    <img :src="cover_url" />
+    <img loading="lazy" :src="cover_url"/>
     <div class="links">
       <a :href="edition.key" target="_blank">OL</a>
       <a

--- a/openlibrary/components/MergeUI/EditionSnippet.vue
+++ b/openlibrary/components/MergeUI/EditionSnippet.vue
@@ -113,6 +113,8 @@ export default {
     object-position: top center;
     float: left;
     margin-right: 7px;
+    // Min Height added for lazy loading so that the lazy loaded images are not 1 pixel and start having many books start loading
+    min-height: 80px;
     &:hover {
       object-fit: contain;
     }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9201

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Add lazy loading for covers in works merge tool

### Technical
<!-- What should be noted about the implementation? -->
Just adds loading lazy to images for books in merge

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. docker compose up
2. docker compose run --rm home npm run build-assets
3. docker compose exec -e PYTHONPATH=. web bash -c "./scripts/copydocs.py /works/OL21868175W /works/OL41495W" 
4. http://localhost:8080/works/merge?records=OL21868175W,OL41495W
5. Inspect
6. Look at number of requests
7. Observe how number of requests stops around 180


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot from 2024-05-22 09-03-23](https://github.com/internetarchive/openlibrary/assets/56459277/c85397f6-00e2-4f4e-bc15-2df62c41e5bd)
![Screenshot from 2024-05-22 09-05-50](https://github.com/internetarchive/openlibrary/assets/56459277/5d5df053-91f9-4d69-90da-ee8202a00a86)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini  @RayBB 


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
