### PR TITLE
Implement Figma mockup for registration

### DIFF
--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -280,7 +280,7 @@ msgstr ""
 msgid "password:"
 msgstr ""
 
-#: login.html
+#: forms.py login.html
 msgid "Email"
 msgstr ""
 
@@ -593,11 +593,11 @@ msgstr ""
 msgid "Send"
 msgstr ""
 
-#: CreateListModal.html EditButtons.html account/create.html
-#: account/notifications.html account/password/reset.html account/privacy.html
-#: admin/imports-add.html admin/permissions.html books/add.html covers/add.html
-#: covers/manage.html databarEdit.html merge/authors.html
-#: my_books/dropdown_content.html support.html tag/add.html
+#: CreateListModal.html EditButtons.html account/notifications.html
+#: account/password/reset.html account/privacy.html admin/imports-add.html
+#: admin/permissions.html books/add.html covers/add.html covers/manage.html
+#: databarEdit.html merge/authors.html my_books/dropdown_content.html
+#: support.html tag/add.html
 msgid "Cancel"
 msgstr ""
 
@@ -857,11 +857,25 @@ msgid "Sign Up"
 msgstr ""
 
 #: account/create.html
-msgid "Complete the form below to create a new Internet Archive account."
+msgid ""
+"Get your free Open Library card and borrow digital books from the "
+"nonprofit Internet Archive"
 msgstr ""
 
 #: account/create.html
-msgid "Each field is required"
+msgid ""
+"<a href=\"/help/faq/borrow\" target=\"_blank\">Borrow</a> up to 5 books "
+"at a time"
+msgstr ""
+
+#: account/create.html
+msgid ""
+"<a href=\"/help/faq/reading-log\" target=\"_blank\">Keep track</a> of "
+"what you're reading"
+msgstr ""
+
+#: account/create.html
+msgid "<a href=\"/help\" target=\"_blank\">Learn More</a> about how it works"
 msgstr ""
 
 #: account/create.html
@@ -881,10 +895,18 @@ msgid "screenname"
 msgstr ""
 
 #: account/create.html
+msgid "Sign Up with Email"
+msgstr ""
+
+#: account/create.html
 msgid ""
 "By signing up, you agree to the Internet Archive's <a "
-"href='//archive.org/about/terms.php' target='_blank'>Terms of "
+"href=\"//archive.org/about/terms.php\" target=\"_blank\">Terms of "
 "Service</a>."
+msgstr ""
+
+#: account/create.html
+msgid "Already an Internet Archive user? <a href=\"/account/login\">Log in</a>"
 msgstr ""
 
 #: account/delete.html
@@ -6523,7 +6545,7 @@ msgid "Username must be between 3-20 characters"
 msgstr ""
 
 #: account.py
-msgid "Username may only contain numbers and letters"
+msgid "Username may only contain numbers, letters, - or _"
 msgstr ""
 
 #: account.py
@@ -6611,19 +6633,7 @@ msgid "Must be between 3 and 20 letters and numbers"
 msgstr ""
 
 #: forms.py
-msgid "Your email address"
-msgstr ""
-
-#: forms.py
-msgid "Choose a screen name. Screen names are public and cannot be changed later."
-msgstr ""
-
-#: forms.py
-msgid "Letters and numbers only please, and at least 3 characters."
-msgstr ""
-
-#: forms.py
-msgid "Choose a password"
+msgid "Public, and cannot be changed later."
 msgstr ""
 
 #: forms.py
@@ -6635,5 +6645,13 @@ msgstr ""
 
 #: forms.py
 msgid "Invalid password"
+msgstr ""
+
+#: forms.py
+msgid "Your email address"
+msgstr ""
+
+#: forms.py
+msgid "Choose a password"
 msgstr ""
 

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -863,24 +863,6 @@ msgid ""
 msgstr ""
 
 #: account/create.html
-msgid ""
-"<a class=\"ol-signup-form__link\" href=\"/help/faq/borrow\" "
-"target=\"_blank\">Borrow</a> up to 5 books at a time"
-msgstr ""
-
-#: account/create.html
-msgid ""
-"<a class=\"ol-signup-form__link\" href=\"/help/faq/reading-log\" "
-"target=\"_blank\">Keep track</a> of what you're reading"
-msgstr ""
-
-#: account/create.html
-msgid ""
-"<a class=\"ol-signup-form__link\" href=\"/help\" target=\"_blank\">Learn "
-"More</a> about how it works"
-msgstr ""
-
-#: account/create.html
 msgid "Show password"
 msgstr ""
 
@@ -903,14 +885,12 @@ msgstr ""
 #: account/create.html
 msgid ""
 "By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
-"form__link--muted\" href=\"//archive.org/about/terms.php\" "
+"form__link\" href=\"//archive.org/about/terms.php\" "
 "target=\"_blank\">Terms of Service</a>."
 msgstr ""
 
 #: account/create.html
-msgid ""
-"Already an Internet Archive user? <a class=\"ol-signup-form__link\" "
-"href=\"/account/login\">Log in</a>"
+msgid "Already have an account? <a href=\"/account/login\">Log in</a>"
 msgstr ""
 
 #: account/delete.html

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -452,9 +452,8 @@ msgstr ""
 
 #: authors/index.html lib/nav_head.html lists/home.html
 #: publishers/notfound.html publishers/view.html search/advancedsearch.html
