### PR TITLE
Add pagination to user following/follower lists

### DIFF
--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -1,6 +1,5 @@
 import logging
-import web
-from typing import cast, Any
+from typing import cast
 from openlibrary.core.bookshelves import Bookshelves
 
 from . import db
@@ -38,17 +37,21 @@ class PubSub:
         return len(subscription)
 
     @classmethod
-    def get_followers(cls, publisher):
+    def get_followers(cls, publisher, limit=None, offset=0):
         """Get publishers subscribers"""
         oldb = db.get_db()
         where = 'publisher=$publisher'
         subscribers = oldb.select(
-            cls.TABLENAME, where=where, vars={'publisher': publisher}
+            cls.TABLENAME, 
+            where=where, 
+            vars={'publisher': publisher},
+            limit=limit,
+            offset=offset
         )
         return subscribers
 
     @classmethod
-    def get_following(cls, subscriber, exclude_disabled=False):
+    def get_following(cls, subscriber, limit=None, offset=0, exclude_disabled=False):
         """Get subscriber's subscriptions"""
         oldb = db.get_db()
         where = 'subscriber=$subscriber'
@@ -58,6 +61,8 @@ class PubSub:
             cls.TABLENAME,
             where=where,
             vars={'subscriber': subscriber},
+            limit=limit,
+            offset=offset
         )
         return [dict(s) for s in subscriptions]
 

--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -42,11 +42,11 @@ class PubSub:
         oldb = db.get_db()
         where = 'publisher=$publisher'
         subscribers = oldb.select(
-            cls.TABLENAME, 
-            where=where, 
+            cls.TABLENAME,
+            where=where,
             vars={'publisher': publisher},
             limit=limit,
-            offset=offset
+            offset=offset,
         )
         return subscribers
 
@@ -62,7 +62,7 @@ class PubSub:
             where=where,
             vars={'subscriber': subscriber},
             limit=limit,
-            offset=offset
+            offset=offset,
         )
         return [dict(s) for s in subscriptions]
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1134,8 +1134,8 @@ class my_follows(delegate.page):
     path = r"/people/([^/]+)/(followers|following)"
 
     def GET(self, username, key=""):
