### PR TITLE
Fix and improve page number validation for following/followers pages

### DIFF
--- a/openlibrary/plugins/upstream/account.py
+++ b/openlibrary/plugins/upstream/account.py
@@ -1130,12 +1130,14 @@ class export_books(delegate.page):
 
         return csv_string(Ratings.select_all_by_username(username), format_rating)
 
+
 def _validate_follows_page(page):
     if isinstance(page, int):
         return max(1, page)
     if isinstance(page, str) and page.isdigit():
         return max(1, int(page))
     return 1
+
 
 class my_follows(delegate.page):
     path = r"/people/([^/]+)/(followers|following)"


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9283 (cont'd)

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
- Fixes page validation for followers/following pages in the event that the page ID is already an integer and not a string
- Defaults to the last valid page if the provided page is too high

### Technical
- I extracted page validation into an "unexported" function for cleanliness. It covers the `page` qparam being either an int or a string as well as a fallback to just return 1.
- I noticed I had no checks for invalid pages that are too highly numbered, so I added that as well.

### Testing
I repeated my tests from https://github.com/internetarchive/openlibrary/pull/9323, but also tried loading the page with invalid high values like 21, 100, etc.

### Screenshot
There was no change in the results of my tests from https://github.com/internetarchive/openlibrary/pull/9323.

Here is another screenshot with a page number that is too high:
<img width="983" alt="image" src="https://github.com/internetarchive/openlibrary/assets/26495758/50edb195-3613-4d61-a649-489d39e09635">

### Stakeholders
@mekarpeles 

Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code.