-#: search/authors.html search/inside.html search/lists.html
-#: search/publishers.html search/subjects.html subjects.html
-#: subjects/notfound.html type/local_id/view.html work_search.html
+#: search/publishers.html search/searchbox.html subjects.html
+#: subjects/notfound.html type/local_id/view.html
 msgid "Search"
 msgstr ""
 
@@ -4398,7 +4397,7 @@ msgstr ""
 msgid "Recent Activity"
 msgstr ""
 
-#: lists/home.html
+#: lists/home.html lists/showcase.html
 msgid "See all"
 msgstr ""
 
@@ -6621,7 +6620,7 @@ msgid "Screen Name"
 msgstr ""
 
 #: forms.py
-msgid "Public, and cannot be changed later."
+msgid "Public and cannot be changed later."
 msgstr ""
 
 #: forms.py

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -864,18 +864,20 @@ msgstr ""
 
 #: account/create.html
 msgid ""
-"<a href=\"/help/faq/borrow\" target=\"_blank\">Borrow</a> up to 5 books "
-"at a time"
+"<a class=\"ol-signup-form__link\" href=\"/help/faq/borrow\" "
+"target=\"_blank\">Borrow</a> up to 5 books at a time"
 msgstr ""
 
 #: account/create.html
 msgid ""
-"<a href=\"/help/faq/reading-log\" target=\"_blank\">Keep track</a> of "
-"what you're reading"
+"<a class=\"ol-signup-form__link\" href=\"/help/faq/reading-log\" "
+"target=\"_blank\">Keep track</a> of what you're reading"
 msgstr ""
 
 #: account/create.html
-msgid "<a href=\"/help\" target=\"_blank\">Learn More</a> about how it works"
+msgid ""
+"<a class=\"ol-signup-form__link\" href=\"/help\" target=\"_blank\">Learn "
+"More</a> about how it works"
 msgstr ""
 
 #: account/create.html
@@ -900,13 +902,15 @@ msgstr ""
 
 #: account/create.html
 msgid ""
-"By signing up, you agree to the Internet Archive's <a "
-"href=\"//archive.org/about/terms.php\" target=\"_blank\">Terms of "
-"Service</a>."
+"By signing up, you agree to the Internet Archive's <a class=\"ol-signup-"
+"form__link--muted\" href=\"//archive.org/about/terms.php\" "
+"target=\"_blank\">Terms of Service</a>."
 msgstr ""
 
 #: account/create.html
-msgid "Already an Internet Archive user? <a href=\"/account/login\">Log in</a>"
+msgid ""
+"Already an Internet Archive user? <a class=\"ol-signup-form__link\" "
+"href=\"/account/login\">Log in</a>"
 msgstr ""
 
 #: account/delete.html
@@ -6630,6 +6634,10 @@ msgstr ""
 
 #: forms.py
 msgid "Must be between 3 and 20 letters and numbers"
