### PR TITLE
remove outdate jquery comment

### DIFF
--- a/openlibrary/templates/site/footer.html
+++ b/openlibrary/templates/site/footer.html
@@ -19,7 +19,6 @@ $if ("stats" in ctx.features) and query_param('debug'):
 $if show_ol_shell:
   $:render_template("lib/nav_foot", page)
 
-<!-- Must be loaded after jquery -->
 <script src="/cdn/archive.org/analytics.js" type="text/javascript"></script>
 <script src="$static_url('build/all.js')" type="text/javascript"></script>
 <!-- Passes total_time for analytics to ol.analytics.js -->


### PR DESCRIPTION
<!-- What issue does this PR close? -->
This comment is no longer true. Probably hasn't been for a long time.
We load jquery in all.js and the analytics file doesn't need it.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