-        i = web.input(page=1, limit=25)
-        page_size = max(1, i.limit)
+        i = web.input(page=1)
+        page_size = 25
         offset = (max(0, i.page - 1)) * page_size
 
         follows = (

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1136,7 +1136,8 @@ class my_follows(delegate.page):
     def GET(self, username, key=""):
         i = web.input(page=1)
         page_size = 25
-        offset = (max(0, int(i.page) - 1)) * page_size
+        page = 1 if not i.page.isdigit() else max(1, int(i.page))
+        offset = (page - 1) * page_size
 
         follows = (
             PubSub.get_followers(username, page_size, offset)
@@ -1152,7 +1153,7 @@ class my_follows(delegate.page):
         mb = MyBooksTemplate(username, 'following')
         manage = key == 'following' and mb.is_my_page
         template = render['account/follows'](
-            mb.user, follow_count, page_size, follows, manage=manage
+            mb.user, follow_count, page, page_size, follows, manage=manage
         )
         return mb.render(header_title=_(key.capitalize()), template=template)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1152,7 +1152,9 @@ class my_follows(delegate.page):
 
         mb = MyBooksTemplate(username, 'following')
         manage = key == 'following' and mb.is_my_page
-        template = render['account/follows'](mb.user, page_count, page_size, follows, manage=manage)
+        template = render['account/follows'](
+            mb.user, page_count, page_size, follows, manage=manage
+        )
         return mb.render(header_title=_(key.capitalize()), template=template)
 
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1136,6 +1136,8 @@ class my_follows(delegate.page):
     def GET(self, username, key=""):
         i = web.input(page=1)
         page_size = 25
+
+        # Force invalid page query params to default to the first page
         page = 1 if not i.page.isdigit() else max(1, int(i.page))
         offset = (page - 1) * page_size
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -6,6 +6,7 @@ import requests
 from typing import Any, TYPE_CHECKING, Final
 from collections.abc import Callable
 from collections.abc import Iterable, Mapping
+from math import ceil
 
 import web
 
@@ -1148,7 +1149,7 @@ class my_follows(delegate.page):
             if key == 'followers'
             else PubSub.count_following(username)
         )
-        page_count = max(follow_count / page_size)
+        page_count = ceil(follow_count / page_size)
 
         mb = MyBooksTemplate(username, 'following')
         manage = key == 'following' and mb.is_my_page

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -6,7 +6,6 @@ import requests
 from typing import Any, TYPE_CHECKING, Final
 from collections.abc import Callable
 from collections.abc import Iterable, Mapping
-from math import ceil
 
 import web
 
@@ -1137,7 +1136,7 @@ class my_follows(delegate.page):
     def GET(self, username, key=""):
         i = web.input(page=1)
         page_size = 25
-        offset = (max(0, i.page - 1)) * page_size
+        offset = (max(0, int(i.page) - 1)) * page_size
 
         follows = (
             PubSub.get_followers(username, page_size, offset)
@@ -1149,12 +1148,11 @@ class my_follows(delegate.page):
             if key == 'followers'
             else PubSub.count_following(username)
         )
-        page_count = ceil(follow_count / page_size)
 
         mb = MyBooksTemplate(username, 'following')
         manage = key == 'following' and mb.is_my_page
         template = render['account/follows'](
-            mb.user, page_count, page_size, follows, manage=manage
+            mb.user, follow_count, page_size, follows, manage=manage
         )
         return mb.render(header_title=_(key.capitalize()), template=template)
 

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1134,14 +1134,25 @@ class my_follows(delegate.page):
     path = r"/people/([^/]+)/(followers|following)"
 
     def GET(self, username, key=""):
-        mb = MyBooksTemplate(username, 'following')
+        i = web.input(page=1, limit=25)
+        page_size = max(1, i.limit)
+        offset = (max(0, i.page - 1)) * page_size
+
         follows = (
-            PubSub.get_followers(username)
+            PubSub.get_followers(username, page_size, offset)
             if key == 'followers'
-            else PubSub.get_following(username)
+            else PubSub.get_following(username, page_size, offset)
         )
+        follow_count = (
+            PubSub.count_followers(username)
+            if key == 'followers'
+            else PubSub.count_following(username)
+        )
+        page_count = max(follow_count / page_size)
+
+        mb = MyBooksTemplate(username, 'following')
         manage = key == 'following' and mb.is_my_page
-        template = render['account/follows'](mb.user, follows, manage=manage)
+        template = render['account/follows'](mb.user, page_count, page_size, follows, manage=manage)
         return mb.render(header_title=_(key.capitalize()), template=template)
 
 

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -1,7 +1,8 @@
-$def with (user, page_count, results_per_page, follows=None, manage=False)
+$def with (user, num_found, results_per_page, follows=None, manage=False)
 
 $if follows:
   $ username = user.key.split('/')[-1]
+  $ page = int(input(page=1).page)
   $for follow in follows:
     <ul>
       <li class="follow-row">
@@ -17,9 +18,8 @@ $if follows:
         </div>
       </li>
     </ul>
-  $ page = int(input(page=1).page)
   <div class="pager">
-    $:macros.Pager(page, page_count, results_per_page)
+    $:macros.Pager(page, num_found, results_per_page)
   </div>
 $else:
   <p>$_("There is nothing to see here yet.")</p>

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -1,8 +1,7 @@
-$def with (user, num_found, results_per_page, follows=None, manage=False)
+$def with (user, num_found, page, results_per_page, follows=None, manage=False)
 
 $if follows:
   $ username = user.key.split('/')[-1]
-  $ page = int(input(page=1).page)
   $for follow in follows:
     <ul>
       <li class="follow-row">

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -1,21 +1,25 @@
-$def with (user, follows=None, manage=False)
+$def with (user, page_count, results_per_page, follows=None, manage=False)
 
 $if follows:
   $ username = user.key.split('/')[-1]
   $for follow in follows:
     <ul>
       <li class="follow-row">
-	<div class="follow-row--name">
+	      <div class="follow-row--name">
           $if follow['publisher'] == username:
             <a href="/people/$follow['subscriber']/books" class="username-avatar"><img src="/people/$follow['subscriber']/avatar" class="account-avatar">$follow['subscriber']</a>
           $else:
             <a href="/people/$follow['publisher']/books" class="username-avatar"><img src="/people/$follow['publisher']/avatar" class="account-avatar">$follow['publisher']</a>
-	</div>
-	<div>
+	      </div>
+	      <div>
           $if manage:
             $:macros.Follow(follow['publisher'], following=1)
-	</div>
+	      </div>
       </li>
     </ul>
+  $ page = int(input(page=1).page)
+  <div class="pager">
+    $:macros.Pager(page, page_count, results_per_page)
+  </div>
 $else:
   <p>$_("There is nothing to see here yet.")</p>

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -10,8 +10,8 @@ $if follows:
             <a href="/people/$follow['subscriber']/books" class="username-avatar"><img src="/people/$follow['subscriber']/avatar" class="account-avatar">$follow['subscriber']</a>
           $else:
             <a href="/people/$follow['publisher']/books" class="username-avatar"><img src="/people/$follow['publisher']/avatar" class="account-avatar">$follow['publisher']</a>
-	      </div>
-	      <div>
+        </div>
+        <div>
           $if manage:
             $:macros.Follow(follow['publisher'], following=1)
 	      </div>

--- a/openlibrary/templates/account/follows.html
+++ b/openlibrary/templates/account/follows.html
@@ -5,7 +5,7 @@ $if follows:
   $for follow in follows:
     <ul>
       <li class="follow-row">
-	      <div class="follow-row--name">
+        <div class="follow-row--name">
           $if follow['publisher'] == username:
             <a href="/people/$follow['subscriber']/books" class="username-avatar"><img src="/people/$follow['subscriber']/avatar" class="account-avatar">$follow['subscriber']</a>
           $else:
@@ -14,7 +14,7 @@ $if follows:
         <div>
           $if manage:
             $:macros.Follow(follow['publisher'], following=1)
-	      </div>
+        </div>
       </li>
     </ul>
   $ page = int(input(page=1).page)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9283 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds pagination support to `people/:username/followers` and `people/:username/following`

### Technical
- I added `results_per_page` as a mandatory variable in the template instead of optional, so that the page size given to the macro will always match the page size used for calculating the offset in the DB query
- An easier way to solve this issue would have just been to pass a slice of `follows` to the template, but I don't think returning the whole DB contents would be solving an issue of performance as well as returning a constant 25 or fewer rows does.
- I added limits and offsets to the methods in core/follows.py, but I made these params optional so as to not break other parts of the code that use `get_following`. I looked in other parts of the codebase to verify that None and 0 are appropriate defaults.
- Also removed some unused imports and replaced some spacing in the HTML file that was loading weirdly in my code editor

### Testing
I inserted dummy data into the `follows` table to verify that both lists loaded correctly at 0, 1-25, and 26+ entries, and verified that the pagination UI loads the correct section of the list depending on the page (http://localhost:8080/people/openlibrary/followers, http://localhost:8080/people/openlibrary/followers?page=1, http://localhost:8080/people/openlibrary/followers?page=2).

### Screenshot
These are zoomed out.

**Following list, 25 entries in total:** 
<img width="546" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/441f5c45-0cf5-483a-90f1-2db759f882b1">

**Following list, 26 entries:**
<img width="548" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/5ce29728-f808-4d28-b722-906d42fc081c"> 
<img width="551" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/6962923b-666e-4236-b456-1de0cd2ce175">

**Following list, empty:**
<img width="554" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/1f09c7a5-2144-4a6b-a6f3-67afbab8c4f2">

**Followers list, 25 entries in total:**
<img width="547" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/8b8b8c93-2a70-4931-9a15-e0dcd4aa4a35">

**Followers list, 26 entries:**
<img width="541" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/3af288cb-f7cf-4e2a-8b46-5ddb3d480e1b">
<img width="542" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/4f653501-afab-4c16-ab97-5494211c8cc4">


**Followers list, empty:**
<img width="552" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/a4f1fc3a-6aed-41f8-8b7e-826fbafe6b06">

### Stakeholders
@mekarpeles 


Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.