+msgstr ""
+
+#: forms.py
+msgid "Screen Name"
 msgstr ""
 
 #: forms.py

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -32,7 +32,7 @@ export function initRealTimeValidation() {
     function renderError(inputId, errorDiv, errorMsg) {
         $(inputId).addClass('invalid');
         $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
-        $(errorDiv).show().text(errorMsg);
+        $(errorDiv).text(errorMsg);
     }
 
     /**
@@ -44,7 +44,7 @@ export function initRealTimeValidation() {
     function clearError(inputId, errorDiv) {
         $(inputId).removeClass('invalid');
         $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');
-        $(errorDiv).hide().text('');
+        $(errorDiv).text('');
     }
 
     function validateUsername() {

--- a/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
+++ b/openlibrary/plugins/openlibrary/js/realtime_account_validation.js
@@ -32,7 +32,7 @@ export function initRealTimeValidation() {
     function renderError(inputId, errorDiv, errorMsg) {
         $(inputId).addClass('invalid');
         $(`label[for=${inputId.slice(1)}]`).addClass('invalid');
-        $(errorDiv).addClass('invalid').text(errorMsg);
+        $(errorDiv).show().text(errorMsg);
     }
 
     /**
@@ -44,7 +44,7 @@ export function initRealTimeValidation() {
     function clearError(inputId, errorDiv) {
         $(inputId).removeClass('invalid');
         $(`label[for=${inputId.slice(1)}]`).removeClass('invalid');
-        $(errorDiv).removeClass('invalid').text('');
+        $(errorDiv).hide().text('');
     }
 
     function validateUsername() {

--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -573,7 +573,7 @@ class account_validation(delegate.page):
         if not 3 <= len(username) <= 20:
             return _('Username must be between 3-20 characters')
         if not re.match('^[A-Za-z0-9-_]{3,20}$', username):
-            return _('Username may only contain numbers and letters')
+            return _('Username may only contain numbers, letters, - or _')
 
         ol_account = OpenLibraryAccount.get(username=username)
         if ol_account:

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -77,7 +77,7 @@ class RegisterForm(Form):
         Email(
             'email',
             description=_('Email'),
-            klass='required create-form__input',
+            klass='required',
             id='emailAddr',
             required="true",
             validators=[
@@ -89,7 +89,7 @@ class RegisterForm(Form):
         ),
         Textbox(
             'username',
-            description=_("Username"),
+            description=_("Screen Name"),
             klass='required',
             help=_("Public, and cannot be changed later."),
             autocapitalize="off",

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -76,8 +76,8 @@ class RegisterForm(Form):
     INPUTS = [
         Email(
             'email',
-            description=_('Your email address'),
-            klass='required',
+            description=_('Email'),
+            klass='required create-form__input',
             id='emailAddr',
             required="true",
             validators=[
@@ -89,12 +89,9 @@ class RegisterForm(Form):
         ),
         Textbox(
             'username',
-            description=_(
-                "Choose a screen name. Screen names are public and cannot be changed "
-                "later."
-            ),
+            description=_("Username"),
             klass='required',
-            help=_("Letters and numbers only please, and at least 3 characters."),
+            help=_("Public, and cannot be changed later."),
             autocapitalize="off",
             validators=[vlogin, username_validator],
             pattern=vlogin.rexp.pattern,
@@ -103,7 +100,7 @@ class RegisterForm(Form):
         ),
         Password(
             'password',
-            description=_('Choose a password'),
+            description=_('Password'),
             klass='required',
             validators=[vpass],
             minlength="3",

--- a/openlibrary/plugins/upstream/forms.py
+++ b/openlibrary/plugins/upstream/forms.py
@@ -91,7 +91,7 @@ class RegisterForm(Form):
             'username',
             description=_("Screen Name"),
             klass='required',
-            help=_("Public, and cannot be changed later."),
+            help=_("Public and cannot be changed later."),
             autocapitalize="off",
             validators=[vlogin, username_validator],
             pattern=vlogin.rexp.pattern,

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -12,20 +12,15 @@ $var title: $_("Sign Up to Open Library")
 
 <div class="ol-page-signup">
     <div id="contentHead" class="ol-signup-hero">
-        <h1>$_("Sign Up")</h1>
-        <p class="ol-signup-form__subtitle lighter">$_("Get your free Open Library card and borrow digital books from the nonprofit Internet Archive")</p>
-        <ul class="ol-signup-form__iconlist">
-            <li>📚 $:_('<a class="ol-signup-form__link" href="/help/faq/borrow" target="_blank">Borrow</a> up to 5 books at a time')</li>
-            <li>📋 $:_('<a class="ol-signup-form__link" href="/help/faq/reading-log" target="_blank">Keep track</a> of what you\'re reading')</li>
-            <li>🎓 $:_('<a class="ol-signup-form__link" href="/help" target="_blank">Learn More</a> about how it works')</li>
-        </ul>
+        <h1 class="ol-signup-hero__title">$_("Sign Up")</h1>
+        <p class="ol-signup-hero__subtitle">$_("Get your free Open Library card and borrow digital books from the nonprofit Internet Archive")</p>
     </div>
 
     <div id="contentBody" class="ol-signup-form">
 
     $if not ctx.user:
         $:render_template("account/ia_thirdparty_logins")
-        <div class="login-big-or lighter">$_('OR')</div>
+        <div class="ol-signup-form__big-or">$_('OR')</div>
 
     $def field(input, suffix=''):
         $# :param openlibrary.utils.form.Input input:
@@ -35,7 +30,7 @@ $var title: $_("Sign Up to Open Library")
             <div class="label">
                 <label for="$input.id">$input.description</label>
                 $if input.help:
-                    <div class="ol-signup-form__note lighter">$input.help</div>
+                    <div class="ol-signup-form__note">$input.help</div>
             </div>
             <div class="ol-signup-form__error" id="$(input.id)Message" style="display:none">$input.note</div>
             <div class="input">
@@ -45,9 +40,9 @@ $var title: $_("Sign Up to Open Library")
                     $    "show_password": _('Show password'),
                     $    "hide_password": _('Hide password')
                     $  }
-                    <a href="javascript:;" class="password-visibility-toggle ol-signup-form__link--muted lighter" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
+                    <a href="javascript:;" class="password-visibility-toggle ol-signup-form__link" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
             </div>
-            <div class="ol-signup-form__note sansserif lighter">$:suffix</div>
+            <div class="ol-signup-form__suffix">$:suffix</div>
         </div>
 
 
@@ -58,7 +53,7 @@ $var title: $_("Sign Up to Open Library")
     $else:
         <form class="olform create create-form" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
             $if form.note:
-                <div class="note">$form.note</div>
+                <div class="ol-signup-form__note">$form.note</div>
 
             $def screenname_url(): $_('Your URL'): https://openlibrary.org/people/<span id="userUrl">$(form.username.value or _('screenname'))</span>
 
@@ -78,9 +73,9 @@ $var title: $_("Sign Up to Open Library")
                     $ classes = 'g-recaptcha'
                     $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
                     $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
-                <button type="submit" name="signup" id="signup" class="larger $classes cta-btn cta-btn--primary" $sitekey $callback>$_("Sign Up with Email")</button>
-                <p class="ol-signup-form__tos sansserif lighter">$:_('By signing up, you agree to the Internet Archive\'s <a class="ol-signup-form__link--muted" href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</p>
-                <p class="ol-signup-form__login-hint">$:_('Already an Internet Archive user? <a class="ol-signup-form__link" href="/account/login">Log in</a>')</p>
+                <button type="submit" name="signup" id="signup" class="$classes cta-btn cta-btn--primary" $sitekey $callback>$_("Sign Up with Email")</button>
+                <small class="ol-signup-form__tos">$:_('By signing up, you agree to the Internet Archive\'s <a class="ol-signup-form__link" href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</small>
+                <p class="ol-signup-form__login-hint">$:_('Already have an account? <a href="/account/login">Log in</a>')</p>
             </div>
         </form>
     </div>

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -1,5 +1,7 @@
 $def with (form)
 
+$putctx("cssfile", "signup")
+
 $ i18n_strings = {
     $ "password_length_err": _("Must be between 3 and 20 characters")
     $ }
@@ -11,11 +13,11 @@ $var title: $_("Sign Up to Open Library")
 <div class="ol-page-signup">
     <div id="contentHead" class="ol-signup-hero">
         <h1>$_("Sign Up")</h1>
-        <p>$_("Get your free Open Library card and borrow digital books from the nonprofit Internet Archive")</p>
-        <ul className="create-form__iconlist">
-            <li>📚 $:_('<a href="/help/faq/borrow" target="_blank">Borrow</a> up to 5 books at a time')</li>
-            <li>📋 $:_('<a href="/help/faq/reading-log" target="_blank">Keep track</a> of what you\'re reading')</li>
-            <li>🎓 $:_('<a href="/help" target="_blank">Learn More</a> about how it works')</li>
+        <p class="ol-signup-form__subtitle lighter">$_("Get your free Open Library card and borrow digital books from the nonprofit Internet Archive")</p>
+        <ul class="ol-signup-form__iconlist">
+            <li>📚 $:_('<a class="ol-signup-form__link" href="/help/faq/borrow" target="_blank">Borrow</a> up to 5 books at a time')</li>
+            <li>📋 $:_('<a class="ol-signup-form__link" href="/help/faq/reading-log" target="_blank">Keep track</a> of what you\'re reading')</li>
+            <li>🎓 $:_('<a class="ol-signup-form__link" href="/help" target="_blank">Learn More</a> about how it works')</li>
         </ul>
     </div>
 
@@ -23,18 +25,19 @@ $var title: $_("Sign Up to Open Library")
 
     $if not ctx.user:
         $:render_template("account/ia_thirdparty_logins")
-        <div class="login-big-or">$_('OR')</div>
+        <div class="login-big-or lighter">$_('OR')</div>
 
     $def field(input, suffix=''):
         $# :param openlibrary.utils.form.Input input:
         $# :param str suffix: HTML to put at bottom of input
 
-        <div class="formElement">
+        <div class="formElement ol-signup-form__input">
             <div class="label">
                 <label for="$input.id">$input.description</label>
                 $if input.help:
-                    <span class="smaller lighter">$input.help</span>
+                    <div class="ol-signup-form__note lighter">$input.help</div>
             </div>
+            <div class="ol-signup-form__error" id="$(input.id)Message" style="display:none">$input.note</div>
             <div class="input">
                 $:input.render()
                 $if input.name == 'password':
@@ -42,10 +45,9 @@ $var title: $_("Sign Up to Open Library")
                     $    "show_password": _('Show password'),
                     $    "hide_password": _('Hide password')
                     $  }
-                    <a href="javascript:;" class="password-visibility-toggle" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
-                <span class="invalid clearfix create-form__error" id="$(input.id)Message">$input.note</span>
-                <span class="sansserif smaller lighter">$:suffix</span>
+                    <a href="javascript:;" class="password-visibility-toggle ol-signup-form__link--muted lighter" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
             </div>
+            <div class="ol-signup-form__note sansserif lighter">$:suffix</div>
         </div>
 
 
@@ -64,11 +66,10 @@ $var title: $_("Sign Up to Open Library")
             $:field(form.username, suffix=str(screenname_url()))
             $:field(form.password)
 
-            <label>
-                $:form.ia_newsletter.render() $:form.ia_newsletter.description
-            </label>
+            <div class="ol-signup-form__newsletter">
+                $:form.ia_newsletter.render() <label for="ia_newsletter">$:form.ia_newsletter.description</label>
+            </div>
 
-            <hr/>
             <div class="formElement bottom">
                 <br/>
                 $ sitekey = classes = callback = ''
@@ -77,11 +78,11 @@ $var title: $_("Sign Up to Open Library")
                     $ classes = 'g-recaptcha'
                     $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
                     $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
-                <button type="submit" name="signup" id="signup" class="larger $classes cta-btn" $sitekey $callback>$_("Sign Up with Email")</button>
-                <small>$:_('By signing up, you agree to the Internet Archive\'s <a href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</small>
+                <button type="submit" name="signup" id="signup" class="larger $classes cta-btn cta-btn--primary" $sitekey $callback>$_("Sign Up with Email")</button>
+                <p class="ol-signup-form__tos sansserif lighter">$:_('By signing up, you agree to the Internet Archive\'s <a class="ol-signup-form__link--muted" href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</p>
+                <p class="ol-signup-form__login-hint">$:_('Already an Internet Archive user? <a class="ol-signup-form__link" href="/account/login">Log in</a>')</p>
             </div>
         </form>
-        <p>$:_('Already an Internet Archive user? <a href="/account/login">Log in</a>')</p>
     </div>
 </div>
 

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -8,76 +8,80 @@ $# :param openlibrary.plugins.upstream.forms.RegisterForm form:
 
 $var title: $_("Sign Up to Open Library")
 
-<div id="contentHead">
-    <h1>$_("Sign Up")</h1>
-</div>
-
-<div id="contentBody">
-
-$if not ctx.user:
-    $:render_template("account/ia_thirdparty_logins")
-    <div class="login-big-or">$_('OR')</div>
-
-    <p class="instruct">$_("Complete the form below to create a new Internet Archive account.")
-    <span class="attn remind">$_("Each field is required")</span></p>
-
-$def field(input, suffix=''):
-    $# :param openlibrary.utils.form.Input input:
-    $# :param str suffix: HTML to put at bottom of input
-
-    <div class="formElement">
-        <div class="label">
-            <label for="$input.id">$input.description</label>
-            $if input.help:
-                <span class="smaller lighter">$input.help</span>
-        </div>
-        <div class="input">
-            $:input.render()
-            $if input.name == 'password':
-                $ i18n_strings = {
-                $    "show_password": _('Show password'),
-                $    "hide_password": _('Hide password')
-                $  }
-                <a href="javascript:;" class="password-visibility-toggle" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
-            <span class="invalid clearfix" id="$(input.id)Message">$input.note</span>
-            <span class="sansserif smaller lighter">$:suffix</span>
-        </div>
+<div class="ol-page-signup">
+    <div id="contentHead" class="ol-signup-hero">
+        <h1>$_("Sign Up")</h1>
+        <p>$_("Get your free Open Library card and borrow digital books from the nonprofit Internet Archive")</p>
+        <ul className="create-form__iconlist">
+            <li>📚 $:_('<a href="/help/faq/borrow" target="_blank">Borrow</a> up to 5 books at a time')</li>
+            <li>📋 $:_('<a href="/help/faq/reading-log" target="_blank">Keep track</a> of what you\'re reading')</li>
+            <li>🎓 $:_('<a href="/help" target="_blank">Learn More</a> about how it works')</li>
+        </ul>
     </div>
 
+    <div id="contentBody" class="ol-signup-form">
 
-$if ctx.user:
-    $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
-    <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
-    <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
-$else:
-    <form class="olform create" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
-        $if form.note:
-            <div class="note">$form.note</div>
+    $if not ctx.user:
+        $:render_template("account/ia_thirdparty_logins")
+        <div class="login-big-or">$_('OR')</div>
 
-        $def screenname_url(): $_('Your URL'): https://openlibrary.org/people/<span id="userUrl">$(form.username.value or _('screenname'))</span>
+    $def field(input, suffix=''):
+        $# :param openlibrary.utils.form.Input input:
+        $# :param str suffix: HTML to put at bottom of input
 
-        $:field(form.email)
-        $:field(form.username, suffix=str(screenname_url()))
-        $:field(form.password)
-
-        <label>
-            $:form.ia_newsletter.render() $:form.ia_newsletter.description
-        </label>
-
-        <hr/>
-
-        <small>$:_("By signing up, you agree to the Internet Archive's <a href='//archive.org/about/terms.php' target='_blank'>Terms of Service</a>.")</small>
-
-        <div class="formElement bottom">
-            <br/>
-            $ sitekey = classes = callback = ''
-            $if form.has_recaptcha:
-                $ callback = "data-callback=submitCreateAccountForm"
-                $ classes = 'g-recaptcha'
-                $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
-                $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
-            <button type="submit" name="signup" id="signup" class="larger $classes" $sitekey $callback>$_("Sign Up")</button>
-            <a href="javascript:history.go(-1);" class="smaller attn">$_("Cancel")</a>
+        <div class="formElement">
+            <div class="label">
+                <label for="$input.id">$input.description</label>
+                $if input.help:
+                    <span class="smaller lighter">$input.help</span>
+            </div>
+            <div class="input">
+                $:input.render()
+                $if input.name == 'password':
+                    $ i18n_strings = {
+                    $    "show_password": _('Show password'),
+                    $    "hide_password": _('Hide password')
+                    $  }
+                    <a href="javascript:;" class="password-visibility-toggle" data-i18n="$json_encode(i18n_strings)">$i18n_strings["show_password"]</a>
+                <span class="invalid clearfix create-form__error" id="$(input.id)Message">$input.note</span>
+                <span class="sansserif smaller lighter">$:suffix</span>
+            </div>
         </div>
-    </form>
+
+
+    $if ctx.user:
+        $def user_link(): <a href="$ctx.user.key">$ctx.user.displayname</a>
+        <p>$:_("You are already logged into Open Library as %(user)s.", user=str(user_link()))</p>
+        <p>$:_('If you\'d like to create a new, different Open Library account, you\'ll need to <a href="javascript:;" onclick="document.forms[\'hamburger-logout\'].submit()">log out</a> and start the signup process afresh.')</p>
+    $else:
+        <form class="olform create create-form" name="signup" method="post" data-i18n="$json_encode(i18n_strings)" action="">
+            $if form.note:
+                <div class="note">$form.note</div>
+
+            $def screenname_url(): $_('Your URL'): https://openlibrary.org/people/<span id="userUrl">$(form.username.value or _('screenname'))</span>
+
+            $:field(form.email)
+            $:field(form.username, suffix=str(screenname_url()))
+            $:field(form.password)
+
+            <label>
+                $:form.ia_newsletter.render() $:form.ia_newsletter.description
+            </label>
+
+            <hr/>
+            <div class="formElement bottom">
+                <br/>
+                $ sitekey = classes = callback = ''
+                $if form.has_recaptcha:
+                    $ callback = "data-callback=submitCreateAccountForm"
+                    $ classes = 'g-recaptcha'
+                    $ sitekey = "data-sitekey=%s" % form['recaptcha'].public_key
+                    $:render_template("recaptcha", form['recaptcha'].public_key, error=None, invisible=True)
+                <button type="submit" name="signup" id="signup" class="larger $classes cta-btn" $sitekey $callback>$_("Sign Up with Email")</button>
+                <small>$:_('By signing up, you agree to the Internet Archive\'s <a href="//archive.org/about/terms.php" target="_blank">Terms of Service</a>.')</small>
+            </div>
+        </form>
+        <p>$:_('Already an Internet Archive user? <a href="/account/login">Log in</a>')</p>
+    </div>
 </div>
+

--- a/openlibrary/templates/account/create.html
+++ b/openlibrary/templates/account/create.html
@@ -32,7 +32,7 @@ $var title: $_("Sign Up to Open Library")
                 $if input.help:
                     <div class="ol-signup-form__note">$input.help</div>
             </div>
-            <div class="ol-signup-form__error" id="$(input.id)Message" style="display:none">$input.note</div>
+            <div class="ol-signup-form__error" id="$(input.id)Message">$input.note</div>
             <div class="input">
                 $:input.render()
                 $if input.name == 'password':

--- a/openlibrary/templates/account/ia_thirdparty_logins.html
+++ b/openlibrary/templates/account/ia_thirdparty_logins.html
@@ -4,5 +4,5 @@ $ params = {'origin': request.home.replace('http:', 'https:')}
 <iframe
     id="ia-third-party-logins"
     src="https://$get_ia_host(allow_dev=True)/account/login.thirdparty.php?$(urlencode(params))"
-    style="border:0; width: 100%; height: 44px"
+    style="border:0; width: auto; height: 44px"
 ></iframe>

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -1,0 +1,156 @@
+/**
+ * Stylesheet for signup and (soon) login forms
+
+ * Used in templates:
+ * - openlibrary/templates/account/create.html
+ *
+ * Used on pages:
+ * - /account/create
+ */
+
+@import (less) "less/index.less";
+
+// Import all base styles
+@import (less) "base/index.less";
+
+// Import colors
+@import (less) "less/colors.less";
+
+// layout rules
+@import (less) "layout/index.less";
+@import (less) "page-user.less";
+
+// Components (modules) in order of appearance on page
+@import (less) "components/header.less";
+@import (less) "components/form.olform.less";
+@import (less) "components/footer.less";
+@import (less) "components/language.less";
+
+.ol-page-signup {
+  display: flex;
+  flex-direction: row;
+
+  .ol-signup-hero > *, .ol-signup-form > * {
+    width: 70%;
+  }
+
+  .ol-signup-hero {
+    width: 55%;
+    background-color: @grey-fafafa;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    border-radius: 5px 0 0 5px;
+
+    h1 {
+      color: @black;
+    }
+
+    .ol-signup-form__subtitle {
+      font-size: 18px;
+    }
+
+    li {
+      margin-bottom: 18px;
+    }
+
+    @media only screen and (max-width: @width-breakpoint-tablet) {
+      display: none;
+    }
+  }
+
+  .ol-signup-form__link {
+    color: @link-blue;
+    text-decoration: none;
+    border-bottom: 1px solid @link-blue;
+  }
+
+  .ol-signup-form__link--muted, .ol-signup-form__newsletter a {
+    color: inherit;
+  }
+
+  .ol-signup-form {
+    flex: 1 1 0;
+    padding: 20px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Specificity added to override original padding*/
+  #contentBody.ol-signup-form {
+    padding: 30px 0;
+  }
+
+  .ol-signup-form__input {
+    padding-top: 6px;
+    input {
+      border: 1px solid @light-grey;
+      border-radius: 5px;
+      width: 100%;
+    }
+
+    input.invalid {
+      border: 1px solid @red;
+    }
+  }
+
+  .ol-signup-form__error {
+    color: @red;
+    background-color: @baby-pink;
+    border: .5px @red;
+    border-style: solid solid none;
+    border-radius: 5px 5px 0 0;
+    margin-bottom: -3px;
+    width: 100%;
+    padding: 10px 5px;
+  }
+
+  .ol-signup-form__note, .ol-signup-form__tos, .ol-signup-form__error, .ol-signup-form__newsletter {
+    font-size: 14px;
+  }
+
+  .ol-signup-form__newsletter {
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    align-items: flex-start;
+    padding-top: 16px;
+    width: 100%;
+
+    > * {
+      display: block;
+    }
+
+    input {
+      margin-top: 2px;
+    }
+  }
+
+  .password-visibility-toggle {
+    float: right;
+  }
+
+  .bottom > *  {
+    text-align: center;
+  }
+
+  .ol-signup-form__input .label > * {
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  .ol-signup-form__tos {
+    margin-top: 5px;
+    margin-bottom: 20px;
+  }
+
+  #ia-third-party-logins {
+    margin: 0 auto;
+    display: flex;
+  }
+
+}

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -16,13 +16,16 @@
 // Import colors
 @import (less) "less/colors.less";
 
-// layout rules
+// Import fonts
+@import (less) "less/font-families.less";
+
+// Layout rules
 @import (less) "layout/index.less";
-@import (less) "page-user.less";
 
 // Components (modules) in order of appearance on page
 @import (less) "components/header.less";
 @import (less) "components/form.olform.less";
+@import (less) "components/buttonCta.less";
 @import (less) "components/footer.less";
 @import (less) "components/language.less";
 
@@ -33,75 +36,101 @@
   .ol-signup-hero > *, .ol-signup-form > * {
     width: 70%;
   }
+}
 
