### PR TITLE
Fix: add spaces when matching author honorifics

### DIFF
--- a/openlibrary/catalog/add_book/load_book.py
+++ b/openlibrary/catalog/add_book/load_book.py
@@ -236,11 +236,11 @@ def remove_author_honorifics(name: str) -> str:
         (
             honorific
             for honorific in HONORIFICS
-            if name.casefold().startswith(honorific)
+            if name.casefold().startswith(f"{honorific} ")  # Note the trailing space.
         ),
         None,
     ):
-        return name[len(honorific) :].lstrip() or name
+        return name[len(f"{honorific} ") :].lstrip() or name
 
     return name
 

--- a/openlibrary/catalog/add_book/tests/test_load_book.py
+++ b/openlibrary/catalog/add_book/tests/test_load_book.py
@@ -83,6 +83,7 @@ class TestImportAuthor:
     @pytest.mark.parametrize(
         ["name", "expected"],
         [
+            ("Drake von Drake", "Drake von Drake"),
             ("Dr. Seuss", "Dr. Seuss"),
             ("dr. Seuss", "dr. Seuss"),
             ("Dr Seuss", "Dr Seuss"),


### PR DESCRIPTION
Matching and stripping honorifics should match `honorific + " "` and not just `honorific`. Thanks @hornc for catching this!

<!-- What issue does this PR close? -->
Closes #7349
Closes #9321 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fixes cases where names beginning with an honorific (e.g. `Dr` and `Drini` would incorrectly match as an honorific).

### Technical
<!-- What should be noted about the implementation? -->
This matches and removes `honorific + " "`, rather than just `honorific`.

It also incorporates the test from #9321.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
See the updated unit test.
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini
@hornc 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
