### PR TITLE
Update MARC importer language mapping table

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -281,9 +281,37 @@ lang_map = {
     'ent': 'eng',
     'jap': 'jpn',
     'fra': 'fre',
-    'fr ': 'fre',
     'fle': 'dut',  # Flemish -> Dutch
+    # 2 character to 3 character codes
+    'fr ': 'fre',
     'it ': 'ita',
+    # LOC MARC Deprecated code updates
+    'cam': 'khm',  # Khmer
+    'esp': 'epo',  # Esperanto
+    'eth': 'gez',  # Ethiopic
+    'far': 'fao',  # Faroese
+    'fri': 'fry',  # Frisian
+    'gae': 'gla',  # Scottish Gaelic
+    'gag': 'glg',  # Galician
+    'gal': 'orm',  # Oromo
+    'gua': 'grn',  # Guarani
+    'int': 'ina',  # Interlingua (International Auxiliary Language Association)
+    'iri': 'gle',  # Irish
+    'lan': 'oci',  # Occitan (post 1500)
+    'lap': 'smi',  # Sami
+    'mla': 'mlg',  # Malagasy
+    'mol': 'rum',  # Romanian
+    'sao': 'smo',  # Samoan
+    'scc': 'srp',  # Serbian
+    'scr': 'hrv',  # Croatian
+    'sho': 'sna',  # Shona
+    'snh': 'sin',  # Sinhalese
+    'sso': 'sot',  # Sotho
+    'swz': 'ssw',  # Swazi
+    'tag': 'tgi',  # Tagalog
+    'taj': 'tgk',  # Tajik
+    'tar': 'tat',  # Tatar
+    'tsw': 'tsn',  # Tswana
 }
 
 

--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -279,11 +279,8 @@ lang_map = {
     'end': 'eng',
     'enk': 'eng',
     'ent': 'eng',
-    'cro': 'chu',
     'jap': 'jpn',
     'fra': 'fre',
-    'gwr': 'ger',
-    'sze': 'slo',
     'fr ': 'fre',
     'fle': 'dut',  # Flemish -> Dutch
     'it ': 'ita',


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #8140

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->

Updates the MARC import table mappings to correct LOC deprecated 3 character language codes to their current code.

This will ensure records imported from older MARCs have the up-to-date codes in Open Library.


### Technical
<!-- What should be noted about the implementation? -->

This will not modify language codes on existing records (#8139), it only affects new imports.

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 
@tfmorris 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
