### PR TITLE
Hide user preference changes in /recentchanges

### DIFF
--- a/openlibrary/templates/recentchanges/render.html
+++ b/openlibrary/templates/recentchanges/render.html
@@ -29,7 +29,7 @@ $if "ip" in query and ctx.user and ctx.user.is_admin():
     </thead>
     <tbody>
     $for c in changes:
-        $if c.comment != "updating user preferences":
+        $if not c.get_changes()[0].key.endswith("preferences"):
             <tr>
                 <td class="time">$datestr(c.timestamp)</td>
                 <td class="path">$:call_template("path", c)</td>

--- a/openlibrary/templates/recentchanges/render.html
+++ b/openlibrary/templates/recentchanges/render.html
@@ -29,7 +29,7 @@ $if "ip" in query and ctx.user and ctx.user.is_admin():
     </thead>
     <tbody>
     $for c in changes:
-        $if not c.get_changes()[0].key.endswith("preferences"):
+        $if not c.get_changes()[0].key.endswith("/preferences"):
             <tr>
                 <td class="time">$datestr(c.timestamp)</td>
                 <td class="path">$:call_template("path", c)</td>

--- a/openlibrary/templates/recentchanges/render.html
+++ b/openlibrary/templates/recentchanges/render.html
@@ -29,28 +29,29 @@ $if "ip" in query and ctx.user and ctx.user.is_admin():
     </thead>
     <tbody>
     $for c in changes:
-        <tr>
-            <td class="time">$datestr(c.timestamp)</td>
-            <td class="path">$:call_template("path", c)</td>
-            $if c.author:
-                <td class="displayname"><a rel="nofollow" href="$c.author.key">$c.author.displayname</a></td>
-            $elif c.ip and c.ip != '127.0.0.1':
-                $if ctx.user and ctx.user.is_admin():
-                    $ ip_url = "/admin/ip/%s" % c.ip
-                    $ klass = cond(c.ip in get_blocked_ips(), 'red', "")
+        $if c.comment != "updating user preferences":
+            <tr>
+                <td class="time">$datestr(c.timestamp)</td>
+                <td class="path">$:call_template("path", c)</td>
+                $if c.author:
+                    <td class="displayname"><a rel="nofollow" href="$c.author.key">$c.author.displayname</a></td>
+                $elif c.ip and c.ip != '127.0.0.1':
+                    $if ctx.user and ctx.user.is_admin():
+                        $ ip_url = "/admin/ip/%s" % c.ip
+                        $ klass = cond(c.ip in get_blocked_ips(), 'red', "")
+                    $else:
+                        $ ip_url = changequery(ip=c.ip)
+                        $ klass = ""
+                    <td class="history"><a rel="nofollow" href="$ip_url" class="$klass" title="$_('When you see numbers here, that\'s the IP address of the anonymous editor')">$c.ip</a></td>
                 $else:
-                    $ ip_url = changequery(ip=c.ip)
-                    $ klass = ""
-                <td class="history"><a rel="nofollow" href="$ip_url" class="$klass" title="$_('When you see numbers here, that\'s the IP address of the anonymous editor')">$c.ip</a></td>
-            $else:
-                <td class="history">$c.ip</td>
-            <td class="comment">
-                $if c.kind == 'add-cover':
-                    Added new cover <img class="comment__cover" src='$:call_template("comment", c)' alt=""/>
-                $else:
-                    $:call_template("comment", c)
-            </td>
-        </tr>
+                    <td class="history">$c.ip</td>
+                <td class="comment">
+                    $if c.kind == 'add-cover':
+                        Added new cover <img class="comment__cover" src='$:call_template("comment", c)' alt=""/>
+                    $else:
+                        $:call_template("comment", c)
+                </td>
+            </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9197 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
The /recentchanges page will no longer display individual user preference changes

### Technical
<!-- What should be noted about the implementation? -->
In `templates/recentchanges/render.html`, checks that a change's path (specifically `c.get_changes()[0].key`) does not end in `preferences` before rendering the change. This is the best solution I could think of (over e.g. `call_template("path", c)`) due to lack of access to regular expressions in the templating engine. In a previous commit I used `c.comment` which is simpler and somewhat more prone to breaking.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. By commenting out or switching to another branch, ensure that there is at least one /recentchanges entry recording a user preferences change (comment is `updating user preferences`) in your testing environment. If not, you can switch your safe mode preference to generate one.
2. Observe that after implementing the fix, there are no user preference changes visible in the /recentchanges log.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
Before:
![image](https://github.com/internetarchive/openlibrary/assets/17033120/14326da6-67fe-431c-971d-d71394350697)
After:
![image](https://github.com/internetarchive/openlibrary/assets/17033120/758f73f9-1b49-419c-8e8f-81cf972915e0)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@jimchamp (Lead) @cdrini (Issue creator)


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
