### PR TITLE
Automatically label assigned issues that may not have had recent progress

### DIFF
--- a/.github/workflows/stale_assignee_digest.yml
+++ b/.github/workflows/stale_assignee_digest.yml
@@ -28,5 +28,3 @@ jobs:
       - run: node scripts/gh_scripts/stale_assignee_digest.mjs --repoOwner "internetarchive" --daysSince 14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ABC_TEAM_PLUS}}

--- a/.github/workflows/stale_assignee_digest.yml
+++ b/.github/workflows/stale_assignee_digest.yml
@@ -1,7 +1,7 @@
 name: stale_assignee_digest
 on:
   schedule:
-    - cron: '0 16 * * 1'
+    - cron: '30 7 * * 1'
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/stale_assignee_digest.yml
+++ b/.github/workflows/stale_assignee_digest.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  issues: write
 env:
   NODE_VERSION: '20'
 jobs:

--- a/scripts/gh_scripts/README.md
+++ b/scripts/gh_scripts/README.md
@@ -21,7 +21,7 @@ If a lead is assigned to the issue, and the lead is not also the PR's author, th
 
 ## `stale_assignee_digest.mjs`
 
-This script fetches all open issues that have assignees and publishes a Slack message listing all that have met the following criteria:
+This script fetches all open issues that have assignees and adds the https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Review%20Assignee label to all that have met the following criteria:
 - Assignee has been assigned for more than a given number of days and has not created and linked a pull request to the issue.
 - Assignee's GitHub username does not appear on the exclude list.
 
@@ -40,7 +40,8 @@ __Correct:__
 __Incorrect:__
 `node stale_assignee_digest.mjs --daysSince=21`
 
-The GitHub action that runs this script automatically sets `--repoOwner` to the owner of the repository that triggered the action.
+The GitHub action that runs this script automatically sets `--repoOwner` to the owner of the repository that triggered the action.  The action itself will
+only run if the repository owner is `internetarchive` (it will not run on forks).
 
 To quickly see a script's purpose and arguments, run the script with the `-h` or `--help` flag.
 

--- a/scripts/gh_scripts/stale_assignee_digest.mjs
+++ b/scripts/gh_scripts/stale_assignee_digest.mjs
@@ -7,17 +7,26 @@
  */
 import {Octokit} from "@octokit/action";
 
-console.log('Script starting...')
-
 /**
  * Default arguments that are used if no command-line options are passed.
  *
  * @type { Record }
  */