-  .ol-signup-hero {
-    width: 55%;
-    background-color: @grey-fafafa;
+.ol-signup-hero {
+  width: 55%;
+  background-color: @grey-fafafa;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 5px 0 0 5px;
+
+  .ol-signup-hero__title {
+    color: @black;
+    font-size: @font-size-headline-large;
+  }
+
+  .ol-signup-hero__subtitle {
+    color: @grey;
+    font-size: @font-size-title-large;
+  }
+
+  @media only screen and (max-width: @width-breakpoint-tablet) {
+    display: none;
+  }
+}
+
+/* Specificity added to override original padding*/
+#contentBody.ol-signup-form {
+  padding: 30px 0;
+}
+
+.ol-signup-form {
+  flex: 1 1 0;
+  padding: 20px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  #ia-third-party-logins {
+    margin: 0 auto;
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+  }
+
+  .ol-signup-form__big-or {
+    display: flex;
     gap: 10px;
-    border-radius: 5px 0 0 5px;
+    margin-top: 10px;
+    max-width: 600px;
+    color: @grey;
+  }
 
-    h1 {
-      color: @black;
-    }
-
-    .ol-signup-form__subtitle {
-      font-size: 18px;
-    }
-
-    li {
-      margin-bottom: 18px;
-    }
-
-    @media only screen and (max-width: @width-breakpoint-tablet) {
-      display: none;
-    }
+  .ol-signup-form__big-or::before, .ol-signup-form__big-or::after {
+    content: "";
+    display: block;
+    flex: 1;
+    border-bottom: 1px solid @grey;
+    transform: translateY(-50%);
   }
 
   .ol-signup-form__link {
-    color: @link-blue;
-    text-decoration: none;
-    border-bottom: 1px solid @link-blue;
-  }
-
-  .ol-signup-form__link--muted, .ol-signup-form__newsletter a {
     color: inherit;
   }
 
