### PR TITLE
Added script for metadata dumping of coverstore id/width/height

### DIFF
--- a/scripts/dump-covers-metadata.sql
+++ b/scripts/dump-covers-metadata.sql
@@ -1,0 +1,15 @@
+-- To run locally:
+-- docker compose exec web psql -h db -d coverstore --set=upto="$(date +%Y-%m-%d)" -f scripts/dump-covers-metadata.sql
+
+COPY (
+  SELECT
+    id AS id,
+    width AS width,
+    height AS height,
+    -- Truncate created to day precision as a privacy precaution
+    DATE(cover.created) AS created
+  FROM cover
+  -- By default in postgres, "2010-05-17T10:20:30" <= "2010-05-17" ->> FALSE
+  -- We need to go up a day to get <= behaviour
+  WHERE cover.created <= (:'upto'::date + '1 day'::interval)
+) TO stdout WITH (format csv, delimiter E'\t')

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -118,7 +118,7 @@ then
   if [[ ! -f $(compgen -G "ol_dump_covers_metadata_$yyyymm*.txt.gz") ]]
   then
       log "generating coverstore dump: ol_dump_covers_metadata_$yyyymmdd.txt.gz"
-      # Note: this throws a psql warning since a db is already specified in PSQL_PARAMS, but the 
+      # Note: this throws a psql warning since a db is already specified in PSQL_PARAMS, but the
       # -d param takes precedence like we want it to!
       time psql $PSQL_PARAMS -d coverstore --set=upto="$yyyymmdd" -f $SCRIPTS/dump-covers-metadata.sql | gzip -c > ol_dump_covers_metadata$yyyymmdd.txt.gz
   else

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -118,7 +118,9 @@ then
   if [[ ! -f $(compgen -G "ol_dump_covers_metadata_$yyyymm*.txt.gz") ]]
   then
       log "generating coverstore dump: ol_dump_covers_metadata_$yyyymmdd.txt.gz"
-      time psql $PSQL_PARAMS --set=upto="$yyyymmdd" -f $SCRIPTS/dump-covers-metadata.sql | gzip -c > ol_dump_covers_metadata$yyyymmdd.txt.gz
+      # Note: this throws a psql warning since a db is already specified in PSQL_PARAMS, but the 
+      # -d param takes precedence like we want it to!
+      time psql $PSQL_PARAMS -d coverstore --set=upto="$yyyymmdd" -f $SCRIPTS/dump-covers-metadata.sql | gzip -c > ol_dump_covers_metadata$yyyymmdd.txt.gz
   else
       log "Skipping: $(compgen -G "ol_dump_reading-log_$yyyymm*.txt.gz")"
 

--- a/scripts/oldump.sh
+++ b/scripts/oldump.sh
@@ -113,8 +113,16 @@ then
       log "Skipping: $(compgen -G "ol_dump_reading-log_$yyyymm*.txt.gz")"
   fi
 
-
   log "=== Step 2 ==="
+  #generate cover metadata dumps
+  if [[ ! -f $(compgen -G "ol_dump_covers_metadata_$yyyymm*.txt.gz") ]]
+  then
+      log "generating coverstore dump: ol_dump_covers_metadata_$yyyymmdd.txt.gz"
+      time psql $PSQL_PARAMS --set=upto="$yyyymmdd" -f $SCRIPTS/dump-covers-metadata.sql | gzip -c > ol_dump_covers_metadata$yyyymmdd.txt.gz
+  else
+      log "Skipping: $(compgen -G "ol_dump_reading-log_$yyyymm*.txt.gz")"
+
+  log "=== Step 3 ==="
   if [[ ! -f $(compgen -G "ol_dump_ratings_$yyyymm*.txt.gz") ]]
   then
       log "generating ratings table: ol_dump_ratings_$yyyymmdd.txt.gz"
@@ -124,7 +132,7 @@ then
   fi
 
 
-  log "=== Step 3 ==="
+  log "=== Step 4 ==="
   if [[ ! -f "data.txt.gz" ]]
   then
       log "generating the data table: data.txt.gz -- takes approx. 110 minutes..."
@@ -138,7 +146,7 @@ then
   fi
 
 
-  log "=== Step 4 ==="
+  log "=== Step 5 ==="
   if [[ ! -f $(compgen -G "ol_cdump_$yyyymm*.txt.gz") ]]
   then
       # generate cdump, sort and generate dump
@@ -151,7 +159,7 @@ then
   fi
 
 
-  log "=== Step 5 ==="
+  log "=== Step 6 ==="
   if [[ ! -f $(compgen -G "ol_dump_*.txt.gz") ]]
   then
       log "generating the dump -- takes approx. 485 minutes for 173,000,000+ records..."
@@ -162,7 +170,7 @@ then
   fi
 
 
-  log "=== Step 6 ==="
+  log "=== Step 7 ==="
   if [[ ! -f $(compgen -G "ol_dump_*_$yyyymm*.txt.gz") ]]
   then
       mkdir -p $TMPDIR/oldumpsort


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #9157 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->
This PR adds a script to create a memory dump of ids, widths, and heights from the cover databse, as requested by #9156.  The command to run this SQL file on the local version is listed in the file itself. 

### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->
First, upload a few images to coverstore on your localhosted version, then run the script file added by this PR. 
### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