-const DEFAULT_OPTIONS = {
+ const DEFAULT_OPTIONS = {
     daysSince: 14,
     repoOwner: 'internetarchive'
 }
+
+/**
+ * Default headers that will be added to each GitHub API request.
+ *
+ * @type { Record<string, string>}
+ */
+const GITHUB_HEADERS = {
+    'X-GitHub-Api-Version': '2022-11-28'
+}
+
+console.log('Script starting...')
 
 const passedArguments = parseArgs()
 
@@ -146,9 +155,7 @@ async function fetchIssues() {
     return await octokit.paginate('GET /repos/{owner}/{repo}/issues', {
             owner: mainOptions.repoOwner,
             repo: 'openlibrary',
-            headers: {
-                'X-GitHub-Api-Version': '2022-11-28'
-            },
+            headers: GITHUB_HEADERS,
             assignee: '*',
             state: 'open',
             per_page: 100
@@ -181,9 +188,7 @@ async function getTimeline(issue) {
             repo: 'openlibrary',
             issue_number: issueNumber,
             per_page: 100,
-            headers: {
-                'X-GitHub-Api-Version': '2022-11-28'
-            }
+            headers: GITHUB_HEADERS
         })
 
     // Store timeline for future use:

--- a/scripts/gh_scripts/stale_assignee_digest.mjs
+++ b/scripts/gh_scripts/stale_assignee_digest.mjs
@@ -162,7 +162,7 @@ async function fetchIssues() {
  * timeline is found, calls GitHub's Timeline API and stores the result
  * before returning.
  *
- * @param issue {Record}
+ * @param {Record} issue
  * @returns {Promise<Array<Record>>}
  * @see {issueTimelines}
  */
@@ -195,7 +195,7 @@ async function getTimeline(issue) {
 /**
  * Publishes digest of stale issues to Slack.
  *
- * @param issues {Array<Record>}
+ * @param {Array<Record>} issues
  * @returns {Promise<boolean>}
  */
 async function postSlackDigest(issues) {
@@ -247,8 +247,8 @@ async function postSlackDigest(issues) {
      * Publishes given `message` int the thread identified by the Slack channel
      * (found in the environment) and the given timestamp ID `ts`.
      *
-     * @param message { string }
-     * @param ts { string }
+     * @param { string } message
+     * @param { string } ts
      * @returns {Promise<void>}
      */
     async function commentOnThread(message, ts) {
@@ -277,7 +277,7 @@ async function postSlackDigest(issues) {
     /**
      * Waits for the given number of milliseconds, then resolves.
      *
-     * @param ms {number}
+     * @param {number} ms
      * @returns {Promise}
      */
     function wait(ms) {
@@ -294,8 +294,8 @@ async function postSlackDigest(issues) {
  *
  * The given filters are functions that are meant to be
  * passed to Array.
- * @param issues {Array<Record>}
- * @param filters {Array<CallableFunction>}
+ * @param {Array<Record>} issues
+ * @param {Array<CallableFunction>} filters
  * @returns {Promise<Array<Record>>}
  */
 async function filterIssues(issues, filters) {
@@ -313,7 +313,7 @@ async function filterIssues(issues, filters) {
  *
  * Necessary because GitHub's REST API considers pull requests to be a
  * type of issue.
- * @param issues {Array<Record>}
+ * @param {Array<Record>} issues
  * @returns {Promise<Array<Record>>}
  */
 async function excludePullRequestsFilter(issues) {
@@ -330,7 +330,7 @@ async function excludePullRequestsFilter(issues) {
  * Checks each given issue and returns array of issues that do not have
  * an exclusion label.
  *
- * @param issues {Array<Record>}
+ * @param {Array<Record>} issues
  * @returns {Promise<Array<Record>>}
  * @see {excludeLabels}
  */
@@ -359,7 +359,7 @@ async function excludeLabelsFilter(issues) {
  * __Important__: This function also updates the given issue. A `ol_unassign_ignore`
  * flag is added to any `assignee` that appears on the exclude list.
  *
- * @param issues {Array<Record>}
+ * @param {Array<Record>} issues
  * @returns {Promise<Array<Record>>}
  * @see {excludeAssignees}
  */
@@ -394,7 +394,7 @@ async function excludeAssigneesFilter(issues) {
  *
  * __Important__: This function adds the `ol_unassign_ignore` flag to
  * assignees that haven't yet been assigned for too long.
- * @param issues {Array<Record>}
+ * @param {Array<Record>} issues
  * @returns {Promise<Array<Record>>}
  */
 async function recentAssigneeFilter(issues) {
@@ -433,8 +433,8 @@ async function recentAssigneeFilter(issues) {
 /**
  * Returns the date that the given assignee was assigned to an issue.
  *
- * @param assignee {Record}
- * @param issueTimeline {Record}
+ * @param {Record} assignee
+ * @param {Record} issueTimeline
  * @returns {Date}
  */
 function getAssignmentDate(assignee, issueTimeline) {
@@ -455,7 +455,7 @@ function getAssignmentDate(assignee, issueTimeline) {
  * Iterates over given issues, and returns array containing issues that
  * have no linked pull requests that are open.
  *
- * @param issues {Array<Record>}
+ * @param {Array<Record>} issues
  * @returns {Promise<*[]>}
  */
 async function linkedPullRequestFilter(issues) {

--- a/scripts/gh_scripts/weekly_status_report.mjs
+++ b/scripts/gh_scripts/weekly_status_report.mjs
@@ -241,7 +241,7 @@ async function prepareUntriagedIssues(leads) {
  * Finds all issues with the "Needs: Review Assignee" label, prepares a message containing a
  * summary for each given lead, and returns the prepared messages
  *
- * @param {Array<Lead>} leads 
+ * @param {Array<Lead>} leads
  * @returns {Promise<Array<string>>}
  */
 async function prepareReviewAssigneeIssues(leads) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9335

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Updates the `stale_assignee_digest` script in the following ways:
1. Adds the https://github.com/internetarchive/openlibrary/labels/Needs%3A%20Review%20Assignee link to any issues that may be stale
2. Removes code that publishes messages to Slack
3. Adds a section for stale issues to our biweekly Slack project management digest
4. Updates stale assignee workflow to run an hour before Monday's Slack digest is published

> [!TIP]
> It may be easier to review the first two commits individually.  The first commit updates some malformed `jsdoc` strings, and the second DRYs the GitHub request headers.  These commits are somewhat unrelated to the task at hand, and may cause confusion when viewed with all other changes. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->


<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
