### PR TITLE
Run weekly PM digest on Monday and Friday

### DIFF
--- a/.github/workflows/weekly_status_report.yml
+++ b/.github/workflows/weekly_status_report.yml
@@ -1,7 +1,7 @@
 name: weekly_status_report
 on:
   schedule:
-    - cron: '30 8 * * *'  # XXX : set to appropriate time (before ABC)
+    - cron: '30 8 * * 1,5'
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9340

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Changes scheduled execution of the `weekly_status_report` digest to twice a week, on Mondays and Fridays.

> [!IMPORTANT]
> As of writing, the `weekly_status_report` workflow is disabled.  After merging this, please enable the workflow again.  Instructions for doing so can be found [here](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#enabling-a-workflow).

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
