### PR TITLE
Update email regexes to detect `+`

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -582,7 +582,7 @@ class account_validation(delegate.page):
 
     @staticmethod
     def validate_email(email):
-        if not (email and re.match(r'.*@.*\..*', email)):
+        if not (email and re.match(r'[^+]+@.*\..*', email)):
             return _('Must be a valid email address')
 
         ol_account = OpenLibraryAccount.get(email=email)

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -58,7 +58,7 @@ vlogin = RegexpValidator(
     r"^[A-Za-z0-9\-_]{3,20}$", _('Must be between 3 and 20 letters and numbers')
 )
 vpass = RegexpValidator(r".{3,20}", _('Must be between 3 and 20 characters'))
-vemail = RegexpValidator(r".*@.*", _("Must be a valid email address"))
+vemail = RegexpValidator(r"[^+]+@.*\..*", _("Must be a valid email address"))
 
 
 class EqualToValidator(Validator):
@@ -80,6 +80,7 @@ class RegisterForm(Form):
             klass='required',
             id='emailAddr',
             required="true",
+            pattern=vemail.rexp.pattern,
             validators=[
                 vemail,
                 email_not_already_used,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9325.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Fix. Adds `+` detection to email regex for live & backend validation.

### Technical
<!-- What should be noted about the implementation? -->
Simply added a specification that one or more characters that are not a plus sign must appear before the `@`. Also made the regexes more consistent, preferring the current `account.py` regex which also confirms the existence of a period after the `@`.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log out (if logged in)
2. Go to `/account/create`
3. Attempt to make an account using an email with a plus sign
4. A realtime error should appear
5. Ignore the error and try to submit
6. An HTML-generated error should appear and prevent submission

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
(pending testing on GitPod)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
