### PR TITLE
Followers Count To Stats Page Added Issue #9284

### DIFF
--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -2,11 +2,11 @@ import logging
 import web
 from typing import cast, Any
 from openlibrary.core.bookshelves import Bookshelves
+from openlibrary.utils.dateutil import DATE_ONE_MONTH_AGO, DATE_ONE_WEEK_AGO
 
 from . import db
 
 logger = logging.getLogger(__name__)
-
 
 class PubSub:
     TABLENAME = "follows"
@@ -113,7 +113,7 @@ class PubSub:
             vars={'subscriber': subscriber},
         )
         return cast(tuple[int], count)[0].get('count', 0)
-
+        
     @classmethod
     def count_followers(cls, publisher):
         oldb = db.get_db()
@@ -124,6 +124,23 @@ class PubSub:
             vars={'publisher': publisher},
         )
         return cast(tuple[int], count)[0].get('count', 0)
+
+    @classmethod
+    def total_followers(cls, since=None) -> int:
+        oldb = db.get_db()
+        query = f"SELECT count(DISTINCT subscriber) from {cls.TABLENAME}"
+        if since:
+            query += " WHERE created >= $since"
+        results = oldb.query(query, vars={'since': since})
+        return results[0]['count'] if results else 0
+
+    @classmethod
+    def summary(cls):
+        return {"total_following_count": {
+            "total":cls.total_followers(),
+            "month":cls.total_followers(since=DATE_ONE_MONTH_AGO),
+            "week":cls.total_followers(since=DATE_ONE_WEEK_AGO)
+        }}
 
     @classmethod
     def count_total_subscribers(cls):

--- a/openlibrary/core/follows.py
+++ b/openlibrary/core/follows.py
@@ -8,6 +8,7 @@ from . import db
 
 logger = logging.getLogger(__name__)
 
+
 class PubSub:
     TABLENAME = "follows"
     PRIMARY_KEY = ["subscriber", "publisher"]
@@ -113,7 +114,7 @@ class PubSub:
             vars={'subscriber': subscriber},
         )
         return cast(tuple[int], count)[0].get('count', 0)
-        
+
     @classmethod
     def count_followers(cls, publisher):
         oldb = db.get_db()
@@ -136,11 +137,13 @@ class PubSub:
 
     @classmethod
     def summary(cls):
-        return {"total_following_count": {
-            "total":cls.total_followers(),
-            "month":cls.total_followers(since=DATE_ONE_MONTH_AGO),
-            "week":cls.total_followers(since=DATE_ONE_WEEK_AGO)
-        }}
+        return {
+            "total_following_count": {
+                "total": cls.total_followers(),
+                "month": cls.total_followers(since=DATE_ONE_MONTH_AGO),
+                "week": cls.total_followers(since=DATE_ONE_WEEK_AGO),
+            }
+        }
 
     @classmethod
     def count_total_subscribers(cls):

--- a/openlibrary/i18n/messages.pot
+++ b/openlibrary/i18n/messages.pot
@@ -839,47 +839,6 @@ msgstr[1] ""
 msgid "BARF! Search engine ERROR!"
 msgstr ""
 
-#: work_search.html
-msgid "Zoom In"
-msgstr ""
-
-#: work_search.html
-msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
-msgstr ""
-
-#: work_search.html
-msgid "Merge duplicate authors from this search"
-msgstr ""
-
-#: type/work/editions.html work_search.html
-msgid "Merge duplicates"
-msgstr ""
-
-#: work_search.html
-msgid "yes"
-msgstr ""
-
-#: work_search.html
-msgid "no"
-msgstr ""
-
-#: work_search.html
-msgid "Filter results for ebook availability"
-msgstr ""
-
-#: work_search.html
-#, python-format
-msgid "Filter results for %(facet)s"
-msgstr ""
-
-#: work_search.html
-msgid "more"
-msgstr ""
-
-#: work_search.html
-msgid "less"
-msgstr ""
-
 #: about/index.html
 msgid "The Open Library Team"
 msgstr ""
@@ -1888,6 +1847,10 @@ msgid "Users Reviewing"
 msgstr ""
 
 #: admin/index.html
+msgid "Patrons Following"
+msgstr ""
+
+#: admin/index.html
 msgid "Notes Created"
 msgstr ""
 
@@ -2600,7 +2563,7 @@ msgstr ""
 msgid "Not in Library"
 msgstr ""
 
-#: books/custom_carousel.html
+#: books/custom_carousel.html search/work_search_facets.html
 msgid "Loading..."
 msgstr ""
 
@@ -5094,6 +5057,47 @@ msgstr ""
 
 #: search/subjects.html
 msgid "work"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "Merge duplicate authors from this search"
+msgstr ""
+
+#: search/work_search_facets.html type/work/editions.html
+msgid "Merge duplicates"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "more"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "less"
+msgstr ""
+
+#: search/work_search_facets.html
+#, python-format
+msgid "Filter results for %(facet)s"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "Filter results for ebook availability"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "yes"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "no"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "Zoom In"
+msgstr ""
+
+#: search/work_search_facets.html
+msgid "Focus your results using these <a href=\"/search/howto\">filters</a>"
 msgstr ""
 
 #: site/around_the_library.html

--- a/openlibrary/templates/admin/index.html
+++ b/openlibrary/templates/admin/index.html
@@ -191,7 +191,13 @@ $ stats = get_admin_stats()
       <td></td>
       <td class="amount">$commify(counts.reading_log['total_reviewers']['total'])</td>
     </tr>
-
+    <tr class="major even">
+      <td>$_("Patrons Following")</td>
+      <td class="amount">$commify(counts.reading_log['total_following_count']['week'])</td>
+      <td class="amount">$commify(counts.reading_log['total_following_count']['month'])</td>
+      <td></td>
+      <td class="amount">$commify(counts.reading_log['total_reviewers']['total'])</td>
+    </tr>
     <tr class="major">
       <td>$_("Notes Created")</td>
       <td class="amount">$commify(counts.reading_log['total_notes_created']['week'])</td>

--- a/openlibrary/views/loanstats.py
+++ b/openlibrary/views/loanstats.py
@@ -11,6 +11,7 @@ from .. import app
 from ..core import cache
 from ..core.observations import Observations
 from ..core.booknotes import Booknotes
+from ..core.follows import PubSub
 from ..core.bookshelves import Bookshelves
 from ..core.ratings import Ratings
 from ..plugins.admin.code import get_counts
@@ -38,6 +39,7 @@ def reading_log_summary():
     stats.update(Ratings.summary())
     stats.update(Observations.summary())
     stats.update(Booknotes.summary())
+    stats.update(PubSub.summary())
     return stats
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9284

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
Adds feature of following count displayed on stats page

### Technical
<!-- What should be noted about the implementation? -->
The implementation includes addition of a class called total_followers() with functionality of sorting based upon days (week, month, total) and updation of summary method in PubSub class to return total count of followers (previous code replaced because summary method was not being used anywhere except stats, hence loanstats.py also updated)

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
Implementing total_followers method in follows.py and importing DATE_ONE_MONTH_AGO and DATE_ONE_WEEK_AGO from utils.dateutil, importing PubSub class in loanstats.py and adding updation on line 40 or line 41. Updating admin/index.html to include new followers count from reading_log.

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->
![Screenshot 2024-05-29 at 3 29 44 PM](https://github.com/internetarchive/openlibrary/assets/10382237/672109a5-3d24-4179-a5ba-ad832bd22813)

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->



<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
