### PR TITLE
fix typo on Tagalog, tgi should be tgl

### DIFF
--- a/openlibrary/catalog/marc/parse.py
+++ b/openlibrary/catalog/marc/parse.py
@@ -286,6 +286,8 @@ lang_map = {
     'fr ': 'fre',
     'it ': 'ita',
     # LOC MARC Deprecated code updates
+    # Only covers deprecated codes where there
+    # is a direct 1-to-1 mapping to a single new code.
     'cam': 'khm',  # Khmer
     'esp': 'epo',  # Esperanto
     'eth': 'gez',  # Ethiopic
@@ -308,7 +310,7 @@ lang_map = {
     'snh': 'sin',  # Sinhalese
     'sso': 'sot',  # Sotho
     'swz': 'ssw',  # Swazi
-    'tag': 'tgi',  # Tagalog
+    'tag': 'tgl',  # Tagalog
     'taj': 'tgk',  # Tajik
     'tar': 'tat',  # Tatar
     'tsw': 'tsn',  # Tswana


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Fixes a typo in the new Tagalog code, relates to #8139 and #8140

Adds a comment to clarify that not all deprecated codes are auto-converted, just the ones which have clear 1-to-1 mappings. 

<!-- What does this PR achieve? [feature|hotfix|fix|refactor] -->


### Technical
<!-- What should be noted about the implementation? -->

### Testing
<!-- Steps for reviewer to reproduce/verify what this PR does/fixes. -->

### Screenshot
<!-- If this PR touches UI, please post evidence (screenshots) of it behaving correctly. -->

### Stakeholders
<!-- @ tag the lead (as labeled on the issue) and other stakeholders -->

@tfmorris 
@mekarpeles , you merged the last one of these, after the fact I noticed a typo in one of the codes, This is a fix that should go in quickly, before any imports go through.

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
