### PR TITLE
Expand `issue_comment_bot` to include more leads

### DIFF
--- a/.github/workflows/config/new_comment_digest.json
+++ b/.github/workflows/config/new_comment_digest.json
@@ -1,0 +1,49 @@
+{
+  "leads": [
+    {
+      "githubUsername": "mekarpeles",
+      "leadLabel": "Lead: @mekarpeles",
+      "slackId": "<@U0AB3N5L7>"
+    },
+    {
+      "githubUsername": "cdrini",
+      "leadLabel": "Lead: @cdrini",
+      "slackId": "<@U709VCNLD>"
+    },
+    {
+      "githubUsername": "scottbarnes",
+      "leadLabel": "Lead: @scottbarnes",
+      "slackId": "<@U03MNR6T7FH>"
+    },
+    {
+      "githubUsername": "seabelis",
+      "leadLabel": "Lead: @seabelis",
+      "slackId": "<@UAHQ39ACT>"
+    },
+    {
+      "githubUsername": "jimchamp",
+      "leadLabel": "Lead: @jimchamp",
+      "slackId": "<@U01ARTHG9EV>"
+    },
+    {
+      "githubUsername": "hornc",
+      "leadLabel": "Lead: @hornc",
+      "slackId": "<@U0EUS8DV0>"
+    },
+    {
+      "githubUsername": "mheiman",
+      "leadLabel": "Lead: @mheiman",
+      "slackId": "<@U01MQBRDN5D>"
+    },
+    {
+      "githubUsername": "RayBB",
+      "leadLabel": "Lead: @RayBB",
+      "slackId": "<@U01TC3EG9LJ>"
+    },
+    {
+      "githubUsername": "rebecca-shoptaw",
+      "leadLabel": "Lead: @rebecca-shoptaw",
+      "slackId": "<@U06D09YC69L>"
+    }
+  ]
+}

--- a/.github/workflows/new_comment_digest.yml
+++ b/.github/workflows/new_comment_digest.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install requests
-      - run: scripts/gh_scripts/issue_comment_bot.py 24 -c "$SLACK_CHANNEL" -t "$SLACK_TOKEN"
+      - run: scripts/gh_scripts/issue_comment_bot.py 24 -c .github/workflows/config/new_comment_digest.json -s "$SLACK_CHANNEL" -t "$SLACK_TOKEN"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/scripts/gh_scripts/README.md
+++ b/scripts/gh_scripts/README.md
@@ -49,19 +49,38 @@ To quickly see a script's purpose and arguments, run the script with the `-h` or
 This script fetches issues that have new comments from contributors within the past number of hours, then posts a message to the team in our Slack channel.
 
 ### Usage:
-This script has three positional arguments:
 ```
-  hours        Fetch issues that have been updated since this many hours ago
-  channel      Issues will be published to this Slack channel
-  slack-token  Slack authentication token
+positional arguments:
+  hours                 Fetch issues that have been updated since this many hours ago
+
+options:
+  -h, --help                                       show this help message and exit
+  -c CONFIG, --config CONFIG                       Path to configuration file
+  -s SLACK_CHANNEL, --slack-channel SLACK_CHANNEL  Issues will be published to this Slack channel
+  -t SLACK_TOKEN, --slack-token SLACK_TOKEN        Slack auth token
+  --no-labels                                      Prevent the script from labeling the issues
+  -v, --verbose                                    Print detailed information about the issues that were found
 ```
+
+#### Configuration
+
+A configuration file is required for this script to run properly.  The file should contain a JSON string with the following fields:
+
+`leads` : Array of configurations for each lead.
+
+`leads.githubUsername` : The lead's GitHub username.
+
+`leads.leadLabel`: Text of the lead's `Lead: @` label.
+
+`leads.slackId`: The lead's Slack ID in their `mrkdwn` format, which is used to trigger Slack 
+
 
 __Running the script locally:__
 ```
 docker compose exec -e PYTHONPATH=. web bash
 
 # Publish digest of new comments from the past day to #openlibrary-g:
-./scripts/gh_scripts/issue_comment_bot.py 24 "#openlibrary-g" "replace-with-slack-token"
+./scripts/gh_scripts/issue_comment_bot.py 24 -s "#openlibrary-g" -t "replace-with-slack-token" -c "path/to/config/file"
 ```
 
 __Note:__ When adding arguments, be sure to place any hyphenated values within double quotes.

--- a/scripts/gh_scripts/README.md
+++ b/scripts/gh_scripts/README.md
@@ -72,7 +72,7 @@ A configuration file is required for this script to run properly.  The file shou
 
 `leads.leadLabel`: Text of the lead's `Lead: @` label.
 
-`leads.slackId`: The lead's Slack ID in their `mrkdwn` format, which is used to trigger Slack 
+`leads.slackId`: The lead's Slack ID in their `mrkdwn` format, which is used to trigger Slack
 
 
 __Running the script locally:__

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -73,7 +73,7 @@ def fetch_issues(updated_since: str):
     return results
 
 
-def filter_issues(issues: list, since: datetime, leads: list[str]):
+def filter_issues(issues: list, since: datetime, leads: list[dict[str, str]]):
     """
     Returns list of issues that were not last responded to by leads.
     Requires fetching the most recent comments for the given issues.
@@ -255,7 +255,7 @@ def verbose_output(issues):
 
 
 def read_config(config_path):
-    with open(config_path, 'r', encoding='utf-8') as f:
+    with open(config_path, encoding='utf-8') as f:
         return json.load(f)
 
 

--- a/scripts/gh_scripts/issue_comment_bot.py
+++ b/scripts/gh_scripts/issue_comment_bot.py
@@ -211,8 +211,14 @@ def publish_digest(
         commenter = i['commenter']
         message = f'<{comment_url}|Latest comment for: *{issue_title}*>\n'
 
-        username = next(lead['githubUsername'] for lead in leads if lead['leadLabel'] == i['lead_label'])
-        slack_id = next(lead['slackId'] for lead in leads if lead['leadLabel'] == username)
+        username = next(
+            lead['githubUsername']
+            for lead in leads
+            if lead['leadLabel'] == i['lead_label']
+        )
+        slack_id = next(
+            lead['slackId'] for lead in leads if lead['leadLabel'] == username
+        )
         if slack_id:
             message += f'Lead: {slack_id}\n'
         elif i['lead_label']:
@@ -274,7 +280,9 @@ def start_job(args: argparse.Namespace):
         add_label_to_issues(filtered_issues)
         print('Issues labeled as "Needs: Response"')
     if args.slack_token and args.channel:
-        publish_digest(filtered_issues, args.channel, args.slack_token, args.hours, leads)
+        publish_digest(
+            filtered_issues, args.channel, args.slack_token, args.hours, leads
+        )
         print('Digest posted to Slack')
     if args.verbose:
         verbose_output(filtered_issues)


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9336

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates script to read a configuration that contains the GitHub username, Slack ID, and lead label text for project leads.  The script will avoid adding the https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Response label to any issue that was last responded to by a lead, if that lead's information is included in the configuration file.

### Technical
<!-- What should be noted about the implementation? --> 

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
