### PR TITLE
Cache `octokit` in GitHub workflows

### DIFF
--- a/.github/workflows/new_pr_labeler.yml
+++ b/.github/workflows/new_pr_labeler.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types:
       - opened
+env:
+  NODE_VERSION: '20'
 jobs:
   label_pr:
     # Continue only if the PR is not a draft, and was opened in the same repository that is running this action:
@@ -16,8 +18,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-      - run: npm install @octokit/action
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v4
+        id: cache-octokit
+        with:
+          path: 'node_modules'
+          # Cache key shared across workflows
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION}}-octokit-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache-octokit.outputs.cache-hit != 'true'
+        run: npm install @octokit/action
       - run: node scripts/gh_scripts/new_pr_labeler.mjs ${{ github.repository }} ${{ github.event.pull_request.user.login }} ${{ github.event.pull_request.number }} "$PR_BODY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale_assignee_digest.yml
+++ b/.github/workflows/stale_assignee_digest.yml
@@ -5,7 +5,8 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-
+env:
+  NODE_VERSION: '20'
 jobs:
   stale_assignee_digest:
     if: ${{ github.repository == 'internetarchive/openlibrary'}}
@@ -14,8 +15,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-      - run: npm install @octokit/action
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v4
+        id: cache-octokit
+        with:
+          path: 'node_modules'
+          # Cache key shared across workflows
+          key: ${{ runner.os }}-node${{ env.NODE_VERSION}}-octokit-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache-octokit.outputs.cache-hit != 'true'
+        run: npm install @octokit/action
       - run: node scripts/gh_scripts/stale_assignee_digest.mjs --repoOwner "internetarchive" --daysSince 14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9250

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Caches `@octokit/action` for applicable GitHub workflows.

### Technical
<!-- What should be noted about the implementation? -->
Caches `octokit` in the same way that it is cached in #9311.  The key is reused for each `octokit` cache entry.  If additional JS dependencies are added to any workflow that caches `octokit`, the cache key may need to be updated for that particular workflow.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Merge this into your forked repo's `master` branch, then trigger one of the workflows.  If there is no cache hit, wait until the workflow is finished, then trigger it again.  Expect the `npm install` step to be skipped on the second run.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
