### PR TITLE
conditionally import validate js

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "static/build/markdown-editor.*.js",
-      "maxSize": "11KB"
+      "maxSize": "12KB"
     },
     {
       "path": "static/build/carousel.*.js",
@@ -70,7 +70,7 @@
     },
     {
       "path": "static/build/all.js",
-      "maxSize": "130KB"
+      "maxSize": "117KB"
     },
     {
       "path": "static/build/page-admin.css",

--- a/openlibrary/plugins/openlibrary/js/automatic.js
+++ b/openlibrary/plugins/openlibrary/js/automatic.js
@@ -2,8 +2,6 @@
  * Setup actions on document.ready for standard classNames.
  */
 export default function($) {
-    // validate forms
-    $('form.validate').ol_validate();
 
     // hide all images in .no-img
     $('.no-img img').hide();

--- a/openlibrary/plugins/openlibrary/js/index.js
+++ b/openlibrary/plugins/openlibrary/js/index.js
@@ -1,5 +1,4 @@
 import 'jquery';
-import 'jquery-validation';
 import 'jquery-ui/ui/widgets/dialog';
 import 'jquery-ui/ui/widgets/autocomplete';
 // For dialog boxes (e.g. add to list)
@@ -18,7 +17,6 @@ import * as Browser from './Browser';
 import { commify, urlencode, slice } from './python';
 import Template from './template.js';
 import { truncate, cond } from './utils';
-import initValidate from './validate';
 import '../../../../static/css/js-all.less';
 // polyfill Promise support for IE11
 import Promise from 'promise-polyfill';
@@ -97,7 +95,6 @@ jQuery(function () {
             .then((module) => module.initTabs($tabs));
     }
 
-    initValidate($);
     autocompleteInit($);
     automaticInit($);
     // wmd editor
@@ -541,6 +538,12 @@ jQuery(function () {
     if (leaveWaitlistLinks.length && document.getElementById('leave-waitinglist-dialog')) {
         import(/* webpackChunkName: "waitlist" */ './waitlist')
             .then(module => module.initLeaveWaitlist(leaveWaitlistLinks));
+    }
+
+    const formsToValidate = document.querySelectorAll('form.validate');
+    if (formsToValidate.length) {
+        import(/* webpackChunkName: "validate" */ './validate')
+            .then(module => module.initValidate(formsToValidate));
     }
 
     const thirdPartyLoginsIframe = document.getElementById('ia-third-party-logins');

--- a/openlibrary/plugins/openlibrary/js/validate.js
+++ b/openlibrary/plugins/openlibrary/js/validate.js
@@ -1,4 +1,5 @@
 import { ungettext, ugettext } from './i18n';
+import 'jquery-validation';
 
 /**
  * jQuery plugin to add form validations.
@@ -14,7 +15,7 @@ import { ungettext, ugettext } from './i18n';
  *          <input type="submit" name="submit" value="Register"/>
  *      </form>
  */
-export default function initValidate() {
+export function initValidate(formsToValidate) {
 
 
     // validate publish-date to make sure the date is not in future
@@ -79,4 +80,8 @@ export default function initValidate() {
         $(this).validate($.extend(defaults, options));
     };
 
+    // validate forms
+    for (const form of formsToValidate) {
+        $(form).ol_validate();
+    }
 }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9319

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->
Not sure why bundlesize of the markdown editor went up.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Based on my understanding,
`jquery-validation` is only ever used by `validate.js` and `validate.js` is only ever used when we have a `form.validate` selected.
So I think this is a pretty safe change.

Here are the pages that have a form.validate:

- openlibrary/templates/support.html (https://openlibrary.org/contact)
- openlibrary/templates/account/create.html (https://openlibrary.org/account/create)
- openlibrary/templates/admin/people/index.html
- openlibrary/templates/admin/people/view.html
- openlibrary/templates/books/add.html (https://openlibrary.org/books/add)
- openlibrary/templates/books/edit.html
- openlibrary/templates/tag/add.html
- openlibrary/templates/type/author/edit.html
- openlibrary/templates/type/tag/edit.html


### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