-  .ol-signup-form {
-    flex: 1 1 0;
-    padding: 20px 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-
-  /* Specificity added to override original padding*/
-  #contentBody.ol-signup-form {
-    padding: 30px 0;
+  .ol-signup-form__note {
+    font-size: 14px;
+    color: @grey;
   }
 
   .ol-signup-form__input {
     padding-top: 6px;
+
     input {
       border: 1px solid @light-grey;
       border-radius: 5px;
       width: 100%;
+      padding: 6px 4px;
     }
 
     input.invalid {
       border: 1px solid @red;
     }
+
+    label, .ol-signup-form__note {
+      display: block;
+      margin-bottom: 4px;
+    }
   }
 
   .ol-signup-form__error {
+    font-size: 14px;
     color: @red;
     background-color: @baby-pink;
-    border: .5px @red;
+    border: .5px fade(@red, 50%);
     border-style: solid solid none;
     border-radius: 5px 5px 0 0;
     margin-bottom: -3px;
@@ -109,8 +138,14 @@
     padding: 10px 5px;
   }
 
-  .ol-signup-form__note, .ol-signup-form__tos, .ol-signup-form__error, .ol-signup-form__newsletter {
-    font-size: 14px;
+  .ol-signup-form__suffix {
+    font-size: 12px;
+    color: @grey;
+  }
+
+  .password-visibility-toggle {
+    float: right;
+    color: @grey;
   }
 
   .ol-signup-form__newsletter {
@@ -120,37 +155,31 @@
     align-items: flex-start;
     padding-top: 16px;
     width: 100%;
-
-    > * {
-      display: block;
-    }
+    font-size: 14px;
 
     input {
       margin-top: 2px;
     }
-  }
 
-  .password-visibility-toggle {
-    float: right;
-  }
-
-  .bottom > *  {
-    text-align: center;
-  }
-
-  .ol-signup-form__input .label > * {
-    display: block;
-    margin-bottom: 4px;
+    a {
+      color: inherit;
+    }
   }
 
   .ol-signup-form__tos {
+    font-size: 14px;
+    color: @grey;
+    display: block;
     margin-top: 5px;
     margin-bottom: 20px;
+    text-align: center;
   }
 
-  #ia-third-party-logins {
-    margin: 0 auto;
-    display: flex;
-  }
+  .ol-signup-form__login-hint {
+    text-align: center;
 
+    a {
+      color: @link-blue;
+    }
+  }
 }

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -129,13 +129,17 @@
   .ol-signup-form__error {
     font-size: 14px;
     color: @red;
-    background-color: @baby-pink;
+    background-color: fade(@baby-pink, 50%);
     border: .5px fade(@red, 50%);
     border-style: solid solid none;
     border-radius: 5px 5px 0 0;
     margin-bottom: -3px;
     width: 100%;
     padding: 10px 5px;
+
+    &:empty {
+      display: none;
+    }
   }
 
   .ol-signup-form__suffix {

--- a/static/css/page-signup.less
+++ b/static/css/page-signup.less
@@ -36,6 +36,12 @@
   .ol-signup-hero > *, .ol-signup-form > * {
     width: 70%;
   }
+
+  @media only screen and (max-width: @width-breakpoint-tablet) {
+    .ol-signup-form > * {
+      width: calc(100% - 60px);
+    }
+  }
 }
 
 .ol-signup-hero {
@@ -163,6 +169,7 @@
 
     input {
       margin-top: 2px;
+      flex-shrink: 0;
     }
 
     a {

--- a/tests/unit/js/realtime_account_validation.test.js
+++ b/tests/unit/js/realtime_account_validation.test.js
@@ -5,7 +5,7 @@ beforeEach(() => {
     <form id="signup" name="signup" data-i18n={}>
       <input type="text" id="username">
       <input type="text" id="emailAddr">
-      <div id="passwordMessage"></div>
+      <div id="passwordMessage" style="display:none"></div>
       <label for="password">Label for password</label>
       <input type="password" class="required" id="password">
     </form>
@@ -13,7 +13,7 @@ beforeEach(() => {
 });
 
 describe('Password tests', () => {
-    let label, passwordField, passwordMessage
+    let label, passwordField
 
     beforeEach(() => {
         // call the function
@@ -22,7 +22,6 @@ describe('Password tests', () => {
         //declare the elements
         label = document.querySelector('label[for="password"]');
         passwordField = document.getElementById('password');
-        passwordMessage = document.getElementById('passwordMessage');
     })
 
     test('validatePassword should update elements correctly on success', () => {
@@ -49,7 +48,6 @@ describe('Password tests', () => {
         expect(passwordField.classList.contains('required')).toBe(true);
         expect(passwordField.classList.contains('invalid')).toBe(false);
         expect(label.classList.contains('invalid')).toBe(false);
-        expect(passwordMessage.textContent).toBe('');
     });
 
     test('validatePassword should update elements correctly for passwords over 20 chars', () => {
@@ -63,7 +61,6 @@ describe('Password tests', () => {
         expect(passwordField.classList.contains('required')).toBe(true);
         expect(passwordField.classList.contains('invalid')).toBe(true);
         expect(label.classList.contains('invalid')).toBe(true);
-        expect(passwordMessage.classList.contains('invalid')).toBe(true);
     });
 
     test('validatePassword should update elements correctly for passwords under 3 chars', () => {
@@ -77,6 +74,5 @@ describe('Password tests', () => {
         expect(passwordField.classList.contains('required')).toBe(true);
         expect(passwordField.classList.contains('invalid')).toBe(true);
         expect(label.classList.contains('invalid')).toBe(true);
-        expect(passwordMessage.classList.contains('invalid')).toBe(true);
     });
 });


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9316.

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Feature. Implements a full design overhaul for the registration page.

### Technical
<!-- What should be noted about the implementation? -->
**Requirements:**
- [x] Update all HTML to match mockup
- [x] Initial CSS build to match mockup
- [x] Mobile responsiveness (left panel `display: none` after breakpoint)
- [x] Center "Sign In with Google" iframe 
- [x] Make submit button blue (`cta-button--primary`)
- [x] Resize note text for legibility
- [x] Error message styling
- [x] Error messages `display: none` when no error, to avoid phantom errors
- [x] Final spacing adjustments
- [x] Adjust mobile view spacing

**Note:**
- The PR involved modifying the tests in `realtime_account_validation.test.js` as a result of replacing the `invalid` class toggle with a `display:none` vs. `display:block` toggle for the error divs to avoid phantom errors; further improvements to the test can be included in the final refactor, or as part of the PR
- The "Subscriptions" label from the mockup is currently not included to avoid `label` clashes that could interfere with accessibility, could certainly be added once we have a reasonable solution for how to do so

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
1. Log out (if logged in)
2. Go to `/account/create`
3. The page should look like this v

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

<img width="1328" alt="Registration UI in progress" src="https://github.com/internetarchive/openlibrary/assets/140550988/e6747bd6-fece-4d11-9cf3-bfa1dfb9dbf9">

<img width="495" alt="
Registration UI Mobile View" src="https://github.com/internetarchive/openlibrary/assets/140550988/fca26bd2-560f-471a-b379-7a5375d3c23e">

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
